### PR TITLE
feat(observability): full OTEL instrumentation epic — closes #53–#60

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -67,18 +67,16 @@ from api.orchestrator import router as orchestrator_router
 
 from core.rate_limit import rate_limit_dependency
 
-# Configure logging
-log_dir = Path.home() / '.deeptempo'
-log_dir.mkdir(parents=True, exist_ok=True)
-
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(),
-        logging.FileHandler(log_dir / 'api.log')
-    ]
-)
+# Initialize telemetry before creating the FastAPI app so instrumentation
+# is registered before the first request handler is defined.
+try:
+    from core.telemetry import init_telemetry
+    init_telemetry("vigil-backend")
+except Exception as _tel_err:
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger(__name__).warning(
+        "Telemetry init failed (non-fatal): %s", _tel_err
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +86,16 @@ app = FastAPI(
     description="REST API for Vigil SOC Application",
     version="1.0.0"
 )
+
+# Instrument FastAPI with OTEL tracing (health + metrics endpoints excluded)
+try:
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentation
+    FastAPIInstrumentation().instrument_app(
+        app,
+        excluded_urls="api/health,metrics",
+    )
+except Exception as _inst_err:
+    logger.debug("FastAPI OTEL instrumentation skipped: %s", _inst_err)
 
 # Configure CORS
 app.add_middleware(
@@ -154,7 +162,14 @@ async def startup_event():
     logger.info("=" * 60)
     logger.info("Starting Vigil SOC Backend")
     logger.info("=" * 60)
-    
+
+    # Initialize Sentry error tracking (was never called before — bug fix)
+    try:
+        from backend.monitoring import init_sentry
+        init_sentry()
+    except Exception as e:
+        logger.warning("Sentry initialization failed (non-fatal): %s", e)
+
     # Load secrets into environment for MCP servers
     try:
         from backend.secrets_manager import get_secret
@@ -351,13 +366,13 @@ async def shutdown_event():
     logger.info("Shutting down MCP connections...")
     try:
         from services.mcp_client import get_mcp_client
-        
+
         mcp_client = get_mcp_client()
         if mcp_client:
             # Close all MCP sessions
             await mcp_client.close_all()
             logger.info("All MCP connections closed")
-            
+
             # Stop all MCP server processes managed by MCPService
             mcp_service = mcp_client.mcp_service
             if mcp_service:
@@ -366,6 +381,13 @@ async def shutdown_event():
                 logger.info(f"Stopped {stopped_count} MCP server processes")
     except Exception as e:
         logger.error(f"Error during shutdown cleanup: {e}")
+
+    # Flush and shut down OTEL providers
+    try:
+        from core.telemetry import shutdown_telemetry
+        shutdown_telemetry()
+    except Exception as e:
+        logger.warning("Telemetry shutdown error (non-fatal): %s", e)
 
 
 # Health check endpoint

--- a/backend/monitoring.py
+++ b/backend/monitoring.py
@@ -1,11 +1,16 @@
 """
 Monitoring and error tracking configuration.
 Integrates Sentry for error tracking and performance monitoring.
+
+When OTEL is active (VIGIL_OTEL_ENABLED=true), Sentry's own distributed
+tracing is disabled (traces_sample_rate=0) to prevent double-tracing.
+The SentrySpanProcessor bridges OTEL error spans to Sentry breadcrumbs so
+both systems remain useful without creating duplicate transaction records.
 """
 
 import os
 import logging
-from typing import Optional
+from typing import Any, Optional
 import sentry_sdk
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
@@ -14,44 +19,123 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# OTEL ↔ Sentry bridge
+# ---------------------------------------------------------------------------
+
+try:
+    from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
+    from opentelemetry.trace import StatusCode
+
+    class SentrySpanProcessor(SpanProcessor):
+        """
+        Forwards OTEL ERROR spans to Sentry as breadcrumbs and attaches the
+        OTEL trace_id to the Sentry scope for cross-system correlation.
+
+        Registered in core/telemetry.py when SENTRY_DSN is present.
+        Does NOT create Sentry transactions — Sentry tracing is disabled
+        when OTEL is active to prevent double-tracing.
+        """
+
+        def on_start(self, span: Any, parent_context: Any = None) -> None:
+            try:
+                ctx = span.get_span_context()
+                if ctx and ctx.is_valid:
+                    sentry_sdk.set_tag(
+                        "otel.trace_id", format(ctx.trace_id, "032x")
+                    )
+            except Exception:
+                pass
+
+        def on_end(self, span: Any) -> None:
+            try:
+                if span.status.status_code != StatusCode.ERROR:
+                    return
+                sentry_sdk.add_breadcrumb(
+                    message=span.name,
+                    category="otel.span",
+                    level="error",
+                    data={
+                        "span_id": format(
+                            span.get_span_context().span_id, "016x"
+                        ),
+                    },
+                )
+            except Exception:
+                pass
+
+        def on_shutdown(self) -> None:
+            pass
+
+        def force_flush(self, timeout_millis: int = 30_000) -> bool:
+            return True
+
+except ImportError:
+    # OTEL SDK not installed — provide a stub so the import never fails
+    class SentrySpanProcessor:  # type: ignore[no-redef]
+        def on_start(self, span: Any, parent_context: Any = None) -> None:
+            pass
+
+        def on_end(self, span: Any) -> None:
+            pass
+
+        def on_shutdown(self) -> None:
+            pass
+
+        def force_flush(self, timeout_millis: int = 30_000) -> bool:
+            return True
+
+
+# ---------------------------------------------------------------------------
+# Sentry initialization
+# ---------------------------------------------------------------------------
+
+
 def init_sentry() -> None:
     """Initialize Sentry error tracking and performance monitoring."""
-    
+
     sentry_dsn = os.getenv("SENTRY_DSN")
     environment = os.getenv("ENVIRONMENT", "development")
     release = os.getenv("RELEASE_VERSION", "unknown")
-    
+
     if not sentry_dsn:
         logger.info("Sentry DSN not configured, skipping initialization")
         return
-    
+
+    # When OTEL is active, disable Sentry's own distributed tracing to prevent
+    # double-tracing. Sentry still captures errors — tracing is OTEL's job.
+    otel_active = os.getenv("VIGIL_OTEL_ENABLED", "").lower() in ("true", "1", "yes")
+    traces_sample_rate = 0.0 if otel_active else (
+        0.1 if environment == "production" else 1.0
+    )
+
     sentry_sdk.init(
         dsn=sentry_dsn,
         environment=environment,
         release=release,
-        # Performance Monitoring
-        traces_sample_rate=0.1 if environment == "production" else 1.0,
-        # Error tracking
-        send_default_pii=False,  # Don't send PII
+        traces_sample_rate=traces_sample_rate,
+        send_default_pii=False,
         attach_stacktrace=True,
-        # Integrations
         integrations=[
             FastApiIntegration(),
             SqlalchemyIntegration(),
             LoggingIntegration(
                 level=logging.INFO,
-                event_level=logging.ERROR
+                event_level=logging.ERROR,
             ),
         ],
-        # Filtering
         before_send=before_send_filter,
         ignore_errors=[
             KeyboardInterrupt,
             "asyncio.CancelledError",
         ],
     )
-    
-    logger.info(f"Sentry initialized for environment: {environment}")
+
+    logger.info(
+        "Sentry initialized for environment: %s (OTEL tracing: %s)",
+        environment,
+        "disabled" if otel_active else "enabled",
+    )
 
 
 def before_send_filter(event, hint):

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -1,0 +1,471 @@
+"""
+core/telemetry.py — OpenTelemetry bootstrap for Vigil SOC.
+
+When VIGIL_OTEL_ENABLED is falsy OR the SDK cannot be imported, every
+public function returns a no-op object. Telemetry failures never crash
+the application.
+
+Environment variables:
+    VIGIL_OTEL_ENABLED              Master switch ("true"/"1"/"yes" to enable)
+    OTEL_EXPORTER_OTLP_ENDPOINT     Collector address (default http://localhost:4317)
+    VIGIL_OTEL_RECORD_LLM_CONTENT   Opt-in to recording LLM prompts/responses (default off)
+    VIGIL_OTEL_RECORD_IOC_VALUES    Opt-in to recording raw finding/IOC content (default off)
+    ENVIRONMENT                     Deployment environment label (default "development")
+    RELEASE_VERSION                 Service version label (default "unknown")
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module state
+# ---------------------------------------------------------------------------
+_initialized: bool = False
+_tracer_provider: Any = None
+_meter_provider: Any = None
+
+# Context variable for investigation correlation across async tasks
+_investigation_id_var: ContextVar[Optional[str]] = ContextVar(
+    "vigil_investigation_id", default=None
+)
+
+
+# ---------------------------------------------------------------------------
+# Context helpers
+# ---------------------------------------------------------------------------
+
+def set_investigation_id(investigation_id: Optional[str]) -> None:
+    """Attach an investigation ID to the current async context."""
+    _investigation_id_var.set(investigation_id)
+
+
+def get_investigation_id() -> Optional[str]:
+    """Return the investigation ID bound to the current async context."""
+    return _investigation_id_var.get()
+
+
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+def _is_otel_enabled() -> bool:
+    val = os.environ.get("VIGIL_OTEL_ENABLED", "").lower()
+    return val in ("true", "1", "yes")
+
+
+def _should_record_llm_content() -> bool:
+    """Return True only when the operator has explicitly opted in."""
+    val = os.environ.get("VIGIL_OTEL_RECORD_LLM_CONTENT", "").lower()
+    return val in ("true", "1", "yes")
+
+
+def _should_record_ioc_values() -> bool:
+    """Return True only when the operator has explicitly opted in."""
+    val = os.environ.get("VIGIL_OTEL_RECORD_IOC_VALUES", "").lower()
+    return val in ("true", "1", "yes")
+
+
+# ---------------------------------------------------------------------------
+# Fallback no-op classes (used when OTEL is disabled or SDK missing)
+# ---------------------------------------------------------------------------
+
+class _NoOpSpan:
+    """No-op span satisfying the OpenTelemetry Span interface."""
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        pass
+
+    def set_status(self, status: Any, description: Optional[str] = None) -> None:
+        pass
+
+    def record_exception(
+        self,
+        exception: BaseException,
+        attributes: Any = None,
+        timestamp: Any = None,
+        escaped: bool = False,
+    ) -> None:
+        pass
+
+    def add_event(
+        self, name: str, attributes: Any = None, timestamp: Any = None
+    ) -> None:
+        pass
+
+    def end(self, end_time: Any = None) -> None:
+        pass
+
+    def is_recording(self) -> bool:
+        """OTEL SDK defines is_recording as a callable method, not a property."""
+        return False
+
+    def get_span_context(self) -> Any:
+        return None
+
+    def __enter__(self) -> "_NoOpSpan":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
+        return False
+
+
+class _FallbackNoOpTracer:
+    """No-op tracer returned when OTEL is disabled or unavailable."""
+
+    def start_span(self, name: str, **kwargs: Any) -> _NoOpSpan:
+        return _NoOpSpan()
+
+    def start_as_current_span(self, name: str, **kwargs: Any) -> _NoOpSpan:
+        return _NoOpSpan()
+
+
+class _NoOpInstrument:
+    """No-op metric instrument (counter, histogram, gauge, etc.)."""
+
+    def add(self, amount: Any, attributes: Any = None) -> None:
+        pass
+
+    def record(self, amount: Any, attributes: Any = None) -> None:
+        pass
+
+
+class _FallbackNoOpMeter:
+    """No-op meter returned when OTEL is disabled or unavailable."""
+
+    def create_counter(self, name: str, **kwargs: Any) -> _NoOpInstrument:
+        return _NoOpInstrument()
+
+    def create_histogram(self, name: str, **kwargs: Any) -> _NoOpInstrument:
+        return _NoOpInstrument()
+
+    def create_observable_gauge(self, name: str, **kwargs: Any) -> _NoOpInstrument:
+        return _NoOpInstrument()
+
+    def create_up_down_counter(self, name: str, **kwargs: Any) -> _NoOpInstrument:
+        return _NoOpInstrument()
+
+    def create_observable_counter(self, name: str, **kwargs: Any) -> _NoOpInstrument:
+        return _NoOpInstrument()
+
+    def create_observable_up_down_counter(
+        self, name: str, **kwargs: Any
+    ) -> _NoOpInstrument:
+        return _NoOpInstrument()
+
+
+# ---------------------------------------------------------------------------
+# Internal initialization
+# ---------------------------------------------------------------------------
+
+def _do_init(service_name: str) -> None:
+    """Actually initialize OTEL providers. Raises on any failure."""
+    from opentelemetry import trace, metrics
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.resources import Resource
+
+    global _tracer_provider, _meter_provider
+
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    environment = os.environ.get("ENVIRONMENT", "development")
+    version = os.environ.get("RELEASE_VERSION", "unknown")
+
+    resource = Resource.create(
+        {
+            "service.name": service_name,
+            "service.version": version,
+            "deployment.environment": environment,
+            "vigil.component": service_name,
+        }
+    )
+
+    # --- TracerProvider ---
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        span_exporter = OTLPSpanExporter(endpoint=endpoint, insecure=True)
+    except Exception:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter as OTLPSpanExporterHTTP,
+        )
+        span_exporter = OTLPSpanExporterHTTP(endpoint=endpoint)
+
+    batch_processor = BatchSpanProcessor(
+        span_exporter,
+        max_queue_size=2048,
+        max_export_batch_size=512,
+        schedule_delay_millis=5000,
+        export_timeout_millis=30000,
+    )
+
+    from core.telemetry_sanitizer import SensitiveAttributeScrubber
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(SensitiveAttributeScrubber())
+    tracer_provider.add_span_processor(batch_processor)
+
+    # Wire Sentry alongside OTEL when configured (prevents double-tracing)
+    sentry_dsn = os.environ.get("SENTRY_DSN", "")
+    if sentry_dsn:
+        try:
+            from backend.monitoring import SentrySpanProcessor
+            tracer_provider.add_span_processor(SentrySpanProcessor())
+        except Exception:
+            pass  # backend.monitoring may not be importable in daemon context
+
+    trace.set_tracer_provider(tracer_provider)
+    _tracer_provider = tracer_provider
+
+    # --- MeterProvider ---
+    try:
+        from opentelemetry.exporter.prometheus import PrometheusMetricReader
+        metric_reader = PrometheusMetricReader()
+        logger.debug("Using PrometheusMetricReader on port 9090")
+    except Exception:
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+                OTLPMetricExporter,
+            )
+            from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+            metric_reader = PeriodicExportingMetricReader(
+                OTLPMetricExporter(endpoint=endpoint, insecure=True)
+            )
+        except Exception:
+            metric_reader = None
+
+    meter_kwargs: dict = {"resource": resource}
+    if metric_reader is not None:
+        meter_kwargs["metric_readers"] = [metric_reader]
+
+    meter_provider = MeterProvider(**meter_kwargs)
+    metrics.set_meter_provider(meter_provider)
+    _meter_provider = meter_provider
+
+    logger.info(
+        "OpenTelemetry initialized for service '%s' → %s", service_name, endpoint
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def init_telemetry(service_name: str) -> bool:
+    """
+    Bootstrap tracing and metrics for a process.
+
+    Safe to call multiple times — subsequent calls are no-ops if already
+    initialized. Returns True if OTEL was actually enabled and initialized.
+    """
+    global _initialized
+
+    if not _is_otel_enabled():
+        logger.debug("VIGIL_OTEL_ENABLED is not set — telemetry disabled")
+        return False
+
+    if _initialized:
+        return True
+
+    try:
+        _do_init(service_name)
+        _initialized = True
+        _install_json_logging()
+        return True
+    except Exception as exc:
+        logger.warning(
+            "OpenTelemetry initialization failed (non-fatal): %s", exc
+        )
+        return False
+
+
+def get_tracer(name: str) -> Any:
+    """Return a tracer. Always safe to call — returns a no-op when disabled."""
+    if _initialized:
+        try:
+            from opentelemetry import trace
+
+            return trace.get_tracer(name)
+        except Exception:
+            pass
+    return _FallbackNoOpTracer()
+
+
+def get_meter(name: str) -> Any:
+    """Return a meter. Always safe to call — returns a no-op when disabled."""
+    if _initialized:
+        try:
+            from opentelemetry import metrics
+
+            return metrics.get_meter(name)
+        except Exception:
+            pass
+    return _FallbackNoOpMeter()
+
+
+def inject_traceparent(carrier: Optional[dict] = None) -> dict:
+    """
+    Inject the current W3C traceparent into *carrier* (mutates and returns it).
+    Used to propagate trace context across async boundaries (e.g. ARQ jobs).
+    """
+    if carrier is None:
+        carrier = {}
+    if _initialized:
+        try:
+            from opentelemetry.propagators.textmap import TraceContextTextMapPropagator
+
+            TraceContextTextMapPropagator().inject(carrier)
+        except Exception:
+            pass
+    return carrier
+
+
+def extract_traceparent(carrier: dict) -> Any:
+    """
+    Extract W3C trace context from *carrier* and return an OTEL Context.
+    Returns None when disabled or on any error.
+    """
+    if _initialized and carrier:
+        try:
+            from opentelemetry.propagators.textmap import TraceContextTextMapPropagator
+
+            return TraceContextTextMapPropagator().extract(carrier)
+        except Exception:
+            pass
+    return None
+
+
+def create_genai_metrics(meter: Any) -> dict:
+    """
+    Create and return the 4 GenAI metric instruments used for LLM observability.
+
+    Keys: llm_calls, llm_duration, llm_tokens, llm_cost_usd
+    """
+    return {
+        "llm_calls": meter.create_counter(
+            "vigil.llm.calls.total",
+            description="Total LLM API calls",
+        ),
+        "llm_duration": meter.create_histogram(
+            "vigil.llm.duration.seconds",
+            description="LLM call duration in seconds",
+        ),
+        "llm_tokens": meter.create_counter(
+            "vigil.llm.tokens.total",
+            description="Total LLM tokens consumed",
+        ),
+        "llm_cost_usd": meter.create_counter(
+            "vigil.llm.cost.usd.total",
+            description="Cumulative LLM cost in USD",
+        ),
+    }
+
+
+def shutdown() -> None:
+    """
+    Flush and shut down all telemetry providers.
+
+    Safe to call even when OTEL was never initialized.
+    After shutdown, init_telemetry() may be called again.
+    """
+    global _initialized, _tracer_provider, _meter_provider
+
+    if _tracer_provider is not None:
+        try:
+            _tracer_provider.force_flush(timeout_millis=30000)
+            _tracer_provider.shutdown()
+        except Exception as exc:
+            logger.warning("TracerProvider shutdown error (non-fatal): %s", exc)
+
+    if _meter_provider is not None:
+        try:
+            _meter_provider.force_flush(timeout_millis=30000)
+            _meter_provider.shutdown()
+        except Exception as exc:
+            logger.warning("MeterProvider shutdown error (non-fatal): %s", exc)
+
+    _tracer_provider = None
+    _meter_provider = None
+    _initialized = False  # reset so init_telemetry() can be called again
+
+
+# Alias used in the plan and by callers that prefer the longer name
+shutdown_telemetry = shutdown
+
+
+# ---------------------------------------------------------------------------
+# Structured JSON logging with OTEL trace correlation (#59)
+# ---------------------------------------------------------------------------
+
+def _install_json_logging() -> None:
+    """
+    Replace the root logger's handlers with structured JSON output.
+
+    Each log line includes trace_id and span_id from the current OTEL span
+    so that logs can be correlated with traces in Jaeger/Grafana.
+    Retains file output alongside stdout.
+    """
+
+    class _OTELJsonFormatter(logging.Formatter):
+        def format(self, record: logging.LogRecord) -> str:
+            trace_id = ""
+            span_id = ""
+            try:
+                from opentelemetry import trace
+
+                span = trace.get_current_span()
+                ctx = span.get_span_context()
+                if ctx and ctx.is_valid:
+                    trace_id = format(ctx.trace_id, "032x")
+                    span_id = format(ctx.span_id, "016x")
+            except Exception:
+                pass
+
+            entry: dict = {
+                "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S.%f"),
+                "level": record.levelname,
+                "logger": record.name,
+                "message": record.getMessage(),
+                "trace_id": trace_id,
+                "span_id": span_id,
+            }
+
+            inv_id = get_investigation_id()
+            if inv_id:
+                entry["vigil.investigation.id"] = inv_id
+
+            if record.exc_info:
+                entry["exception"] = self.formatException(record.exc_info)
+
+            for key, val in record.__dict__.items():
+                if key.startswith("vigil."):
+                    entry[key] = val
+
+            return json.dumps(entry, default=str)
+
+    root = logging.getLogger()
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    formatter = _OTELJsonFormatter()
+
+    console = logging.StreamHandler()
+    console.setFormatter(formatter)
+    root.addHandler(console)
+
+    try:
+        log_dir = Path.home() / ".deeptempo"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(log_dir / "vigil.log")
+        file_handler.setFormatter(formatter)
+        root.addHandler(file_handler)
+    except Exception as exc:
+        logger.warning("Could not set up file logging (non-fatal): %s", exc)

--- a/core/telemetry_sanitizer.py
+++ b/core/telemetry_sanitizer.py
@@ -1,0 +1,222 @@
+"""
+core/telemetry_sanitizer.py — Blocklist-based span processor for Vigil SOC.
+
+Scrubs sensitive attributes from OTEL spans before they reach any exporter.
+Runs synchronously in on_end() so redacted data never leaves the process.
+
+Design: BLOCKLIST — attributes whose keys match known-sensitive patterns, or
+whose values contain recognisable secrets, are replaced with "[REDACTED]".
+Unrecognised attributes pass through. This is defence-in-depth; rely on
+careful attribute naming conventions to prevent accidental leakage.
+
+Note: LLM content (prompts/responses) and raw finding/IOC values are always
+redacted unless the operator has explicitly opted in via environment variables
+VIGIL_OTEL_RECORD_LLM_CONTENT and VIGIL_OTEL_RECORD_IOC_VALUES respectively.
+"""
+from __future__ import annotations
+
+import re
+import logging
+from types import MappingProxyType
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from opentelemetry.sdk.trace import SpanProcessor
+    _SDK_AVAILABLE = True
+except ImportError:
+    SpanProcessor = object  # type: ignore[assignment,misc]
+    _SDK_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Blocklist patterns
+# ---------------------------------------------------------------------------
+
+# Key substrings that indicate a sensitive attribute (matched as whole segments)
+_SENSITIVE_KEY_SUBSTRINGS: frozenset[str] = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "auth_token",
+        "authorization",
+        "password",
+        "passwd",
+        "secret",
+        "private_key",
+        "access_token",
+        "refresh_token",
+        "session_id",
+        "cookie",
+        "dsn",
+        "connection_string",
+        "credential",
+        "bearer",
+        "jwt",
+        "x-api-key",
+    }
+)
+
+# Key substrings that indicate the value contains PII or raw security content
+_CONTENT_KEY_SUBSTRINGS: frozenset[str] = frozenset(
+    {
+        "finding.description",
+        "finding.raw",
+        "finding.payload",
+        "finding.entity_context",
+        "llm.prompt",
+        "llm.response",
+        "gen_ai.prompt",
+        "gen_ai.completion",
+        "tool.input",
+        "tool.output",
+        "tool.result",
+    }
+)
+
+# Value-based regexes that detect secret material regardless of key name
+_SECRET_VALUE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"sk-ant-", re.IGNORECASE),  # Anthropic API key prefix
+    re.compile(
+        r"eyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+"
+    ),  # JWT (base64url.base64url.base64url)
+    re.compile(
+        r"(postgresql|postgres|redis|mysql|mongodb)://[^\s]+:[^\s]+@",
+        re.IGNORECASE,
+    ),  # Database / cache connection strings with credentials
+    re.compile(
+        r"(?<![a-fA-F0-9])[a-fA-F0-9]{32,}(?![a-fA-F0-9])"
+    ),  # Long hex tokens (API keys, hashes used as secrets)
+    re.compile(r"AKIA[0-9A-Z]{16}"),  # AWS access key ID
+]
+
+# Separator characters used when splitting key segments
+_KEY_SEP_RE = re.compile(r"[._\-]")
+
+
+class SensitiveAttributeScrubber(SpanProcessor):  # type: ignore[misc]
+    """
+    Blocklist-based SpanProcessor that redacts sensitive span attributes.
+
+    Registered *before* the BatchSpanProcessor so scrubbing happens before
+    any data leaves the process boundary.
+    """
+
+    # ------------------------------------------------------------------
+    # Redaction logic (public for unit testing)
+    # ------------------------------------------------------------------
+
+    def _key_segment_matches(self, key_lower: str, substr: str) -> bool:
+        """Return True if *substr* appears as a contiguous run of whole segments
+        within *key_lower* (segments are split on '.', '_', '-').
+
+        Multi-word patterns (e.g. "api_key") are split into ["api","key"] and
+        matched as a contiguous sub-sequence, so:
+          - "my.api.key"   matches "api_key"  ✓
+          - "x-api-key"    matches "api_key"  ✓
+          - "vigil.dsnark" does NOT match "dsn"  ✓  (false-positive prevention)
+          - "redesign_count" does NOT match "dsn" ✓
+        """
+        key_segs = _KEY_SEP_RE.split(key_lower)
+        sub_segs = _KEY_SEP_RE.split(substr)
+        n, m = len(key_segs), len(sub_segs)
+        if m > n:
+            return False
+        for i in range(n - m + 1):
+            if key_segs[i : i + m] == sub_segs:
+                return True
+        return False
+
+    def _should_redact(self, key: str, value: Any) -> bool:
+        """Return True if this attribute should be replaced with [REDACTED]."""
+        key_lower = key.lower()
+
+        # 1. Key-based: check for whole-segment (contiguous) matches
+        for substr in _SENSITIVE_KEY_SUBSTRINGS:
+            if self._key_segment_matches(key_lower, substr):
+                return True
+
+        # 2. Key-based: content fields that may carry PII / raw security data
+        for content_key in _CONTENT_KEY_SUBSTRINGS:
+            if content_key in key_lower:
+                return True
+
+        # 3. Value-based: detect recognisable secrets in string values
+        if isinstance(value, str) and len(value) > 6:
+            for pattern in _SECRET_VALUE_PATTERNS:
+                if pattern.search(value):
+                    return True
+
+        return False
+
+    # ------------------------------------------------------------------
+    # SpanProcessor interface
+    # ------------------------------------------------------------------
+
+    def on_start(self, span: Any, parent_context: Optional[Any] = None) -> None:
+        pass  # Nothing to do before span ends
+
+    def on_end(self, span: Any) -> None:
+        if not _SDK_AVAILABLE:
+            return
+
+        try:
+            attrs = span.attributes
+            if not attrs:
+                return
+
+            # Check operator opt-in flags for LLM content and IOC values
+            from core.telemetry import _should_record_llm_content, _should_record_ioc_values
+
+            record_llm = _should_record_llm_content()
+            record_ioc = _should_record_ioc_values()
+
+            new_attrs: dict[str, Any] = {}
+            modified = False
+
+            for key, value in attrs.items():
+                key_lower = key.lower()
+
+                # LLM prompt/response: redact unless operator opted in
+                if not record_llm and any(
+                    k in key_lower
+                    for k in (
+                        "llm.prompt",
+                        "llm.response",
+                        "gen_ai.prompt",
+                        "gen_ai.completion",
+                    )
+                ):
+                    new_attrs[key] = "[REDACTED]"
+                    modified = True
+                    continue
+
+                # Raw finding / IOC values: redact unless operator opted in
+                if not record_ioc and "finding." in key_lower and any(
+                    k in key_lower for k in ("raw", "payload", "description", "entity")
+                ):
+                    new_attrs[key] = "[REDACTED]"
+                    modified = True
+                    continue
+
+                # General blocklist check
+                if self._should_redact(key, value):
+                    new_attrs[key] = "[REDACTED]"
+                    modified = True
+                else:
+                    new_attrs[key] = value
+
+            if modified:
+                # ReadableSpan._attributes is immutable after end().
+                # We patch the internal dict and rewrap with MappingProxyType.
+                span._attributes = MappingProxyType(new_attrs)
+
+        except Exception as exc:
+            logger.debug("Sanitizer on_end failed (non-fatal): %s", exc)
+
+    def on_shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True

--- a/daemon/agent_runner.py
+++ b/daemon/agent_runner.py
@@ -21,6 +21,13 @@ from daemon.workdir import WorkdirManager
 
 logger = logging.getLogger(__name__)
 
+try:
+    from core.telemetry import get_tracer, extract_traceparent
+    from opentelemetry.trace import SpanKind
+    _tracer = get_tracer("vigil.daemon.agent_runner")
+except Exception:
+    _tracer = None  # type: ignore[assignment]
+
 SONNET_INPUT_COST = 3.0 / 1_000_000
 SONNET_OUTPUT_COST = 15.0 / 1_000_000
 
@@ -260,6 +267,24 @@ class AgentRunner:
         total_output_tokens = 0
         total_cost = 0.0
 
+        # Re-attach to the root investigation span as a child span
+        _agent_span = None
+        try:
+            if _tracer is not None:
+                _tp = investigation.get("otel_traceparent", "")
+                _parent_ctx = extract_traceparent({"traceparent": _tp}) if _tp else None
+                _agent_span = _tracer.start_span(
+                    "agent_run",
+                    context=_parent_ctx,
+                    kind=SpanKind.INTERNAL,
+                    attributes={
+                        "vigil.investigation.id": inv_id,
+                        "vigil.investigation.workflow_id": investigation.get("workflow_id", ""),
+                    },
+                )
+        except Exception:
+            pass
+
         try:
             while not shutdown_event.is_set():
                 state = self.workdir.read_state(inv_id)
@@ -306,11 +331,32 @@ class AgentRunner:
                 plan = self.workdir.read_file(inv_id, "plan.md")
                 prompt = self._build_prompt(inv_id, plan, state, iteration)
 
+                # Iteration-level span
+                _iter_span = None
+                try:
+                    if _tracer is not None:
+                        _iter_span = _tracer.start_span(
+                            "iteration",
+                            kind=SpanKind.INTERNAL,
+                            attributes={
+                                "vigil.investigation.id": inv_id,
+                                "vigil.agent.iteration": iteration,
+                                "vigil.investigation.current_step": state.get("current_step", 1),
+                            },
+                        )
+                except Exception:
+                    pass
+
                 try:
                     result = await self._call_claude(inv_id, prompt)
                 except Exception as e:
                     logger.error(f"{inv_id}: Claude call failed: {e}")
                     self.workdir.append_log(inv_id, {"event": "error", "error": str(e)})
+                    if _iter_span is not None:
+                        try:
+                            _iter_span.end()
+                        except Exception:
+                            pass
                     state["error_count"] = state.get("error_count", 0) + 1
                     if state["error_count"] >= 3:
                         self._mark_failed(inv_id, f"Repeated errors: {e}")
@@ -348,6 +394,15 @@ class AgentRunner:
                     "current_step": refreshed.get("current_step", 0),
                 })
 
+                # Close iteration span with token/cost summary
+                try:
+                    if _iter_span is not None:
+                        _iter_span.set_attribute("gen_ai.usage.input_tokens", in_tokens)
+                        _iter_span.set_attribute("gen_ai.usage.output_tokens", out_tokens)
+                        _iter_span.end()
+                except Exception:
+                    pass
+
                 if refreshed.get("status") in ("completed", "review_submitted", "failed"):
                     break
 
@@ -373,6 +428,14 @@ class AgentRunner:
             })
         finally:
             self._active_agents.pop(inv_id, None)
+            try:
+                if _agent_span is not None:
+                    _agent_span.set_attribute("vigil.agent.total_iterations", iteration)
+                    _agent_span.set_attribute("gen_ai.usage.input_tokens", total_input_tokens)
+                    _agent_span.set_attribute("gen_ai.usage.output_tokens", total_output_tokens)
+                    _agent_span.end()
+            except Exception:
+                pass
 
     def _build_prompt(self, inv_id: str, plan: str, state: Dict, iteration: int) -> str:
         """Build the Claude prompt from plan, context, and state."""
@@ -513,6 +576,23 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
         max_tok = max(16000, thinking_budget + 4096) if thinking_enabled else 4096
 
         for turn in range(max_turns):
+            # LLM call span (one per tool-use round)
+            _llm_span = None
+            try:
+                if _tracer is not None:
+                    _llm_span = _tracer.start_span(
+                        "llm_call",
+                        kind=SpanKind.CLIENT,
+                        attributes={
+                            "vigil.investigation.id": inv_id,
+                            "gen_ai.system": "anthropic",
+                            "gen_ai.request.model": self.config.plan_model,
+                            "gen_ai.tool_use.round": turn,
+                        },
+                    )
+            except Exception:
+                pass
+
             try:
                 response = await self._llm_gateway.submit_investigation_turn(
                     inv_id=inv_id,
@@ -526,7 +606,21 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                 )
             except Exception as e:
                 logger.error(f"{inv_id}: LLM queue error: {e}")
+                try:
+                    if _llm_span is not None:
+                        _llm_span.end()
+                except Exception:
+                    pass
                 raise
+
+            try:
+                if _llm_span is not None:
+                    _llm_span.set_attribute("gen_ai.usage.input_tokens", response.get("input_tokens", 0))
+                    _llm_span.set_attribute("gen_ai.usage.output_tokens", response.get("output_tokens", 0))
+                    _llm_span.set_attribute("gen_ai.finish_reason", response.get("stop_reason", ""))
+                    _llm_span.end()
+            except Exception:
+                pass
 
             total_input += response.get("input_tokens", 0)
             total_output += response.get("output_tokens", 0)
@@ -676,7 +770,25 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
 
     async def _execute_external_tool(self, inv_id: str, tool_name: str, tool_input: Dict) -> str:
         """Route to backend or MCP tool execution, enforcing safety guardrails."""
+        import time as _time
         tier = _get_tool_tier(tool_name)
+
+        _tool_span = None
+        _t0 = _time.monotonic()
+        try:
+            if _tracer is not None:
+                _tool_span = _tracer.start_span(
+                    "tool_call",
+                    kind=SpanKind.CLIENT,
+                    attributes={
+                        "vigil.investigation.id": inv_id,
+                        "vigil.tool.name": tool_name,
+                        "vigil.tool.tier": tier,
+                        "vigil.tool.input_size": len(json.dumps(tool_input, default=str)),
+                    },
+                )
+        except Exception:
+            pass
 
         if tier == "forbidden":
             msg = f"Tool '{tool_name}' is forbidden for autonomous agents."
@@ -684,6 +796,12 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
             self.workdir.append_log(inv_id, {
                 "event": "tool_blocked", "tool": tool_name, "tier": "forbidden",
             })
+            try:
+                if _tool_span is not None:
+                    _tool_span.set_attribute("vigil.tool.success", False)
+                    _tool_span.end()
+            except Exception:
+                pass
             return msg
 
         if self.config.dry_run and tier in ("managed", "requires_approval"):
@@ -702,7 +820,16 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                     tool_name, tool_input
                 )
                 if result is not None:
-                    return json.dumps(result, default=str) if not isinstance(result, str) else result
+                    _r = json.dumps(result, default=str) if not isinstance(result, str) else result
+                    try:
+                        if _tool_span is not None:
+                            _tool_span.set_attribute("vigil.tool.success", True)
+                            _tool_span.set_attribute("vigil.tool.output_size", len(_r))
+                            _tool_span.set_attribute("vigil.tool.duration_ms", round((_time.monotonic() - _t0) * 1000, 1))
+                            _tool_span.end()
+                    except Exception:
+                        pass
+                    return _r
             except Exception:
                 pass
 
@@ -729,11 +856,28 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                 if server_name:
                     result = await client.call_tool(server_name, actual_tool_name, tool_input)
                     if result is not None:
-                        return json.dumps(result, default=str) if not isinstance(result, str) else result
+                        _r = json.dumps(result, default=str) if not isinstance(result, str) else result
+                        try:
+                            if _tool_span is not None:
+                                _tool_span.set_attribute("vigil.tool.success", True)
+                                _tool_span.set_attribute("vigil.tool.output_size", len(_r))
+                                _tool_span.set_attribute("vigil.tool.duration_ms", round((_time.monotonic() - _t0) * 1000, 1))
+                                _tool_span.end()
+                        except Exception:
+                            pass
+                        return _r
         except Exception as e:
             logger.debug(f"MCP tool {tool_name} call failed: {e}")
 
-        return f"Tool '{tool_name}' not found or unavailable"
+        _result_str = f"Tool '{tool_name}' not found or unavailable"
+        try:
+            if _tool_span is not None:
+                _tool_span.set_attribute("vigil.tool.success", False)
+                _tool_span.set_attribute("vigil.tool.duration_ms", round((_time.monotonic() - _t0) * 1000, 1))
+                _tool_span.end()
+        except Exception:
+            pass
+        return _result_str
 
     async def _request_tool_approval(self, inv_id: str, tool_name: str, tool_input: Dict) -> str:
         """Create an approval request and put the agent into waiting_approval state."""

--- a/daemon/config.py
+++ b/daemon/config.py
@@ -69,7 +69,7 @@ class SchedulerConfig:
 class MetricsConfig:
     """Configuration for metrics/health endpoint."""
     enabled: bool = True
-    port: int = 9090
+    port: int = 9091
     path: str = "/metrics"
 
 
@@ -170,7 +170,7 @@ class DaemonConfig:
         
         # Metrics
         config.metrics.enabled = os.getenv("DAEMON_METRICS_ENABLED", "true").lower() == "true"
-        config.metrics.port = int(os.getenv("DAEMON_METRICS_PORT", "9090"))
+        config.metrics.port = int(os.getenv("DAEMON_HEALTH_PORT", "9091"))
         
         # Orchestrator
         config.orchestrator.enabled = os.getenv("ORCHESTRATOR_ENABLED", "false").lower() == "true"

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -21,7 +21,14 @@ class SOCDaemon:
     def __init__(self, config: Optional[DaemonConfig] = None):
         self.config = config or DaemonConfig.from_env()
         self.config.setup_logging()
-        
+
+        # Initialize OTEL telemetry after logging is set up
+        try:
+            from core.telemetry import init_telemetry
+            init_telemetry("vigil-daemon")
+        except Exception as _tel_err:
+            logger.warning("Telemetry init failed (non-fatal): %s", _tel_err)
+
         self._running = False
         self._shutdown_event = asyncio.Event()
         
@@ -141,6 +148,14 @@ class SOCDaemon:
         await asyncio.gather(*tasks, return_exceptions=True)
         
         self._running = False
+
+        # Flush and shut down OTEL providers
+        try:
+            from core.telemetry import shutdown_telemetry
+            shutdown_telemetry()
+        except Exception as e:
+            logger.warning("Telemetry shutdown error (non-fatal): %s", e)
+
         logger.info("SOC Daemon shutdown complete")
     
     async def stop(self):

--- a/daemon/metrics.py
+++ b/daemon/metrics.py
@@ -1,10 +1,23 @@
-"""Metrics server for Prometheus-compatible health monitoring."""
+"""Metrics collection for daemon operations.
+
+DaemonMetrics is a thin wrapper around OpenTelemetry instruments.  It
+preserves the existing public interface (record_poll, record_processing,
+get_summary, reset, get_poll_count, get_total_processed) so all callers
+(poller.py, processor.py, responder.py, scheduler.py) need zero changes.
+
+Prometheus-format /metrics is now served on port 9090 by the OTEL
+PrometheusMetricReader initialised in core/telemetry.init_telemetry().
+
+MetricsServer has been narrowed to a health-only server on
+DAEMON_HEALTH_PORT (default 9091) exposing /health and /status.
+"""
 
 import asyncio
 import logging
-from datetime import datetime
-from typing import Dict, Any, Optional
+import os
 from collections import defaultdict
+from datetime import datetime
+from typing import Any, Dict, Optional
 
 from aiohttp import web
 
@@ -12,93 +25,139 @@ from daemon.config import MetricsConfig
 
 logger = logging.getLogger(__name__)
 
+DAEMON_HEALTH_PORT = int(os.getenv("DAEMON_HEALTH_PORT", "9091"))
+
+
+# ---------------------------------------------------------------------------
+# DaemonMetrics — OTEL-backed, public interface unchanged
+# ---------------------------------------------------------------------------
 
 class DaemonMetrics:
-    """Simple metrics tracking class for daemon operations."""
-    
+    """Metrics tracking backed by OpenTelemetry instruments.
+
+    Falls back to in-memory counters if OTEL is unavailable so the daemon
+    boots cleanly even without telemetry configured.
+    """
+
     def __init__(self):
-        """Initialize metrics tracking."""
+        self._start_time = datetime.utcnow()
+
+        # In-memory shadow counters (used by get_summary / get_poll_count /
+        # get_total_processed which must return values synchronously).
         self._poll_counts: Dict[str, int] = defaultdict(int)
         self._poll_durations: Dict[str, list] = defaultdict(list)
         self._events_counts: Dict[str, int] = defaultdict(int)
         self._processing_count: int = 0
         self._processing_durations: list = []
-        self._start_time = datetime.utcnow()
-    
+
+        # OTEL instruments — created lazily; None if OTEL not available.
+        self._polls_counter = None
+        self._events_counter = None
+        self._poll_duration_hist = None
+        self._processed_counter = None
+        self._processing_duration_hist = None
+
+        try:
+            from core.telemetry import get_meter
+            meter = get_meter("vigil.daemon")
+
+            self._polls_counter = meter.create_counter(
+                name="soc_daemon_poller_polls_total",
+                description="Total number of polls per source",
+                unit="1",
+            )
+            self._events_counter = meter.create_counter(
+                name="soc_daemon_poller_findings_total",
+                description="Total findings/events retrieved per source",
+                unit="1",
+            )
+            self._poll_duration_hist = meter.create_histogram(
+                name="soc_daemon_poller_duration_seconds",
+                description="Poll duration in seconds",
+                unit="s",
+            )
+            self._processed_counter = meter.create_counter(
+                name="soc_daemon_processor_processed_total",
+                description="Total findings processed",
+                unit="1",
+            )
+            self._processing_duration_hist = meter.create_histogram(
+                name="soc_daemon_processor_duration_seconds",
+                description="Processing batch duration in seconds",
+                unit="s",
+            )
+        except Exception as _err:
+            logger.debug("OTEL instruments unavailable, using in-memory only: %s", _err)
+
+    # ------------------------------------------------------------------
+    # Public interface (preserved exactly)
+    # ------------------------------------------------------------------
+
     def record_poll(self, source: str, duration: float, events_count: int):
-        """
-        Record a poll operation.
-        
-        Args:
-            source: Source system (e.g., "splunk", "crowdstrike")
-            duration: Duration in seconds
-            events_count: Number of events retrieved
-        """
+        """Record a poll operation."""
+        attrs = {"source": source}
+
+        # Shadow counters
         self._poll_counts[source] += 1
         self._poll_durations[source].append(duration)
         self._events_counts[source] += events_count
-        logger.debug(f"Recorded poll for {source}: {events_count} events in {duration:.2f}s")
-    
+
+        # OTEL
+        try:
+            if self._polls_counter is not None:
+                self._polls_counter.add(1, attrs)
+            if self._events_counter is not None:
+                self._events_counter.add(events_count, attrs)
+            if self._poll_duration_hist is not None:
+                self._poll_duration_hist.record(duration, attrs)
+        except Exception as _err:
+            logger.debug("OTEL record_poll failed (non-fatal): %s", _err)
+
+        logger.debug("Recorded poll for %s: %d events in %.2fs", source, events_count, duration)
+
     def get_poll_count(self, source: str) -> int:
-        """
-        Get total poll count for a source.
-        
-        Args:
-            source: Source system name
-            
-        Returns:
-            Total number of polls for this source
-        """
+        """Get total poll count for a source."""
         return self._poll_counts.get(source, 0)
-    
+
     def record_processing(self, findings_count: int, duration: float):
-        """
-        Record findings processing operation.
-        
-        Args:
-            findings_count: Number of findings processed
-            duration: Duration in seconds
-        """
+        """Record findings processing operation."""
         self._processing_count += findings_count
         self._processing_durations.append(duration)
-        logger.debug(f"Recorded processing: {findings_count} findings in {duration:.2f}s")
-    
+
+        try:
+            if self._processed_counter is not None:
+                self._processed_counter.add(findings_count)
+            if self._processing_duration_hist is not None:
+                self._processing_duration_hist.record(duration)
+        except Exception as _err:
+            logger.debug("OTEL record_processing failed (non-fatal): %s", _err)
+
+        logger.debug("Recorded processing: %d findings in %.2fs", findings_count, duration)
+
     def get_total_processed(self) -> int:
-        """
-        Get total number of findings processed.
-        
-        Returns:
-            Total findings processed
-        """
+        """Get total number of findings processed."""
         return self._processing_count
-    
+
     def get_summary(self) -> Dict[str, Any]:
-        """
-        Get summary of all metrics.
-        
-        Returns:
-            Dictionary containing metrics summary
-        """
+        """Get summary of all metrics (used for /status display only)."""
         uptime = (datetime.utcnow() - self._start_time).total_seconds()
-        
-        # Calculate total polls across all sources
         total_polls = sum(self._poll_counts.values())
-        
-        # Calculate averages
+
         poll_stats = {}
         for source, durations in self._poll_durations.items():
             avg_duration = sum(durations) / len(durations) if durations else 0
             poll_stats[source] = {
                 "count": self._poll_counts[source],
                 "events": self._events_counts[source],
-                "avg_duration": avg_duration
+                "avg_duration": avg_duration,
             }
-        
+
         processing_avg = (
             sum(self._processing_durations) / len(self._processing_durations)
-            if self._processing_durations else 0
+            if self._processing_durations
+            else 0
         )
-        
+
         return {
             "uptime_seconds": uptime,
             "total_polls": total_polls,
@@ -107,12 +166,12 @@ class DaemonMetrics:
             "processing": {
                 "total_processed": self._processing_count,
                 "avg_duration": processing_avg,
-                "batch_count": len(self._processing_durations)
-            }
+                "batch_count": len(self._processing_durations),
+            },
         }
-    
+
     def reset(self):
-        """Reset all metrics."""
+        """Reset in-memory shadow counters (OTEL instruments are cumulative by design)."""
         self._poll_counts.clear()
         self._poll_durations.clear()
         self._events_counts.clear()
@@ -122,199 +181,107 @@ class DaemonMetrics:
         logger.info("Metrics reset")
 
 
+# ---------------------------------------------------------------------------
+# MetricsServer — health/status only on DAEMON_HEALTH_PORT
+# Prometheus /metrics is served by core/telemetry PrometheusMetricReader on 9090
+# ---------------------------------------------------------------------------
+
 class MetricsServer:
-    """Exposes daemon metrics via HTTP for monitoring."""
-    
+    """Health and status HTTP server for the daemon.
+
+    Serves /health and /status on DAEMON_HEALTH_PORT (default 9091).
+    Prometheus metrics are emitted on port 9090 by the OTEL
+    PrometheusMetricReader; this server no longer renders them.
+    """
+
     def __init__(self, config: MetricsConfig):
         self.config = config
         self._start_time = datetime.utcnow()
-        
+
         # Component references (set externally)
         self.poller = None
         self.processor = None
         self.responder = None
         self.scheduler = None
         self.orchestrator = None
-    
+
+    @property
+    def _health_port(self) -> int:
+        return DAEMON_HEALTH_PORT
+
     async def run(self, shutdown_event: asyncio.Event):
-        """Run the metrics HTTP server."""
+        """Run the health HTTP server."""
         app = web.Application()
-        app.router.add_get(self.config.path, self._handle_metrics)
-        app.router.add_get('/health', self._handle_health)
-        app.router.add_get('/status', self._handle_status)
-        
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/status", self._handle_status)
+
         runner = web.AppRunner(app)
         await runner.setup()
-        site = web.TCPSite(runner, '0.0.0.0', self.config.port)
-        
-        logger.info(f"Metrics server starting on port {self.config.port}")
+        site = web.TCPSite(runner, "0.0.0.0", self._health_port)
+
+        logger.info("Health server starting on port %d", self._health_port)
         await site.start()
-        
+
         await shutdown_event.wait()
-        
+
         await runner.cleanup()
-        logger.info("Metrics server stopped")
-    
-    async def _handle_metrics(self, request: web.Request) -> web.Response:
-        """Handle Prometheus metrics request."""
-        metrics = self._collect_metrics()
-        
-        # Format as Prometheus text format
-        lines = []
-        
-        # Uptime
-        uptime = (datetime.utcnow() - self._start_time).total_seconds()
-        lines.append(f"# HELP soc_daemon_uptime_seconds Daemon uptime in seconds")
-        lines.append(f"# TYPE soc_daemon_uptime_seconds gauge")
-        lines.append(f"soc_daemon_uptime_seconds {uptime}")
-        
-        # Poller metrics
-        if metrics.get("poller"):
-            poller = metrics["poller"]
-            lines.append(f"# HELP soc_daemon_poller_polls_total Total number of polls")
-            lines.append(f"# TYPE soc_daemon_poller_polls_total counter")
-            lines.append(f'soc_daemon_poller_polls_total{{source="splunk"}} {poller.get("splunk_polls", 0)}')
-            lines.append(f'soc_daemon_poller_polls_total{{source="crowdstrike"}} {poller.get("crowdstrike_polls", 0)}')
-            
-            lines.append(f"# HELP soc_daemon_poller_findings_total Total findings polled")
-            lines.append(f"# TYPE soc_daemon_poller_findings_total counter")
-            lines.append(f'soc_daemon_poller_findings_total{{source="splunk"}} {poller.get("splunk_findings", 0)}')
-            lines.append(f'soc_daemon_poller_findings_total{{source="crowdstrike"}} {poller.get("crowdstrike_findings", 0)}')
-            lines.append(f'soc_daemon_poller_findings_total{{source="webhook"}} {poller.get("webhook_findings", 0)}')
-        
-        # Processor metrics
-        if metrics.get("processor"):
-            proc = metrics["processor"]
-            lines.append(f"# HELP soc_daemon_processor_processed_total Total findings processed")
-            lines.append(f"# TYPE soc_daemon_processor_processed_total counter")
-            lines.append(f"soc_daemon_processor_processed_total {proc.get('processed', 0)}")
-            
-            lines.append(f"# HELP soc_daemon_processor_triaged_total Total findings AI triaged")
-            lines.append(f"# TYPE soc_daemon_processor_triaged_total counter")
-            lines.append(f"soc_daemon_processor_triaged_total {proc.get('triaged', 0)}")
-            
-            lines.append(f"# HELP soc_daemon_processor_enriched_total Total findings enriched")
-            lines.append(f"# TYPE soc_daemon_processor_enriched_total counter")
-            lines.append(f"soc_daemon_processor_enriched_total {proc.get('enriched', 0)}")
-        
-        # Responder metrics
-        if metrics.get("responder"):
-            resp = metrics["responder"]
-            lines.append(f"# HELP soc_daemon_responder_evaluated_total Total response candidates evaluated")
-            lines.append(f"# TYPE soc_daemon_responder_evaluated_total counter")
-            lines.append(f"soc_daemon_responder_evaluated_total {resp.get('evaluated', 0)}")
-            
-            lines.append(f"# HELP soc_daemon_responder_auto_executed_total Total auto-executed actions")
-            lines.append(f"# TYPE soc_daemon_responder_auto_executed_total counter")
-            lines.append(f"soc_daemon_responder_auto_executed_total {resp.get('auto_executed', 0)}")
-            
-            lines.append(f"# HELP soc_daemon_responder_escalated_total Total escalations sent")
-            lines.append(f"# TYPE soc_daemon_responder_escalated_total counter")
-            lines.append(f"soc_daemon_responder_escalated_total {resp.get('escalated', 0)}")
-        
-        # Scheduler metrics
-        if metrics.get("scheduler"):
-            sched = metrics["scheduler"]
-            lines.append(f"# HELP soc_daemon_scheduler_tasks_total Total scheduled tasks run")
-            lines.append(f"# TYPE soc_daemon_scheduler_tasks_total counter")
-            lines.append(f"soc_daemon_scheduler_tasks_total {sched.get('tasks_run', 0)}")
-        
-        # Orchestrator metrics
-        if metrics.get("orchestrator"):
-            orch = metrics["orchestrator"]
-            lines.append(f"# HELP soc_daemon_orchestrator_investigations_created_total Total investigations created")
-            lines.append(f"# TYPE soc_daemon_orchestrator_investigations_created_total counter")
-            lines.append(f"soc_daemon_orchestrator_investigations_created_total {orch.get('investigations_created', 0)}")
-            
-            lines.append(f"# HELP soc_daemon_orchestrator_investigations_completed_total Total investigations completed")
-            lines.append(f"# TYPE soc_daemon_orchestrator_investigations_completed_total counter")
-            lines.append(f"soc_daemon_orchestrator_investigations_completed_total {orch.get('investigations_completed', 0)}")
-            
-            lines.append(f"# HELP soc_daemon_orchestrator_active_agents Current running agents")
-            lines.append(f"# TYPE soc_daemon_orchestrator_active_agents gauge")
-            lines.append(f"soc_daemon_orchestrator_active_agents {orch.get('active_agents', 0)}")
-            
-            lines.append(f"# HELP soc_daemon_orchestrator_cost_usd_total Total cost in USD")
-            lines.append(f"# TYPE soc_daemon_orchestrator_cost_usd_total counter")
-            lines.append(f"soc_daemon_orchestrator_cost_usd_total {orch.get('total_cost_usd', 0)}")
-            
-            lines.append(f"# HELP soc_daemon_orchestrator_stuck_agents_total Stuck agents detected and killed")
-            lines.append(f"# TYPE soc_daemon_orchestrator_stuck_agents_total counter")
-            lines.append(f"soc_daemon_orchestrator_stuck_agents_total {orch.get('stuck_agents_killed', 0)}")
-        
-        # Error metrics
-        total_errors = sum([
-            metrics.get("poller", {}).get("errors", 0),
-            metrics.get("processor", {}).get("errors", 0),
-            metrics.get("responder", {}).get("errors", 0),
-            metrics.get("scheduler", {}).get("errors", 0)
-        ])
-        lines.append(f"# HELP soc_daemon_errors_total Total errors across all components")
-        lines.append(f"# TYPE soc_daemon_errors_total counter")
-        lines.append(f"soc_daemon_errors_total {total_errors}")
-        
-        return web.Response(
-            text="\n".join(lines) + "\n",
-            content_type="text/plain; version=0.0.4"
-        )
-    
+        logger.info("Health server stopped")
+
     async def _handle_health(self, request: web.Request) -> web.Response:
         """Handle health check request."""
-        health = {
+        health: Dict[str, Any] = {
             "status": "healthy",
             "timestamp": datetime.utcnow().isoformat(),
-            "uptime_seconds": (datetime.utcnow() - self._start_time).total_seconds()
+            "uptime_seconds": (datetime.utcnow() - self._start_time).total_seconds(),
         }
-        
-        # Check component health
+
         components = {}
-        
+
         if self.poller:
             components["poller"] = "running"
         else:
             components["poller"] = "not_initialized"
-        
+
         if self.processor:
             components["processor"] = "running"
         else:
             components["processor"] = "not_initialized"
-        
+
         if self.responder:
             components["responder"] = "running"
         else:
             components["responder"] = "not_initialized"
-        
+
         if self.scheduler:
             components["scheduler"] = "running"
         else:
             components["scheduler"] = "not_initialized"
-        
+
         if self.orchestrator:
             components["orchestrator"] = "running" if self.orchestrator.enabled else "disabled"
         else:
             components["orchestrator"] = "not_initialized"
-        
+
         health["components"] = components
-        
-        # Determine overall status
+
         if all(v == "running" for v in components.values()):
             health["status"] = "healthy"
         elif any(v == "running" for v in components.values()):
             health["status"] = "degraded"
         else:
             health["status"] = "unhealthy"
-        
+
         status_code = 200 if health["status"] != "unhealthy" else 503
         return web.json_response(health, status=status_code)
-    
+
     async def _handle_status(self, request: web.Request) -> web.Response:
         """Handle detailed status request."""
         metrics = self._collect_metrics()
-        
+
         status = {
             "daemon": {
                 "start_time": self._start_time.isoformat(),
-                "uptime_seconds": (datetime.utcnow() - self._start_time).total_seconds()
+                "uptime_seconds": (datetime.utcnow() - self._start_time).total_seconds(),
             },
             "poller": metrics.get("poller", {}),
             "processor": metrics.get("processor", {}),
@@ -322,29 +289,29 @@ class MetricsServer:
             "scheduler": metrics.get("scheduler", {}),
             "orchestrator": metrics.get("orchestrator", {}),
         }
-        
+
         return web.json_response(status)
-    
+
     def _collect_metrics(self) -> Dict[str, Any]:
-        """Collect metrics from all components."""
-        metrics = {}
-        
+        """Collect metrics from all component stats dicts."""
+        metrics: Dict[str, Any] = {}
+
         if self.poller:
             metrics["poller"] = self.poller.stats.copy()
-        
+
         if self.processor:
             metrics["processor"] = self.processor.stats.copy()
-        
+
         if self.responder:
             metrics["responder"] = self.responder.stats.copy()
-        
+
         if self.scheduler:
             metrics["scheduler"] = self.scheduler.stats.copy()
-        
+
         if self.orchestrator:
             orch_stats = self.orchestrator.stats.copy()
             orch_stats["active_agents"] = self.orchestrator.agent_runner.active_count
             orch_stats["enabled"] = self.orchestrator.enabled
             metrics["orchestrator"] = orch_stats
-        
+
         return metrics

--- a/daemon/orchestrator.py
+++ b/daemon/orchestrator.py
@@ -20,6 +20,40 @@ from typing import Any, Dict, List, Optional
 
 from daemon.agent_runner import AgentRunner
 from daemon.config import OrchestratorConfig
+
+try:
+    from core.telemetry import get_meter, get_tracer, inject_traceparent
+    from opentelemetry.trace import SpanKind
+    _tracer = get_tracer("vigil.daemon.orchestrator")
+    _orch_meter = get_meter("vigil.daemon.orchestrator")
+    _inv_created = _orch_meter.create_counter(
+        "soc_daemon_orchestrator_investigations_created_total",
+        description="Total investigations created",
+        unit="1",
+    )
+    _inv_completed = _orch_meter.create_counter(
+        "soc_daemon_orchestrator_investigations_completed_total",
+        description="Total investigations completed",
+        unit="1",
+    )
+    _inv_failed = _orch_meter.create_counter(
+        "soc_daemon_orchestrator_investigations_failed_total",
+        description="Total investigations failed",
+        unit="1",
+    )
+    _dedup_prevented = _orch_meter.create_counter(
+        "soc_daemon_orchestrator_dedup_prevented_total",
+        description="Total investigations deduplicated",
+        unit="1",
+    )
+    _stuck_agents = _orch_meter.create_counter(
+        "soc_daemon_orchestrator_stuck_agents_total",
+        description="Stuck agents detected and killed",
+        unit="1",
+    )
+except Exception:
+    _tracer = None  # type: ignore[assignment]
+    _inv_created = _inv_completed = _inv_failed = _dedup_prevented = _stuck_agents = None  # type: ignore[assignment]
 from daemon.plan_generator import (
     count_steps,
     generate_case_review_context,
@@ -201,6 +235,8 @@ class Orchestrator:
         if overlapping:
             logger.info(f"Finding {finding_id} overlaps with {overlapping}, adding to existing investigation")
             self.stats["dedup_prevented"] += 1
+            if _dedup_prevented is not None:
+                _dedup_prevented.add(1)
             self._log_ai_decision(
                 decision_type="dedup_prevention",
                 inv_id=overlapping,
@@ -284,6 +320,28 @@ class Orchestrator:
             and self.agent_runner.active_count < self.config.max_concurrent_agents
         )
 
+        # Start root investigation span — will be the parent for all agent spans
+        _inv_span = None
+        _tp = ""
+        try:
+            if _tracer is not None:
+                _inv_span = _tracer.start_span(
+                    "investigation",
+                    kind=SpanKind.INTERNAL,
+                    attributes={
+                        "vigil.investigation.id": inv_id,
+                        "vigil.investigation.workflow_id": workflow_id,
+                        "vigil.investigation.trigger_type": trigger_type,
+                        "vigil.investigation.priority": priority,
+                        "vigil.investigation.finding_count": len(findings),
+                    },
+                )
+                _tp_carrier: Dict = {}
+                inject_traceparent(_tp_carrier)
+                _tp = _tp_carrier.get("traceparent", "")
+        except Exception:
+            pass
+
         inv_record = {
             "investigation_id": inv_id,
             "case_id": case_id,
@@ -298,10 +356,20 @@ class Orchestrator:
             "max_iterations": self.config.max_iterations_per_agent,
             "max_cost_usd": self.config.max_cost_per_investigation,
             "max_runtime_seconds": self.config.max_runtime_per_investigation,
+            "otel_traceparent": _tp,  # propagated to agent_runner across async boundary
         }
 
         self._save_investigation(inv_record)
         self.stats["investigations_created"] += 1
+        if _inv_created is not None:
+            _inv_created.add(1)
+
+        # End the root span here — agent_runner will re-attach as a child
+        try:
+            if _inv_span is not None:
+                _inv_span.end()
+        except Exception:
+            pass
 
         self.workdir.append_log(inv_id, {
             "event": "investigation_created",
@@ -393,6 +461,8 @@ class Orchestrator:
                             await self.agent_runner.stop_agent(inv_id)
                             self._update_investigation_status(inv_id, "failed", "Stale: no activity")
                             self.stats["stuck_agents_killed"] += 1
+                            if _stuck_agents is not None:
+                                _stuck_agents.add(1)
                             self._send_notification(
                                 inv_id, "agent_stuck",
                                 f"Agent stuck: {inv_id}",
@@ -486,6 +556,8 @@ class Orchestrator:
         if completeness >= 0.8 and summary:
             self._update_investigation_status(inv_id, "completed")
             self.stats["investigations_completed"] += 1
+            if _inv_completed is not None:
+                _inv_completed.add(1)
             self.stats["reviews_completed"] += 1
             self.shared_intel.unregister_investigation(inv_id)
 

--- a/daemon/workdir.py
+++ b/daemon/workdir.py
@@ -113,6 +113,17 @@ class WorkdirManager:
     
     def append_log(self, investigation_id: str, event: Dict[str, Any]):
         event.setdefault("ts", datetime.utcnow().isoformat())
+        event.setdefault("vigil.investigation.id", investigation_id)
+        # Embed current OTEL trace context so log lines are correlatable in Jaeger/Grafana
+        try:
+            from opentelemetry import trace
+            span = trace.get_current_span()
+            ctx = span.get_span_context()
+            if ctx and ctx.is_valid:
+                event["trace_id"] = format(ctx.trace_id, "032x")
+                event["span_id"] = format(ctx.span_id, "016x")
+        except Exception:
+            pass
         line = json.dumps(event, default=str) + "\n"
         self.append_file(investigation_id, "log.jsonl", line)
     

--- a/database/connection.py
+++ b/database/connection.py
@@ -109,7 +109,15 @@ class DatabaseManager:
                 pool_recycle=self.config.pool_recycle,
                 pool_pre_ping=True,  # Verify connections before using them
             )
-            
+
+            # Instrument SQLAlchemy with OTEL tracing
+            try:
+                from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+                SQLAlchemyInstrumentor().instrument(engine=self._engine)
+                logger.debug("SQLAlchemy OTEL instrumentation enabled")
+            except Exception as _inst_err:
+                logger.debug("SQLAlchemy OTEL instrumentation skipped: %s", _inst_err)
+
             # Set up event listeners
             @event.listens_for(self._engine, "connect")
             def receive_connect(dbapi_conn, connection_record):

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -98,9 +98,9 @@ services:
       - DAEMON_THREAT_HUNT_ENABLED=${DAEMON_THREAT_HUNT_ENABLED:-true}
       - DAEMON_THREAT_HUNT_INTERVAL=${DAEMON_THREAT_HUNT_INTERVAL:-86400}
       - DAEMON_CLEANUP_RETENTION_DAYS=${DAEMON_CLEANUP_RETENTION_DAYS:-90}
-      # Metrics
+      # Metrics / Health
       - DAEMON_METRICS_ENABLED=${DAEMON_METRICS_ENABLED:-true}
-      - DAEMON_METRICS_PORT=${DAEMON_METRICS_PORT:-9090}
+      - DAEMON_HEALTH_PORT=${DAEMON_HEALTH_PORT:-9091}
       # Webhook
       - DAEMON_WEBHOOK_ENABLED=${DAEMON_WEBHOOK_ENABLED:-true}
       - DAEMON_WEBHOOK_PORT=${DAEMON_WEBHOOK_PORT:-8081}
@@ -119,7 +119,8 @@ services:
       - PAGERDUTY_ROUTING_KEY=${PAGERDUTY_ROUTING_KEY}
     ports:
       - "8081:8081"  # Webhook ingestion
-      - "9090:9090"  # Metrics/health
+      - "9090:9090"  # Prometheus /metrics (OTEL PrometheusMetricReader)
+      - "9091:9091"  # Health /health + /status
     depends_on:
       postgres:
         condition: service_healthy
@@ -170,6 +171,78 @@ services:
     profiles:
       - dev  # Only start in dev profile
 
+  # ─── Observability stack (opt-in: --profile observability) ────────────────
+
+  # OpenTelemetry Collector — receives OTLP spans/metrics, fans out to Jaeger + Prometheus
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.100.0
+    container_name: deeptempo-otel-collector
+    command: ["--config=/etc/otel/otel-collector.yaml"]
+    volumes:
+      - ./otel-collector.yaml:/etc/otel/otel-collector.yaml:ro
+    ports:
+      - "4317:4317"  # OTLP gRPC
+      - "4318:4318"  # OTLP HTTP
+    networks:
+      - deeptempo-network
+    profiles:
+      - observability
+
+  # Jaeger — distributed trace UI
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    container_name: deeptempo-jaeger
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - "16686:16686"  # Jaeger UI
+    networks:
+      - deeptempo-network
+    profiles:
+      - observability
+
+  # Prometheus — scrapes /metrics from daemon and backend
+  prometheus:
+    image: prom/prometheus:v2.51.2
+    container_name: deeptempo-prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.console.libraries=/usr/share/prometheus/console_libraries
+      - --web.console.templates=/usr/share/prometheus/consoles
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "9095:9090"  # Prometheus UI on host port 9095 (avoids conflict with daemon's 9090)
+    networks:
+      - deeptempo-network
+    profiles:
+      - observability
+
+  # Grafana — dashboards for system overview, LLM costs, investigation lifecycle
+  grafana:
+    image: grafana/grafana:10.4.0
+    container_name: deeptempo-grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/datasources:/etc/grafana/provisioning/datasources:ro
+    ports:
+      - "3001:3000"  # Grafana UI
+    depends_on:
+      - prometheus
+    networks:
+      - deeptempo-network
+    profiles:
+      - observability
+
+  # ─── SIEM testing ─────────────────────────────────────────────────────────
+
   # Splunk Enterprise for SIEM testing
   splunk:
     image: splunk/splunk:latest
@@ -210,6 +283,10 @@ volumes:
   splunk_data:
     driver: local
   splunk_etc:
+    driver: local
+  prometheus_data:
+    driver: local
+  grafana_data:
     driver: local
 
 networks:

--- a/docker/grafana/dashboards/dashboard-provider.yaml
+++ b/docker/grafana/dashboards/dashboard-provider.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: vigil-dashboards
+    orgId: 1
+    folder: Vigil SOC
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/docker/grafana/dashboards/investigation_lifecycle.json
+++ b/docker/grafana/dashboards/investigation_lifecycle.json
@@ -1,0 +1,172 @@
+{
+  "title": "Vigil SOC — Investigation Lifecycle",
+  "uid": "vigil-investigation-lifecycle",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Investigations Created",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "soc_daemon_orchestrator_investigations_created_total",
+          "legendFormat": "created"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Investigations Completed",
+      "type": "stat",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "soc_daemon_orchestrator_investigations_completed_total",
+          "legendFormat": "completed"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Investigations Failed",
+      "type": "stat",
+      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "thresholds": {
+          "steps": [
+            { "value": 0, "color": "green" },
+            { "value": 1, "color": "red" }
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "soc_daemon_orchestrator_investigations_failed_total",
+          "legendFormat": "failed"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Active Agents",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "soc_daemon_orchestrator_active_agents",
+          "legendFormat": "active"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Dedup Prevented",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "soc_daemon_orchestrator_dedup_prevented_total",
+          "legendFormat": "dedup"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Investigation Rate (created/hr)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(soc_daemon_orchestrator_investigations_created_total[1h]) * 3600",
+          "legendFormat": "created/hr"
+        },
+        {
+          "expr": "rate(soc_daemon_orchestrator_investigations_completed_total[1h]) * 3600",
+          "legendFormat": "completed/hr"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Agent Concurrency Over Time",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "soc_daemon_orchestrator_active_agents",
+          "legendFormat": "active agents"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Tool Success Rate by Tier",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 } },
+      "targets": [
+        {
+          "expr": "rate(vigil_tool_success_total[5m]) / rate(vigil_tool_calls_total[5m])",
+          "legendFormat": "tier {{vigil_tool_tier}}"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "MCP Tool Duration P95 by Tool",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "ms" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(vigil_tool_duration_ms_bucket[5m]))",
+          "legendFormat": "P95 {{vigil_tool_name}}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "LLM Cost per Investigation (avg)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 20, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } },
+      "targets": [
+        {
+          "expr": "rate(soc_daemon_llm_cost_usd_total[1h]) / rate(soc_daemon_orchestrator_investigations_completed_total[1h])",
+          "legendFormat": "cost/investigation"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "Stuck Agents Killed",
+      "type": "stat",
+      "gridPos": { "x": 20, "y": 0, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "thresholds": {
+          "steps": [
+            { "value": 0, "color": "green" },
+            { "value": 1, "color": "orange" },
+            { "value": 5, "color": "red" }
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "soc_daemon_orchestrator_stuck_agents_total",
+          "legendFormat": "stuck"
+        }
+      ]
+    }
+  ]
+}

--- a/docker/grafana/dashboards/llm_costs.json
+++ b/docker/grafana/dashboards/llm_costs.json
@@ -1,0 +1,123 @@
+{
+  "title": "Vigil SOC — LLM Costs",
+  "uid": "vigil-llm-costs",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-24h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Total Cost (USD) — Last 24h",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["sum"] },
+        "unit": "currencyUSD"
+      },
+      "targets": [
+        {
+          "expr": "increase(soc_daemon_llm_cost_usd_total[24h])",
+          "legendFormat": "cost"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Hourly LLM Cost",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } },
+      "targets": [
+        {
+          "expr": "rate(soc_daemon_llm_cost_usd_total[1h]) * 3600",
+          "legendFormat": "cost/hour"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Tokens per Model",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(soc_daemon_llm_tokens_total[5m])",
+          "legendFormat": "{{gen_ai_request_model}} {{token_type}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Call Duration P50 / P95 / P99",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(soc_daemon_llm_duration_seconds_bucket[5m]))",
+          "legendFormat": "P50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(soc_daemon_llm_duration_seconds_bucket[5m]))",
+          "legendFormat": "P95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(soc_daemon_llm_duration_seconds_bucket[5m]))",
+          "legendFormat": "P99"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "LLM Calls / min",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 20, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(soc_daemon_llm_calls_total[1m]) * 60",
+          "legendFormat": "calls/min {{gen_ai_request_model}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "LLM Call Rate — Last hour",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "rate(soc_daemon_llm_calls_total[1h]) * 3600",
+          "legendFormat": "calls/hr"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Input Tokens — Last 24h",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["sum"] } },
+      "targets": [
+        {
+          "expr": "increase(soc_daemon_llm_tokens_total{token_type=\"input\"}[24h])",
+          "legendFormat": "input tokens"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Output Tokens — Last 24h",
+      "type": "stat",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["sum"] } },
+      "targets": [
+        {
+          "expr": "increase(soc_daemon_llm_tokens_total{token_type=\"output\"}[24h])",
+          "legendFormat": "output tokens"
+        }
+      ]
+    }
+  ]
+}

--- a/docker/grafana/dashboards/system_overview.json
+++ b/docker/grafana/dashboards/system_overview.json
@@ -1,0 +1,123 @@
+{
+  "title": "Vigil SOC — System Overview",
+  "uid": "vigil-system-overview",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Daemon Uptime",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "unit": "s" },
+      "targets": [
+        {
+          "expr": "soc_daemon_uptime_seconds",
+          "legendFormat": "uptime"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Findings Polled / 5m",
+      "type": "stat",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "rate(soc_daemon_poller_findings_total[5m]) * 300",
+          "legendFormat": "findings/5m"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP Request Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(http_server_duration_milliseconds_count[1m])",
+          "legendFormat": "{{http_route}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Error Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(soc_daemon_errors_total[1m])",
+          "legendFormat": "errors/s"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Active Agents",
+      "type": "stat",
+      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "soc_daemon_orchestrator_active_agents",
+          "legendFormat": "active agents"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Investigations Created",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "soc_daemon_orchestrator_investigations_created_total",
+          "legendFormat": "created"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Investigations Completed",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "soc_daemon_orchestrator_investigations_completed_total",
+          "legendFormat": "completed"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Polls by Source",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(soc_daemon_poller_polls_total[5m])",
+          "legendFormat": "{{source}}"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Poll Duration P95 by Source",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(soc_daemon_poller_duration_seconds_bucket[5m]))",
+          "legendFormat": "P95 {{source}}"
+        }
+      ]
+    }
+  ]
+}

--- a/docker/grafana/datasources/prometheus.yaml
+++ b/docker/grafana/datasources/prometheus.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/docker/otel-collector.yaml
+++ b/docker/otel-collector.yaml
@@ -1,0 +1,56 @@
+# OpenTelemetry Collector configuration for Vigil SOC
+#
+# Receives OTLP spans and metrics from all Vigil processes,
+# then fans out to Jaeger (traces) and Prometheus (metrics).
+# No external exporters — all data stays within the SOC network.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 512
+    send_batch_max_size: 1024
+
+  # Drop spans/metrics that have no service.name to avoid noisy cardinality
+  filter/drop_unnamed:
+    error_mode: ignore
+    traces:
+      span:
+        - 'resource.attributes["service.name"] == ""'
+
+exporters:
+  # Jaeger receives traces via OTLP gRPC (all-in-one image supports this natively)
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+  # Prometheus pulls metrics from the collector's built-in exporter endpoint
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    namespace: vigil
+    const_labels:
+      environment: docker
+
+  # Debug logging at warn level — change to "detailed" for local troubleshooting
+  debug:
+    verbosity: warn
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch, filter/drop_unnamed]
+      exporters: [otlp/jaeger, debug]
+
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus, debug]

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,31 @@
+# Prometheus scrape configuration for Vigil SOC
+# Scrapes Prometheus-format metrics from daemon and backend (via OTEL PrometheusMetricReader)
+# and from the OTEL Collector's built-in Prometheus exporter.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    cluster: vigil-local
+
+scrape_configs:
+  # SOC Daemon — OTEL PrometheusMetricReader on port 9090
+  - job_name: soc-daemon
+    static_configs:
+      - targets: ["soc-daemon:9090"]
+        labels:
+          service: soc-daemon
+
+  # Backend API — OTEL PrometheusMetricReader on port 9090
+  - job_name: backend
+    static_configs:
+      - targets: ["backend:9090"]
+        labels:
+          service: backend
+
+  # OTEL Collector's Prometheus exporter (fan-out of all OTLP metrics)
+  - job_name: otel-collector
+    static_configs:
+      - targets: ["otel-collector:8889"]
+        labels:
+          service: otel-collector

--- a/env.example
+++ b/env.example
@@ -224,3 +224,32 @@ ORCHESTRATOR_CONTEXT_MAX_CHARS="10000"
 # Models used for plan generation and review
 ORCHESTRATOR_PLAN_MODEL="claude-sonnet-4-5-20250929"
 ORCHESTRATOR_REVIEW_MODEL="claude-sonnet-4-5-20250929"
+# =============================================================================
+# OPENTELEMETRY (OTEL) OBSERVABILITY
+# =============================================================================
+
+# Enable/disable the full OTEL stack (traces, metrics, structured logging)
+# When true: PrometheusMetricReader serves /metrics on port 9090 and
+#            all processes emit structured JSON logs with trace_id/span_id.
+VIGIL_OTEL_ENABLED="false"
+
+# OTLP exporter endpoint (gRPC) — points to the OTEL Collector
+# Default: local docker-compose collector
+OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+
+# Traces sampler — "parentbased_always_on" | "parentbased_traceidratio" | "always_off"
+OTEL_TRACES_SAMPLER="parentbased_always_on"
+
+# When using traceidratio, set the sampling fraction (0.0–1.0)
+# OTEL_TRACES_SAMPLER_ARG="0.1"
+
+# Allow LLM prompt/completion content to be recorded in spans (default: false)
+# WARNING: may capture PII / sensitive IOC data — review before enabling
+VIGIL_OTEL_LOG_LLM_CONTENT="false"
+
+# Health server port (daemon only) — /health and /status endpoints
+# Port 9090 is reserved for the Prometheus /metrics endpoint (OTEL reader)
+DAEMON_HEALTH_PORT="9091"
+
+# Grafana admin password (used by docker-compose observability profile)
+GRAFANA_PASSWORD="admin"

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,15 @@ redis>=5.0.0
 sentry-sdk>=1.40.0
 prometheus-client>=0.19.0
 
+# OpenTelemetry
+opentelemetry-api>=1.25.0
+opentelemetry-sdk>=1.25.0
+opentelemetry-exporter-otlp-proto-grpc>=1.25.0
+opentelemetry-exporter-otlp-proto-http>=1.25.0
+opentelemetry-exporter-prometheus>=0.46b0
+opentelemetry-instrumentation-fastapi>=0.46b0
+opentelemetry-instrumentation-sqlalchemy>=0.46b0
+opentelemetry-instrumentation-redis>=0.46b0
+opentelemetry-instrumentation-logging>=0.46b0
+opentelemetry-semantic-conventions-ai>=0.4.0
+

--- a/services/claude_service.py
+++ b/services/claude_service.py
@@ -28,6 +28,17 @@ try:
 except ImportError:
     ANTHROPIC_AVAILABLE = False
 
+# OTEL instrumentation (lazy to avoid hard dependency)
+try:
+    from core.telemetry import get_tracer, get_meter, create_genai_metrics
+    from opentelemetry.trace import SpanKind, StatusCode as _SpanStatusCode
+    _cs_tracer = get_tracer("vigil.services.claude")
+    _cs_meter = get_meter("vigil.services.claude")
+    _cs_genai_metrics = create_genai_metrics(_cs_meter)
+    _OTEL_CS_AVAILABLE = True
+except Exception:
+    _OTEL_CS_AVAILABLE = False
+
 try:
     from claude_agent_sdk import query as agent_query, ClaudeAgentOptions
     AGENT_SDK_AVAILABLE = True
@@ -1532,7 +1543,50 @@ Provide a structured summary preserving all critical context."""
             
             logger.debug(f"🚀 Making API call with {len(messages)} messages")
             logger.debug(f"📋 API kwargs keys: {list(api_kwargs.keys())}")
+
+            # OTEL: wrap the API call in a span and record GenAI metrics
+            import time as _time
+            _chat_span = None
+            _chat_t0 = _time.monotonic()
+            if _OTEL_CS_AVAILABLE:
+                try:
+                    _chat_span = _cs_tracer.start_span(
+                        "claude.chat",
+                        kind=SpanKind.CLIENT,
+                        attributes={
+                            "gen_ai.system": "anthropic",
+                            "gen_ai.request.model": model,
+                            "gen_ai.request.max_tokens": max_tokens,
+                        },
+                    )
+                except Exception:
+                    pass
+
             response = self.client.messages.create(**api_kwargs)
+
+            if _OTEL_CS_AVAILABLE and _chat_span is not None:
+                try:
+                    _duration = _time.monotonic() - _chat_t0
+                    _in_tok = response.usage.input_tokens if hasattr(response, "usage") else 0
+                    _out_tok = response.usage.output_tokens if hasattr(response, "usage") else 0
+                    _model_used = response.model if hasattr(response, "model") else model
+                    _chat_span.set_attribute("gen_ai.response.model", _model_used)
+                    _chat_span.set_attribute("gen_ai.usage.input_tokens", _in_tok)
+                    _chat_span.set_attribute("gen_ai.usage.output_tokens", _out_tok)
+                    _chat_span.set_attribute("gen_ai.finish_reason", response.stop_reason or "")
+                    _chat_span.end()
+                    # Update metric counters
+                    _labels = {"gen_ai.system": "anthropic", "gen_ai.request.model": _model_used}
+                    _cs_genai_metrics["llm_calls"].add(1, _labels)
+                    _cs_genai_metrics["llm_duration"].record(_duration, _labels)
+                    _cs_genai_metrics["llm_tokens"].add(_in_tok, {**_labels, "gen_ai.token.type": "input"})
+                    _cs_genai_metrics["llm_tokens"].add(_out_tok, {**_labels, "gen_ai.token.type": "output"})
+                    from daemon.agent_runner import SONNET_INPUT_COST, SONNET_OUTPUT_COST
+                    _cost = _in_tok * SONNET_INPUT_COST + _out_tok * SONNET_OUTPUT_COST
+                    _cs_genai_metrics["llm_cost_usd"].add(_cost, _labels)
+                except Exception:
+                    pass
+
             logger.debug(f"📥 API response received - stop_reason: {response.stop_reason}")
             logger.debug(f"   - Response ID: {response.id if hasattr(response, 'id') else 'N/A'}")
             logger.debug(f"   - Model: {response.model if hasattr(response, 'model') else 'N/A'}")

--- a/services/llm_gateway.py
+++ b/services/llm_gateway.py
@@ -115,11 +115,33 @@ class LLMGateway:
     async def create(cls, settings: Optional[RedisSettings] = None) -> "LLMGateway":
         settings = settings or _redis_settings()
         pool = await create_pool(settings)
+
+        # Instrument the underlying Redis client with OTEL tracing
+        try:
+            from opentelemetry.instrumentation.redis import RedisInstrumentor
+            RedisInstrumentor().instrument()
+            logger.debug("Redis OTEL instrumentation enabled")
+        except Exception as _inst_err:
+            logger.debug("Redis OTEL instrumentation skipped: %s", _inst_err)
+
         return cls(pool)
 
     async def close(self):
         if self._pool:
             await self._pool.aclose()
+
+    # -- Trace context helpers -----------------------------------------------
+
+    @staticmethod
+    def _get_traceparent() -> str:
+        """Capture the current W3C traceparent for ARQ job propagation."""
+        try:
+            from core.telemetry import inject_traceparent
+            carrier: Dict[str, str] = {}
+            inject_traceparent(carrier)
+            return carrier.get("traceparent", "")
+        except Exception:
+            return ""
 
     # -- Convenience enqueue methods ----------------------------------------
 
@@ -143,6 +165,7 @@ class LLMGateway:
             thinking_budget=0,
             tools=None,
             temperature=None,
+            traceparent=self._get_traceparent(),
             _queue_name=QUEUE_NAME,
         )
         try:
@@ -183,6 +206,7 @@ class LLMGateway:
             thinking_budget=thinking_budget,
             tools=tools,
             temperature=None,
+            traceparent=self._get_traceparent(),
             _queue_name=QUEUE_NAME,
         )
         try:
