### PR TITLE
VStrike (CloudCurrent) integration + dev-env fixes

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -935,7 +935,10 @@ async def get_orchestrator_config():
 
 @router.post("/orchestrator")
 async def set_orchestrator_config(config: OrchestratorSettingsConfig):
-    """Set orchestrator configuration. Persists to DB and attempts runtime apply."""
+    """Set orchestrator configuration. Persists settings AND syncs the
+    runtime enabled flag used by GET /api/orchestrator/status (which
+    NavigationRail uses to show/hide the Auto Ops tab).
+    """
     try:
         config_data = config.model_dump()
 
@@ -950,6 +953,21 @@ async def set_orchestrator_config(config: OrchestratorSettingsConfig):
 
         if not success:
             raise HTTPException(status_code=500, detail="Failed to save orchestrator config to database")
+
+        # Poke the in-process orchestrator (if the API happens to share one)
+        # so a running daemon reacts immediately. No-op in backend-only
+        # deployments — the daemon polls orchestrator.settings every few
+        # seconds.
+        try:
+            from backend.api.orchestrator import _get_orchestrator
+            orch = _get_orchestrator()
+            if orch is not None:
+                if config_data.get("enabled"):
+                    orch.enable()
+                else:
+                    orch.disable()
+        except Exception as e:
+            logger.debug("In-process orchestrator runtime apply skipped: %s", e)
 
         return {"success": True, "message": "Orchestrator settings saved"}
     except HTTPException:

--- a/backend/api/orchestrator.py
+++ b/backend/api/orchestrator.py
@@ -65,14 +65,14 @@ async def get_orchestrator_status():
             cost_summary = orch.get_cost_summary()
             stats = orch.stats
 
+        # Enabled is persisted inside the single `orchestrator.settings` key.
+        # See services/config_service and backend/api/config.py.
         enabled = False
         try:
-            from database.connection import get_db_manager
-            from database.models import SystemConfig
-            with get_db_manager().session_scope() as session:
-                cfg = session.query(SystemConfig).filter_by(key="orchestrator_enabled").first()
-                if cfg and isinstance(cfg.value, dict):
-                    enabled = cfg.value.get("enabled", False)
+            from services.config_service import get_config_service
+            settings = get_config_service().get_system_config('orchestrator.settings')
+            if isinstance(settings, dict):
+                enabled = bool(settings.get("enabled", False))
         except Exception:
             enabled = orch.enabled if orch else False
         
@@ -109,6 +109,32 @@ async def get_orchestrator_status():
         raise HTTPException(status_code=500, detail=str(e))
 
 
+def _persist_orchestrator_enabled(enabled: bool) -> None:
+    """Write the `enabled` flag into the single `orchestrator.settings` key.
+
+    Read-modify-write so the rest of the settings struct is preserved. If no
+    settings row exists yet (first toggle on a fresh DB), seed it from the
+    defaults defined in backend/api/config.py.
+    """
+    try:
+        from services.config_service import get_config_service
+        from backend.api.config import ORCHESTRATOR_DEFAULTS
+
+        svc = get_config_service(user_id='web_ui')
+        current = svc.get_system_config('orchestrator.settings')
+        base = dict(current) if isinstance(current, dict) else dict(ORCHESTRATOR_DEFAULTS)
+        base["enabled"] = bool(enabled)
+        svc.set_system_config(
+            key='orchestrator.settings',
+            value=base,
+            description='Autonomous orchestrator settings',
+            config_type='orchestrator',
+            change_reason=f'Orchestrator {"enabled" if enabled else "disabled"} via API',
+        )
+    except Exception as e:
+        logger.warning("Could not persist orchestrator.settings.enabled: %s", e)
+
+
 @router.post("/enable")
 async def enable_orchestrator():
     """Enable the orchestrator at runtime."""
@@ -116,25 +142,7 @@ async def enable_orchestrator():
         orch = _get_orchestrator()
         if orch:
             orch.enable()
