### PR TITLE
feat(sandbox): CAPE integration + auto-submission pipeline (#86)

### DIFF
--- a/daemon/processor.py
+++ b/daemon/processor.py
@@ -23,6 +23,7 @@ class FindingProcessor:
         self._data_service = None
         self._claude_service = None
         self._enrichment_services = {}
+        self._sandbox_submitter = None
         
         # Processing semaphore
         self._semaphore = asyncio.Semaphore(config.max_concurrent_tasks)
@@ -87,6 +88,19 @@ class FindingProcessor:
                 logger.info("Shodan enrichment enabled")
             except Exception as e:
                 logger.warning(f"Shodan not available: {e}")
+
+        # Sandbox auto-submission (opt-in, disabled by default)
+        try:
+            from daemon.sandbox_submitter import SandboxSubmitter
+
+            submitter = SandboxSubmitter()
+            if submitter.enabled():
+                self._sandbox_submitter = submitter
+                logger.info("Sandbox auto-submission enabled")
+            else:
+                logger.debug("Sandbox auto-submission disabled (SANDBOX_AUTO_SUBMIT=false or no sandbox enabled)")
+        except Exception as e:
+            logger.warning(f"Sandbox submitter not available: {e}")
     
     async def run(self, shutdown_event: asyncio.Event):
         """Run the processing loop."""
@@ -354,12 +368,31 @@ REASONING: [Brief explanation]
             hash_enrichment = await self._enrich_hash(hash_val)
             if hash_enrichment:
                 enrichment[f"hash_{hash_val[:16]}"] = hash_enrichment
-        
+
+        # Opt-in sandbox auto-submission (see daemon/sandbox_submitter.py)
+        if self._sandbox_submitter is not None and hashes:
+            file_hint = {
+                "file_name": (entity_context.get("file_names") or [None])[0]
+                if isinstance(entity_context.get("file_names"), list)
+                else entity_context.get("file_name"),
+                "file_size": entity_context.get("file_size"),
+            }
+            submissions: Dict[str, Any] = {}
+            for hash_val in hashes[:3]:
+                try:
+                    res = await self._sandbox_submitter.submit_hash(hash_val, file_hint)
+                    if res and res.get("status") not in ("disabled", "rejected"):
+                        submissions[hash_val] = res
+                except Exception as e:
+                    logger.debug(f"Sandbox submission failed for {hash_val}: {e}")
+            if submissions:
+                enrichment["sandbox_submissions"] = submissions
+
         if enrichment:
             finding["enrichment"] = enrichment
             finding["enriched_at"] = datetime.utcnow().isoformat()
             self.stats["enriched"] += 1
-        
+
         return finding
     
     async def _enrich_ip(self, ip: str) -> Optional[Dict[str, Any]]:

--- a/daemon/sandbox_poller.py
+++ b/daemon/sandbox_poller.py
@@ -1,0 +1,274 @@
+"""Polls pending sandbox submissions and correlates completed reports.
+
+The daemon's enrichment step (``daemon/processor.py``) records
+``finding.enrichment.sandbox_submissions`` with task IDs per sandbox. Those
+tasks take minutes to complete — so a separate poller checks them on a
+cadence, pulls the report when ready, and writes it back to the finding
+plus (if the finding is tied to a case) the case as evidence + IOCs.
+
+All HTTP is wrapped with ``asyncio.to_thread`` so the scheduler loop stays
+async. DB writes go through the same pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_SANDBOX_TIMEOUT_DEFAULT = 300
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+class SandboxPoller:
+    """Resolve pending sandbox submissions into reports + IOCs."""
+
+    def __init__(self, data_service: Any = None) -> None:
+        self._data_service = data_service
+        self._correlation = None
+        self._timeout_seconds = _env_int(
+            "SANDBOX_ANALYSIS_TIMEOUT", _SANDBOX_TIMEOUT_DEFAULT
+        )
+
+    def _init_services(self) -> None:
+        if self._data_service is None:
+            try:
+                from services.database_data_service import DatabaseDataService
+
+                self._data_service = DatabaseDataService()
+            except Exception as e:
+                logger.warning(f"Sandbox poller could not init data service: {e}")
+        if self._correlation is None:
+            try:
+                from services.sandbox_correlation_service import (
+                    SandboxCorrelationService,
+                )
+
+                self._correlation = SandboxCorrelationService()
+            except Exception as e:
+                logger.warning(f"Sandbox correlation service unavailable: {e}")
+
+    async def run_once(self) -> Dict[str, int]:
+        """Scan recent findings, advance any pending sandbox submissions."""
+        self._init_services()
+        if not self._data_service:
+            return {"checked": 0, "completed": 0, "expired": 0, "errors": 0}
+
+        try:
+            findings = await asyncio.to_thread(self._data_service.get_findings)
+        except TypeError:
+            findings = self._data_service.get_findings()
+        except Exception as e:
+            logger.error(f"Failed to list findings for sandbox poll: {e}")
+            return {"checked": 0, "completed": 0, "expired": 0, "errors": 1}
+
+        stats = {"checked": 0, "completed": 0, "expired": 0, "errors": 0}
+
+        for finding in findings or []:
+            enrichment = finding.get("enrichment") or {}
+            pending = enrichment.get("sandbox_submissions") or {}
+            reports = enrichment.get("sandbox_reports") or {}
+            if not pending:
+                continue
+
+            updated = False
+            for hash_val, per_sandbox in list(pending.items()):
+                if not isinstance(per_sandbox, dict):
+                    continue
+                for sandbox_name, sub in list(per_sandbox.items()):
+                    if not isinstance(sub, dict):
+                        continue
+                    task_id = sub.get("task_id")
+                    if not task_id:
+                        continue
+                    stats["checked"] += 1
+
+                    # Skip if we already have a report for this (hash, sandbox)
+                    report_key = f"{hash_val}:{sandbox_name}"
+                    if report_key in reports:
+                        continue
+
+                    # Enforce timeout
+                    if self._is_expired(sub):
+                        sub["status"] = "expired"
+                        stats["expired"] += 1
+                        updated = True
+                        continue
+
+                    try:
+                        report = await self._fetch_report(sandbox_name, task_id)
+                    except Exception as e:
+                        logger.debug(
+                            f"Fetch report failed for {sandbox_name}/{task_id}: {e}"
+                        )
+                        stats["errors"] += 1
+                        continue
+
+                    if not report:
+                        continue
+
+                    reports[report_key] = {
+                        "sandbox": sandbox_name,
+                        "task_id": task_id,
+                        "fetched_at": datetime.utcnow().isoformat(),
+                        "report": report,
+                    }
+                    sub["status"] = "reported"
+                    stats["completed"] += 1
+                    updated = True
+
+                    case_id = finding.get("case_id")
+                    if case_id and self._correlation:
+                        try:
+                            await asyncio.to_thread(
+                                self._correlation.attach_report,
+                                case_id,
+                                sandbox_name,
+                                str(task_id),
+                                report,
+                            )
+                        except Exception as e:
+                            logger.error(
+                                f"Correlation failed for {sandbox_name}/{task_id}: {e}"
+                            )
+
+            if updated:
+                enrichment["sandbox_submissions"] = pending
+                enrichment["sandbox_reports"] = reports
+                try:
+                    await asyncio.to_thread(
+                        self._data_service.update_finding,
+                        finding.get("finding_id"),
+                        enrichment=enrichment,
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to persist sandbox updates on finding: {e}")
+                    stats["errors"] += 1
+
+        return stats
+
+    # ---------- per-sandbox fetch ----------
+
+    async def _fetch_report(
+        self, sandbox_name: str, task_id: str
+    ) -> Optional[Dict[str, Any]]:
+        name = sandbox_name.lower()
+        if name in ("cape", "cape-sandbox", "cape_sandbox"):
+            return await self._fetch_cape(task_id)
+        if name in ("hybrid_analysis", "hybrid-analysis", "hybrid"):
+            return await self._fetch_hybrid(task_id)
+        if name in ("anyrun", "any.run"):
+            return await self._fetch_anyrun(task_id)
+        if name in ("joe", "joe_sandbox", "joe-sandbox"):
+            return await self._fetch_joe(task_id)
+        return None
+
+    async def _fetch_cape(self, task_id: str) -> Optional[Dict[str, Any]]:
+        base = os.getenv("CAPE_SANDBOX_URL", "").rstrip("/")
+        api_key = os.getenv("CAPE_SANDBOX_API_KEY", "")
+        if not base:
+            return None
+        headers = {"Authorization": f"Token {api_key}"} if api_key else {}
+        status_resp = await asyncio.to_thread(
+            requests.get,
+            f"{base}/apiv2/tasks/status/{task_id}/",
+            headers=headers,
+            timeout=15,
+        )
+        if status_resp.status_code != 200:
+            return None
+        status_data = status_resp.json()
+        status = (status_data.get("data") or status_data).get("status")
+        if status != "reported":
+            return None
+        report_resp = await asyncio.to_thread(
+            requests.get,
+            f"{base}/apiv2/tasks/get/report/{task_id}/",
+            headers=headers,
+            timeout=60,
+        )
+        if report_resp.status_code == 200:
+            return report_resp.json()
+        return None
+
+    async def _fetch_hybrid(self, task_id: str) -> Optional[Dict[str, Any]]:
+        from core.config import get_integration_config
+
+        cfg = get_integration_config("hybrid_analysis") or {}
+        api_key = cfg.get("api_key") or os.getenv("HYBRID_ANALYSIS_API_KEY", "")
+        if not api_key:
+            return None
+        resp = await asyncio.to_thread(
+            requests.get,
+            f"https://www.hybrid-analysis.com/api/v2/report/{task_id}/summary",
+            headers={"api-key": api_key, "User-Agent": "Falcon Sandbox"},
+            timeout=30,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            # Hybrid Analysis returns state=SUCCESS when done
+            if str(data.get("state", "")).upper() == "SUCCESS":
+                return data
+        return None
+
+    async def _fetch_anyrun(self, task_id: str) -> Optional[Dict[str, Any]]:
+        from core.config import get_integration_config
+
+        cfg = get_integration_config("anyrun") or {}
+        api_key = cfg.get("api_key") or os.getenv("ANYRUN_API_KEY", "")
+        if not api_key:
+            return None
+        resp = await asyncio.to_thread(
+            requests.get,
+            f"https://api.any.run/v1/analysis/{task_id}",
+            headers={"Authorization": f"API-Key {api_key}"},
+            timeout=30,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            if str(data.get("status", "")).lower() == "done":
+                return data
+        return None
+
+    async def _fetch_joe(self, task_id: str) -> Optional[Dict[str, Any]]:
+        api_key = os.getenv("JOE_SANDBOX_API_KEY", "") or os.getenv("JBXAPIKEY", "")
+        base = os.getenv(
+            "JOE_SANDBOX_URL", "https://jbxcloud.joesecurity.org/api"
+        ).rstrip("/")
+        if not api_key:
+            return None
+        resp = await asyncio.to_thread(
+            requests.post,
+            f"{base}/v2/analysis/info",
+            data={"apikey": api_key, "webid": task_id},
+            timeout=30,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            if str(data.get("status", "")).lower() == "finished":
+                return data
+        return None
+
+    # ---------- helpers ----------
+
+    def _is_expired(self, sub: Dict[str, Any]) -> bool:
+        ts = sub.get("submitted_at")
+        if not ts:
+            return False
+        try:
+            submitted = datetime.fromisoformat(ts)
+        except ValueError:
+            return False
+        return datetime.utcnow() - submitted > timedelta(seconds=self._timeout_seconds)

--- a/daemon/sandbox_submitter.py
+++ b/daemon/sandbox_submitter.py
@@ -1,0 +1,318 @@
+"""Sandbox auto-submission with safety gating.
+
+Entry point for the daemon's opt-in detonation pipeline. Given a file hash
+extracted from a finding, this module:
+
+1. Respects the master ``SANDBOX_AUTO_SUBMIT`` switch (default: disabled).
+2. Enforces a file-type allowlist and a max-size cap.
+3. Checks each enabled sandbox's hash cache first — only submits when unknown.
+4. Submits in parallel to all enabled sandboxes, returning their task IDs
+   for later polling.
+
+Only hash-based submissions are supported here. File bytes (required for the
+initial detonation) must already live in an upstream system; the current
+pipeline operates on hashes observed in events. The submit step therefore
+tells the sandbox "detonate this hash" only when the sandbox's own cache has
+already seen the binary. This is a conservative default — safer than
+exfiltrating arbitrary binaries from the Vigil process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_ALLOWED_TYPES = "exe,dll,doc,docx,xls,xlsx,pdf,js,vbs,ps1,bat,msi"
+_MD5_LEN = 32
+_SHA1_LEN = 40
+_SHA256_LEN = 64
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass
+class SandboxSettings:
+    auto_submit: bool
+    max_file_size_mb: int
+    allowed_types: List[str]
+    timeout_seconds: int
+    joe_enabled: bool
+    cape_enabled: bool
+    hybrid_enabled: bool
+    anyrun_enabled: bool
+
+    @classmethod
+    def from_env(cls) -> "SandboxSettings":
+        allowed = os.getenv("SANDBOX_ALLOWED_FILE_TYPES", _DEFAULT_ALLOWED_TYPES)
+        return cls(
+            auto_submit=_env_bool("SANDBOX_AUTO_SUBMIT", False),
+            max_file_size_mb=_env_int("SANDBOX_MAX_FILE_SIZE_MB", 100),
+            allowed_types=[t.strip().lower() for t in allowed.split(",") if t.strip()],
+            timeout_seconds=_env_int("SANDBOX_ANALYSIS_TIMEOUT", 300),
+            joe_enabled=_env_bool("JOE_SANDBOX_ENABLED", False),
+            cape_enabled=_env_bool("CAPE_SANDBOX_ENABLED", False),
+            hybrid_enabled=_env_bool("HYBRID_ANALYSIS_ENABLED", False),
+            anyrun_enabled=_env_bool("ANYRUN_ENABLED", False),
+        )
+
+
+class SandboxSubmitter:
+    """Encapsulates hash-based sandbox submission with safety gating.
+
+    Designed to be instantiated once per daemon process and reused across
+    many findings. All HTTP calls are routed through ``asyncio.to_thread``
+    so the caller stays async.
+    """
+
+    def __init__(self, settings: Optional[SandboxSettings] = None):
+        self.settings = settings or SandboxSettings.from_env()
+
+    # ---------- public API ----------
+
+    def enabled(self) -> bool:
+        """Return True if auto-submission is globally on and at least one
+        sandbox is enabled."""
+        return self.settings.auto_submit and (
+            self.settings.joe_enabled
+            or self.settings.cape_enabled
+            or self.settings.hybrid_enabled
+            or self.settings.anyrun_enabled
+        )
+
+    def is_hash_safe_to_submit(
+        self, hash_val: str, file_hint: Optional[Dict[str, Any]] = None
+    ) -> bool:
+        """Apply safety rules before any network call.
+
+        ``file_hint`` may include ``file_name``, ``file_size`` pulled from
+        the finding's entity_context when available; when missing, the
+        hash-only path is allowed (we cannot verify type/size upstream).
+        """
+        if not self._looks_like_hash(hash_val):
+            return False
+
+        hint = file_hint or {}
+        size = hint.get("file_size")
+        if size is not None:
+            try:
+                if int(size) > self.settings.max_file_size_mb * 1024 * 1024:
+                    logger.info("Skipping sandbox submission: size exceeds cap")
+                    return False
+            except (TypeError, ValueError):
+                pass
+
+        fname = hint.get("file_name")
+        if fname:
+            ext = fname.rsplit(".", 1)[-1].lower() if "." in fname else ""
+            if ext and ext not in self.settings.allowed_types:
+                logger.info(
+                    "Skipping sandbox submission: extension %s not allowlisted", ext
+                )
+                return False
+
+        return True
+
+    async def submit_hash(
+        self,
+        hash_val: str,
+        file_hint: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Submit a hash to all enabled sandboxes in parallel.
+
+        Returns a dict like::
+
+            {
+                "cape": {"status": "cached", "task_id": "123"},
+                "hybrid_analysis": {"status": "submitted", "task_id": "..."},
+                "joe_sandbox": {"status": "skipped", "reason": "disabled"},
+            }
+        """
+        if not self.enabled():
+            return {"status": "disabled"}
+
+        if not self.is_hash_safe_to_submit(hash_val, file_hint):
+            return {"status": "rejected", "reason": "safety_gate"}
+
+        coros = []
+        names: List[str] = []
+
+        if self.settings.cape_enabled:
+            names.append("cape")
+            coros.append(self._submit_cape(hash_val))
+        if self.settings.hybrid_enabled:
+            names.append("hybrid_analysis")
+            coros.append(self._submit_hybrid(hash_val))
+        if self.settings.anyrun_enabled:
+            names.append("anyrun")
+            coros.append(self._submit_anyrun(hash_val))
+        if self.settings.joe_enabled:
+            names.append("joe_sandbox")
+            coros.append(self._submit_joe(hash_val))
+
+        results = await asyncio.gather(*coros, return_exceptions=True)
+
+        now_iso = datetime.utcnow().isoformat()
+        out: Dict[str, Any] = {}
+        for name, res in zip(names, results):
+            if isinstance(res, Exception):
+                out[name] = {
+                    "status": "error",
+                    "error": str(res),
+                    "submitted_at": now_iso,
+                }
+            else:
+                if isinstance(res, dict):
+                    res.setdefault("submitted_at", now_iso)
+                out[name] = res
+        return out
+
+    # ---------- per-sandbox handlers ----------
+
+    async def _submit_cape(self, hash_val: str) -> Dict[str, Any]:
+        url = os.getenv("CAPE_SANDBOX_URL", "").rstrip("/")
+        api_key = os.getenv("CAPE_SANDBOX_API_KEY", "")
+        if not url:
+            return {"status": "skipped", "reason": "no_url"}
+        headers = {"Authorization": f"Token {api_key}"} if api_key else {}
+        hash_type = self._hash_type(hash_val)
+        if not hash_type:
+            return {"status": "skipped", "reason": "unknown_hash_format"}
+        try:
+            resp = await asyncio.to_thread(
+                requests.get,
+                f"{url}/apiv2/tasks/search/{hash_type}/{hash_val}/",
+                headers=headers,
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                tasks = data.get("data") if isinstance(data, dict) else data
+                if tasks:
+                    task_id = tasks[0].get("id") if isinstance(tasks[0], dict) else None
+                    return {
+                        "status": "cached",
+                        "task_id": str(task_id) if task_id else None,
+                    }
+        except Exception as e:
+            logger.debug("CAPE hash search failed: %s", e)
+            return {"status": "error", "error": str(e)}
+        return {
+            "status": "unknown",
+            "note": "Hash not in CAPE cache; binary upload required for detonation",
+        }
+
+    async def _submit_hybrid(self, hash_val: str) -> Dict[str, Any]:
+        from core.config import get_integration_config
+
+        cfg = get_integration_config("hybrid_analysis") or {}
+        api_key = cfg.get("api_key") or os.getenv("HYBRID_ANALYSIS_API_KEY", "")
+        if not api_key:
+            return {"status": "skipped", "reason": "no_api_key"}
+        try:
+            resp = await asyncio.to_thread(
+                requests.post,
+                "https://www.hybrid-analysis.com/api/v2/search/hash",
+                headers={"api-key": api_key, "User-Agent": "Falcon Sandbox"},
+                data={"hash": hash_val},
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                if data:
+                    jid = data[0].get("job_id") if isinstance(data[0], dict) else None
+                    return {"status": "cached", "task_id": jid}
+        except Exception as e:
+            logger.debug("Hybrid Analysis hash search failed: %s", e)
+            return {"status": "error", "error": str(e)}
+        return {"status": "unknown"}
+
+    async def _submit_anyrun(self, hash_val: str) -> Dict[str, Any]:
+        from core.config import get_integration_config
+
+        cfg = get_integration_config("anyrun") or {}
+        api_key = cfg.get("api_key") or os.getenv("ANYRUN_API_KEY", "")
+        if not api_key:
+            return {"status": "skipped", "reason": "no_api_key"}
+        try:
+            resp = await asyncio.to_thread(
+                requests.get,
+                "https://api.any.run/v1/tasks",
+                headers={"Authorization": f"API-Key {api_key}"},
+                params={"hash": hash_val},
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                tasks = resp.json().get("data", {}).get("tasks", [])
+                if tasks:
+                    tid = tasks[0].get("uuid") or tasks[0].get("id")
+                    return {"status": "cached", "task_id": tid}
+        except Exception as e:
+            logger.debug("Any.Run hash search failed: %s", e)
+            return {"status": "error", "error": str(e)}
+        return {"status": "unknown"}
+
+    async def _submit_joe(self, hash_val: str) -> Dict[str, Any]:
+        api_key = os.getenv("JOE_SANDBOX_API_KEY", "") or os.getenv("JBXAPIKEY", "")
+        base = os.getenv(
+            "JOE_SANDBOX_URL", "https://jbxcloud.joesecurity.org/api"
+        ).rstrip("/")
+        if not api_key:
+            return {"status": "skipped", "reason": "no_api_key"}
+        try:
+            resp = await asyncio.to_thread(
+                requests.post,
+                f"{base}/v2/analysis/search",
+                data={"apikey": api_key, "q": hash_val},
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                data = resp.json().get("data", [])
+                if data:
+                    webid = data[0].get("webid")
+                    return {"status": "cached", "task_id": webid}
+        except Exception as e:
+            logger.debug("Joe Sandbox hash search failed: %s", e)
+            return {"status": "error", "error": str(e)}
+        return {"status": "unknown"}
+
+    # ---------- helpers ----------
+
+    @staticmethod
+    def _looks_like_hash(s: str) -> bool:
+        if not s or not isinstance(s, str):
+            return False
+        s = s.strip().lower()
+        if len(s) not in (_MD5_LEN, _SHA1_LEN, _SHA256_LEN):
+            return False
+        return all(c in "0123456789abcdef" for c in s)
+
+    @staticmethod
+    def _hash_type(s: str) -> Optional[str]:
+        length = len(s.strip())
+        if length == _MD5_LEN:
+            return "md5"
+        if length == _SHA1_LEN:
+            return "sha1"
+        if length == _SHA256_LEN:
+            return "sha256"
+        return None

--- a/daemon/scheduler.py
+++ b/daemon/scheduler.py
@@ -11,6 +11,21 @@ from daemon.config import SchedulerConfig
 logger = logging.getLogger(__name__)
 
 
+def _sandbox_poll_enabled() -> bool:
+    import os
+
+    return os.getenv("SANDBOX_AUTO_SUBMIT", "false").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _sandbox_poll_interval() -> int:
+    import os
+
+    try:
+        return max(30, int(os.getenv("SANDBOX_POLL_INTERVAL", "60")))
+    except ValueError:
+        return 60
+
+
 @dataclass
 class ScheduledTask:
     """Represents a scheduled task."""
@@ -82,6 +97,16 @@ class TaskScheduler:
             enabled=True,
             run_on_start=True
         ))
+
+        # Sandbox poller — only runs when auto-submit is enabled
+        if _sandbox_poll_enabled():
+            self._tasks.append(ScheduledTask(
+                name="sandbox_poll",
+                func=self._run_sandbox_poll,
+                interval=_sandbox_poll_interval(),
+                enabled=True,
+                run_on_start=False,
+            ))
     
     def _init_services(self):
         """Initialize required services."""
@@ -356,6 +381,20 @@ class TaskScheduler:
         
         return {"cutoff_date": cutoff.isoformat()}
     
+    async def _run_sandbox_poll(self):
+        """Advance pending sandbox submissions to completed reports."""
+        try:
+            from daemon.sandbox_poller import SandboxPoller
+        except Exception as e:
+            logger.warning(f"Sandbox poller unavailable: {e}")
+            return
+
+        poller = SandboxPoller(data_service=self._data_service)
+        stats = await poller.run_once()
+        if stats.get("completed") or stats.get("expired") or stats.get("errors"):
+            logger.info(f"Sandbox poll: {stats}")
+        return stats
+
     async def _run_health_check(self):
         """Run system health check."""
         logger.info("Running health check...")

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -137,6 +137,7 @@ The backend discovers workflows automatically on startup. Use `POST /api/workflo
 - Family classification
 - IOC extraction
 - C2 identification
+- Sandbox tools: CAPE (`cape_*`), Hybrid Analysis (`ha_*`), Any.Run (`anyrun_*`), URL analysis (`url_analyze`). Agents should cache-check via `*_search_hash` before submitting new detonations.
 
 ### Network Analyst Agent
 - Flow analysis
@@ -176,7 +177,7 @@ All agents use these tools via Claude API function calling:
 | MITRE Analyst | `technique_rollup`, `get_findings_by_technique`, coverage analysis, gap identification |
 | Forensics | `search_findings`, evidence tools, detection search |
 | Threat Intel | Detection search, IOC analysis tools |
-| Malware Analyst | Detection search, pattern analysis |
+| Malware Analyst | Detection search, pattern analysis, sandbox detonation (CAPE, Hybrid Analysis, Any.Run) |
 | Network Analyst | Detection search, traffic pattern tools |
 | Auto-Responder | `correlate_and_create_action`, approval tools, detection validation |
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -40,7 +40,7 @@ Backend tools are automatically enabled for web UI users via the Claude Agent SD
 | Timeline | Timesketch | Implemented |
 | Threat Intel | VirusTotal, Shodan, AlienVault OTX, MISP, URL Analysis, IP Geolocation | Implemented |
 | EDR | CrowdStrike | Implemented |
-| Sandbox | Hybrid Analysis, Joe Sandbox, ANY.RUN | Implemented |
+| Sandbox | Hybrid Analysis, Joe Sandbox, ANY.RUN, CAPE Sandbox | Implemented |
 | Ticketing | Jira | Implemented |
 | Communication | Slack | Implemented |
 | Data Pipeline | Cribl Stream | Implemented |
@@ -277,6 +277,40 @@ ANYRUN_API_KEY="your_api_key"
 ```
 
 Tools: `anyrun_get_report`, `anyrun_search`, `anyrun_get_iocs`
+
+### CAPE Sandbox
+
+Open-source Cuckoo fork for on-prem detonation. Vigil ships an MCP client
+(`tools/cape_sandbox.py`) that talks to an existing CAPE deployment over
+its REST API — Vigil does **not** host CAPE itself. CAPE requires KVM and
+Windows guest VMs, so it's typically deployed on bare metal, not inside
+Docker Desktop.
+
+```bash
+CAPE_SANDBOX_ENABLED="true"
+CAPE_SANDBOX_URL="http://cape.internal:8000"
+CAPE_SANDBOX_API_KEY="your_cape_api_token"
+```
+
+Tools: `cape_submit_file`, `cape_submit_url`, `cape_get_report`,
+`cape_get_iocs`, `cape_get_pcap`, `cape_list_tasks`, `cape_search_hash`,
+`cape_task_status`.
+
+### Auto-submission pipeline
+
+When `SANDBOX_AUTO_SUBMIT=true` and at least one sandbox is enabled, the
+daemon will, during finding enrichment, consult each sandbox's hash cache
+for any file hash on the finding. Safety gates:
+
+- File extension must be in `SANDBOX_ALLOWED_FILE_TYPES` (default list
+  matches common malware extensions).
+- `file_size` (when known) must be ≤ `SANDBOX_MAX_FILE_SIZE_MB`.
+- No binary bytes are ever sent from Vigil. Only hash-cache lookups and
+  sandbox-API submission-by-hash are performed.
+
+A companion scheduler task (`sandbox_poll`, default every 60s) picks up
+completed reports and writes them into the case as `CaseEvidence` plus
+extracted IOCs into `CaseIOC`. See [SANDBOX.md](./SANDBOX.md).
 
 ## EDR/XDR
 

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -1,0 +1,107 @@
+# Sandbox & Malware Detonation
+
+Vigil integrates with four sandboxes:
+
+| Sandbox | Hosting | MCP source |
+|---|---|---|
+| Hybrid Analysis | cloud (Falcon) | `tools/hybrid_analysis.py` |
+| Any.Run | cloud | `tools/anyrun.py` |
+| Joe Sandbox | cloud or on-prem | external MCP (`joesandboxMCP`) wired via `mcp-config.json` |
+| CAPE Sandbox | self-hosted (bring your own) | `tools/cape_sandbox.py` (new in #86) |
+
+The Malware Analyst agent loads all four. The daemon has an opt-in
+auto-submission pipeline that ties sandbox output back to findings and
+cases.
+
+## Architecture
+
+```
+┌────────────────┐      ┌──────────────────────┐      ┌──────────────────┐
+│  Poller/SIEM   │─────▶│ FindingProcessor     │─────▶│ Response queue   │
+│  (finding in)  │      │ ._enrich_finding()   │      │ Investigation q. │
+└────────────────┘      │   • VirusTotal       │      └──────────────────┘
+                        │   • Shodan           │
+                        │   • Sandbox submit ◀─┼──── daemon/sandbox_submitter.py
+                        └──────────────────────┘            (safety gates +
+                                                             hash-cache lookup)
+                                 │
+                                 ▼
+                        enrichment.sandbox_submissions = {hash: {cape:{task_id}}}
+                                 │
+                                 ▼  (every SANDBOX_POLL_INTERVAL s)
+                        daemon/sandbox_poller.py
+                                 │
+                                 ├─ fetches completed report
+                                 ├─ writes back to finding.enrichment.sandbox_reports
+                                 └─ services/sandbox_correlation_service.py
+                                         │
+                                         ▼
+                                CaseEvidence (analysis_results = raw report)
+                                CaseIOC      (ips, domains, hashes, mutexes)
+```
+
+## Configuration
+
+All env vars live in `env.example`. Minimum for CAPE:
+
+```bash
+CAPE_SANDBOX_ENABLED=true
+CAPE_SANDBOX_URL=http://cape.internal:8000
+CAPE_SANDBOX_API_KEY=<token>
+```
+
+Enable the pipeline (off by default):
+
+```bash
+SANDBOX_AUTO_SUBMIT=true
+```
+
+Safety knobs (defaults shown):
+
+```bash
+SANDBOX_MAX_FILE_SIZE_MB=100
+SANDBOX_ALLOWED_FILE_TYPES=exe,dll,doc,docx,xls,xlsx,pdf,js,vbs,ps1,bat,msi
+SANDBOX_ANALYSIS_TIMEOUT=300   # seconds before a submission is marked expired
+SANDBOX_POLL_INTERVAL=60       # seconds between poller passes
+```
+
+## Safety posture
+
+- **Opt-in**: the master `SANDBOX_AUTO_SUBMIT` switch defaults to `false`.
+- **Hash-only**: Vigil never uploads binary bytes. Submission is via hash
+  search against the sandbox's own cache. A sandbox returning "unknown"
+  means a human operator (or the agent, via the MCP tool) must upload the
+  sample manually.
+- **Allowlist + size cap**: safety gating lives in
+  `daemon/sandbox_submitter.py::is_hash_safe_to_submit`.
+- **API-only transport**: no shared filesystems between Vigil and the
+  sandbox; all traffic is HTTPS REST.
+
+## Result correlation
+
+Completed reports are written into existing tables — no schema changes:
+
+- `case_evidence` row per `(case_id, sandbox, task_id)` with
+  `evidence_type="sandbox_report"` and the raw report in
+  `analysis_results`.
+- `case_iocs` rows for network and dropped-file indicators. Each IOC's
+  `enrichment_data.sandbox_runs[]` records which sandbox/task observed it
+  (dedup + merge on re-observation).
+- Reputation/threat-level fields on `CaseIOC` are derived from the
+  sandbox's malscore via `_score_to_threat_level` /
+  `_score_to_confidence`.
+
+## Future work
+
+- **Self-hosted CAPE via docker-compose.** CAPE needs KVM and Windows
+  guest VMs, which don't fit cleanly inside Docker Desktop. A production
+  deployment typically runs CAPE on a bare-metal or dedicated Linux host
+  with nested virtualisation. We document `CAPE_SANDBOX_URL` as external
+  and leave the infra outside this repo.
+- **Binary upload path.** When the daemon gains access to the original
+  file bytes (e.g. via email attachment extraction or network capture
+  ingestion), add a second branch to `SandboxSubmitter.submit_file` that
+  uploads via `cape_submit_file` / `ha_submit_file`.
+- **Signature merge with MITRE Analyst.** Sandbox reports surface
+  `mitre_techniques`; the correlation service records them on evidence,
+  but the MITRE Analyst agent does not yet read them back.

--- a/env.example
+++ b/env.example
@@ -122,6 +122,37 @@ SHODAN_API_KEY=""
 ALIENVAULT_OTX_API_KEY=""
 
 # -----------------------------------------------------------------------------
+# Sandbox / Malware Detonation (issue #86)
+# -----------------------------------------------------------------------------
+# Joe Sandbox (external MCP server — see mcp-config.json joe-sandbox entry)
+JOE_SANDBOX_ENABLED="false"
+JOE_SANDBOX_URL="https://jbxcloud.joesecurity.org/api"
+JOE_SANDBOX_API_KEY=""
+
+# CAPE Sandbox (open-source Cuckoo fork — tools/cape_sandbox.py)
+# Assumes you bring your own CAPE deployment (docker-compose self-hosting is
+# out of scope; CAPE needs KVM + Windows guest VMs).
+CAPE_SANDBOX_ENABLED="false"
+CAPE_SANDBOX_URL="http://localhost:8000"
+CAPE_SANDBOX_API_KEY=""
+
+# Hybrid Analysis / Any.Run already use get_integration_config(); these flags
+# just toggle whether the daemon auto-submission pipeline consults them.
+HYBRID_ANALYSIS_ENABLED="false"
+ANYRUN_ENABLED="false"
+
+# Auto-submission pipeline (off by default — opt-in)
+# When true, daemon/processor.py will call sandbox search APIs during the
+# enrichment step for each file hash on a finding. Binary upload is NOT
+# performed from Vigil — only hash-cache lookups + submission-by-hash where
+# the sandbox supports it.
+SANDBOX_AUTO_SUBMIT="false"
+SANDBOX_MAX_FILE_SIZE_MB="100"
+SANDBOX_ALLOWED_FILE_TYPES="exe,dll,doc,docx,xls,xlsx,pdf,js,vbs,ps1,bat,msi"
+SANDBOX_ANALYSIS_TIMEOUT="300"
+SANDBOX_POLL_INTERVAL="60"
+
+# -----------------------------------------------------------------------------
 # Notification / Escalation
 # -----------------------------------------------------------------------------
 

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -310,6 +310,16 @@
       "cwd": "${workspaceFolder}"
     },
 
+    "cape-sandbox": {
+      "command": "python3",
+      "args": ["tools/cape_sandbox.py"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "CAPE_SANDBOX_URL": "${CAPE_SANDBOX_URL}",
+        "CAPE_SANDBOX_API_KEY": "${CAPE_SANDBOX_API_KEY}"
+      }
+    },
+
     "ip-geolocation": {
       "command": "python3",
       "args": ["tools/ip_geolocation.py"],

--- a/services/integration_bridge_service.py
+++ b/services/integration_bridge_service.py
@@ -54,6 +54,8 @@ class IntegrationBridgeService:
         'hybrid-analysis': 'hybrid-analysis-server',
         'joe-sandbox': 'joe-sandbox-server',
         'anyrun': 'anyrun-server',
+        'cape-sandbox': 'cape-sandbox-server',
+        'cape_sandbox': 'cape-sandbox-server',
     }
     
     # Map integration field names to environment variable names

--- a/services/sandbox_correlation_service.py
+++ b/services/sandbox_correlation_service.py
@@ -1,0 +1,364 @@
+"""Correlate completed sandbox reports into case evidence + IOCs.
+
+Sandbox reports (CAPE, Joe, Hybrid Analysis, Any.Run) are large JSON blobs.
+This service normalises their salient parts into Vigil's existing
+``CaseEvidence`` and ``CaseIOC`` tables so they show up on the case view
+alongside human-entered evidence, without needing a new schema.
+
+Design notes
+------------
+- ``CaseEvidence.analysis_results`` (JSONB) is the natural home for the raw
+  sandbox report. We also populate ``file_hash_*`` when the report exposes a
+  primary sample hash.
+- ``CaseIOC`` is used for extracted IOCs (network IPs/domains/URLs, dropped
+  file hashes, mutexes). Per-IOC ``enrichment_data`` captures which sandbox
+  report it came from, for back-reference.
+- ``reputation_score`` is derived heuristically from the sandbox verdict
+  score where present.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from database.models import CaseEvidence, CaseIOC
+from database.connection import get_db_session
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxCorrelationService:
+    """Attach a sandbox report to a case as evidence + IOCs."""
+
+    def __init__(self) -> None:
+        pass
+
+    def attach_report(
+        self,
+        case_id: str,
+        sandbox_name: str,
+        task_id: str,
+        report: Dict[str, Any],
+        collected_by: str = "sandbox-poller",
+        session: Optional[Session] = None,
+    ) -> Dict[str, Any]:
+        """Insert one ``CaseEvidence`` row + N ``CaseIOC`` rows.
+
+        Returns a small summary dict for caller logging.
+        """
+        should_close = session is None
+        if session is None:
+            session = get_db_session()
+
+        try:
+            normalised = _normalise_report(sandbox_name, report)
+            evidence = CaseEvidence(
+                case_id=case_id,
+                evidence_type="sandbox_report",
+                name=f"{sandbox_name} report {task_id}",
+                description=f"Automated sandbox detonation from {sandbox_name}",
+                file_path=None,
+                file_size=None,
+                file_hash_md5=normalised.get("md5"),
+                file_hash_sha256=normalised.get("sha256"),
+                source=sandbox_name,
+                collected_by=collected_by,
+                collected_at=datetime.utcnow(),
+                chain_of_custody=[
+                    {
+                        "timestamp": datetime.utcnow().isoformat(),
+                        "action": "collected",
+                        "user": collected_by,
+                        "notes": f"Retrieved from {sandbox_name} task {task_id}",
+                    }
+                ],
+                analysis_results={
+                    "sandbox": sandbox_name,
+                    "task_id": task_id,
+                    "verdict": normalised.get("verdict"),
+                    "score": normalised.get("score"),
+                    "mitre_techniques": normalised.get("mitre_techniques", []),
+                    "raw": report,
+                },
+                tags=["sandbox", sandbox_name],
+            )
+            session.add(evidence)
+            session.flush()
+
+            iocs_added = 0
+            for ioc_type, value in _iter_iocs(normalised.get("iocs", {})):
+                if self._upsert_ioc(
+                    session=session,
+                    case_id=case_id,
+                    ioc_type=ioc_type,
+                    value=value,
+                    source=sandbox_name,
+                    sandbox_task_id=task_id,
+                    score=normalised.get("score"),
+                ):
+                    iocs_added += 1
+
+            session.commit()
+            return {
+                "evidence_id": evidence.evidence_id,
+                "iocs_added": iocs_added,
+                "verdict": normalised.get("verdict"),
+            }
+        except Exception as e:
+            session.rollback()
+            logger.exception("Failed to correlate sandbox report")
+            return {"error": str(e)}
+        finally:
+            if should_close:
+                session.close()
+
+    # ---------- internals ----------
+
+    def _upsert_ioc(
+        self,
+        session: Session,
+        case_id: str,
+        ioc_type: str,
+        value: str,
+        source: str,
+        sandbox_task_id: str,
+        score: Optional[float],
+    ) -> bool:
+        if not value:
+            return False
+        existing = (
+            session.query(CaseIOC)
+            .filter(
+                CaseIOC.case_id == case_id,
+                CaseIOC.ioc_type == ioc_type,
+                CaseIOC.value == value,
+            )
+            .first()
+        )
+        now = datetime.utcnow()
+        enrichment_chunk = {
+            "sandbox": source,
+            "task_id": sandbox_task_id,
+            "observed_at": now.isoformat(),
+        }
+        if existing:
+            existing.last_seen = now
+            merged = dict(existing.enrichment_data or {})
+            runs = list(merged.get("sandbox_runs") or [])
+            runs.append(enrichment_chunk)
+            merged["sandbox_runs"] = runs[-10:]
+            existing.enrichment_data = merged
+            if score is not None:
+                existing.reputation_score = max(
+                    existing.reputation_score or 0.0, float(score)
+                )
+            return False
+
+        ioc = CaseIOC(
+            case_id=case_id,
+            ioc_type=ioc_type,
+            value=value,
+            threat_level=_score_to_threat_level(score),
+            confidence=_score_to_confidence(score),
+            source=source,
+            first_seen=now,
+            last_seen=now,
+            enrichment_data={"sandbox_runs": [enrichment_chunk]},
+            reputation_score=float(score) if score is not None else None,
+            tags=["sandbox", source],
+            is_active=True,
+            is_false_positive=False,
+        )
+        session.add(ioc)
+        return True
+
+
+# ---------- pure helpers (unit-testable without a DB) ----------
+
+
+def _normalise_report(sandbox_name: str, report: Dict[str, Any]) -> Dict[str, Any]:
+    """Pick a common subset of fields across sandbox vendors."""
+    sandbox = sandbox_name.lower()
+    if sandbox in ("cape", "cape_sandbox", "cape-sandbox"):
+        return _normalise_cape(report)
+    if sandbox in ("joe", "joe_sandbox", "joe-sandbox"):
+        return _normalise_joe(report)
+    if sandbox in ("hybrid", "hybrid_analysis", "hybrid-analysis"):
+        return _normalise_hybrid(report)
+    if sandbox in ("anyrun", "any.run"):
+        return _normalise_anyrun(report)
+    # Unknown — best effort
+    return {"iocs": {}, "mitre_techniques": [], "verdict": None, "score": None}
+
+
+def _normalise_cape(report: Dict[str, Any]) -> Dict[str, Any]:
+    analysis = report.get("data") if isinstance(report.get("data"), dict) else report
+    target = (analysis.get("target") or {}).get("file", {}) or {}
+    info = analysis.get("info") or {}
+    malscore = info.get("score")
+    signatures = analysis.get("signatures") or []
+
+    iocs: Dict[str, List[str]] = {
+        "ip": [],
+        "domain": [],
+        "url": [],
+        "hash": [],
+        "mutex": [],
+    }
+    network = analysis.get("network") or {}
+    for host in network.get("hosts", []) or []:
+        ip = host.get("ip") if isinstance(host, dict) else host
+        if ip:
+            iocs["ip"].append(ip)
+    for dns in network.get("dns", []) or []:
+        req = dns.get("request") if isinstance(dns, dict) else None
+        if req:
+            iocs["domain"].append(req)
+    for http in network.get("http", []) or []:
+        u = http.get("uri") if isinstance(http, dict) else None
+        if u:
+            iocs["url"].append(u)
+    for dropped in analysis.get("dropped", []) or []:
+        if isinstance(dropped, dict):
+            sha = dropped.get("sha256") or dropped.get("sha1") or dropped.get("md5")
+            if sha:
+                iocs["hash"].append(sha)
+    for mx in (analysis.get("behavior", {}).get("summary", {}) or {}).get(
+        "mutexes", []
+    ) or []:
+        iocs["mutex"].append(mx)
+
+    mitre = []
+    for sig in signatures:
+        for tech in sig.get("ttp", []) or []:
+            if isinstance(tech, str) and tech.upper().startswith("T"):
+                mitre.append(tech)
+
+    return {
+        "md5": target.get("md5"),
+        "sha256": target.get("sha256"),
+        "score": malscore,
+        "verdict": _cape_verdict(malscore),
+        "mitre_techniques": sorted(set(mitre)),
+        "iocs": iocs,
+    }
+
+
+def _normalise_joe(report: Dict[str, Any]) -> Dict[str, Any]:
+    analysis = report.get("analysis") or report
+    score = analysis.get("detection", {}).get("score")
+    verdict = analysis.get("detection", {}).get("category")
+    return {
+        "md5": analysis.get("md5"),
+        "sha256": analysis.get("sha256"),
+        "score": score,
+        "verdict": verdict,
+        "mitre_techniques": analysis.get("mitre", []) or [],
+        "iocs": _flatten_iocs(analysis.get("iocs", {})),
+    }
+
+
+def _normalise_hybrid(report: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "md5": report.get("md5"),
+        "sha256": report.get("sha256"),
+        "score": report.get("threat_score"),
+        "verdict": report.get("verdict"),
+        "mitre_techniques": report.get("mitre_attcks", []) or [],
+        "iocs": _flatten_iocs(
+            {
+                "ip": report.get("hosts", []) or [],
+                "domain": report.get("domains", []) or [],
+            }
+        ),
+    }
+
+
+def _normalise_anyrun(report: Dict[str, Any]) -> Dict[str, Any]:
+    data = report.get("data") or report
+    return {
+        "md5": (data.get("sample") or {}).get("md5"),
+        "sha256": (data.get("sample") or {}).get("sha256"),
+        "score": data.get("scores", {}).get("malconf"),
+        "verdict": data.get("verdict"),
+        "mitre_techniques": [],
+        "iocs": _flatten_iocs(data.get("iocs", {})),
+    }
+
+
+def _flatten_iocs(raw: Dict[str, Any]) -> Dict[str, List[str]]:
+    out: Dict[str, List[str]] = {
+        "ip": [],
+        "domain": [],
+        "url": [],
+        "hash": [],
+        "mutex": [],
+    }
+    for key, bucket in (raw or {}).items():
+        norm = key.lower()
+        if norm in out and isinstance(bucket, list):
+            for item in bucket:
+                if isinstance(item, str):
+                    out[norm].append(item)
+                elif isinstance(item, dict):
+                    val = item.get("value") or item.get("address") or item.get("url")
+                    if val:
+                        out[norm].append(val)
+    return out
+
+
+def _iter_iocs(iocs: Dict[str, List[str]]):
+    seen = set()
+    for ioc_type, values in iocs.items():
+        for v in values or []:
+            key = (ioc_type, v)
+            if key in seen or not v:
+                continue
+            seen.add(key)
+            yield ioc_type, v
+
+
+def _cape_verdict(score: Optional[float]) -> Optional[str]:
+    if score is None:
+        return None
+    try:
+        s = float(score)
+    except (TypeError, ValueError):
+        return None
+    if s >= 8:
+        return "malicious"
+    if s >= 5:
+        return "suspicious"
+    if s > 0:
+        return "benign"
+    return "clean"
+
+
+def _score_to_threat_level(score: Optional[float]) -> Optional[str]:
+    if score is None:
+        return None
+    try:
+        s = float(score)
+    except (TypeError, ValueError):
+        return None
+    if s >= 8:
+        return "critical"
+    if s >= 6:
+        return "high"
+    if s >= 3:
+        return "medium"
+    return "low"
+
+
+def _score_to_confidence(score: Optional[float]) -> Optional[float]:
+    if score is None:
+        return None
+    try:
+        s = float(score)
+    except (TypeError, ValueError):
+        return None
+    return max(0.0, min(1.0, s / 10.0))

--- a/services/soc_agents.py
+++ b/services/soc_agents.py
@@ -329,18 +329,38 @@ Confidence scoring:
         "color": "#FF6B9D",
         "description": "Malware analysis and reverse engineering",
         "specialization": "Malware Analysis",
-        "tools": ["get_finding"],
+        "tools": [
+            "get_finding",
+            # CAPE Sandbox (open-source detonation — tools/cape_sandbox.py)
+            "cape_search_hash",
+            "cape_submit_file",
+            "cape_submit_url",
+            "cape_get_report",
+            "cape_get_iocs",
+            "cape_task_status",
+            "cape_list_tasks",
+            # Hybrid Analysis (tools/hybrid_analysis.py)
+            "ha_search_hash",
+            "ha_get_report",
+            # Any.Run (tools/anyrun.py)
+            "anyrun_search_hash",
+            "anyrun_get_report",
+            # URL behavioral analysis (tools/url_analysis.py)
+            "url_analyze",
+        ],
         "max_tokens": 16384,
         "thinking": True,
-        "extra_principles": "- Static before dynamic analysis\n- Use multiple sandboxes\n- Extract comprehensive IOCs\n- Memory: mempalace_search in threat-intel/ioc-registry for known file hashes before sandboxing; mempalace_add_drawer malware family and IOCs; mempalace_kg_add malware → actor relationships",
+        "extra_principles": "- Static before dynamic analysis\n- Use multiple sandboxes; prefer cache lookup (cape_search_hash / ha_search_hash / anyrun_search_hash) before submitting new detonations\n- Extract comprehensive IOCs\n- Memory: mempalace_search in threat-intel/ioc-registry for known file hashes before sandboxing; mempalace_add_drawer malware family and IOCs; mempalace_kg_add malware → actor relationships",
         "methodology": """<methodology>
 1. Retrieve context and extract file hashes
 2. Static analysis: File properties, strings, imports, PE structure
-3. Dynamic analysis: Sandbox execution (Joe Sandbox, Any.Run, Hybrid Analysis)
-4. Network analysis: C2 infrastructure, protocols
-5. Determine capabilities: Data theft, ransomware, backdoor, RAT
-6. Identify malware family and threat actor
-7. Extract IOCs and create detection rules
+3. Cache lookup: check prior analyses via cape_search_hash, ha_search_hash, anyrun_search_hash before submitting
+4. Dynamic analysis: Sandbox execution (CAPE, Joe Sandbox, Any.Run, Hybrid Analysis) — submit only if no prior report exists
+5. Pull behavioral report + IOCs (cape_get_report / cape_get_iocs) once the detonation completes
+6. Network analysis: C2 infrastructure, protocols
+7. Determine capabilities: Data theft, ransomware, backdoor, RAT
+8. Identify malware family and threat actor
+9. Extract IOCs and create detection rules
 </methodology>""",
     },
     "network_analyst": {

--- a/tests/unit/test_cape_sandbox_tool.py
+++ b/tests/unit/test_cape_sandbox_tool.py
@@ -1,0 +1,131 @@
+"""Unit tests for tools/cape_sandbox.py.
+
+We test the pure helpers (IOC extraction from a CAPE report) and the tool
+dispatcher with ``requests`` fully mocked. No CAPE instance required.
+"""
+
+import json
+
+import pytest
+
+import tools.cape_sandbox as cape
+
+
+@pytest.mark.unit
+class TestIocExtraction:
+    def test_empty_report(self):
+        out = cape._extract_iocs({})
+        assert out["ips"] == []
+        assert out["domains"] == []
+        assert out["hashes"] == []
+
+    def test_extracts_network_and_dropped(self):
+        report = {
+            "network": {
+                "hosts": [{"ip": "8.8.8.8"}, "9.9.9.9"],
+                "dns": [{"request": "bad.example"}, {"request": "bad.example"}],
+                "http": [{"uri": "http://bad.example/p"}],
+            },
+            "dropped": [{"sha256": "z" * 64}],
+            "behavior": {"summary": {"mutexes": ["m1"]}},
+        }
+        out = cape._extract_iocs(report)
+        assert "8.8.8.8" in out["ips"]
+        assert "9.9.9.9" in out["ips"]
+        assert "bad.example" in out["domains"]
+        # deduped
+        assert out["domains"].count("bad.example") == 1
+        assert "http://bad.example/p" in out["urls"]
+        assert "z" * 64 in out["hashes"]
+        assert "m1" in out["mutexes"]
+
+
+@pytest.mark.unit
+class TestCallTool:
+    @pytest.mark.asyncio
+    async def test_missing_config(self, monkeypatch):
+        monkeypatch.setattr(cape, "_load_config", lambda: {"url": "", "api_key": ""})
+        out = await cape.handle_call_tool("cape_search_hash", {"hash": "a" * 64})
+        body = json.loads(out[0].text)
+        assert "error" in body
+
+    @pytest.mark.asyncio
+    async def test_search_hash_found_sha256(self, monkeypatch):
+        monkeypatch.setattr(
+            cape, "_load_config", lambda: {"url": "http://cape.test", "api_key": "k"}
+        )
+
+        class FakeResp:
+            status_code = 200
+
+            def json(self):
+                return {"data": [{"id": 42, "target": "f.exe"}]}
+
+        calls = []
+
+        def fake_get(url, headers=None, timeout=None, params=None):
+            calls.append(url)
+            return FakeResp()
+
+        monkeypatch.setattr(cape.requests, "get", fake_get)
+
+        out = await cape.handle_call_tool("cape_search_hash", {"hash": "a" * 64})
+        body = json.loads(out[0].text)
+        assert body["found"] is True
+        assert body["hash_type"] == "sha256"
+        assert body["tasks"][0]["id"] == 42
+        # ensure we hit the sha256 path first
+        assert "/sha256/" in calls[0]
+
+    @pytest.mark.asyncio
+    async def test_search_hash_not_found(self, monkeypatch):
+        monkeypatch.setattr(
+            cape, "_load_config", lambda: {"url": "http://cape.test", "api_key": "k"}
+        )
+
+        class FakeResp:
+            status_code = 200
+
+            def json(self):
+                return {"data": []}
+
+        monkeypatch.setattr(cape.requests, "get", lambda *a, **kw: FakeResp())
+
+        out = await cape.handle_call_tool("cape_search_hash", {"hash": "a" * 64})
+        body = json.loads(out[0].text)
+        assert body["found"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_iocs_returns_extracted(self, monkeypatch):
+        monkeypatch.setattr(
+            cape, "_load_config", lambda: {"url": "http://cape.test", "api_key": "k"}
+        )
+
+        class FakeResp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "data": {
+                        "network": {"hosts": [{"ip": "1.1.1.1"}]},
+                        "dropped": [],
+                    }
+                }
+
+        monkeypatch.setattr(cape.requests, "get", lambda *a, **kw: FakeResp())
+
+        out = await cape.handle_call_tool("cape_get_iocs", {"task_id": "5"})
+        body = json.loads(out[0].text)
+        assert "1.1.1.1" in body["iocs"]["ips"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool(self, monkeypatch):
+        monkeypatch.setattr(
+            cape, "_load_config", lambda: {"url": "http://cape.test", "api_key": "k"}
+        )
+        out = await cape.handle_call_tool("does_not_exist", {})
+        body = json.loads(out[0].text)
+        assert "Unknown tool" in body["error"]

--- a/tests/unit/test_sandbox_correlation.py
+++ b/tests/unit/test_sandbox_correlation.py
@@ -1,0 +1,125 @@
+"""Unit tests for services.sandbox_correlation_service normalisation helpers.
+
+The DB-writing path (``SandboxCorrelationService.attach_report``) is
+integration-only — these tests cover the pure helpers that don't need a
+live database.
+"""
+
+import pytest
+
+from services.sandbox_correlation_service import (
+    _cape_verdict,
+    _iter_iocs,
+    _normalise_cape,
+    _normalise_report,
+    _score_to_confidence,
+    _score_to_threat_level,
+)
+
+
+@pytest.mark.unit
+class TestCapeNormalisation:
+    def test_extracts_primary_hashes_and_score(self):
+        report = {
+            "data": {
+                "target": {"file": {"md5": "a" * 32, "sha256": "b" * 64}},
+                "info": {"score": 8.5},
+                "network": {},
+                "signatures": [],
+            }
+        }
+        out = _normalise_cape(report)
+        assert out["md5"] == "a" * 32
+        assert out["sha256"] == "b" * 64
+        assert out["score"] == 8.5
+        assert out["verdict"] == "malicious"
+
+    def test_extracts_network_and_dropped_iocs(self):
+        report = {
+            "data": {
+                "target": {"file": {}},
+                "info": {"score": 3},
+                "network": {
+                    "hosts": [{"ip": "1.2.3.4"}, "5.6.7.8"],
+                    "dns": [{"request": "evil.example"}],
+                    "http": [{"uri": "http://evil.example/a"}],
+                },
+                "dropped": [{"sha256": "c" * 64}],
+                "behavior": {"summary": {"mutexes": ["Global\\Badness"]}},
+                "signatures": [{"ttp": ["T1059.001"]}, {"ttp": ["T1055"]}],
+            }
+        }
+        out = _normalise_cape(report)
+        assert "1.2.3.4" in out["iocs"]["ip"]
+        assert "5.6.7.8" in out["iocs"]["ip"]
+        assert "evil.example" in out["iocs"]["domain"]
+        assert "http://evil.example/a" in out["iocs"]["url"]
+        assert "c" * 64 in out["iocs"]["hash"]
+        assert "Global\\Badness" in out["iocs"]["mutex"]
+        assert "T1059.001" in out["mitre_techniques"]
+        assert "T1055" in out["mitre_techniques"]
+
+
+@pytest.mark.unit
+class TestVerdictAndScoreMapping:
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (None, None),
+            (0, "clean"),
+            (2, "benign"),
+            (5, "suspicious"),
+            (8, "malicious"),
+            (10, "malicious"),
+        ],
+    )
+    def test_cape_verdict(self, score, expected):
+        assert _cape_verdict(score) == expected
+
+    def test_score_to_threat_level(self):
+        assert _score_to_threat_level(None) is None
+        assert _score_to_threat_level(1) == "low"
+        assert _score_to_threat_level(5) == "medium"
+        assert _score_to_threat_level(7) == "high"
+        assert _score_to_threat_level(9) == "critical"
+
+    def test_score_to_confidence_clamps(self):
+        assert _score_to_confidence(None) is None
+        assert _score_to_confidence(0) == 0.0
+        assert _score_to_confidence(5) == 0.5
+        assert _score_to_confidence(100) == 1.0
+
+
+@pytest.mark.unit
+class TestIocIteration:
+    def test_dedupes_across_same_type(self):
+        iocs = {"ip": ["1.1.1.1", "1.1.1.1", "2.2.2.2"], "domain": ["ex.com"]}
+        pairs = list(_iter_iocs(iocs))
+        assert ("ip", "1.1.1.1") in pairs
+        assert ("ip", "2.2.2.2") in pairs
+        assert ("domain", "ex.com") in pairs
+        assert len(pairs) == 3
+
+    def test_skips_empty_values(self):
+        pairs = list(_iter_iocs({"ip": ["", None]}))
+        assert pairs == []
+
+
+@pytest.mark.unit
+class TestDispatch:
+    def test_unknown_sandbox_returns_empty(self):
+        out = _normalise_report("made-up", {"anything": True})
+        assert out["iocs"] == {}
+        assert out["verdict"] is None
+
+    def test_cape_routing(self):
+        report = {
+            "data": {
+                "target": {"file": {"md5": "d" * 32}},
+                "info": {"score": 9},
+                "network": {},
+                "signatures": [],
+            }
+        }
+        out = _normalise_report("cape-sandbox", report)
+        assert out["verdict"] == "malicious"

--- a/tests/unit/test_sandbox_submitter.py
+++ b/tests/unit/test_sandbox_submitter.py
@@ -1,0 +1,172 @@
+"""Unit tests for daemon.sandbox_submitter — safety gating and dispatch."""
+
+import pytest
+from unittest.mock import patch
+
+from daemon.sandbox_submitter import SandboxSettings, SandboxSubmitter
+
+
+@pytest.mark.unit
+class TestSandboxSettings:
+    def test_defaults(self, monkeypatch):
+        for key in (
+            "SANDBOX_AUTO_SUBMIT",
+            "SANDBOX_MAX_FILE_SIZE_MB",
+            "SANDBOX_ALLOWED_FILE_TYPES",
+            "SANDBOX_ANALYSIS_TIMEOUT",
+            "JOE_SANDBOX_ENABLED",
+            "CAPE_SANDBOX_ENABLED",
+            "HYBRID_ANALYSIS_ENABLED",
+            "ANYRUN_ENABLED",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        s = SandboxSettings.from_env()
+        assert s.auto_submit is False
+        assert s.max_file_size_mb == 100
+        assert "exe" in s.allowed_types
+        assert s.cape_enabled is False
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("SANDBOX_AUTO_SUBMIT", "true")
+        monkeypatch.setenv("SANDBOX_MAX_FILE_SIZE_MB", "25")
+        monkeypatch.setenv("SANDBOX_ALLOWED_FILE_TYPES", "exe,dll")
+        monkeypatch.setenv("CAPE_SANDBOX_ENABLED", "1")
+
+        s = SandboxSettings.from_env()
+        assert s.auto_submit is True
+        assert s.max_file_size_mb == 25
+        assert s.allowed_types == ["exe", "dll"]
+        assert s.cape_enabled is True
+
+
+@pytest.mark.unit
+class TestSafetyGate:
+    def _make(self, **overrides):
+        defaults = dict(
+            auto_submit=True,
+            max_file_size_mb=10,
+            allowed_types=["exe", "dll"],
+            timeout_seconds=300,
+            joe_enabled=False,
+            cape_enabled=True,
+            hybrid_enabled=False,
+            anyrun_enabled=False,
+        )
+        defaults.update(overrides)
+        return SandboxSubmitter(SandboxSettings(**defaults))
+
+    def test_enabled_requires_auto_submit_and_at_least_one_sandbox(self):
+        off = self._make(auto_submit=False)
+        assert off.enabled() is False
+
+        nothing = self._make(cape_enabled=False)
+        assert nothing.enabled() is False
+
+        good = self._make()
+        assert good.enabled() is True
+
+    def test_bad_hash_rejected(self):
+        s = self._make()
+        assert s.is_hash_safe_to_submit("not-a-hash") is False
+        assert s.is_hash_safe_to_submit("") is False
+        assert s.is_hash_safe_to_submit("g" * 64) is False  # wrong alphabet
+
+    def test_valid_hashes_accepted(self):
+        s = self._make()
+        assert s.is_hash_safe_to_submit("a" * 32) is True  # md5
+        assert s.is_hash_safe_to_submit("b" * 40) is True  # sha1
+        assert s.is_hash_safe_to_submit("c" * 64) is True  # sha256
+
+    def test_size_cap_rejects_large_file(self):
+        s = self._make()
+        hint = {"file_size": 100 * 1024 * 1024}  # 100 MB, cap is 10
+        assert s.is_hash_safe_to_submit("a" * 64, hint) is False
+
+    def test_size_cap_accepts_under_limit(self):
+        s = self._make()
+        hint = {"file_size": 5 * 1024 * 1024}
+        assert s.is_hash_safe_to_submit("a" * 64, hint) is True
+
+    def test_extension_allowlist_rejects(self):
+        s = self._make()
+        assert s.is_hash_safe_to_submit("a" * 64, {"file_name": "song.mp3"}) is False
+
+    def test_extension_allowlist_accepts(self):
+        s = self._make()
+        assert s.is_hash_safe_to_submit("a" * 64, {"file_name": "payload.exe"}) is True
+
+    def test_hint_without_extension_is_permissive(self):
+        s = self._make()
+        assert s.is_hash_safe_to_submit("a" * 64, {"file_name": "noext"}) is True
+
+
+@pytest.mark.unit
+class TestSubmitDispatch:
+    @pytest.mark.asyncio
+    async def test_disabled_short_circuits(self):
+        settings = SandboxSettings(
+            auto_submit=False,
+            max_file_size_mb=100,
+            allowed_types=["exe"],
+            timeout_seconds=300,
+            joe_enabled=False,
+            cape_enabled=False,
+            hybrid_enabled=False,
+            anyrun_enabled=False,
+        )
+        s = SandboxSubmitter(settings)
+        out = await s.submit_hash("a" * 64)
+        assert out == {"status": "disabled"}
+
+    @pytest.mark.asyncio
+    async def test_rejected_when_hash_bad(self):
+        settings = SandboxSettings(
+            auto_submit=True,
+            max_file_size_mb=100,
+            allowed_types=["exe"],
+            timeout_seconds=300,
+            joe_enabled=False,
+            cape_enabled=True,
+            hybrid_enabled=False,
+            anyrun_enabled=False,
+        )
+        s = SandboxSubmitter(settings)
+        out = await s.submit_hash("not-a-hash")
+        assert out["status"] == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_dispatches_only_enabled_sandboxes(self):
+        settings = SandboxSettings(
+            auto_submit=True,
+            max_file_size_mb=100,
+            allowed_types=["exe"],
+            timeout_seconds=300,
+            joe_enabled=False,
+            cape_enabled=True,
+            hybrid_enabled=True,
+            anyrun_enabled=False,
+        )
+        s = SandboxSubmitter(settings)
+
+        async def fake_cape(self_arg, h):
+            return {"status": "cached", "task_id": "c1"}
+
+        async def fake_hybrid(self_arg, h):
+            return {"status": "unknown"}
+
+        async def fail(*a, **kw):
+            raise AssertionError("disabled sandbox should not be called")
+
+        with patch.object(SandboxSubmitter, "_submit_cape", fake_cape), patch.object(
+            SandboxSubmitter, "_submit_hybrid", fake_hybrid
+        ), patch.object(SandboxSubmitter, "_submit_anyrun", fail), patch.object(
+            SandboxSubmitter, "_submit_joe", fail
+        ):
+            out = await s.submit_hash("a" * 64)
+
+        assert "cape" in out and out["cape"]["task_id"] == "c1"
+        assert "hybrid_analysis" in out
+        assert "anyrun" not in out
+        assert "joe_sandbox" not in out
+        assert "submitted_at" in out["cape"]

--- a/tools/cape_sandbox.py
+++ b/tools/cape_sandbox.py
@@ -1,0 +1,399 @@
+"""CAPE Sandbox MCP server (stdio).
+
+CAPE (Config And Payload Extraction) is an open-source malware detonation
+sandbox — the actively maintained fork of Cuckoo. This MCP server wraps the
+CAPEv2 REST API so SOC agents can submit files/URLs for detonation and
+retrieve behavioral reports, IOCs, and PCAPs.
+
+Config comes from ``~/.deeptempo/integrations_config.json`` under the
+``cape_sandbox`` key — fields: ``url``, ``api_key``.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+from mcp.server import NotificationOptions, Server
+from mcp.server.models import InitializationOptions
+import mcp.server.stdio
+import mcp.types as types
+
+from core.config import get_integration_config
+
+logger = logging.getLogger(__name__)
+server = Server("cape-sandbox")
+
+
+DEFAULT_TIMEOUT = 30
+REPORT_TIMEOUT = 60
+
+
+def result(data: Any) -> List[types.TextContent]:
+    return [
+        types.TextContent(type="text", text=json.dumps(data, indent=2, default=str))
+    ]
+
+
+def _load_config() -> Dict[str, str]:
+    """Return CAPE config, falling back to env vars for container deployments."""
+    config = get_integration_config("cape_sandbox") or {}
+    url = config.get("url") or os.getenv("CAPE_SANDBOX_URL", "").rstrip("/")
+    api_key = config.get("api_key") or os.getenv("CAPE_SANDBOX_API_KEY", "")
+    return {"url": url.rstrip("/") if url else "", "api_key": api_key}
+
+
+def _headers(api_key: str) -> Dict[str, str]:
+    # CAPEv2 uses Token auth; some deployments use Bearer — Token is the canonical format.
+    return {"Authorization": f"Token {api_key}"} if api_key else {}
+
+
+def _extract_iocs(report: Dict[str, Any]) -> Dict[str, List[str]]:
+    """Pull IPs, domains, hashes, mutexes, URLs out of a CAPE report."""
+    iocs: Dict[str, set] = {
+        "ips": set(),
+        "domains": set(),
+        "urls": set(),
+        "hashes": set(),
+        "mutexes": set(),
+    }
+
+    network = report.get("network") or {}
+    for host in network.get("hosts", []) or []:
+        if isinstance(host, dict):
+            ip = host.get("ip")
+            if ip:
+                iocs["ips"].add(ip)
+        elif isinstance(host, str):
+            iocs["ips"].add(host)
+
+    for dns in network.get("dns", []) or []:
+        req = dns.get("request") if isinstance(dns, dict) else None
+        if req:
+            iocs["domains"].add(req)
+
+    for http in network.get("http", []) or []:
+        u = http.get("uri") if isinstance(http, dict) else None
+        if u:
+            iocs["urls"].add(u)
+
+    for dropped in report.get("dropped", []) or []:
+        if isinstance(dropped, dict):
+            sha = dropped.get("sha256") or dropped.get("sha1") or dropped.get("md5")
+            if sha:
+                iocs["hashes"].add(sha)
+
+    behavior = report.get("behavior") or {}
+    for summary_key in ("mutexes", "mutex"):
+        for mx in behavior.get("summary", {}).get(summary_key, []) or []:
+            iocs["mutexes"].add(mx)
+
+    return {k: sorted(v) for k, v in iocs.items()}
+
+
+@server.list_tools()
+async def handle_list_tools() -> List[types.Tool]:
+    return [
+        types.Tool(
+            name="cape_submit_file",
+            description=(
+                "Submit a file to CAPE Sandbox for detonation. "
+                "Accepts a local file_path or base64 file_b64 + filename."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "file_path": {
+                        "type": "string",
+                        "description": "Absolute path to a local file",
+                    },
+                    "file_b64": {
+                        "type": "string",
+                        "description": "Base64-encoded file contents",
+                    },
+                    "filename": {
+                        "type": "string",
+                        "description": "Filename when file_b64 is used",
+                    },
+                    "options": {
+                        "type": "string",
+                        "description": "CAPE options string (optional)",
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Analysis timeout in seconds",
+                    },
+                },
+            },
+        ),
+        types.Tool(
+            name="cape_submit_url",
+            description="Submit a URL to CAPE Sandbox for behavioral analysis.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string"},
+                    "timeout": {"type": "integer"},
+                },
+                "required": ["url"],
+            },
+        ),
+        types.Tool(
+            name="cape_get_report",
+            description="Retrieve the full analysis report for a CAPE task.",
+            inputSchema={
+                "type": "object",
+                "properties": {"task_id": {"type": "string"}},
+                "required": ["task_id"],
+            },
+        ),
+        types.Tool(
+            name="cape_get_iocs",
+            description="Extract IOCs (IPs, domains, URLs, dropped hashes, mutexes) from a completed CAPE task.",
+            inputSchema={
+                "type": "object",
+                "properties": {"task_id": {"type": "string"}},
+                "required": ["task_id"],
+            },
+        ),
+        types.Tool(
+            name="cape_get_pcap",
+            description="Retrieve the PCAP download URL for a CAPE task (does not download bytes).",
+            inputSchema={
+                "type": "object",
+                "properties": {"task_id": {"type": "string"}},
+                "required": ["task_id"],
+            },
+        ),
+        types.Tool(
+            name="cape_list_tasks",
+            description="List recent CAPE analysis tasks with status.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max tasks (default 20)",
+                    },
+                    "offset": {"type": "integer", "description": "Pagination offset"},
+                },
+            },
+        ),
+        types.Tool(
+            name="cape_search_hash",
+            description=(
+                "Look up prior CAPE analyses by file hash (md5/sha1/sha256). "
+                "Use before submitting to avoid duplicate detonation."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {"hash": {"type": "string"}},
+                "required": ["hash"],
+            },
+        ),
+        types.Tool(
+            name="cape_task_status",
+            description="Lightweight status check for a single task (pending / running / reported / failed).",
+            inputSchema={
+                "type": "object",
+                "properties": {"task_id": {"type": "string"}},
+                "required": ["task_id"],
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def handle_call_tool(name: str, arguments: Optional[dict]):
+    cfg = _load_config()
+    base = cfg["url"]
+    api_key = cfg["api_key"]
+
+    if not base:
+        return result({"error": "CAPE Sandbox not configured (missing url)"})
+
+    args = arguments or {}
+    headers = _headers(api_key)
+
+    try:
+        if name == "cape_submit_file":
+            file_path = args.get("file_path")
+            file_b64 = args.get("file_b64")
+            filename = args.get("filename")
+            data = {}
+            if args.get("options"):
+                data["options"] = args["options"]
+            if args.get("timeout"):
+                data["timeout"] = str(args["timeout"])
+
+            if file_path:
+                with open(file_path, "rb") as fh:
+                    files = {"file": (os.path.basename(file_path), fh)}
+                    resp = requests.post(
+                        f"{base}/apiv2/tasks/create/file/",
+                        headers=headers,
+                        files=files,
+                        data=data,
+                        timeout=DEFAULT_TIMEOUT,
+                    )
+            elif file_b64:
+                if not filename:
+                    return result(
+                        {"error": "filename required when submitting via file_b64"}
+                    )
+                import base64
+
+                files = {"file": (filename, base64.b64decode(file_b64))}
+                resp = requests.post(
+                    f"{base}/apiv2/tasks/create/file/",
+                    headers=headers,
+                    files=files,
+                    data=data,
+                    timeout=DEFAULT_TIMEOUT,
+                )
+            else:
+                return result(
+                    {"error": "Provide either file_path or (file_b64 + filename)"}
+                )
+
+            resp.raise_for_status()
+            return result(resp.json())
+
+        if name == "cape_submit_url":
+            target = args.get("url")
+            if not target:
+                return result({"error": "url required"})
+            data = {"url": target}
+            if args.get("timeout"):
+                data["timeout"] = str(args["timeout"])
+            resp = requests.post(
+                f"{base}/apiv2/tasks/create/url/",
+                headers=headers,
+                data=data,
+                timeout=DEFAULT_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return result(resp.json())
+
+        if name == "cape_get_report":
+            tid = args.get("task_id")
+            if not tid:
+                return result({"error": "task_id required"})
+            resp = requests.get(
+                f"{base}/apiv2/tasks/get/report/{tid}/",
+                headers=headers,
+                timeout=REPORT_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return result(resp.json())
+
+        if name == "cape_get_iocs":
+            tid = args.get("task_id")
+            if not tid:
+                return result({"error": "task_id required"})
+            resp = requests.get(
+                f"{base}/apiv2/tasks/get/report/{tid}/",
+                headers=headers,
+                timeout=REPORT_TIMEOUT,
+            )
+            resp.raise_for_status()
+            report = resp.json()
+            # CAPE wraps the analysis under 'data' in some versions
+            analysis = report.get("data") or report
+            return result({"task_id": tid, "iocs": _extract_iocs(analysis)})
+
+        if name == "cape_get_pcap":
+            tid = args.get("task_id")
+            if not tid:
+                return result({"error": "task_id required"})
+            return result(
+                {
+                    "task_id": tid,
+                    "pcap_url": f"{base}/apiv2/tasks/get/pcap/{tid}/",
+                    "note": "Authenticated download — use Authorization header.",
+                }
+            )
+
+        if name == "cape_list_tasks":
+            limit = int(args.get("limit", 20))
+            offset = int(args.get("offset", 0))
+            resp = requests.get(
+                f"{base}/apiv2/tasks/list/{limit}/{offset}/",
+                headers=headers,
+                timeout=DEFAULT_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return result(resp.json())
+
+        if name == "cape_search_hash":
+            h = args.get("hash")
+            if not h:
+                return result({"error": "hash required"})
+            # CAPE search endpoint accepts md5/sha1/sha256 paths.
+            # Probe sha256 first, then md5 as fallback.
+            for hash_type in ("sha256", "md5"):
+                resp = requests.get(
+                    f"{base}/apiv2/tasks/search/{hash_type}/{h}/",
+                    headers=headers,
+                    timeout=DEFAULT_TIMEOUT,
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    tasks = data.get("data", []) if isinstance(data, dict) else data
+                    if tasks:
+                        return result(
+                            {
+                                "hash": h,
+                                "hash_type": hash_type,
+                                "found": True,
+                                "tasks": tasks[:10],
+                            }
+                        )
+            return result({"hash": h, "found": False, "tasks": []})
+
+        if name == "cape_task_status":
+            tid = args.get("task_id")
+            if not tid:
+                return result({"error": "task_id required"})
+            resp = requests.get(
+                f"{base}/apiv2/tasks/status/{tid}/",
+                headers=headers,
+                timeout=DEFAULT_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return result(resp.json())
+
+        return result({"error": f"Unknown tool: {name}"})
+
+    except requests.HTTPError as e:
+        return result(
+            {
+                "error": f"CAPE HTTP error: {e}",
+                "status_code": getattr(e.response, "status_code", None),
+            }
+        )
+    except Exception as e:
+        logger.exception("CAPE tool call failed")
+        return result({"error": str(e)})
+
+
+async def main() -> None:
+    async with mcp.server.stdio.stdio_server() as (read, write):
+        await server.run(
+            read,
+            write,
+            InitializationOptions(
+                server_name="cape-sandbox",
+                server_version="0.1.0",
+                capabilities=server.get_capabilities(
+                    notification_options=NotificationOptions(),
+                    experimental_capabilities={},
+                ),
+            ),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Closes #86

## Summary

Deepens sandbox integrations with a new CAPE MCP server, wires the Malware Analyst agent to actually use the existing sandbox tooling, and adds an opt-in automated detonation pipeline that writes sandbox reports back to findings and cases.

- **New CAPE MCP server** (`tools/cape_sandbox.py`) wrapping the CAPEv2 REST API (8 tools: submit_file, submit_url, get_report, get_iocs, get_pcap, list_tasks, search_hash, task_status). Follows the existing `tools/hybrid_analysis.py` / `tools/anyrun.py` pattern.
- **Agent wiring**: Malware Analyst's `recommended_tools` expanded from `["get_finding"]` to include CAPE, Hybrid Analysis, Any.Run, and URL analysis surfaces. Methodology updated to cache-check before submitting.
- **Auto-submission pipeline** (`daemon/sandbox_submitter.py` + hook in `daemon/processor.py`): opt-in (`SANDBOX_AUTO_SUBMIT=false` by default), hash-only (never uploads binaries), with file-type allowlist + size cap safety gates. Parallel dispatch to enabled sandboxes.
- **Result correlation** (`services/sandbox_correlation_service.py` + `daemon/sandbox_poller.py`): completed reports land in `CaseEvidence.analysis_results` (JSONB) with IOCs unpacked into `CaseIOC`. Reuses existing tables — **no schema migration**.
- **CAPE hosting**: externally-hosted only (user supplies `CAPE_SANDBOX_URL`). Self-hosted CAPE via docker-compose is out of scope — CAPE needs KVM + Windows guest VMs that don't fit Docker Desktop.
- **34 new unit tests** cover MCP tool dispatch, safety gates, dispatch logic, and report normalisation. All passing.

## Files changed

| Area | Path | Change |
|------|------|--------|
| MCP tool | `tools/cape_sandbox.py` | **new** — stdio MCP server |
| Registration | `mcp-config.json` | add `cape-sandbox` entry |
| Integration bridge | `services/integration_bridge_service.py` | map `cape-sandbox` → server |
| Agent | `services/soc_agents.py` | expand Malware Analyst tools |
| Daemon submit | `daemon/sandbox_submitter.py` | **new** — safety + dispatch |
| Daemon hook | `daemon/processor.py` | call submitter in `_enrich_finding` |
| Daemon poll | `daemon/sandbox_poller.py` | **new** — resolve pending submissions |
| Scheduler | `daemon/scheduler.py` | register `sandbox_poll` task (only when auto-submit on) |
| Correlation | `services/sandbox_correlation_service.py` | **new** — report → Evidence/IOC |
| Config | `env.example` | sandbox env vars |
| Docs | `docs/INTEGRATIONS.md`, `docs/AGENTS.md`, `docs/SANDBOX.md` | document config + architecture |
| Tests | `tests/unit/test_cape_sandbox_tool.py` | **new** — 7 tests |
| Tests | `tests/unit/test_sandbox_submitter.py` | **new** — 14 tests |
| Tests | `tests/unit/test_sandbox_correlation.py` | **new** — 13 tests |

## Test plan

- [x] `black --check` clean on all new/modified files
- [x] `flake8 --max-line-length 120` clean on all new/modified files
- [x] `pytest tests/unit/test_sandbox_submitter.py tests/unit/test_sandbox_correlation.py tests/unit/test_cape_sandbox_tool.py` — **34 passed**
- [x] `pytest tests/unit/test_daemon.py` — still green (3 passed, pre-existing 29 skips unchanged)
- [ ] Manual smoke: `python3 tools/cape_sandbox.py` starts on stdio and responds to a `tools/list` JSON-RPC request
- [ ] Integration smoke (requires a CAPE deployment): set `CAPE_SANDBOX_URL` + `CAPE_SANDBOX_API_KEY`, invoke Malware Analyst agent with a hash, confirm `cape_search_hash` / `cape_get_report` tool calls work
- [ ] Pipeline smoke: set `SANDBOX_AUTO_SUBMIT=true` + `CAPE_SANDBOX_ENABLED=true`, inject a finding with a file hash, watch daemon logs for submission → poller picks up the report → `CaseEvidence` + `CaseIOC` rows created

## Safety posture

- `SANDBOX_AUTO_SUBMIT=false` default — pipeline is dormant unless operator opts in.
- No binary bytes leave Vigil. Submission is hash-cache lookup + submission-by-hash only.
- File-type allowlist (`exe,dll,doc,docx,xls,xlsx,pdf,js,vbs,ps1,bat,msi` default) and `SANDBOX_MAX_FILE_SIZE_MB=100` cap enforced in `SandboxSubmitter.is_hash_safe_to_submit`.
- Poller task is only registered in the scheduler when `SANDBOX_AUTO_SUBMIT=true`.

## Out of scope (future work, documented in `docs/SANDBOX.md`)

- Self-hosted CAPE docker-compose profile (needs KVM + Windows VMs).
- Binary upload path (requires email/pcap parsing layer that doesn't exist yet).
- Sandbox MITRE techniques reflow into MITRE Analyst agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)