@@ -219,6 +243,7 @@ class LLMGateway:
             thinking_budget=thinking_budget,
             tools=tools,
             temperature=None,
+            traceparent=self._get_traceparent(),
             _queue_name=QUEUE_NAME,
         )
         try:
@@ -254,6 +279,7 @@ class LLMGateway:
             thinking_budget=thinking_budget,
             tools=None,
             temperature=None,
+            traceparent=self._get_traceparent(),
             _queue_name=QUEUE_NAME,
         )
         try:
@@ -285,6 +311,7 @@ class LLMGateway:
             thinking_budget=0,
             tools=None,
             temperature=temperature,
+            traceparent=self._get_traceparent(),
             _queue_name=QUEUE_NAME,
         )
         try:

--- a/services/llm_worker.py
+++ b/services/llm_worker.py
@@ -60,6 +60,7 @@ async def llm_call(
     thinking_budget: int,
     tools: Optional[List[Dict]],
     temperature: Optional[float],
+    traceparent: str = "",
 ) -> Any:
     """Execute a single LLM call through the shared ClaudeService.
 
@@ -73,6 +74,22 @@ async def llm_call(
     rate_limiter: asyncio.Semaphore = ctx["rate_limiter"]
     claude_service = ctx["claude_service"]
     session_store: RedisSessionStore = ctx["session_store"]
+
+    # Restore parent span context propagated across the ARQ/Redis boundary
+    try:
+        from core.telemetry import extract_traceparent, get_tracer
+        from opentelemetry.trace import SpanKind
+        parent_ctx = extract_traceparent({"traceparent": traceparent})
+        _tracer = get_tracer("vigil.services.llm_worker")
+        worker_span = _tracer.start_span(
+            "llm_worker.execute",
+            context=parent_ctx,
+            kind=SpanKind.CONSUMER,
+        )
+        worker_span.set_attribute("gen_ai.system", "anthropic")
+        worker_span.set_attribute("gen_ai.request.model", model)
+    except Exception:
+        worker_span = None
 
     # Load session history if applicable
     if session_id:
@@ -99,6 +116,12 @@ async def llm_call(
 
     result = _extract_result(response)
 
+    if worker_span is not None:
+        try:
+            worker_span.end()
+        except Exception:
+            pass
+
     # Persist session
     if session_id:
         updated = messages + [{"role": "assistant", "content": result.get("content", "")}]
@@ -116,6 +139,7 @@ async def llm_call_raw(
     thinking_budget: int,
     tools: Optional[List[Dict]],
     temperature: Optional[float],
+    traceparent: str = "",
 ) -> Dict[str, Any]:
     """Execute a raw multi-turn LLM call (used by AgentRunner tool loop).
 
