### PR TITLE
feat(ingestion): Kafka ingestion pipeline

### DIFF
--- a/backend/api/kafka.py
+++ b/backend/api/kafka.py
@@ -1,0 +1,167 @@
+"""Kafka ingestion API endpoints.
+
+Provides configuration + live status for the Kafka consumer that runs
+inside the daemon. Config is persisted in the ``kafka.settings``
+SystemConfig row; secrets (SASL password, SSL cert path) are
+intentionally NOT accepted here — they must be set via env vars.
+
+Live stats (messages consumed, last message time, error counters) are
+fetched from the daemon's health server on ``DAEMON_HEALTH_PORT``.
+If the daemon isn't reachable, the endpoint returns the persisted
+config with ``connected=false`` so the UI still renders.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/api/kafka", tags=["kafka"])
+logger = logging.getLogger(__name__)
+
+SYSTEMCONFIG_KEY = "kafka.settings"
+DAEMON_STATUS_TIMEOUT_SECONDS = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+
+class KafkaConfigBody(BaseModel):
+    """Non-secret Kafka settings persisted in SystemConfig."""
+
+    enabled: bool = False
+    bootstrap_servers: str = "localhost:9092"
+    consumer_group: str = "vigil-soc"
+    topics: List[str] = Field(default_factory=list)
+    auto_offset_reset: str = "latest"
+    security_protocol: str = "PLAINTEXT"
+    sasl_mechanism: Optional[str] = None
+    sasl_username: Optional[str] = None
+    max_poll_records: int = 500
+    session_timeout_ms: int = 30_000
+
+
+def _default_config() -> Dict[str, Any]:
+    return KafkaConfigBody().model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _daemon_status_url() -> str:
+    host = os.getenv("DAEMON_HEALTH_HOST", "localhost")
+    port = os.getenv("DAEMON_HEALTH_PORT", "9091")
+    return f"http://{host}:{port}/status"
+
+
+async def _fetch_daemon_kafka_stats() -> Optional[Dict[str, Any]]:
+    """Pull the kafka sub-object from the daemon's /status endpoint."""
+    url = _daemon_status_url()
+    try:
+        timeout = aiohttp.ClientTimeout(total=DAEMON_STATUS_TIMEOUT_SECONDS)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url) as resp:
+                if resp.status != 200:
+                    return None
+                body = await resp.json()
+                return body.get("kafka") or None
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        logger.debug("Daemon status unreachable at %s: %s", url, e)
+        return None
+    except Exception as e:
+        logger.debug("Daemon status fetch failed: %s", e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/config")
+async def get_kafka_config() -> Dict[str, Any]:
+    """Return the persisted Kafka config, falling back to defaults."""
+    from database.config_service import get_config_service
+
+    try:
+        stored = get_config_service().get_system_config(SYSTEMCONFIG_KEY) or {}
+    except Exception as e:
+        logger.error("Failed to read kafka config: %s", e)
+        raise HTTPException(500, f"Failed to read kafka config: {e}")
+
+    merged = {**_default_config(), **(stored if isinstance(stored, dict) else {})}
+    # SASL password is env-only; never return it from the API
+    merged.pop("sasl_password", None)
+    return merged
+
+
+@router.put("/config")
+async def put_kafka_config(body: KafkaConfigBody) -> Dict[str, Any]:
+    """Upsert the persisted Kafka config. Secrets are not accepted here."""
+    from database.config_service import get_config_service
+
+    payload = body.model_dump()
+    try:
+        ok = get_config_service().set_system_config(
+            key=SYSTEMCONFIG_KEY,
+            value=payload,
+            description="Kafka ingestion settings",
+            config_type="ingestion",
+            change_reason="Updated via /api/kafka/config",
+        )
+        if not ok:
+            raise HTTPException(500, "Failed to save kafka config")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to write kafka config: %s", e)
+        raise HTTPException(500, f"Failed to save kafka config: {e}")
+
+    return {"status": "ok", "config": payload}
+
+
+@router.get("/status")
+async def get_kafka_status() -> Dict[str, Any]:
+    """Return live consumer stats plus the persisted enabled/config state."""
+    from database.config_service import get_config_service
+
+    try:
+        stored = get_config_service().get_system_config(SYSTEMCONFIG_KEY) or {}
+    except Exception:
+        stored = {}
+    merged = {**_default_config(), **(stored if isinstance(stored, dict) else {})}
+    merged.pop("sasl_password", None)
+
+    stats = await _fetch_daemon_kafka_stats()
+    daemon_reachable = stats is not None
+    if stats is None:
+        stats = {
+            "connected": False,
+            "messages_consumed": 0,
+            "messages_enqueued": 0,
+            "duplicates_skipped": 0,
+            "decode_errors": 0,
+            "missing_id_errors": 0,
+            "last_message_at": None,
+            "last_error": None,
+            "last_error_at": None,
+            "topics": merged.get("topics", []),
+            "consumer_group": merged.get("consumer_group", ""),
+        }
+
+    return {
+        "enabled": bool(merged.get("enabled", False)),
+        "daemon_reachable": daemon_reachable,
+        "config": merged,
+        "stats": stats,
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -70,6 +70,9 @@ from api.detection_rules import router as detection_rules_router
 # Orchestrator router
 from api.orchestrator import router as orchestrator_router
 
+# Kafka ingestion router
+from api.kafka import router as kafka_router
+
 from core.rate_limit import rate_limit_dependency
 from monitoring import init_sentry, PROMETHEUS_AVAILABLE, get_metrics_response
 if PROMETHEUS_AVAILABLE:
@@ -163,6 +166,7 @@ app.include_router(workflows_router, prefix="/api", tags=["workflows"])
 
 # Autonomous orchestrator
 app.include_router(orchestrator_router, prefix="/api/orchestrator", tags=["orchestrator"])
+app.include_router(kafka_router)
 
 # Enhanced case management routers
 app.include_router(case_templates_router, prefix="/api/cases/templates", tags=["case-templates"])

--- a/daemon/config.py
+++ b/daemon/config.py
@@ -97,6 +97,30 @@ class OrchestratorConfig:
 
 
 @dataclass
+class KafkaConfig:
+    """Configuration for Kafka ingestion.
+
+    MVP scope: JSON-only deserialization, single consumer group,
+    enable/disable + bootstrap servers + topics overridable via
+    ``SystemConfig["kafka.settings"]``. Secrets (SASL password,
+    SSL cert path) stay in env only.
+    """
+    enabled: bool = False
+    bootstrap_servers: str = "localhost:9092"
+    consumer_group: str = "vigil-soc"
+    topics: List[str] = field(default_factory=list)
+    auto_offset_reset: str = "latest"  # "latest" | "earliest"
+    max_poll_records: int = 500
+    session_timeout_ms: int = 30_000
+    # Security (env-only for secrets)
+    security_protocol: str = "PLAINTEXT"  # PLAINTEXT | SASL_SSL | SSL
+    sasl_mechanism: Optional[str] = None  # PLAIN | SCRAM-SHA-256 | SCRAM-SHA-512
+    sasl_username: Optional[str] = None
+    sasl_password: Optional[str] = None
+    ssl_ca_location: Optional[str] = None
+
+
+@dataclass
 class LLMQueueConfig:
     """Configuration for the ARQ-based LLM request queue."""
     redis_url: str = "redis://localhost:6379/0"
@@ -118,6 +142,7 @@ class DaemonConfig:
     metrics: MetricsConfig = field(default_factory=MetricsConfig)
     orchestrator: OrchestratorConfig = field(default_factory=OrchestratorConfig)
     llm_queue: LLMQueueConfig = field(default_factory=LLMQueueConfig)
+    kafka: KafkaConfig = field(default_factory=KafkaConfig)
     
     # Database
     database_url: Optional[str] = None
@@ -193,7 +218,26 @@ class DaemonConfig:
         # LLM Queue
         config.llm_queue.redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
         config.llm_queue.max_concurrent_llm_calls = int(os.getenv("LLM_MAX_CONCURRENT", "5"))
-        
+
+        # Kafka ingestion (env defaults; may be overridden by SystemConfig below)
+        config.kafka.enabled = os.getenv("KAFKA_ENABLED", "false").lower() == "true"
+        config.kafka.bootstrap_servers = os.getenv(
+            "KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"
+        )
+        config.kafka.consumer_group = os.getenv("KAFKA_CONSUMER_GROUP", "vigil-soc")
+        topics = os.getenv("KAFKA_TOPICS", "").strip()
+        config.kafka.topics = [t.strip() for t in topics.split(",") if t.strip()]
+        config.kafka.auto_offset_reset = os.getenv("KAFKA_AUTO_OFFSET_RESET", "latest")
+        config.kafka.max_poll_records = int(os.getenv("KAFKA_MAX_POLL_RECORDS", "500"))
+        config.kafka.session_timeout_ms = int(
+            os.getenv("KAFKA_SESSION_TIMEOUT_MS", "30000")
+        )
+        config.kafka.security_protocol = os.getenv("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT")
+        config.kafka.sasl_mechanism = os.getenv("KAFKA_SASL_MECHANISM") or None
+        config.kafka.sasl_username = os.getenv("KAFKA_SASL_USERNAME") or None
+        config.kafka.sasl_password = os.getenv("KAFKA_SASL_PASSWORD") or None
+        config.kafka.ssl_ca_location = os.getenv("KAFKA_SSL_CA_LOCATION") or None
+
         # Override with DB-persisted settings (set via Settings UI)
         try:
             from database.config_service import get_config_service
@@ -229,7 +273,37 @@ class DaemonConfig:
                 logger.info("Orchestrator config overridden from database settings")
         except Exception as e:
             logger.debug(f"Could not load orchestrator config from DB (using env/defaults): {e}")
-        
+
+        # Kafka: merge non-secret DB settings on top of env defaults
+        try:
+            from database.config_service import get_config_service
+            config_service = get_config_service()
+            kafka_db = config_service.get_system_config('kafka.settings')
+            if kafka_db and isinstance(kafka_db, dict):
+                if 'enabled' in kafka_db:
+                    config.kafka.enabled = bool(kafka_db['enabled'])
+                if 'bootstrap_servers' in kafka_db:
+                    config.kafka.bootstrap_servers = str(kafka_db['bootstrap_servers'])
+                if 'consumer_group' in kafka_db:
+                    config.kafka.consumer_group = str(kafka_db['consumer_group'])
+                if 'topics' in kafka_db and isinstance(kafka_db['topics'], list):
+                    config.kafka.topics = [str(t) for t in kafka_db['topics']]
+                if 'auto_offset_reset' in kafka_db:
+                    config.kafka.auto_offset_reset = str(kafka_db['auto_offset_reset'])
+                if 'security_protocol' in kafka_db:
+                    config.kafka.security_protocol = str(kafka_db['security_protocol'])
+                if 'sasl_mechanism' in kafka_db:
+                    config.kafka.sasl_mechanism = kafka_db['sasl_mechanism'] or None
+                if 'sasl_username' in kafka_db:
+                    config.kafka.sasl_username = kafka_db['sasl_username'] or None
+                if 'max_poll_records' in kafka_db:
+                    config.kafka.max_poll_records = int(kafka_db['max_poll_records'])
+                if 'session_timeout_ms' in kafka_db:
+                    config.kafka.session_timeout_ms = int(kafka_db['session_timeout_ms'])
+                logger.info("Kafka config overridden from database settings")
+        except Exception as e:
+            logger.debug(f"Could not load Kafka config from DB (using env/defaults): {e}")
+
         return config
     
     def setup_logging(self):

--- a/daemon/dedup.py
+++ b/daemon/dedup.py
@@ -1,0 +1,151 @@
+"""Redis-backed durable deduplication for ingestion pipelines.
+
+Replaces the in-memory ``PollState.processed_ids`` set (bounded, FIFO,
+lost on restart) with a Redis sorted set that survives daemon restarts
+and is shared across processes.
+
+Used by both the polling ingester (``daemon/poller.py``) and the Kafka
+consumer (``services/kafka_consumer_service.py``). Each caller picks a
+namespace (e.g. ``"splunk"``, ``"kafka"``) so dedup sets are isolated.
+
+If Redis is unavailable at init time or any call fails, the helper falls
+back to an in-memory set so ingestion keeps working — the trade-off is
+that restarts may re-process findings (same behaviour as the old
+``PollState``). A warning is logged on fallback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REDIS_URL = "redis://localhost:6379/0"
+DEFAULT_MAX_SIZE = 10_000
+DEFAULT_TTL_SECONDS = 86_400  # 24h
+
+
+class RedisDedupSet:
+    """Durable finding-ID dedup set, per-namespace.
+
+    Backed by a Redis sorted set keyed ``vigil:dedup:{namespace}`` where
+    the score is the insertion unix timestamp. On each ``mark_processed``
+    call, entries older than ``ttl_seconds`` are evicted and the set is
+    trimmed to ``max_size`` (oldest-first) to bound memory.
+    """
+
+    def __init__(
+        self,
+        namespace: str,
+        *,
+        redis_url: Optional[str] = None,
+        max_size: int = DEFAULT_MAX_SIZE,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    ):
+        self.namespace = namespace
+        self.key = f"vigil:dedup:{namespace}"
+        self.redis_url = redis_url or os.getenv("REDIS_URL", DEFAULT_REDIS_URL)
+        self.max_size = max_size
+        self.ttl_seconds = ttl_seconds
+
+        self._redis = None
+        self._fallback: set[str] = set()
+        self._fallback_warned = False
+        self._lock = asyncio.Lock()
+
+    async def _get_redis(self):
+        if self._redis is not None:
+            return self._redis
+        try:
+            import redis.asyncio as aioredis  # type: ignore
+
+            self._redis = aioredis.from_url(self.redis_url, decode_responses=True)
+            # Probe connection so we fail fast here rather than per-call
+            await self._redis.ping()
+            logger.info(
+                "RedisDedupSet[%s] connected to %s", self.namespace, self.redis_url
+            )
+        except Exception as e:
+            self._warn_fallback(f"init failed: {e}")
+            self._redis = None
+        return self._redis
+
+    def _warn_fallback(self, reason: str):
+        if not self._fallback_warned:
+            logger.warning(
+                "RedisDedupSet[%s] using in-memory fallback (%s)",
+                self.namespace,
+                reason,
+            )
+            self._fallback_warned = True
+
+    async def is_processed(self, finding_id: str) -> bool:
+        if not finding_id:
+            return False
+        r = await self._get_redis()
+        if r is None:
+            return finding_id in self._fallback
+        try:
+            return await r.zscore(self.key, finding_id) is not None
+        except Exception as e:
+            self._warn_fallback(f"zscore error: {e}")
+            self._redis = None
+            return finding_id in self._fallback
+
+    async def mark_processed(self, finding_id: str) -> None:
+        if not finding_id:
+            return
+        now = time.time()
+        r = await self._get_redis()
+        if r is None:
+            self._fallback.add(finding_id)
+            if len(self._fallback) > self.max_size:
+                # FIFO-ish trim
+                for item in list(self._fallback)[: self.max_size // 2]:
+                    self._fallback.discard(item)
+            return
+        try:
+            async with self._lock:
+                pipe = r.pipeline()
+                pipe.zadd(self.key, {finding_id: now})
+                # TTL eviction: drop entries older than ttl_seconds
+                pipe.zremrangebyscore(self.key, 0, now - self.ttl_seconds)
+                # Size cap: trim oldest if over max_size
+                pipe.zremrangebyrank(self.key, 0, -(self.max_size + 1))
+                await pipe.execute()
+        except Exception as e:
+            self._warn_fallback(f"zadd error: {e}")
+            self._redis = None
+            self._fallback.add(finding_id)
+
+    async def size(self) -> int:
+        r = await self._get_redis()
+        if r is None:
+            return len(self._fallback)
+        try:
+            return int(await r.zcard(self.key))
+        except Exception:
+            return len(self._fallback)
+
+    async def clear(self) -> None:
+        """Drop the entire dedup set — test/admin helper."""
+        self._fallback.clear()
+        r = await self._get_redis()
+        if r is None:
+            return
+        try:
+            await r.delete(self.key)
+        except Exception as e:
+            logger.debug("RedisDedupSet[%s] clear failed: %s", self.namespace, e)
+
+    async def close(self) -> None:
+        if self._redis is not None:
+            try:
+                await self._redis.close()
+            except Exception:
+                pass
+            self._redis = None

--- a/daemon/kafka_ingestor.py
+++ b/daemon/kafka_ingestor.py
@@ -1,0 +1,142 @@
+"""Daemon-side wrapper that runs the Kafka consumer.
+
+Mirrors the shape of ``daemon/poller.py``'s ``DataPoller`` so
+``SOCDaemon`` can plug it in the same way: instantiate, hand it the
+shared output queue, start its ``run()`` as an asyncio task.
+
+The Kafka broker config is re-read from the SystemConfig ``kafka.settings``
+row on each startup attempt, so toggling ``enabled`` in the Settings UI
+starts or stops the consumer on the next sync tick.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, Optional
+
+from daemon.config import KafkaConfig
+from daemon.dedup import RedisDedupSet
+from services.kafka_consumer_service import KafkaConsumerService
+
+logger = logging.getLogger(__name__)
+
+
+class KafkaIngestor:
+    """Starts/stops the Kafka consumer based on the enabled flag."""
+
+    SYNC_INTERVAL_SECONDS = 5
+
+    def __init__(self, config: KafkaConfig):
+        self.config = config
+        self._output_queue: Optional[asyncio.Queue] = None
+        self._dedup = RedisDedupSet("kafka")
+        self._service: Optional[KafkaConsumerService] = None
+        self._task: Optional[asyncio.Task] = None
+        self._consumer_shutdown: Optional[asyncio.Event] = None
+
+    @property
+    def stats(self) -> Dict[str, Any]:
+        if self._service is not None:
+            return self._service.stats
+        return {
+            "connected": False,
+            "messages_consumed": 0,
+            "messages_enqueued": 0,
+            "duplicates_skipped": 0,
+            "decode_errors": 0,
+            "missing_id_errors": 0,
+            "last_message_at": None,
+            "last_error": None,
+            "last_error_at": None,
+            "topics": list(self.config.topics),
+            "consumer_group": self.config.consumer_group,
+        }
+
+    def set_output_queue(self, queue: asyncio.Queue) -> None:
+        self._output_queue = queue
+
+    def _sync_config_from_db(self) -> None:
+        """Re-read ``kafka.settings`` from SystemConfig (non-secret fields only)."""
+        try:
+            from database.config_service import get_config_service
+
+            db_cfg = get_config_service().get_system_config("kafka.settings")
+            if not db_cfg or not isinstance(db_cfg, dict):
+                return
+            if "enabled" in db_cfg:
+                self.config.enabled = bool(db_cfg["enabled"])
+            if "bootstrap_servers" in db_cfg:
+                self.config.bootstrap_servers = str(db_cfg["bootstrap_servers"])
+            if "consumer_group" in db_cfg:
+                self.config.consumer_group = str(db_cfg["consumer_group"])
+            if "topics" in db_cfg and isinstance(db_cfg["topics"], list):
+                self.config.topics = [str(t) for t in db_cfg["topics"]]
+            if "auto_offset_reset" in db_cfg:
+                self.config.auto_offset_reset = str(db_cfg["auto_offset_reset"])
+            if "security_protocol" in db_cfg:
+                self.config.security_protocol = str(db_cfg["security_protocol"])
+        except Exception as e:
+            logger.debug("Kafka config sync from DB failed (non-fatal): %s", e)
+
+    async def run(self, shutdown_event: asyncio.Event) -> None:
+        """Start/stop the consumer based on the enabled flag; exit on shutdown."""
+        if self._output_queue is None:
+            logger.error("KafkaIngestor: output queue not set, exiting")
+            return
+
+        logger.info("Kafka ingestor started (waiting for enabled flag)")
+
+        while not shutdown_event.is_set():
+            self._sync_config_from_db()
+
+            should_run = self.config.enabled and bool(self.config.topics)
+            is_running = self._task is not None and not self._task.done()
+
+            if should_run and not is_running:
+                logger.info("Kafka ingestor: starting consumer task")
+                self._consumer_shutdown = asyncio.Event()
+                self._service = KafkaConsumerService(
+                    self.config, self._output_queue, self._dedup
+                )
+                self._task = asyncio.create_task(
+                    self._service.run(self._consumer_shutdown)
+                )
+            elif not should_run and is_running:
+                reason = (
+                    "disabled" if not self.config.enabled else "no topics configured"
+                )
+                logger.info("Kafka ingestor: stopping consumer (%s)", reason)
+                await self._stop_consumer()
+
+            # Wait until next sync tick or shutdown
+            try:
+                await asyncio.wait_for(
+                    shutdown_event.wait(),
+                    timeout=self.SYNC_INTERVAL_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                pass
+
+        # Global shutdown
+        await self._stop_consumer()
+        logger.info("Kafka ingestor stopped")
+
+    async def _stop_consumer(self) -> None:
+        if self._consumer_shutdown is not None:
+            self._consumer_shutdown.set()
+        if self._task is not None:
+            try:
+                await asyncio.wait_for(self._task, timeout=30)
+            except asyncio.TimeoutError:
+                logger.warning("Kafka consumer did not stop within 30s, cancelling")
+                self._task.cancel()
+                try:
+                    await self._task
+                except Exception:
+                    pass
+            except Exception as e:
+                logger.warning("Kafka consumer stop error: %s", e)
+        self._task = None
+        self._service = None
+        self._consumer_shutdown = None

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -34,6 +34,7 @@ class SOCDaemon:
         
         # Components (lazy loaded)
         self._poller = None
+        self._kafka_ingestor = None
         self._processor = None
         self._responder = None
         self._scheduler = None
@@ -67,8 +68,10 @@ class SOCDaemon:
         from daemon.metrics import MetricsServer
         from daemon.orchestrator import Orchestrator
         from daemon.llm_worker_manager import LLMWorkerManager
+        from daemon.kafka_ingestor import KafkaIngestor
 
         self._poller = DataPoller(self.config.polling)
+        self._kafka_ingestor = KafkaIngestor(self.config.kafka)
         self._processor = FindingProcessor(self.config.processing)
         self._responder = AutonomousResponder(self.config.response, self.config.escalation)
         self._scheduler = TaskScheduler(self.config.scheduler)
@@ -77,15 +80,17 @@ class SOCDaemon:
 
         if self.config.metrics.enabled:
             self._metrics_server = MetricsServer(self.config.metrics)
-        
+
         # Connect components via queues
         self._poller.set_output_queue(self._processor.input_queue)
+        self._kafka_ingestor.set_output_queue(self._processor.input_queue)
         self._processor.set_response_queue(self._responder.input_queue)
         self._processor.set_investigation_queue(self._orchestrator.investigation_queue)
-        
+
         # Wire up metrics server with component references
         if self._metrics_server:
             self._metrics_server.poller = self._poller
+            self._metrics_server.kafka_ingestor = self._kafka_ingestor
             self._metrics_server.processor = self._processor
             self._metrics_server.responder = self._responder
             self._metrics_server.scheduler = self._scheduler
@@ -112,7 +117,11 @@ class SOCDaemon:
         if self._poller:
             tasks.append(asyncio.create_task(self._poller.run(self._shutdown_event)))
             logger.info("Data poller started")
-        
+
+        if self._kafka_ingestor:
+            tasks.append(asyncio.create_task(self._kafka_ingestor.run(self._shutdown_event)))
+            logger.info("Kafka ingestor started (controlled by kafka.settings enabled flag)")
+
         if self._processor:
             tasks.append(asyncio.create_task(self._processor.run(self._shutdown_event)))
             logger.info("Finding processor started")

--- a/daemon/metrics.py
+++ b/daemon/metrics.py
@@ -200,6 +200,7 @@ class MetricsServer:
 
         # Component references (set externally)
         self.poller = None
+        self.kafka_ingestor = None
         self.processor = None
         self.responder = None
         self.scheduler = None
@@ -284,6 +285,7 @@ class MetricsServer:
                 "uptime_seconds": (datetime.utcnow() - self._start_time).total_seconds(),
             },
             "poller": metrics.get("poller", {}),
+            "kafka": metrics.get("kafka", {}),
             "processor": metrics.get("processor", {}),
             "responder": metrics.get("responder", {}),
             "scheduler": metrics.get("scheduler", {}),
@@ -298,6 +300,9 @@ class MetricsServer:
 
         if self.poller:
             metrics["poller"] = self.poller.stats.copy()
+
+        if self.kafka_ingestor:
+            metrics["kafka"] = dict(self.kafka_ingestor.stats)
 
         if self.processor:
             metrics["processor"] = self.processor.stats.copy()

--- a/daemon/poller.py
+++ b/daemon/poller.py
@@ -3,34 +3,24 @@
 import asyncio
 import logging
 from datetime import datetime, timedelta
-from typing import Optional, Dict, List, Any, Set
-from dataclasses import dataclass, field
+from typing import Optional, Dict, List, Any
+from dataclasses import dataclass
 
 from daemon.config import PollingConfig
+from daemon.dedup import RedisDedupSet
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class PollState:
-    """Track polling state for deduplication."""
+    """Per-source polling cursor.
+
+    Deduplication lives in ``RedisDedupSet`` (see ``DataPoller``);
+    this dataclass tracks only the last-poll timestamp used to compute
+    query windows.
+    """
     last_poll_time: Optional[datetime] = None
-    processed_ids: Set[str] = field(default_factory=set)
-    max_processed_ids: int = 10000  # Limit memory usage
-    
-    def mark_processed(self, finding_id: str):
-        """Mark a finding as processed."""
-        self.processed_ids.add(finding_id)
-        # Trim if too large (FIFO-ish)
-        if len(self.processed_ids) > self.max_processed_ids:
-            # Remove oldest half
-            to_remove = list(self.processed_ids)[:self.max_processed_ids // 2]
-            for item in to_remove:
-                self.processed_ids.discard(item)
-    
-    def is_processed(self, finding_id: str) -> bool:
-        """Check if a finding was already processed."""
-        return finding_id in self.processed_ids
 
 
 class DataPoller:
@@ -40,7 +30,7 @@ class DataPoller:
         self.config = config
         self._output_queue: Optional[asyncio.Queue] = None
         
-        # Polling state for each source
+        # Polling cursors for each source
         self._splunk_state = PollState()
         self._crowdstrike_state = PollState()
         self._azure_sentinel_state = PollState()
@@ -48,6 +38,15 @@ class DataPoller:
         self._microsoft_defender_state = PollState()
         self._elastic_state = PollState()
         self._generic_state = PollState()
+
+        # Durable per-source dedup sets (Redis-backed)
+        self._splunk_dedup = RedisDedupSet("poller:splunk")
+        self._crowdstrike_dedup = RedisDedupSet("poller:crowdstrike")
+        self._azure_sentinel_dedup = RedisDedupSet("poller:azure_sentinel")
+        self._aws_security_hub_dedup = RedisDedupSet("poller:aws_security_hub")
+        self._microsoft_defender_dedup = RedisDedupSet("poller:microsoft_defender")
+        self._elastic_dedup = RedisDedupSet("poller:elastic")
+        self._webhook_dedup = RedisDedupSet("poller:webhook")
 
         # Services (lazy loaded)
         self._splunk_service = None
@@ -273,9 +272,9 @@ class DataPoller:
         new_count = 0
         for event in findings:
             finding = self._splunk_event_to_finding(event)
-            if finding and not self._splunk_state.is_processed(finding['finding_id']):
+            if finding and not await self._splunk_dedup.is_processed(finding['finding_id']):
                 await self._enqueue_finding(finding, "splunk")
-                self._splunk_state.mark_processed(finding['finding_id'])
+                await self._splunk_dedup.mark_processed(finding['finding_id'])
                 new_count += 1
         
         if new_count > 0:
@@ -382,9 +381,9 @@ class DataPoller:
             new_count = 0
             for detection in detections:
                 finding = self._crowdstrike_detection_to_finding(detection)
-                if finding and not self._crowdstrike_state.is_processed(finding['finding_id']):
+                if finding and not await self._crowdstrike_dedup.is_processed(finding['finding_id']):
                     await self._enqueue_finding(finding, "crowdstrike")
-                    self._crowdstrike_state.mark_processed(finding['finding_id'])
+                    await self._crowdstrike_dedup.mark_processed(finding['finding_id'])
                     new_count += 1
             
             if new_count > 0:
@@ -464,10 +463,10 @@ class DataPoller:
                         finding_id = f"webhook-{uuid.uuid4().hex[:16]}"
                         finding_data['finding_id'] = finding_id
                     
-                    if not self._generic_state.is_processed(finding_id):
+                    if not await self._webhook_dedup.is_processed(finding_id):
                         finding_data['data_source'] = finding_data.get('data_source', 'webhook')
                         await self._enqueue_finding(finding_data, "webhook")
-                        self._generic_state.mark_processed(finding_id)
+                        await self._webhook_dedup.mark_processed(finding_id)
                         count += 1
                 
                 self.stats["webhook_findings"] += count
@@ -680,9 +679,9 @@ class DataPoller:
             new_count = 0
             for alert in alerts:
                 finding = self._elastic_service.transform_alert_to_finding(alert)
-                if finding and not self._elastic_state.is_processed(finding["finding_id"]):
+                if finding and not await self._elastic_dedup.is_processed(finding["finding_id"]):
                     await self._enqueue_finding(finding, "elastic")
-                    self._elastic_state.mark_processed(finding["finding_id"])
+                    await self._elastic_dedup.mark_processed(finding["finding_id"])
                     new_count += 1
 
             if new_count > 0:

--- a/daemon/scheduler.py
+++ b/daemon/scheduler.py
@@ -351,9 +351,8 @@ class TaskScheduler:
         # In production, would delete old findings/processed events
         logger.info(f"Cleanup would remove data older than {cutoff.isoformat()}")
         
-        # Clean up processed ID caches in poller (memory management)
-        # This is handled automatically by the PollState class
-        
+        # Dedup sets are pruned by RedisDedupSet itself (TTL + size cap)
+
         return {"cutoff_date": cutoff.isoformat()}
     
     async def _run_health_check(self):

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -119,6 +119,19 @@ services:
       - SHODAN_API_KEY=${SHODAN_API_KEY}
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
       - PAGERDUTY_ROUTING_KEY=${PAGERDUTY_ROUTING_KEY}
+      # Kafka ingestion (opt-in; UI toggle at /settings?tab=kafka)
+      - KAFKA_ENABLED=${KAFKA_ENABLED:-false}
+      - KAFKA_BOOTSTRAP_SERVERS=${KAFKA_BOOTSTRAP_SERVERS:-kafka:9092}
+      - KAFKA_CONSUMER_GROUP=${KAFKA_CONSUMER_GROUP:-vigil-soc}
+      - KAFKA_TOPICS=${KAFKA_TOPICS:-}
+      - KAFKA_AUTO_OFFSET_RESET=${KAFKA_AUTO_OFFSET_RESET:-latest}
+      - KAFKA_SECURITY_PROTOCOL=${KAFKA_SECURITY_PROTOCOL:-PLAINTEXT}
+      - KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM:-}
+      - KAFKA_SASL_USERNAME=${KAFKA_SASL_USERNAME:-}
+      - KAFKA_SASL_PASSWORD=${KAFKA_SASL_PASSWORD:-}
+      - KAFKA_SSL_CA_LOCATION=${KAFKA_SSL_CA_LOCATION:-}
+      - KAFKA_MAX_POLL_RECORDS=${KAFKA_MAX_POLL_RECORDS:-500}
+      - KAFKA_SESSION_TIMEOUT_MS=${KAFKA_SESSION_TIMEOUT_MS:-30000}
     ports:
       - "8081:8081"  # Webhook ingestion
       - "9090:9090"  # Prometheus /metrics (OTEL PrometheusMetricReader)
@@ -275,6 +288,39 @@ services:
     profiles:
       - splunk  # Only start when splunk profile is active
 
+  # ─── Kafka (opt-in: --profile kafka) ─────────────────────────────────────
+  # Single-broker KRaft-mode Kafka for local streaming ingestion. See the
+  # "Kafka" tab in Settings to enable the consumer and configure topics.
+  kafka:
+    image: apache/kafka:3.7.0
+    container_name: deeptempo-kafka
+    hostname: kafka
+    ports:
+      - "9092:9092"  # External listener (host)
+    environment:
+      # KRaft single-broker controller/broker combined
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,INTERNAL://0.0.0.0:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,INTERNAL://kafka:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    volumes:
+      - kafka_data:/var/lib/kafka/data
+    restart: unless-stopped
+    networks:
+      - deeptempo-network
+    profiles:
+      - kafka
+
 volumes:
   postgres_data:
     driver: local
@@ -289,6 +335,8 @@ volumes:
   prometheus_data:
     driver: local
   grafana_data:
+    driver: local
+  kafka_data:
     driver: local
 
 networks:

--- a/docs/KAFKA_INGESTION.md
+++ b/docs/KAFKA_INGESTION.md
@@ -1,0 +1,349 @@
+# Kafka Ingestion
+
+Stream security findings into Vigil from Apache Kafka topics. Runs
+alongside the existing REST polling (`daemon/poller.py`) and file/webhook
+upload (`backend/api/ingestion.py`) paths — Kafka messages land in the
+same processing pipeline (triage, enrichment, autonomous investigation).
+
+---
+
+## When to use it
+
+- You already publish security events to Kafka (Splunk HEC forwarders, Falco, custom
+  producers) and want Vigil to consume them directly, rather than polling the source.
+- You need lower ingestion latency than polling (REST pollers run on 60–300s intervals).
+- You want horizontal scalability via Kafka consumer groups.
+
+If none of those apply, stick with polling or the webhook upload — Kafka adds infra
+overhead you don't need.
+
+---
+
+## Scope (MVP)
+
+| Supported                                            | Not supported (yet)                   |
+|------------------------------------------------------|---------------------------------------|
+| JSON messages                                        | Avro, Protobuf                        |
+| One consumer group                                   | Confluent Schema Registry             |
+| Redis-backed durable dedup                           | Dead-letter topic                     |
+| PLAINTEXT / SSL / SASL_PLAINTEXT / SASL_SSL          | Per-partition lag metrics / Grafana   |
+| Settings UI config + env-var fallback                | Topic → normalizer mapping            |
+
+See the "Follow-ups" section of
+[plans/please-examine-gh-issue-squishy-hippo.md](../.claude/plans/please-examine-gh-issue-squishy-hippo.md)
+or [GH issue #83](https://github.com/Vigil-SOC/vigil/issues/83) for the
+post-MVP roadmap.
+
+---
+
+## Quick start
+
+### 1. Start the Kafka broker
+
+Vigil ships a single-broker KRaft-mode Kafka service under the `kafka`
+Docker Compose profile (no Zookeeper):
+
+```bash
+cd docker
+docker compose --profile kafka up -d kafka
+```
+
+Broker listens on `localhost:9092` (host) and `kafka:29092` (inside the
+`deeptempo-network` Docker network). Data is persisted in the
+`kafka_data` named volume.
+
+### 2. Create a topic (optional)
+
+Auto-create is enabled in the bundled broker, so producers can publish
+to new topics on first write. To pre-create one:
+
+```bash
+docker exec deeptempo-kafka /opt/kafka/bin/kafka-topics.sh \
+  --bootstrap-server localhost:9092 \
+  --create --if-not-exists --topic security.findings \
+  --partitions 1 --replication-factor 1
+```
+
+### 3. Enable Kafka in Vigil
+
+Two equivalent paths — pick whichever you prefer.
+
+**Option A: Settings UI** (recommended)
+
+1. Open Vigil → **Settings** → **Kafka**.
+2. Toggle **Enable Kafka consumer** on.
+3. Set **Bootstrap servers** (e.g. `localhost:9092` for local dev,
+   `kafka:29092` when the daemon runs inside Docker).
+4. Add one or more **Topics**.
+5. Click **Save Kafka settings**. The daemon picks up the change within
+   ~5 seconds — no restart needed.
+
+**Option B: REST API**
+
+```bash
+curl -X PUT http://localhost:6987/api/kafka/config \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "enabled": true,
+    "bootstrap_servers": "localhost:9092",
+    "consumer_group": "vigil-soc",
+    "topics": ["security.findings"],
+    "auto_offset_reset": "latest",
+    "security_protocol": "PLAINTEXT",
+    "max_poll_records": 500,
+    "session_timeout_ms": 30000
+  }'
+```
+
+**Option C: Env vars only** (no DB write)
+
+Set these before starting the daemon; they're the fallback when no
+`kafka.settings` row exists in `SystemConfig`:
+
+```bash
+export KAFKA_ENABLED=true
+export KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+export KAFKA_TOPICS=security.findings
+```
+
+### 4. Publish a message
+
+Messages must be UTF-8 JSON objects. At minimum each message needs a
+`finding_id`. Everything else is passed through to
+`IngestionService.ingest_finding` — same schema as the REST upload
+endpoint.
+
+```python
+# produce.py
+import asyncio, json
+from aiokafka import AIOKafkaProducer
+
+async def main():
+    p = AIOKafkaProducer(bootstrap_servers="localhost:9092")
+    await p.start()
+    try:
+        finding = {
+            "finding_id": "my-producer-0001",
+            "data_source": "my-edr",
+            "severity": "high",
+            "description": "Suspicious PowerShell command line",
+            "entity_context": {
+                "src_ips": ["10.0.0.42"],
+                "hostnames": ["WORKSTATION-07"],
+                "usernames": ["alice"],
+            },
+        }
+        await p.send_and_wait("security.findings", json.dumps(finding).encode())
+    finally:
+        await p.stop()
+
+asyncio.run(main())
+```
+
+```bash
+python produce.py
+```
+
+### 5. Verify
+
+- **Settings UI → Kafka tab**: the status panel shows
+  `CONNECTED — N consumed, N enqueued, N dupes skipped` and a last-message
+  timestamp.
+- **Findings page**: the new finding appears with `data_source` set to
+  `kafka:<topic>` (auto-populated if the producer didn't set one).
+- **Daemon health**: `curl http://localhost:9091/status | jq .kafka`
+  gives the same stats the UI shows.
+- **Direct DB check**:
+
+  ```bash
+  docker exec -e PGPASSWORD=$POSTGRES_PASSWORD deeptempo-postgres \
+    psql -U deeptempo -d deeptempo_soc \
+    -c "SELECT finding_id, data_source, severity FROM findings \
+        WHERE data_source LIKE 'kafka:%' ORDER BY created_at DESC LIMIT 5;"
+  ```
+
+---
+
+## Message format
+
+The consumer accepts any JSON object with a `finding_id` string. Common
+fields (all optional except `finding_id`):
+
+```jsonc
+{
+  "finding_id": "unique-string",       // required — used for dedup
+  "data_source": "my-edr",             // defaults to "kafka:<topic>"
+  "severity": "critical|high|medium|low",
+  "description": "human-readable summary",
+  "entity_context": {
+    "src_ips":    ["1.2.3.4"],
+    "dest_ips":   ["5.6.7.8"],
+    "hostnames":  ["host-01"],
+    "usernames":  ["alice"]
+  },
+  "mitre_predictions": ["T1059.001"],
+  "anomaly_score": 0.87,
+  "timestamp": "2026-04-21T12:00:00Z"
+}
+```
+
+Malformed messages are logged at WARNING and skipped — the consumer
+keeps running. Check `stats.decode_errors` / `stats.missing_id_errors`
+in the status endpoint to see how many were dropped.
+
+---
+
+## Deduplication
+
+Each `finding_id` is tracked in a Redis sorted set
+(`vigil:dedup:kafka`). A duplicate within the retention window (24h
+TTL, capped at 10k entries) is skipped and `stats.duplicates_skipped`
+is incremented — the finding is **not** re-enqueued and does **not**
+create a second DB row.
+
+If Redis is unreachable, the consumer falls back to an in-memory set
+(identical behaviour to the pre-Kafka poller). A warning is logged
+and the dedup set is lost on daemon restart.
+
+The same `RedisDedupSet` now backs the REST poller too
+(`daemon/poller.py`), so poller restarts no longer re-process findings.
+
+---
+
+## Configuration reference
+
+All env vars, with their defaults:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `KAFKA_ENABLED` | `false` | Master switch — also toggleable in UI |
+| `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9092` | Broker list |
+| `KAFKA_CONSUMER_GROUP` | `vigil-soc` | Consumer group id |
+| `KAFKA_TOPICS` | _(empty)_ | Comma-separated list |
+| `KAFKA_AUTO_OFFSET_RESET` | `latest` | `latest` or `earliest` |
+| `KAFKA_SECURITY_PROTOCOL` | `PLAINTEXT` | `PLAINTEXT`\|`SSL`\|`SASL_PLAINTEXT`\|`SASL_SSL` |
+| `KAFKA_SASL_MECHANISM` | _(empty)_ | `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512` |
+| `KAFKA_SASL_USERNAME` | _(empty)_ | |
+| `KAFKA_SASL_PASSWORD` | _(empty)_ | **env-only — never stored in DB** |
+| `KAFKA_SSL_CA_LOCATION` | _(empty)_ | Path to CA cert — **env-only** |
+| `KAFKA_MAX_POLL_RECORDS` | `500` | Per-poll batch size |
+| `KAFKA_SESSION_TIMEOUT_MS` | `30000` | Broker session timeout |
+
+**Precedence:** env vars set the defaults when the daemon starts;
+values in `SystemConfig["kafka.settings"]` (written by the Settings
+UI / `PUT /api/kafka/config`) override on top. Secrets (`SASL_PASSWORD`,
+`SSL_CA_LOCATION`) are **never** read from or written to the DB — they
+must be set via env.
+
+---
+
+## Applying config changes
+
+- **Enabled flag**: picked up within ~5s by the daemon's sync loop. No
+  restart needed.
+- **Other fields (topics, broker list, consumer group…)**: the daemon
+  reads them into its in-memory config on each sync tick, but the
+  running consumer isn't rebuilt automatically. To apply changes to a
+  running consumer, **toggle Enabled off and back on** via the Settings
+  UI. This will gracefully stop the consumer (committing offsets) and
+  restart it with the new config.
+
+A future issue will make non-enabled config changes trigger an
+automatic restart.
+
+---
+
+## Docker deployment
+
+In production docker-compose, the daemon reads Kafka env vars from the
+`soc-daemon` service block. When running everything in Docker:
+
+```bash
+KAFKA_ENABLED=true \
+KAFKA_BOOTSTRAP_SERVERS=kafka:29092 \
+KAFKA_TOPICS=security.findings \
+docker compose --profile kafka up -d
+```
+
+Note the internal hostname `kafka:29092` (the `INTERNAL` listener),
+not `localhost:9092` — that one's for producers running on the host.
+
+---
+
+## REST endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/kafka/config` | Current persisted config (secrets redacted) |
+| PUT | `/api/kafka/config` | Upsert config — body matches `KafkaConfigBody` |
+| GET | `/api/kafka/status` | Config + live stats from the daemon |
+
+`GET /api/kafka/status` response shape:
+
+```json
+{
+  "enabled": true,
+  "daemon_reachable": true,
+  "config": { /* persisted non-secret config */ },
+  "stats": {
+    "connected": true,
+    "messages_consumed": 42,
+    "messages_enqueued": 40,
+    "duplicates_skipped": 1,
+    "decode_errors": 1,
+    "missing_id_errors": 0,
+    "last_message_at": "2026-04-21T12:00:00",
+    "last_error": null,
+    "last_error_at": null,
+    "topics": ["security.findings"],
+    "consumer_group": "vigil-soc"
+  }
+}
+```
+
+If the daemon's health endpoint (port 9091) is unreachable,
+`daemon_reachable` is `false` and `stats` is returned with zeroed
+counters so the UI still renders.
+
+---
+
+## Troubleshooting
+
+**UI shows `ENABLED (not yet connected)` indefinitely**
+- Check `logs/daemon.log` for `aiokafka` errors.
+- Verify broker reachability: `docker exec deeptempo-daemon nc -z kafka 29092`
+  (inside Docker) or `nc -z localhost 9092` (from host).
+- If using SASL/SSL, confirm the secret env vars are set on the
+  daemon process — they're env-only.
+
+**Messages not deduplicated across daemon restarts**
+- Redis is probably unreachable — check for
+  `RedisDedupSet[kafka] using in-memory fallback` in `logs/daemon.log`.
+- Once Redis is healthy, restart the daemon; dedup will rebuild
+  automatically on first message.
+
+**Consumer keeps re-reading old messages after restart**
+- You changed `consumer_group` — a new group starts from the earliest
+  offset (or `latest`, depending on `auto_offset_reset`). Use the same
+  group id to pick up where the previous instance left off.
+
+**"Decoding error on topic X" logged repeatedly**
+- A producer is publishing non-JSON or malformed JSON. The consumer
+  skips these safely — find the producer via the topic name and fix it
+  there. Check `stats.decode_errors` for volume.
+
+**Changes to topics don't take effect**
+- Toggle **Enabled** off and back on in the Settings UI (see "Applying
+  config changes" above).
+
+---
+
+## Related files
+
+- [services/kafka_consumer_service.py](../services/kafka_consumer_service.py) — consumer loop
+- [daemon/kafka_ingestor.py](../daemon/kafka_ingestor.py) — start/stop wrapper
+- [daemon/dedup.py](../daemon/dedup.py) — Redis-backed dedup shared with the poller
+- [backend/api/kafka.py](../backend/api/kafka.py) — REST endpoints
+- [frontend/src/components/settings/KafkaTab.tsx](../frontend/src/components/settings/KafkaTab.tsx) — UI
+- [docker/docker-compose.yml](../docker/docker-compose.yml) — `kafka` profile
+- [tests/unit/test_dedup.py](../tests/unit/test_dedup.py), [tests/unit/test_kafka_consumer.py](../tests/unit/test_kafka_consumer.py) — unit tests

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,5 +69,6 @@ AI-powered Security Operations Center using Claude and MCP (Model Context Protoc
 - [CONFIGURATION.md](CONFIGURATION.md) - Environment variables, secrets, setup
 - [AGENTS.md](AGENTS.md) - 12 specialized SOC AI agents
 - [INTEGRATIONS.md](INTEGRATIONS.md) - Splunk, Timesketch, Cribl, 27+ tools
+- [KAFKA_INGESTION.md](KAFKA_INGESTION.md) - Stream findings from Kafka topics
 - [FEATURES.md](FEATURES.md) - Cases, approvals, enrichment, reports
 - [API.md](API.md) - MCP tool contracts, data models

--- a/env.example
+++ b/env.example
@@ -292,3 +292,26 @@ DAEMON_HEALTH_PORT="9091"
 
 # Grafana admin password (used by docker-compose observability profile)
 GRAFANA_PASSWORD="admin"
+
+# =============================================================================
+# Kafka Ingestion (optional; start with: docker compose --profile kafka up)
+# =============================================================================
+# Most of these can be overridden at runtime in the Settings > Kafka tab.
+# Secrets (SASL password, SSL cert path) are intentionally env-only — the
+# Settings UI will not read or write them.
+KAFKA_ENABLED="false"
+KAFKA_BOOTSTRAP_SERVERS="localhost:9092"
+KAFKA_CONSUMER_GROUP="vigil-soc"
+# Comma-separated list of topics (leave empty to disable until configured)
+KAFKA_TOPICS=""
+# "latest" (default) | "earliest"
+KAFKA_AUTO_OFFSET_RESET="latest"
+# PLAINTEXT | SSL | SASL_SSL | SASL_PLAINTEXT
+KAFKA_SECURITY_PROTOCOL="PLAINTEXT"
+# PLAIN | SCRAM-SHA-256 | SCRAM-SHA-512 (empty if not using SASL)
+KAFKA_SASL_MECHANISM=""
+KAFKA_SASL_USERNAME=""
+KAFKA_SASL_PASSWORD=""
+KAFKA_SSL_CA_LOCATION=""
+KAFKA_MAX_POLL_RECORDS="500"
+KAFKA_SESSION_TIMEOUT_MS="30000"

--- a/frontend/src/components/settings/KafkaTab.tsx
+++ b/frontend/src/components/settings/KafkaTab.tsx
@@ -1,0 +1,404 @@
+import { useState, useEffect, useRef } from 'react'
+import {
+  Box,
+  Typography,
+  TextField,
+  Button,
+  Switch,
+  FormControlLabel,
+  Divider,
+  Chip,
+  Card,
+  CardContent,
+  Alert,
+  CircularProgress,
+  Grid,
+  MenuItem,
+  Stack,
+} from '@mui/material'
+import {
+  Save as SaveIcon,
+  Stream as StreamIcon,
+  Add as AddIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material'
+import { kafkaApi } from '../../services/api'
+
+interface KafkaConfig {
+  enabled: boolean
+  bootstrap_servers: string
+  consumer_group: string
+  topics: string[]
+  auto_offset_reset: string
+  security_protocol: string
+  sasl_mechanism: string | null
+  sasl_username: string | null
+  max_poll_records: number
+  session_timeout_ms: number
+}
+
+interface KafkaStats {
+  connected: boolean
+  messages_consumed: number
+  messages_enqueued: number
+  duplicates_skipped: number
+  decode_errors: number
+  missing_id_errors: number
+  last_message_at: string | null
+  last_error: string | null
+  last_error_at: string | null
+  topics: string[]
+  consumer_group: string
+}
+
+const DEFAULTS: KafkaConfig = {
+  enabled: false,
+  bootstrap_servers: 'localhost:9092',
+  consumer_group: 'vigil-soc',
+  topics: [],
+  auto_offset_reset: 'latest',
+  security_protocol: 'PLAINTEXT',
+  sasl_mechanism: null,
+  sasl_username: null,
+  max_poll_records: 500,
+  session_timeout_ms: 30000,
+}
+
+const OFFSET_RESETS = ['latest', 'earliest']
+const SECURITY_PROTOCOLS = ['PLAINTEXT', 'SSL', 'SASL_PLAINTEXT', 'SASL_SSL']
+const SASL_MECHANISMS = ['', 'PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512']
+
+interface Props {
+  onMessage: (msg: { type: 'success' | 'error'; text: string }) => void
+}
+
+export default function KafkaTab({ onMessage }: Props) {
+  const [config, setConfig] = useState<KafkaConfig>(DEFAULTS)
+  const [stats, setStats] = useState<KafkaStats | null>(null)
+  const [daemonReachable, setDaemonReachable] = useState<boolean>(false)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [topicInput, setTopicInput] = useState('')
+  const statusTimer = useRef<number | null>(null)
+
+  const loadStatus = async () => {
+    try {
+      const res = await kafkaApi.getStatus()
+      const data = res.data
+      setDaemonReachable(!!data.daemon_reachable)
+      setStats(data.stats || null)
+      if (data.config) {
+        setConfig({ ...DEFAULTS, ...data.config })
+      }
+    } catch {
+      setDaemonReachable(false)
+    }
+  }
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await kafkaApi.getConfig()
+        setConfig({ ...DEFAULTS, ...res.data })
+      } catch {
+        /* use defaults */
+      }
+      await loadStatus()
+      setLoading(false)
+    })()
+    statusTimer.current = window.setInterval(loadStatus, 5000)
+    return () => {
+      if (statusTimer.current !== null) {
+        window.clearInterval(statusTimer.current)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleSave = async () => {
+    setSaving(true)
+    try {
+      await kafkaApi.setConfig({
+        ...config,
+        sasl_mechanism: config.sasl_mechanism || null,
+        sasl_username: config.sasl_username || null,
+      })
+      onMessage({ type: 'success', text: 'Kafka settings saved' })
+      await loadStatus()
+    } catch (e: any) {
+      onMessage({
+        type: 'error',
+        text: `Failed to save Kafka settings: ${e?.response?.data?.detail || e?.message || e}`,
+      })
+    } finally {
+      setSaving(false)
+      setTimeout(() => onMessage({ type: 'success', text: '' }), 3000)
+    }
+  }
+
+  const addTopic = () => {
+    const t = topicInput.trim()
+    if (!t) return
+    if (config.topics.includes(t)) {
+      setTopicInput('')
+      return
+    }
+    setConfig({ ...config, topics: [...config.topics, t] })
+    setTopicInput('')
+  }
+
+  const removeTopic = (topic: string) => {
+    setConfig({ ...config, topics: config.topics.filter((x) => x !== topic) })
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <StreamIcon />
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+          Kafka Ingestion
+        </Typography>
+      </Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Stream security findings from Kafka topics into Vigil. Messages
+        must be JSON-encoded finding objects containing at minimum a
+        <code> finding_id</code> field. Secrets (SASL password, SSL CA
+        path) must be set via environment variables — they are not
+        editable here.
+      </Typography>
+
+      {!daemonReachable && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Daemon health endpoint unreachable — live stats unavailable.
+          Changes will apply once the daemon can read the updated config.
+        </Alert>
+      )}
+
+      <Alert
+        severity={stats?.connected ? 'success' : config.enabled ? 'warning' : 'info'}
+        sx={{ mb: 3 }}
+      >
+        Consumer is{' '}
+        <strong>
+          {stats?.connected
+            ? 'CONNECTED'
+            : config.enabled
+              ? 'ENABLED (not yet connected)'
+              : 'DISABLED'}
+        </strong>
+        {stats && ` — ${stats.messages_consumed} consumed, ${stats.messages_enqueued} enqueued, ${stats.duplicates_skipped} dupes skipped`}
+        {stats?.last_message_at && ` | last message: ${new Date(stats.last_message_at).toLocaleString()}`}
+        {stats?.last_error && (
+          <Box sx={{ mt: 1, fontSize: '0.85rem' }}>
+            Last error: {stats.last_error}
+          </Box>
+        )}
+      </Alert>
+
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={config.enabled}
+                onChange={(e) => setConfig({ ...config, enabled: e.target.checked })}
+              />
+            }
+            label={
+              <Box>
+                <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                  Enable Kafka consumer
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  The daemon re-reads this flag every few seconds — no restart needed.
+                </Typography>
+              </Box>
+            }
+          />
+        </CardContent>
+      </Card>
+
+      <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 600 }}>
+        Connection
+      </Typography>
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid item xs={12} md={6}>
+          <TextField
+            fullWidth
+            size="small"
+            label="Bootstrap servers"
+            value={config.bootstrap_servers}
+            onChange={(e) => setConfig({ ...config, bootstrap_servers: e.target.value })}
+            helperText="Comma-separated host:port list"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            fullWidth
+            size="small"
+            label="Consumer group"
+            value={config.consumer_group}
+            onChange={(e) => setConfig({ ...config, consumer_group: e.target.value })}
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            select
+            fullWidth
+            size="small"
+            label="Auto offset reset"
+            value={config.auto_offset_reset}
+            onChange={(e) => setConfig({ ...config, auto_offset_reset: e.target.value })}
+          >
+            {OFFSET_RESETS.map((o) => (
+              <MenuItem key={o} value={o}>{o}</MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            select
+            fullWidth
+            size="small"
+            label="Security protocol"
+            value={config.security_protocol}
+            onChange={(e) => setConfig({ ...config, security_protocol: e.target.value })}
+          >
+            {SECURITY_PROTOCOLS.map((p) => (
+              <MenuItem key={p} value={p}>{p}</MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+      </Grid>
+
+      <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 600 }}>
+        Topics
+      </Typography>
+      <Stack direction="row" spacing={1} sx={{ mb: 1 }} alignItems="center">
+        <TextField
+          size="small"
+          label="Add topic"
+          value={topicInput}
+          onChange={(e) => setTopicInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              addTopic()
+            }
+          }}
+          sx={{ flex: 1 }}
+        />
+        <Button onClick={addTopic} startIcon={<AddIcon />} variant="outlined" size="small">
+          Add
+        </Button>
+      </Stack>
+      <Box sx={{ mb: 3 }}>
+        {config.topics.length === 0 ? (
+          <Typography variant="caption" color="text.secondary">
+            No topics configured — the consumer will not start until you add at least one.
+          </Typography>
+        ) : (
+          config.topics.map((t) => (
+            <Chip
+              key={t}
+              label={t}
+              onDelete={() => removeTopic(t)}
+              deleteIcon={<CloseIcon />}
+              sx={{ mr: 1, mb: 1 }}
+            />
+          ))
+        )}
+      </Box>
+
+      <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 600 }}>
+        Authentication (SASL)
+      </Typography>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
+        Passwords and SSL CA paths must be set via env vars
+        (<code>KAFKA_SASL_PASSWORD</code>, <code>KAFKA_SSL_CA_LOCATION</code>).
+      </Typography>
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid item xs={12} md={6}>
+          <TextField
+            select
+            fullWidth
+            size="small"
+            label="SASL mechanism"
+            value={config.sasl_mechanism ?? ''}
+            onChange={(e) =>
+              setConfig({ ...config, sasl_mechanism: e.target.value || null })
+            }
+          >
+            {SASL_MECHANISMS.map((m) => (
+              <MenuItem key={m || 'none'} value={m}>
+                {m || '(none)'}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            fullWidth
+            size="small"
+            label="SASL username"
+            value={config.sasl_username ?? ''}
+            onChange={(e) =>
+              setConfig({ ...config, sasl_username: e.target.value || null })
+            }
+          />
+        </Grid>
+      </Grid>
+
+      <Divider sx={{ mb: 3 }} />
+
+      <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 600 }}>
+        Advanced
+      </Typography>
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid item xs={12} md={6}>
+          <TextField
+            fullWidth
+            type="number"
+            size="small"
+            label="Max poll records"
+            value={config.max_poll_records}
+            onChange={(e) =>
+              setConfig({ ...config, max_poll_records: Number(e.target.value) })
+            }
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            fullWidth
+            type="number"
+            size="small"
+            label="Session timeout (ms)"
+            value={config.session_timeout_ms}
+            onChange={(e) =>
+              setConfig({ ...config, session_timeout_ms: Number(e.target.value) })
+            }
+          />
+        </Grid>
+      </Grid>
+
+      <Stack direction="row" spacing={2}>
+        <Button
+          variant="contained"
+          startIcon={<SaveIcon />}
+          onClick={handleSave}
+          disabled={saving}
+        >
+          {saving ? 'Saving…' : 'Save Kafka settings'}
+        </Button>
+      </Stack>
+    </Box>
+  )
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -64,6 +64,7 @@ import { getAllIntegrations, loadCustomIntegrations } from '../config/integratio
 import UserManagementTab from '../components/settings/UserManagementTab'
 import DetectionRulesTab from '../components/settings/DetectionRulesTab'
 import AutoInvestigateTab from '../components/settings/AutoInvestigateTab'
+import KafkaTab from '../components/settings/KafkaTab'
 
 interface TabPanelProps {
   children?: React.ReactNode
@@ -94,6 +95,7 @@ const TAB_DEFS: { key: string; label: string; devOnly: boolean }[] = [
   { key: 'integrations', label: 'Integrations / MCP', devOnly: false },
   { key: 'users', label: 'Users', devOnly: false },
   { key: 'autoinvestigate', label: 'Auto Investigate', devOnly: false },
+  { key: 'kafka', label: 'Kafka', devOnly: false },
   { key: 'general', label: 'General', devOnly: false },
   { key: 'dev', label: 'Developer', devOnly: true },
 ]
@@ -1399,6 +1401,15 @@ export default function Settings() {
           <TabPanel value={currentTab} index={idx} key={tabKey}>
             <Box sx={{ maxWidth: 800 }}>
               <AutoInvestigateTab onMessage={setMessage} showConfirm={showConfirm} />
+            </Box>
+          </TabPanel>
+        )
+
+      case 'kafka':
+        return (
+          <TabPanel value={currentTab} index={idx} key={tabKey}>
+            <Box sx={{ maxWidth: 900 }}>
+              <KafkaTab onMessage={setMessage} />
             </Box>
           </TabPanel>
         )

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -859,5 +859,23 @@ export const orchestratorApi = {
   getCost: () => api.get('/orchestrator/cost'),
 }
 
+// Kafka ingestion API
+export const kafkaApi = {
+  getConfig: () => api.get('/kafka/config'),
+  setConfig: (config: {
+    enabled: boolean
+    bootstrap_servers: string
+    consumer_group: string
+    topics: string[]
+    auto_offset_reset: string
+    security_protocol: string
+    sasl_mechanism?: string | null
+    sasl_username?: string | null
+    max_poll_records: number
+    session_timeout_ms: number
+  }) => api.put('/kafka/config', config),
+  getStatus: () => api.get('/kafka/status'),
+}
+
 export default api
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,9 @@ faker>=22.0.0
 arq>=0.27.0
 redis>=5.0.0
 
+# Kafka ingestion (optional; only used when KAFKA_ENABLED=true)
+aiokafka>=0.10.0
+
 # Monitoring & Observability
 sentry-sdk>=1.40.0
 prometheus-client>=0.19.0

--- a/services/kafka_consumer_service.py
+++ b/services/kafka_consumer_service.py
@@ -1,0 +1,198 @@
+"""Kafka consumer service for streaming finding ingestion.
+
+Subscribes to one or more Kafka topics and forwards each JSON message
+to the daemon's finding queue (``daemon/processor.py`` consumes from
+the same queue as ``daemon/poller.py``'s output). Per-message flow:
+
+    Kafka record -> JSON decode -> dedup check (Redis) ->
+    enqueue for processing -> mark processed -> commit offset
+
+MVP scope: JSON only. No Avro, no Schema Registry, no DLQ.
+Malformed messages are logged and skipped; the consumer keeps going.
+
+Each message must be a finding dict matching what
+``services/ingestion_service.IngestionService.ingest_finding`` accepts:
+at minimum a ``finding_id`` field (string). ``data_source`` will be
+auto-set to ``"kafka:<topic>"`` if the producer didn't set one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from daemon.config import KafkaConfig
+from daemon.dedup import RedisDedupSet
+
+logger = logging.getLogger(__name__)
+
+
+class KafkaConsumerService:
+    """Async Kafka consumer that feeds findings into the daemon pipeline."""
+
+    def __init__(
+        self,
+        config: KafkaConfig,
+        output_queue: asyncio.Queue,
+        dedup: Optional[RedisDedupSet] = None,
+    ):
+        self.config = config
+        self._output_queue = output_queue
+        self._dedup = dedup or RedisDedupSet("kafka")
+        self._consumer = None
+        self._running = False
+
+        self.stats: Dict[str, Any] = {
+            "connected": False,
+            "messages_consumed": 0,
+            "messages_enqueued": 0,
+            "duplicates_skipped": 0,
+            "decode_errors": 0,
+            "missing_id_errors": 0,
+            "last_message_at": None,
+            "last_error": None,
+            "last_error_at": None,
+            "topics": list(config.topics),
+            "consumer_group": config.consumer_group,
+        }
+
+    async def _build_consumer(self):
+        """Instantiate an ``AIOKafkaConsumer`` from our config."""
+        from aiokafka import AIOKafkaConsumer  # lazy import
+
+        kwargs: Dict[str, Any] = dict(
+            bootstrap_servers=self.config.bootstrap_servers,
+            group_id=self.config.consumer_group,
+            auto_offset_reset=self.config.auto_offset_reset,
+            enable_auto_commit=False,
+            max_poll_records=self.config.max_poll_records,
+            session_timeout_ms=self.config.session_timeout_ms,
+            security_protocol=self.config.security_protocol,
+        )
+        if self.config.sasl_mechanism:
+            kwargs["sasl_mechanism"] = self.config.sasl_mechanism
+            kwargs["sasl_plain_username"] = self.config.sasl_username
+            kwargs["sasl_plain_password"] = self.config.sasl_password
+        if self.config.ssl_ca_location:
+            import ssl
+
+            ssl_ctx = ssl.create_default_context(cafile=self.config.ssl_ca_location)
+            kwargs["ssl_context"] = ssl_ctx
+
+        if not self.config.topics:
+            raise ValueError("KafkaConsumerService: no topics configured")
+
+        return AIOKafkaConsumer(*self.config.topics, **kwargs)
+
+    async def run(self, shutdown_event: asyncio.Event) -> None:
+        """Main consumer loop. Exits when ``shutdown_event`` is set."""
+        if not self.config.topics:
+            logger.warning("Kafka consumer: no topics configured, refusing to start")
+            return
+
+        logger.info(
+            "Kafka consumer starting (group=%s topics=%s servers=%s)",
+            self.config.consumer_group,
+            ",".join(self.config.topics),
+            self.config.bootstrap_servers,
+        )
+
+        try:
+            self._consumer = await self._build_consumer()
+            await self._consumer.start()
+            self.stats["connected"] = True
+            self._running = True
+            logger.info("Kafka consumer connected")
+        except Exception as e:
+            self.stats["connected"] = False
+            self._record_error(f"startup failed: {e}")
+            logger.error("Kafka consumer failed to start: %s", e)
+            return
+
+        try:
+            while not shutdown_event.is_set():
+                try:
+                    # getmany so we can check shutdown frequently
+                    batches = await self._consumer.getmany(timeout_ms=1000)
+                    for tp, msgs in batches.items():
+                        for msg in msgs:
+                            await self._handle_message(tp.topic, msg)
+                        # Commit offsets for this partition after processing
+                        if msgs:
+                            await self._consumer.commit()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    self._record_error(f"poll error: {e}")
+                    logger.error("Kafka consumer poll error: %s", e)
+                    # Brief backoff before retry
+                    await asyncio.sleep(2)
+        finally:
+            self._running = False
+            self.stats["connected"] = False
+            try:
+                if self._consumer is not None:
+                    await self._consumer.stop()
+                    logger.info("Kafka consumer stopped cleanly")
+            except Exception as e:
+                logger.warning("Kafka consumer stop error: %s", e)
+            try:
+                await self._dedup.close()
+            except Exception:
+                pass
+
+    async def _handle_message(self, topic: str, msg) -> None:
+        """Decode, dedupe, and enqueue a single Kafka message."""
+        self.stats["messages_consumed"] += 1
+        self.stats["last_message_at"] = datetime.utcnow().isoformat()
+
+        try:
+            raw = msg.value
+            if isinstance(raw, (bytes, bytearray)):
+                raw = raw.decode("utf-8")
+            finding = json.loads(raw)
+        except Exception as e:
+            self.stats["decode_errors"] += 1
+            self._record_error(f"decode error on topic {topic}: {e}")
+            logger.warning("Kafka: skipping malformed message on %s: %s", topic, e)
+            return
+
+        if not isinstance(finding, dict):
+            self.stats["decode_errors"] += 1
+            logger.warning(
+                "Kafka: skipping non-object message on %s (type=%s)",
+                topic,
+                type(finding).__name__,
+            )
+            return
+
+        finding_id = finding.get("finding_id")
+        if not finding_id:
+            self.stats["missing_id_errors"] += 1
+            logger.warning("Kafka: skipping message on %s with no finding_id", topic)
+            return
+
+        if await self._dedup.is_processed(finding_id):
+            self.stats["duplicates_skipped"] += 1
+            logger.debug("Kafka: duplicate finding_id=%s skipped", finding_id)
+            return
+
+        finding.setdefault("data_source", f"kafka:{topic}")
+
+        await self._output_queue.put(
+            {
+                "type": "finding",
+                "source": f"kafka:{topic}",
+                "data": finding,
+                "timestamp": datetime.utcnow().isoformat(),
+            }
+        )
+        await self._dedup.mark_processed(finding_id)
+        self.stats["messages_enqueued"] += 1
+
+    def _record_error(self, msg: str) -> None:
+        self.stats["last_error"] = msg
+        self.stats["last_error_at"] = datetime.utcnow().isoformat()

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -1,0 +1,163 @@
+"""Unit tests for the Redis-backed dedup helper.
+
+These tests exercise the in-memory fallback path (i.e. Redis is
+unreachable) because that's what runs deterministically in CI without
+a live Redis. A corresponding integration test that hits real Redis
+belongs under tests/integration and is tagged with the ``integration``
+marker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from daemon.dedup import RedisDedupSet
+
+
+@pytest.fixture
+def no_redis(monkeypatch):
+    """Force the dedup helper into fallback mode by pointing it at a dead URL."""
+    monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:1/0")
+    return monkeypatch
+
+
+def _make() -> RedisDedupSet:
+    # Small max_size so size-cap trimming is easy to exercise
+    return RedisDedupSet("unit-test", max_size=4, ttl_seconds=3600)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestRedisDedupFallback:
+    def test_is_processed_empty(self, no_redis):
+        dedup = _make()
+
+        async def go():
+            return await dedup.is_processed("abc")
+
+        assert _run(go()) is False
+
+    def test_mark_and_check(self, no_redis):
+        dedup = _make()
+
+        async def go():
+            await dedup.mark_processed("finding-1")
+            return await dedup.is_processed("finding-1")
+
+        assert _run(go()) is True
+
+    def test_empty_finding_id_is_noop(self, no_redis):
+        dedup = _make()
+
+        async def go():
+            # empty strings / None should not blow up and should not be marked
+            await dedup.mark_processed("")
+            return await dedup.is_processed("")
+
+        assert _run(go()) is False
+
+    def test_fallback_trims_when_over_max(self, no_redis):
+        dedup = _make()  # max_size=4
+
+        async def go():
+            for i in range(10):
+                await dedup.mark_processed(f"id-{i}")
+            # fallback set should be bounded (trims roughly to max_size/2)
+            return len(dedup._fallback)
+
+        size = _run(go())
+        assert size <= 4
+
+
+class TestRedisDedupWithFakeRedis:
+    """Substitute a stub Redis client to exercise the happy path without a server."""
+
+    def test_marks_survive_new_instance(self, monkeypatch):
+        # Shared in-process store shared between two RedisDedupSet instances
+        store: dict[str, dict[str, float]] = {}
+
+        class StubPipeline:
+            def __init__(self, store):
+                self._store = store
+                self._ops = []
+
+            def zadd(self, key, mapping):
+                self._ops.append(("zadd", key, mapping))
+                return self
+
+            def zremrangebyscore(self, key, min_score, max_score):
+                self._ops.append(("zremrangebyscore", key, min_score, max_score))
+                return self
+
+            def zremrangebyrank(self, key, start, stop):
+                self._ops.append(("zremrangebyrank", key, start, stop))
+                return self
+
+            async def execute(self):
+                for op in self._ops:
+                    if op[0] == "zadd":
+                        _, key, mapping = op
+                        self._store.setdefault(key, {}).update(mapping)
+                    elif op[0] == "zremrangebyscore":
+                        _, key, lo, hi = op
+                        bucket = self._store.setdefault(key, {})
+                        for k, v in list(bucket.items()):
+                            if lo <= v <= hi:
+                                bucket.pop(k, None)
+                    elif op[0] == "zremrangebyrank":
+                        # Best-effort emulation; size-cap trimming is exercised
+                        # separately via the in-memory fallback test.
+                        pass
+                self._ops = []
+
+        class StubRedis:
+            def __init__(self, store):
+                self._store = store
+
+            async def ping(self):
+                return True
+
+            async def zscore(self, key, member):
+                bucket = self._store.get(key) or {}
+                return bucket.get(member)
+
+            async def zcard(self, key):
+                return len(self._store.get(key) or {})
+
+            async def delete(self, key):
+                self._store.pop(key, None)
+
+            def pipeline(self):
+                return StubPipeline(self._store)
+
+            async def close(self):
+                pass
+
+        def fake_from_url(url, decode_responses=True):
+            return StubRedis(store)
+
+        fake_aioredis = type(
+            "FakeAioredisModule", (), {"from_url": staticmethod(fake_from_url)}
+        )
+        import sys
+
+        monkeypatch.setitem(sys.modules, "redis.asyncio", fake_aioredis)
+
+        async def go():
+            d1 = RedisDedupSet("unit-shared")
+            await d1.mark_processed("keep-1")
+            await d1.mark_processed("keep-2")
+            await d1.close()
+
+            d2 = RedisDedupSet("unit-shared")
+            seen_keep_1 = await d2.is_processed("keep-1")
+            seen_missing = await d2.is_processed("never-marked")
+            await d2.close()
+            return seen_keep_1, seen_missing
+
+        seen_keep_1, seen_missing = _run(go())
+        assert seen_keep_1 is True
+        assert seen_missing is False

--- a/tests/unit/test_kafka_consumer.py
+++ b/tests/unit/test_kafka_consumer.py
@@ -1,0 +1,155 @@
+"""Unit tests for KafkaConsumerService message handling.
+
+These tests exercise the _handle_message path directly (no real Kafka
+broker, no real Redis) so they can run in CI without infrastructure.
+The aiokafka dependency is intentionally not imported at module scope —
+the consumer only imports it lazily inside _build_consumer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import pytest
+
+from daemon.config import KafkaConfig
+from daemon.dedup import RedisDedupSet
+from services.kafka_consumer_service import KafkaConsumerService
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _make_service(monkeypatch, topics=None):
+    # Force dedup into in-memory fallback
+    monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:1/0")
+    cfg = KafkaConfig(
+        enabled=True,
+        bootstrap_servers="localhost:9092",
+        consumer_group="test",
+        topics=topics or ["security.findings"],
+    )
+    queue: asyncio.Queue = asyncio.Queue()
+    dedup = RedisDedupSet("test-kafka", max_size=32)
+    svc = KafkaConsumerService(cfg, queue, dedup)
+    return svc, queue
+
+
+class _Msg:
+    """Stand-in for aiokafka's ConsumerRecord."""
+
+    def __init__(self, value):
+        self.value = value
+
+
+class TestKafkaMessageHandling:
+    def test_valid_json_message_enqueued(self, monkeypatch):
+        svc, queue = _make_service(monkeypatch)
+        payload = {"finding_id": "f-1", "severity": "high"}
+        msg = _Msg(json.dumps(payload).encode("utf-8"))
+
+        async def go():
+            await svc._handle_message("security.findings", msg)
+            return await queue.get()
+
+        item = _run(go())
+        assert item["type"] == "finding"
+        assert item["source"] == "kafka:security.findings"
+        assert item["data"]["finding_id"] == "f-1"
+        assert item["data"]["data_source"] == "kafka:security.findings"
+        assert svc.stats["messages_enqueued"] == 1
+        assert svc.stats["messages_consumed"] == 1
+        assert svc.stats["decode_errors"] == 0
+
+    def test_producer_data_source_is_preserved(self, monkeypatch):
+        svc, queue = _make_service(monkeypatch)
+        payload = {"finding_id": "f-2", "data_source": "custom-edr"}
+        msg = _Msg(json.dumps(payload).encode("utf-8"))
+
+        async def go():
+            await svc._handle_message("sec.t", msg)
+            return await queue.get()
+
+        item = _run(go())
+        assert item["data"]["data_source"] == "custom-edr"
+
+    def test_malformed_json_skipped(self, monkeypatch):
+        svc, queue = _make_service(monkeypatch)
+        msg = _Msg(b"{not valid json")
+
+        async def go():
+            await svc._handle_message("sec.t", msg)
+            return queue.qsize()
+
+        assert _run(go()) == 0
+        assert svc.stats["decode_errors"] == 1
+        assert svc.stats["messages_enqueued"] == 0
+
+    def test_non_object_payload_skipped(self, monkeypatch):
+        svc, queue = _make_service(monkeypatch)
+        msg = _Msg(json.dumps([1, 2, 3]).encode("utf-8"))
+
+        async def go():
+            await svc._handle_message("sec.t", msg)
+            return queue.qsize()
+
+        assert _run(go()) == 0
+        assert svc.stats["decode_errors"] == 1
+
+    def test_missing_finding_id_skipped(self, monkeypatch):
+        svc, queue = _make_service(monkeypatch)
+        msg = _Msg(json.dumps({"severity": "high"}).encode("utf-8"))
+
+        async def go():
+            await svc._handle_message("sec.t", msg)
+            return queue.qsize()
+
+        assert _run(go()) == 0
+        assert svc.stats["missing_id_errors"] == 1
+
+    def test_duplicate_skipped_after_first(self, monkeypatch):
+        svc, queue = _make_service(monkeypatch)
+        payload = {"finding_id": "dup-1"}
+        msg = _Msg(json.dumps(payload).encode("utf-8"))
+
+        async def go():
+            await svc._handle_message("sec.t", msg)
+            await svc._handle_message("sec.t", msg)
+            return queue.qsize()
+
+        assert _run(go()) == 1  # only the first landed on the queue
+        assert svc.stats["messages_enqueued"] == 1
+        assert svc.stats["duplicates_skipped"] == 1
+        assert svc.stats["messages_consumed"] == 2
+
+    def test_stats_surface_topics_and_group(self, monkeypatch):
+        svc, _queue = _make_service(monkeypatch, topics=["t1", "t2"])
+        assert svc.stats["topics"] == ["t1", "t2"]
+        assert svc.stats["consumer_group"] == "test"
+
+
+class TestKafkaBuildConsumer:
+    def test_build_consumer_raises_without_topics(self, monkeypatch):
+        cfg = KafkaConfig(enabled=True, topics=[])
+        queue: asyncio.Queue = asyncio.Queue()
+        svc = KafkaConsumerService(cfg, queue, RedisDedupSet("x"))
+
+        # Stub aiokafka so the test doesn't require it installed.
+        import sys
+        import types
+
+        fake_mod = types.ModuleType("aiokafka")
+
+        class FakeConsumer:
+            def __init__(self, *a, **kw):
+                pass
+
+        fake_mod.AIOKafkaConsumer = FakeConsumer
+        monkeypatch.setitem(sys.modules, "aiokafka", fake_mod)
+
+        async def go():
+            with pytest.raises(ValueError, match="no topics"):
+                await svc._build_consumer()
+
+        _run(go())


### PR DESCRIPTION
Closes #83

## Summary

Adds Apache Kafka as a third ingestion path alongside REST polling (`daemon/poller.py`) and file/webhook upload (`backend/api/ingestion.py`). JSON-only consumer runs inside the daemon, wired into the existing finding queue so Kafka messages flow through the same triage/enrichment/investigation pipeline.

**Scope: MVP + frontend config tab.** Avro, Protobuf, Schema Registry, DLQ, per-partition lag metrics deliberately left out — see follow-ups section in [docs/KAFKA_INGESTION.md](docs/KAFKA_INGESTION.md).

### What's new

- **Kafka consumer** ([services/kafka_consumer_service.py](services/kafka_consumer_service.py)): `aiokafka` consumer with manual offset commits. Malformed / missing-id messages skipped safely with counters.
- **Daemon wiring** ([daemon/kafka_ingestor.py](daemon/kafka_ingestor.py), [daemon/main.py](daemon/main.py)): start/stop driven by `SystemConfig["kafka.settings"].enabled` — toggle from the UI, no daemon restart needed.
- **Redis-backed dedup** ([daemon/dedup.py](daemon/dedup.py)): shared with the REST poller. Side-benefit: fixes the poller's in-memory dedup losing state on daemon restart.
- **REST API** ([backend/api/kafka.py](backend/api/kafka.py)): `GET/PUT /api/kafka/config`, `GET /api/kafka/status`. Secrets (SASL password, SSL cert path) are env-only, never stored in or returned from the API.
- **Settings UI** ([frontend/src/components/settings/KafkaTab.tsx](frontend/src/components/settings/KafkaTab.tsx)): enable toggle, topics chip input, 5s-polled live status panel.
- **Infra** ([docker/docker-compose.yml](docker/docker-compose.yml)): single-broker KRaft-mode Kafka 3.7.0 under a new `kafka` profile. No Zookeeper.
- **Docs** ([docs/KAFKA_INGESTION.md](docs/KAFKA_INGESTION.md)): full operator guide — when to use, quickstart, message format, config reference, troubleshooting.

### Verification

End-to-end tested against a real broker:

| Behaviour | Result |
|---|---|
| Consumer connects, joins group, gets partition assignment | ✅ |
| Publish → consume → dedup → persist (`data_source=kafka:<topic>`) | ✅ |
| Republish same `finding_id` → skipped, 1 DB row for 2 publishes | ✅ |
| Malformed JSON / missing `finding_id` → skipped, consumer survives | ✅ |
| `GET /api/kafka/status` proxies live daemon stats | ✅ |
| `PUT /api/kafka/config` persists to `SystemConfig` | ✅ |
| Enable/disable toggle: consumer starts/stops cleanly within 5s | ✅ |

## Test plan

- [ ] `pytest tests/unit/test_dedup.py tests/unit/test_kafka_consumer.py` — 13 new tests pass (run automatically in CI)
- [ ] `pytest tests/unit/` — full suite: **245 passed, 0 regressions**
- [ ] `docker compose -f docker/docker-compose.yml config --quiet` — valid
- [ ] `tsc --noEmit` — clean for new frontend files
- [ ] `black .`, `flake8 .` — clean
- [ ] Manual smoke: `docker compose --profile kafka up -d kafka`, enable in Settings → Kafka, publish a JSON finding, verify it appears in the Findings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)