### PR TITLE
feat(elastic): add Elastic Security service client and config

### DIFF
--- a/backend/api/cases.py
+++ b/backend/api/cases.py
@@ -138,6 +138,60 @@ async def create_case(case_data: CaseCreate):
     return case
 
 
+async def _sync_upstream_status(case_id: str, new_status: str) -> None:
+    """Best-effort sync of case status to the upstream SIEM."""
+    import logging
+    _logger = logging.getLogger(__name__)
+    try:
+        case = data_service.get_case(case_id)
+        if not case:
+            return
+        # Only sync findings that came from a SIEM with upstream support
+        finding_ids = case.get("finding_ids", [])
+        for fid in finding_ids:
+            finding = data_service.get_finding(fid)
+            if not finding:
+                continue
+            source = finding.get("data_source", "")
+            alert_id = (finding.get("metadata") or {}).get(
+                f"{source}_alert_id"
+            ) or (finding.get("metadata") or {}).get("elastic_alert_id")
+            if not alert_id:
+                continue
+            # Lazy-load the right ingestion service
+            svc = _get_ingestion_service(source)
+            if svc is None:
+                continue
+            try:
+                await svc.update_upstream_alert_status(alert_id, new_status)
+                _logger.info(
+                    f"Synced status '{new_status}' to {source} alert {alert_id}"
+                )
+            except NotImplementedError:
+                pass
+            except Exception as exc:
+                _logger.warning(
+                    f"Failed to sync status to {source} alert {alert_id}: {exc}"
+                )
+    except Exception as exc:
+        import logging
+        logging.getLogger(__name__).warning(
+            f"Upstream status sync error for case {case_id}: {exc}"
+        )
+
+
+def _get_ingestion_service(source: str):
+    """Return the ingestion service for a given data source, or None."""
+    if source == "elastic":
+        try:
+            from services.elastic_ingestion import ElasticIngestion
+            return ElasticIngestion()
+        except Exception:
+            return None
+    # Future: add splunk, crowdstrike, etc.
+    return None
+
+
 @router.patch("/{case_id}")
 async def update_case(case_id: str, case_data: CaseUpdate):
     """
@@ -164,10 +218,17 @@ async def update_case(case_id: str, case_data: CaseUpdate):
         updates['notes'] = case_data.notes
     
     success = data_service.update_case(case_id, **updates)
-    
+
     if not success:
         raise HTTPException(status_code=404, detail="Case not found or update failed")
-    
+
+    # Fire upstream SIEM status sync when status changes
+    if case_data.status is not None:
+        import asyncio
+        asyncio.ensure_future(
+            _sync_upstream_status(case_id, case_data.status)
+        )
+
     return {"success": True}
 
 

--- a/daemon/poller.py
+++ b/daemon/poller.py
@@ -46,8 +46,9 @@ class DataPoller:
         self._azure_sentinel_state = PollState()
         self._aws_security_hub_state = PollState()
         self._microsoft_defender_state = PollState()
+        self._elastic_state = PollState()
         self._generic_state = PollState()
-        
+
         # Services (lazy loaded)
         self._splunk_service = None
         self._crowdstrike_service = None
@@ -55,7 +56,8 @@ class DataPoller:
         self._azure_sentinel_service = None
         self._aws_security_hub_service = None
         self._microsoft_defender_service = None
-        
+        self._elastic_service = None
+
         # Stats
         self.stats = {
             "splunk_polls": 0,
@@ -68,6 +70,8 @@ class DataPoller:
             "aws_security_hub_findings": 0,
             "microsoft_defender_polls": 0,
             "microsoft_defender_findings": 0,
+            "elastic_polls": 0,
+            "elastic_findings": 0,
             "webhook_findings": 0,
             "errors": 0
         }
@@ -136,7 +140,16 @@ class DataPoller:
                     logger.info("Microsoft Defender service initialized")
                 except Exception as e:
                     logger.warning(f"Failed to initialize Microsoft Defender service: {e}")
-            
+
+            # Initialize Elastic Security service if configured
+            if is_integration_enabled('elastic-siem'):
+                try:
+                    from services.elastic_ingestion import ElasticIngestion
+                    self._elastic_service = ElasticIngestion()
+                    logger.info("Elastic Security service initialized")
+                except Exception as e:
+                    logger.warning(f"Failed to initialize Elastic Security service: {e}")
+
             # Initialize data service for database access
             from services.database_data_service import DatabaseDataService
             self._data_service = DatabaseDataService()
@@ -176,7 +189,12 @@ class DataPoller:
             tasks.append(asyncio.create_task(
                 self._poll_microsoft_defender_loop(shutdown_event)
             ))
-        
+
+        if self._elastic_service:
+            tasks.append(asyncio.create_task(
+                self._poll_elastic_loop(shutdown_event)
+            ))
+
         if self.config.webhook_enabled:
             tasks.append(asyncio.create_task(
                 self._run_webhook_server(shutdown_event)
@@ -623,3 +641,54 @@ class DataPoller:
                 logger.error(f"Microsoft Defender ingestion failed: {result.get('errors')}")
         except Exception as e:
             logger.error(f"Error polling Microsoft Defender: {e}")
+
+    async def _poll_elastic_loop(self, shutdown_event: asyncio.Event):
+        """Poll Elastic Security for new detection alerts on interval."""
+        interval = self.config.splunk_interval  # Use same interval as Splunk
+        logger.info(f"Elastic Security polling loop started (interval: {interval}s)")
+
+        while not shutdown_event.is_set():
+            try:
+                await self._poll_elastic()
+                self._elastic_state.last_poll_time = datetime.utcnow()
+            except Exception as e:
+                logger.error(f"Elastic Security polling error: {e}")
+                self.stats["errors"] += 1
+
+            try:
+                await asyncio.wait_for(shutdown_event.wait(), timeout=interval)
+                break
+            except asyncio.TimeoutError:
+                pass
+
+    async def _poll_elastic(self):
+        """Poll Elastic Security for new detection alerts."""
+        if not self._elastic_service:
+            return
+
+        self.stats["elastic_polls"] += 1
+        logger.debug("Polling Elastic Security for new alerts...")
+
+        try:
+            lookback_minutes = max(self.config.splunk_interval // 60 + 1, 5)
+            start_time = datetime.utcnow() - timedelta(minutes=lookback_minutes)
+
+            alerts = await self._elastic_service.fetch_alerts(
+                start_time=start_time, limit=100
+            )
+
+            new_count = 0
+            for alert in alerts:
+                finding = self._elastic_service.transform_alert_to_finding(alert)
+                if finding and not self._elastic_state.is_processed(finding["finding_id"]):
+                    await self._enqueue_finding(finding, "elastic")
+                    self._elastic_state.mark_processed(finding["finding_id"])
+                    new_count += 1
+
+            if new_count > 0:
+                logger.info(f"Polled {new_count} new findings from Elastic Security")
+                self.stats["elastic_findings"] += new_count
+
+        except Exception as e:
+            logger.error(f"Elastic Security API error: {e}")
+            raise

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -36,7 +36,7 @@ Backend tools are automatically enabled for web UI users via the Claude Agent SD
 | Core | deeptempo-findings, approval, attack-layer, tempo-flow | Implemented |
 | Community | GitHub, PostgreSQL | Active |
 | Detection Engineering | Security-Detections-MCP | Implemented |
-| SIEM | Splunk | Implemented |
+| SIEM | Splunk, Elastic Security | Implemented |
 | Timeline | Timesketch | Implemented |
 | Threat Intel | VirusTotal, Shodan, AlienVault OTX, MISP, URL Analysis, IP Geolocation | Implemented |
 | EDR | CrowdStrike | Implemented |
@@ -158,6 +158,42 @@ Settings > Integrations > Splunk:
 | `search_by_username` | Quick user search |
 | `natural_language_search` | Generate and execute |
 | `get_splunk_indexes` | List available indexes |
+
+## Elastic Security
+
+Elasticsearch SIEM with detection alert ingestion, bi-directional case sync, and IOC enrichment.
+
+### Configuration
+
+```bash
+ELASTIC_HOST="https://elasticsearch.example.com:9200"
+ELASTIC_KIBANA_URL="https://kibana.example.com:5601"
+ELASTIC_API_KEY="your_api_key"
+# Or use basic auth:
+# ELASTIC_USERNAME="elastic"
+# ELASTIC_PASSWORD="your_password"
+```
+
+Settings > Integrations > Elastic Security (SIEM):
+- Elasticsearch URL
+- Kibana URL (required for detection alerts and case sync)
+- API Key or Username/Password
+- Alert Index Pattern (default: `.alerts-security.alerts-default`)
+
+### MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `elastic_search_logs` | Search Elasticsearch with query DSL |
+| `elastic_search_by_ioc` | Search by IOC (IP, hash, username, hostname) |
+| `elastic_get_indices` | List available indices |
+| `elastic_get_detection_alerts` | Fetch recent detection alerts |
+
+### Features
+
+- **Alert Ingestion**: Daemon poller fetches detection alerts from Kibana Detections API
+- **Bi-directional Sync**: Case status changes in Vigil sync back to Elastic Security alerts
+- **IOC Enrichment**: Agents query Elasticsearch indices for logs matching case IOCs
 
 ## Timesketch
 

--- a/env.example
+++ b/env.example
@@ -58,6 +58,16 @@ CROWDSTRIKE_CLIENT_ID=""
 CROWDSTRIKE_CLIENT_SECRET=""
 CROWDSTRIKE_BASE_URL="https://api.crowdstrike.com"
 
+# Elastic Security / Elasticsearch SIEM
+ELASTIC_HOST="https://elasticsearch.example.com:9200"
+ELASTIC_KIBANA_URL="https://kibana.example.com:5601"
+ELASTIC_API_KEY=""
+# Alternative to API key — basic auth:
+# ELASTIC_USERNAME="elastic"
+# ELASTIC_PASSWORD="your_elastic_password"
+ELASTIC_VERIFY_SSL="true"
+ELASTIC_INDEX_PATTERN=".alerts-security.alerts-default"
+
 # Timesketch
 TIMESKETCH_URL="http://localhost:5000"
 TIMESKETCH_USERNAME="admin"

--- a/frontend/src/config/integrations.ts
+++ b/frontend/src/config/integrations.ts
@@ -846,6 +846,22 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
         helpText: 'Required if using username auth',
       },
       {
+        name: 'kibana_url',
+        label: 'Kibana URL',
+        type: 'url',
+        required: false,
+        placeholder: 'https://kibana.example.com:5601',
+        helpText: 'Required for detection alert ingestion and case sync. Leave blank if only using Elasticsearch search.',
+      },
+      {
+        name: 'index_pattern',
+        label: 'Alert Index Pattern',
+        type: 'text',
+        required: false,
+        default: '.alerts-security.alerts-default',
+        helpText: 'Elasticsearch index pattern for security alerts.',
+      },
+      {
         name: 'verify_ssl',
         label: 'Verify SSL Certificate',
         type: 'boolean',

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -100,6 +100,15 @@
       }
     },
 
+    "elastic": {
+      "command": "python3",
+      "args": ["tools/elastic.py"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "_setup_note": "Elastic Security via Elasticsearch REST API. Set ELASTIC_HOST (e.g., https://elasticsearch.example.com:9200), ELASTIC_API_KEY or ELASTIC_USERNAME/ELASTIC_PASSWORD, and optionally ELASTIC_KIBANA_URL in .env."
+      }
+    },
+
     "pagerduty": {
       "command": "uvx",
       "args": ["pagerduty-mcp", "--enable-write-tools"],

--- a/services/elastic_enrichment_service.py
+++ b/services/elastic_enrichment_service.py
@@ -1,0 +1,191 @@
+"""Elastic enrichment service with Claude AI analysis."""
+
+import json
+import logging
+import re
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from services.elastic_service import ElasticService
+from services.database_data_service import DatabaseDataService
+
+logger = logging.getLogger(__name__)
+
+
+class ElasticEnrichmentService:
+    """Service for enriching cases and findings with Elasticsearch data."""
+
+    def __init__(
+        self,
+        elastic_service: ElasticService,
+        claude_service=None,
+    ):
+        self.elastic_service = elastic_service
+        self.claude_service = claude_service
+        self.data_service = DatabaseDataService()
+
+    # ------------------------------------------------------------------
+    # IOC extraction
+    # ------------------------------------------------------------------
+
+    def extract_indicators(
+        self, case: Dict, findings: List[Dict]
+    ) -> Dict[str, List[str]]:
+        """Extract IOCs from case and findings."""
+        ip_pattern = r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
+        hash_pattern = (
+            r"\b[a-fA-F0-9]{32}\b|\b[a-fA-F0-9]{40}\b|\b[a-fA-F0-9]{64}\b"
+        )
+
+        indicators: Dict[str, set] = {
+            "ips": set(),
+            "hashes": set(),
+            "usernames": set(),
+            "hostnames": set(),
+        }
+
+        for blob in [case] + findings:
+            text = json.dumps(blob)
+            indicators["ips"].update(re.findall(ip_pattern, text))
+            indicators["hashes"].update(re.findall(hash_pattern, text))
+
+            ctx = blob.get("entity_context", {})
+            for key in ("src_ips", "dest_ips"):
+                for ip in ctx.get(key, []):
+                    indicators["ips"].add(str(ip))
+            for u in ctx.get("usernames", []):
+                indicators["usernames"].add(str(u))
+            for h in ctx.get("hostnames", []):
+                indicators["hostnames"].add(str(h))
+
+        # Filter private IPs
+        indicators["ips"] = {
+            ip for ip in indicators["ips"] if not _is_private_ip(ip)
+        }
+
+        return {k: sorted(v) for k, v in indicators.items()}
+
+    # ------------------------------------------------------------------
+    # Elasticsearch queries
+    # ------------------------------------------------------------------
+
+    async def query_elastic_for_indicators(
+        self,
+        indicators: Dict[str, List[str]],
+        hours: int = 168,
+        index: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Query Elasticsearch for each indicator type."""
+        enrichment: Dict[str, Any] = {
+            "query_time": datetime.utcnow().isoformat(),
+            "lookback_hours": hours,
+            "results": {},
+            "summary": {},
+        }
+        total = 0
+
+        if indicators.get("ips"):
+            enrichment["results"]["ips"] = {}
+            for ip in indicators["ips"][:10]:
+                result = await self.elastic_service.search_by_ip(
+                    ip, index=index, hours=hours
+                )
+                if result:
+                    hits = result.get("hits", {}).get("hits", [])[:100]
+                    enrichment["results"]["ips"][ip] = hits
+                    total += len(hits)
+
+        if indicators.get("hashes"):
+            enrichment["results"]["hashes"] = {}
+            for h in indicators["hashes"][:10]:
+                result = await self.elastic_service.search_by_hash(
+                    h, index=index, hours=hours
+                )
+                if result:
+                    hits = result.get("hits", {}).get("hits", [])[:100]
+                    enrichment["results"]["hashes"][h] = hits
+                    total += len(hits)
+
+        if indicators.get("usernames"):
+            enrichment["results"]["usernames"] = {}
+            for u in indicators["usernames"][:10]:
+                result = await self.elastic_service.search_by_username(
+                    u, index=index, hours=hours
+                )
+                if result:
+                    hits = result.get("hits", {}).get("hits", [])[:100]
+                    enrichment["results"]["usernames"][u] = hits
+                    total += len(hits)
+
+        if indicators.get("hostnames"):
+            enrichment["results"]["hostnames"] = {}
+            for h in indicators["hostnames"][:10]:
+                result = await self.elastic_service.search_by_hostname(
+                    h, index=index, hours=hours
+                )
+                if result:
+                    hits = result.get("hits", {}).get("hits", [])[:100]
+                    enrichment["results"]["hostnames"][h] = hits
+                    total += len(hits)
+
+        enrichment["summary"] = {
+            "total_events": total,
+            "ips_queried": len(indicators.get("ips", [])),
+            "hashes_queried": len(indicators.get("hashes", [])),
+            "usernames_queried": len(indicators.get("usernames", [])),
+            "hostnames_queried": len(indicators.get("hostnames", [])),
+        }
+        return enrichment
+
+    # ------------------------------------------------------------------
+    # Case enrichment
+    # ------------------------------------------------------------------
+
+    async def enrich_case(
+        self, case_id: str, lookback_hours: int = 168
+    ) -> Dict[str, Any]:
+        """Enrich a case with Elasticsearch data."""
+        case = self.data_service.get_case(case_id)
+        if not case:
+            return {"success": False, "error": f"Case {case_id} not found"}
+
+        findings = []
+        for fid in case.get("finding_ids", []):
+            f = self.data_service.get_finding(fid)
+            if f:
+                findings.append(f)
+
+        indicators = self.extract_indicators(case, findings)
+        enrichment = await self.query_elastic_for_indicators(
+            indicators, hours=lookback_hours
+        )
+
+        return {
+            "success": True,
+            "case_id": case_id,
+            "enrichment_timestamp": datetime.utcnow().isoformat(),
+            "indicators": {k: v for k, v in indicators.items() if v},
+            "elastic_data": enrichment,
+        }
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+def _is_private_ip(ip: str) -> bool:
+    try:
+        parts = [int(p) for p in ip.split(".")]
+        if len(parts) != 4:
+            return True
+        if parts[0] == 10:
+            return True
+        if parts[0] == 172 and 16 <= parts[1] <= 31:
+            return True
+        if parts[0] == 192 and parts[1] == 168:
+            return True
+        if parts[0] == 127:
+            return True
+        return False
+    except Exception:
+        return True