@@ -125,6 +149,22 @@ async def llm_call_raw(
     """
     rate_limiter: asyncio.Semaphore = ctx["rate_limiter"]
     claude_service = ctx["claude_service"]
+
+    # Restore parent span context propagated across the ARQ/Redis boundary
+    try:
+        from core.telemetry import extract_traceparent, get_tracer
+        from opentelemetry.trace import SpanKind
+        parent_ctx = extract_traceparent({"traceparent": traceparent})
+        _tracer = get_tracer("vigil.services.llm_worker")
+        worker_span = _tracer.start_span(
+            "llm_worker.execute",
+            context=parent_ctx,
+            kind=SpanKind.CONSUMER,
+        )
+        worker_span.set_attribute("gen_ai.system", "anthropic")
+        worker_span.set_attribute("gen_ai.request.model", model)
+    except Exception:
+        worker_span = None
 
     await rate_limiter.acquire()
     try:
@@ -142,7 +182,20 @@ async def llm_call_raw(
     finally:
         rate_limiter.release()
 
-    return _serialize_raw_response(response)
+    result = _serialize_raw_response(response)
+
+    if worker_span is not None:
+        try:
+            in_tok = result.get("input_tokens", 0)
+            out_tok = result.get("output_tokens", 0)
+            worker_span.set_attribute("gen_ai.usage.input_tokens", in_tok)
+            worker_span.set_attribute("gen_ai.usage.output_tokens", out_tok)
+            worker_span.set_attribute("gen_ai.finish_reason", result.get("stop_reason", ""))
+            worker_span.end()
+        except Exception:
+            pass
+
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -266,10 +319,16 @@ def _serialize_raw_response(response: Any) -> Dict[str, Any]:
 
 async def on_startup(ctx: Dict[str, Any]):
     """Initialise shared resources when the ARQ worker boots."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
+    # Initialize OTEL telemetry (replaces basicConfig with structured JSON logging)
+    try:
+        from core.telemetry import init_telemetry
+        init_telemetry("vigil-llm-worker")
+    except Exception as _tel_err:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+        logger.warning("Telemetry init failed (non-fatal): %s", _tel_err)
 
     from services.claude_service import ClaudeService
 

--- a/services/mcp_client.py
+++ b/services/mcp_client.py
@@ -306,51 +306,104 @@ class MCPClient:
     async def call_tool(self, server_name: str, tool_name: str, arguments: Dict[str, Any], timeout: float = 30.0) -> Dict[str, Any]:
         """
         Call a tool on an MCP server using persistent connection with timeout.
-        
+
         Args:
             server_name: Name of the server
             tool_name: Name of the tool to call
             arguments: Tool arguments
             timeout: Timeout in seconds (default: 30)
-            
+
         Returns:
             Tool result dictionary
         """
+        import json as _json
+        import time as _time
+
         if not MCP_AVAILABLE:
             return {"error": "MCP SDK not available", "content": [{"type": "text", "text": "MCP SDK not available"}]}
-        
+
         if server_name not in self.mcp_service.servers:
             return {"error": f"Unknown server: {server_name}", "content": [{"type": "text", "text": f"Unknown server: {server_name}"}]}
-        
+
+        # OTEL span for transport-level MCP call
+        _mcp_span = None
+        _mcp_t0 = _time.monotonic()
+        try:
+            from core.telemetry import get_tracer
+            from opentelemetry.trace import SpanKind, StatusCode as _SC
+            _mcp_tracer = get_tracer("vigil.services.mcp_client")
+            _mcp_span = _mcp_tracer.start_span(
+                "mcp.call_tool",
+                kind=SpanKind.CLIENT,
+                attributes={
+                    "mcp.server.name": server_name,
+                    "mcp.transport": "stdio",
+                    "vigil.tool.name": tool_name,
+                    "vigil.tool.input_size": len(_json.dumps(arguments, default=str)),
+                },
+            )
+        except Exception:
+            _SC = None
+
         # Ensure we have a persistent session
         if server_name not in self.persistent_sessions:
             logger.info(f"Creating persistent connection to {server_name}...")
             if not await self.connect_to_server(server_name, persistent=True):
-                return {
+                _err = {
                     "error": True,
                     "content": [{"type": "text", "text": f"Failed to connect to server: {server_name}"}]
                 }
-        
+                try:
+                    if _mcp_span is not None:
+                        _mcp_span.set_attribute("vigil.tool.success", False)
+                        _mcp_span.end()
+                except Exception:
+                    pass
+                return _err
+
         persistent_session = self.persistent_sessions[server_name]
-        
+
         async def _call_tool_persistent():
             try:
                 return await persistent_session.call_tool(tool_name, arguments)
             except Exception as e:
                 logger.error(f"Error in tool call {tool_name} on {server_name}: {e}")
                 raise
-        
+
         try:
             # Apply timeout
-            return await asyncio.wait_for(_call_tool_persistent(), timeout=timeout)
+            result = await asyncio.wait_for(_call_tool_persistent(), timeout=timeout)
+            try:
+                if _mcp_span is not None:
+                    is_err = result.get("error", False) if isinstance(result, dict) else False
+                    _mcp_span.set_attribute("vigil.tool.success", not is_err)
+                    _mcp_span.set_attribute("vigil.tool.output_size", len(_json.dumps(result, default=str)))
+                    _mcp_span.set_attribute("vigil.tool.duration_ms", round((_time.monotonic() - _mcp_t0) * 1000, 1))
+                    _mcp_span.end()
+            except Exception:
+                pass
+            return result
         except asyncio.TimeoutError:
             logger.error(f"Tool call {tool_name} on {server_name} timed out after {timeout}s")
+            try:
+                if _mcp_span is not None and _SC is not None:
+                    _mcp_span.set_attribute("vigil.tool.success", False)
+                    _mcp_span.set_status(_SC.ERROR, f"Timeout after {timeout}s")
+                    _mcp_span.end()
+            except Exception:
+                pass
             return {
                 "error": True,
                 "content": [{"type": "text", "text": f"Tool call timed out after {timeout} seconds. The MCP server may not be responding."}]
             }
         except Exception as e:
             logger.error(f"Error calling tool {tool_name} on {server_name}: {e}")
+            try:
+                if _mcp_span is not None:
+                    _mcp_span.set_attribute("vigil.tool.success", False)
+                    _mcp_span.end()
+            except Exception:
+                pass
             return {"error": True, "content": [{"type": "text", "text": f"Error: {str(e)}"}]}
     
     def get_tools_for_claude(self) -> List[Dict]:

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,0 +1,436 @@
+"""
+Tests for core.telemetry and core.telemetry_sanitizer.
+
+The sanitizer tests are **security-critical** — they verify that sensitive
+data patterns are scrubbed before leaving the process.
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reload_telemetry():
+    """Force-reset telemetry module state to allow re-initialization in tests."""
+    import core.telemetry as mod
+
+    mod._initialized = False
+    mod._tracer_provider = None
+    mod._meter_provider = None
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# core.telemetry — no-op behaviour when disabled
+# ---------------------------------------------------------------------------
+
+class TestTelemetryDisabled:
+    """When VIGIL_OTEL_ENABLED is not set or false, everything is no-op."""
+
+    def test_init_returns_false_when_disabled(self):
+        tel = _reload_telemetry()
+        with patch.dict(os.environ, {"VIGIL_OTEL_ENABLED": "false"}, clear=False):
+            assert tel.init_telemetry("test-service") is False
+
+    def test_init_returns_false_when_unset(self):
+        tel = _reload_telemetry()
+        env = {k: v for k, v in os.environ.items() if k != "VIGIL_OTEL_ENABLED"}
+        with patch.dict(os.environ, env, clear=True):
+            assert tel.init_telemetry("test-service") is False
+
+    def test_get_tracer_returns_noop_when_disabled(self):
+        tel = _reload_telemetry()
+        with patch.dict(os.environ, {"VIGIL_OTEL_ENABLED": "false"}, clear=False):
+            tel.init_telemetry("test-service")
+            tracer = tel.get_tracer("test")
+            span = tracer.start_span("noop")
+            span.set_attribute("key", "value")
+            span.end()
+
+    def test_get_meter_returns_noop_when_disabled(self):
+        tel = _reload_telemetry()
+        with patch.dict(os.environ, {"VIGIL_OTEL_ENABLED": "false"}, clear=False):
+            tel.init_telemetry("test-service")
+            meter = tel.get_meter("test")
+            counter = meter.create_counter("test.counter")
+            counter.add(1)  # must not raise
+            hist = meter.create_histogram("test.hist")
+            hist.record(42.0)  # must not raise
+
+    def test_noop_span_context_manager(self):
+        tel = _reload_telemetry()
+        with patch.dict(os.environ, {"VIGIL_OTEL_ENABLED": "false"}, clear=False):
+            tel.init_telemetry("test-service")
+            tracer = tel.get_tracer("test")
+            with tracer.start_as_current_span("op") as span:
+                span.set_attribute("key", "val")
+                span.add_event("thing_happened")
+                # is_recording is a callable method — call it correctly
+                assert span.is_recording() is False
+
+    def test_double_init_is_idempotent(self):
+        tel = _reload_telemetry()
+        with patch.dict(os.environ, {"VIGIL_OTEL_ENABLED": "false"}, clear=False):
+            r1 = tel.init_telemetry("svc")
+            r2 = tel.init_telemetry("svc")
+            assert r1 is False
+            assert r2 is False
+
+    def test_shutdown_is_safe_when_disabled(self):
+        tel = _reload_telemetry()
+        with patch.dict(os.environ, {"VIGIL_OTEL_ENABLED": "false"}, clear=False):
+            tel.init_telemetry("svc")
+            tel.shutdown()  # must not raise
+
+    def test_shutdown_resets_initialized_flag(self):
+        """After shutdown(), init_telemetry() must be callable again (bug fix #3)."""
+        tel = _reload_telemetry()
+        with patch.dict(os.environ, {"VIGIL_OTEL_ENABLED": "false"}, clear=False):
+            tel.init_telemetry("svc")
+            tel.shutdown()
+            # _initialized must be False after shutdown so re-init is possible
+            assert tel._initialized is False
+
+
+class TestTelemetryInitFailure:
+    """Verify graceful degradation when OTEL SDK is broken or missing."""
+
+    def test_init_catches_import_error(self):
+        tel = _reload_telemetry()
+        with patch.dict(os.environ, {"VIGIL_OTEL_ENABLED": "true"}, clear=False):
+            with patch.dict(
+                sys.modules,
+                {"opentelemetry": None, "opentelemetry.trace": None},
+            ):
+                result = tel.init_telemetry("svc")
+                assert result is False
+
+    def test_tracer_still_works_after_init_failure(self):
+        tel = _reload_telemetry()
+        with patch.dict(os.environ, {"VIGIL_OTEL_ENABLED": "true"}, clear=False):
+            with patch.object(tel, "_do_init", side_effect=RuntimeError("boom")):
+                tel.init_telemetry("svc")
+            tracer = tel.get_tracer("test")
+            span = tracer.start_span("safe")
+            span.set_attribute("k", "v")
+            span.end()
+
+
+# ---------------------------------------------------------------------------
+# Investigation ID context var
+# ---------------------------------------------------------------------------
+
+class TestInvestigationContext:
+    def test_default_is_none(self):
+        from core.telemetry import get_investigation_id
+        get_investigation_id()  # must not raise
+
+    def test_set_and_get(self):
+        from core.telemetry import set_investigation_id, get_investigation_id
+        set_investigation_id("inv-test-123")
+        assert get_investigation_id() == "inv-test-123"
+        set_investigation_id(None)
+        assert get_investigation_id() is None
+
+
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+class TestConfigHelpers:
+    def test_is_otel_enabled_true(self):
+        from core.telemetry import _is_otel_enabled
+        for val in ("true", "True", "1", "yes", "YES"):
+            with patch.dict(os.environ, {"VIGIL_OTEL_ENABLED": val}):
+                assert _is_otel_enabled() is True
+
+    def test_is_otel_enabled_false(self):
+        from core.telemetry import _is_otel_enabled
+        for val in ("false", "0", "no", ""):
+            with patch.dict(os.environ, {"VIGIL_OTEL_ENABLED": val}):
+                assert _is_otel_enabled() is False
+
+    def test_llm_content_default_off(self):
+        from core.telemetry import _should_record_llm_content
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "VIGIL_OTEL_RECORD_LLM_CONTENT"
+        }
+        with patch.dict(os.environ, env, clear=True):
+            assert _should_record_llm_content() is False
+
+    def test_ioc_values_default_off(self):
+        from core.telemetry import _should_record_ioc_values
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "VIGIL_OTEL_RECORD_IOC_VALUES"
+        }
+        with patch.dict(os.environ, env, clear=True):
+            assert _should_record_ioc_values() is False
+
+
+# ---------------------------------------------------------------------------
+# core.telemetry_sanitizer — SECURITY TESTS
+# ---------------------------------------------------------------------------
+
+class TestSensitiveAttributeScrubber:
+    """
+    Security-critical tests. Verify that the sanitizer correctly identifies
+    and redacts sensitive data. If any of these fail, sensitive data may leak
+    to the telemetry backend.
+    """
+
+    @pytest.fixture
+    def scrubber(self):
+        from core.telemetry_sanitizer import SensitiveAttributeScrubber
+        return SensitiveAttributeScrubber()
+
+    # ---- Key-based redaction ----
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "http.request.header.authorization",
+            "api_key",
+            "my.api.key",
+            "auth_token",
+            "auth.token",
+            "user.password",
+            "db.secret",
+            "x-api-key",
+            "private_key",
+            "access_token",
+            "refresh_token",
+            "session_id",
+            "cookie",
+            "sentry.dsn",
+            "sentry_dsn",
+            "my_dsn",
+            "connection_string",
+            "credential",
+            "bearer",
+            "jwt",
+        ],
+    )
+    def test_sensitive_keys_are_redacted(self, scrubber, key):
+        assert scrubber._should_redact(key, "some_value") is True
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "http.method",
+            "http.status_code",
+            "vigil.tool.name",
+            "vigil.tool.tier",
+            "vigil.investigation.id",
+            "gen_ai.request.model",
+            "gen_ai.usage.input_tokens",
+            "service.name",
+            "deployment.environment",
+            "net.peer.name",
+        ],
+    )
+    def test_safe_keys_are_not_redacted(self, scrubber, key):
+        assert scrubber._should_redact(key, "some_value") is False
+
+    # ---- Content-key redaction (PII defence) ----
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "finding.description",
+            "finding.raw",
+            "finding.payload",
+            "finding.entity_context",
+            "llm.prompt",
+            "llm.response",
+            "gen_ai.prompt",
+            "gen_ai.completion",
+            "tool.input",
+            "tool.output",
+            "tool.result",
+        ],
+    )
+    def test_content_keys_are_redacted(self, scrubber, key):
+        assert scrubber._should_redact(key, "benign text") is True
+
+    # ---- Value-based redaction ----
+
+    def test_anthropic_api_key_in_value(self, scrubber):
+        value = "Authorization: sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890"
+        assert scrubber._should_redact("some.random.key", value) is True
+
+    def test_jwt_in_value(self, scrubber):
+        value = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+        assert scrubber._should_redact("some.header", value) is True
+
+    def test_postgres_connection_string_in_value(self, scrubber):
+        value = "postgresql://user:s3cretpass@db.example.com:5432/soc_db"
+        assert scrubber._should_redact("db.connection", value) is True
+
+    def test_redis_connection_string_in_value(self, scrubber):
+        value = "redis://default:mypassword@redis.example.com:6379/0"
+        assert scrubber._should_redact("cache.url", value) is True
+
+    def test_long_hex_token_in_value(self, scrubber):
+        value = "token=" + "a1b2c3d4" * 5  # 40 hex chars
+        assert scrubber._should_redact("some.field", value) is True
+
+    def test_aws_access_key_in_value(self, scrubber):
+        value = "AKIAIOSFODNN7EXAMPLE"
+        assert scrubber._should_redact("cloud.key", value) is True
+
+    def test_short_benign_values_not_redacted(self, scrubber):
+        assert scrubber._should_redact("http.method", "GET") is False
+        assert scrubber._should_redact("http.status_code", 200) is False
+        assert scrubber._should_redact("vigil.tool.tier", "safe") is False
+        assert scrubber._should_redact(
+            "gen_ai.request.model", "claude-sonnet-4-5-20250929"
+        ) is False
+
+    def test_numeric_values_not_redacted(self, scrubber):
+        assert scrubber._should_redact("gen_ai.usage.input_tokens", 1500) is False
+        assert scrubber._should_redact("vigil.llm.cost_usd", 0.0255) is False
+
+    def test_dsn_substring_false_positive(self, scrubber):
+        """Keys containing 'dsn' as part of another word must not be redacted."""
+        assert scrubber._should_redact("redesign_count", "5") is False
+        assert scrubber._should_redact("vigil.dsnark", "hello") is False
+
+    # ---- Span integration test ----
+
+    def test_on_end_scrubs_span_attributes(self):
+        try:
+            from opentelemetry.sdk.trace import TracerProvider
+        except ImportError:
+            pytest.skip("opentelemetry-sdk not installed")
+
+        from core.telemetry_sanitizer import SensitiveAttributeScrubber
+
+        provider = TracerProvider()
+        tracer = provider.get_tracer("test")
+        scrubber = SensitiveAttributeScrubber()
+
+        span = tracer.start_span("test-op")
+        span.set_attribute("http.method", "POST")
+        span.set_attribute("safe.attr", "hello")
+        span.set_attribute("my.api_key", "sk-ant-api03-secretstuff1234567890abcdef")
+        span.set_attribute(
+            "finding.description", "User admin logged in from 10.0.0.1"
+        )
+        span.set_attribute("gen_ai.usage.input_tokens", 500)
+        span.end()
+
+        scrubber.on_end(span)
+
+        attrs = dict(span.attributes)
+        assert attrs["http.method"] == "POST"
+        assert attrs["safe.attr"] == "hello"
+        assert attrs["gen_ai.usage.input_tokens"] == 500
+        assert attrs["my.api_key"] == "[REDACTED]"
+        assert attrs["finding.description"] == "[REDACTED]"
+
+        provider.shutdown()
+
+    def test_on_end_handles_empty_attributes(self):
+        from core.telemetry_sanitizer import SensitiveAttributeScrubber
+
+        scrubber = SensitiveAttributeScrubber()
+        mock_span = MagicMock()
+        mock_span.attributes = None
+        scrubber.on_end(mock_span)  # must not raise
+
+        mock_span.attributes = {}
+        scrubber.on_end(mock_span)  # must not raise
+
+    def test_on_end_handles_all_clean_attributes(self):
+        try:
+            from opentelemetry.sdk.trace import TracerProvider
+        except ImportError:
+            pytest.skip("opentelemetry-sdk not installed")
+
+        from core.telemetry_sanitizer import SensitiveAttributeScrubber
+
+        provider = TracerProvider()
+        tracer = provider.get_tracer("test")
+        scrubber = SensitiveAttributeScrubber()
+
+        span = tracer.start_span("clean-op")
+        span.set_attribute("http.method", "GET")
+        span.set_attribute("http.status_code", 200)
+        span.end()
+
+        scrubber.on_end(span)
+        attrs = dict(span.attributes)
+        assert attrs["http.method"] == "GET"
+        assert attrs["http.status_code"] == 200
+        provider.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Sanitizer stub when SDK not installed
+# ---------------------------------------------------------------------------
+
+class TestSanitizerStub:
+    def test_stub_methods_exist(self):
+        from core.telemetry_sanitizer import SensitiveAttributeScrubber
+
+        s = SensitiveAttributeScrubber()
+        s.on_start(MagicMock())
+        s.on_end(MagicMock())
+        s.on_shutdown()
+        assert s.force_flush() is True
+
+
+# ---------------------------------------------------------------------------
+# Fallback no-op types
+# ---------------------------------------------------------------------------
+
+class TestFallbackNoOps:
+    """The fallback types must be fully functional no-ops."""
+
+    def test_noop_span_all_methods(self):
+        from core.telemetry import _NoOpSpan
+
+        span = _NoOpSpan()
+        span.set_attribute("k", "v")
+        span.set_status("ok")
+        span.record_exception(ValueError("test"))
+        span.add_event("evt", {"key": "val"})
+        span.end()
+        # is_recording is a method (not a property) — call it correctly
+        assert span.is_recording() is False
+
+    def test_noop_span_context_manager(self):
+        from core.telemetry import _NoOpSpan
+
+        with _NoOpSpan() as span:
+            span.set_attribute("k", "v")
+
+    def test_fallback_tracer(self):
+        from core.telemetry import _FallbackNoOpTracer
+
+        tracer = _FallbackNoOpTracer()
+        span = tracer.start_span("test")
+        assert span.is_recording() is False
+        with tracer.start_as_current_span("test2") as s:
+            s.set_attribute("k", "v")
+
+    def test_fallback_meter(self):
+        from core.telemetry import _FallbackNoOpMeter
+
+        meter = _FallbackNoOpMeter()
+        c = meter.create_counter("c")
+        c.add(1)
+        h = meter.create_histogram("h")
+        h.record(1.0)
+        meter.create_observable_gauge("g")
+        u = meter.create_up_down_counter("u")
+        u.add(-1)


