### PR TITLE
fix: remove double /api prefix in analytics API call

### DIFF
--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -159,7 +159,7 @@ export default function Analytics() {
     setLoading(true)
     setError(null)
     try {
-      const response = await api.get(`/api/analytics?timeRange=${timeRange}`)
+      const response = await api.get(`/analytics?timeRange=${timeRange}`)
       setAnalyticsData(response.data)
     } catch (error) {
       console.error('Error fetching analytics:', error)


### PR DESCRIPTION
## Summary
- Fix `Analytics.tsx` requesting `/api/api/analytics` instead of `/api/analytics`
- The axios instance has `baseURL: '/api'`, so the path should be `/analytics` not `/api/analytics`

Before:
<img width="1672" height="1380" alt="Screenshot from 2026-03-30 04-46-31" src="https://github.com/user-attachments/assets/fb94ca43-3dcd-48ab-9fa3-a8c1013449cd" />


## Test plan
- [ ] Analytics Dashboard page loads data (was showing 404 error)
- [ ] Network tab shows request to `/api/analytics?timeRange=7d` (not `/api/api/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)