### PR TITLE
fix(frontend): analytics 404 and case metrics duplicate key warning

### DIFF
--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -159,7 +159,7 @@ export default function Analytics() {
     setLoading(true)
     setError(null)
     try {
-      const response = await api.get(`/api/analytics?timeRange=${timeRange}`)
+      const response = await api.get(`/analytics?time_range=${timeRange}`)
       setAnalyticsData(response.data)
     } catch (error) {
       console.error('Error fetching analytics:', error)

--- a/frontend/src/pages/CaseMetrics.tsx
+++ b/frontend/src/pages/CaseMetrics.tsx
@@ -293,8 +293,8 @@ export default function CaseMetricsDashboard() {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {analystPerformance.map((analyst: any) => (
-                    <TableRow key={analyst.analyst}>
+                  {analystPerformance.map((analyst: any, index: number) => (
+                    <TableRow key={analyst.analyst ?? `unassigned-${index}`}>
                       <TableCell>
                         <Box display="flex" alignItems="center" gap={1}>
                           <PersonIcon fontSize="small" color="primary" />


### PR DESCRIPTION
## Summary
Two small frontend fixes found while exploring a deployed instance.

### Analytics Dashboard returning 404
`Analytics.tsx` was calling `api.get('/api/analytics?timeRange=...')`, but the axios client already has `baseURL: '/api'`, so every request hit `/api/api/analytics` and 404'd. Additionally, the backend expects `time_range` (snake_case), not `timeRange`. Changed to `api.get('/analytics?time_range=...')`.

### CaseMetrics duplicate-key warning
`TableRow` used `analyst.analyst` as its key, which is `undefined` for unassigned cases. When multiple analysts had null names, React logged a duplicate-key warning. Fallback to `unassigned-${index}` for missing names.

## Test plan
- [ ] Visit the Analytics Dashboard — charts and metrics render (no 404)
- [ ] Visit Case Metrics — no React key warning in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)