### PR DESCRIPTION
## Summary

End-to-end OpenTelemetry observability across all Vigil processes, closing the full #53–#60 epic in one PR. **Supersedes PR #62** — this branch includes everything from #62 plus all subsequent instrumentation phases, with 4 bugs from #62's review fixed.

Closes #53, #54, #55, #56, #57, #58, #59, #60

---

### Phase 0 — OTEL SDK bootstrap + data sanitizer (closes #53)

Ports and corrects `core/telemetry.py` and `core/telemetry_sanitizer.py` from PR #62, fixing all 4 bugs flagged in review:

| # | Bug | Fix |
|---|-----|-----|
| 1 | `_should_record_llm_content()` / `_should_record_ioc_values()` never called | Wired into `SensitiveAttributeScrubber.on_end()` |
| 2 | Docstring claimed "allowlist" but implementation is blocklist | Docstring corrected |
| 3 | `shutdown()` left `_initialized=True`, blocking reinitialization | Reset to `False` at end of shutdown |
| 4 | `_NoOpSpan.is_recording` was a `@property`; OTEL SDK defines it as a method | Converted to `def is_recording(self) -> bool:` |

Additionally fixes a 5th bug not in PR #62: `_key_segment_matches()` used a per-segment comparison that failed to match multi-word patterns (`api_key`, `auth_token`) across separator types while simultaneously producing false positives. Replaced with a contiguous sub-sequence algorithm.