-        
-        try:
-            from database.connection import get_db_manager
-            from database.models import SystemConfig
-            with get_db_manager().session_scope() as session:
-                cfg = session.query(SystemConfig).filter_by(key="orchestrator_enabled").first()
-                if cfg:
-                    cfg.value = {"enabled": True}
-                else:
-                    cfg = SystemConfig(
-                        key="orchestrator_enabled",
-                        value={"enabled": True},
-                        config_type="orchestrator",
-                        description="Orchestrator enabled state",
-                    )
-                    session.add(cfg)
-        except Exception:
-            pass
-        
+        _persist_orchestrator_enabled(True)
         return {"success": True, "enabled": True, "message": "Orchestrator enabled"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -147,25 +155,7 @@ async def disable_orchestrator():
         orch = _get_orchestrator()
         if orch:
             orch.disable()
-        
-        try:
-            from database.connection import get_db_manager
-            from database.models import SystemConfig
-            with get_db_manager().session_scope() as session:
-                cfg = session.query(SystemConfig).filter_by(key="orchestrator_enabled").first()
-                if cfg:
-                    cfg.value = {"enabled": False}
-                else:
-                    cfg = SystemConfig(
-                        key="orchestrator_enabled",
-                        value={"enabled": False},
-                        config_type="orchestrator",
-                        description="Orchestrator enabled state",
-                    )
-                    session.add(cfg)
-        except Exception:
-            pass
-        
+        _persist_orchestrator_enabled(False)
         return {"success": True, "enabled": False, "message": "Orchestrator disabled (graceful)"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/api/vstrike.py
+++ b/backend/api/vstrike.py
@@ -1,0 +1,318 @@
+"""VStrike (CloudCurrent) integration API.
+
+Endpoints:
+  - POST /findings           Receive VStrike-enriched findings (push)
+  - GET  /health             Outbound reachability check
+  - GET  /topology/asset/{id}  Proxy to VStrike topology lookup
+
+Inbound push is authenticated with a Bearer API key stored via the secrets
+manager under `VSTRIKE_INBOUND_API_KEY`. When `DEV_MODE=true` the auth check
+is bypassed (matches the rest of the Vigil codebase).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+
+from backend.schemas.vstrike import (
+    VStrikeFindingResult,
+    VStrikeHealthResponse,
+    VStrikePushRequest,
+    VStrikePushResponse,
+)
+from services.database_data_service import DatabaseDataService
+from services.vstrike_service import get_vstrike_service
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+data_service = DatabaseDataService()
+
+
+def _is_dev_mode() -> bool:
+    return os.environ.get("DEV_MODE", "").lower() == "true"
+
+
+def _expected_inbound_key() -> Optional[str]:
+    """Return the expected inbound bearer key, or None if unset."""
+    key = os.environ.get("VSTRIKE_INBOUND_API_KEY")
+    if key:
+        return key
+    try:
+        from backend.secrets_manager import get_secret
+
+        return get_secret("VSTRIKE_INBOUND_API_KEY")
+    except Exception as e:
+        logger.debug("Could not read VSTRIKE_INBOUND_API_KEY from secrets: %s", e)
+        return None
+
+
+def verify_inbound_key(
+    authorization: Optional[str] = Header(default=None),
+) -> None:
+    """Bearer-token dependency for the inbound push endpoint.
+
+    Bypassed when `DEV_MODE=true`. Returns 401 otherwise when the header is
+    missing or the token does not match the configured key. Returns 503 if
+    no key is configured and DEV_MODE is off (we refuse to run open).
+    """
+    if _is_dev_mode():
+        return
+
+    expected = _expected_inbound_key()
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "VStrike inbound API key not configured. Set "
+                "VSTRIKE_INBOUND_API_KEY or enable DEV_MODE."
+            ),
+        )
+
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(
+            status_code=401, detail="Missing bearer token"
+        )
+
+    token = authorization.split(" ", 1)[1].strip()
+    if token != expected:
+        raise HTTPException(status_code=401, detail="Invalid bearer token")
+
+
+@router.post("/findings", response_model=VStrikePushResponse)
+async def ingest_findings(
+    request: VStrikePushRequest,
+    _auth: None = Depends(verify_inbound_key),
+) -> VStrikePushResponse:
+    """Receive a batch of VStrike-enriched findings.
+
+    For each finding:
+      - If it exists in Vigil, merge VStrike enrichment into
+        `entity_context["vstrike"]` (read-modify-write to avoid clobbering
+        other keys) and update MITRE fields if supplied.
+      - Otherwise, create it with `data_source="vstrike"` if enough fields
+        are present (timestamp + anomaly_score); fail the finding otherwise.
+
+    When `auto_cluster_cases` is true, upserted findings are grouped into
+    cases keyed by `(segment, attack_path[0] or asset_id)`.
+    """
+    results: list[VStrikeFindingResult] = []
+    updated = 0
+    created = 0
+    failed = 0
+    upserted_ids: list[str] = []
+
+    for item in request.findings:
+        try:
+            enrichment_dict = item.vstrike_enrichment.model_dump(mode="json")
+            existing = data_service.get_finding(item.finding_id)
+            if existing is not None:
+                existing_ctx = existing.get("entity_context") or {}
+                if not isinstance(existing_ctx, dict):
+                    existing_ctx = {}
+                merged_ctx = dict(existing_ctx)
+                if item.entity_context_extra:
+                    merged_ctx.update(item.entity_context_extra)
+                merged_ctx["vstrike"] = enrichment_dict
+
+                updates: dict = {"entity_context": merged_ctx}
+                if item.mitre_predictions is not None:
+                    updates["mitre_predictions"] = item.mitre_predictions
+                if item.predicted_techniques is not None:
+                    updates["predicted_techniques"] = item.predicted_techniques
+                if item.severity is not None:
+                    updates["severity"] = item.severity
+                if item.description is not None:
+                    updates["description"] = item.description
+
+                success = data_service.update_finding(item.finding_id, **updates)
+                if success:
+                    updated += 1
+                    upserted_ids.append(item.finding_id)
+                    results.append(
+                        VStrikeFindingResult(
+                            finding_id=item.finding_id, status="updated"
+                        )
+                    )
+                else:
+                    failed += 1
+                    results.append(
+                        VStrikeFindingResult(
+                            finding_id=item.finding_id,
+                            status="failed",
+                            error="update_finding returned False",
+                        )
+                    )
+                continue
+
+            # Create path: require minimum fields for a useful record
+            if item.timestamp is None or item.anomaly_score is None:
+                failed += 1
+                results.append(
+                    VStrikeFindingResult(
+                        finding_id=item.finding_id,
+                        status="failed",
+                        error=(
+                            "Finding not found and insufficient fields to "
+                            "create (timestamp and anomaly_score required)"
+                        ),
+                    )
+                )
+                continue
+
+            new_ctx: dict = dict(item.entity_context_extra or {})
+            new_ctx["vstrike"] = enrichment_dict
+            finding_data = {
+                "finding_id": item.finding_id,
+                "timestamp": item.timestamp,
+                "anomaly_score": float(item.anomaly_score),
+                "data_source": "vstrike",
+                "entity_context": new_ctx,
+                "severity": item.severity,
+                "description": item.description,
+                "mitre_predictions": item.mitre_predictions or {},
+            }
+            if item.predicted_techniques is not None:
+                finding_data["predicted_techniques"] = item.predicted_techniques
+
+            created_finding = data_service.create_finding(finding_data)
+            if created_finding:
+                created += 1
+                upserted_ids.append(item.finding_id)
+                results.append(
+                    VStrikeFindingResult(
+                        finding_id=item.finding_id, status="created"
+                    )
+                )
+            else:
+                failed += 1
+                results.append(
+                    VStrikeFindingResult(
+                        finding_id=item.finding_id,
+                        status="failed",
+                        error="create_finding returned None",
+                    )
+                )
+        except Exception as e:
+            failed += 1
+            logger.exception("VStrike ingest failed for %s", item.finding_id)
+            results.append(
+                VStrikeFindingResult(
+                    finding_id=item.finding_id,
+                    status="failed",
+                    error=str(e),
+                )
+            )
+
+    case_ids: list[str] = []
+    if request.auto_cluster_cases and upserted_ids:
+        try:
+            from services.case_automation_service import (
+                cluster_findings_by_attack_path,
+            )
+
+            case_ids = cluster_findings_by_attack_path(upserted_ids)
+        except Exception as e:
+            logger.exception("VStrike auto-cluster failed: %s", e)
+
+    logger.info(
+        "VStrike batch %s: received=%d updated=%d created=%d failed=%d cases=%d",
+        request.batch_id,
+        len(request.findings),
+        updated,
+        created,
+        failed,
+        len(case_ids),
+    )
+
+    return VStrikePushResponse(
+        batch_id=request.batch_id,
+        received=len(request.findings),
+        updated=updated,
+        created=created,
+        failed=failed,
+        results=results,
+        case_ids=case_ids,
+    )
+
+
+@router.get("/health", response_model=VStrikeHealthResponse)
+async def health_check() -> VStrikeHealthResponse:
+    """Check outbound connectivity to the configured VStrike server."""
+    service = get_vstrike_service()
+    if service is None:
+        return VStrikeHealthResponse(
+            configured=False,
+            reachable=False,
+            base_url=None,
+            message=(
+                "VStrike not configured. Set VSTRIKE_BASE_URL + VSTRIKE_API_KEY "
+                "or configure the integration in Settings."
+            ),
+        )
+    success, message = service.test_connection()
+    return VStrikeHealthResponse(
+        configured=True,
+        reachable=success,
+        base_url=service.base_url,
+        message=message,
+    )
+
+
+@router.get("/topology/asset/{asset_id}")
+async def get_asset_topology(asset_id: str) -> dict:
+    """Proxy to VStrike asset-topology lookup (outbound)."""
+    service = get_vstrike_service()
+    if service is None:
+        raise HTTPException(
+            status_code=503, detail="VStrike not configured"
+        )
+    topology = service.get_asset_topology(asset_id)
+    if topology is None:
+        raise HTTPException(
+            status_code=502,
+            detail=f"VStrike did not return topology for asset {asset_id}",
+        )
+    return {
+        "asset_id": asset_id,
+        "topology": topology,
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/topology/asset/{asset_id}/adjacent")
+async def list_adjacent_assets(asset_id: str) -> dict:
+    """Proxy to VStrike adjacent-assets lookup."""
+    service = get_vstrike_service()
+    if service is None:
+        raise HTTPException(
+            status_code=503, detail="VStrike not configured"
+        )
+    adjacent = service.list_adjacent(asset_id)
+    if adjacent is None:
+        raise HTTPException(
+            status_code=502,
+            detail=f"VStrike did not return adjacency for asset {asset_id}",
+        )
+    return {"asset_id": asset_id, "adjacent": adjacent}
+
+
+@router.get("/topology/asset/{asset_id}/blast-radius")
+async def get_blast_radius(asset_id: str) -> dict:
+    """Proxy to VStrike blast-radius lookup."""
+    service = get_vstrike_service()
+    if service is None:
+        raise HTTPException(
+            status_code=503, detail="VStrike not configured"
+        )
+    blast = service.get_blast_radius(asset_id)
+    if blast is None:
+        raise HTTPException(
+            status_code=502,
+            detail=f"VStrike did not return blast radius for asset {asset_id}",
+        )
+    return {"asset_id": asset_id, "blast_radius": blast}

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,6 +42,7 @@ from api.integrations_compatibility import router as compatibility_router
 from api.ingestion import router as ingestion_router
 from api.timeline import router as timeline_router
 from api.graph import router as graph_router
+from api.vstrike import router as vstrike_router
 
 # Enhanced case management routers
 from api.case_templates import router as case_templates_router
@@ -148,6 +149,7 @@ app.include_router(agents_router, prefix="/api/agents", tags=["agents"])
 app.include_router(compatibility_router, prefix="/api/integrations", tags=["integrations"])
 app.include_router(custom_integrations_router, prefix="/api/custom-integrations", tags=["custom-integrations"])
 app.include_router(ingestion_router, prefix="/api/ingest", tags=["ingestion"])
+app.include_router(vstrike_router, prefix="/api/integrations/vstrike", tags=["vstrike"])
 app.include_router(storage_status_router, prefix="/api/storage", tags=["storage"])
 app.include_router(ai_decisions_router, prefix="/api/ai", tags=["ai-decisions"])
 app.include_router(timeline_router, prefix="/api/timeline", tags=["timeline"])

--- a/backend/schemas/vstrike.py
+++ b/backend/schemas/vstrike.py
@@ -1,0 +1,125 @@
+"""Pydantic schemas for the VStrike (CloudCurrent) integration.
+
+VStrike is a network-topology fusion layer that enriches DeepTempo LogLM
+findings with operational context (asset, segment, site, mission system,
+adjacent nodes, attack path, blast radius) and pushes the enriched findings
+to Vigil via `POST /api/integrations/vstrike/findings`.
+
+Enrichment is persisted inside `finding.entity_context["vstrike"]`.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class VStrikeAdjacentAsset(BaseModel):
+    """A neighbor of the primary asset in the network graph."""
+
+    asset_id: str
+    asset_name: Optional[str] = None
+    segment: Optional[str] = None
+    hop_distance: int = 1
+    edge_technique: Optional[str] = Field(
+        None,
+        description="MITRE ATT&CK technique ID (e.g. T1021.002) if this edge "
+        "represents an observed or inferred attack-path step.",
+    )
+
+
+class VStrikeEnrichment(BaseModel):
+    """Network-topology context attached to a finding.
+
+    Persisted at `finding.entity_context["vstrike"]`.
+    """
+
+    asset_id: str
+    asset_name: Optional[str] = None
+    segment: str
+    site: Optional[str] = None
+    criticality: Literal["low", "medium", "high", "critical"]
+    mission_system: Optional[str] = None
+    adjacent_assets: List[VStrikeAdjacentAsset] = Field(default_factory=list)
+    attack_path: List[str] = Field(
+        default_factory=list,
+        description="Ordered list of asset_ids from initial access to this "
+        "finding's asset. The last element is the asset tied to this finding.",
+    )
+    blast_radius: Optional[int] = Field(
+        None, description="Count of assets reachable from this one."
+    )
+    topology_metadata: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Escape hatch for VStrike-specific fields not yet modelled.",
+    )
+    enriched_at: datetime
+
+
+class VStrikeFinding(BaseModel):
+    """A single finding pushed from VStrike.
+
+    `finding_id` must match a DeepTempo LogLM finding already known to Vigil
+    (update path). If it does not exist and `timestamp` + `anomaly_score` are
+    supplied, a new finding is created with `data_source="vstrike"`.
+    """
+
+    finding_id: str
+    vstrike_enrichment: VStrikeEnrichment
+
+    # Optional finding-creation fields (used only if finding_id is new)
+    timestamp: Optional[datetime] = None
+    anomaly_score: Optional[float] = None
+    severity: Optional[Literal["low", "medium", "high", "critical"]] = None
+    mitre_predictions: Optional[Dict[str, float]] = None
+    predicted_techniques: Optional[List[Dict[str, Any]]] = None
+    description: Optional[str] = None
+
+    # Merged into entity_context alongside the vstrike sub-dict
+    entity_context_extra: Optional[Dict[str, Any]] = None
+
+
+class VStrikePushRequest(BaseModel):
+    """Batch payload from VStrike.
+
+    Example:
+        {
+            "batch_id": "vstrike-2026-05-20-1420",
+            "findings": [...],
+            "auto_cluster_cases": true
+        }
+    """
+
+    batch_id: str
+    source: str = "vstrike"
+    findings: List[VStrikeFinding]
+    auto_cluster_cases: bool = True
+
+
+class VStrikeFindingResult(BaseModel):
+    """Per-finding outcome in the push response."""
+
+    finding_id: str
+    status: Literal["updated", "created", "failed"]
+    error: Optional[str] = None
+
+
+class VStrikePushResponse(BaseModel):
+    """Response for POST /api/integrations/vstrike/findings."""
+
+    batch_id: str
+    received: int
+    updated: int
+    created: int
+    failed: int
+    results: List[VStrikeFindingResult]
+    case_ids: List[str] = Field(default_factory=list)
+
+
+class VStrikeHealthResponse(BaseModel):
+    """Response for GET /api/integrations/vstrike/health."""
+
+    configured: bool
+    reachable: bool
+    base_url: Optional[str] = None
+    message: str

--- a/daemon/llm_worker_manager.py
+++ b/daemon/llm_worker_manager.py
@@ -3,10 +3,11 @@
 The ARQ worker (``services.run_llm_worker``) processes queued Claude API
 calls.  Because ARQ's ``run_worker()`` blocks, it must live in a separate
 process.  This manager runs as an async task inside the daemon and polls
-the ``orchestrator_enabled`` SystemConfig key every few seconds.  When the
-orchestrator is enabled the worker subprocess is started; when disabled it
-is stopped.  If the worker crashes while enabled it is automatically
-restarted on the next poll cycle.
+the ``orchestrator.settings`` SystemConfig key every few seconds, reading
+the ``enabled`` field.  When the orchestrator is enabled the worker
+subprocess is started; when disabled it is stopped.  If the worker
+crashes while enabled it is automatically restarted on the next poll
+cycle.
 """
 
 import asyncio
@@ -64,7 +65,8 @@ class LLMWorkerManager:
     # ------------------------------------------------------------------
 
     def _sync_enabled_from_db(self):
-        """Read the orchestrator enabled state from SystemConfig."""
+        """Read the orchestrator enabled state from the single
+        ``orchestrator.settings`` SystemConfig row."""
         try:
             from database.connection import get_db_manager
             from database.models import SystemConfig
@@ -72,11 +74,11 @@ class LLMWorkerManager:
             with get_db_manager().session_scope() as session:
                 cfg = (
                     session.query(SystemConfig)
-                    .filter_by(key="orchestrator_enabled")
+                    .filter_by(key="orchestrator.settings")
                     .first()
                 )
                 if cfg and isinstance(cfg.value, dict):
-                    db_enabled = cfg.value.get("enabled", False)
+                    db_enabled = bool(cfg.value.get("enabled", False))
                     if db_enabled != self._enabled:
                         self._enabled = db_enabled
                         logger.info(

--- a/daemon/orchestrator.py
+++ b/daemon/orchestrator.py
@@ -177,7 +177,8 @@ class Orchestrator:
         logger.info("Orchestrator shutdown complete")
 
     def _sync_enabled_from_db(self):
-        """Read the enabled state from the database (set by the API/UI toggle)."""
+        """Read the enabled state from the single ``orchestrator.settings``
+        SystemConfig row (set by the API/UI toggle or the Settings page)."""
         try:
             from database.connection import get_db_manager
             from database.models import SystemConfig
@@ -185,11 +186,11 @@ class Orchestrator:
             with get_db_manager().session_scope() as session:
                 cfg = (
                     session.query(SystemConfig)
-                    .filter_by(key="orchestrator_enabled")
+                    .filter_by(key="orchestrator.settings")
                     .first()
                 )
                 if cfg and isinstance(cfg.value, dict):
-                    db_enabled = cfg.value.get("enabled", False)
+                    db_enabled = bool(cfg.value.get("enabled", False))
                     if db_enabled != self._enabled:
                         self._enabled = db_enabled
                         logger.info(

--- a/database/init/01_init_schema.sql
+++ b/database/init/01_init_schema.sql
@@ -3,6 +3,11 @@
 
 -- Enable required extensions
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+-- pg_trgm powers GIN trigram indexes used for full-text search on findings
+-- (idx_finding_description and similar). Without it the ORM's create_all
+-- fails with: operator class "gin_trgm_ops" does not exist for access
+-- method "gin".
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 -- Create indexes for better performance (SQLAlchemy will create tables)
 -- These will be created if they don't already exist

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -340,6 +340,117 @@ Settings > Integrations > Custom Integration Builder:
 3. Review and test
 4. Deploy to `tools/` directory
 
+## CloudCurrent VStrike (Network Topology Fusion)
+
+VStrike enriches DeepTempo findings with network topology, asset, segment,
+and mission-system context, then pushes the enriched findings back into
+Vigil. Vigil can also query VStrike on demand for asset topology and blast
+radius.
+
+### Integration surface
+
+| Direction | Endpoint / Tool | Purpose |
+|-----------|-----------------|---------|
+| VStrike → Vigil | `POST /api/integrations/vstrike/findings` | Push enriched findings (batched) |
+| Vigil → VStrike | `GET /api/integrations/vstrike/health` | Outbound reachability check |
+| Vigil → VStrike | `GET /api/integrations/vstrike/topology/asset/{id}` | Asset topology lookup |
+| Vigil → VStrike | `GET /api/integrations/vstrike/topology/asset/{id}/adjacent` | One-hop neighbors |
+| Vigil → VStrike | `GET /api/integrations/vstrike/topology/asset/{id}/blast-radius` | Blast radius |
+| MCP | `tools/vstrike.py` (`vstrike_*` tools) | Agent-invokable topology queries |
+
+### Configuration
+
+Either set env vars (recommended for push/CI) or configure via the UI:
+
+```bash
+# .env
+VSTRIKE_BASE_URL="https://vstrike.example.com"
+VSTRIKE_API_KEY="<outbound bearer token>"
+VSTRIKE_VERIFY_SSL="true"
+VSTRIKE_INBOUND_API_KEY="<bearer token Vigil expects on inbound push>"
+```
+
+UI: **Settings → Integrations → CloudCurrent VStrike**.
+
+### Storage model
+
+VStrike enrichment lives at `finding.entity_context["vstrike"]` (JSONB —
+no DB migration required). Shape is defined by
+`backend/schemas/vstrike.py::VStrikeEnrichment` and mirrored by
+`frontend/src/types/vstrike.ts`.
+
+The ingest handler does read-modify-write on `entity_context` so existing
+keys (`src_ip`, `hostname`, etc.) are never clobbered.
+
+### Auto-case clustering
+
+When `auto_cluster_cases: true` (default), the ingest handler groups
+upserted findings by `(segment, attack_path[0] or asset_id)` and creates
+one case per group via
+`services.case_automation_service.cluster_findings_by_attack_path`.
+
+### Authentication
+
+Inbound push uses a bearer token:
+
+```
+Authorization: Bearer $VSTRIKE_INBOUND_API_KEY
+```
+
+When `DEV_MODE=true`, the auth check is bypassed (matches the rest of the
+codebase). Outside dev mode, the endpoint returns:
+- `401` if the header is missing or wrong
+- `503` if `VSTRIKE_INBOUND_API_KEY` is unset (refuses to run open)
+
+### Example push
+
+```bash
+export DEV_MODE=true
+curl -X POST http://localhost:6987/api/integrations/vstrike/findings \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "batch_id": "demo-1",
+    "findings": [{
+      "finding_id": "f-test-1",
+      "timestamp": "2026-05-20T14:00:00Z",
+      "anomaly_score": 0.87,
+      "vstrike_enrichment": {
+        "asset_id": "srv-01",
+        "asset_name": "SAP-PROD-01",
+        "segment": "mgmt-vlan-10",
+        "site": "JBSA",
+        "criticality": "high",
+        "mission_system": "C2-AWACS",
+        "attack_path": ["ext-gw-01", "dmz-web-02", "srv-01"],
+        "blast_radius": 14,
+        "adjacent_assets": [
+          {"asset_id": "dc-01", "hop_distance": 1, "edge_technique": "T1021.002"}
+        ],
+        "enriched_at": "2026-05-20T14:00:00Z"
+      }
+    }]
+  }'
+```
+
+### Visualization
+
+- **Finding detail**: `NetworkContextPanel` renders the VStrike sub-dict
+  (criticality, segment, mission system, blast radius, attack-path
+  breadcrumb, clickable adjacent-asset chips).
+- **Entity graph**: nodes are tinted by segment when VStrike metadata is
+  present; the first MITRE technique on a link is rendered as an edge
+  label (always on highlighted links, and at zoom > 2.0 otherwise).
+- **Pivot**: clicking an adjacent-asset chip dispatches
+  `vstrike-graph-highlight` — `pages/Investigation.tsx` listens for this
+  event and feeds the node id into `EntityGraph.highlightedNodes`.
+
+### Testing
+
+```bash
+pytest tests/integration/test_vstrike_ingest.py -v
+pytest tests/unit/test_vstrike_service.py -v
+```
+
 ## Stub Servers (Not Implemented)
 
 Available for future implementation:

--- a/env.example
+++ b/env.example
@@ -99,6 +99,15 @@ DARKTRACE_WEBHOOK_SECRET=""
 # Optional hard cap on webhook body size (KB). Default 1024.
 DARKTRACE_MAX_BODY_KB="1024"
 
+# VStrike (CloudCurrent network topology fusion layer)
+# Outbound: Vigil queries VStrike for asset topology / blast radius.
+# Inbound: VStrike pushes enriched findings to Vigil using VSTRIKE_INBOUND_API_KEY
+# as a Bearer token. DEV_MODE=true bypasses the inbound auth check.
+VSTRIKE_BASE_URL="https://vstrike.net"
+VSTRIKE_API_KEY=""
+VSTRIKE_VERIFY_SSL="true"
+VSTRIKE_INBOUND_API_KEY=""
+
 # -----------------------------------------------------------------------------
 # Threat Intelligence
 # -----------------------------------------------------------------------------

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,17 +8,15 @@
       "name": "deeptempo-ai-soc-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@emotion/react": "^11.11.3",
-        "@emotion/styled": "^11.11.0",
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^5.15.10",
         "@mui/lab": "^5.0.0-alpha.166",
         "@mui/material": "^5.15.10",
         "@mui/x-data-grid": "^6.19.4",
         "@tanstack/react-query": "^5.17.0",
         "axios": "^1.6.7",
-        "d3": "^7.9.0",
         "date-fns": "^4.1.0",
-        "moment": "^2.30.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-force-graph-2d": "^1.29.0",
@@ -30,8 +28,6 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.5",
         "@testing-library/react": "^14.1.2",
-        "@testing-library/user-event": "^14.5.1",
-        "@types/d3": "^7.4.3",
         "@types/react": "^18.2.55",
         "@types/react-dom": "^18.2.19",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -42,7 +38,6 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
         "jsdom": "^23.0.1",
-        "msw": "^2.0.11",
         "typescript": "^5.3.3",
         "vite": "^5.1.0",
         "vitest": "^1.0.4"
@@ -562,6 +557,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -602,6 +598,7 @@
       "version": "11.14.1",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1183,89 +1180,6 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
     },
-    "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
-      "dev": true,
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
-      "dev": true,
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -1326,23 +1240,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@mswjs/interceptors": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.40.0.tgz",
-      "integrity": "sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==",
-      "dev": true,
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@mui/base": {
@@ -1495,6 +1392,12 @@
         }
       }
     },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
     "node_modules/@mui/private-theming": {
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
@@ -1634,6 +1537,12 @@
         }
       }
     },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
     "node_modules/@mui/x-data-grid": {
       "version": "6.20.4",
       "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-6.20.4.tgz",
@@ -1693,28 +1602,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true
-    },
-    "node_modules/@open-draft/logger": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "dev": true,
-      "dependencies": {
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.0"
-      }
-    },
-    "node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -2094,26 +1981,6 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2185,19 +2052,6 @@
         "deep-equal": "^2.0.5"
       }
     },
-    "node_modules/@testing-library/user-event": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
-      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
-      }
-    },
     "node_modules/@tweenjs/tween.js": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
@@ -2250,155 +2104,20 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/d3": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
-      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-      "dev": true,
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/d3-axis": "*",
-        "@types/d3-brush": "*",
-        "@types/d3-chord": "*",
-        "@types/d3-color": "*",
-        "@types/d3-contour": "*",
-        "@types/d3-delaunay": "*",
-        "@types/d3-dispatch": "*",
-        "@types/d3-drag": "*",
-        "@types/d3-dsv": "*",
-        "@types/d3-ease": "*",
-        "@types/d3-fetch": "*",
-        "@types/d3-force": "*",
-        "@types/d3-format": "*",
-        "@types/d3-geo": "*",
-        "@types/d3-hierarchy": "*",
-        "@types/d3-interpolate": "*",
-        "@types/d3-path": "*",
-        "@types/d3-polygon": "*",
-        "@types/d3-quadtree": "*",
-        "@types/d3-random": "*",
-        "@types/d3-scale": "*",
-        "@types/d3-scale-chromatic": "*",
-        "@types/d3-selection": "*",
-        "@types/d3-shape": "*",
-        "@types/d3-time": "*",
-        "@types/d3-time-format": "*",
-        "@types/d3-timer": "*",
-        "@types/d3-transition": "*",
-        "@types/d3-zoom": "*"
-      }
-    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
-    },
-    "node_modules/@types/d3-axis": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
-      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-      "dev": true,
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-brush": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
-      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-      "dev": true,
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-chord": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
-      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-      "dev": true
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
     },
-    "node_modules/@types/d3-contour": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
-      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-      "dev": true,
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-      "dev": true
-    },
-    "node_modules/@types/d3-dispatch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
-      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
-      "dev": true
-    },
-    "node_modules/@types/d3-drag": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
-      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-dsv": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-      "dev": true
-    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
-    },
-    "node_modules/@types/d3-fetch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-      "dev": true,
-      "dependencies": {
-        "@types/d3-dsv": "*"
-      }
-    },
-    "node_modules/@types/d3-force": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
-      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-      "dev": true
-    },
-    "node_modules/@types/d3-format": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-      "dev": true
-    },
-    "node_modules/@types/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-hierarchy": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-      "dev": true
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
@@ -2413,24 +2132,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
     },
-    "node_modules/@types/d3-polygon": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
-      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-      "dev": true
-    },
-    "node_modules/@types/d3-quadtree": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-      "dev": true
-    },
-    "node_modules/@types/d3-random": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
-      "dev": true
-    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
@@ -2438,18 +2139,6 @@
       "dependencies": {
         "@types/d3-time": "*"
       }
-    },
-    "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "dev": true
-    },
-    "node_modules/@types/d3-selection": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
-      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-      "dev": true
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
@@ -2464,46 +2153,15 @@
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
     },
-    "node_modules/@types/d3-time-format": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-      "dev": true
-    },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
-    "node_modules/@types/d3-transition": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
-      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
-      "dev": true,
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-zoom": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
-      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
-      "dev": true,
-      "dependencies": {
-        "@types/d3-interpolate": "*",
-        "@types/d3-selection": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true
-    },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true
     },
     "node_modules/@types/hammerjs": {
@@ -2558,12 +2216,6 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-      "dev": true
-    },
-    "node_modules/@types/statuses": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
-      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3379,46 +3031,6 @@
         "node": "*"
       }
     },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3456,14 +3068,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -3489,19 +3093,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
-    },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -3581,46 +3172,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
-    "node_modules/d3": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
-      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-      "dependencies": {
-        "d3-array": "3",
-        "d3-axis": "3",
-        "d3-brush": "3",
-        "d3-chord": "3",
-        "d3-color": "3",
-        "d3-contour": "4",
-        "d3-delaunay": "6",
-        "d3-dispatch": "3",
-        "d3-drag": "3",
-        "d3-dsv": "3",
-        "d3-ease": "3",
-        "d3-fetch": "3",
-        "d3-force": "3",
-        "d3-format": "3",
-        "d3-geo": "3",
-        "d3-hierarchy": "3",
-        "d3-interpolate": "3",
-        "d3-path": "3",
-        "d3-polygon": "3",
-        "d3-quadtree": "3",
-        "d3-random": "3",
-        "d3-scale": "4",
-        "d3-scale-chromatic": "3",
-        "d3-selection": "3",
-        "d3-shape": "3",
-        "d3-time": "3",
-        "d3-time-format": "4",
-        "d3-timer": "3",
-        "d3-transition": "3",
-        "d3-zoom": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -3632,71 +3183,15 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-axis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-binarytree": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
       "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw=="
     },
-    "node_modules/d3-brush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "3",
-        "d3-transition": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-chord": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-      "dependencies": {
-        "d3-path": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-contour": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-      "dependencies": {
-        "d3-array": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "dependencies": {
-        "delaunator": "5"
-      },
       "engines": {
         "node": ">=12"
       }
@@ -3721,58 +3216,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "dependencies": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json.js",
-        "csv2tsv": "bin/dsv2dsv.js",
-        "dsv2dsv": "bin/dsv2dsv.js",
-        "dsv2json": "bin/dsv2json.js",
-        "json2csv": "bin/json2dsv.js",
-        "json2dsv": "bin/json2dsv.js",
-        "json2tsv": "bin/json2dsv.js",
-        "tsv2csv": "bin/dsv2dsv.js",
-        "tsv2json": "bin/dsv2json.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "dependencies": {
-        "d3-dsv": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-force": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
       "engines": {
         "node": ">=12"
       }
@@ -3796,25 +3243,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.1.tgz",
       "integrity": "sha512-ryitBnaRbXQtgZ/gU50GSn6jQRwinSCQclpakXymvLd8ytTgE5bmSfgYcUxD7XYL34qHhFDyVk71qqKsfSyvmA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-      "dependencies": {
-        "d3-array": "2.5.0 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "engines": {
         "node": ">=12"
       }
@@ -3843,26 +3271,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-polygon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
       "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-random": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
       "engines": {
         "node": ">=12"
       }
@@ -4109,14 +3521,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delaunator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
-      "dependencies": {
-        "robust-predicates": "^3.0.2"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -4199,12 +3603,6 @@
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
-      "dev": true
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "node_modules/entities": {
@@ -4830,15 +4228,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -5002,15 +4391,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/graphql": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
-      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5080,12 +4460,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/headers-polyfill": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
-      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
-      "dev": true
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -5095,9 +4469,10 @@
       }
     },
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -5156,6 +4531,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -5372,15 +4748,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -5404,12 +4771,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-node-process": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
-      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6025,6 +5386,7 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -6033,86 +5395,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/msw": {
-      "version": "2.12.7",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.7.tgz",
-      "integrity": "sha512-retd5i3xCZDVWMYjHEVuKTmhqY8lSsxujjVrZiGbbdoxxIBg5S7rCuYy/YQpfrTYIxpd/o0Kyb/3H+1udBMoYg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@inquirer/confirm": "^5.0.0",
-        "@mswjs/interceptors": "^0.40.0",
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@types/statuses": "^2.0.6",
-        "cookie": "^1.0.2",
-        "graphql": "^16.12.0",
-        "headers-polyfill": "^4.0.2",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "path-to-regexp": "^6.3.0",
-        "picocolors": "^1.1.1",
-        "rettime": "^0.7.0",
-        "statuses": "^2.0.2",
-        "strict-event-emitter": "^0.5.1",
-        "tough-cookie": "^6.0.0",
-        "type-fest": "^5.2.0",
-        "until-async": "^3.0.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.8.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/msw/node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "dev": true,
-      "dependencies": {
-        "tldts": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/msw/node_modules/type-fest": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
-      "integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
-      "dev": true,
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -6277,12 +5559,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/outvariant": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
-      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-      "dev": true
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6384,12 +5660,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -6530,10 +5800,11 @@
       }
     },
     "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6546,9 +5817,10 @@
       }
     },
     "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/propagating-hammerjs": {
       "version": "3.0.0",
@@ -6649,11 +5921,6 @@
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/react-is": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
-      "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA=="
     },
     "node_modules/react-kapsule": {
       "version": "2.5.7",
@@ -6805,15 +6072,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6861,12 +6119,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/rettime": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.7.0.tgz",
-      "integrity": "sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==",
-      "dev": true
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6892,11 +6144,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/rollup": {
       "version": "4.55.1",
@@ -6971,11 +6218,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
-    },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -6996,7 +6238,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -7205,15 +6448,6 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -7231,26 +6465,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
@@ -7353,18 +6567,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -7440,24 +6642,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/tldts": {
-      "version": "7.0.19",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
-      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
-      "dev": true,
-      "dependencies": {
-        "tldts-core": "^7.0.19"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tldts-core": {
-      "version": "7.0.19",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
-      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
-      "dev": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -7569,15 +6753,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/until-async": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
-      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -8013,20 +7188,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -8091,15 +7252,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "peer": true
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -8114,33 +7266,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -8148,18 +7273,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8881,51 +7994,6 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
     },
-    "@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
-      "dev": true
-    },
-    "@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
-      "dev": true,
-      "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      }
-    },
-    "@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
-      "dev": true,
-      "requires": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
-      }
-    },
-    "@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
-      "dev": true
-    },
-    "@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
-      "dev": true,
-      "requires": {}
-    },
     "@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -8977,20 +8045,6 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "@mswjs/interceptors": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.40.0.tgz",
-      "integrity": "sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==",
-      "dev": true,
-      "requires": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "strict-event-emitter": "^0.5.1"
       }
     },
     "@mui/base": {
@@ -9049,8 +8103,15 @@
         "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.0.0",
+        "react-is": "^18.3.1",
         "react-transition-group": "^4.4.5"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+        }
       }
     },
     "@mui/private-theming": {
@@ -9106,7 +8167,14 @@
         "@types/prop-types": "^15.7.12",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.0.0"
+        "react-is": "^18.3.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+        }
       }
     },
     "@mui/x-data-grid": {
@@ -9146,28 +8214,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true
-    },
-    "@open-draft/logger": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "dev": true,
-      "requires": {
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.0"
-      }
-    },
-    "@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
     },
     "@popperjs/core": {
       "version": "2.11.8",
@@ -9379,23 +8425,6 @@
         "@tanstack/query-core": "5.90.20"
       }
     },
-    "@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      }
-    },
     "@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -9456,13 +8485,6 @@
         }
       }
     },
-    "@testing-library/user-event": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
-      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true,
-      "requires": {}
-    },
     "@tweenjs/tween.js": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
@@ -9515,155 +8537,20 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "@types/d3": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
-      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-      "dev": true,
-      "requires": {
-        "@types/d3-array": "*",
-        "@types/d3-axis": "*",
-        "@types/d3-brush": "*",
-        "@types/d3-chord": "*",
-        "@types/d3-color": "*",
-        "@types/d3-contour": "*",
-        "@types/d3-delaunay": "*",
-        "@types/d3-dispatch": "*",
-        "@types/d3-drag": "*",
-        "@types/d3-dsv": "*",
-        "@types/d3-ease": "*",
-        "@types/d3-fetch": "*",
-        "@types/d3-force": "*",
-        "@types/d3-format": "*",
-        "@types/d3-geo": "*",
-        "@types/d3-hierarchy": "*",
-        "@types/d3-interpolate": "*",
-        "@types/d3-path": "*",
-        "@types/d3-polygon": "*",
-        "@types/d3-quadtree": "*",
-        "@types/d3-random": "*",
-        "@types/d3-scale": "*",
-        "@types/d3-scale-chromatic": "*",
-        "@types/d3-selection": "*",
-        "@types/d3-shape": "*",
-        "@types/d3-time": "*",
-        "@types/d3-time-format": "*",
-        "@types/d3-timer": "*",
-        "@types/d3-transition": "*",
-        "@types/d3-zoom": "*"
-      }
-    },
     "@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
-    },
-    "@types/d3-axis": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
-      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-      "dev": true,
-      "requires": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "@types/d3-brush": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
-      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-      "dev": true,
-      "requires": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "@types/d3-chord": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
-      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-      "dev": true
     },
     "@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
     },
-    "@types/d3-contour": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
-      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-      "dev": true,
-      "requires": {
-        "@types/d3-array": "*",
-        "@types/geojson": "*"
-      }
-    },
-    "@types/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-      "dev": true
-    },
-    "@types/d3-dispatch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
-      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
-      "dev": true
-    },
-    "@types/d3-drag": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
-      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
-      "dev": true,
-      "requires": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "@types/d3-dsv": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-      "dev": true
-    },
     "@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
-    },
-    "@types/d3-fetch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-      "dev": true,
-      "requires": {
-        "@types/d3-dsv": "*"
-      }
-    },
-    "@types/d3-force": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
-      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-      "dev": true
-    },
-    "@types/d3-format": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-      "dev": true
-    },
-    "@types/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-      "dev": true,
-      "requires": {
-        "@types/geojson": "*"
-      }
-    },
-    "@types/d3-hierarchy": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-      "dev": true
     },
     "@types/d3-interpolate": {
       "version": "3.0.4",
@@ -9678,24 +8565,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
     },
-    "@types/d3-polygon": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
-      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-      "dev": true
-    },
-    "@types/d3-quadtree": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-      "dev": true
-    },
-    "@types/d3-random": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
-      "dev": true
-    },
     "@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
@@ -9703,18 +8572,6 @@
       "requires": {
         "@types/d3-time": "*"
       }
-    },
-    "@types/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "dev": true
-    },
-    "@types/d3-selection": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
-      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-      "dev": true
     },
     "@types/d3-shape": {
       "version": "3.1.8",
@@ -9729,46 +8586,15 @@
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
     },
-    "@types/d3-time-format": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-      "dev": true
-    },
     "@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
-    "@types/d3-transition": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
-      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
-      "dev": true,
-      "requires": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "@types/d3-zoom": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
-      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
-      "dev": true,
-      "requires": {
-        "@types/d3-interpolate": "*",
-        "@types/d3-selection": "*"
-      }
-    },
     "@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true
-    },
-    "@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true
     },
     "@types/hammerjs": {
@@ -9819,12 +8645,6 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-      "dev": true
-    },
-    "@types/statuses": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
-      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -10033,7 +8853,7 @@
           "requires": {
             "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
+            "react-is": "^18.3.1"
           }
         },
         "react-is": {
@@ -10079,7 +8899,7 @@
           "requires": {
             "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
+            "react-is": "^18.3.1"
           }
         },
         "react-is": {
@@ -10368,36 +9188,6 @@
         "get-func-name": "^2.0.2"
       }
     },
-    "cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true
-    },
-    "cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        }
-      }
-    },
     "clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -10426,11 +9216,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-    },
     "component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -10453,12 +9238,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
-    },
-    "cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true
     },
     "cosmiconfig": {
       "version": "7.1.0",
@@ -10528,43 +9307,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
-    "d3": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
-      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-      "requires": {
-        "d3-array": "3",
-        "d3-axis": "3",
-        "d3-brush": "3",
-        "d3-chord": "3",
-        "d3-color": "3",
-        "d3-contour": "4",
-        "d3-delaunay": "6",
-        "d3-dispatch": "3",
-        "d3-drag": "3",
-        "d3-dsv": "3",
-        "d3-ease": "3",
-        "d3-fetch": "3",
-        "d3-force": "3",
-        "d3-format": "3",
-        "d3-geo": "3",
-        "d3-hierarchy": "3",
-        "d3-interpolate": "3",
-        "d3-path": "3",
-        "d3-polygon": "3",
-        "d3-quadtree": "3",
-        "d3-random": "3",
-        "d3-scale": "4",
-        "d3-scale-chromatic": "3",
-        "d3-selection": "3",
-        "d3-shape": "3",
-        "d3-time": "3",
-        "d3-time-format": "4",
-        "d3-timer": "3",
-        "d3-transition": "3",
-        "d3-zoom": "3"
-      }
-    },
     "d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -10573,56 +9315,15 @@
         "internmap": "1 - 2"
       }
     },
-    "d3-axis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
-    },
     "d3-binarytree": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
       "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw=="
     },
-    "d3-brush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-      "requires": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "3",
-        "d3-transition": "3"
-      }
-    },
-    "d3-chord": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-      "requires": {
-        "d3-path": "1 - 3"
-      }
-    },
     "d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
-    },
-    "d3-contour": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-      "requires": {
-        "d3-array": "^3.2.0"
-      }
-    },
-    "d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "requires": {
-        "delaunator": "5"
-      }
     },
     "d3-dispatch": {
       "version": "3.0.1",
@@ -10638,38 +9339,10 @@
         "d3-selection": "3"
       }
     },
-    "d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "requires": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      }
-    },
     "d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
-    },
-    "d3-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "requires": {
-        "d3-dsv": "1 - 3"
-      }
-    },
-    "d3-force": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "requires": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      }
     },
     "d3-force-3d": {
       "version": "3.0.6",
@@ -10687,19 +9360,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.1.tgz",
       "integrity": "sha512-ryitBnaRbXQtgZ/gU50GSn6jQRwinSCQclpakXymvLd8ytTgE5bmSfgYcUxD7XYL34qHhFDyVk71qqKsfSyvmA=="
-    },
-    "d3-geo": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-      "requires": {
-        "d3-array": "2.5.0 - 3"
-      }
-    },
-    "d3-hierarchy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
     },
     "d3-interpolate": {
       "version": "3.0.1",
@@ -10719,20 +9379,10 @@
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
     },
-    "d3-polygon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
-    },
     "d3-quadtree": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
       "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
-    },
-    "d3-random": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
     },
     "d3-scale": {
       "version": "4.0.2",
@@ -10910,14 +9560,6 @@
         "object-keys": "^1.1.1"
       }
     },
-    "delaunator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
-      "requires": {
-        "robust-predicates": "^3.0.2"
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -10982,12 +9624,6 @@
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
-      "dev": true
-    },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "entities": {
@@ -11455,12 +10091,6 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
-    "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
     "get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -11577,12 +10207,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "graphql": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
-      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
-      "dev": true
-    },
     "has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -11625,24 +10249,18 @@
         "function-bind": "^1.1.2"
       }
     },
-    "headers-polyfill": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
-      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
-      "dev": true
-    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "requires": {
-        "react-is": "^16.7.0"
+        "react-is": "^18.3.1"
       },
       "dependencies": {
         "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
         }
       }
     },
@@ -11691,6 +10309,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -11834,12 +10453,6 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
-    "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
-    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -11853,12 +10466,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-      "dev": true
-    },
-    "is-node-process": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
-      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "dev": true
     },
     "is-number": {
@@ -12315,64 +10922,13 @@
     "moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "peer": true
     },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "msw": {
-      "version": "2.12.7",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.7.tgz",
-      "integrity": "sha512-retd5i3xCZDVWMYjHEVuKTmhqY8lSsxujjVrZiGbbdoxxIBg5S7rCuYy/YQpfrTYIxpd/o0Kyb/3H+1udBMoYg==",
-      "dev": true,
-      "requires": {
-        "@inquirer/confirm": "^5.0.0",
-        "@mswjs/interceptors": "^0.40.0",
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@types/statuses": "^2.0.6",
-        "cookie": "^1.0.2",
-        "graphql": "^16.12.0",
-        "headers-polyfill": "^4.0.2",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "path-to-regexp": "^6.3.0",
-        "picocolors": "^1.1.1",
-        "rettime": "^0.7.0",
-        "statuses": "^2.0.2",
-        "strict-event-emitter": "^0.5.1",
-        "tough-cookie": "^6.0.0",
-        "type-fest": "^5.2.0",
-        "until-async": "^3.0.2",
-        "yargs": "^17.7.2"
-      },
-      "dependencies": {
-        "tough-cookie": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-          "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-          "dev": true,
-          "requires": {
-            "tldts": "^7.0.5"
-          }
-        },
-        "type-fest": {
-          "version": "5.4.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
-          "integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
-          "dev": true,
-          "requires": {
-            "tagged-tag": "^1.0.0"
-          }
-        }
-      }
-    },
-    "mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true
     },
     "nanoid": {
       "version": "3.3.11",
@@ -12482,12 +11038,6 @@
         "word-wrap": "^1.2.5"
       }
     },
-    "outvariant": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
-      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-      "dev": true
-    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -12556,12 +11106,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -12646,7 +11190,7 @@
       "requires": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "react-is": "^18.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12656,9 +11200,9 @@
           "dev": true
         },
         "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
           "dev": true
         }
       }
@@ -12670,13 +11214,13 @@
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
+        "react-is": "^18.3.1"
       },
       "dependencies": {
         "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
         }
       }
     },
@@ -12745,11 +11289,6 @@
         "prop-types": "15",
         "react-kapsule": "^2.5"
       }
-    },
-    "react-is": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
-      "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA=="
     },
     "react-kapsule": {
       "version": "2.5.7",
@@ -12857,12 +11396,6 @@
         "set-function-name": "^2.0.2"
       }
     },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true
-    },
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -12895,12 +11428,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
-    "rettime": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.7.0.tgz",
-      "integrity": "sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==",
-      "dev": true
-    },
     "reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -12915,11 +11442,6 @@
       "requires": {
         "glob": "^7.1.3"
       }
-    },
-    "robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "rollup": {
       "version": "4.55.1",
@@ -12971,11 +11493,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
-    },
     "safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -12990,7 +11507,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "saxes": {
       "version": "6.0.0",
@@ -13139,12 +11657,6 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
-    "statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true
-    },
     "std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -13159,23 +11671,6 @@
       "requires": {
         "es-errors": "^1.3.0",
         "internal-slot": "^1.1.0"
-      }
-    },
-    "strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
-    },
-    "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
       }
     },
     "strip-ansi": {
@@ -13250,12 +11745,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true
-    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -13320,21 +11809,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
       "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
-      "dev": true
-    },
-    "tldts": {
-      "version": "7.0.19",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
-      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
-      "dev": true,
-      "requires": {
-        "tldts-core": "^7.0.19"
-      }
-    },
-    "tldts-core": {
-      "version": "7.0.19",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
-      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
       "dev": true
     },
     "to-regex-range": {
@@ -13411,12 +11885,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true
-    },
-    "until-async": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
-      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
       "dev": true
     },
     "update-browserslist-db": {
@@ -13652,17 +12120,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
-    "wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -13706,12 +12163,6 @@
         }
       }
     },
-    "y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
-    },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -13723,37 +12174,10 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
-    "yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "requires": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      }
-    },
-    "yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true
-    },
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
-    },
-    "yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "dev": true
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,8 @@
     "test:ci": "vitest run --reporter=verbose --reporter=json --outputFile=test-results.json"
   },
   "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^5.15.10",
     "@mui/lab": "^5.0.0-alpha.166",
     "@mui/material": "^5.15.10",
@@ -30,6 +32,9 @@
     "recharts": "^2.12.0",
     "vis-data": "^8.0.3",
     "vis-timeline": "^8.5.0"
+  },
+  "overrides": {
+    "react-is": "^18.3.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",

--- a/frontend/src/components/findings/FindingDetailDialog.tsx
+++ b/frontend/src/components/findings/FindingDetailDialog.tsx
@@ -40,6 +40,8 @@ import {
 import { findingsApi, timelineApi } from '../../services/api'
 import EventTimeline from '../timeline/EventTimeline'
 import EventVisualizationDialog from '../timeline/EventVisualizationDialog'
+import NetworkContextPanel from './NetworkContextPanel'
+import { VStrikeEnrichment } from '../../types/vstrike'
 
 interface FindingDetailDialogProps {
   open: boolean
@@ -449,6 +451,18 @@ export default function FindingDetailDialog({
                     Predicted by DeepTempo LogLM model during ingestion
                   </Typography>
                 </Paper>
+              </Grid>
+            )}
+
+            {/* VStrike Network Context (only renders when enrichment present) */}
+            {displayFinding.entity_context?.vstrike && (
+              <Grid item xs={12}>
+                <Divider sx={{ my: 2 }} />
+                <NetworkContextPanel
+                  context={
+                    displayFinding.entity_context.vstrike as VStrikeEnrichment
+                  }
+                />
               </Grid>
             )}
 

--- a/frontend/src/components/findings/NetworkContextPanel.tsx
+++ b/frontend/src/components/findings/NetworkContextPanel.tsx
@@ -1,0 +1,244 @@
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Box,
+  Chip,
+  Divider,
+  Grid,
+  Paper,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import {
+  AccountTree as TopologyIcon,
+  ArrowForward as ArrowForwardIcon,
+  ExpandMore as ExpandMoreIcon,
+  Hub as HubIcon,
+  LocationOn as LocationIcon,
+} from '@mui/icons-material'
+import {
+  VSTRIKE_GRAPH_HIGHLIGHT_EVENT,
+  VStrikeAdjacentAsset,
+  VStrikeCriticality,
+  VStrikeEnrichment,
+} from '../../types/vstrike'
+
+interface NetworkContextPanelProps {
+  context?: VStrikeEnrichment | null
+}
+
+const CRITICALITY_COLOR: Record<
+  VStrikeCriticality,
+  'default' | 'success' | 'warning' | 'error'
+> = {
+  low: 'success',
+  medium: 'warning',
+  high: 'error',
+  critical: 'error',
+}
+
+function pivotToGraphNode(nodeId: string) {
+  window.dispatchEvent(
+    new CustomEvent(VSTRIKE_GRAPH_HIGHLIGHT_EVENT, {
+      detail: { nodeId },
+    })
+  )
+}
+
+function AttackPathBreadcrumb({
+  path,
+  currentAssetId,
+}: {
+  path: string[]
+  currentAssetId: string
+}) {
+  if (!path || path.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No attack path available.
+      </Typography>
+    )
+  }
+  return (
+    <Stack direction="row" alignItems="center" flexWrap="wrap" gap={0.5}>
+      {path.map((asset, idx) => {
+        const isCurrent = asset === currentAssetId
+        return (
+          <Stack
+            key={`${asset}-${idx}`}
+            direction="row"
+            alignItems="center"
+            gap={0.5}
+          >
+            <Chip
+              label={asset}
+              size="small"
+              color={isCurrent ? 'primary' : 'default'}
+              variant={isCurrent ? 'filled' : 'outlined'}
+              onClick={() => pivotToGraphNode(asset)}
+              sx={{ cursor: 'pointer' }}
+            />
+            {idx < path.length - 1 && (
+              <ArrowForwardIcon fontSize="small" color="action" />
+            )}
+          </Stack>
+        )
+      })}
+    </Stack>
+  )
+}
+
+function AdjacentAssetChip({ asset }: { asset: VStrikeAdjacentAsset }) {
+  const label = asset.edge_technique
+    ? `${asset.asset_id} · ${asset.edge_technique}`
+    : asset.asset_id
+  const title = [
+    asset.asset_name ? `Name: ${asset.asset_name}` : null,
+    asset.segment ? `Segment: ${asset.segment}` : null,
+    `Hop distance: ${asset.hop_distance}`,
+    asset.edge_technique ? `MITRE: ${asset.edge_technique}` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+  return (
+    <Tooltip title={title}>
+      <Chip
+        label={label}
+        size="small"
+        variant="outlined"
+        onClick={() => pivotToGraphNode(asset.asset_id)}
+        sx={{ cursor: 'pointer' }}
+      />
+    </Tooltip>
+  )
+}
+
+export default function NetworkContextPanel({
+  context,
+}: NetworkContextPanelProps) {
+  if (!context) return null
+
+  return (
+    <Accordion defaultExpanded elevation={2}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Box display="flex" alignItems="center">
+          <TopologyIcon sx={{ mr: 1, color: 'primary.main' }} />
+          <Typography fontWeight="bold">Network Context (VStrike)</Typography>
+          <Chip
+            label={context.criticality}
+            color={CRITICALITY_COLOR[context.criticality] || 'default'}
+            size="small"
+            sx={{ ml: 1, textTransform: 'capitalize' }}
+          />
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Paper sx={{ p: 2, bgcolor: 'background.default' }} elevation={0}>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <Typography variant="subtitle2" color="text.secondary">
+                Asset
+              </Typography>
+              <Typography variant="body1">
+                {context.asset_name || context.asset_id}
+                {context.asset_name && (
+                  <Typography
+                    component="span"
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ ml: 1 }}
+                  >
+                    ({context.asset_id})
+                  </Typography>
+                )}
+              </Typography>
+            </Grid>
+
+            <Grid item xs={12} sm={6}>
+              <Typography variant="subtitle2" color="text.secondary">
+                Segment
+              </Typography>
+              <Stack direction="row" alignItems="center" gap={1}>
+                <HubIcon fontSize="small" color="action" />
+                <Typography variant="body1">{context.segment}</Typography>
+                {context.site && (
+                  <>
+                    <LocationIcon fontSize="small" color="action" />
+                    <Typography variant="body2" color="text.secondary">
+                      {context.site}
+                    </Typography>
+                  </>
+                )}
+              </Stack>
+            </Grid>
+
+            {context.mission_system && (
+              <Grid item xs={12} sm={6}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  Mission System
+                </Typography>
+                <Typography variant="body1">{context.mission_system}</Typography>
+              </Grid>
+            )}
+
+            {typeof context.blast_radius === 'number' && (
+              <Grid item xs={12} sm={6}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  Blast Radius
+                </Typography>
+                <Typography variant="body1">
+                  {context.blast_radius} asset
+                  {context.blast_radius === 1 ? '' : 's'} reachable
+                </Typography>
+              </Grid>
+            )}
+
+            <Grid item xs={12}>
+              <Divider sx={{ my: 1 }} />
+              <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                Attack Path
+              </Typography>
+              <AttackPathBreadcrumb
+                path={context.attack_path}
+                currentAssetId={context.asset_id}
+              />
+            </Grid>
+
+            {context.adjacent_assets && context.adjacent_assets.length > 0 && (
+              <Grid item xs={12}>
+                <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                  Adjacent Assets
+                </Typography>
+                <Box display="flex" flexWrap="wrap" gap={1}>
+                  {context.adjacent_assets.map((asset) => (
+                    <AdjacentAssetChip
+                      key={`${asset.asset_id}-${asset.hop_distance}`}
+                      asset={asset}
+                    />
+                  ))}
+                </Box>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ mt: 1, display: 'block' }}
+                >
+                  Click a chip to highlight the corresponding node in the
+                  entity graph.
+                </Typography>
+              </Grid>
+            )}
+
+            <Grid item xs={12}>
+              <Typography variant="caption" color="text.secondary">
+                Enriched by CloudCurrent VStrike at{' '}
+                {new Date(context.enriched_at).toLocaleString()}
+              </Typography>
+            </Grid>
+          </Grid>
+        </Paper>
+      </AccordionDetails>
+    </Accordion>
+  )
+}

--- a/frontend/src/components/graph/EntityGraph.tsx
+++ b/frontend/src/components/graph/EntityGraph.tsx
@@ -87,6 +87,39 @@ function throttle<T extends (...args: any[]) => any>(
   }
 }
 
+// Segment palette (VStrike-aware). Deterministic hash → categorical color.
+// Used when a node has no explicit severity but carries a VStrike segment.
+const SEGMENT_PALETTE = [
+  '#1976d2',
+  '#7b1fa2',
+  '#0097a7',
+  '#f57c00',
+  '#5d4037',
+  '#c2185b',
+  '#388e3c',
+  '#455a64',
+  '#6a1b9a',
+  '#00796b',
+]
+
+function hashString(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) {
+    h = (h << 5) - h + s.charCodeAt(i)
+    h |= 0
+  }
+  return Math.abs(h)
+}
+
+function getSegmentColor(segment: string): string {
+  return SEGMENT_PALETTE[hashString(segment) % SEGMENT_PALETTE.length]
+}
+
+function getNodeSegment(node: GraphNode): string | undefined {
+  const meta = node.metadata || {}
+  return meta.segment || meta?.vstrike?.segment
+}
+
 // Memoized color getter
 const getNodeColorMemo = (
   node: GraphNode,
@@ -107,6 +140,11 @@ const getNodeColorMemo = (
       case 'low':
         return '#388e3c'
     }
+  }
+
+  const segment = getNodeSegment(node)
+  if (segment) {
+    return getSegmentColor(segment)
   }
 
   switch (node.type) {
@@ -469,8 +507,19 @@ const EntityGraph = memo(function EntityGraph({
         ctx.stroke()
       }
 
-      // Draw label only if present and zoomed in enough (LOD optimization)
-      if (link.label && globalScale > 2.0) {
+      // Edge label: prefer explicit label, fall back to first MITRE technique
+      // Always show on highlighted links; otherwise require zoom > 2.0 (LOD).
+      const sourceIdForLabel = getLinkNodeId(link.source)
+      const targetIdForLabel = getLinkNodeId(link.target)
+      const isLinkHighlighted = highlightLinks.has(
+        `${sourceIdForLabel}-${targetIdForLabel}`
+      )
+      const labelText =
+        link.label ||
+        (link.techniques && link.techniques.length > 0
+          ? link.techniques[0]
+          : undefined)
+      if (labelText && (isLinkHighlighted || globalScale > 2.0)) {
         const midX = (source.x + target.x) / 2
         const midY = (source.y + target.y) / 2
         const fontSize = 10 / globalScale
@@ -478,11 +527,11 @@ const EntityGraph = memo(function EntityGraph({
         ctx.font = `${fontSize}px Sans-Serif`
         ctx.textAlign = 'center'
         ctx.textBaseline = 'middle'
-        ctx.fillStyle = '#666'
-        ctx.fillText(link.label, midX, midY)
+        ctx.fillStyle = isLinkHighlighted ? '#b71c1c' : '#666'
+        ctx.fillText(labelText, midX, midY)
       }
     },
-    [filteredNodes, getLinkColor, getLinkWidth]
+    [filteredNodes, getLinkColor, getLinkWidth, getLinkNodeId, highlightLinks]
   )
 
   // Get unique node types for filter
@@ -798,6 +847,16 @@ const EntityGraph = memo(function EntityGraph({
             {hoverNode.findingCount && hoverNode.findingCount > 0 && (
               <Typography variant="body2" color="text.secondary">
                 Findings: {hoverNode.findingCount}
+              </Typography>
+            )}
+            {getNodeSegment(hoverNode) && (
+              <Typography variant="body2" color="text.secondary">
+                Segment: {getNodeSegment(hoverNode)}
+              </Typography>
+            )}
+            {hoverNode.metadata?.vstrike?.mission_system && (
+              <Typography variant="body2" color="text.secondary">
+                Mission: {hoverNode.metadata.vstrike.mission_system}
               </Typography>
             )}
           </Paper>

--- a/frontend/src/config/integrations.ts
+++ b/frontend/src/config/integrations.ts
@@ -3007,6 +3007,51 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     ],
     docs_url: 'https://cuckoo.readthedocs.io/en/latest/',
   },
+
+  // NETWORK TOPOLOGY FUSION
+  {
+    id: 'vstrike',
+    name: 'CloudCurrent VStrike',
+    category: 'Network Security',
+    description:
+      'Network topology fusion layer. Correlates DeepTempo findings with asset, segment, mission system, and attack-path context, and pushes enriched findings back into Vigil.',
+    functionality_type: 'Data Enrichment',
+    fields: [
+      {
+        name: 'url',
+        label: 'VStrike Base URL',
+        type: 'url',
+        required: true,
+        placeholder: 'https://vstrike.net',
+        helpText: 'Base URL of your VStrike deployment.',
+      },
+      {
+        name: 'api_key',
+        label: 'Outbound API Key',
+        type: 'password',
+        required: true,
+        placeholder: 'Bearer token for Vigil → VStrike calls',
+        helpText:
+          'Used for outbound topology lookups. Stored as VSTRIKE_API_KEY.',
+      },
+      {
+        name: 'inbound_api_key',
+        label: 'Inbound API Key',
+        type: 'password',
+        required: false,
+        placeholder: 'Bearer token VStrike presents to Vigil',
+        helpText:
+          'Required for /api/integrations/vstrike/findings unless DEV_MODE=true. Stored as VSTRIKE_INBOUND_API_KEY.',
+      },
+      {
+        name: 'verify_ssl',
+        label: 'Verify SSL Certificate',
+        type: 'boolean',
+        default: true,
+      },
+    ],
+    docs_url: 'https://cloudcurrent.biz/vstrike',
+  },
 ]
 
 export const INTEGRATION_CATEGORIES = [

--- a/frontend/src/pages/Investigation.tsx
+++ b/frontend/src/pages/Investigation.tsx
@@ -25,6 +25,10 @@ import {
 import { timelineApi, graphApi } from '../services/api'
 import EventTimeline, { TimelineEvent } from '../components/timeline/EventTimeline'
 import EntityGraph, { GraphNode, GraphLink } from '../components/graph/EntityGraph'
+import {
+  VSTRIKE_GRAPH_HIGHLIGHT_EVENT,
+  VStrikeGraphHighlightDetail,
+} from '../types/vstrike'
 
 export default function Investigation() {
   const [searchParams] = useSearchParams()
@@ -49,6 +53,27 @@ export default function Investigation() {
   useEffect(() => {
     loadData()
   }, [caseId, findingIds, clusterId])
+
+  // Listen for pivot events dispatched by the VStrike NetworkContextPanel.
+  useEffect(() => {
+    const handleVStrikeHighlight = (event: Event) => {
+      const detail = (event as CustomEvent<VStrikeGraphHighlightDetail>).detail
+      if (!detail?.nodeId) return
+      setHighlightedNodes((prev) =>
+        prev.includes(detail.nodeId) ? prev : [detail.nodeId]
+      )
+    }
+    window.addEventListener(
+      VSTRIKE_GRAPH_HIGHLIGHT_EVENT,
+      handleVStrikeHighlight as EventListener
+    )
+    return () => {
+      window.removeEventListener(
+        VSTRIKE_GRAPH_HIGHLIGHT_EVENT,
+        handleVStrikeHighlight as EventListener
+      )
+    }
+  }, [])
 
   const loadData = async () => {
     setLoading(true)

--- a/frontend/src/types/vstrike.ts
+++ b/frontend/src/types/vstrike.ts
@@ -1,0 +1,45 @@
+/**
+ * Frontend types for VStrike enrichment.
+ *
+ * Mirrors `backend/schemas/vstrike.py::VStrikeEnrichment`. The Pydantic
+ * schema is the source of truth — keep these in sync when it changes.
+ *
+ * This data lives at `finding.entity_context.vstrike` and is produced by
+ * CloudCurrent's VStrike fusion layer.
+ */
+
+export type VStrikeCriticality = 'low' | 'medium' | 'high' | 'critical'
+
+export interface VStrikeAdjacentAsset {
+  asset_id: string
+  asset_name?: string
+  segment?: string
+  hop_distance: number
+  /** MITRE ATT&CK technique ID for attack-path edges (e.g. "T1021.002"). */
+  edge_technique?: string
+}
+
+export interface VStrikeEnrichment {
+  asset_id: string
+  asset_name?: string
+  segment: string
+  site?: string
+  criticality: VStrikeCriticality
+  mission_system?: string
+  adjacent_assets: VStrikeAdjacentAsset[]
+  /** Ordered asset_ids from initial access to the finding's asset. */
+  attack_path: string[]
+  blast_radius?: number
+  topology_metadata?: Record<string, any>
+  enriched_at: string
+}
+
+/**
+ * Custom event name used to pivot the EntityGraph from the
+ * NetworkContextPanel. Event `detail` carries `{ nodeId }`.
+ */
+export const VSTRIKE_GRAPH_HIGHLIGHT_EVENT = 'vstrike-graph-highlight'
+
+export interface VStrikeGraphHighlightDetail {
+  nodeId: string
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -27,6 +27,41 @@ export default defineConfig(({ mode }) => {
         },
       },
     },
+    resolve: {
+      // Dedupe React + emotion so pre-bundled deps share one instance.
+      // Without this, react-router-dom gets its own React copy and hook
+      // calls throw "Cannot read properties of null (reading 'useRef')".
+      dedupe: [
+        'react',
+        'react-dom',
+        'react-is',
+        'react-transition-group',
+        '@emotion/react',
+        '@emotion/styled',
+      ],
+    },
+    optimizeDeps: {
+      // Force all MUI + emotion + react-transition-group into a single
+      // esbuild optimize pass so React lives in ONE shared chunk instead
+      // of being duplicated per dep. Also works around the esbuild 0.21.x
+      // cross-chunk splitting bug ("Export 'import_react3' is not defined")
+      // because all interdependent modules are discovered together.
+      include: [
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+        'react-transition-group',
+        '@emotion/react',
+        '@emotion/styled',
+        '@mui/material',
+        '@mui/material/styles',
+        '@mui/icons-material',
+        '@mui/lab',
+        'react-router-dom',
+      ],
+    },
     build: {
       outDir: 'build',
     },

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -256,6 +256,18 @@
       "cwd": "${workspaceFolder}"
     },
 
+    "vstrike": {
+      "command": "python3",
+      "args": ["tools/vstrike.py"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "_setup_note": "CloudCurrent VStrike network topology fusion layer. Set VSTRIKE_BASE_URL and VSTRIKE_API_KEY in .env, or configure in Settings > Integrations.",
+        "VSTRIKE_BASE_URL": "${VSTRIKE_BASE_URL}",
+        "VSTRIKE_API_KEY": "${VSTRIKE_API_KEY}",
+        "VSTRIKE_VERIFY_SSL": "${VSTRIKE_VERIFY_SSL}"
+      }
+    },
+
     "microsoft-defender": {
       "command": "python3",
       "args": ["tools/microsoft_defender.py"],

--- a/services/case_automation_service.py
+++ b/services/case_automation_service.py
@@ -293,3 +293,101 @@ class CaseAutomationService:
 # Singleton instance
 automation_service = CaseAutomationService()
 
+
+# ---------------------------------------------------------------------------
+# VStrike attack-path clustering
+# ---------------------------------------------------------------------------
+
+_SEVERITY_ORDER = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+
+
+def _max_severity(findings: List[Dict]) -> str:
+    best = "low"
+    for f in findings:
+        sev = (f.get("severity") or "low").lower()
+        if _SEVERITY_ORDER.get(sev, 0) > _SEVERITY_ORDER.get(best, 0):
+            best = sev
+    return best
+
+
+def cluster_findings_by_attack_path(finding_ids: List[str]) -> List[str]:
+    """Group VStrike-enriched findings into cases by (segment, attack_path[0]).
+
+    For each cluster with at least one finding, create a case titled
+    "VStrike: {segment} via {initial_asset}". Returns the list of newly
+    created case_ids.
+
+    Findings without a `vstrike` sub-dict in `entity_context` are skipped —
+    this function is VStrike-specific by design.
+    """
+    from services.database_data_service import DatabaseDataService
+
+    data_service = DatabaseDataService()
+
+    clusters: Dict[tuple, List[Dict]] = {}
+    for fid in finding_ids:
+        finding = data_service.get_finding(fid)
+        if not finding:
+            continue
+        ctx = finding.get("entity_context") or {}
+        vstrike = ctx.get("vstrike") if isinstance(ctx, dict) else None
+        if not vstrike:
+            continue
+        segment = vstrike.get("segment") or "unknown-segment"
+        attack_path = vstrike.get("attack_path") or []
+        initial_asset = (
+            attack_path[0]
+            if attack_path
+            else (vstrike.get("asset_id") or "unknown-asset")
+        )
+        key = (segment, initial_asset)
+        clusters.setdefault(key, []).append(finding)
+
+    created_case_ids: List[str] = []
+    for (segment, initial_asset), findings in clusters.items():
+        ids = [f.get("finding_id") for f in findings if f.get("finding_id")]
+        if not ids:
+            continue
+
+        severity = _max_severity(findings)
+        priority = severity  # treat severity as priority for VStrike cases
+        mission_systems = sorted(
+            {
+                (f.get("entity_context") or {})
+                .get("vstrike", {})
+                .get("mission_system")
+                for f in findings
+                if (f.get("entity_context") or {})
+                .get("vstrike", {})
+                .get("mission_system")
+            }
+        )
+        mission_str = (
+            f" Mission systems impacted: {', '.join(mission_systems)}."
+            if mission_systems
+            else ""
+        )
+        description = (
+            f"{len(findings)} enriched finding(s) from the VStrike fusion layer "
+            f"across segment '{segment}'. Attack path origin: {initial_asset}."
+            f"{mission_str}"
+        )
+        title = f"VStrike: {segment} via {initial_asset}"
+
+        case = data_service.create_case(
+            title=title,
+            finding_ids=ids,
+            priority=priority,
+            description=description,
+            status="open",
+        )
+        if case and case.get("case_id"):
+            created_case_ids.append(case["case_id"])
+            logger.info(
+                "Created VStrike auto-cluster case %s (%s findings)",
+                case["case_id"],
+                len(ids),
+            )
+
+    return created_case_ids
+

--- a/services/vstrike_service.py
+++ b/services/vstrike_service.py
@@ -1,0 +1,161 @@
+"""Outbound REST client for the VStrike (CloudCurrent) fusion layer.
+
+VStrike pushes enriched findings to Vigil, but we also query it for asset
+topology, adjacent-asset lookup, and blast-radius computation during
+investigations. This service is consumed by `backend/api/vstrike.py` (proxy
+endpoints) and `tools/vstrike.py` (MCP server).
+
+Auth: bearer token in the `Authorization` header. Read from env var
+`VSTRIKE_API_KEY` or from the per-integration config
+(`core.config.get_integration_config("vstrike")`).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30
+
+
+class VStrikeService:
+    """Thin REST client for the VStrike API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        verify_ssl: bool = True,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.verify_ssl = verify_ssl
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.verify = verify_ssl
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+        )
+
+    def _get(self, path: str, **kwargs) -> requests.Response:
+        url = f"{self.base_url}{path}"
+        return self.session.get(url, timeout=self.timeout, **kwargs)
+
+    def test_connection(self) -> Tuple[bool, str]:
+        """Ping the VStrike health endpoint.
+
+        Returns a (success, message) tuple.
+        """
+        try:
+            response = self._get("/api/v1/health")
+            if response.status_code == 200:
+                return True, "Connection successful"
+            return False, f"HTTP {response.status_code}: {response.text[:200]}"
+        except requests.exceptions.RequestException as e:
+            return False, f"Connection error: {e}"
+
+    def get_asset_topology(self, asset_id: str) -> Optional[Dict[str, Any]]:
+        """Return full topology info for an asset (neighbors, segment, site)."""
+        try:
+            response = self._get(f"/api/v1/topology/asset/{asset_id}")
+            if response.status_code == 200:
+                return response.json()
+            logger.warning(
+                "VStrike get_asset_topology(%s) returned HTTP %s",
+                asset_id,
+                response.status_code,
+            )
+            return None
+        except requests.exceptions.RequestException as e:
+            logger.error("VStrike get_asset_topology(%s) failed: %s", asset_id, e)
+            return None
+
+    def list_adjacent(self, asset_id: str) -> Optional[List[Dict[str, Any]]]:
+        """Return adjacent assets (one hop) for an asset."""
+        try:
+            response = self._get(f"/api/v1/topology/asset/{asset_id}/adjacent")
+            if response.status_code == 200:
+                return response.json().get("adjacent", [])
+            return None
+        except requests.exceptions.RequestException as e:
+            logger.error("VStrike list_adjacent(%s) failed: %s", asset_id, e)
+            return None
+
+    def get_blast_radius(self, asset_id: str) -> Optional[Dict[str, Any]]:
+        """Return blast-radius info (count + sample assets) for an asset."""
+        try:
+            response = self._get(f"/api/v1/topology/asset/{asset_id}/blast-radius")
+            if response.status_code == 200:
+                return response.json()
+            return None
+        except requests.exceptions.RequestException as e:
+            logger.error("VStrike get_blast_radius(%s) failed: %s", asset_id, e)
+            return None
+
+    def find_findings_by_segment(
+        self, segment: str, limit: int = 100
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Return VStrike-enriched findings for a network segment."""
+        try:
+            response = self._get(
+                "/api/v1/findings",
+                params={"segment": segment, "limit": limit},
+            )
+            if response.status_code == 200:
+                return response.json().get("findings", [])
+            return None
+        except requests.exceptions.RequestException as e:
+            logger.error(
+                "VStrike find_findings_by_segment(%s) failed: %s", segment, e
+            )
+            return None
+
+
+def _config_value(key: str, config: Optional[Dict[str, Any]]) -> Optional[str]:
+    if config is None:
+        return None
+    return config.get(key)
+
+
+def get_vstrike_service() -> Optional[VStrikeService]:
+    """Construct a VStrikeService from env or integration config, or None.
+
+    Precedence (first hit wins):
+      1. `VSTRIKE_BASE_URL` + `VSTRIKE_API_KEY` env vars
+      2. `get_integration_config("vstrike")` → `{url, api_key, verify_ssl}`
+    """
+    base_url = os.environ.get("VSTRIKE_BASE_URL")
+    api_key = os.environ.get("VSTRIKE_API_KEY")
+    verify_ssl_env = os.environ.get("VSTRIKE_VERIFY_SSL", "true").lower() != "false"
+
+    config: Optional[Dict[str, Any]] = None
+    if not (base_url and api_key):
+        try:
+            from core.config import get_integration_config
+
+            config = get_integration_config("vstrike")
+        except Exception as e:
+            logger.debug("VStrike integration config not loaded: %s", e)
+            config = None
+
+    base_url = base_url or _config_value("url", config)
+    api_key = api_key or _config_value("api_key", config)
+
+    if not base_url or not api_key:
+        return None
+
+    verify_ssl = verify_ssl_env
+    if config is not None and "verify_ssl" in config:
+        verify_ssl = bool(config.get("verify_ssl", True))
+
+    return VStrikeService(base_url=base_url, api_key=api_key, verify_ssl=verify_ssl)

--- a/tests/integration/test_vstrike_ingest.py
+++ b/tests/integration/test_vstrike_ingest.py
@@ -1,0 +1,282 @@
+"""Integration tests for the VStrike ingest endpoint.
+
+Focus: the handler must read-modify-write `entity_context` so that a push
+from VStrike does not clobber pre-existing keys (src_ip, hostname, etc).
+
+The tests patch `backend.api.vstrike.data_service` with an in-memory fake
+so no DB / Redis is required.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+# backend/main.py adds both the repo root and `backend/` to sys.path at
+# runtime so that imports written as `from api.findings import ...` resolve.
+# Mirror that here for standalone pytest runs.
+for _p in (ROOT, ROOT / "backend"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+os.environ.setdefault("DEV_MODE", "true")
+
+
+class _FakeDataService:
+    """In-memory stand-in for DatabaseDataService."""
+
+    def __init__(self, seed: Optional[List[Dict[str, Any]]] = None):
+        self._findings: Dict[str, Dict[str, Any]] = {}
+        self.created_cases: List[Dict[str, Any]] = []
+        for f in seed or []:
+            self._findings[f["finding_id"]] = dict(f)
+
+    def get_finding(self, finding_id: str):
+        return self._findings.get(finding_id)
+
+    def update_finding(self, finding_id: str, **updates) -> bool:
+        if finding_id not in self._findings:
+            return False
+        self._findings[finding_id].update(updates)
+        return True
+
+    def create_finding(self, finding_data: Dict[str, Any]):
+        fid = finding_data["finding_id"]
+        stored = dict(finding_data)
+        stored.setdefault("severity", "medium")
+        stored.setdefault("status", "new")
+        self._findings[fid] = stored
+        return stored
+
+    def create_case(
+        self,
+        title: str,
+        finding_ids: List[str],
+        priority: str = "medium",
+        description: str = "",
+        status: str = "open",
+    ):
+        case = {
+            "case_id": f"case-test-{len(self.created_cases)+1:04d}",
+            "title": title,
+            "finding_ids": list(finding_ids),
+            "priority": priority,
+            "description": description,
+            "status": status,
+        }
+        self.created_cases.append(case)
+        return case
+
+
+def _push_payload(finding_id: str, **overrides) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "batch_id": "test-batch-1",
+        "findings": [
+            {
+                "finding_id": finding_id,
+                "vstrike_enrichment": {
+                    "asset_id": "srv-01",
+                    "asset_name": "SAP-PROD-01",
+                    "segment": "mgmt-vlan-10",
+                    "site": "JBSA",
+                    "criticality": "high",
+                    "mission_system": "C2-AWACS",
+                    "attack_path": ["ext-gw-01", "dmz-web-02", "srv-01"],
+                    "blast_radius": 14,
+                    "adjacent_assets": [
+                        {
+                            "asset_id": "dc-01",
+                            "hop_distance": 1,
+                            "edge_technique": "T1021.002",
+                        }
+                    ],
+                    "enriched_at": "2026-05-20T14:00:00Z",
+                },
+            }
+        ],
+        "auto_cluster_cases": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture
+def fake_service():
+    return _FakeDataService(
+        seed=[
+            {
+                "finding_id": "f-existing-1",
+                "anomaly_score": 0.5,
+                "timestamp": "2026-05-20T13:55:00Z",
+                "data_source": "splunk",
+                "entity_context": {
+                    "src_ip": "10.1.1.5",
+                    "hostname": "workstation-42",
+                    "user": "jdoe",
+                },
+            }
+        ]
+    )
+
+
+def _invoke_ingest(fake_service: _FakeDataService, payload: Dict[str, Any]):
+    """Call the handler with `data_service` patched to the fake.
+
+    Patches both the imported reference in `backend.api.vstrike` and the
+    one used by `services.case_automation_service.cluster_findings_by_attack_path`.
+    """
+    import asyncio
+
+    from backend.api import vstrike as vstrike_module
+    from backend.schemas.vstrike import VStrikePushRequest
+
+    req = VStrikePushRequest(**payload)
+
+    with patch.object(vstrike_module, "data_service", fake_service), patch(
+        "services.database_data_service.DatabaseDataService",
+        return_value=fake_service,
+    ):
+        response = asyncio.run(vstrike_module.ingest_findings(req))
+    return response
+
+
+def test_entity_context_merge_preserves_existing_keys(fake_service):
+    """Critical path: pushing VStrike enrichment must not clobber existing keys."""
+    response = _invoke_ingest(fake_service, _push_payload("f-existing-1"))
+
+    assert response.received == 1
+    assert response.updated == 1
+    assert response.created == 0
+    assert response.failed == 0
+
+    stored = fake_service.get_finding("f-existing-1")
+    ctx = stored["entity_context"]
+    # Pre-existing keys are preserved
+    assert ctx["src_ip"] == "10.1.1.5"
+    assert ctx["hostname"] == "workstation-42"
+    assert ctx["user"] == "jdoe"
+    # VStrike enrichment is nested
+    assert ctx["vstrike"]["asset_id"] == "srv-01"
+    assert ctx["vstrike"]["segment"] == "mgmt-vlan-10"
+    assert ctx["vstrike"]["adjacent_assets"][0]["edge_technique"] == "T1021.002"
+
+
+def test_entity_context_extra_merges_into_top_level(fake_service):
+    """entity_context_extra from the payload is merged into top-level ctx."""
+    payload = _push_payload("f-existing-1")
+    payload["findings"][0]["entity_context_extra"] = {
+        "dst_ip": "10.1.1.99",
+        "segment_hint": "dmz",
+    }
+
+    _invoke_ingest(fake_service, payload)
+
+    ctx = fake_service.get_finding("f-existing-1")["entity_context"]
+    assert ctx["src_ip"] == "10.1.1.5"  # preserved
+    assert ctx["dst_ip"] == "10.1.1.99"  # added
+    assert ctx["segment_hint"] == "dmz"  # added
+    assert "vstrike" in ctx
+
+
+def test_create_path_when_finding_is_new(fake_service):
+    payload = _push_payload("f-new-1")
+    payload["findings"][0]["timestamp"] = "2026-05-20T14:00:00Z"
+    payload["findings"][0]["anomaly_score"] = 0.91
+
+    response = _invoke_ingest(fake_service, payload)
+
+    assert response.updated == 0
+    assert response.created == 1
+    stored = fake_service.get_finding("f-new-1")
+    assert stored["data_source"] == "vstrike"
+    assert stored["entity_context"]["vstrike"]["asset_id"] == "srv-01"
+
+
+def test_create_path_fails_without_minimum_fields(fake_service):
+    payload = _push_payload("f-new-broken")
+    # No timestamp / anomaly_score supplied
+    response = _invoke_ingest(fake_service, payload)
+
+    assert response.created == 0
+    assert response.failed == 1
+    assert "timestamp" in (response.results[0].error or "")
+
+
+def test_auto_cluster_creates_case(fake_service):
+    response = _invoke_ingest(fake_service, _push_payload("f-existing-1"))
+
+    assert len(response.case_ids) == 1
+    case = fake_service.created_cases[0]
+    assert case["title"] == "VStrike: mgmt-vlan-10 via ext-gw-01"
+    assert "f-existing-1" in case["finding_ids"]
+
+
+def test_mitre_fields_propagate_on_update(fake_service):
+    payload = _push_payload("f-existing-1")
+    payload["findings"][0]["mitre_predictions"] = {"T1021.002": 0.87}
+    payload["findings"][0]["predicted_techniques"] = [
+        {"technique_id": "T1021.002", "confidence": 0.87}
+    ]
+    payload["findings"][0]["severity"] = "high"
+
+    _invoke_ingest(fake_service, payload)
+
+    stored = fake_service.get_finding("f-existing-1")
+    assert stored["mitre_predictions"] == {"T1021.002": 0.87}
+    assert stored["severity"] == "high"
+    assert stored["predicted_techniques"][0]["technique_id"] == "T1021.002"
+
+
+def test_auth_bypass_in_dev_mode():
+    """verify_inbound_key returns without error when DEV_MODE=true."""
+    from backend.api.vstrike import verify_inbound_key
+
+    os.environ["DEV_MODE"] = "true"
+    # No Authorization header → should still pass (no exception)
+    verify_inbound_key(authorization=None)
+
+
+def test_auth_requires_token_when_dev_mode_off(monkeypatch):
+    """verify_inbound_key rejects missing token when DEV_MODE is off and a key is configured."""
+    from fastapi import HTTPException
+
+    from backend.api import vstrike as vstrike_module
+
+    monkeypatch.setenv("DEV_MODE", "false")
+    monkeypatch.setattr(
+        vstrike_module, "_expected_inbound_key", lambda: "secret-key"
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        vstrike_module.verify_inbound_key(authorization=None)
+    assert excinfo.value.status_code == 401
+
+
+def test_auth_rejects_wrong_token(monkeypatch):
+    from fastapi import HTTPException
+
+    from backend.api import vstrike as vstrike_module
+
+    monkeypatch.setenv("DEV_MODE", "false")
+    monkeypatch.setattr(
+        vstrike_module, "_expected_inbound_key", lambda: "secret-key"
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        vstrike_module.verify_inbound_key(authorization="Bearer wrong")
+    assert excinfo.value.status_code == 401
+
+
+def test_auth_accepts_correct_token(monkeypatch):
+    from backend.api import vstrike as vstrike_module
+
+    monkeypatch.setenv("DEV_MODE", "false")
+    monkeypatch.setattr(
+        vstrike_module, "_expected_inbound_key", lambda: "secret-key"
+    )
+    # Should not raise
+    vstrike_module.verify_inbound_key(authorization="Bearer secret-key")

--- a/tests/unit/test_vstrike_service.py
+++ b/tests/unit/test_vstrike_service.py
@@ -1,0 +1,147 @@
+"""Unit tests for services/vstrike_service.py (mocked HTTP)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from services.vstrike_service import (  # noqa: E402
+    VStrikeService,
+    get_vstrike_service,
+)
+
+
+def _service(**kwargs) -> VStrikeService:
+    return VStrikeService(
+        base_url=kwargs.get("base_url", "https://vstrike.example.com"),
+        api_key=kwargs.get("api_key", "test-key"),
+        verify_ssl=kwargs.get("verify_ssl", False),
+    )
+
+
+def _mock_response(status_code=200, json_body=None, text=""):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body or {}
+    resp.text = text
+    return resp
+
+
+def test_sets_bearer_auth_header():
+    svc = _service(api_key="abc123")
+    assert svc.session.headers["Authorization"] == "Bearer abc123"
+
+
+def test_test_connection_success():
+    svc = _service()
+    with patch.object(svc.session, "get", return_value=_mock_response(200)):
+        ok, msg = svc.test_connection()
+    assert ok is True
+    assert "success" in msg.lower()
+
+
+def test_test_connection_http_error():
+    svc = _service()
+    with patch.object(
+        svc.session, "get", return_value=_mock_response(503, text="down")
+    ):
+        ok, msg = svc.test_connection()
+    assert ok is False
+    assert "503" in msg
+
+
+def test_test_connection_network_error():
+    import requests
+
+    svc = _service()
+    with patch.object(
+        svc.session,
+        "get",
+        side_effect=requests.exceptions.ConnectionError("boom"),
+    ):
+        ok, msg = svc.test_connection()
+    assert ok is False
+    assert "Connection error" in msg
+
+
+def test_get_asset_topology_returns_body_on_200():
+    svc = _service()
+    body = {"asset_id": "srv-01", "segment": "vlan-10"}
+    with patch.object(
+        svc.session, "get", return_value=_mock_response(200, json_body=body)
+    ):
+        result = svc.get_asset_topology("srv-01")
+    assert result == body
+
+
+def test_get_asset_topology_returns_none_on_error():
+    svc = _service()
+    with patch.object(svc.session, "get", return_value=_mock_response(404)):
+        assert svc.get_asset_topology("srv-missing") is None
+
+
+def test_list_adjacent_returns_list():
+    svc = _service()
+    body = {"adjacent": [{"asset_id": "dc-01", "hop_distance": 1}]}
+    with patch.object(
+        svc.session, "get", return_value=_mock_response(200, json_body=body)
+    ):
+        adjacent = svc.list_adjacent("srv-01")
+    assert adjacent == [{"asset_id": "dc-01", "hop_distance": 1}]
+
+
+def test_find_findings_by_segment_uses_query_params():
+    svc = _service()
+    body = {"findings": [{"finding_id": "f1"}]}
+    with patch.object(
+        svc.session, "get", return_value=_mock_response(200, json_body=body)
+    ) as mock_get:
+        result = svc.find_findings_by_segment("dmz", limit=50)
+
+    assert result == [{"finding_id": "f1"}]
+    call_kwargs = mock_get.call_args.kwargs
+    assert call_kwargs["params"] == {"segment": "dmz", "limit": 50}
+
+
+def test_get_vstrike_service_returns_none_when_unconfigured(monkeypatch):
+    monkeypatch.delenv("VSTRIKE_BASE_URL", raising=False)
+    monkeypatch.delenv("VSTRIKE_API_KEY", raising=False)
+    with patch(
+        "core.config.get_integration_config",
+        return_value={},
+    ):
+        assert get_vstrike_service() is None
+
+
+def test_get_vstrike_service_from_env(monkeypatch):
+    monkeypatch.setenv("VSTRIKE_BASE_URL", "https://vstrike.example.com")
+    monkeypatch.setenv("VSTRIKE_API_KEY", "env-key")
+    svc = get_vstrike_service()
+    assert svc is not None
+    assert svc.base_url == "https://vstrike.example.com"
+    assert svc.api_key == "env-key"
+
+
+def test_get_vstrike_service_falls_back_to_integration_config(monkeypatch):
+    monkeypatch.delenv("VSTRIKE_BASE_URL", raising=False)
+    monkeypatch.delenv("VSTRIKE_API_KEY", raising=False)
+    with patch(
+        "core.config.get_integration_config",
+        return_value={
+            "url": "https://cfg.example.com",
+            "api_key": "cfg-key",
+            "verify_ssl": False,
+        },
+    ):
+        svc = get_vstrike_service()
+    assert svc is not None
+    assert svc.base_url == "https://cfg.example.com"
+    assert svc.api_key == "cfg-key"
+    assert svc.verify_ssl is False

--- a/tools/vstrike.py
+++ b/tools/vstrike.py
@@ -1,0 +1,187 @@
+"""MCP server exposing VStrike (CloudCurrent) topology lookups as tools.
+
+Read-only surface. Writes (quarantine, isolate) are intentionally not
+exposed in this server — they require the approval workflow.
+
+Tools:
+  - vstrike_get_asset_topology
+  - vstrike_list_adjacent_assets
+  - vstrike_get_blast_radius
+  - vstrike_get_segment_findings
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import mcp.server.stdio
+import mcp.types as types
+from mcp.server import NotificationOptions, Server
+from mcp.server.models import InitializationOptions
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+# Ensure the repo root is on sys.path so `services.*` imports work when this
+# module is launched as a stand-alone MCP server via stdio.
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+logger = logging.getLogger(__name__)
+server = Server("vstrike")
+
+
+def _result(data) -> list[types.TextContent]:
+    return [types.TextContent(type="text", text=json.dumps(data, indent=2, default=str))]
+
+
+def _get_service():
+    try:
+        from services.vstrike_service import get_vstrike_service
+
+        return get_vstrike_service()
+    except Exception as e:
+        logger.error("Failed to load VStrike service: %s", e)
+        return None
+
+
+@server.list_tools()
+async def handle_list_tools():
+    return [
+        types.Tool(
+            name="vstrike_get_asset_topology",
+            description=(
+                "Return full topology info for a VStrike asset: segment, "
+                "site, criticality, neighbors."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {"asset_id": {"type": "string"}},
+                "required": ["asset_id"],
+            },
+        ),
+        types.Tool(
+            name="vstrike_list_adjacent_assets",
+            description=(
+                "List one-hop neighbors of an asset. Each neighbor may "
+                "include a MITRE ATT&CK technique if the edge represents "
+                "an observed or inferred attack-path step."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {"asset_id": {"type": "string"}},
+                "required": ["asset_id"],
+            },
+        ),
+        types.Tool(
+            name="vstrike_get_blast_radius",
+            description=(
+                "Return blast-radius info for an asset (count of reachable "
+                "assets plus a sample)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {"asset_id": {"type": "string"}},
+                "required": ["asset_id"],
+            },
+        ),
+        types.Tool(
+            name="vstrike_get_segment_findings",
+            description=(
+                "List VStrike-enriched findings for a given network segment."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "segment": {"type": "string"},
+                    "limit": {"type": "integer", "default": 100},
+                },
+                "required": ["segment"],
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def handle_call_tool(name: str, arguments: dict | None):
+    args = arguments or {}
+    service = _get_service()
+    if service is None:
+        return _result(
+            {
+                "error": "VStrike not configured",
+                "message": (
+                    "Set VSTRIKE_BASE_URL + VSTRIKE_API_KEY or configure the "
+                    "integration in Settings > Integrations."
+                ),
+            }
+        )
+
+    if name == "vstrike_get_asset_topology":
+        asset_id = args.get("asset_id")
+        if not asset_id:
+            return _result({"error": "asset_id required"})
+        topology = service.get_asset_topology(asset_id)
+        if topology is None:
+            return _result({"error": f"No topology returned for {asset_id}"})
+        return _result({"asset_id": asset_id, "topology": topology})
+
+    if name == "vstrike_list_adjacent_assets":
+        asset_id = args.get("asset_id")
+        if not asset_id:
+            return _result({"error": "asset_id required"})
+        adjacent = service.list_adjacent(asset_id)
+        if adjacent is None:
+            return _result({"error": f"No adjacency returned for {asset_id}"})
+        return _result({"asset_id": asset_id, "adjacent": adjacent})
+
+    if name == "vstrike_get_blast_radius":
+        asset_id = args.get("asset_id")
+        if not asset_id:
+            return _result({"error": "asset_id required"})
+        blast = service.get_blast_radius(asset_id)
+        if blast is None:
+            return _result({"error": f"No blast radius returned for {asset_id}"})
+        return _result({"asset_id": asset_id, "blast_radius": blast})
+
+    if name == "vstrike_get_segment_findings":
+        segment = args.get("segment")
+        if not segment:
+            return _result({"error": "segment required"})
+        limit = int(args.get("limit", 100))
+        findings = service.find_findings_by_segment(segment, limit=limit)
+        if findings is None:
+            return _result({"error": f"Failed to fetch findings for segment {segment}"})
+        return _result(
+            {"segment": segment, "count": len(findings), "findings": findings}
+        )
+
+    return _result({"error": f"Unknown tool: {name}"})
+
+
+async def main():
+    async with mcp.server.stdio.stdio_server() as (read, write):
+        await server.run(
+            read,
+            write,
+            InitializationOptions(
+                server_name="vstrike",
+                server_version="0.1.0",
+                capabilities=server.get_capabilities(
+                    notification_options=NotificationOptions(),
+                    experimental_capabilities={},
+                ),
+            ),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- **feat:** CloudCurrent VStrike fusion-layer integration (demo driver for AFCEA TECHNET CYBER 2026).
  - Inbound: `POST /api/integrations/vstrike/findings` accepts enriched findings with bearer auth (DEV_MODE bypass). Read-modify-writes `entity_context` so existing keys survive. Auto-clusters upserted findings into cases by `(segment, attack_path[0] or asset_id)`.
  - Outbound: `/api/integrations/vstrike/topology/*` proxies to VStrike + `tools/vstrike.py` MCP server exposing 4 read-only topology tools to agents.
  - Frontend: `NetworkContextPanel` inside `FindingDetailDialog`; `EntityGraph` tints nodes by segment and shows MITRE technique labels on highlighted edges; `Investigation` page pivots the graph on an adjacent-asset chip click via the `vstrike-graph-highlight` custom event.
  - Enrichment is persisted inside `finding.entity_context['vstrike']` (JSONB — no DB migration needed for the feature itself).
  - Tests: 10 integration + 11 unit tests, covering the `entity_context` merge, upsert paths, auto-cluster, DEV_MODE auth bypass, and the outbound client.

- **fix(frontend):** The dev server wouldn't render after a clean install due to three stacked MUI/React issues:
  1. `@emotion/react` / `@emotion/styled` were MUI peer deps but missing from `package.json`.
  2. MUI 5.18 transitively pulled `react-is@19` against React 18 — cascading `Invalid prop 'children'` warnings from prop-types Symbol mismatch. Pinned via `overrides`.
  3. esbuild 0.21.x (bundled with Vite 5.4.x) emitted a broken cross-chunk `import_react3 as import_react` export for react-transition-group. Fixed with `resolve.dedupe` + `optimizeDeps.include` forcing MUI/emotion/rtg/router into a single pre-bundle pass.

- **fix(db):** `CREATE EXTENSION pg_trgm` added to `database/init/01_init_schema.sql` so fresh Postgres containers don't fail schema create_all on GIN trigram indexes.

- **fix(orchestrator):** Consolidated two SystemConfig rows (`orchestrator.settings` + `orchestrator_enabled`) into a single source of truth. Previously, saving from Settings → Auto Investigate updated `orchestrator.settings` but `/api/orchestrator/status` and NavigationRail read from `orchestrator_enabled` — so toggling Enable + Save didn't surface the Auto Ops tab. Now everything reads/writes `orchestrator.settings.enabled`.

## One-shot migration (required for existing deployments)

Run against any environment that already has an `orchestrator_enabled` row:

```sql
UPDATE system_config
SET value = jsonb_set(
              COALESCE(value, '{}'::jsonb),
              '{enabled}',
              to_jsonb(
                COALESCE(
                  (SELECT (value->>'enabled')::boolean FROM system_config WHERE key = 'orchestrator_enabled'),
                  COALESCE((value->>'enabled')::boolean, false)
                )
              )
            )
WHERE key = 'orchestrator.settings';

DELETE FROM system_config WHERE key = 'orchestrator_enabled';
```

Fresh clones don't need this.

## Test plan

- [x] `pytest tests/integration/test_vstrike_ingest.py tests/unit/test_vstrike_service.py` — 21/21 pass
- [x] Frontend `tsc --noEmit` clean on changed files
- [x] Dev server renders login + dashboard, no `import_react3` error, no `Invalid prop 'children'` cascade
- [x] `POST /api/integrations/vstrike/findings` round-trips a seeded payload (curl recipe in `docs/INTEGRATIONS.md`); `entity_context.vstrike` persists and the auto-case is created
- [x] Saving from Settings → Auto Investigate with `enabled=true` flips `GET /api/orchestrator/status` enabled → true (and the Auto Ops nav item appears after refresh)
- [x] `POST /api/orchestrator/enable` / `/disable` still work and update the same single key
- [x] Verified on the live test box (136.109.106.60): both toggle paths hit the same DB row, legacy key removed after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)