### PR TITLE
Add Darktrace webhook push ingestion

### DIFF
--- a/backend/api/darktrace_webhook.py
+++ b/backend/api/darktrace_webhook.py
@@ -1,0 +1,186 @@
+"""
+Darktrace inbound webhook receiver.
+
+Accepts pushes from Darktrace (SaaS tenants and on-prem master appliances)
+for three alert streams — Model Breach, AI Analyst, and System Status —
+verifies an HMAC-SHA256 signature against a shared secret, transforms each
+payload into a Vigil finding via ``DarktraceIngestionService``, and ingests
+it through the shared ``IngestionService``.
+
+Endpoints:
+    POST /api/webhooks/darktrace/model-breach
+    POST /api/webhooks/darktrace/ai-analyst
+    POST /api/webhooks/darktrace/system-status
+    GET  /api/webhooks/darktrace/health
+
+Signature header: ``X-Darktrace-Signature`` (hex HMAC-SHA256 of raw body).
+"""
+
+import hmac
+import logging
+import os
+from hashlib import sha256
+from typing import Callable, Dict, Optional
+
+from fastapi import APIRouter, Header, HTTPException, Request, status
+
+from services.darktrace_ingestion import DarktraceIngestionService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Hard cap on webhook body size (1 MiB is generous for a single alert).
+MAX_BODY_BYTES = int(os.environ.get("DARKTRACE_MAX_BODY_KB", "1024")) * 1024
+
+
+def _get_secret() -> Optional[str]:
+    """Fetch the HMAC shared secret at request time (not import time) so
+    tests and runtime env changes are picked up."""
+    secret = os.environ.get("DARKTRACE_WEBHOOK_SECRET")
+    return secret or None
+
+
+def _get_console_url() -> str:
+    return os.environ.get("DARKTRACE_URL", "") or ""
+
+
+def _verify_signature(raw_body: bytes, provided: Optional[str]) -> bool:
+    secret = _get_secret()
+    if not secret:
+        # Fail closed: without a configured secret we cannot authenticate.
+        return False
+    if not provided:
+        return False
+    expected = hmac.new(secret.encode("utf-8"), raw_body, sha256).hexdigest()
+    # Strip common prefix if Darktrace wraps signature (e.g. "sha256=...").
+    clean = provided.split("=", 1)[-1].strip()
+    return hmac.compare_digest(expected, clean)
+
+
+async def _read_and_verify(
+    request: Request, signature: Optional[str]
+) -> bytes:
+    if not _get_secret():
+        logger.error(
+            "DARKTRACE_WEBHOOK_SECRET not configured; rejecting webhook"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Darktrace webhook receiver not configured",
+        )
+    raw = await request.body()
+    if len(raw) > MAX_BODY_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Body exceeds {MAX_BODY_BYTES} bytes",
+        )
+    if not _verify_signature(raw, signature):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing X-Darktrace-Signature",
+        )
+    return raw
+
+
+def _parse_json(raw: bytes) -> Dict:
+    import json
+
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid JSON body: {e}",
+        )
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Webhook payload must be a JSON object",
+        )
+    return payload
+
+
+def _ingest(
+    payload: Dict,
+    transform: Callable[[DarktraceIngestionService, Dict], Optional[Dict]],
+    alert_type: str,
+) -> Dict:
+    service = DarktraceIngestionService(console_url=_get_console_url())
+    finding = transform(service, payload)
+    if finding is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unable to transform Darktrace {alert_type} payload",
+        )
+    try:
+        ok = service.ingestion_service.ingest_finding(finding)
+    except Exception as e:
+        logger.exception("Darktrace %s ingestion failed", alert_type)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Ingestion error: {e}",
+        )
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Finding was not persisted",
+        )
+    logger.info(
+        "Darktrace %s ingested: finding_id=%s",
+        alert_type,
+        finding.get("finding_id"),
+    )
+    return {"accepted": True, "finding_id": finding["finding_id"]}
+
+
+@router.get("/health")
+async def health() -> Dict:
+    """Liveness probe for Darktrace's webhook test feature."""
+    return {
+        "status": "ok",
+        "receiver": "darktrace",
+        "secret_configured": _get_secret() is not None,
+    }
+
+
+@router.post("/model-breach", status_code=status.HTTP_202_ACCEPTED)
+async def model_breach(
+    request: Request,
+    x_darktrace_signature: Optional[str] = Header(default=None),
+) -> Dict:
+    raw = await _read_and_verify(request, x_darktrace_signature)
+    payload = _parse_json(raw)
+    return _ingest(
+        payload,
+        lambda svc, p: svc.transform_model_breach(p),
+        "model-breach",
+    )
+
+
+@router.post("/ai-analyst", status_code=status.HTTP_202_ACCEPTED)
+async def ai_analyst(
+    request: Request,
+    x_darktrace_signature: Optional[str] = Header(default=None),
+) -> Dict:
+    raw = await _read_and_verify(request, x_darktrace_signature)
+    payload = _parse_json(raw)
+    return _ingest(
+        payload,
+        lambda svc, p: svc.transform_ai_analyst(p),
+        "ai-analyst",
+    )
+
+
+@router.post("/system-status", status_code=status.HTTP_202_ACCEPTED)
+async def system_status(
+    request: Request,
+    x_darktrace_signature: Optional[str] = Header(default=None),
+) -> Dict:
+    raw = await _read_and_verify(request, x_darktrace_signature)
+    payload = _parse_json(raw)
+    return _ingest(
+        payload,
+        lambda svc, p: svc.transform_system_status(p),
+        "system-status",
+    )