**74 unit tests, all passing.**

Public API (`from core.telemetry import ...`):
```python
init_telemetry(service_name)   # call once at process start
shutdown_telemetry()           # call at process shutdown
get_tracer(name)               # NoOp when disabled
get_meter(name)                # NoOp when disabled
inject_traceparent(carrier)    # dict with W3C traceparent key
extract_traceparent(carrier)   # restore context from dict
create_genai_metrics(meter)    # {llm_calls, llm_duration, llm_tokens, llm_cost_usd}
```

---

### Phase 1 — Structured JSON logging (closes #59)

- `init_telemetry()` installs `_OTELJsonFormatter` on the root logger replacing `basicConfig`, emitting JSON lines with `trace_id`, `span_id`, `service.name`, and any `vigil.*` extras
- `daemon/workdir.py` `append_log()`: every JSONL investigation event now includes `trace_id`, `span_id`, and `vigil.investigation.id` for direct correlation in Jaeger/Grafana

---

### Phase 2 — Backend instrumentation (closes #54)

- **`backend/main.py`**: `init_telemetry("vigil-backend")` before app creation; `FastAPIInstrumentation` auto-instruments all routes (excluding `/api/health,metrics`); **fixes pre-existing bug** where `init_sentry()` was imported but never called at startup
- **`backend/monitoring.py`**: `SentrySpanProcessor` forwards ERROR spans as Sentry breadcrumbs and attaches `otel.trace_id` to Sentry scope; `traces_sample_rate=0` in Sentry when OTEL active (prevents double-tracing)
- **`database/connection.py`**: `SQLAlchemyInstrumentor` after engine creation (try/except, non-fatal)
- **`services/llm_gateway.py`**: `RedisInstrumentor`; W3C `traceparent` injected into all 5 `enqueue_job()` calls crossing the Redis/ARQ boundary

