### PR TITLE
docs: add submodules section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ ai-opensoc/
 └── data/schemas/      # JSON validation schemas
 ```
 
+## Submodules
+
+Vigil depends on two git submodules that must be initialized alongside the main repo (hence `--recurse-submodules` in the clone command). **`deeptempo-core`** provides the shared core library used by the backend and agents. **`mcp-servers`** contains the 30+ Model Context Protocol server implementations (Splunk, CrowdStrike, VirusTotal, Jira, Slack, etc.) that give every agent access to your existing security tooling. If you cloned without `--recurse-submodules`, run `git submodule update --init --recursive` to pull them in.
+
 ## Example Usage
 
 ### Run a Workflow


### PR DESCRIPTION
## Summary
- Adds a new `## Submodules` section to the README explaining the two git submodules (`deeptempo-core` and `mcp-servers`)
- Clarifies why `--recurse-submodules` is required and provides the recovery command for users who cloned without it

## Test plan
- [ ] Verify the new section renders correctly on GitHub
- [ ] Confirm placement between Project Structure and Example Usage sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)