### PR TITLE
fix: support docker compose v2 plugin alongside v1 standalone

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
         run: |
           ssh ${{ secrets.PROD_VM_USER }}@${{ secrets.PROD_VM_HOST }} '
             cd /opt/ai-opensoc &&
-            docker-compose ps > backup-${{ steps.version.outputs.version }}.txt &&
+            docker compose ps > backup-${{ steps.version.outputs.version }}.txt &&
             docker images | grep ai-opensoc >> backup-${{ steps.version.outputs.version }}.txt
           '
       
@@ -227,8 +227,8 @@ jobs:
           echo "Deployment failed, initiating rollback..."
           ssh ${{ secrets.PROD_VM_USER }}@${{ secrets.PROD_VM_HOST }} '
             cd /opt/ai-opensoc &&
-            docker-compose down &&
-            docker-compose up -d --force-recreate
+            docker compose down &&
+            docker compose up -d --force-recreate
           '
       
       - name: Cleanup old images

--- a/backend/api/local_services.py
+++ b/backend/api/local_services.py
@@ -37,8 +37,12 @@ def run_docker_compose_command(service: str, action: str, profile: Optional[str]
                 "message": "Docker directory not found"
             }
         
-        # Build command
-        cmd = ['docker-compose']
+        # Build command (support both v1 standalone and v2 plugin)
+        import shutil
+        if shutil.which('docker-compose'):
+            cmd = ['docker-compose']
+        else:
+            cmd = ['docker', 'compose']
         
         if profile:
             cmd.extend(['--profile', profile])

--- a/scripts/deploy_to_vm.sh
+++ b/scripts/deploy_to_vm.sh
@@ -36,6 +36,9 @@ run_remote() {
     ssh -o StrictHostKeyChecking=no $VM_USER@$VM_HOST "$1"
 }
 