---

### Phase 3 — Daemon distributed tracing (closes #55)

- **`daemon/main.py`**: `init_telemetry("vigil-daemon")` / `shutdown_telemetry()` lifecycle
- **`daemon/orchestrator.py`**: root `"investigation"` span with `vigil.investigation.id`, `workflow_id`, `priority`; `traceparent` stored in `inv_record` for cross-async reconnection; OTEL counters dual-written alongside `self.stats` dict (zero callers changed)
- **`daemon/agent_runner.py`**: full `agent_run → iteration → llm_call → tool_call` span hierarchy; token counts + `gen_ai.finish_reason` from response; tool spans with `vigil.tool.tier`, `input_size`, `output_size`, `duration_ms`, `success`
- **`services/llm_worker.py`**: `init_telemetry("vigil-llm-worker")`; `traceparent: str = ""` default kwarg on both ARQ worker functions — old queued jobs without the kwarg degrade gracefully to no parent context

---

### Phase 4 — LLM call instrumentation with GenAI conventions (closes #56)

- **`services/claude_service.py`**: `"claude.chat"` span (`SpanKind.CLIENT`) wrapping `client.messages.create()`; sets `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.finish_reason`
- 4 metric instruments via `create_genai_metrics()`: `llm_calls_total`, `llm_duration_seconds`, `llm_tokens_total`, `llm_cost_usd_total` (using existing cost constants in the file)
- Prompt/completion content **never** recorded in spans (controlled by `VIGIL_OTEL_LOG_LLM_CONTENT`)

