### PR TITLE
fix: resolve frontend TypeScript build errors

### DIFF
--- a/frontend/src/components/settings/AutoInvestigateTab.tsx
+++ b/frontend/src/components/settings/AutoInvestigateTab.tsx
@@ -241,13 +241,13 @@ export default function AutoInvestigateTab({ onMessage, showConfirm }: Props) {
         <CardContent>
           <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 2 }}>Agent Limits</Typography>
           <Grid container spacing={2}>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               {numField('Max concurrent agents', 'max_concurrent_agents', { min: 1, max: 10, helperText: '1-10 simultaneous agents' })}
             </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               {numField('Max iterations per agent', 'max_iterations_per_agent', { min: 1, max: 500, helperText: 'Claude calls per investigation' })}
             </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               {numField('Max runtime (seconds)', 'max_runtime_per_investigation', { min: 60, max: 86400, suffix: 's', helperText: `${Math.round(config.max_runtime_per_investigation / 60)} minutes` })}
             </Grid>
           </Grid>
@@ -259,13 +259,13 @@ export default function AutoInvestigateTab({ onMessage, showConfirm }: Props) {
         <CardContent>
           <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 2 }}>Cost Guardrails</Typography>
           <Grid container spacing={2}>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               {numField('Per investigation limit', 'max_cost_per_investigation', { min: 0.5, max: 100, prefix: '$', helperText: 'Max spend per investigation' })}
             </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               {numField('Hourly cost limit', 'max_total_hourly_cost', { min: 1, max: 500, prefix: '$', helperText: 'Pause intake if exceeded' })}
             </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               {numField('Daily cost limit', 'max_total_daily_cost', { min: 1, max: 1000, prefix: '$', helperText: 'Hard daily ceiling' })}
             </Grid>
           </Grid>
@@ -277,19 +277,19 @@ export default function AutoInvestigateTab({ onMessage, showConfirm }: Props) {
         <CardContent>
           <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 2 }}>Timing &amp; Advanced</Typography>
           <Grid container spacing={2}>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               {numField('Loop interval', 'loop_interval', { min: 10, max: 600, suffix: 's', helperText: 'Orchestrator check interval' })}
             </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               {numField('Agent loop delay', 'agent_loop_delay', { min: 1, max: 30, suffix: 's', helperText: 'Pause between agent iterations' })}
             </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               {numField('Stale threshold', 'stale_threshold', { min: 60, max: 3600, suffix: 's', helperText: 'Kill idle agents after this' })}
             </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               {numField('Dedup window', 'dedup_window_minutes', { min: 5, max: 1440, suffix: 'min', helperText: 'Overlap detection window' })}
             </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               {numField('Context max chars', 'context_max_chars', { min: 1000, max: 100000, helperText: 'Max context.md in prompt' })}
             </Grid>
           </Grid>
@@ -297,7 +297,7 @@ export default function AutoInvestigateTab({ onMessage, showConfirm }: Props) {
           <Divider sx={{ my: 2 }} />
 
           <Grid container spacing={2}>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               <TextField
                 fullWidth
                 label="Plan model"
@@ -308,7 +308,7 @@ export default function AutoInvestigateTab({ onMessage, showConfirm }: Props) {
                 sx={{ mb: 2 }}
               />
             </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               <TextField
                 fullWidth
                 label="Review model"
@@ -319,7 +319,7 @@ export default function AutoInvestigateTab({ onMessage, showConfirm }: Props) {
                 sx={{ mb: 2 }}
               />
             </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid item xs={12} sm={4}>
               <TextField
                 fullWidth
                 label="Working directory"

--- a/frontend/src/components/settings/DetectionRulesTab.tsx
+++ b/frontend/src/components/settings/DetectionRulesTab.tsx
@@ -23,7 +23,6 @@ import {
   InputLabel,
   CircularProgress,
   alpha,
-  useTheme,
 } from '@mui/material'
 import {
   Refresh as RefreshIcon,
@@ -82,7 +81,6 @@ const STATUS_ICON: Record<string, React.ReactNode> = {
 }
 
 export default function DetectionRulesTab() {
-  const theme = useTheme()
   const [sources, setSources] = useState<Source[]>([])
   const [stats, setStats] = useState<Stats | null>(null)
   const [loading, setLoading] = useState(false)
@@ -97,7 +95,7 @@ export default function DetectionRulesTab() {
   const [newSource, setNewSource] = useState({
     name: '',
     source_type: 'git' as 'git' | 'local',
-    format: 'sigma' as string,
+    format: 'sigma' as 'sigma' | 'splunk' | 'elastic' | 'kql' | 'auto',
     url: '',
     path: '',
     subdirectory: '',
@@ -382,7 +380,7 @@ export default function DetectionRulesTab() {
               <Select
                 value={newSource.format}
                 label="Rule Format"
-                onChange={(e) => setNewSource({ ...newSource, format: e.target.value })}
+                onChange={(e) => setNewSource({ ...newSource, format: e.target.value as typeof newSource.format })}
               >
                 <MenuItem value="sigma">Sigma (YAML)</MenuItem>
                 <MenuItem value="splunk">Splunk ESCU (YAML)</MenuItem>


### PR DESCRIPTION
## Summary
- **AutoInvestigateTab.tsx**: Replace MUI Grid v2 `size` prop with v5 `item xs sm` props — the project uses MUI v5
- **DetectionRulesTab.tsx**: Remove unused `useTheme` import, narrow `format` state type to match the `addSource` API union type

## Test plan
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] CI "Build Frontend" job passes (was failing)
- [ ] Settings > Auto Investigate tab renders correctly
- [ ] Settings > Detection Rules tab renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)