### PR TITLE
fix repo name in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ MCP servers live in `mcp-servers/` and are configured via the Settings UI or `mc
 
 ```bash
 git clone --recurse-submodules https://github.com/Vigil-Soc/vigil.git
-cd Vigil-Soc
+cd vigil
 ./start_web.sh
 ```
 


### PR DESCRIPTION
Typo in quick start has a typo.  Changed Vigil-Soc to vigil