---

### Phase 5 — MCP and tool call tracing (closes #57)

- **`services/mcp_client.py`**: `"mcp.call_tool"` span (`SpanKind.CLIENT`) with `mcp.server.name`, `mcp.transport="stdio"`, `vigil.tool.name`, `input_size`, `output_size`, `duration_ms`, `success`; `asyncio.TimeoutError` → `StatusCode.ERROR`
- **`daemon/agent_runner.py`** (tool dispatch): `"tool_call"` spans with `vigil.tool.tier` — content never logged, only sizes

---

### Phase 6 — Prometheus metrics migration (closes #58)

- **`daemon/metrics.py`**: `DaemonMetrics` rewritten as a thin OTEL wrapper around `soc_daemon_*` counters/histograms. **Public interface preserved exactly** — `record_poll()`, `record_processing()`, `get_summary()`, `reset()`, `get_poll_count()`, `get_total_processed()` signatures unchanged; all callers (poller, processor, responder, scheduler) need zero changes. In-memory shadow counters maintained for synchronous reads.
- **`MetricsServer`** drops `_handle_metrics()` entirely (Prometheus `/metrics` on 9090 now served by OTEL `PrometheusMetricReader`); server moves to `DAEMON_HEALTH_PORT` (default 9091) serving only `/health` and `/status`
- **`daemon/config.py`**: default port 9090 → 9091; env var `DAEMON_METRICS_PORT` → `DAEMON_HEALTH_PORT`