+# Determine remote docker compose command (v2 plugin vs v1 standalone)
+DOCKER_COMPOSE=$(run_remote "command -v docker-compose &>/dev/null && echo docker-compose || echo 'docker compose'")
+
 # Function to check service health
 check_health() {
     local service=$1
@@ -64,7 +67,7 @@ run_remote "
     cd $DEPLOY_DIR &&
     mkdir -p backups &&
     timestamp=\$(date +%Y%m%d_%H%M%S) &&
-    docker-compose ps > backups/pre-deploy-\$timestamp.txt &&
+    $DOCKER_COMPOSE ps > backups/pre-deploy-\$timestamp.txt &&
     echo 'Backup created: backups/pre-deploy-\$timestamp.txt'
 "
 
@@ -76,7 +79,7 @@ run_remote "
     docker pull $REGISTRY/$IMAGE_NAME-daemon:$IMAGE_TAG
 "
 
-# Step 3: Update docker-compose configuration
+# Step 3: Update docker compose configuration
 echo -e "\n${YELLOW}Step 3: Updating configuration...${NC}"
 run_remote "
     cd $DEPLOY_DIR &&
@@ -89,7 +92,7 @@ run_remote "
 echo -e "\n${YELLOW}Step 4: Running database migrations...${NC}"
 run_remote "
     cd $DEPLOY_DIR &&
-    docker-compose run --rm backend alembic upgrade head || echo 'Migration completed'
+    $DOCKER_COMPOSE run --rm backend alembic upgrade head || echo 'Migration completed'
 "
 
 # Step 5: Rolling restart services
@@ -99,9 +102,9 @@ echo -e "\n${YELLOW}Step 5: Performing rolling restart...${NC}"
 echo "Restarting daemon..."
 run_remote "
     cd $DEPLOY_DIR &&
-    docker-compose stop soc-daemon &&
-    docker-compose rm -f soc-daemon &&
-    docker-compose up -d soc-daemon
+    $DOCKER_COMPOSE stop soc-daemon &&
+    $DOCKER_COMPOSE rm -f soc-daemon &&
+    $DOCKER_COMPOSE up -d soc-daemon
 "
 check_health "soc-daemon"
 
@@ -109,9 +112,9 @@ check_health "soc-daemon"
 echo "Restarting backend..."
 run_remote "
     cd $DEPLOY_DIR &&
-    docker-compose stop backend &&
-    docker-compose rm -f backend &&
-    docker-compose up -d backend
+    $DOCKER_COMPOSE stop backend &&
+    $DOCKER_COMPOSE rm -f backend &&
+    $DOCKER_COMPOSE up -d backend
 "
 check_health "backend"
 
@@ -127,7 +130,7 @@ if [ "$api_health" = "200" ]; then
 else
     echo -e "${RED}✗ API health check failed (HTTP $api_health)${NC}"
     echo -e "${YELLOW}Initiating rollback...${NC}"
-    run_remote "cd $DEPLOY_DIR && docker-compose down && docker-compose up -d"
+    run_remote "cd $DEPLOY_DIR && $DOCKER_COMPOSE down && $DOCKER_COMPOSE up -d"
     exit 1
 fi
 
@@ -151,10 +154,10 @@ echo -e "\n${YELLOW}Step 8: Verifying deployment...${NC}"
 run_remote "
     cd $DEPLOY_DIR &&
     echo '--- Running Services ---' &&
-    docker-compose ps &&
+    $DOCKER_COMPOSE ps &&
     echo '' &&
     echo '--- Recent Logs ---' &&
-    docker-compose logs --tail=20 backend
+    $DOCKER_COMPOSE logs --tail=20 backend
 "
 
 # Success!

--- a/scripts/migrate_orchestrator.py
+++ b/scripts/migrate_orchestrator.py
@@ -51,7 +51,7 @@ def main():
     except Exception as e:
         print(f"\nERROR: {e}")
         print("\nMake sure PostgreSQL is running:")
-        print("  cd docker && docker-compose up -d postgres")
+        print("  cd docker && docker compose up -d postgres")
         sys.exit(1)
 
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -13,6 +13,13 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Determine docker compose command (v2 plugin vs v1 standalone)
+if command -v docker-compose &> /dev/null; then
+    DOCKER_COMPOSE="docker-compose"
+else
+    DOCKER_COMPOSE="docker compose"
+fi
+
 # Configuration
 API_URL="${API_URL:-http://localhost:6987}"
 FRONTEND_URL="${FRONTEND_URL:-http://localhost:6988}"
@@ -136,12 +143,12 @@ else
   echo -e "${RED}✗ Not running${NC}"
   echo ""
   echo -e "${RED}ERROR: API service not accessible at $API_URL${NC}"
-  echo "Please start the services with: docker-compose up -d"
+  echo "Please start the services with: $DOCKER_COMPOSE up -d"
   exit 1
 fi
 
 echo -n "  [*] Checking database... "
-if docker-compose ps | grep -q postgres.*Up; then
+if $DOCKER_COMPOSE ps | grep -q postgres.*Up; then
   echo -e "${GREEN}✓ Running${NC}"
 else
   echo -e "${YELLOW}⚠ Cannot verify${NC}"
@@ -263,7 +270,7 @@ fi
 print_header "Phase 7: Database Health"
 
 echo -n "  [*] Checking database connection... "
-if docker-compose exec -T postgres psql -U postgres -d deeptempo -c "SELECT 1;" > /dev/null 2>&1; then
+if $DOCKER_COMPOSE exec -T postgres psql -U postgres -d deeptempo -c "SELECT 1;" > /dev/null 2>&1; then
   echo -e "${GREEN}✓ PASS${NC}"
   ((PASSED_TESTS++))
 else
@@ -274,7 +281,7 @@ fi
 ((TOTAL_TESTS++))
 
 echo -n "  [*] Checking table existence... "
-TABLE_COUNT=$(docker-compose exec -T postgres psql -U postgres -d deeptempo -t -c "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='public';" 2>/dev/null | tr -d ' ')
+TABLE_COUNT=$($DOCKER_COMPOSE exec -T postgres psql -U postgres -d deeptempo -t -c "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='public';" 2>/dev/null | tr -d ' ')
 
 if [ "$TABLE_COUNT" -gt "5" ]; then
   echo -e "${GREEN}✓ PASS${NC} ($TABLE_COUNT tables)"
@@ -292,7 +299,7 @@ SERVICES=("postgres" "soc-api" "soc-daemon")
 
 for service in "${SERVICES[@]}"; do
   echo -n "  [*] Checking $service... "
-  if docker-compose ps | grep -q "$service.*Up"; then
+  if $DOCKER_COMPOSE ps | grep -q "$service.*Up"; then
     echo -e "${GREEN}✓ Running${NC}"
     ((PASSED_TESTS++))
   else

--- a/start_daemon.sh
+++ b/start_daemon.sh
@@ -111,6 +111,13 @@ elif [ -f "env.example" ]; then
     set +a
 fi
 
+# Determine docker compose command (v2 plugin vs v1 standalone)
+if command -v docker-compose &> /dev/null; then
+    DOCKER_COMPOSE="docker-compose"
+else
+    DOCKER_COMPOSE="docker compose"
+fi
+
 # Check and start PostgreSQL if needed
 echo "Checking PostgreSQL database..."
 if command -v docker &> /dev/null; then
@@ -119,9 +126,9 @@ if command -v docker &> /dev/null; then
     else
         echo "Starting PostgreSQL..."
         cd docker
-        docker-compose up -d postgres
+        $DOCKER_COMPOSE up -d postgres
         cd ..
-        
+
         echo "Waiting for PostgreSQL..."
         for i in {1..30}; do
             if docker exec deeptempo-postgres pg_isready -U deeptempo -d deeptempo_soc &> /dev/null 2>&1; then
@@ -141,7 +148,7 @@ if command -v docker &> /dev/null; then
     else
         echo "Starting Redis (LLM job queue)..."
         cd docker
-        docker-compose up -d redis
+        $DOCKER_COMPOSE up -d redis
         cd ..
         echo "Waiting for Redis..."
         sleep 2

--- a/start_web.sh
+++ b/start_web.sh
@@ -110,6 +110,13 @@ else
     fi
 fi
 
+# Determine docker compose command (v2 plugin vs v1 standalone)
+if command -v docker-compose &> /dev/null; then
+    DOCKER_COMPOSE="docker-compose"
+else
+    DOCKER_COMPOSE="docker compose"
+fi
+
 # Check and start PostgreSQL database
 echo ""
 echo "Checking PostgreSQL database..."
@@ -119,7 +126,7 @@ if command -v docker &> /dev/null; then
     else
         echo "Starting PostgreSQL..."
         cd docker
-        docker-compose up -d postgres
+        $DOCKER_COMPOSE up -d postgres
         cd ..
         
         echo "Waiting for PostgreSQL..."
@@ -141,7 +148,7 @@ if command -v docker &> /dev/null; then
     else
         echo "Starting Redis (LLM job queue)..."
         cd docker
-        docker-compose up -d redis
+        $DOCKER_COMPOSE up -d redis
         cd ..
         echo "Waiting for Redis..."
         sleep 2
@@ -204,7 +211,7 @@ cleanup() {
     echo "✓ Servers stopped"
     echo ""
     echo "Database and Redis are still running. To stop:"
-    echo "  cd docker && docker-compose stop postgres redis"
+    echo "  cd docker && $DOCKER_COMPOSE stop postgres redis"
     exit 0
 }
 


### PR DESCRIPTION
## Summary
- All shell scripts now auto-detect `docker-compose` (v1 standalone) vs `docker compose` (v2 plugin) and use whichever is available
- Python backend (`local_services.py`) uses `shutil.which()` for the same detection
- CI workflow updated to use v2 syntax (GitHub Actions runners ship v2)

`docker-compose` v1 standalone has been EOL since July 2023. Most modern Docker installs only have the v2 plugin (`docker compose`). This was causing `command not found` errors on startup.

## Test plan
- [x] Verify `./start_web.sh` works on a system with only `docker compose` (v2)
- [x] Verify `./start_web.sh` still works on a system with `docker-compose` (v1)
- [x] Shell script syntax validated with `bash -n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)