### PR TITLE
feat(auth): JWT env secret, remove public /register, rate limiting, lockout

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -5,13 +5,15 @@ Handles login, logout, token refresh, password management, and MFA.
 """
 
 import logging
+from datetime import datetime
 from typing import Optional
-from fastapi import APIRouter, HTTPException, Depends, status
+from fastapi import APIRouter, HTTPException, Depends, Request, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
-from backend.services.auth_service import AuthService
+from backend.services.auth_service import AccountLockedError, AuthService
 from backend.middleware.auth import get_current_user, get_current_active_user
+from backend.middleware.rate_limit import limiter
 from database.models import User
 from database.connection import get_db_session
 
@@ -34,15 +36,6 @@ class LoginResponse(BaseModel):
     refresh_token: str
     token_type: str = "bearer"
     user: dict
-
-
-class RegisterRequest(BaseModel):
-    """User registration request."""
-    username: str
-    email: EmailStr
-    password: str
-    full_name: str
-    role_id: str = "role-analyst"  # Default role
 
 
 class ChangePasswordRequest(BaseModel):
@@ -68,55 +61,66 @@ class MFAVerifyRequest(BaseModel):
 
 
 @router.post("/login", response_model=LoginResponse)
+@limiter.limit("5/minute")
 async def login(
-    request: LoginRequest,
+    request: Request,
+    payload: LoginRequest,
     session: Session = Depends(get_db_session)
 ):
     """
     Authenticate user and return JWT tokens.
-    
+
     Args:
-        request: Login credentials
+        request: FastAPI request (used by the rate limiter).
+        payload: Login credentials
         session: Database session
-    
+
     Returns:
         Access and refresh tokens with user info
     """
     # Authenticate user
-    user = AuthService.authenticate_user(
-        request.username_or_email,
-        request.password,
-        session
-    )
-    
+    try:
+        user = AuthService.authenticate_user(
+            payload.username_or_email,
+            payload.password,
+            session
+        )
+    except AccountLockedError as exc:
+        retry_after = max(1, int((exc.locked_until - datetime.utcnow()).total_seconds()))
+        raise HTTPException(
+            status_code=status.HTTP_423_LOCKED,
+            detail="Account locked due to repeated failed login attempts",
+            headers={"Retry-After": str(retry_after)},
+        )
+
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid username/email or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    
+
     # Check MFA if enabled
     if user.mfa_enabled:
-        if not request.mfa_code:
+        if not payload.mfa_code:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="MFA code required",
                 headers={"X-MFA-Required": "true"},
             )
-        
-        if not AuthService.verify_mfa_code(user.user_id, request.mfa_code, session):
+
+        if not AuthService.verify_mfa_code(user.user_id, payload.mfa_code, session):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid MFA code",
             )
-    
+
     # Generate tokens
     access_token = AuthService.generate_jwt_token(user, "access")
     refresh_token = AuthService.generate_jwt_token(user, "refresh")
-    
+
     logger.info(f"User logged in: {user.username}")
-    
+
     return LoginResponse(
         access_token=access_token,
         refresh_token=refresh_token,
@@ -140,22 +144,25 @@ async def logout(current_user: User = Depends(get_current_active_user)):
 
 
 @router.post("/refresh", response_model=LoginResponse)
+@limiter.limit("30/minute")
 async def refresh_token(
-    request: RefreshTokenRequest,
+    request: Request,
+    body: RefreshTokenRequest,
     session: Session = Depends(get_db_session)
 ):
     """
     Refresh access token using refresh token.
-    
+
     Args:
-        request: Refresh token
+        request: FastAPI request (used by the rate limiter).
+        body: Refresh token
         session: Database session
-    
+
     Returns:
         New access and refresh tokens
     """
     # Verify refresh token
-    payload = AuthService.verify_jwt_token(request.refresh_token)
+    payload = AuthService.verify_jwt_token(body.refresh_token)
     if not payload or payload.get("token_type") != "refresh":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -258,41 +265,44 @@ async def update_current_user(
 
 
 @router.post("/change-password")
+@limiter.limit("5/minute")
 async def change_password(
-    request: ChangePasswordRequest,
+    request: Request,
+    body: ChangePasswordRequest,
     current_user: User = Depends(get_current_active_user),
     session: Session = Depends(get_db_session)
 ):
     """
     Change user password.
-    
+
     Args:
-        request: Current and new password
+        request: FastAPI request (used by the rate limiter).
+        body: Current and new password
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         Success message
     """
     # Verify current password
-    if not AuthService.verify_password(request.current_password, current_user.password_hash):
+    if not AuthService.verify_password(body.current_password, current_user.password_hash):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Current password is incorrect"
         )
-    
+
     # Validate new password
-    if len(request.new_password) < 8:
+    if len(body.new_password) < 8:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Password must be at least 8 characters"
         )
-    
+
     try:
         # Update password
-        current_user.password_hash = AuthService.hash_password(request.new_password)
+        current_user.password_hash = AuthService.hash_password(body.new_password)
         session.commit()
-        
+
         logger.info(f"Password changed for user: {current_user.username}")
         return {"message": "Password changed successfully"}
     
@@ -397,53 +407,8 @@ async def disable_mfa(
         )
 
 
-@router.post("/register", response_model=LoginResponse)
-async def register(
-    request: RegisterRequest,
-    session: Session = Depends(get_db_session)
-):
-    """
-    Register a new user (public endpoint - consider restricting in production).
-    
-    Args:
-        request: Registration details
-        session: Database session
-    
-    Returns:
-        Access and refresh tokens with user info
-    """
-    # Validate password
-    if len(request.password) < 8:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Password must be at least 8 characters"
-        )
-    
-    # Create user
-    user = AuthService.create_user(
-        username=request.username,
-        email=request.email,
-        password=request.password,
-        full_name=request.full_name,
-        role_id=request.role_id,
-        session=session
-    )
-    
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Username or email already exists"
-        )
-    
-    # Generate tokens
-    access_token = AuthService.generate_jwt_token(user, "access")
-    refresh_token = AuthService.generate_jwt_token(user, "refresh")
-    
-    logger.info(f"New user registered: {user.username}")
-    
-    return LoginResponse(
-        access_token=access_token,
-        refresh_token=refresh_token,
-        user=user.to_dict()
-    )
+# Public self-registration was removed intentionally. All user creation
+# goes through the admin-gated POST /api/users/ endpoint (backend/api/users.py)
+# which validates the requested role against the caller's privileges.
+
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,10 @@ from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
+from slowapi.errors import RateLimitExceeded
+from slowapi import _rate_limit_exceeded_handler
+
+from backend.middleware.rate_limit import limiter
 
 from api import (
     findings_router,
@@ -97,6 +101,11 @@ app = FastAPI(
     description="REST API for Vigil SOC Application",
     version="1.0.0"
 )
+
+# Wire the shared slowapi Limiter used by auth endpoints. The decorator-based
+# limits (@limiter.limit) read state from app.state.limiter, so both must be set.
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 # Instrument FastAPI with OTEL tracing (health + metrics endpoints excluded)
 try:

--- a/backend/middleware/rate_limit.py
+++ b/backend/middleware/rate_limit.py
@@ -1,0 +1,32 @@
+"""
+Shared slowapi Limiter for auth and other sensitive endpoints.
+
+Uses Redis as the distributed storage backend so rate limits apply across
+workers. Falls back to in-memory storage if Redis is unreachable so a cache
+outage does not take authentication offline.
+"""
+
+import logging
+import os
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+logger = logging.getLogger(__name__)
+
+
+_redis_url = os.getenv("REDIS_URL")
+
+try:
+    limiter = Limiter(
+        key_func=get_remote_address,
+        storage_uri=_redis_url,
+        strategy="fixed-window",
+    )
+except Exception as exc:
+    logger.warning(
+        "Rate limiter Redis storage unavailable (%s); falling back to in-memory. "
+        "Limits will not be shared across processes.",
+        exc,
+    )
+    limiter = Limiter(key_func=get_remote_address, strategy="fixed-window")

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -5,6 +5,7 @@ Handles password hashing, JWT generation/validation, MFA, and session management
 """
 
 import logging
+import os
 import secrets
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
@@ -18,11 +19,58 @@ from database.connection import get_db_session
 
 logger = logging.getLogger(__name__)
 
+
+def _is_dev_mode() -> bool:
+    return os.getenv("DEV_MODE", "false").lower() in ("true", "1", "yes")
+
+
+def _load_jwt_secret() -> str:
+    """
+    Load the JWT signing secret at import time.
+
+    Priority: env var / secrets backend. In DEV_MODE, fall back to a
+    deterministic dev secret so tokens survive restarts locally. In
+    production (DEV_MODE=false), fail-closed at startup if unset.
+    """
+    try:
+        from backend.secrets_manager import get_secret
+        value = get_secret("JWT_SECRET_KEY")
+    except Exception:
+        value = os.environ.get("JWT_SECRET_KEY")
+
+    if value:
+        return value
+
+    if _is_dev_mode():
+        logger.warning(
+            "JWT_SECRET_KEY not set; using deterministic DEV_MODE fallback. "
+            "Tokens issued in dev are not portable to production."
+        )
+        return "dev-mode-insecure-jwt-secret-do-not-use-in-production"
+
+    raise RuntimeError(
+        "JWT_SECRET_KEY is required when DEV_MODE=false. "
+        "Set it in the environment or .env before starting the backend."
+    )
+
+
 # JWT Configuration