---

### Phase 7 — Docker observability stack (closes #60)

Opt-in via `docker-compose --profile observability up -d` — zero impact on the base stack:

| Service | Image | Port |
|---------|-------|------|
| `otel-collector` | `otel/opentelemetry-collector-contrib:0.100.0` | 4317 (gRPC), 4318 (HTTP) |
| `jaeger` | `jaegertracing/all-in-one:1.57` | 16686 (UI) |
| `prometheus` | `prom/prometheus:v2.51.2` | 9095 on host |
| `grafana` | `grafana/grafana:10.4.0` | 3001 |

3 pre-provisioned Grafana dashboards:
- **System Overview**: daemon uptime, findings rate, HTTP rate, error rate, active agents
- **LLM Costs**: hourly cost, tokens/model, call duration P50/P95/P99
- **Investigation Lifecycle**: investigations created/completed/failed, agent concurrency, tool success rate by tier, cost per investigation

No external exporters — all telemetry stays within the SOC network boundary.

`env.example` updated with full OTEL variable documentation.

---

## Test plan

- [x] `pytest tests/unit/test_telemetry.py -v` — 74/74 passing
- [ ] `docker-compose --profile observability up -d` → Jaeger UI at `http://localhost:16686`
- [ ] Make an API request → verify trace in Jaeger with SQLAlchemy child spans
- [ ] Trigger daemon investigation → verify `investigation → agent_run → iteration → llm_call → llm_worker.execute → claude.chat` chain in Jaeger
- [ ] `curl http://localhost:9090/metrics | grep soc_daemon_` → all counter families present
- [ ] `tail -f ~/.deeptempo/vigil.log | jq .` → JSON lines with `trace_id`, `span_id` fields
- [ ] Verify `docker-compose up -d` (no profile) still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)