### PR TITLE
feat(http): security headers middleware + tighten CORS

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -26,6 +26,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi import _rate_limit_exceeded_handler
 
 from backend.middleware.rate_limit import limiter
+from backend.middleware.security_headers import SecurityHeadersMiddleware
 
 from api import (
     findings_router,
@@ -120,20 +121,40 @@ try:
 except Exception as _inst_err:
     logger.debug("FastAPI OTEL instrumentation skipped: %s", _inst_err)
 
-# Configure CORS
+# Configure CORS — origins come from VIGIL_CORS_ORIGINS (comma-separated).
+# Default keeps the existing dev hosts; production deployments must override.
+_DEFAULT_CORS_ORIGINS = [
+    "http://localhost:6988",
+    "http://127.0.0.1:6988",
+    "http://localhost:3000",
+    "http://localhost:5173",
+]
+_cors_origins_raw = os.getenv("VIGIL_CORS_ORIGINS")
+if _cors_origins_raw:
+    _cors_origins = [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]
+else:
+    _cors_origins = _DEFAULT_CORS_ORIGINS
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:6988",  # Frontend dev server
-        "http://127.0.0.1:6988",  # Frontend dev server (IPv4)
-        "http://localhost:3000",  # Alternative React dev server
-        "http://localhost:5173"   # Alternative Vite dev server
-    ],
+    allow_origins=_cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=[
+        "Authorization",
+        "Content-Type",
+        "X-CSRF-Token",
+        "X-MFA-Required",
+        "X-Requested-With",
+    ],
     expose_headers=["X-MFA-Required"],
 )
+
+# Security headers added AFTER CORS so it is the outermost middleware on the
+# response path. That way HSTS/CSP/X-Frame-Options apply to CORS preflight
+# responses too (CORSMiddleware short-circuits OPTIONS without calling inner
+# middleware, so anything added before CORS would be skipped on preflight).
+app.add_middleware(SecurityHeadersMiddleware)
 
 if PROMETHEUS_AVAILABLE:
     app.add_middleware(PrometheusMiddleware)

--- a/backend/middleware/security_headers.py
+++ b/backend/middleware/security_headers.py
@@ -1,0 +1,121 @@
+"""
+Security headers middleware.
+
+Adds HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, and a
+Content-Security-Policy to every response. Each header is individually
+togglable via env so deployments fronted by a reverse proxy that already
+sets these can disable the in-app version and avoid duplicates.
+
+HSTS is only emitted on HTTPS requests (best-effort detection via
+request.url.scheme and the X-Forwarded-Proto header) because browsers
+ignore HSTS on plain HTTP anyway and emitting it would be noise.
+"""
+
+import logging
+import os
+from typing import Callable, Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_CSP = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data: blob:; "
+    "font-src 'self' data:; "
+    "connect-src 'self'; "
+    "frame-ancestors 'none'; "
+    "base-uri 'self'; "
+    "form-action 'self'"
+)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("true", "1", "yes", "on")
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app,
+        *,
+        hsts_enabled: Optional[bool] = None,
+        frame_options_enabled: Optional[bool] = None,
+        content_type_options_enabled: Optional[bool] = None,
+        referrer_policy_enabled: Optional[bool] = None,
+        csp_enabled: Optional[bool] = None,
+        csp_policy: Optional[str] = None,
+        hsts_max_age: Optional[int] = None,
+    ):
+        super().__init__(app)
+        self.hsts_enabled = (
+            _env_bool("VIGIL_HSTS_ENABLED", True)
+            if hsts_enabled is None
+            else hsts_enabled
+        )
+        self.frame_options_enabled = (
+            _env_bool("VIGIL_FRAME_OPTIONS_ENABLED", True)
+            if frame_options_enabled is None
+            else frame_options_enabled
+        )
+        self.content_type_options_enabled = (
+            _env_bool("VIGIL_CONTENT_TYPE_OPTIONS_ENABLED", True)
+            if content_type_options_enabled is None
+            else content_type_options_enabled
+        )
+        self.referrer_policy_enabled = (
+            _env_bool("VIGIL_REFERRER_POLICY_ENABLED", True)
+            if referrer_policy_enabled is None
+            else referrer_policy_enabled
+        )
+        self.csp_enabled = (
+            _env_bool("VIGIL_CSP_ENABLED", True)
+            if csp_enabled is None
+            else csp_enabled
+        )
+        self.csp_policy = csp_policy or os.getenv("VIGIL_CSP_POLICY") or DEFAULT_CSP
+        self.hsts_max_age = (
+            int(os.getenv("VIGIL_HSTS_MAX_AGE", "31536000"))
+            if hsts_max_age is None
+            else hsts_max_age
+        )
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        response = await call_next(request)
+
+        if self.content_type_options_enabled:
+            response.headers.setdefault("X-Content-Type-Options", "nosniff")
+
+        if self.frame_options_enabled:
+            response.headers.setdefault("X-Frame-Options", "DENY")
+
+        if self.referrer_policy_enabled:
+            response.headers.setdefault(
+                "Referrer-Policy", "strict-origin-when-cross-origin"
+            )
+
+        if self.csp_enabled:
+            response.headers.setdefault("Content-Security-Policy", self.csp_policy)
+
+        if self.hsts_enabled and self._is_https(request):
+            response.headers.setdefault(
+                "Strict-Transport-Security",
+                f"max-age={self.hsts_max_age}; includeSubDomains",
+            )
+
+        return response
+
+    @staticmethod
+    def _is_https(request: Request) -> bool:
+        if request.url.scheme == "https":
+            return True
+        forwarded_proto = request.headers.get("x-forwarded-proto", "").lower()
+        return forwarded_proto == "https"