-JWT_SECRET_KEY = secrets.token_urlsafe(32)  # In production, load from env
+JWT_SECRET_KEY = _load_jwt_secret()
 JWT_ALGORITHM = "HS256"
 JWT_EXPIRATION_HOURS = 24
 JWT_REFRESH_EXPIRATION_DAYS = 30
+
+# Account lockout configuration
+LOCKOUT_THRESHOLD = int(os.getenv("AUTH_LOCKOUT_THRESHOLD", "5"))
+LOCKOUT_DURATION_MINUTES = int(os.getenv("AUTH_LOCKOUT_DURATION_MINUTES", "15"))
+
+
+class AccountLockedError(Exception):
+    """Raised when authentication is refused because the account is locked."""
+
+    def __init__(self, locked_until: datetime):
+        self.locked_until = locked_until
+        super().__init__(f"Account locked until {locked_until.isoformat()}")
 
 
 class AuthService:
@@ -133,33 +181,56 @@ class AuthService:
             user = session.query(User).filter(
                 (User.username == username_or_email) | (User.email == username_or_email)
             ).first()
-            
+
             if not user:
                 logger.warning(f"User not found: {username_or_email}")
                 return None
-            
+
             if not user.is_active:
                 logger.warning(f"User is inactive: {username_or_email}")
                 return None
-            
+
+            # Reject while locked. Lockout is authoritative even over a correct
+            # password — otherwise an attacker who eventually guesses right
+            # would bypass the wait.
+            now = datetime.utcnow()
+            if user.locked_until and user.locked_until > now:
+                logger.warning(
+                    f"Login rejected, account locked: {username_or_email} "
+                    f"until {user.locked_until.isoformat()}"
+                )
+                raise AccountLockedError(user.locked_until)
+
             # Verify password
             if not AuthService.verify_password(password, user.password_hash):
+                user.failed_login_count = (user.failed_login_count or 0) + 1
+                if user.failed_login_count >= LOCKOUT_THRESHOLD:
+                    user.locked_until = now + timedelta(minutes=LOCKOUT_DURATION_MINUTES)
+                    logger.warning(
+                        f"Account locked after {user.failed_login_count} failed "
+                        f"attempts: {username_or_email}"
+                    )
+                session.commit()
                 logger.warning(f"Invalid password for user: {username_or_email}")
                 return None
-            
-            # Update last login
-            user.last_login = datetime.utcnow()
+
+            # Success — reset lockout state and update session tracking
+            user.failed_login_count = 0
+            user.locked_until = None
+            user.last_login = now
             user.login_count += 1
             session.commit()
-            
+
             logger.info(f"User authenticated successfully: {username_or_email}")
             return user
-        
+
+        except AccountLockedError:
+            raise
         except Exception as e:
             logger.error(f"Authentication error: {e}")
             session.rollback()
             return None
-        
+
         finally:
             if should_close_session:
                 session.close()

--- a/database/init/06_auth_tables.sql
+++ b/database/init/06_auth_tables.sql
@@ -28,9 +28,15 @@ CREATE TABLE IF NOT EXISTS users (
     mfa_secret VARCHAR(255),
     last_login TIMESTAMP,
     login_count INTEGER NOT NULL DEFAULT 0,
+    failed_login_count INTEGER NOT NULL DEFAULT 0,
+    locked_until TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+-- Additive migration for existing deployments (safe to rerun)
+ALTER TABLE users ADD COLUMN IF NOT EXISTS failed_login_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP;
 
 CREATE INDEX IF NOT EXISTS idx_user_username ON users(username);
 CREATE INDEX IF NOT EXISTS idx_user_email ON users(email);

--- a/database/models.py
+++ b/database/models.py
@@ -1765,7 +1765,13 @@ class User(Base):
     # Session tracking
     last_login: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     login_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    
+
+    # Failed-login tracking and account lockout
+    failed_login_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default='0'
+    )
+    locked_until: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
         DateTime,
@@ -1780,7 +1786,7 @@ class User(Base):
         onupdate=datetime.utcnow,
         server_default='now()'
     )
