### PR TITLE
fix(db): ensure SQLAlchemy schema is created at startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -210,7 +210,27 @@ async def startup_event():
         from services.database_data_service import DatabaseDataService
         from core.config import is_demo_mode
         import os
-        
+
+        # Defense-in-depth: ensure the SQLAlchemy-managed schema exists before
+        # any endpoint tries to query it. start_web.sh runs scripts/init_schema.py
+        # first, but this covers environments that launch uvicorn directly
+        # (e.g. Docker, systemd, CI). When DATA_BACKEND=database, a failure
+        # here is fatal — we do NOT silently fall back to JSON because that
+        # leaves the DB in an inconsistent state (some endpoints use
+        # get_db_session() directly, see backend/api/case_metrics.py).
+        data_backend_env = os.getenv('DATA_BACKEND', 'database').lower()
+        if not is_demo_mode() and data_backend_env == 'database':
+            try:
+                from database.connection import init_database
+                init_database(echo=False, create_tables=True)
+                logger.info("✓ Database schema ensured (create_all)")
+            except Exception as schema_err:
+                logger.error(
+                    "Fatal: could not initialize database schema: %s",
+                    schema_err,
+                )
+                raise
+
         # Check for demo mode first
         if is_demo_mode():
             logger.info("=" * 40)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,9 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./database/init:/docker-entrypoint-initdb.d
+      # Path is relative to this compose file (docker/), so ../ points at
+      # the repo root where database/init/ actually lives.
+      - ../database/init:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U deeptempo -d deeptempo_soc"]
       interval: 10s

--- a/scripts/init_schema.py
+++ b/scripts/init_schema.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Initialize Vigil SOC database schema.
+
+Calls ``init_database(create_tables=True)`` which runs
+``Base.metadata.create_all()`` against the configured PostgreSQL database.
+All ORM models are imported inside ``database/connection.py`` so every
+``__tablename__`` is registered with ``Base.metadata`` before creation.
+
+This script is idempotent (``CREATE TABLE IF NOT EXISTS`` semantics) and
+is meant to run during startup before any user/role bootstrap script.
+
+Exits non-zero on failure so the caller can fail loudly instead of
+silently falling through to a JSON storage fallback.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path when invoked directly
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
+
+from database.connection import init_database, get_db_manager  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("init_schema")
+
+
+def main() -> int:
+    logger.info("Initializing database schema (create_all)...")
+    try:
+        init_database(echo=False, create_tables=True)
+    except Exception as exc:
+        logger.error("Failed to initialize database schema: %s", exc)
+        return 1
+
+    db_manager = get_db_manager()
+    if not db_manager.health_check():
+        logger.error("Database health check failed after schema init")
+        return 1
+
+    logger.info("Database schema ready")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start_web.sh
+++ b/start_web.sh
@@ -155,6 +155,19 @@ if command -v docker &> /dev/null; then
         echo "✓ Redis started"
     fi
     
+    # Initialize database schema (SQLAlchemy Base.metadata.create_all)
+    # Runs BEFORE init_default_user.py because user/role tables and all
+    # case_* tables must exist before any bootstrap or API query.
+    echo ""
+    echo "Initializing database schema..."
+    if ! python3 scripts/init_schema.py; then
+        echo "❌ Database schema initialization failed."
+        echo "   The backend will not start correctly without a valid schema."
+        echo "   Check PostgreSQL connectivity and the error above."
+        exit 1
+    fi
+    echo "✓ Database schema ready"
+
     # Initialize default admin user
     echo ""
     echo "Initializing default admin user..."


### PR DESCRIPTION
## Summary
- Adds `scripts/init_schema.py` that runs `Base.metadata.create_all()` and exits non-zero on failure; wired into `start_web.sh` before `init_default_user.py`.
- Hardens `backend/main.py` startup to call `init_database(create_tables=True)` explicitly and raise on failure instead of silently falling back to JSON.
- Fixes the `docker-compose.yml` init-scripts volume path (`./database/init` → `../database/init`).

## Why
Users hit `500 relation "cases" does not exist` on `/api/cases/metrics/by-status` and `/api/cases/metrics/analyst-performance`. The `cases` table and ~14 related `case_*` tables are defined only as SQLAlchemy models (`database/models.py`), not in `database/init/*.sql`. Schema creation was only attempted via `DatabaseDataService()` at backend startup, which swallowed errors and fell through to a JSON fallback — leaving endpoints that call `get_db_session()` directly (e.g. `backend/api/case_metrics.py:383,435`) querying a DB with no tables.

## Test plan
- [ ] Clean slate: `cd docker && docker compose down -v && cd .. && ./start_web.sh`
- [ ] Verify tables exist: `docker exec deeptempo-postgres psql -U deeptempo -d deeptempo_soc -c "\dt"` shows `cases` and `case_*` tables
- [ ] `curl -sf http://localhost:6987/api/cases/metrics/by-status` returns 200
- [ ] `curl -sf http://localhost:6987/api/cases/metrics/analyst-performance` returns 200
- [ ] `pytest tests/ -k case -v`

## Note (out of scope)
Logs also show `GET /api/api/analytics?timeRange=7d → 404` — a frontend double-prefix bug (client prepending `/api` to an already-prefixed URL). Not fixed here; worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)