--- a/backend/api/darktrace_webhook.py
+++ b/backend/api/darktrace_webhook.py
@@ -16,6 +16,7 @@ Endpoints:
 Signature header: ``X-Darktrace-Signature`` (hex HMAC-SHA256 of raw body).
 """
 
+import asyncio
 import hmac
 import logging
 import os
@@ -58,13 +59,9 @@ def _verify_signature(raw_body: bytes, provided: Optional[str]) -> bool:
     return hmac.compare_digest(expected, clean)
 
 
-async def _read_and_verify(
-    request: Request, signature: Optional[str]
-) -> bytes:
+async def _read_and_verify(request: Request, signature: Optional[str]) -> bytes:
     if not _get_secret():
-        logger.error(
-            "DARKTRACE_WEBHOOK_SECRET not configured; rejecting webhook"
-        )
+        logger.error("DARKTRACE_WEBHOOK_SECRET not configured; rejecting webhook")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Darktrace webhook receiver not configured",
@@ -151,7 +148,8 @@ async def model_breach(
 ) -> Dict:
     raw = await _read_and_verify(request, x_darktrace_signature)
     payload = _parse_json(raw)
-    return _ingest(
+    return await asyncio.to_thread(
+        _ingest,
         payload,
         lambda svc, p: svc.transform_model_breach(p),
         "model-breach",
@@ -165,7 +163,8 @@ async def ai_analyst(
 ) -> Dict:
     raw = await _read_and_verify(request, x_darktrace_signature)
     payload = _parse_json(raw)
-    return _ingest(
+    return await asyncio.to_thread(
+        _ingest,
         payload,
         lambda svc, p: svc.transform_ai_analyst(p),
         "ai-analyst",
@@ -179,7 +178,8 @@ async def system_status(
 ) -> Dict:
     raw = await _read_and_verify(request, x_darktrace_signature)
     payload = _parse_json(raw)
-    return _ingest(
+    return await asyncio.to_thread(
+        _ingest,
         payload,
         lambda svc, p: svc.transform_system_status(p),
         "system-status",

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ Main application entry point for the REST API server.
 
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -166,11 +167,15 @@ app.include_router(case_templates_router, prefix="/api/cases/templates", tags=["
 app.include_router(case_metrics_router, prefix="/api/cases/metrics", tags=["case-metrics"])
 app.include_router(case_search_router, prefix="/api/cases/search", tags=["case-search"])
 app.include_router(webhooks_router, prefix="/api/webhooks", tags=["webhooks"])
-app.include_router(
-    darktrace_webhook_router,
-    prefix="/api/webhooks/darktrace",
-    tags=["darktrace"],
-)
+# Darktrace inbound webhook receiver — only mount when explicitly enabled.
+# env.example and docs/integrations/DARKTRACE.md document DARKTRACE_ENABLED
+# as the on/off toggle; leaving it unset must leave the receiver off.
+if os.environ.get("DARKTRACE_ENABLED", "false").lower() == "true":
+    app.include_router(
+        darktrace_webhook_router,
+        prefix="/api/webhooks/darktrace",
+        tags=["darktrace"],
+    )
 app.include_router(sla_policies_router, prefix="/api/sla-policies", tags=["sla-policies"])
 
 @app.on_event("startup")

--- a/backend/main.py
+++ b/backend/main.py
@@ -49,6 +49,9 @@ from api.case_search import router as case_search_router
 from api.webhooks import router as webhooks_router
 from api.sla_policies import router as sla_policies_router
 
+# Darktrace inbound webhook receiver
+from api.darktrace_webhook import router as darktrace_webhook_router
+
 # Authentication routers
 from api.auth import router as auth_router
 from api.users import router as users_router
@@ -163,6 +166,11 @@ app.include_router(case_templates_router, prefix="/api/cases/templates", tags=["
 app.include_router(case_metrics_router, prefix="/api/cases/metrics", tags=["case-metrics"])
 app.include_router(case_search_router, prefix="/api/cases/search", tags=["case-search"])
 app.include_router(webhooks_router, prefix="/api/webhooks", tags=["webhooks"])
+app.include_router(
+    darktrace_webhook_router,
+    prefix="/api/webhooks/darktrace",
+    tags=["darktrace"],
+)
 app.include_router(sla_policies_router, prefix="/api/sla-policies", tags=["sla-policies"])
 
 @app.on_event("startup")

--- a/docs/integrations/DARKTRACE.md
+++ b/docs/integrations/DARKTRACE.md
@@ -1,0 +1,93 @@
+# Darktrace Integration
+
+Vigil accepts **pushed alerts** from Darktrace via signed HTTP webhooks. Both
+Darktrace SaaS tenants and on-prem master appliances are supported — they
+emit the same JSON payload shapes.
+
+There is currently no MCP (agent-pull) tool for Darktrace; this cut is
+push-only. Investigations that want to pivot back into Darktrace should
+follow the console link stored on each ingested finding.
+
+## Supported alert streams
+
+| Stream | Endpoint |
+|---|---|
+| Model Breach Alerts | `POST /api/webhooks/darktrace/model-breach` |
+| AI Analyst Incidents | `POST /api/webhooks/darktrace/ai-analyst` |
+| System Status Alerts | `POST /api/webhooks/darktrace/system-status` |
+| Health probe (GET) | `GET  /api/webhooks/darktrace/health` |
+
+Each alert is transformed into a Vigil `finding` (`data_source = "darktrace"`)
+and passed to the standard ingestion pipeline, so triage, correlation, and
+case creation work identically to Splunk/CrowdStrike sources.
+
+## Vigil configuration
+
+Set in `.env`:
+
+```
+DARKTRACE_ENABLED=true
+DARKTRACE_URL=https://<tenant>.cloud.darktrace.com    # or https://<on-prem-master>
+DARKTRACE_WEBHOOK_SECRET=<random-32+-char-string>
+# optional — hard cap on webhook body size (default 1024 KB)
+DARKTRACE_MAX_BODY_KB=1024
+```
+
+Generate a secret:
+
+```
+openssl rand -hex 32
+```
+
+`DARKTRACE_URL` is optional. When set, every ingested finding gets an
+`evidence_links` entry pointing back to the originating console (model
+breach or AI Analyst incident URL).
+
+## Darktrace configuration
+
+1. In the Darktrace Threat Visualizer: **System Config → Workflow Integrations → Add** → choose **Custom Webhook** (or the specific integration if available for AI Analyst).
+2. **URL**: `https://<vigil-host>:6987/api/webhooks/darktrace/model-breach` (repeat for `ai-analyst` and `system-status` — each endpoint is separate so you can wire each stream independently).
+3. **Authentication**: select **HMAC-SHA256**. Paste the same value you used for `DARKTRACE_WEBHOOK_SECRET`.
+4. **Signature header**: `X-Darktrace-Signature` — hex HMAC-SHA256 over the raw request body. Vigil also accepts the `sha256=...` prefix style.
+5. Click **Test** — Vigil returns `202 Accepted` on success, `401` if the signature doesn't match.
+
+### SaaS vs on-prem notes
+
+- **SaaS** tenants cannot emit syslog over the public internet — webhooks are the only option. Make sure Vigil is reachable at a TLS-terminated, publicly-routable URL.
+- **On-prem** masters work the same way; if your Vigil instance is only reachable internally, point Darktrace at the internal hostname. Syslog remains possible for on-prem deployments but is not used by this integration.
+
+## Verifying end-to-end
+
+1. Run Vigil's backend (`./start_web.sh` or `uvicorn backend.main:app --reload`).
+2. Confirm the receiver is live:
+   ```bash
+   curl https://<vigil-host>:6987/api/webhooks/darktrace/health
+   ```
+3. Smoke test with a signed payload:
+   ```bash
+   BODY='{"pbid":12345,"model":{"name":"Device / Anomalous Connection"},"score":0.92,"device":{"ip":"10.0.0.5","hostname":"laptop-01"},"time":1712995200000}'
+   SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$DARKTRACE_WEBHOOK_SECRET" -hex | awk '{print $2}')
+   curl -X POST https://<vigil-host>:6987/api/webhooks/darktrace/model-breach \
+     -H "Content-Type: application/json" \
+     -H "X-Darktrace-Signature: $SIG" \
+     -d "$BODY"
+   ```
+   Expect `HTTP 202` with `{"accepted": true, "finding_id": "f-YYYYMMDD-xxxxxxxx"}`.
+4. Confirm ingestion: `curl https://<vigil-host>:6987/api/findings?data_source=darktrace`.
+
+## Idempotency
+
+Vigil derives each `finding_id` from the alert's stable identifier
+(`pbid` for Model Breach, `uuid` for AI Analyst, `id`/`name` fallback for
+System Status). Replaying the same webhook produces the same finding ID,
+which the ingestion layer skips as a duplicate — safe to re-deliver.
+
+## Security
+
+- Every request body is HMAC-verified before any parsing. Unsigned/invalid
+  requests are rejected with `401` and no content is touched.
+- If `DARKTRACE_WEBHOOK_SECRET` is unset the receiver fails closed with
+  `503` — it never ingests unauthenticated traffic.
+- Bodies above `DARKTRACE_MAX_BODY_KB` are rejected with `413`.
+- Expose the endpoint over TLS only; the signature protects integrity but
+  not confidentiality.

--- a/env.example
+++ b/env.example
@@ -69,6 +69,17 @@ CRIBL_USERNAME="admin"
 CRIBL_PASSWORD="your_cribl_password"
 CRIBL_WORKER_GROUP="default"
 
+# Darktrace (inbound webhook receiver — push-only in this integration)
+# Works with both SaaS tenants and on-prem master appliances.
+# DARKTRACE_URL is optional; when set it's used to build back-links from
+# findings into the Darktrace console (SaaS: https://<tenant>.cloud.darktrace.com,
+# on-prem: https://<master-ip-or-host>).
+DARKTRACE_ENABLED="false"
+DARKTRACE_URL=""
+DARKTRACE_WEBHOOK_SECRET=""
+# Optional hard cap on webhook body size (KB). Default 1024.
+DARKTRACE_MAX_BODY_KB="1024"
+
 # -----------------------------------------------------------------------------
 # Threat Intelligence
 # -----------------------------------------------------------------------------

--- a/services/darktrace_ingestion.py
+++ b/services/darktrace_ingestion.py
@@ -12,6 +12,7 @@ as a no-op to satisfy the interface.
 """
 
 import hashlib