--- a/services/elastic_ingestion.py
+++ b/services/elastic_ingestion.py
@@ -1,0 +1,223 @@
+"""
+Elastic Security Ingestion Service - Ingest detection alerts from Elastic Security.
+
+Fetches detection alerts via the Kibana Detections API and converts them to findings.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+from services.siem_ingestion_service import SIEMIngestionService
+from services.elastic_service import ElasticService
+from core.config import get_integration_config
+
+logger = logging.getLogger(__name__)
+
+
+class ElasticIngestion(SIEMIngestionService):
+    """Elastic Security ingestion service."""
+
+    def __init__(self):
+        super().__init__()
+        self.siem_name = "Elastic Security"
+        self.config = get_integration_config("elastic-siem")
+        self._elastic_service: Optional[ElasticService] = None
+
+    def _get_elastic_service(self) -> Optional[ElasticService]:
+        if self._elastic_service:
+            return self._elastic_service
+
+        try:
+            host = self.config.get("elasticsearch_url")
+            if not host:
+                logger.error("Elastic configuration incomplete: missing elasticsearch_url")
+                return None
+
+            self._elastic_service = ElasticService(
+                elasticsearch_url=host,
+                kibana_url=self.config.get("kibana_url"),
+                api_key=self.config.get("api_key"),
+                username=self.config.get("username"),
+                password=self.config.get("password"),
+                verify_ssl=self.config.get("verify_ssl", True),
+                index_pattern=self.config.get(
+                    "index_pattern", ".alerts-security.alerts-default"
+                ),
+            )
+            return self._elastic_service
+        except Exception as e:
+            logger.error(f"Error creating Elastic service: {e}")
+            return None
+
+    async def fetch_alerts(
+        self,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        try:
+            svc = self._get_elastic_service()
+            if not svc:
+                return []
+
+            if not start_time:
+                start_time = datetime.utcnow() - timedelta(hours=24)
+
+            time_filter: Dict[str, Any] = {
+                "bool": {
+                    "filter": [
+                        {
+                            "range": {
+                                "@timestamp": {
+                                    "gte": start_time.isoformat() + "Z",
+                                    **(
+                                        {"lte": end_time.isoformat() + "Z"}
+                                        if end_time
+                                        else {}
+                                    ),
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+
+            result = await svc.fetch_detection_alerts(
+                query=time_filter, size=limit
+            )
+            if not result:
+                return []
+
+            hits = result.get("hits", {}).get("hits", [])
+            logger.info(f"Fetched {len(hits)} detection alerts from Elastic Security")
+            return hits
+        except Exception as e:
+            logger.error(f"Error fetching Elastic alerts: {e}")
+            return []
+
+    def transform_alert_to_finding(
+        self, alert: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        try:
+            source = alert.get("_source", {})
+            alert_id = alert.get("_id", uuid.uuid4().hex[:12])
+            finding_id = f"elastic-{alert_id}"
+
+            # Title from kibana.alert.rule.name or signal.rule.name
+            kibana_alert = source.get("kibana.alert.rule.name") or ""
+            signal = source.get("signal", {})
+            rule = signal.get("rule", {})
+            title = (
+                kibana_alert
+                or rule.get("name")
+                or source.get("rule", {}).get("name")
+                or "Elastic Security Alert"
+            )
+
+            description = (
+                source.get("kibana.alert.rule.description")
+                or rule.get("description")
+                or source.get("message", "")
+            )
+
+            # Severity
+            raw_severity = (
+                source.get("kibana.alert.severity")
+                or rule.get("severity")
+                or source.get("event", {}).get("severity")
+                or "medium"
+            )
+            severity = self.normalize_severity(raw_severity)
+
+            # Entities
+            entity_context: Dict[str, List[str]] = {
+                "src_ips": [],
+                "dest_ips": [],
+                "hostnames": [],
+                "usernames": [],
+            }
+
+            # Source / destination IPs
+            src = source.get("source", {})
+            dst = source.get("destination", {})
+            if src.get("ip"):
+                entity_context["src_ips"].append(str(src["ip"]))
+            if dst.get("ip"):
+                entity_context["dest_ips"].append(str(dst["ip"]))
+
+            # Host
+            host = source.get("host", {})
+            if host.get("name"):
+                entity_context["hostnames"].append(str(host["name"]))
+
+            # User
+            user = source.get("user", {})
+            if user.get("name"):
+                entity_context["usernames"].append(str(user["name"]))
+
+            # MITRE ATT&CK from rule threat metadata
+            mitre_predictions: Dict[str, float] = {}
+            threats = (
+                source.get("kibana.alert.rule.threat", [])
+                or rule.get("threat", [])
+            )
+            if isinstance(threats, list):
+                for threat in threats:
+                    technique = threat.get("technique", [])
+                    if isinstance(technique, list):
+                        for t in technique:
+                            tid = t.get("id")
+                            if tid:
+                                mitre_predictions[tid] = 0.9
+
+            return {
+                "finding_id": finding_id,
+                "data_source": "elastic",
+                "timestamp": source.get("@timestamp", datetime.utcnow().isoformat()),
+                "severity": severity,
+                "status": "new",
+                "title": title,
+                "description": description[:500] if description else "",
+                "entity_context": entity_context,
+                "raw_event": alert,
+                "anomaly_score": 0.5,
+                "mitre_predictions": mitre_predictions,
+                "embedding": [],
+                "metadata": {
+                    "elastic_alert_id": alert_id,
+                    "rule_id": (
+                        source.get("kibana.alert.rule.uuid")
+                        or rule.get("id", "")
+                    ),
+                    "rule_name": title,
+                    "index": alert.get("_index", ""),
+                    "kibana_case_ids": source.get("kibana.alert.case_ids", []),
+                },
+            }
+        except Exception as e:
+            logger.error(f"Error transforming Elastic alert: {e}")
+            return None
+
+    async def update_upstream_alert_status(
+        self,
+        alert_id: str,
+        status: str,
+        note: Optional[str] = None,
+    ) -> bool:
+        """Push a status change back to Elastic Security."""
+        svc = self._get_elastic_service()
+        if not svc:
+            return False
+
+        elastic_status_map = {
+            "acknowledged": "acknowledged",
+            "in_progress": "acknowledged",
+            "closed": "closed",
+            "resolved": "closed",
+            "open": "open",
+            "new": "open",
+        }
+        es_status = elastic_status_map.get(status, status)
+        return await svc.update_alert_status([alert_id], es_status)

--- a/services/elastic_service.py
+++ b/services/elastic_service.py
@@ -1,0 +1,339 @@
+"""Elastic Security / Elasticsearch API service for SIEM integration."""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class ElasticService:
+    """Service for interacting with Elasticsearch and Kibana Security APIs."""
+
+    def __init__(
+        self,
+        elasticsearch_url: str,
+        kibana_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        verify_ssl: bool = True,
+        index_pattern: str = ".alerts-security.alerts-default",
+    ):
+        self.elasticsearch_url = elasticsearch_url.rstrip("/")
+        self.kibana_url = (kibana_url or "").rstrip("/") or None
+        self.api_key = api_key
+        self.username = username
+        self.password = password
+        self.verify_ssl = verify_ssl
+        self.index_pattern = index_pattern
+
+        self._es_client: Optional[httpx.AsyncClient] = None
+        self._kibana_client: Optional[httpx.AsyncClient] = None
+
+    # ------------------------------------------------------------------
+    # Client lifecycle
+    # ------------------------------------------------------------------
+
+    def _build_es_client(self) -> httpx.AsyncClient:
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
+        auth = None
+        if self.api_key:
+            headers["Authorization"] = f"ApiKey {self.api_key}"
+        elif self.username and self.password:
+            auth = httpx.BasicAuth(self.username, self.password)
+        return httpx.AsyncClient(
+            base_url=self.elasticsearch_url,
+            headers=headers,
+            auth=auth,
+            verify=self.verify_ssl,
+            timeout=30.0,
+        )
+
+    def _build_kibana_client(self) -> httpx.AsyncClient:
+        if not self.kibana_url:
+            raise ValueError(
+                "kibana_url is required for Kibana Security API calls"
+            )
+        headers: Dict[str, str] = {
+            "Content-Type": "application/json",
+            "kbn-xsrf": "true",
+        }
+        auth = None
+        if self.api_key:
+            headers["Authorization"] = f"ApiKey {self.api_key}"
+        elif self.username and self.password:
+            auth = httpx.BasicAuth(self.username, self.password)
+        return httpx.AsyncClient(
+            base_url=self.kibana_url,
+            headers=headers,
+            auth=auth,
+            verify=self.verify_ssl,
+            timeout=30.0,
+        )
+
+    @property
+    def es_client(self) -> httpx.AsyncClient:
+        if self._es_client is None or self._es_client.is_closed:
+            self._es_client = self._build_es_client()
+        return self._es_client
+
+    @property
+    def kibana_client(self) -> httpx.AsyncClient:
+        if self._kibana_client is None or self._kibana_client.is_closed:
+            self._kibana_client = self._build_kibana_client()
+        return self._kibana_client
+
+    async def close(self) -> None:
+        if self._es_client and not self._es_client.is_closed:
+            await self._es_client.aclose()
+        if self._kibana_client and not self._kibana_client.is_closed:
+            await self._kibana_client.aclose()
+
+    # ------------------------------------------------------------------
+    # Connection test
+    # ------------------------------------------------------------------
+
+    async def test_connection(self) -> Tuple[bool, str]:
+        """Test connectivity to Elasticsearch (and Kibana if configured)."""
+        try:
+            resp = await self.es_client.get("/")
+            resp.raise_for_status()
+            info = resp.json()
+            version = info.get("version", {}).get("number", "unknown")
+            cluster = info.get("cluster_name", "unknown")
+            msg = f"Connected to Elasticsearch {version} (cluster: {cluster})"
+
+            if self.kibana_url:
+                kb_resp = await self.kibana_client.get("/api/status")
+                kb_resp.raise_for_status()
+                kb_info = kb_resp.json()
+                kb_version = kb_info.get("version", {}).get("number", "unknown")
+                msg += f"; Kibana {kb_version}"
+
+            logger.info(msg)
+            return True, msg
+
+        except httpx.HTTPStatusError as exc:
+            err = f"HTTP {exc.response.status_code}: {exc.response.text[:200]}"
+            logger.error(f"Elastic connection test failed: {err}")
+            return False, err
+        except Exception as exc:
+            logger.error(f"Elastic connection test error: {exc}")
+            return False, str(exc)
+
+    # ------------------------------------------------------------------
+    # Elasticsearch search
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: Dict[str, Any],
+        index: Optional[str] = None,
+        size: int = 100,
+        sort: Optional[List[Dict[str, Any]]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Run an Elasticsearch query and return the raw response body."""
+        target = index or self.index_pattern
+        body: Dict[str, Any] = {"query": query, "size": size}
+        if sort:
+            body["sort"] = sort
+        try:
+            resp = await self.es_client.post(
+                f"/{target}/_search", json=body
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            logger.error(f"Elasticsearch search error: {exc}")
+            return None
+
+    async def search_by_ip(
+        self, ip: str, index: Optional[str] = None, hours: int = 24
+    ) -> Optional[Dict[str, Any]]:
+        return await self.search(
+            query={
+                "bool": {
+                    "must": [{"multi_match": {"query": ip, "fields": ["*"]}}],
+                    "filter": [
+                        {"range": {"@timestamp": {"gte": f"now-{hours}h"}}}
+                    ],
+                }
+            },
+            index=index,
+        )
+
+    async def search_by_hash(
+        self, file_hash: str, index: Optional[str] = None, hours: int = 24
+    ) -> Optional[Dict[str, Any]]:
+        return await self.search(
+            query={
+                "bool": {
+                    "must": [
+                        {"multi_match": {"query": file_hash, "fields": ["*"]}}
+                    ],
+                    "filter": [
+                        {"range": {"@timestamp": {"gte": f"now-{hours}h"}}}
+                    ],
+                }
+            },
+            index=index,
+        )
+
+    async def search_by_username(
+        self, username: str, index: Optional[str] = None, hours: int = 24
+    ) -> Optional[Dict[str, Any]]:
+        return await self.search(
+            query={
+                "bool": {
+                    "must": [
+                        {
+                            "multi_match": {
+                                "query": username,
+                                "fields": [
+                                    "user.name",
+                                    "user.id",
+                                    "winlog.event_data.TargetUserName",
+                                ],
+                            }
+                        }
+                    ],
+                    "filter": [
+                        {"range": {"@timestamp": {"gte": f"now-{hours}h"}}}
+                    ],
+                }
+            },
+            index=index,
+        )
+
+    async def search_by_hostname(
+        self, hostname: str, index: Optional[str] = None, hours: int = 24
+    ) -> Optional[Dict[str, Any]]:
+        return await self.search(
+            query={
+                "bool": {
+                    "must": [
+                        {
+                            "multi_match": {
+                                "query": hostname,
+                                "fields": [
+                                    "host.name",
+                                    "host.hostname",
+                                    "agent.hostname",
+                                ],
+                            }
+                        }
+                    ],
+                    "filter": [
+                        {"range": {"@timestamp": {"gte": f"now-{hours}h"}}}
+                    ],
+                }
+            },
+            index=index,
+        )
+
+    async def get_indices(self) -> Optional[List[str]]:
+        """List available indices."""
+        try:
+            resp = await self.es_client.get("/_cat/indices?format=json")
+            resp.raise_for_status()
+            return [idx["index"] for idx in resp.json() if "index" in idx]
+        except Exception as exc:
+            logger.error(f"Error listing indices: {exc}")
+            return None
+
+    # ------------------------------------------------------------------
+    # Kibana Security — Detections (alerts)
+    # ------------------------------------------------------------------
+
+    async def fetch_detection_alerts(
+        self,
+        query: Optional[Dict[str, Any]] = None,
+        size: int = 100,
+        sort_field: str = "@timestamp",
+        sort_order: str = "desc",
+    ) -> Optional[Dict[str, Any]]:
+        """Fetch detection alerts via the Kibana Detections API."""
+        body: Dict[str, Any] = {
+            "query": query or {"match_all": {}},
+            "size": size,
+            "sort": [{sort_field: {"order": sort_order}}],
+        }
+        try:
+            resp = await self.kibana_client.post(
+                "/api/detection_engine/signals/search", json=body
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            logger.error(f"Error fetching detection alerts: {exc}")
+            return None
+
+    async def update_alert_status(
+        self,
+        signal_ids: List[str],
+        status: str,
+    ) -> bool:
+        """Update alert status (open, acknowledged, closed)."""
+        body: Dict[str, Any] = {
+            "signal_ids": signal_ids,
+            "status": status,
+        }
+        try:
+            resp = await self.kibana_client.post(
+                "/api/detection_engine/signals/status", json=body
+            )
+            resp.raise_for_status()
+            logger.info(
+                f"Updated {len(signal_ids)} alerts to status '{status}'"
+            )
+            return True
+        except Exception as exc:
+            logger.error(f"Error updating alert status: {exc}")
+            return False
+
+    # ------------------------------------------------------------------
+    # Kibana Security — Cases
+    # ------------------------------------------------------------------
+
+    async def get_case(self, case_id: str) -> Optional[Dict[str, Any]]:
+        """Get a Kibana Security case by ID."""
+        try:
+            resp = await self.kibana_client.get(
+                f"/api/cases/{case_id}"
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            logger.error(f"Error fetching case {case_id}: {exc}")
+            return None
+
+    async def update_case_status(
+        self,
+        case_id: str,
+        status: str,
+        version: str,
+    ) -> bool:
+        """Update a Kibana Security case status.
+
+        Args:
+            case_id: The Kibana case ID.
+            status: One of 'open', 'in-progress', 'closed'.
+            version: The case version string (required for optimistic concurrency).
+        """
+        body = {
+            "cases": [
+                {"id": case_id, "version": version, "status": status}
+            ]
+        }
+        try:
+            resp = await self.kibana_client.patch(
+                "/api/cases", json=body
+            )
+            resp.raise_for_status()
+            logger.info(f"Updated case {case_id} to status '{status}'")
+            return True
+        except Exception as exc:
+            logger.error(f"Error updating case {case_id}: {exc}")
+            return False

--- a/services/siem_ingestion_service.py
+++ b/services/siem_ingestion_service.py
@@ -136,6 +136,21 @@ class SIEMIngestionService(ABC):
                 "errors": [str(e)]
             }
     
+    async def update_upstream_alert_status(
+        self,
+        alert_id: str,
+        status: str,
+        note: Optional[str] = None,
+    ) -> bool:
+        """Push a status change back to the upstream SIEM.
+
+        Override in subclasses that support bi-directional sync.
+        Returns True on success, False on failure or if not supported.
+        """
+        raise NotImplementedError(
+            f"{self.siem_name} does not support upstream status sync"
+        )
+
     def normalize_severity(self, severity: Any) -> str:
         """
         Normalize severity to standard values.

--- a/tests/fixtures/elastic_alerts.json
+++ b/tests/fixtures/elastic_alerts.json
@@ -1,0 +1,131 @@
+[
+  {
+    "_index": ".internal.alerts-security.alerts-default-000001",
+    "_id": "abc123def456",
+    "_score": null,
+    "_source": {
+      "@timestamp": "2026-04-13T14:30:00.000Z",
+      "kibana.alert.rule.name": "Suspicious PowerShell Execution",
+      "kibana.alert.rule.description": "Detected a suspicious PowerShell command using encoded arguments, commonly associated with fileless malware and post-exploitation frameworks.",
+      "kibana.alert.severity": "high",
+      "kibana.alert.rule.uuid": "rule-uuid-001",
+      "kibana.alert.rule.threat": [
+        {
+          "framework": "MITRE ATT&CK",
+          "tactic": {
+            "id": "TA0002",
+            "name": "Execution"
+          },
+          "technique": [
+            {
+              "id": "T1059.001",
+              "name": "PowerShell"
+            }
+          ]
+        }
+      ],
+      "kibana.alert.case_ids": [],
+      "event": {
+        "kind": "signal",
+        "severity": 73
+      },
+      "host": {
+        "name": "WORKSTATION-01",
+        "os": {
+          "name": "Windows 10"
+        }
+      },
+      "user": {
+        "name": "jsmith"
+      },
+      "source": {
+        "ip": "10.0.1.50"
+      },
+      "destination": {
+        "ip": "198.51.100.42"
+      },
+      "process": {
+        "name": "powershell.exe",
+        "args": ["-EncodedCommand", "SQBuAHYAbwBrAGUALQBXAGUAYgBSAGUAcQB1AGUAcwB0AA=="],
+        "pid": 4832
+      },
+      "message": "Process powershell.exe executed with encoded command"
+    }
+  },
+  {
+    "_index": ".internal.alerts-security.alerts-default-000001",
+    "_id": "xyz789ghi012",
+    "_score": null,
+    "_source": {
+      "@timestamp": "2026-04-13T15:10:00.000Z",
+      "kibana.alert.rule.name": "Brute Force Attempt Detected",
+      "kibana.alert.rule.description": "Multiple failed login attempts detected from a single source IP within a short time window, indicating a potential brute force attack.",
+      "kibana.alert.severity": "medium",
+      "kibana.alert.rule.uuid": "rule-uuid-002",
+      "kibana.alert.rule.threat": [
+        {
+          "framework": "MITRE ATT&CK",
+          "tactic": {
+            "id": "TA0006",
+            "name": "Credential Access"
+          },
+          "technique": [
+            {
+              "id": "T1110.001",
+              "name": "Password Guessing"
+            }
+          ]
+        }
+      ],
+      "kibana.alert.case_ids": ["case-elastic-001"],
+      "event": {
+        "kind": "signal",
+        "severity": 47
+      },
+      "host": {
+        "name": "AUTH-SERVER-02"
+      },
+      "user": {
+        "name": "admin"
+      },
+      "source": {
+        "ip": "203.0.113.77"
+      },
+      "destination": {
+        "ip": "10.0.2.10"
+      },
+      "message": "50 failed login attempts from 203.0.113.77 in 5 minutes"
+    }
+  },
+  {
+    "_index": ".internal.alerts-security.alerts-default-000001",
+    "_id": "lowsev345",
+    "_score": null,
+    "_source": {
+      "@timestamp": "2026-04-13T16:00:00.000Z",
+      "signal": {
+        "rule": {
+          "name": "DNS Query to Newly Registered Domain",
+          "description": "A DNS query was made to a domain registered within the last 30 days.",
+          "severity": "low",
+          "id": "rule-legacy-003",
+          "threat": []
+        }
+      },
+      "event": {
+        "kind": "signal",
+        "severity": 21
+      },
+      "host": {
+        "name": "LAPTOP-DEV-03"
+      },
+      "source": {
+        "ip": "10.0.3.15"
+      },
+      "destination": {
+        "ip": "93.184.216.34"
+      },
+      "message": "DNS query to freshly-registered domain newmalware-c2.xyz"
+    }
+  }
+]

--- a/tests/unit/test_elastic_bidirectional_sync.py
+++ b/tests/unit/test_elastic_bidirectional_sync.py
@@ -1,0 +1,116 @@
+"""Unit tests for bi-directional case-status sync (sub-issue #68)."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ------------------------------------------------------------------
+# Base class contract
+# ------------------------------------------------------------------
+
+class TestBaseClassContract:
+
+    def test_update_upstream_raises_not_implemented(self):
+        """Default implementation should raise NotImplementedError."""
+        from services.siem_ingestion_service import SIEMIngestionService
+
+        class StubSIEM(SIEMIngestionService):
+            async def fetch_alerts(self, **kw):
+                return []
+
+            def transform_alert_to_finding(self, alert):
+                return None
+
+        svc = StubSIEM.__new__(StubSIEM)
+        svc.siem_name = "Stub"
+
+        with pytest.raises(NotImplementedError, match="Stub"):
+            import asyncio
+            asyncio.get_event_loop().run_until_complete(
+                svc.update_upstream_alert_status("a1", "closed")
+            )
+
+
+# ------------------------------------------------------------------
+# Elastic implementation
+# ------------------------------------------------------------------
+
+class TestElasticUpstreamSync:
+
+    @pytest.mark.asyncio
+    async def test_sync_closed(self):
+        with patch("services.elastic_ingestion.get_integration_config") as cfg:
+            cfg.return_value = {
+                "elasticsearch_url": "https://es.test:9200",
+                "kibana_url": "https://kibana.test:5601",
+                "api_key": "k",
+            }
+            from services.elastic_ingestion import ElasticIngestion
+
+            svc = ElasticIngestion()
+            svc.ingestion_service = MagicMock()
+            mock_es = MagicMock()
+            mock_es.update_alert_status = AsyncMock(return_value=True)
+            svc._elastic_service = mock_es
+
+            result = await svc.update_upstream_alert_status("alert-1", "closed")
+            assert result is True
+            mock_es.update_alert_status.assert_called_once_with(
+                ["alert-1"], "closed"
+            )
+
+    @pytest.mark.asyncio
+    async def test_sync_maps_resolved_to_closed(self):
+        with patch("services.elastic_ingestion.get_integration_config") as cfg:
+            cfg.return_value = {
+                "elasticsearch_url": "https://es.test:9200",
+                "kibana_url": "https://kibana.test:5601",
+                "api_key": "k",
+            }
+            from services.elastic_ingestion import ElasticIngestion
+
+            svc = ElasticIngestion()
+            svc.ingestion_service = MagicMock()
+            mock_es = MagicMock()
+            mock_es.update_alert_status = AsyncMock(return_value=True)
+            svc._elastic_service = mock_es
+
+            await svc.update_upstream_alert_status("alert-1", "resolved")
+            mock_es.update_alert_status.assert_called_once_with(
+                ["alert-1"], "closed"
+            )
+
+    @pytest.mark.asyncio
+    async def test_sync_maps_new_to_open(self):
+        with patch("services.elastic_ingestion.get_integration_config") as cfg:
+            cfg.return_value = {
+                "elasticsearch_url": "https://es.test:9200",
+                "kibana_url": "https://kibana.test:5601",
+                "api_key": "k",
+            }
+            from services.elastic_ingestion import ElasticIngestion
+
+            svc = ElasticIngestion()
+            svc.ingestion_service = MagicMock()
+            mock_es = MagicMock()
+            mock_es.update_alert_status = AsyncMock(return_value=True)
+            svc._elastic_service = mock_es
+
+            await svc.update_upstream_alert_status("alert-1", "new")
+            mock_es.update_alert_status.assert_called_once_with(
+                ["alert-1"], "open"
+            )
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_service_unavailable(self):
+        with patch("services.elastic_ingestion.get_integration_config") as cfg:
+            cfg.return_value = {}
+            from services.elastic_ingestion import ElasticIngestion
+
+            svc = ElasticIngestion()
+            svc.ingestion_service = MagicMock()
+            svc._elastic_service = None
+
+            with patch.object(svc, "_get_elastic_service", return_value=None):
+                result = await svc.update_upstream_alert_status("a1", "closed")
+                assert result is False

--- a/tests/unit/test_elastic_enrichment.py
+++ b/tests/unit/test_elastic_enrichment.py
@@ -1,0 +1,116 @@
+"""Unit tests for services/elastic_enrichment_service.py."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from services.elastic_enrichment_service import ElasticEnrichmentService, _is_private_ip
+
+
+@pytest.fixture
+def enrichment_svc():
+    mock_elastic = MagicMock()
+    svc = ElasticEnrichmentService(elastic_service=mock_elastic)
+    svc.data_service = MagicMock()
+    return svc
+
+
+class TestExtractIndicators:
+
+    def test_extracts_ips_from_entity_context(self, enrichment_svc):
+        case = {}
+        findings = [
+            {
+                "entity_context": {
+                    "src_ips": ["203.0.113.10"],
+                    "dest_ips": ["198.51.100.5"],
+                    "usernames": ["jdoe"],
+                    "hostnames": ["web-server-01"],
+                }
+            }
+        ]
+        indicators = enrichment_svc.extract_indicators(case, findings)
+        assert "203.0.113.10" in indicators["ips"]
+        assert "198.51.100.5" in indicators["ips"]
+        assert "jdoe" in indicators["usernames"]
+        assert "web-server-01" in indicators["hostnames"]
+
+    def test_filters_private_ips(self, enrichment_svc):
+        findings = [
+            {
+                "entity_context": {
+                    "src_ips": ["10.0.1.1", "203.0.113.10"],
+                    "dest_ips": ["192.168.1.1"],
+                }
+            }
+        ]
+        indicators = enrichment_svc.extract_indicators({}, findings)
+        assert "10.0.1.1" not in indicators["ips"]
+        assert "192.168.1.1" not in indicators["ips"]
+        assert "203.0.113.10" in indicators["ips"]
+
+    def test_extracts_hashes_from_text(self, enrichment_svc):
+        case = {"description": "File hash: d41d8cd98f00b204e9800998ecf8427e"}
+        indicators = enrichment_svc.extract_indicators(case, [])
+        assert "d41d8cd98f00b204e9800998ecf8427e" in indicators["hashes"]
+
+
+class TestQueryElasticForIndicators:
+
+    @pytest.mark.asyncio
+    async def test_queries_all_indicator_types(self, enrichment_svc):
+        mock_elastic = enrichment_svc.elastic_service
+        mock_elastic.search_by_ip = AsyncMock(
+            return_value={"hits": {"hits": [{"_id": "1", "_source": {}}]}}
+        )
+        mock_elastic.search_by_hash = AsyncMock(
+            return_value={"hits": {"hits": []}}
+        )
+        mock_elastic.search_by_username = AsyncMock(
+            return_value={"hits": {"hits": [{"_id": "2", "_source": {}}]}}
+        )
+        mock_elastic.search_by_hostname = AsyncMock(
+            return_value={"hits": {"hits": []}}
+        )
+
+        indicators = {
+            "ips": ["203.0.113.10"],
+            "hashes": ["abc123"],
+            "usernames": ["admin"],
+            "hostnames": ["server-01"],
+        }
+        result = await enrichment_svc.query_elastic_for_indicators(indicators)
+        assert result["summary"]["total_events"] == 2
+        assert result["summary"]["ips_queried"] == 1
+        mock_elastic.search_by_ip.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_limits_indicators_to_ten(self, enrichment_svc):
+        mock_elastic = enrichment_svc.elastic_service
+        mock_elastic.search_by_ip = AsyncMock(
+            return_value={"hits": {"hits": []}}
+        )
+
+        indicators = {"ips": [f"1.2.3.{i}" for i in range(20)]}
+        await enrichment_svc.query_elastic_for_indicators(indicators)
+        assert mock_elastic.search_by_ip.call_count == 10
+
+
+class TestIsPrivateIP:
+
+    def test_private_10(self):
+        assert _is_private_ip("10.0.0.1") is True
+
+    def test_private_172(self):
+        assert _is_private_ip("172.16.0.1") is True
+
+    def test_private_192(self):
+        assert _is_private_ip("192.168.1.1") is True
+
+    def test_loopback(self):
+        assert _is_private_ip("127.0.0.1") is True
+
+    def test_public(self):
+        assert _is_private_ip("203.0.113.10") is False
+
+    def test_invalid(self):
+        assert _is_private_ip("not-an-ip") is True

--- a/tests/unit/test_elastic_ingestion.py
+++ b/tests/unit/test_elastic_ingestion.py
@@ -1,0 +1,143 @@
+"""Unit tests for services/elastic_ingestion.py."""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from services.elastic_ingestion import ElasticIngestion
+
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+@pytest.fixture
+def sample_alerts():
+    with open(FIXTURES_DIR / "elastic_alerts.json") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def ingestion():
+    with patch("services.elastic_ingestion.get_integration_config") as mock_cfg:
+        mock_cfg.return_value = {
+            "elasticsearch_url": "https://es.test:9200",
+            "kibana_url": "https://kibana.test:5601",
+            "api_key": "test-key",
+        }
+        svc = ElasticIngestion()
+        # Prevent actual IngestionService init
+        svc.ingestion_service = MagicMock()
+        yield svc
+
+
+class TestTransformAlert:
+
+    def test_transforms_kibana_alert_fields(self, ingestion, sample_alerts):
+        finding = ingestion.transform_alert_to_finding(sample_alerts[0])
+        assert finding is not None
+        assert finding["finding_id"] == "elastic-abc123def456"
+        assert finding["data_source"] == "elastic"
+        assert finding["severity"] == "high"
+        assert finding["title"] == "Suspicious PowerShell Execution"
+        assert "WORKSTATION-01" in finding["entity_context"]["hostnames"]
+        assert "jsmith" in finding["entity_context"]["usernames"]
+        assert "10.0.1.50" in finding["entity_context"]["src_ips"]
+        assert "198.51.100.42" in finding["entity_context"]["dest_ips"]
+
+    def test_extracts_mitre_techniques(self, ingestion, sample_alerts):
+        finding = ingestion.transform_alert_to_finding(sample_alerts[0])
+        assert "T1059.001" in finding["mitre_predictions"]
+
+    def test_transforms_brute_force_alert(self, ingestion, sample_alerts):
+        finding = ingestion.transform_alert_to_finding(sample_alerts[1])
+        assert finding["severity"] == "medium"
+        assert finding["title"] == "Brute Force Attempt Detected"
+        assert "T1110.001" in finding["mitre_predictions"]
+
+    def test_transforms_legacy_signal_format(self, ingestion, sample_alerts):
+        """Alerts using the older signal.rule structure should still work."""
+        finding = ingestion.transform_alert_to_finding(sample_alerts[2])
+        assert finding is not None
+        assert finding["title"] == "DNS Query to Newly Registered Domain"
+        assert finding["severity"] == "low"
+
+    def test_metadata_contains_alert_id(self, ingestion, sample_alerts):
+        finding = ingestion.transform_alert_to_finding(sample_alerts[0])
+        assert finding["metadata"]["elastic_alert_id"] == "abc123def456"
+        assert finding["metadata"]["rule_id"] == "rule-uuid-001"
+
+    def test_handles_missing_fields_gracefully(self, ingestion):
+        sparse_alert = {"_id": "sparse-1", "_source": {}}
+        finding = ingestion.transform_alert_to_finding(sparse_alert)
+        assert finding is not None
+        assert finding["finding_id"] == "elastic-sparse-1"
+        assert finding["title"] == "Elastic Security Alert"
+        assert finding["severity"] == "medium"
+
+    def test_handles_transform_error(self, ingestion):
+        # Pass completely invalid data
+        finding = ingestion.transform_alert_to_finding(None)
+        assert finding is None
+
+
+class TestFetchAlerts:
+
+    @pytest.mark.asyncio
+    async def test_fetch_delegates_to_service(self, ingestion, sample_alerts):
+        mock_svc = MagicMock()
+        mock_svc.fetch_detection_alerts = AsyncMock(
+            return_value={"hits": {"hits": sample_alerts}}
+        )
+        ingestion._elastic_service = mock_svc
+
+        alerts = await ingestion.fetch_alerts(limit=50)
+        assert len(alerts) == 3
+        mock_svc.fetch_detection_alerts.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fetch_returns_empty_on_no_service(self, ingestion):
+        ingestion._elastic_service = None
+        with patch.object(ingestion, "_get_elastic_service", return_value=None):
+            alerts = await ingestion.fetch_alerts()
+            assert alerts == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_returns_empty_on_error(self, ingestion):
+        mock_svc = MagicMock()
+        mock_svc.fetch_detection_alerts = AsyncMock(side_effect=Exception("fail"))
+        ingestion._elastic_service = mock_svc
+
+        alerts = await ingestion.fetch_alerts()
+        assert alerts == []
+
+
+class TestUpdateUpstreamAlertStatus:
+
+    @pytest.mark.asyncio
+    async def test_maps_vigil_status_to_elastic(self, ingestion):
+        mock_svc = MagicMock()
+        mock_svc.update_alert_status = AsyncMock(return_value=True)
+        ingestion._elastic_service = mock_svc
+
+        result = await ingestion.update_upstream_alert_status("a1", "closed")
+        assert result is True
+        mock_svc.update_alert_status.assert_called_once_with(["a1"], "closed")
+
+    @pytest.mark.asyncio
+    async def test_maps_in_progress_to_acknowledged(self, ingestion):
+        mock_svc = MagicMock()
+        mock_svc.update_alert_status = AsyncMock(return_value=True)
+        ingestion._elastic_service = mock_svc
+
+        await ingestion.update_upstream_alert_status("a1", "in_progress")
+        mock_svc.update_alert_status.assert_called_once_with(
+            ["a1"], "acknowledged"
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_service(self, ingestion):
+        ingestion._elastic_service = None
+        with patch.object(ingestion, "_get_elastic_service", return_value=None):
+            result = await ingestion.update_upstream_alert_status("a1", "closed")
+            assert result is False

--- a/tests/unit/test_elastic_service.py
+++ b/tests/unit/test_elastic_service.py
@@ -1,0 +1,383 @@
+"""Unit tests for services/elastic_service.py."""
+
+import pytest
+import httpx
+import respx
+
+from services.elastic_service import ElasticService
+
+
+ES_URL = "https://es.test:9200"
+KIBANA_URL = "https://kibana.test:5601"
+
+
+@pytest.fixture
+def service():
+    return ElasticService(
+        elasticsearch_url=ES_URL,
+        kibana_url=KIBANA_URL,
+        api_key="test-api-key",
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture
+def service_basic_auth():
+    return ElasticService(
+        elasticsearch_url=ES_URL,
+        kibana_url=KIBANA_URL,
+        username="elastic",
+        password="secret",
+        verify_ssl=False,
+    )
+
+
+# ------------------------------------------------------------------
+# Client construction
+# ------------------------------------------------------------------
+
+class TestClientConstruction:
+
+    def test_api_key_auth_header(self, service):
+        client = service._build_es_client()
+        assert client.headers["Authorization"] == "ApiKey test-api-key"
+
+    def test_basic_auth(self, service_basic_auth):
+        client = service_basic_auth._build_es_client()
+        assert client._auth is not None
+
+    def test_kibana_client_requires_url(self):
+        svc = ElasticService(elasticsearch_url=ES_URL)
+        with pytest.raises(ValueError, match="kibana_url is required"):
+            svc._build_kibana_client()
+
+    def test_kibana_client_has_kbn_xsrf(self, service):
+        client = service._build_kibana_client()
+        assert client.headers["kbn-xsrf"] == "true"
+
+
+# ------------------------------------------------------------------
+# Connection test
+# ------------------------------------------------------------------
+
+class TestConnectionTest:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_success_es_only(self):
+        svc = ElasticService(
+            elasticsearch_url=ES_URL, api_key="k", verify_ssl=False
+        )
+        respx.get(f"{ES_URL}/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "cluster_name": "test-cluster",
+                    "version": {"number": "8.14.0"},
+                },
+            )
+        )
+
+        ok, msg = await svc.test_connection()
+        assert ok is True
+        assert "8.14.0" in msg
+        assert "test-cluster" in msg
+        await svc.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_success_with_kibana(self, service):
+        respx.get(f"{ES_URL}/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "cluster_name": "c",
+                    "version": {"number": "8.14.0"},
+                },
+            )
+        )
+        respx.get(f"{KIBANA_URL}/api/status").mock(
+            return_value=httpx.Response(
+                200, json={"version": {"number": "8.14.0"}}
+            )
+        )
+
+        ok, msg = await service.test_connection()
+        assert ok is True
+        assert "Kibana 8.14.0" in msg
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_failure_http_error(self, service):
+        respx.get(f"{ES_URL}/").mock(
+            return_value=httpx.Response(401, text="Unauthorized")
+        )
+
+        ok, msg = await service.test_connection()
+        assert ok is False
+        assert "401" in msg
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_failure_connection_error(self, service):
+        respx.get(f"{ES_URL}/").mock(
+            side_effect=httpx.ConnectError("refused")
+        )
+
+        ok, msg = await service.test_connection()
+        assert ok is False
+        await service.close()
+
+
+# ------------------------------------------------------------------
+# Elasticsearch search
+# ------------------------------------------------------------------
+
+class TestSearch:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_search_returns_results(self, service):
+        respx.post(f"{ES_URL}/.alerts-security.alerts-default/_search").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "hits": {
+                        "total": {"value": 1},
+                        "hits": [{"_id": "1", "_source": {"alert": True}}],
+                    }
+                },
+            )
+        )
+
+        result = await service.search({"match_all": {}})
+        assert result is not None
+        assert result["hits"]["total"]["value"] == 1
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_search_custom_index(self, service):
+        route = respx.post(f"{ES_URL}/my-index/_search").mock(
+            return_value=httpx.Response(200, json={"hits": {"hits": []}})
+        )
+
+        await service.search({"match_all": {}}, index="my-index")
+        assert route.called
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_search_error_returns_none(self, service):
+        respx.post(f"{ES_URL}/.alerts-security.alerts-default/_search").mock(
+            return_value=httpx.Response(500, text="Internal Server Error")
+        )
+
+        result = await service.search({"match_all": {}})
+        assert result is None
+        await service.close()
+
+
+# ------------------------------------------------------------------
+# IOC search helpers
+# ------------------------------------------------------------------
+
+class TestIOCSearch:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_search_by_ip(self, service):
+        respx.post(f"{ES_URL}/.alerts-security.alerts-default/_search").mock(
+            return_value=httpx.Response(200, json={"hits": {"hits": []}})
+        )
+        result = await service.search_by_ip("1.2.3.4")
+        assert result is not None
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_search_by_hash(self, service):
+        respx.post(f"{ES_URL}/.alerts-security.alerts-default/_search").mock(
+            return_value=httpx.Response(200, json={"hits": {"hits": []}})
+        )
+        result = await service.search_by_hash("abc123def456")
+        assert result is not None
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_search_by_username(self, service):
+        respx.post(f"{ES_URL}/.alerts-security.alerts-default/_search").mock(
+            return_value=httpx.Response(200, json={"hits": {"hits": []}})
+        )
+        result = await service.search_by_username("admin")
+        assert result is not None
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_search_by_hostname(self, service):
+        respx.post(f"{ES_URL}/.alerts-security.alerts-default/_search").mock(
+            return_value=httpx.Response(200, json={"hits": {"hits": []}})
+        )
+        result = await service.search_by_hostname("workstation-01")
+        assert result is not None
+        await service.close()
+
+
+# ------------------------------------------------------------------
+# get_indices
+# ------------------------------------------------------------------
+
+class TestGetIndices:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_indices(self, service):
+        respx.get(f"{ES_URL}/_cat/indices?format=json").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"index": ".alerts-security.alerts-default"},
+                    {"index": "filebeat-8.14.0"},
+                ],
+            )
+        )
+        indices = await service.get_indices()
+        assert indices == [
+            ".alerts-security.alerts-default",
+            "filebeat-8.14.0",
+        ]
+        await service.close()
+
+
+# ------------------------------------------------------------------
+# Kibana Detections API
+# ------------------------------------------------------------------
+
+class TestDetectionAlerts:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_fetch_alerts(self, service):
+        respx.post(
+            f"{KIBANA_URL}/api/detection_engine/signals/search"
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "hits": {
+                        "total": {"value": 2},
+                        "hits": [
+                            {"_id": "a1", "_source": {}},
+                            {"_id": "a2", "_source": {}},
+                        ],
+                    }
+                },
+            )
+        )
+
+        result = await service.fetch_detection_alerts()
+        assert result is not None
+        assert result["hits"]["total"]["value"] == 2
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_update_alert_status(self, service):
+        respx.post(
+            f"{KIBANA_URL}/api/detection_engine/signals/status"
+        ).mock(return_value=httpx.Response(200, json={}))
+
+        ok = await service.update_alert_status(["a1", "a2"], "closed")
+        assert ok is True
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_update_alert_status_failure(self, service):
+        respx.post(
+            f"{KIBANA_URL}/api/detection_engine/signals/status"
+        ).mock(return_value=httpx.Response(403, text="Forbidden"))
+
+        ok = await service.update_alert_status(["a1"], "closed")
+        assert ok is False
+        await service.close()
+
+
+# ------------------------------------------------------------------
+# Kibana Cases API
+# ------------------------------------------------------------------
+
+class TestCasesAPI:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_case(self, service):
+        respx.get(f"{KIBANA_URL}/api/cases/case-1").mock(
+            return_value=httpx.Response(
+                200, json={"id": "case-1", "status": "open", "version": "v1"}
+            )
+        )
+
+        case = await service.get_case("case-1")
+        assert case is not None
+        assert case["id"] == "case-1"
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_update_case_status(self, service):
+        respx.patch(f"{KIBANA_URL}/api/cases").mock(
+            return_value=httpx.Response(200, json=[{"id": "case-1"}])
+        )
+
+        ok = await service.update_case_status("case-1", "closed", "v1")
+        assert ok is True
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_update_case_status_failure(self, service):
+        respx.patch(f"{KIBANA_URL}/api/cases").mock(
+            return_value=httpx.Response(409, text="Conflict")
+        )
+
+        ok = await service.update_case_status("case-1", "closed", "v1")
+        assert ok is False
+        await service.close()
+
+
+# ------------------------------------------------------------------
+# close()
+# ------------------------------------------------------------------
+
+class TestClose:
+
+    @pytest.mark.asyncio
+    async def test_close_without_clients(self, service):
+        """close() should not raise when no clients have been created."""
+        await service.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_close_after_use(self, service):
+        respx.get(f"{ES_URL}/").mock(
+            return_value=httpx.Response(
+                200,
+                json={"cluster_name": "c", "version": {"number": "8.14.0"}},
+            )
+        )
+        respx.get(f"{KIBANA_URL}/api/status").mock(
+            return_value=httpx.Response(
+                200, json={"version": {"number": "8.14.0"}}
+            )
+        )
+
+        await service.test_connection()
+        await service.close()
+
+        assert service._es_client.is_closed
+        assert service._kibana_client.is_closed

--- a/tools/elastic.py
+++ b/tools/elastic.py
@@ -1,0 +1,278 @@
+"""Elastic Security MCP tool server.
+
+Exposes Elasticsearch search and Kibana Security API capabilities as
+MCP tools for use by Vigil's AI agents.
+"""
+
+import asyncio
+import json
+import logging
+import os
+
+from mcp.server.models import InitializationOptions
+import mcp.types as types
+from mcp.server import NotificationOptions, Server
+import mcp.server.stdio
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+logger = logging.getLogger(__name__)
+server = Server("elastic")
+
+_elastic_service = None
+
+
+def result(data):
+    return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
+
+
+def get_elastic_service():
+    global _elastic_service
+    if _elastic_service is not None:
+        return _elastic_service
+    try:
+        from services.elastic_service import ElasticService
+        host = os.environ.get("ELASTIC_HOST")
+        if not host:
+            return None
+        _elastic_service = ElasticService(
+            elasticsearch_url=host,
+            kibana_url=os.environ.get("ELASTIC_KIBANA_URL"),
+            api_key=os.environ.get("ELASTIC_API_KEY"),
+            username=os.environ.get("ELASTIC_USERNAME"),
+            password=os.environ.get("ELASTIC_PASSWORD"),
+            verify_ssl=os.environ.get("ELASTIC_VERIFY_SSL", "true").lower() == "true",
+            index_pattern=os.environ.get(
+                "ELASTIC_INDEX_PATTERN", ".alerts-security.alerts-default"
+            ),
+        )
+        return _elastic_service
+    except Exception:
+        return None
+
+
+# ------------------------------------------------------------------
+# Tool listing
+# ------------------------------------------------------------------
+
+@server.list_tools()
+async def handle_list_tools():
+    return [
+        types.Tool(
+            name="elastic_search_logs",
+            description="Search Elasticsearch logs with a custom query DSL body",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Elasticsearch query DSL as a JSON string",
+                    },
+                    "index": {
+                        "type": "string",
+                        "description": "Target index (default: configured alert index)",
+                    },
+                    "time_range": {
+                        "type": "string",
+                        "description": "Relative time range, e.g. '24h', '7d'",
+                        "default": "24h",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "default": 100,
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+        types.Tool(
+            name="elastic_search_by_ioc",
+            description="Search Elasticsearch for events matching an IOC (IP, hash, username, hostname)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ioc_type": {
+                        "type": "string",
+                        "enum": ["ip", "hash", "username", "hostname"],
+                    },
+                    "ioc_value": {"type": "string"},
+                    "index": {"type": "string"},
+                    "hours": {"type": "integer", "default": 24},
+                },
+                "required": ["ioc_type", "ioc_value"],
+            },
+        ),
+        types.Tool(
+            name="elastic_get_indices",
+            description="List available Elasticsearch indices",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        types.Tool(
+            name="elastic_get_detection_alerts",
+            description="Fetch recent detection alerts from Elastic Security",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "max_results": {"type": "integer", "default": 50},
+                    "status": {
+                        "type": "string",
+                        "enum": ["open", "acknowledged", "closed"],
+                        "description": "Filter by alert status",
+                    },
+                },
+            },
+        ),
+    ]
+
+
+# ------------------------------------------------------------------
+# Tool dispatch
+# ------------------------------------------------------------------
+
+@server.call_tool()
+async def handle_call_tool(name: str, arguments: dict | None):
+    svc = get_elastic_service()
+    if svc is None:
+        return result({
+            "error": "Elastic service not configured. Set ELASTIC_HOST in .env."
+        })
+
+    if name == "elastic_search_logs":
+        return await _search_logs(svc, arguments or {})
+    elif name == "elastic_search_by_ioc":
+        return await _search_by_ioc(svc, arguments or {})
+    elif name == "elastic_get_indices":
+        return await _get_indices(svc)
+    elif name == "elastic_get_detection_alerts":
+        return await _get_detection_alerts(svc, arguments or {})
+    else:
+        return result({"error": f"Unknown tool: {name}"})
+
+
+async def _search_logs(svc, args: dict):
+    query_str = args.get("query", '{"match_all": {}}')
+    try:
+        query = json.loads(query_str) if isinstance(query_str, str) else query_str
+    except json.JSONDecodeError:
+        return result({"error": "Invalid JSON in query parameter"})
+
+    time_range = args.get("time_range", "24h")
+    # Wrap with time filter
+    wrapped = {
+        "bool": {
+            "must": [query],
+            "filter": [{"range": {"@timestamp": {"gte": f"now-{time_range}"}}}],
+        }
+    }
+
+    data = await svc.search(
+        query=wrapped,
+        index=args.get("index"),
+        size=min(args.get("max_results", 100), 500),
+    )
+    if data is None:
+        return result({"error": "Search failed"})
+
+    hits = data.get("hits", {})
+    return result({
+        "total": hits.get("total", {}).get("value", 0),
+        "results": [
+            {"_id": h["_id"], **h.get("_source", {})}
+            for h in hits.get("hits", [])
+        ],
+    })
+
+
+async def _search_by_ioc(svc, args: dict):
+    ioc_type = args["ioc_type"]
+    ioc_value = args["ioc_value"]
+    index = args.get("index")
+    hours = args.get("hours", 24)
+
+    dispatch = {
+        "ip": svc.search_by_ip,
+        "hash": svc.search_by_hash,
+        "username": svc.search_by_username,
+        "hostname": svc.search_by_hostname,
+    }
+    fn = dispatch.get(ioc_type)
+    if fn is None:
+        return result({"error": f"Unknown ioc_type: {ioc_type}"})
+
+    data = await fn(ioc_value, index=index, hours=hours)
+    if data is None:
+        return result({"error": "Search failed"})
+
+    hits = data.get("hits", {})
+    return result({
+        "ioc_type": ioc_type,
+        "ioc_value": ioc_value,
+        "total": hits.get("total", {}).get("value", 0),
+        "results": [
+            {"_id": h["_id"], **h.get("_source", {})}
+            for h in hits.get("hits", [])
+        ],
+    })
+
+
+async def _get_indices(svc):
+    indices = await svc.get_indices()
+    if indices is None:
+        return result({"error": "Failed to list indices"})
+    return result({"indices": indices, "count": len(indices)})
+
+
+async def _get_detection_alerts(svc, args: dict):
+    query: dict = {"match_all": {}}
+    status = args.get("status")
+    if status:
+        query = {"term": {"kibana.alert.workflow_status": status}}
+
+    data = await svc.fetch_detection_alerts(
+        query=query,
+        size=min(args.get("max_results", 50), 200),
+    )
+    if data is None:
+        return result({"error": "Failed to fetch detection alerts"})
+
+    hits = data.get("hits", {})
+    return result({
+        "total": hits.get("total", {}).get("value", 0),
+        "alerts": [
+            {
+                "_id": h["_id"],
+                "rule": h.get("_source", {}).get("kibana.alert.rule.name", ""),
+                "severity": h.get("_source", {}).get("kibana.alert.severity", ""),
+                "timestamp": h.get("_source", {}).get("@timestamp", ""),
+            }
+            for h in hits.get("hits", [])
+        ],
+    })
+
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+
+async def main():
+    async with mcp.server.stdio.stdio_server() as (read, write):
+        await server.run(
+            read,
+            write,
+            InitializationOptions(
+                server_name="elastic",
+                server_version="0.1.0",
+                capabilities=server.get_capabilities(
+                    notification_options=NotificationOptions(),
+                    experimental_capabilities={},
+                ),
+            ),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
Full Elastic Security / Elasticsearch SIEM integration for Vigil, covering all four sub-issues of the epic.

- **#66 — Service client + config**: `services/elastic_service.py` (async httpx client for Elasticsearch + Kibana APIs), env vars in `env.example`, `kibana_url`/`index_pattern` fields in frontend integration config
- **#67 — Alert ingestion**: `services/elastic_ingestion.py` extending `SIEMIngestionService`, registered in `daemon/poller.py` with dedup, test fixtures
- **#68 — Bi-directional sync**: `update_upstream_alert_status()` added to `SIEMIngestionService` base class, Elastic implementation pushes status to Kibana Detections API, case update endpoint fires async upstream sync
- **#70 — IOC enrichment**: `services/elastic_enrichment_service.py` + `tools/elastic.py` MCP server (4 tools), `mcp-config.json` entry, docs

### New files
- `services/elastic_service.py` — async HTTP client (Elasticsearch + Kibana Security APIs)
- `services/elastic_ingestion.py` — alert ingestion extending SIEMIngestionService
- `services/elastic_enrichment_service.py` — IOC enrichment queries
- `tools/elastic.py` — MCP tool server (search_logs, search_by_ioc, get_indices, get_detection_alerts)
- `tests/unit/test_elastic_service.py` — 24 tests
- `tests/unit/test_elastic_ingestion.py` — 13 tests
- `tests/unit/test_elastic_bidirectional_sync.py` — 5 tests
- `tests/unit/test_elastic_enrichment.py` — 11 tests
- `tests/fixtures/elastic_alerts.json` — sample detection alerts

### Modified files
- `env.example` — Elastic env vars
- `frontend/src/config/integrations.ts` — kibana_url + index_pattern fields
- `daemon/poller.py` — Elastic polling loop
- `services/siem_ingestion_service.py` — `update_upstream_alert_status()` base method
- `backend/api/cases.py` — upstream sync hook on case status change
- `mcp-config.json` — elastic MCP server entry
- `docs/INTEGRATIONS.md` — Elastic Security documentation

## Linked issues

Closes #49
Closes #66
Closes #67
Closes #68
Closes #70

## Test plan
- [x] `pytest tests/unit/test_elastic_service.py` — 24/24 passing
- [x] `pytest tests/unit/test_elastic_ingestion.py` — 13/13 passing
- [x] `pytest tests/unit/test_elastic_bidirectional_sync.py` — 5/5 passing
- [x] `pytest tests/unit/test_elastic_enrichment.py` — 11/11 passing
- [x] All 53 new tests passing
- [ ] CI green
- [ ] Integration test against local Elastic stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)