--- a/env.example
+++ b/env.example
@@ -64,6 +64,29 @@ AUTH_LOCKOUT_THRESHOLD="5"
 AUTH_LOCKOUT_DURATION_MINUTES="15"
 
 # -----------------------------------------------------------------------------
+# HTTP Security (CORS + security headers)
+# -----------------------------------------------------------------------------
+# CORS origins. Comma-separated list. Leave unset to use the built-in dev
+# defaults (localhost:6988, :3000, :5173). Production deployments MUST set
+# this to the real origin(s), e.g. "https://vigil.example.com".
+VIGIL_CORS_ORIGINS=""
+
+# Security headers — each one can be toggled off if a reverse proxy in front
+# of the backend already sets it (to avoid duplicate values).
+VIGIL_HSTS_ENABLED="true"
+VIGIL_HSTS_MAX_AGE="31536000"
+VIGIL_FRAME_OPTIONS_ENABLED="true"
+VIGIL_CONTENT_TYPE_OPTIONS_ENABLED="true"
+VIGIL_REFERRER_POLICY_ENABLED="true"
+
+# Content-Security-Policy. VIGIL_CSP_POLICY overrides the default entirely.
+# The default policy allows 'unsafe-inline' for styles (required by MUI) but
+# not for scripts. If you serve the frontend from a different origin than the
+# API you may need to widen connect-src.
+VIGIL_CSP_ENABLED="true"
+VIGIL_CSP_POLICY=""
+
+# -----------------------------------------------------------------------------
 # MemPalace — Persistent AI Memory Layer
 # -----------------------------------------------------------------------------
 # Path to the ChromaDB palace data directory (used by MCP server and Python API)


### PR DESCRIPTION
## Summary

Second of five auth-hardening PRs tracked under #76. Ships the MEDIUM-priority HTTP hardening items. Purely additive; no existing flows break.

### Security headers middleware
New `backend/middleware/security_headers.py` adds on every response:
- `Strict-Transport-Security: max-age=31536000; includeSubDomains` (HTTPS only — detected via scheme + `X-Forwarded-Proto`)
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Content-Security-Policy` — restrictive by default:
  ```
  default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
  img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self';
  frame-ancestors 'none'; base-uri 'self'; form-action 'self'
  ```
  `unsafe-inline` is allowed for styles (MUI requires it) but NOT for scripts.

Each header is individually togglable via env (`VIGIL_HSTS_ENABLED`, `VIGIL_FRAME_OPTIONS_ENABLED`, etc.) so deployments fronted by a reverse proxy that already sets them can avoid duplicate values. The CSP is fully overridable via `VIGIL_CSP_POLICY`.

Middleware ordering: **added after CORS** so it wraps as the outermost on the response path. `CORSMiddleware` short-circuits `OPTIONS` preflight without calling inner middleware, so anything registered before it would be skipped on preflight — the new security headers need to be outside to apply there too.

### Tightened CORS
- `allow_methods=["*"]` → explicit `GET, POST, PUT, PATCH, DELETE, OPTIONS`
- `allow_headers=["*"]` → explicit `Authorization, Content-Type, X-CSRF-Token, X-MFA-Required, X-Requested-With` (the `X-CSRF-Token` entry is ahead of PR 3 so the middleware plugs in cleanly)
- Origins moved to `VIGIL_CORS_ORIGINS` (comma-separated env var). Default keeps the existing four dev hosts; production deployments now have a way to set their real origin without editing code.

## Operator notes

- **Production deployments using a different frontend origin must set `VIGIL_CORS_ORIGINS`** before upgrading, otherwise the frontend will be blocked by CORS.
- If the backend is behind a reverse proxy (nginx, Cloudflare, ALB) that already sets security headers, disable the in-app ones to avoid duplicate values — e.g. `VIGIL_HSTS_ENABLED=false`.
- CSP may break existing custom integrations that inject inline scripts or load assets from third-party CDNs. Override via `VIGIL_CSP_POLICY` if needed.
- HSTS is only emitted on HTTPS — local HTTP dev is unaffected.

## Test plan

- [ ] `curl -I http://localhost:6987/api/health` returns `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and `Content-Security-Policy` headers
- [ ] `curl -I https://<prod-host>/api/health` also returns `Strict-Transport-Security`
- [ ] Local `curl -I http://localhost:6987/api/health` does NOT return HSTS
- [ ] `VIGIL_HSTS_ENABLED=false` suppresses the HSTS header
- [ ] CORS preflight (`OPTIONS` with `Origin` header) returns security headers alongside CORS headers
- [ ] CORS rejects an origin not in the allowlist
- [ ] `VIGIL_CORS_ORIGINS=https://a.example.com,https://b.example.com` takes effect
- [ ] Frontend dev (`npm run dev` on :6988) still hits the backend without CORS errors
- [ ] MUI-rendered pages still render (CSP allows `style-src 'unsafe-inline'`)

## Scope boundaries

- CSRF enforcement is out of scope — covered by #97. The `X-CSRF-Token` entry in the allowed-headers list is preparation only.
- HttpOnly cookie migration is out of scope — covered by #98.

Closes #96. Part of #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)