-    
+
     # Indexes
     __table_args__ = (
         Index('idx_user_username', 'username'),

--- a/env.example
+++ b/env.example
@@ -44,6 +44,19 @@ SECRETS_BACKEND="dotenv"
 ENABLE_KEYRING="false"
 
 # -----------------------------------------------------------------------------
+# Authentication
+# -----------------------------------------------------------------------------
+# JWT signing secret. REQUIRED when DEV_MODE=false — startup will fail without
+# it. In DEV_MODE the service falls back to a predictable dev value and logs a
+# warning. Generate a strong value with: python -c "import secrets; print(secrets.token_urlsafe(64))"
+JWT_SECRET_KEY=""
+
+# Account lockout — after N consecutive failed logins the account is locked
+# for DURATION minutes. Successful login resets the counter.
+AUTH_LOCKOUT_THRESHOLD="5"
+AUTH_LOCKOUT_DURATION_MINUTES="15"
+
+# -----------------------------------------------------------------------------
 # MemPalace — Persistent AI Memory Layer
 # -----------------------------------------------------------------------------
 # Path to the ChromaDB palace data directory (used by MCP server and Python API)

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -27,8 +27,7 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config
 
-    const isAuthEndpoint = originalRequest?.url?.startsWith('/auth/login') ||
-      originalRequest?.url?.startsWith('/auth/register')
+    const isAuthEndpoint = originalRequest?.url?.startsWith('/auth/login')
 
     if (isAuthEndpoint) {
       return Promise.reject(error)

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ alembic>=1.13.0
 bcrypt>=4.2.0
 pyjwt>=2.10.0
 pyotp>=2.9.0
+slowapi>=0.1.9
 
 # Testing Dependencies
 pytest>=8.0.0


### PR DESCRIPTION
## Summary

First of five auth-hardening PRs tracked under #76. Ships the three HIGH-priority items: JWT secret stability, removal of the role-escalation path in public registration, and brute-force protection.

- **JWT secret** — `backend/services/auth_service.py` previously did `JWT_SECRET_KEY = secrets.token_urlsafe(32)` at import time, invalidating every issued token on restart. Now loaded via `backend/secrets_manager.get_secret("JWT_SECRET_KEY")`. Fails-closed at startup when `DEV_MODE=false` and the var is unset; in `DEV_MODE` falls back to a deterministic dev value with a warning so local restarts don't force re-login.
- **Public registration deleted** — `POST /api/auth/register` accepted any `role_id` including `role-admin`. Rather than patching the validation, the endpoint is removed outright. All user creation goes through the admin-gated `POST /api/users/` endpoint which already validates roles properly. SOC products don't self-signup.
- **Rate limiting** — new `backend/middleware/rate_limit.py` exposes a shared `slowapi.Limiter` with Redis storage and in-memory fallback (fail-open on Redis outage — a cache hiccup shouldn't take auth offline). Decorators applied: `/login` 5/min, `/refresh` 30/min, `/change-password` 5/min.
- **Account lockout** — new `failed_login_count` and `locked_until` columns on the `users` table (additive, safe via `create_all` + idempotent `ALTER TABLE ADD COLUMN IF NOT EXISTS`). After 5 consecutive failures (`AUTH_LOCKOUT_THRESHOLD`), the account is locked for 15 minutes (`AUTH_LOCKOUT_DURATION_MINUTES`). `AccountLockedError` surfaces as HTTP 423 with a `Retry-After` header. Both thresholds are env-configurable.

## Operator notes

- **`JWT_SECRET_KEY` is now required** in production. Deployments running `DEV_MODE=false` without it will fail to start. Generate with `python -c "import secrets; print(secrets.token_urlsafe(64))"`.
- **Existing deployments** need the two new columns applied. Fresh DBs get them via `create_all`; live DBs get them via the idempotent `ALTER TABLE` block at the top of `database/init/06_auth_tables.sql`.
- **New dependency**: `slowapi>=0.1.9`.

## Test plan

- [ ] `pip install -r requirements.txt` picks up `slowapi`
- [ ] With `JWT_SECRET_KEY` set, backend starts; without it + `DEV_MODE=false`, backend fails with the intended error
- [ ] Tokens survive a backend restart
- [ ] `curl -X POST /api/auth/register` returns 404
- [ ] 6th failed login within threshold returns 423 with `Retry-After`
- [ ] Successful login resets the failed-attempt counter
- [ ] 6th `/api/auth/login` request in a minute from a single IP returns 429
- [ ] Admin user creation via `POST /api/users/` still works
- [ ] Frontend login flow unaffected; 401 interceptor still distinguishes `/auth/login`

## Scope boundaries

- Password policy, reset flow, and test-suite repair are intentionally out of scope — covered by #99.
- HttpOnly cookie migration is out of scope — covered by #98.
- Token revocation / CSRF middleware is out of scope — covered by #97.
- Security headers + CORS tightening is out of scope — covered by #96.

Closes #95. Part of #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)