+import json
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -131,9 +132,7 @@ class DarktraceIngestionService(SIEMIngestionService):
         logger.warning("Unrecognized Darktrace payload shape; skipping")
         return None
 
-    def transform_model_breach(
-        self, alert: Dict[str, Any]
-    ) -> Optional[Dict[str, Any]]:
+    def transform_model_breach(self, alert: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Transform a Darktrace Model Breach Alert."""
         pbid = alert.get("pbid")
         if pbid is None:
@@ -178,9 +177,7 @@ class DarktraceIngestionService(SIEMIngestionService):
             "status": "new",
         }
 
-    def transform_ai_analyst(
-        self, alert: Dict[str, Any]
-    ) -> Optional[Dict[str, Any]]:
+    def transform_ai_analyst(self, alert: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Transform a Darktrace AI Analyst Incident/Event."""
         uuid = alert.get("uuid") or alert.get("id")
         if not uuid:
@@ -190,13 +187,18 @@ class DarktraceIngestionService(SIEMIngestionService):
         ts = _parse_dt_time(
             alert.get("createdAt") or alert.get("start") or alert.get("time")
         )
-        # AI Analyst exposes a 0-100 "groupScore" (event criticality)
-        score = _score_to_anomaly(
-            alert.get("groupScore") or alert.get("score") or 0.5
-        )
+        # AI Analyst exposes a 0-100 "groupScore" (event criticality).
+        # Use explicit None checks so a legitimate zero (minimum criticality)
+        # is preserved instead of falling through to the 0.5 default.
+        gs = alert.get("groupScore")
+        sc = alert.get("score")
+        raw_score = gs if gs is not None else (sc if sc is not None else 0.5)
+        score = _score_to_anomaly(raw_score)
 
         entity_context: Dict[str, Any] = {}
-        breach_devices = alert.get("breachDevices") or alert.get("relatedBreaches") or []
+        breach_devices = (
+            alert.get("breachDevices") or alert.get("relatedBreaches") or []
+        )
         if breach_devices and isinstance(breach_devices, list):
             first = breach_devices[0] if isinstance(breach_devices[0], dict) else {}
             if first.get("ip"):
@@ -233,11 +235,15 @@ class DarktraceIngestionService(SIEMIngestionService):
         self, alert: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
         """Transform a Darktrace System Status Alert (health/operational)."""
+        # Deterministic fallback: Python's builtin hash() is seeded per
+        # process (PYTHONHASHSEED), which would make the finding_id change
+        # on every worker restart and break idempotent replay dedup. Use a
+        # stable SHA-1 digest over sorted JSON instead.
+        fallback_key = hashlib.sha1(
+            json.dumps({k: str(v) for k, v in sorted(alert.items())}).encode("utf-8")
+        ).hexdigest()
         key = (
-            alert.get("id")
-            or alert.get("eventId")
-            or alert.get("name")
-            or str(hash(frozenset((k, str(v)) for k, v in alert.items())))
+            alert.get("id") or alert.get("eventId") or alert.get("name") or fallback_key
         )
         ts = _parse_dt_time(alert.get("time") or alert.get("timestamp"))
         # System status is informational/operational — keep score low

--- a/services/darktrace_ingestion.py
+++ b/services/darktrace_ingestion.py
@@ -1,0 +1,261 @@
+"""
+Darktrace Ingestion Service.
+
+Transforms inbound Darktrace webhook payloads (Model Breach, AI Analyst,
+System Status) into Vigil finding dictionaries and hands them to the shared
+``IngestionService``.
+
+Darktrace pushes alerts via outbound webhooks (SaaS tenants have no syslog
+option over the public internet), so this service does not poll. The
+``fetch_alerts`` abstract method from ``SIEMIngestionService`` is implemented
+as a no-op to satisfy the interface.
+"""
+
+import hashlib
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from services.siem_ingestion_service import SIEMIngestionService
+
+logger = logging.getLogger(__name__)
+
+DATA_SOURCE = "darktrace"
+DEFAULT_EMBEDDING_DIM = 768
+
+
+def _finding_id(prefix: str, stable_key: str, ts: datetime) -> str:
+    """Generate a schema-compliant finding_id: f-YYYYMMDD-<8hex>.
+
+    ``stable_key`` is hashed so the same Darktrace event always produces the
+    same finding_id (idempotent replay through the webhook).
+    """
+    digest = hashlib.sha1(f"{prefix}:{stable_key}".encode("utf-8")).hexdigest()[:8]
+    return f"f-{ts.strftime('%Y%m%d')}-{digest}"
+
+
+def _parse_dt_time(value: Any) -> datetime:
+    """Darktrace ships timestamps as epoch-ms ints or ISO strings."""
+    if value is None:
+        return datetime.now(timezone.utc)
+    if isinstance(value, (int, float)):
+        # Darktrace uses epoch milliseconds
+        try:
+            return datetime.fromtimestamp(value / 1000.0, tz=timezone.utc)
+        except (OSError, ValueError, OverflowError):
+            return datetime.now(timezone.utc)
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.now(timezone.utc)
+
+
+def _score_to_anomaly(score: Any) -> float:
+    """Darktrace breach scores are 0-1 floats. Clamp safely."""
+    try:
+        s = float(score)
+    except (TypeError, ValueError):
+        return 0.5
+    # Some older payloads ship 0-100 integers
+    if s > 1.0:
+        s = s / 100.0
+    return max(0.0, min(1.0, s))
+
+
+def _score_to_severity(score: float) -> str:
+    if score >= 0.9:
+        return "critical"
+    if score >= 0.7:
+        return "high"
+    if score >= 0.4:
+        return "medium"
+    if score >= 0.2:
+        return "low"
+    return "info"
+
+
+def _extract_mitre(tags_or_tactics: Any) -> Dict[str, float]:
+    """AI Analyst payloads include MITRE tactic/technique tags.
+
+    Darktrace emits either a list of dicts like ``{"name": "T1071.001"}`` or
+    plain technique strings. We preserve only things that look like MITRE IDs
+    and default confidence to 0.7 (Darktrace does not ship per-tag scores).
+    """
+    out: Dict[str, float] = {}
+    if not tags_or_tactics:
+        return out
+    items = tags_or_tactics if isinstance(tags_or_tactics, list) else [tags_or_tactics]
+    for item in items:
+        if isinstance(item, dict):
+            val = item.get("name") or item.get("id") or item.get("technique")
+        else:
+            val = item
+        if not val:
+            continue
+        val = str(val).strip()
+        # MITRE technique IDs start with T followed by digits
+        if val.startswith("T") and val[1:].split(".")[0].isdigit():
+            out[val] = 0.7
+    return out
+
+
+class DarktraceIngestionService(SIEMIngestionService):
+    """Transform and ingest Darktrace webhook payloads."""
+
+    def __init__(self, console_url: Optional[str] = None):
+        super().__init__()
+        self.siem_name = "Darktrace"
+        self.console_url = (console_url or "").rstrip("/")
+
+    async def fetch_alerts(
+        self,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """Darktrace is push-only in this integration; no polling."""
+        return []
+
+    # Required by the abstract base. For webhook ingress we dispatch by type
+    # via ``transform_model_breach`` / ``transform_ai_analyst`` /
+    # ``transform_system_status`` — this default delegates by payload shape.
+    def transform_alert_to_finding(
+        self, alert: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        if "pbid" in alert or "model" in alert:
+            return self.transform_model_breach(alert)
+        if "uuid" in alert and ("title" in alert or "aianalyst" in str(alert).lower()):
+            return self.transform_ai_analyst(alert)
+        if "systemStatus" in alert or "status" in alert:
+            return self.transform_system_status(alert)
+        logger.warning("Unrecognized Darktrace payload shape; skipping")
+        return None
+
+    def transform_model_breach(
+        self, alert: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Transform a Darktrace Model Breach Alert."""
+        pbid = alert.get("pbid")
+        if pbid is None:
+            logger.warning("Darktrace model breach missing pbid; skipping")
+            return None
+
+        ts = _parse_dt_time(alert.get("time") or alert.get("triggered"))
+        score = _score_to_anomaly(alert.get("score"))
+        device = alert.get("device") or {}
+        model = alert.get("model") or {}
+
+        entity_context: Dict[str, Any] = {}
+        if device.get("ip"):
+            entity_context["src_ip"] = device["ip"]
+        if device.get("hostname"):
+            entity_context["hostname"] = device["hostname"]
+        if device.get("mac"):
+            entity_context["mac"] = device["mac"]
+        if alert.get("destinationIp"):
+            entity_context["dst_ip"] = alert["destinationIp"]
+
+        evidence_links = []
+        if self.console_url:
+            evidence_links.append(
+                {
+                    "type": "flow",
+                    "ref": f"{self.console_url}/#modelbreach/{pbid}",
+                }
+            )
+
+        return {
+            "finding_id": _finding_id("dt-mb", str(pbid), ts),
+            "embedding": [0.0] * DEFAULT_EMBEDDING_DIM,
+            "mitre_predictions": _extract_mitre(model.get("tags")),
+            "anomaly_score": score,
+            "timestamp": ts.isoformat(),
+            "data_source": DATA_SOURCE,
+            "description": model.get("name") or "Darktrace Model Breach",
+            "entity_context": entity_context or None,
+            "evidence_links": evidence_links or None,
+            "severity": _score_to_severity(score),
+            "status": "new",
+        }
+
+    def transform_ai_analyst(
+        self, alert: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Transform a Darktrace AI Analyst Incident/Event."""
+        uuid = alert.get("uuid") or alert.get("id")
+        if not uuid:
+            logger.warning("Darktrace AI Analyst payload missing uuid; skipping")
+            return None
+
+        ts = _parse_dt_time(
+            alert.get("createdAt") or alert.get("start") or alert.get("time")
+        )
+        # AI Analyst exposes a 0-100 "groupScore" (event criticality)
+        score = _score_to_anomaly(
+            alert.get("groupScore") or alert.get("score") or 0.5
+        )
+
+        entity_context: Dict[str, Any] = {}
+        breach_devices = alert.get("breachDevices") or alert.get("relatedBreaches") or []
+        if breach_devices and isinstance(breach_devices, list):
+            first = breach_devices[0] if isinstance(breach_devices[0], dict) else {}
+            if first.get("ip"):
+                entity_context["src_ip"] = first["ip"]
+            if first.get("hostname"):
+                entity_context["hostname"] = first["hostname"]
+
+        evidence_links = []
+        if self.console_url:
+            evidence_links.append(
+                {
+                    "type": "flow",
+                    "ref": f"{self.console_url}/#aianalyst/incident/{uuid}",
+                }
+            )
+
+        return {
+            "finding_id": _finding_id("dt-ai", str(uuid), ts),
+            "embedding": [0.0] * DEFAULT_EMBEDDING_DIM,
+            "mitre_predictions": _extract_mitre(
+                alert.get("mitreTactics") or alert.get("tags")
+            ),
+            "anomaly_score": score,
+            "timestamp": ts.isoformat(),
+            "data_source": DATA_SOURCE,
+            "description": alert.get("title") or "Darktrace AI Analyst Incident",
+            "entity_context": entity_context or None,
+            "evidence_links": evidence_links or None,
+            "severity": _score_to_severity(score),
+            "status": "new",
+        }
+
+    def transform_system_status(
+        self, alert: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Transform a Darktrace System Status Alert (health/operational)."""
+        key = (
+            alert.get("id")
+            or alert.get("eventId")
+            or alert.get("name")
+            or str(hash(frozenset((k, str(v)) for k, v in alert.items())))
+        )
+        ts = _parse_dt_time(alert.get("time") or alert.get("timestamp"))
+        # System status is informational/operational — keep score low
+        score = 0.2
+        status_level = str(alert.get("status") or alert.get("level") or "info").lower()
+        severity = self.normalize_severity(status_level)
+
+        return {
+            "finding_id": _finding_id("dt-sys", str(key), ts),
+            "embedding": [0.0] * DEFAULT_EMBEDDING_DIM,
+            "mitre_predictions": {},
+            "anomaly_score": score,
+            "timestamp": ts.isoformat(),
+            "data_source": DATA_SOURCE,
+            "description": alert.get("message")
+            or alert.get("name")
+            or "Darktrace System Status",
+            "entity_context": None,
+            "severity": severity,
+            "status": "new",
+        }

--- a/tests/test_darktrace_webhook.py
+++ b/tests/test_darktrace_webhook.py
@@ -1,0 +1,293 @@
+"""Tests for the Darktrace inbound webhook receiver."""
+
+import hashlib
+import hmac
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Mirror backend/main.py's sys.path setup so intra-package imports like
+# `from api.foo import ...` in backend/api/__init__.py resolve.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_BACKEND_DIR = _REPO_ROOT / "backend"
+for p in (str(_REPO_ROOT), str(_BACKEND_DIR)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+# Load the receiver module directly (bypassing backend/api/__init__.py which
+# eagerly imports many heavy modules not needed for this test).
+_spec = importlib.util.spec_from_file_location(
+    "darktrace_webhook_under_test",
+    _BACKEND_DIR / "api" / "darktrace_webhook.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["darktrace_webhook_under_test"] = _mod
+_spec.loader.exec_module(_mod)
+darktrace_router = _mod.router
+
+from services.darktrace_ingestion import DarktraceIngestionService  # noqa: E402
+
+
+SECRET = "unit-test-secret"
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def app(monkeypatch):
+    monkeypatch.setenv("DARKTRACE_WEBHOOK_SECRET", SECRET)
+    monkeypatch.setenv("DARKTRACE_URL", "https://dt.example.com")
+    _app = FastAPI()
+    _app.include_router(darktrace_router, prefix="/api/webhooks/darktrace")
+    return _app
+
+
+@pytest.fixture()
+def client(app):
+    return TestClient(app)
+
+
+def _sign(body: bytes) -> str:
+    return hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _post(client, path: str, payload: dict, sig: str | None = None) -> "object":
+    body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if sig is None:
+        sig = _sign(body)
+    if sig:
+        headers["X-Darktrace-Signature"] = sig
+    return client.post(path, content=body, headers=headers)
+
+
+MODEL_BREACH_SAMPLE = {
+    "pbid": 4242,
+    "time": 1712995200000,
+    "score": 0.87,
+    "model": {
+        "name": "Device / Anomalous Connection",
+        "tags": [{"name": "T1071.001"}, {"name": "T1048"}],
+    },
+    "device": {"ip": "10.0.0.5", "hostname": "laptop-01", "mac": "aa:bb:cc:dd:ee:ff"},
+    "destinationIp": "203.0.113.9",
+}
+
+AI_ANALYST_SAMPLE = {
+    "uuid": "e4c1d7ad-1111-4222-8333-9ab00c0de01e",
+    "title": "Possible Command & Control Activity",
+    "createdAt": "2026-04-01T12:34:56Z",
+    "groupScore": 92,
+    "mitreTactics": ["T1071"],
+    "breachDevices": [{"ip": "10.0.0.5", "hostname": "laptop-01"}],
+}
+
+SYSTEM_STATUS_SAMPLE = {
+    "id": "sys-123",
+    "name": "Probe Disconnected",
+    "status": "warning",
+    "time": 1712995200000,
+    "message": "Probe dt-probe-1 lost contact for 5m",
+}
+
+
+# ---------------------------------------------------------------------------
+# Transform unit tests (no network, no ingestion)
+# ---------------------------------------------------------------------------
+
+class TestTransforms:
+    def test_model_breach_maps_core_fields(self):
+        svc = DarktraceIngestionService(console_url="https://dt.example.com")
+        f = svc.transform_model_breach(MODEL_BREACH_SAMPLE)
+        assert f is not None
+        assert re.match(r"^f-\d{8}-[a-f0-9]{8}$", f["finding_id"])
+        assert f["data_source"] == "darktrace"
+        assert f["anomaly_score"] == pytest.approx(0.87)
+        assert f["severity"] == "high"
+        assert f["entity_context"] == {
+            "src_ip": "10.0.0.5",
+            "hostname": "laptop-01",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "dst_ip": "203.0.113.9",
+        }
+        assert f["mitre_predictions"] == {"T1071.001": 0.7, "T1048": 0.7}
+        assert f["evidence_links"][0]["ref"].endswith("/#modelbreach/4242")
+        assert len(f["embedding"]) == 768
+
+    def test_model_breach_idempotent_finding_id(self):
+        svc = DarktraceIngestionService()
+        a = svc.transform_model_breach(MODEL_BREACH_SAMPLE)
+        b = svc.transform_model_breach(MODEL_BREACH_SAMPLE)
+        assert a["finding_id"] == b["finding_id"]
+
+    def test_model_breach_missing_pbid_returns_none(self):
+        svc = DarktraceIngestionService()
+        assert svc.transform_model_breach({"score": 0.5}) is None
+
+    def test_ai_analyst_maps_score_and_mitre(self):
+        svc = DarktraceIngestionService(console_url="https://dt.example.com")
+        f = svc.transform_ai_analyst(AI_ANALYST_SAMPLE)
+        assert f is not None
+        # groupScore 92 is on 0-100 scale -> clamped to 0.92
+        assert f["anomaly_score"] == pytest.approx(0.92)
+        assert f["severity"] == "critical"
+        assert f["mitre_predictions"] == {"T1071": 0.7}
+        assert f["entity_context"]["src_ip"] == "10.0.0.5"
+        assert "aianalyst/incident" in f["evidence_links"][0]["ref"]
+
+    def test_system_status_always_informational(self):
+        svc = DarktraceIngestionService()
+        f = svc.transform_system_status(SYSTEM_STATUS_SAMPLE)
+        assert f is not None
+        assert f["anomaly_score"] == pytest.approx(0.2)
+        assert f["severity"] == "medium"  # "warning" -> medium via normalize
+        assert f["data_source"] == "darktrace"
+
+    def test_dispatch_by_shape(self):
+        svc = DarktraceIngestionService()
+        assert svc.transform_alert_to_finding(MODEL_BREACH_SAMPLE)["description"]
+        assert svc.transform_alert_to_finding(AI_ANALYST_SAMPLE)["description"]
+        assert svc.transform_alert_to_finding(SYSTEM_STATUS_SAMPLE)["description"]
+
+
+# ---------------------------------------------------------------------------
+# HMAC / route tests
+# ---------------------------------------------------------------------------
+
+class TestSignatureVerification:
+    def test_missing_signature_rejected(self, client):
+        body = json.dumps(MODEL_BREACH_SAMPLE).encode()
+        r = client.post(
+            "/api/webhooks/darktrace/model-breach",
+            content=body,
+            headers={"Content-Type": "application/json"},
+        )
+        assert r.status_code == 401
+
+    def test_bad_signature_rejected(self, client):
+        r = _post(
+            client,
+            "/api/webhooks/darktrace/model-breach",
+            MODEL_BREACH_SAMPLE,
+            sig="deadbeef" * 8,
+        )
+        assert r.status_code == 401
+
+    def test_valid_signature_with_sha256_prefix(self, client):
+        body = json.dumps(MODEL_BREACH_SAMPLE).encode()
+        sig = "sha256=" + _sign(body)
+        with patch(
+            "darktrace_webhook_under_test.DarktraceIngestionService"
+        ) as MockSvc:
+            instance = MockSvc.return_value
+            instance.transform_model_breach.return_value = {
+                "finding_id": "f-20260101-deadbeef"
+            }
+            instance.ingestion_service.ingest_finding.return_value = True
+            r = client.post(
+                "/api/webhooks/darktrace/model-breach",
+                content=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Darktrace-Signature": sig,
+                },
+            )
+        assert r.status_code == 202
+
+
+class TestRoutes:
+    def _patched_service(self, finding_id="f-20260101-deadbeef"):
+        p = patch("darktrace_webhook_under_test.DarktraceIngestionService")
+        MockSvc = p.start()
+        instance = MockSvc.return_value
+        instance.transform_model_breach.return_value = {"finding_id": finding_id}
+        instance.transform_ai_analyst.return_value = {"finding_id": finding_id}
+        instance.transform_system_status.return_value = {"finding_id": finding_id}
+        instance.ingestion_service.ingest_finding.return_value = True
+        return p, instance
+
+    def test_model_breach_accepted(self, client):
+        p, inst = self._patched_service()
+        try:
+            r = _post(
+                client, "/api/webhooks/darktrace/model-breach", MODEL_BREACH_SAMPLE
+            )
+        finally:
+            p.stop()
+        assert r.status_code == 202
+        assert r.json()["accepted"] is True
+        inst.ingestion_service.ingest_finding.assert_called_once()
+
+    def test_ai_analyst_accepted(self, client):
+        p, inst = self._patched_service()
+        try:
+            r = _post(
+                client, "/api/webhooks/darktrace/ai-analyst", AI_ANALYST_SAMPLE
+            )
+        finally:
+            p.stop()
+        assert r.status_code == 202
+        inst.ingestion_service.ingest_finding.assert_called_once()
+
+    def test_system_status_accepted(self, client):
+        p, inst = self._patched_service()
+        try:
+            r = _post(
+                client,
+                "/api/webhooks/darktrace/system-status",
+                SYSTEM_STATUS_SAMPLE,
+            )
+        finally:
+            p.stop()
+        assert r.status_code == 202
+
+    def test_malformed_json_422(self, client):
+        body = b"{not valid json"
+        sig = _sign(body)
+        r = client.post(
+            "/api/webhooks/darktrace/model-breach",
+            content=body,
+            headers={
+                "Content-Type": "application/json",
+                "X-Darktrace-Signature": sig,
+            },
+        )
+        assert r.status_code == 422
+
+    def test_untransformable_payload_422(self, client):
+        # Missing pbid makes transform_model_breach return None
+        r = _post(client, "/api/webhooks/darktrace/model-breach", {"score": 0.5})
+        assert r.status_code == 422
+
+    def test_health_endpoint(self, client):
+        r = client.get("/api/webhooks/darktrace/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "ok"
+        assert data["secret_configured"] is True
+
+
+class TestMisconfiguration:
+    def test_no_secret_returns_503(self, monkeypatch):
+        monkeypatch.delenv("DARKTRACE_WEBHOOK_SECRET", raising=False)
+        app = FastAPI()
+        app.include_router(darktrace_router, prefix="/api/webhooks/darktrace")
+        c = TestClient(app)
+        r = c.post(
+            "/api/webhooks/darktrace/model-breach",
+            content=b"{}",
+            headers={
+                "Content-Type": "application/json",
+                "X-Darktrace-Signature": "x",
+            },
+        )
+        assert r.status_code == 503

--- a/tests/test_darktrace_webhook.py
+++ b/tests/test_darktrace_webhook.py
@@ -34,13 +34,13 @@ darktrace_router = _mod.router
 
 from services.darktrace_ingestion import DarktraceIngestionService  # noqa: E402
 
-
 SECRET = "unit-test-secret"
 
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture()
 def app(monkeypatch):
@@ -104,6 +104,7 @@ SYSTEM_STATUS_SAMPLE = {
 # Transform unit tests (no network, no ingestion)
 # ---------------------------------------------------------------------------
 
+
 class TestTransforms:
     def test_model_breach_maps_core_fields(self):
         svc = DarktraceIngestionService(console_url="https://dt.example.com")
@@ -144,6 +145,25 @@ class TestTransforms:
         assert f["entity_context"]["src_ip"] == "10.0.0.5"
         assert "aianalyst/incident" in f["evidence_links"][0]["ref"]
 
+    def test_ai_analyst_zero_groupscore_preserved(self):
+        """Regression: groupScore=0 must map to anomaly_score=0.0 / info.
+
+        A legitimate zero (Darktrace's minimum criticality) used to fall
+        through the ``or``-chain to the 0.5 default, inflating a zero-
+        criticality event to medium severity.
+        """
+        svc = DarktraceIngestionService()
+        payload = {
+            "uuid": "zero-score-incident",
+            "title": "Low Noise Event",
+            "createdAt": "2026-04-01T00:00:00Z",
+            "groupScore": 0,
+        }
+        f = svc.transform_ai_analyst(payload)
+        assert f is not None
+        assert f["anomaly_score"] == pytest.approx(0.0)
+        assert f["severity"] == "info"
+
     def test_system_status_always_informational(self):
         svc = DarktraceIngestionService()
         f = svc.transform_system_status(SYSTEM_STATUS_SAMPLE)
@@ -151,6 +171,34 @@ class TestTransforms:
         assert f["anomaly_score"] == pytest.approx(0.2)
         assert f["severity"] == "medium"  # "warning" -> medium via normalize
         assert f["data_source"] == "darktrace"
+
+    def test_system_status_fallback_finding_id_is_deterministic(self):
+        """Regression: fallback key must be stable across processes.
+
+        Previously used ``hash(frozenset(...))``, which is randomized per
+        process (PYTHONHASHSEED) and would silently duplicate findings
+        across worker restarts. Simulate a second process by patching the
+        builtin ``hash`` to ensure the output no longer depends on it.
+        """
+        svc = DarktraceIngestionService()
+        payload = {
+            "status": "warning",
+            "time": 1712995200000,
+            "message": "Probe lost",
+        }
+        first = svc.transform_system_status(payload)
+
+        # Monkeypatch the builtin hash to prove determinism doesn't rely on it.
+        import builtins
+
+        original_hash = builtins.hash
+        try:
+            builtins.hash = lambda _obj: 424242  # noqa: E731
+            second = svc.transform_system_status(payload)
+        finally:
+            builtins.hash = original_hash
+
+        assert first["finding_id"] == second["finding_id"]
 
     def test_dispatch_by_shape(self):
         svc = DarktraceIngestionService()
@@ -162,6 +210,7 @@ class TestTransforms:
 # ---------------------------------------------------------------------------
 # HMAC / route tests
 # ---------------------------------------------------------------------------
+
 
 class TestSignatureVerification:
     def test_missing_signature_rejected(self, client):
@@ -185,9 +234,7 @@ class TestSignatureVerification:
     def test_valid_signature_with_sha256_prefix(self, client):
         body = json.dumps(MODEL_BREACH_SAMPLE).encode()
         sig = "sha256=" + _sign(body)
-        with patch(
-            "darktrace_webhook_under_test.DarktraceIngestionService"
-        ) as MockSvc:
+        with patch("darktrace_webhook_under_test.DarktraceIngestionService") as MockSvc:
             instance = MockSvc.return_value
             instance.transform_model_breach.return_value = {
                 "finding_id": "f-20260101-deadbeef"
@@ -230,9 +277,7 @@ class TestRoutes:
     def test_ai_analyst_accepted(self, client):
         p, inst = self._patched_service()
         try:
-            r = _post(
-                client, "/api/webhooks/darktrace/ai-analyst", AI_ANALYST_SAMPLE
-            )
+            r = _post(client, "/api/webhooks/darktrace/ai-analyst", AI_ANALYST_SAMPLE)
         finally:
             p.stop()
         assert r.status_code == 202


### PR DESCRIPTION
## Summary
- Adds inbound webhook receiver for Darktrace NDR alerts (Model Breach, AI Analyst, System Status) at `/api/webhooks/darktrace/*`
- HMAC-SHA256 signature verification on every request; fails closed (503) if secret is unconfigured
- Transforms each Darktrace payload → Vigil finding via `DarktraceIngestionService`, feeding the existing `IngestionService` pipeline (triage, correlation, case creation all work unchanged)
- Supports both Darktrace SaaS tenants and on-prem master appliances

## Files changed
| File | What |
|---|---|
| `services/darktrace_ingestion.py` | Transform service: 3 alert-type transforms, idempotent finding IDs, MITRE tag extraction, score normalization, console back-links |
| `backend/api/darktrace_webhook.py` | FastAPI router: HMAC verify, 3 POST endpoints (202), health GET, body-size cap |
| `backend/main.py` | Register router at `/api/webhooks/darktrace` |
| `env.example` | `DARKTRACE_ENABLED`, `DARKTRACE_URL`, `DARKTRACE_WEBHOOK_SECRET`, `DARKTRACE_MAX_BODY_KB` |
| `tests/test_darktrace_webhook.py` | 16 tests: transforms, signature verify, route happy/error paths, health, misconfiguration |
| `docs/integrations/DARKTRACE.md` | Setup guide for SaaS + on-prem |

## Test plan
- [x] 16 unit tests pass (`pytest tests/test_darktrace_webhook.py -v`)
- [ ] Smoke test with signed curl payload against running backend
- [ ] End-to-end: configure webhook in Darktrace lab tenant, trigger Model Breach, confirm finding appears in Vigil

🤖 Generated with [Claude Code](https://claude.com/claude-code)