### PR TITLE
fix: update frontend Skills page to use /workflows endpoints (closes #43)

### DIFF
--- a/frontend/src/pages/Skills.tsx
+++ b/frontend/src/pages/Skills.tsx
@@ -126,7 +126,7 @@ export default function Skills() {
     setError(null)
     try {
       const response = await skillsApi.listSkills()
-      setSkills(response.data.skills || [])
+      setSkills(response.data.workflows || [])
     } catch (err: any) {
       setError(err.response?.data?.detail || 'Failed to load skills')
     } finally {
@@ -140,7 +140,7 @@ export default function Skills() {
     try {
       await skillsApi.reloadSkills()
       const response = await skillsApi.listSkills()
-      setSkills(response.data.skills || [])
+      setSkills(response.data.workflows || [])
       setSnackbar({ open: true, message: 'Skills reloaded from disk', severity: 'success' })
     } catch (err: any) {
       setError(err.response?.data?.detail || 'Failed to reload skills')

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -811,10 +811,10 @@ export const localServicesApi = {
 // Skills API (workflow skill management and execution)
 export const skillsApi = {
   // List all available skills
-  listSkills: () => api.get('/skills'),
+  listSkills: () => api.get('/workflows'),
 
   // Get full details for a specific skill (including markdown body)
-  getSkill: (skillId: string) => api.get(`/skills/${skillId}`),
+  getSkill: (skillId: string) => api.get(`/workflows/${skillId}`),
 
   // Execute a skill workflow
   executeSkill: (skillId: string, params: {
@@ -822,10 +822,10 @@ export const skillsApi = {
     case_id?: string
     context?: string
     hypothesis?: string
-  }) => api.post(`/skills/${skillId}/execute`, params),
+  }) => api.post(`/workflows/${skillId}/execute`, params),
 
   // Force reload skills from disk
-  reloadSkills: () => api.post('/skills/reload'),
+  reloadSkills: () => api.post('/workflows/reload'),
 }
 
 // Orchestrator API (autonomous investigation management)


### PR DESCRIPTION
## Summary
- `frontend/src/services/api.ts`: `skillsApi` now calls `/workflows`, `/workflows/{id}`, `/workflows/{id}/execute`, `/workflows/reload` — the routes that actually exist after the rename in commit `44eed89`
- `frontend/src/pages/Skills.tsx`: reads `response.data.workflows` instead of `response.data.skills` to match the backend response shape

## Root cause
Commit `44eed89` renamed the backend from `skills.py` → `workflows.py` and changed all routes from `/skills` → `/workflows`, but the frontend was never updated. The Skills page has been 404ing ever since.

## Test plan
- [ ] Skills page loads without 404 error
- [ ] Reload button works
- [ ] Clicking a skill to view detail works

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)