### PR TITLE
feat(llm): multi-provider support via Bifrost sidecar (#88)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ logs/
 config.json
 *_config.json
 !mcp-config.json
+!docker/bifrost/config.json
 
 # Node.js / React
 frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Auth bypass is enabled by default (`DEV_MODE=true`) for quick development. Full 
 - **Node.js 18+** (for frontend)
 - **Docker Desktop** (must be running — used for PostgreSQL)
 - **Git** (with submodule support)
-- Claude API key from [console.anthropic.com](https://console.anthropic.com/) *(optional for initial testing)*
+- An LLM provider key. Vigil supports Anthropic Claude (default), OpenAI, and Ollama (local) — configure providers in Settings → AI Config. See [`docker/bifrost/README.md`](docker/bifrost/README.md) for the multi-provider gateway. *(optional for initial testing)*
 
 ### Default Login Credentials
 

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -15,6 +15,7 @@ from api.logs import router as logs_router
 from api.workflows import router as workflows_router
 from api.reasoning import router as reasoning_router
 from api.skills import router as skills_router
+from api.llm_providers import router as llm_providers_router
 
 __all__ = [
     'findings_router',
@@ -32,4 +33,5 @@ __all__ = [
     'workflows_router',
     'reasoning_router',
     'skills_router',
+    'llm_providers_router',
 ]

--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -203,20 +203,57 @@ async def get_claude_config():
 async def set_claude_config(config: ClaudeConfig):
     """
     Set Claude API configuration.
-    
+
     Args:
         config: Claude configuration
-    
+
     Returns:
         Success status
     """
     try:
         # Use standard environment variable name
         success = set_secret("CLAUDE_API_KEY", config.api_key)
-        if success:
-            return {"success": True, "message": "API key saved securely"}
-        else:
+        if not success:
             raise HTTPException(status_code=500, detail="Failed to save API key")
+
+        # GH #88: keep the new llm_provider_configs table in sync so the
+        # Settings "AI Config" tab and the legacy endpoint agree on the
+        # Anthropic default. Best-effort — a DB failure here should NOT
+        # block the secret write that already succeeded.
+        try:
+            from database.connection import get_db_session
+            from database.models import LLMProviderConfig
+
+            session = get_db_session()
+            try:
+                row = session.get(LLMProviderConfig, "anthropic-default")
+                if row is None:
+                    row = LLMProviderConfig(
+                        provider_id="anthropic-default",
+                        provider_type="anthropic",
+                        name="Anthropic (default)",
+                        api_key_ref="CLAUDE_API_KEY",
+                        default_model="claude-sonnet-4-5-20250929",
+                        is_active=True,
+                        is_default=True,
+                        config={},
+                    )
+                    session.add(row)
+                else:
+                    row.api_key_ref = "CLAUDE_API_KEY"
+                    row.is_active = True
+                session.commit()
+            finally:
+                session.close()
+        except Exception as sync_err:  # noqa: BLE001
+            logger.warning(
+                "Legacy /config/claude could not sync llm_provider_configs: %s",
+                sync_err,
+            )
+
+        return {"success": True, "message": "API key saved securely"}
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error setting Claude config: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -1,0 +1,341 @@
+"""LLM provider management API — CRUD + test + model listing.
+
+See GH issue #88. Each row in `llm_provider_configs` represents a configured
+LLM backend (Anthropic, OpenAI, Ollama, ...). API keys are stored in the
+secrets_manager under a generated ref name, never in the DB.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import update
+from sqlalchemy.orm import Session
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from secrets_manager import delete_secret, get_secret, set_secret
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+from database.connection import get_db_session
+from database.models import LLMProviderConfig
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+VALID_PROVIDER_TYPES = {"anthropic", "openai", "ollama"}
+_SLUG_RE = re.compile(r"[^a-z0-9-]+")
+
+# Static list for Anthropic — the SDK doesn't expose a /models endpoint
+# for listing. Kept in sync with docker/bifrost/config.json.
+ANTHROPIC_MODELS = [
+    "claude-sonnet-4-20250514",
+    "claude-sonnet-4-5-20250929",
+    "claude-opus-4-20250514",
+]
+
+
+def _slugify(name: str) -> str:
+    return _SLUG_RE.sub("-", name.lower()).strip("-") or "provider"
+
+
+def _secret_ref_for(provider_id: str) -> str:
+    return f"llm_provider_{provider_id}_api_key"
+
+
+class LLMProviderCreate(BaseModel):
+    provider_id: Optional[str] = Field(
+        None, description="If omitted, derived from name"
+    )
+    provider_type: str
+    name: str
+    base_url: Optional[str] = None
+    api_key: Optional[str] = None
+    default_model: str
+    is_active: bool = True
+    is_default: bool = False
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LLMProviderUpdate(BaseModel):
+    name: Optional[str] = None
+    base_url: Optional[str] = None
+    api_key: Optional[str] = None
+    default_model: Optional[str] = None
+    is_active: Optional[bool] = None
+    is_default: Optional[bool] = None
+    config: Optional[Dict[str, Any]] = None
+
+
+class LLMProviderResponse(BaseModel):
+    provider_id: str
+    provider_type: str
+    name: str
+    base_url: Optional[str]
+    has_api_key: bool
+    default_model: str
+    is_active: bool
+    is_default: bool
+    config: Dict[str, Any]
+    last_test_at: Optional[str]
+    last_test_success: Optional[bool]
+    last_error: Optional[str]
+    created_at: Optional[str]
+    updated_at: Optional[str]
+
+
+def _to_response(row: LLMProviderConfig) -> Dict[str, Any]:
+    d = row.to_dict()
+    d.pop("api_key_ref", None)
+    return d
+
+
+def _validate_type(provider_type: str) -> None:
+    if provider_type not in VALID_PROVIDER_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"provider_type must be one of {sorted(VALID_PROVIDER_TYPES)}",
+        )
+
+
+def _clear_other_defaults(db: Session, provider_type: str, keep_id: str) -> None:
+    """Enforce the 'one default per provider_type' invariant at the app layer.
+
+    The DB has a partial unique index too, but clearing first avoids the
+    index-conflict round-trip on UPDATE.
+    """
+    db.execute(
+        update(LLMProviderConfig)
+        .where(
+            LLMProviderConfig.provider_type == provider_type,
+            LLMProviderConfig.provider_id != keep_id,
+            LLMProviderConfig.is_default.is_(True),
+        )
+        .values(is_default=False)
+    )
+
+
+@router.get("", response_model=List[LLMProviderResponse])
+@router.get("/", response_model=List[LLMProviderResponse])
+async def list_providers(db: Session = Depends(get_db_session)):
+    rows = db.query(LLMProviderConfig).order_by(LLMProviderConfig.created_at).all()
+    return [_to_response(r) for r in rows]
+
+
+@router.post("", response_model=LLMProviderResponse, status_code=201)
+@router.post("/", response_model=LLMProviderResponse, status_code=201)
+async def create_provider(
+    payload: LLMProviderCreate, db: Session = Depends(get_db_session)
+):
+    _validate_type(payload.provider_type)
+
+    provider_id = payload.provider_id or _slugify(payload.name)
+    if db.get(LLMProviderConfig, provider_id) is not None:
+        raise HTTPException(status_code=409, detail=f"provider_id '{provider_id}' already exists")
+
+    api_key_ref: Optional[str] = None
+    if payload.api_key:
+        api_key_ref = _secret_ref_for(provider_id)
+        if not set_secret(api_key_ref, payload.api_key):
+            raise HTTPException(status_code=500, detail="Failed to persist API key")
+
+    row = LLMProviderConfig(
+        provider_id=provider_id,
+        provider_type=payload.provider_type,
+        name=payload.name,
+        base_url=payload.base_url,
+        api_key_ref=api_key_ref,
+        default_model=payload.default_model,
+        is_active=payload.is_active,
+        is_default=payload.is_default,
+        config=payload.config or {},
+    )
+    db.add(row)
+
+    if payload.is_default:
+        _clear_other_defaults(db, payload.provider_type, provider_id)
+
+    db.commit()
+    db.refresh(row)
+    return _to_response(row)
+
+
+@router.put("/{provider_id}", response_model=LLMProviderResponse)
+async def update_provider(
+    provider_id: str,
+    payload: LLMProviderUpdate,
+    db: Session = Depends(get_db_session),
+):
+    row = db.get(LLMProviderConfig, provider_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="provider not found")
+
+    if payload.name is not None:
+        row.name = payload.name
+    if payload.base_url is not None:
+        row.base_url = payload.base_url
+    if payload.default_model is not None:
+        row.default_model = payload.default_model
+    if payload.is_active is not None:
+        row.is_active = payload.is_active
+    if payload.config is not None:
+        row.config = payload.config
+
+    if payload.api_key is not None:
+        # Empty string clears the key; non-empty rotates it.
+        ref = row.api_key_ref or _secret_ref_for(provider_id)
+        if payload.api_key == "":
+            delete_secret(ref)
+            row.api_key_ref = None
+        else:
+            if not set_secret(ref, payload.api_key):
+                raise HTTPException(status_code=500, detail="Failed to persist API key")
+            row.api_key_ref = ref
+
+    if payload.is_default is True:
+        row.is_default = True
+        _clear_other_defaults(db, row.provider_type, provider_id)
+    elif payload.is_default is False:
+        row.is_default = False
+
+    db.commit()
+    db.refresh(row)
+    return _to_response(row)
+
+
+@router.delete("/{provider_id}")
+async def delete_provider(provider_id: str, db: Session = Depends(get_db_session)):
+    row = db.get(LLMProviderConfig, provider_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="provider not found")
+
+    if row.api_key_ref:
+        try:
+            delete_secret(row.api_key_ref)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to delete secret %s: %s", row.api_key_ref, exc)
+
+    db.delete(row)
+    db.commit()
+    return {"success": True, "provider_id": provider_id}
+
+
+@router.post("/{provider_id}/set-default", response_model=LLMProviderResponse)
+async def set_default_provider(
+    provider_id: str, db: Session = Depends(get_db_session)
+):
+    row = db.get(LLMProviderConfig, provider_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="provider not found")
+    row.is_default = True
+    _clear_other_defaults(db, row.provider_type, provider_id)
+    db.commit()
+    db.refresh(row)
+    return _to_response(row)
+
+
+async def _resolve_api_key(row: LLMProviderConfig) -> Optional[str]:
+    if not row.api_key_ref:
+        return None
+    return get_secret(row.api_key_ref)
+
+
+@router.post("/{provider_id}/test")
+async def test_provider(provider_id: str, db: Session = Depends(get_db_session)):
+    row = db.get(LLMProviderConfig, provider_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="provider not found")
+
+    from datetime import datetime
+
+    success = False
+    error: Optional[str] = None
+
+    try:
+        if row.provider_type == "ollama":
+            base_url = row.base_url or "http://localhost:11434"
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(f"{base_url.rstrip('/')}/api/tags")
+                resp.raise_for_status()
+                success = True
+        elif row.provider_type == "openai":
+            base_url = row.base_url or "https://api.openai.com/v1"
+            key = await _resolve_api_key(row)
+            if not key:
+                raise RuntimeError("no api key configured")
+            headers = {"Authorization": f"Bearer {key}"}
+            if row.config and row.config.get("organization"):
+                headers["OpenAI-Organization"] = row.config["organization"]
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.get(
+                    f"{base_url.rstrip('/')}/models", headers=headers
+                )
+                resp.raise_for_status()
+                success = True
+        elif row.provider_type == "anthropic":
+            key = await _resolve_api_key(row)
+            if not key:
+                raise RuntimeError("no api key configured")
+            try:
+                from anthropic import Anthropic
+            except ImportError as exc:
+                raise RuntimeError("anthropic SDK not installed") from exc
+            client = Anthropic(api_key=key, timeout=15.0)
+            client.messages.create(
+                model=row.default_model,
+                max_tokens=1,
+                messages=[{"role": "user", "content": "ping"}],
+            )
+            success = True
+        else:
+            raise RuntimeError(f"unsupported provider_type: {row.provider_type}")
+    except Exception as exc:  # noqa: BLE001
+        error = str(exc)
+        logger.info("Provider test failed for %s: %s", provider_id, error)
+
+    row.last_test_at = datetime.utcnow()
+    row.last_test_success = success
+    row.last_error = None if success else error
+    db.commit()
+
+    return {"success": success, "provider_id": provider_id, "error": error}
+
+
+@router.get("/{provider_id}/models")
+async def list_models(provider_id: str, db: Session = Depends(get_db_session)):
+    row = db.get(LLMProviderConfig, provider_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="provider not found")
+
+    if row.provider_type == "anthropic":
+        return {"models": ANTHROPIC_MODELS}
+
+    if row.provider_type == "ollama":
+        base_url = row.base_url or "http://localhost:11434"
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(f"{base_url.rstrip('/')}/api/tags")
+            resp.raise_for_status()
+            data = resp.json()
+        return {"models": [m.get("name") for m in data.get("models", []) if m.get("name")]}
+
+    if row.provider_type == "openai":
+        base_url = row.base_url or "https://api.openai.com/v1"
+        key = await _resolve_api_key(row)
+        if not key:
+            raise HTTPException(status_code=400, detail="no api key configured")
+        headers = {"Authorization": f"Bearer {key}"}
+        if row.config and row.config.get("organization"):
+            headers["OpenAI-Organization"] = row.config["organization"]
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(f"{base_url.rstrip('/')}/models", headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        return {"models": [m.get("id") for m in data.get("data", []) if m.get("id")]}
+
+    raise HTTPException(status_code=400, detail=f"unsupported provider_type: {row.provider_type}")

--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -283,11 +283,14 @@ async def test_provider(provider_id: str, db: Session = Depends(get_db_session))
             if not key:
                 raise RuntimeError("no api key configured")
             try:
-                from anthropic import Anthropic
+                from anthropic import AsyncAnthropic
             except ImportError as exc:
                 raise RuntimeError("anthropic SDK not installed") from exc
-            client = Anthropic(api_key=key, timeout=15.0)
-            client.messages.create(
+            # Must use AsyncAnthropic (not Anthropic) — this endpoint is
+            # async and the sync client would block the FastAPI event loop
+            # for up to the full timeout on an invalid key or slow network.
+            client = AsyncAnthropic(api_key=key, timeout=15.0)
+            await client.messages.create(
                 model=row.default_model,
                 max_tokens=1,
                 messages=[{"role": "user", "content": "ping"}],

--- a/backend/main.py
+++ b/backend/main.py
@@ -44,6 +44,7 @@ from api import (
     workflows_router,
     reasoning_router,
     skills_router,
+    llm_providers_router,
 )
 from api.local_services import router as local_services_router
 from api.integrations_compatibility import router as compatibility_router
@@ -189,6 +190,7 @@ app.include_router(mcp_router, prefix="/api/mcp", tags=["mcp"])
 app.include_router(claude_router, prefix="/api/claude", tags=["claude"], dependencies=[Depends(rate_limit_dependency)])
 app.include_router(reasoning_router, prefix="/api/reasoning", tags=["reasoning"])
 app.include_router(config_router, prefix="/api/config", tags=["config"])
+app.include_router(llm_providers_router, prefix="/api/llm/providers", tags=["llm-providers"])
 app.include_router(attack_router, prefix="/api/attack", tags=["attack"])
 app.include_router(custom_agents_router, prefix="/api", tags=["custom-agents"])
 app.include_router(agents_router, prefix="/api/agents", tags=["agents"])

--- a/daemon/agent_runner.py
+++ b/daemon/agent_runner.py
@@ -28,6 +28,10 @@ try:
 except Exception:
     _tracer = None  # type: ignore[assignment]
 
+# TODO(#89): Sonnet price constants assume Anthropic. With multi-provider
+# support (#88) landing, cost tracking should resolve per-provider rates
+# from a model registry instead of a single global constant. Update
+# together with the per-agent model assignment work in #89.
 SONNET_INPUT_COST = 3.0 / 1_000_000
 SONNET_OUTPUT_COST = 15.0 / 1_000_000
 

--- a/database/connection.py
+++ b/database/connection.py
@@ -23,6 +23,7 @@ from database.models import (
     CaseClosureInfo, CaseEscalation, CaseAuditLog,
     User, Role, Investigation, InvestigationLog, LLMInteractionLog,
     SharedIOC, CaseNotification, CustomAgent, CustomWorkflow, Skill,
+    LLMProviderConfig,
 )
 
 logger = logging.getLogger(__name__)

--- a/database/init/09_llm_providers.sql
+++ b/database/init/09_llm_providers.sql
@@ -1,0 +1,75 @@
+-- LLM Provider Configuration Tables
+-- Tracks multi-provider LLM configuration (Anthropic, OpenAI, Ollama, ...).
+-- API keys are NOT stored here; api_key_ref points to a secrets_manager key.
+
+-- ============================================================================
+-- LLM Provider Configs Table
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS llm_provider_configs (
+    provider_id VARCHAR(64) PRIMARY KEY,
+    provider_type VARCHAR(32) NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    base_url VARCHAR(500),
+    api_key_ref VARCHAR(200),
+    default_model VARCHAR(200) NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    config JSONB NOT NULL DEFAULT '{}'::jsonb,
+    last_test_at TIMESTAMP,
+    last_test_success BOOLEAN,
+    last_error TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_llm_provider_type ON llm_provider_configs(provider_type);
+CREATE INDEX IF NOT EXISTS idx_llm_provider_active ON llm_provider_configs(is_active);
+
+-- Only one default provider per provider_type
+CREATE UNIQUE INDEX IF NOT EXISTS llm_provider_default_per_type
+    ON llm_provider_configs(provider_type)
+    WHERE is_default = TRUE;
+
+-- Update timestamp trigger
+CREATE OR REPLACE FUNCTION update_llm_provider_configs_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_llm_provider_configs_updated_at ON llm_provider_configs;
+CREATE TRIGGER trigger_llm_provider_configs_updated_at
+    BEFORE UPDATE ON llm_provider_configs
+    FOR EACH ROW
+    EXECUTE FUNCTION update_llm_provider_configs_timestamp();
+
+COMMENT ON TABLE llm_provider_configs IS 'LLM provider configuration (non-sensitive; keys in secrets_manager)';
+COMMENT ON COLUMN llm_provider_configs.provider_type IS 'anthropic | openai | ollama';
+COMMENT ON COLUMN llm_provider_configs.api_key_ref IS 'Secret name in secrets_manager (never the key itself)';
+COMMENT ON COLUMN llm_provider_configs.config IS 'Provider-specific extras (e.g., openai organization, ollama pull policy)';
+
+-- ============================================================================
+-- Seed default Anthropic row to preserve existing behavior
+-- ============================================================================
+INSERT INTO llm_provider_configs (
+    provider_id, provider_type, name, base_url, api_key_ref,
+    default_model, is_active, is_default, config
+) VALUES (
+    'anthropic-default',
+    'anthropic',
+    'Anthropic (default)',
+    NULL,
+    'CLAUDE_API_KEY',
+    'claude-sonnet-4-5-20250929',
+    TRUE,
+    TRUE,
+    '{}'::jsonb
+) ON CONFLICT (provider_id) DO NOTHING;
+
+-- ============================================================================
+-- Grant Permissions
+-- ============================================================================
+GRANT SELECT, INSERT, UPDATE, DELETE ON llm_provider_configs TO deeptempo;

--- a/database/models.py
+++ b/database/models.py
@@ -2407,3 +2407,56 @@ class CustomAgent(Base):
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None,
         }
+
+
+class LLMProviderConfig(Base):
+    """LLM provider configuration (Anthropic, OpenAI, Ollama, ...).
+
+    Keys are not stored here — `api_key_ref` points to a secrets_manager key.
+    See database/init/09_llm_providers.sql for the table definition.
+    """
+
+    __tablename__ = 'llm_provider_configs'
+
+    provider_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    provider_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    base_url: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
+    api_key_ref: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    default_model: Mapped[str] = mapped_column(String(200), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    last_test_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    last_test_success: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, server_default='now()'
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, server_default='now()'
+    )
+
+    __table_args__ = (
+        Index('idx_llm_provider_type', 'provider_type'),
+        Index('idx_llm_provider_active', 'is_active'),
+    )
+
+    def to_dict(self, include_secrets: bool = False) -> dict:
+        return {
+            'provider_id': self.provider_id,
+            'provider_type': self.provider_type,
+            'name': self.name,
+            'base_url': self.base_url,
+            'api_key_ref': self.api_key_ref if include_secrets else None,
+            'has_api_key': bool(self.api_key_ref),
+            'default_model': self.default_model,
+            'is_active': self.is_active,
+            'is_default': self.is_default,
+            'config': self.config or {},
+            'last_test_at': self.last_test_at.isoformat() if self.last_test_at else None,
+            'last_test_success': self.last_test_success,
+            'last_error': self.last_error,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/database/models.py
+++ b/database/models.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
     Boolean,
     ARRAY,
     Numeric,
+    text,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -2440,6 +2441,15 @@ class LLMProviderConfig(Base):
     __table_args__ = (
         Index('idx_llm_provider_type', 'provider_type'),
         Index('idx_llm_provider_active', 'is_active'),
+        # Partial unique index — enforces "one default per provider_type"
+        # for non-Docker deployments too (Base.metadata.create_all path).
+        # Mirrors the SQL in database/init/07_llm_providers.sql.
+        Index(
+            'llm_provider_default_per_type',
+            'provider_type',
+            unique=True,
+            postgresql_where=text('is_default = TRUE'),
+        ),
     )
 
     def to_dict(self, include_secrets: bool = False) -> dict:

--- a/docker/bifrost/README.md
+++ b/docker/bifrost/README.md
@@ -1,0 +1,36 @@
+# Bifrost Gateway (Sidecar)
+
+[Bifrost](https://github.com/maximhq/bifrost) is a compiled Go binary that exposes a unified OpenAI-format API and translates requests to Anthropic, OpenAI, Ollama, and other providers. Vigil uses it so we don't need to write and maintain a per-provider abstraction in Python for every supported backend.
+
+## How Vigil uses Bifrost
+
+- **Non-Anthropic traffic** (Ollama, OpenAI) is sent as OpenAI-format chat completions to `BIFROST_URL` (default `http://bifrost:8080`). Bifrost handles the provider-specific translation.
+- **Anthropic + extended thinking** bypasses Bifrost and goes directly through the `anthropic` Python SDK in `services/claude_service.py`. This is because extended thinking and Anthropic's native prompt caching don't round-trip cleanly through Bifrost's OpenAI-format surface today.
+- The routing decision lives in `services/llm_router.py` (`_select_path`).
+
+## Starting Bifrost
+
+Bifrost runs under the `bifrost` docker-compose profile so a plain `docker compose up` doesn't pull the image:
+
+```bash
+docker compose --profile bifrost up postgres redis bifrost backend llm-worker
+```
+
+Health check: `curl http://localhost:8080/health`.
+
+## Configuration
+
+`docker/bifrost/config.json` declares the providers and the models Bifrost will expose. API keys are **not** written into the config file — they are injected as environment variables at container start time (`env.ANTHROPIC_API_KEY`, `env.OPENAI_API_KEY`, `env.OLLAMA_URL`). Vigil's backend reads per-provider keys from its own `secrets_manager`; what's in Bifrost's env are only the fallback/default keys used when a provider row in `llm_provider_configs` doesn't override them.
+
+To add another provider or model, edit `config.json` and restart the `bifrost` service. See the upstream Bifrost documentation at https://github.com/maximhq/bifrost for the full config schema.
+
+## Tool-use support matrix
+
+| Provider | Basic chat | Tool calling | Streaming | Thinking / caching |
+|---|---|---|---|---|
+| Anthropic via Bifrost | ✅ | ⚠️ limited | ✅ | ❌ (use direct SDK) |
+| Anthropic direct SDK | ✅ | ✅ | ✅ | ✅ |
+| OpenAI via Bifrost | ✅ | ✅ | ✅ | n/a |
+| Ollama via Bifrost | ✅ | ⚠️ model-dependent (Llama 3.1+, Mistral) | ✅ | n/a |
+
+For anything that needs Anthropic-native features, keep `provider_id=anthropic-default` and `enable_thinking=true` — the router will pick the direct SDK path.

--- a/docker/bifrost/config.json
+++ b/docker/bifrost/config.json
@@ -1,0 +1,38 @@
+{
+  "providers": {
+    "anthropic": {
+      "keys": [
+        {
+          "value": "env.ANTHROPIC_API_KEY",
+          "models": [
+            "claude-sonnet-4-20250514",
+            "claude-sonnet-4-5-20250929",
+            "claude-opus-4-20250514"
+          ]
+        }
+      ]
+    },
+    "openai": {
+      "keys": [
+        {
+          "value": "env.OPENAI_API_KEY",
+          "models": [
+            "gpt-4",
+            "gpt-4-turbo",
+            "gpt-4o",
+            "gpt-4o-mini"
+          ]
+        }
+      ]
+    },
+    "ollama": {
+      "base_url": "env.OLLAMA_URL",
+      "models": [
+        "llama3.1:8b",
+        "llama3.1:70b",
+        "mistral:latest",
+        "qwen2.5:latest"
+      ]
+    }
+  }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -52,6 +52,9 @@ services:
     environment:
       - DATABASE_URL=postgresql://deeptempo:${POSTGRES_PASSWORD:-deeptempo_secure_password_change_me}@postgres:5432/deeptempo_soc
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OLLAMA_URL=${OLLAMA_URL:-http://host.docker.internal:11434}
+      - BIFROST_URL=${BIFROST_URL:-http://bifrost:8080}
       - REDIS_URL=redis://redis:6379/0
       - PYTHONUNBUFFERED=1
     ports:
@@ -76,6 +79,9 @@ services:
       - DATABASE_URL=postgresql://deeptempo:${POSTGRES_PASSWORD:-deeptempo_secure_password_change_me}@postgres:5432/deeptempo_soc
       # AI
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OLLAMA_URL=${OLLAMA_URL:-http://host.docker.internal:11434}
+      - BIFROST_URL=${BIFROST_URL:-http://bifrost:8080}
       # Redis (LLM queue)
       - REDIS_URL=redis://redis:6379/0
       # Polling intervals (seconds)
@@ -155,6 +161,9 @@ services:
     environment:
       - DATABASE_URL=postgresql://deeptempo:${POSTGRES_PASSWORD:-deeptempo_secure_password_change_me}@postgres:5432/deeptempo_soc
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OLLAMA_URL=${OLLAMA_URL:-http://host.docker.internal:11434}
+      - BIFROST_URL=${BIFROST_URL:-http://bifrost:8080}
       - REDIS_URL=redis://redis:6379/0
       - PYTHONUNBUFFERED=1
     depends_on:
@@ -165,6 +174,32 @@ services:
     restart: unless-stopped
     networks:
       - deeptempo-network
+
+  # ─── Multi-provider LLM gateway (opt-in: --profile bifrost) ───────────────
+  # Bifrost exposes a unified OpenAI-format API that translates to
+  # OpenAI/Anthropic/Ollama/etc. Vigil routes non-Anthropic calls here.
+  # Anthropic + extended thinking bypasses Bifrost and hits the SDK directly.
+  bifrost:
+    image: maximhq/bifrost:latest
+    container_name: deeptempo-bifrost
+    ports:
+      - "8080:8080"
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OLLAMA_URL=${OLLAMA_URL:-http://host.docker.internal:11434}
+    volumes:
+      - ./bifrost/config.json:/app/config.json:ro
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - deeptempo-network
+    profiles:
+      - bifrost
 
   # PgAdmin for database management (optional, can be commented out in production)
   pgadmin:

--- a/env.example
+++ b/env.example
@@ -460,3 +460,27 @@ KAFKA_SASL_PASSWORD=""
 KAFKA_SSL_CA_LOCATION=""
 KAFKA_MAX_POLL_RECORDS="500"
 KAFKA_SESSION_TIMEOUT_MS="30000"
+
+# =============================================================================
+# Multi-Provider LLM (Issue #88)
+# =============================================================================
+# Bifrost sidecar — unified OpenAI-format gateway for OpenAI/Ollama/etc.
+# Runs under the `bifrost` docker-compose profile; Anthropic thinking calls
+# bypass Bifrost and hit the SDK directly.
+BIFROST_ENABLED="false"
+BIFROST_URL="http://bifrost:8080"
+
+# Ollama (local or remote). base_url and per-provider config are also stored
+# per-row in llm_provider_configs; these are defaults for first-boot seeding.
+OLLAMA_ENABLED="false"
+OLLAMA_URL="http://localhost:11434"
+OLLAMA_DEFAULT_MODEL="llama3.1:70b"
+
+# OpenAI (direct API or OpenAI-compatible endpoint)
+OPENAI_ENABLED="false"
+OPENAI_API_KEY=""
+OPENAI_BASE_URL="https://api.openai.com/v1"
+OPENAI_ORGANIZATION=""
+
+# Default provider for new LLM requests when no provider_id is supplied
+DEFAULT_LLM_PROVIDER="anthropic"

--- a/frontend/src/components/settings/LLMProviderDialog.tsx
+++ b/frontend/src/components/settings/LLMProviderDialog.tsx
@@ -1,0 +1,285 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Stepper,
+  Step,
+  StepLabel,
+  Box,
+  TextField,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  FormControl,
+  FormLabel,
+  Alert,
+  CircularProgress,
+  Select,
+  MenuItem,
+  InputLabel,
+  Typography,
+} from '@mui/material'
+import { llmProviderApi, LLMProvider, LLMProviderCreate } from '../../services/api'
+
+type ProviderType = 'anthropic' | 'openai' | 'ollama'
+
+interface Props {
+  existing: LLMProvider | null
+  onClose: () => void
+  onSaved: () => void
+  onError: (msg: string) => void
+}
+
+const STEPS = ['Provider', 'Connection', 'Test & Save']
+
+const DEFAULT_BASE_URLS: Record<ProviderType, string> = {
+  anthropic: '',
+  openai: 'https://api.openai.com/v1',
+  ollama: 'http://localhost:11434',
+}
+
+const DEFAULT_MODEL: Record<ProviderType, string> = {
+  anthropic: 'claude-sonnet-4-5-20250929',
+  openai: 'gpt-4o-mini',
+  ollama: 'llama3.1:8b',
+}
+
+export default function LLMProviderDialog({ existing, onClose, onSaved, onError }: Props) {
+  const editing = !!existing
+  const [step, setStep] = useState(editing ? 1 : 0)
+
+  const [providerType, setProviderType] = useState<ProviderType>(
+    (existing?.provider_type as ProviderType) ?? 'ollama',
+  )
+  const [name, setName] = useState(existing?.name ?? '')
+  const [baseUrl, setBaseUrl] = useState(existing?.base_url ?? '')
+  const [apiKey, setApiKey] = useState('')
+  const [organization, setOrganization] = useState(existing?.config?.organization ?? '')
+  const [defaultModel, setDefaultModel] = useState(existing?.default_model ?? '')
+  const [isDefault, setIsDefault] = useState(existing?.is_default ?? false)
+
+  // Step 2 state
+  const [testing, setTesting] = useState(false)
+  const [testError, setTestError] = useState<string | null>(null)
+  const [tested, setTested] = useState(false)
+  const [availableModels, setAvailableModels] = useState<string[]>([])
+
+  // First-load helper when switching provider type
+  const selectProviderType = (t: ProviderType) => {
+    setProviderType(t)
+    if (!baseUrl) setBaseUrl(DEFAULT_BASE_URLS[t])
+    if (!defaultModel) setDefaultModel(DEFAULT_MODEL[t])
+  }
+
+  const saveDraftAndTest = async (): Promise<string | null> => {
+    // Upsert the provider so we can call /test and /models against it
+    setTesting(true)
+    setTestError(null)
+    try {
+      let providerId = existing?.provider_id
+      if (!editing) {
+        const payload: LLMProviderCreate = {
+          provider_type: providerType,
+          name: name || `${providerType} provider`,
+          base_url: baseUrl || undefined,
+          api_key: apiKey || undefined,
+          default_model: defaultModel || DEFAULT_MODEL[providerType],
+          is_active: true,
+          is_default: false,
+          config: organization ? { organization } : {},
+        }
+        const resp = await llmProviderApi.create(payload)
+        providerId = resp.data.provider_id
+      } else if (providerId) {
+        await llmProviderApi.update(providerId, {
+          name,
+          base_url: baseUrl || undefined,
+          api_key: apiKey || undefined,
+          default_model: defaultModel,
+          config: organization ? { organization } : {},
+        })
+      }
+      if (!providerId) throw new Error('Failed to create provider')
+
+      const testResp = await llmProviderApi.test(providerId)
+      if (!testResp.data.success) {
+        setTestError(testResp.data.error || 'Connection test failed')
+        return providerId
+      }
+      const modelsResp = await llmProviderApi.listModels(providerId)
+      setAvailableModels(modelsResp.data.models || [])
+      setTested(true)
+      return providerId
+    } catch (e: any) {
+      setTestError(e?.response?.data?.detail || e?.message || 'Test failed')
+      return null
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const finalSave = async () => {
+    try {
+      const providerId = existing?.provider_id
+      if (!providerId) throw new Error('No provider id')
+      if (isDefault || defaultModel !== existing?.default_model) {
+        await llmProviderApi.update(providerId, {
+          default_model: defaultModel,
+          is_default: isDefault || undefined,
+        })
+      }
+      onSaved()
+    } catch (e: any) {
+      onError(e?.response?.data?.detail || 'Save failed')
+    }
+  }
+
+  const renderStep0 = () => (
+    <FormControl>
+      <FormLabel>Provider type</FormLabel>
+      <RadioGroup
+        value={providerType}
+        onChange={(e) => selectProviderType(e.target.value as ProviderType)}
+      >
+        <FormControlLabel value="ollama" control={<Radio />} label="Ollama (local or remote)" />
+        <FormControlLabel value="openai" control={<Radio />} label="OpenAI (or OpenAI-compatible)" />
+        <FormControlLabel value="anthropic" control={<Radio />} label="Anthropic (additional account)" />
+      </RadioGroup>
+    </FormControl>
+  )
+
+  const renderStep1 = () => (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <TextField
+        label="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder={`My ${providerType}`}
+        fullWidth
+      />
+      {providerType !== 'anthropic' && (
+        <TextField
+          label="Base URL"
+          value={baseUrl}
+          onChange={(e) => setBaseUrl(e.target.value)}
+          placeholder={DEFAULT_BASE_URLS[providerType]}
+          fullWidth
+          helperText={
+            providerType === 'ollama'
+              ? 'Ollama server URL (e.g. http://localhost:11434)'
+              : 'OpenAI-compatible endpoint'
+          }
+        />
+      )}
+      {providerType !== 'ollama' && (
+        <TextField
+          label="API Key"
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder={editing ? 'Leave blank to keep existing key' : ''}
+          fullWidth
+        />
+      )}
+      {providerType === 'openai' && (
+        <TextField
+          label="Organization (optional)"
+          value={organization}
+          onChange={(e) => setOrganization(e.target.value)}
+          fullWidth
+        />
+      )}
+      <TextField
+        label="Default model"
+        value={defaultModel}
+        onChange={(e) => setDefaultModel(e.target.value)}
+        placeholder={DEFAULT_MODEL[providerType]}
+        helperText="You can change this after a successful connection test."
+        fullWidth
+      />
+    </Box>
+  )
+
+  const renderStep2 = () => (
+    <Box>
+      {testing && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <CircularProgress size={20} />
+          <Typography>Testing connection…</Typography>
+        </Box>
+      )}
+      {testError && <Alert severity="error">{testError}</Alert>}
+      {tested && (
+        <>
+          <Alert severity="success" sx={{ mb: 2 }}>Connection OK</Alert>
+          {availableModels.length > 0 && (
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <InputLabel>Model</InputLabel>
+              <Select
+                label="Model"
+                value={defaultModel}
+                onChange={(e) => setDefaultModel(e.target.value as string)}
+              >
+                {availableModels.map((m) => (
+                  <MenuItem key={m} value={m}>{m}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          <FormControlLabel
+            control={<Radio checked={isDefault} onClick={() => setIsDefault(!isDefault)} />}
+            label="Set as default for this provider type"
+          />
+        </>
+      )}
+    </Box>
+  )
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{editing ? 'Edit provider' : 'Add LLM provider'}</DialogTitle>
+      <DialogContent>
+        <Stepper activeStep={step} sx={{ mb: 3 }}>
+          {STEPS.map((s) => (
+            <Step key={s}><StepLabel>{s}</StepLabel></Step>
+          ))}
+        </Stepper>
+        {step === 0 && renderStep0()}
+        {step === 1 && renderStep1()}
+        {step === 2 && renderStep2()}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        {step > 0 && !testing && (
+          <Button onClick={() => setStep(step - 1)}>Back</Button>
+        )}
+        {step === 0 && (
+          <Button variant="contained" onClick={() => setStep(1)}>Next</Button>
+        )}
+        {step === 1 && (
+          <Button
+            variant="contained"
+            onClick={async () => {
+              setStep(2)
+              await saveDraftAndTest()
+            }}
+          >
+            Test &amp; continue
+          </Button>
+        )}
+        {step === 2 && (
+          <Button
+            variant="contained"
+            disabled={!tested}
+            onClick={finalSave}
+          >
+            Save
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/settings/LLMProviderDialog.tsx
+++ b/frontend/src/components/settings/LLMProviderDialog.tsx
@@ -61,6 +61,15 @@ export default function LLMProviderDialog({ existing, onClose, onSaved, onError 
   const [defaultModel, setDefaultModel] = useState(existing?.default_model ?? '')
   const [isDefault, setIsDefault] = useState(existing?.is_default ?? false)
 
+  // Tracks the provider id after it's been created (or for edits, the
+  // existing one). This is what finalSave and retry-of-test both need;
+  // if we relied on `existing?.provider_id` we'd lose the id in the new-
+  // provider flow, and retrying the test after a failure would re-POST
+  // the same slug and 409.
+  const [draftProviderId, setDraftProviderId] = useState<string | null>(
+    existing?.provider_id ?? null,
+  )
+
   // Step 2 state
   const [testing, setTesting] = useState(false)
   const [testError, setTestError] = useState<string | null>(null)
@@ -75,12 +84,15 @@ export default function LLMProviderDialog({ existing, onClose, onSaved, onError 
   }
 
   const saveDraftAndTest = async (): Promise<string | null> => {
-    // Upsert the provider so we can call /test and /models against it
+    // Upsert the provider so we can call /test and /models against it.
+    // On retry (user fixed settings and clicked Test again), we update the
+    // draft row we already created instead of re-POSTing and hitting 409.
     setTesting(true)
     setTestError(null)
     try {
-      let providerId = existing?.provider_id
-      if (!editing) {
+      let providerId = draftProviderId
+      const alreadyPersisted = editing || !!providerId
+      if (!alreadyPersisted) {
         const payload: LLMProviderCreate = {
           provider_type: providerType,
           name: name || `${providerType} provider`,
@@ -93,6 +105,7 @@ export default function LLMProviderDialog({ existing, onClose, onSaved, onError 
         }
         const resp = await llmProviderApi.create(payload)
         providerId = resp.data.provider_id
+        setDraftProviderId(providerId)
       } else if (providerId) {
         await llmProviderApi.update(providerId, {
           name,
@@ -123,7 +136,7 @@ export default function LLMProviderDialog({ existing, onClose, onSaved, onError 
 
   const finalSave = async () => {
     try {
-      const providerId = existing?.provider_id
+      const providerId = draftProviderId ?? existing?.provider_id
       if (!providerId) throw new Error('No provider id')
       if (isDefault || defaultModel !== existing?.default_model) {
         await llmProviderApi.update(providerId, {

--- a/frontend/src/components/settings/LLMProvidersTab.tsx
+++ b/frontend/src/components/settings/LLMProvidersTab.tsx
@@ -1,0 +1,234 @@
+import { useState, useEffect } from 'react'
+import {
+  Box,
+  Typography,
+  Button,
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton,
+  Tooltip,
+  CircularProgress,
+} from '@mui/material'
+import {
+  Add as AddIcon,
+  Science as TestIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+  Star as DefaultIcon,
+  StarBorder as NotDefaultIcon,
+} from '@mui/icons-material'
+import { llmProviderApi, LLMProvider } from '../../services/api'
+import LLMProviderDialog from './LLMProviderDialog'
+
+interface Props {
+  setMessage: (m: { type: 'success' | 'error'; text: string } | null) => void
+}
+
+export default function LLMProvidersTab({ setMessage }: Props) {
+  const [providers, setProviders] = useState<LLMProvider[]>([])
+  const [loading, setLoading] = useState(false)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editing, setEditing] = useState<LLMProvider | null>(null)
+  const [testingId, setTestingId] = useState<string | null>(null)
+
+  const load = async () => {
+    setLoading(true)
+    try {
+      const resp = await llmProviderApi.list()
+      setProviders(resp.data)
+    } catch (e: any) {
+      setMessage({ type: 'error', text: e?.response?.data?.detail || 'Failed to load providers' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const handleTest = async (id: string) => {
+    setTestingId(id)
+    try {
+      const resp = await llmProviderApi.test(id)
+      if (resp.data.success) {
+        setMessage({ type: 'success', text: `Connection OK for ${id}` })
+      } else {
+        setMessage({ type: 'error', text: `Test failed: ${resp.data.error || 'unknown error'}` })
+      }
+      await load()
+    } catch (e: any) {
+      setMessage({ type: 'error', text: e?.response?.data?.detail || 'Test request failed' })
+    } finally {
+      setTestingId(null)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm(`Delete provider "${id}"? This also removes its stored API key.`)) return
+    try {
+      await llmProviderApi.remove(id)
+      setMessage({ type: 'success', text: `Deleted ${id}` })
+      await load()
+    } catch (e: any) {
+      setMessage({ type: 'error', text: e?.response?.data?.detail || 'Delete failed' })
+    }
+  }
+
+  const handleSetDefault = async (id: string) => {
+    try {
+      await llmProviderApi.setDefault(id)
+      setMessage({ type: 'success', text: `Default set to ${id}` })
+      await load()
+    } catch (e: any) {
+      setMessage({ type: 'error', text: e?.response?.data?.detail || 'Failed to set default' })
+    }
+  }
+
+  const statusChip = (p: LLMProvider) => {
+    if (!p.is_active) return <Chip size="small" label="Inactive" />
+    if (p.last_test_success === true) return <Chip size="small" color="success" label="Active" />
+    if (p.last_test_success === false) return <Chip size="small" color="error" label="Error" />
+    return <Chip size="small" color="default" label="Untested" />
+  }
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, flexGrow: 1 }}>
+          LLM Providers
+        </Typography>
+        <Button
+          startIcon={<AddIcon />}
+          variant="contained"
+          onClick={() => {
+            setEditing(null)
+            setDialogOpen(true)
+          }}
+        >
+          Add Provider
+        </Button>
+      </Box>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
+        Configure additional Anthropic, OpenAI, or Ollama providers. Non-Anthropic traffic
+        is routed through the Bifrost gateway; Anthropic with extended thinking uses the SDK directly.
+      </Typography>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={24} />
+        </Box>
+      ) : (
+        <TableContainer component={Paper} variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 600 }}>Name</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Type</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Model</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Default</TableCell>
+                <TableCell sx={{ fontWeight: 600 }} align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {providers.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center" sx={{ py: 3, color: 'text.secondary' }}>
+                    No providers configured.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                providers.map((p) => (
+                  <TableRow key={p.provider_id} hover>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ fontWeight: 500 }}>{p.name}</Typography>
+                      <Typography variant="caption" color="text.secondary">{p.provider_id}</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Chip size="small" label={p.provider_type} />
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                        {p.default_model}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{statusChip(p)}</TableCell>
+                    <TableCell>
+                      <Tooltip title={p.is_default ? 'Default for this provider type' : 'Set as default'}>
+                        <IconButton
+                          size="small"
+                          onClick={() => !p.is_default && handleSetDefault(p.provider_id)}
+                          color={p.is_default ? 'primary' : 'default'}
+                        >
+                          {p.is_default ? <DefaultIcon fontSize="small" /> : <NotDefaultIcon fontSize="small" />}
+                        </IconButton>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Tooltip title="Test connection">
+                        <span>
+                          <IconButton
+                            size="small"
+                            disabled={testingId === p.provider_id}
+                            onClick={() => handleTest(p.provider_id)}
+                          >
+                            {testingId === p.provider_id
+                              ? <CircularProgress size={16} />
+                              : <TestIcon fontSize="small" />}
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                      <Tooltip title="Edit">
+                        <IconButton
+                          size="small"
+                          onClick={() => {
+                            setEditing(p)
+                            setDialogOpen(true)
+                          }}
+                        >
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Delete">
+                        <IconButton
+                          size="small"
+                          onClick={() => handleDelete(p.provider_id)}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      {dialogOpen && (
+        <LLMProviderDialog
+          existing={editing}
+          onClose={() => {
+            setDialogOpen(false)
+            setEditing(null)
+          }}
+          onSaved={async () => {
+            setDialogOpen(false)
+            setEditing(null)
+            setMessage({ type: 'success', text: 'Provider saved' })
+            await load()
+          }}
+          onError={(msg) => setMessage({ type: 'error', text: msg })}
+        />
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/components/settings/__tests__/LLMProvidersTab.test.tsx
+++ b/frontend/src/components/settings/__tests__/LLMProvidersTab.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+vi.mock('../../../services/api', () => ({
+  llmProviderApi: {
+    list: vi.fn(),
+    test: vi.fn(),
+    remove: vi.fn(),
+    setDefault: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    listModels: vi.fn(),
+  },
+}))
+
+import LLMProvidersTab from '../LLMProvidersTab'
+import { llmProviderApi } from '../../../services/api'
+
+const providers = [
+  {
+    provider_id: 'anthropic-default',
+    provider_type: 'anthropic',
+    name: 'Anthropic (default)',
+    base_url: null,
+    has_api_key: true,
+    default_model: 'claude-sonnet-4-5-20250929',
+    is_active: true,
+    is_default: true,
+    config: {},
+    last_test_at: null,
+    last_test_success: true,
+    last_error: null,
+    created_at: null,
+    updated_at: null,
+  },
+  {
+    provider_id: 'ollama-local',
+    provider_type: 'ollama',
+    name: 'Local Ollama',
+    base_url: 'http://localhost:11434',
+    has_api_key: false,
+    default_model: 'llama3.1:8b',
+    is_active: true,
+    is_default: false,
+    config: {},
+    last_test_at: null,
+    last_test_success: null,
+    last_error: null,
+    created_at: null,
+    updated_at: null,
+  },
+  {
+    provider_id: 'openai-prod',
+    provider_type: 'openai',
+    name: 'OpenAI',
+    base_url: 'https://api.openai.com/v1',
+    has_api_key: true,
+    default_model: 'gpt-4o-mini',
+    is_active: true,
+    is_default: false,
+    config: {},
+    last_test_at: null,
+    last_test_success: false,
+    last_error: 'bad key',
+    created_at: null,
+    updated_at: null,
+  },
+]
+
+describe('LLMProvidersTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(llmProviderApi.list as any).mockResolvedValue({ data: providers })
+    ;(llmProviderApi.test as any).mockResolvedValue({
+      data: { success: true, provider_id: 'ollama-local', error: null },
+    })
+  })
+
+  it('renders each provider with status chips and default badge', async () => {
+    render(<LLMProvidersTab setMessage={() => {}} />)
+
+    await waitFor(() => expect(llmProviderApi.list).toHaveBeenCalled())
+
+    expect(await screen.findByText('Anthropic (default)')).toBeInTheDocument()
+    expect(screen.getByText('Local Ollama')).toBeInTheDocument()
+    expect(screen.getByText('OpenAI')).toBeInTheDocument()
+
+    // Default chip (filled star) should appear for anthropic-default only
+    const defaultButtons = screen.getAllByLabelText(/default/i)
+    expect(defaultButtons.length).toBeGreaterThan(0)
+
+    // One provider reports an error, another is active, another untested
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText('Untested')).toBeInTheDocument()
+    expect(screen.getByText('Error')).toBeInTheDocument()
+  })
+
+  it('invokes the test API when the beaker button is clicked', async () => {
+    render(<LLMProvidersTab setMessage={() => {}} />)
+    await screen.findByText('Local Ollama')
+
+    // The beaker/test icons are IconButtons with title "Test connection"
+    const testButtons = await screen.findAllByLabelText(/test connection/i)
+    fireEvent.click(testButtons[1]) // click the second (ollama) test button
+
+    await waitFor(() =>
+      expect(llmProviderApi.test).toHaveBeenCalledWith('ollama-local')
+    )
+  })
+})

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -67,6 +67,7 @@ import DetectionRulesTab from '../components/settings/DetectionRulesTab'
 import AutoInvestigateTab from '../components/settings/AutoInvestigateTab'
 import SkillsTab from '../components/settings/SkillsTab'
 import KafkaTab from '../components/settings/KafkaTab'
+import LLMProvidersTab from '../components/settings/LLMProvidersTab'
 
 interface TabPanelProps {
   children?: React.ReactNode
@@ -92,7 +93,7 @@ const IS_DEV_MODE = import.meta.env.VITE_DEV_MODE === 'true'
 
 // Define tabs — some are dev-only
 const TAB_DEFS: { key: string; label: string; devOnly: boolean }[] = [
-  { key: 'claude', label: 'Claude', devOnly: false },
+  { key: 'ai-config', label: 'AI Config', devOnly: false },
   { key: 's3', label: 'S3 Storage', devOnly: false },
   { key: 'integrations', label: 'Integrations / MCP', devOnly: false },
   { key: 'users', label: 'Users', devOnly: false },
@@ -118,6 +119,7 @@ export default function Settings() {
     map['github'] = map['integrations']
     map['postgresql'] = map['dev'] ?? map['integrations'] // postgresql now lives in dev tab
     map['detection-rules'] = map['integrations'] // detection rules now lives inside integrations tab
+    map['claude'] = map['ai-config'] // legacy alias — "Claude" tab renamed to "AI Config" in #88/#89
     return map
   }, [visibleTabs])
 
@@ -864,16 +866,22 @@ export default function Settings() {
   // ---- Tab content renderers ----
   const renderTabContent = (tabKey: string, idx: number) => {
     switch (tabKey) {
-      case 'claude':
+      case 'ai-config':
         return (
           <TabPanel value={currentTab} index={idx} key={tabKey}>
-            <Box sx={{ maxWidth: 500 }}>
-              <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>Claude API</Typography>
+            <Box sx={{ maxWidth: 900 }}>
+              <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>Default Anthropic API Key</Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                Used by the built-in Anthropic provider (<code>anthropic-default</code>). For Ollama / OpenAI / custom Anthropic accounts, add a provider below.
+              </Typography>
               <Box sx={{ mb: 2 }}>
                 <Chip label={claudeConfig.configured ? 'API key configured' : 'API key not configured'} color={claudeConfig.configured ? 'success' : 'default'} size="small" icon={claudeConfig.configured ? <CheckIcon /> : undefined} />
               </Box>
               <TextField fullWidth label="API Key" type="password" value={claudeConfig.api_key} onChange={(e) => setClaudeConfig({ ...claudeConfig, api_key: e.target.value })} sx={{ mb: 2 }} />
               <Button variant="contained" startIcon={<SaveIcon />} onClick={handleSaveClaude}>Save</Button>
+            </Box>
+            <Box sx={{ mt: 4 }}>
+              <LLMProvidersTab setMessage={setMessage} />
             </Box>
           </TabPanel>
         )

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -681,6 +681,62 @@ export const configApi = {
   }) => api.post('/config/orchestrator', data),
 }
 
+// LLM Provider API (GH #88 — multi-provider LLM config)
+export interface LLMProvider {
+  provider_id: string
+  provider_type: 'anthropic' | 'openai' | 'ollama'
+  name: string
+  base_url: string | null
+  has_api_key: boolean
+  default_model: string
+  is_active: boolean
+  is_default: boolean
+  config: Record<string, any>
+  last_test_at: string | null
+  last_test_success: boolean | null
+  last_error: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface LLMProviderCreate {
+  provider_id?: string
+  provider_type: 'anthropic' | 'openai' | 'ollama'
+  name: string
+  base_url?: string
+  api_key?: string
+  default_model: string
+  is_active?: boolean
+  is_default?: boolean
+  config?: Record<string, any>
+}
+
+export interface LLMProviderUpdate {
+  name?: string
+  base_url?: string
+  api_key?: string
+  default_model?: string
+  is_active?: boolean
+  is_default?: boolean
+  config?: Record<string, any>
+}
+
+export const llmProviderApi = {
+  list: () => api.get<LLMProvider[]>('/llm/providers/'),
+  create: (data: LLMProviderCreate) => api.post<LLMProvider>('/llm/providers/', data),
+  update: (providerId: string, data: LLMProviderUpdate) =>
+    api.put<LLMProvider>(`/llm/providers/${providerId}`, data),
+  remove: (providerId: string) => api.delete(`/llm/providers/${providerId}`),
+  test: (providerId: string) =>
+    api.post<{ success: boolean; provider_id: string; error: string | null }>(
+      `/llm/providers/${providerId}/test`,
+    ),
+  listModels: (providerId: string) =>
+    api.get<{ models: string[] }>(`/llm/providers/${providerId}/models`),
+  setDefault: (providerId: string) =>
+    api.post<LLMProvider>(`/llm/providers/${providerId}/set-default`),
+}
+
 // Ingestion API
 export const ingestionApi = {
   listS3Files: (prefix?: string) =>

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pyarrow>=15.0.0
 ijson>=3.2.0
 anthropic>=0.45.0
 claude-agent-sdk>=0.1.0
+openai>=1.40.0
 mempalace>=0.1.0
 chromadb>=0.5.0
 requests>=2.31.0

--- a/services/claude_service.py
+++ b/services/claude_service.py
@@ -69,6 +69,7 @@ class ClaudeService:
         thinking_budget: int = 10000,
         use_agent_sdk: bool = True,
         use_backend_tools: bool = False,
+        provider_api_key_ref: Optional[str] = None,
     ):
         """
         Initialize Claude service.
@@ -79,10 +80,14 @@ class ClaudeService:
             thinking_budget: Token budget for extended thinking (default: 10000)
             use_agent_sdk: Whether to use Claude Agent SDK for agentic workflows
             use_backend_tools: Whether to use backend function calling (bypasses MCP)
+            provider_api_key_ref: Optional secret-manager key for a non-default
+                Anthropic provider row (GH #88). When set, _load_api_key reads
+                this secret first before the legacy CLAUDE_API_KEY fallback chain.
         """
         self.client: Optional[Anthropic] = None
         self.async_client: Optional[AsyncAnthropic] = None
         self.api_key: Optional[str] = None
+        self.provider_api_key_ref = provider_api_key_ref
         self.use_mcp_tools = use_mcp_tools
         self.use_backend_tools = use_backend_tools
         self.mcp_tools: List[Dict] = []
@@ -277,11 +282,23 @@ You have comprehensive tools to manage ALL aspects of cases during investigation
 Your goal is to help SOC analysts work more efficiently by leveraging all available tools and integrations to provide comprehensive, accurate, and actionable security analysis. When investigating, you should automatically build out cases with all relevant findings, activities, timeline entries, and MITRE mappings as the investigation progresses."""
 
     def _load_api_key(self) -> bool:
-        """Load API key from secure storage."""
+        """Load API key from secure storage.
+
+        When ``provider_api_key_ref`` is set (GH #88), the secret named by
+        that ref is tried first. This lets LLMRouter instantiate ClaudeService
+        with a non-default Anthropic provider row. Falls back to the legacy
+        CLAUDE_API_KEY / ANTHROPIC_API_KEY chain for backward compatibility.
+        """
         try:
             # Use secrets manager with fallback to legacy names
+            provider_key = (
+                get_secret(self.provider_api_key_ref)
+                if self.provider_api_key_ref
+                else None
+            )
             self.api_key = (
-                get_secret("CLAUDE_API_KEY")
+                provider_key
+                or get_secret("CLAUDE_API_KEY")
                 or get_secret("ANTHROPIC_API_KEY")
                 or get_secret("claude_api_key")
                 or get_secret("anthropic_api_key")

--- a/services/llm_gateway.py
+++ b/services/llm_gateway.py
@@ -99,6 +99,9 @@ class LLMRequest:
     thinking_budget: int = 10000
     tools: Optional[List[Dict]] = None
     temperature: Optional[float] = None
+    # Multi-provider routing (GH #88). None means "use the default
+    # anthropic provider" which preserves pre-#88 behavior.
+    provider_id: Optional[str] = None
     extra_kwargs: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -158,6 +161,7 @@ class LLMGateway:
         model: str = "claude-sonnet-4-5-20250929",
         max_tokens: int = 2048,
         timeout: int = 90,
+        provider_id: Optional[str] = None,
     ) -> Optional[str]:
         """Enqueue a stateless triage call (highest priority)."""
         job = await self._pool.enqueue_job(
@@ -171,6 +175,7 @@ class LLMGateway:
             thinking_budget=0,
             tools=None,
             temperature=None,
+            provider_id=provider_id,
             traceparent=self._get_traceparent(),
             _queue_name=QUEUE_NAME,
         )
@@ -195,6 +200,7 @@ class LLMGateway:
         thinking_budget: int = 8000,
         tools: Optional[List[Dict]] = None,
         timeout: int = 180,
+        provider_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Enqueue an investigation LLM call (medium priority).
 
@@ -212,6 +218,7 @@ class LLMGateway:
             thinking_budget=thinking_budget,
             tools=tools,
             temperature=None,
+            provider_id=provider_id,
             traceparent=self._get_traceparent(),
             _queue_name=QUEUE_NAME,
         )
@@ -235,6 +242,7 @@ class LLMGateway:
         tools: Optional[List[Dict]] = None,
         timeout: int = 180,
         agent_id: Optional[str] = None,
+        provider_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Enqueue a multi-turn investigation call with explicit messages.
 
@@ -250,6 +258,7 @@ class LLMGateway:
             thinking_budget=thinking_budget,
             tools=tools,
             temperature=None,
+            provider_id=provider_id,
             traceparent=self._get_traceparent(),
             investigation_id=inv_id,
             agent_id=agent_id,
@@ -277,6 +286,7 @@ class LLMGateway:
         timeout: int = 120,
         agent_id: Optional[str] = None,
         investigation_id: Optional[str] = None,
+        provider_id: Optional[str] = None,
     ) -> Any:
         """Enqueue a UI chat call (normal priority)."""
         job = await self._pool.enqueue_job(
@@ -290,6 +300,7 @@ class LLMGateway:
             thinking_budget=thinking_budget,
             tools=None,
             temperature=None,
+            provider_id=provider_id,
             traceparent=self._get_traceparent(),
             agent_id=agent_id,
             investigation_id=investigation_id,
@@ -309,6 +320,7 @@ class LLMGateway:
         max_tokens: int = 2000,
         temperature: float = 0.3,
         timeout: int = 90,
+        provider_id: Optional[str] = None,
     ) -> Optional[str]:
         """Enqueue a background insights/analytics call (lowest priority)."""
         job = await self._pool.enqueue_job(
@@ -322,6 +334,7 @@ class LLMGateway:
             thinking_budget=0,
             tools=None,
             temperature=temperature,
+            provider_id=provider_id,
             traceparent=self._get_traceparent(),
             _queue_name=QUEUE_NAME,
         )

--- a/services/llm_router.py
+++ b/services/llm_router.py
@@ -1,0 +1,312 @@
+"""LLM router: decides whether a call goes through Bifrost or the direct SDK.
+
+Vigil's multi-provider support (GH #88) relies on Bifrost as a unified
+gateway for OpenAI/Ollama/etc. Anthropic + extended thinking bypasses
+Bifrost because extended-thinking and native prompt caching don't
+round-trip cleanly through Bifrost's OpenAI-format surface today.
+
+Usage::
+
+    from services.llm_router import LLMRouter, DispatchPath
+
+    router = LLMRouter()
+    provider = router.resolve_provider(provider_id)   # DB lookup
+    path = router.select_path(provider, enable_thinking=True)  # "anthropic_direct"|"bifrost"
+    result = await router.dispatch(messages=..., provider=provider, enable_thinking=True)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Repo path setup — secrets_manager lives under backend/, which isn't on
+# sys.path in the worker/daemon. Mirror the pattern used elsewhere.
+# ---------------------------------------------------------------------------
+_REPO = Path(__file__).resolve().parent.parent
+if str(_REPO / "backend") not in sys.path:
+    sys.path.insert(0, str(_REPO / "backend"))
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+try:  # soft imports — router is usable in tests without a DB
+    from secrets_manager import get_secret  # type: ignore
+except Exception:  # noqa: BLE001
+    get_secret = None  # type: ignore
+
+
+DispatchPath = Literal["anthropic_direct", "bifrost"]
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """Minimal view of a row from llm_provider_configs.
+
+    Kept as a plain dataclass (not the ORM model) so this module doesn't
+    import the SQLAlchemy session into the worker hot path.
+    """
+
+    provider_id: str
+    provider_type: str
+    base_url: Optional[str]
+    api_key_ref: Optional[str]
+    default_model: str
+    config: Dict[str, Any]
+
+
+def _bifrost_url() -> str:
+    return os.getenv("BIFROST_URL", "http://bifrost:8080").rstrip("/")
+
+
+def select_path(
+    provider: ProviderSpec, *, enable_thinking: bool = False
+) -> DispatchPath:
+    """Decide which dispatch path a request should take.
+
+    Rules (see docker/bifrost/README.md):
+      - anthropic + thinking → direct SDK (extended thinking isn't routed)
+      - everything else → Bifrost
+    """
+    if provider.provider_type == "anthropic" and enable_thinking:
+        return "anthropic_direct"
+    return "bifrost"
+
+
+class LLMRouter:
+    """Thin router that dispatches to Bifrost (openai SDK) or direct Anthropic.
+
+    The router does NOT own the DB session or Anthropic client. Callers
+    construct a ProviderSpec from an `LLMProviderConfig` row (e.g. via
+    ``provider_spec_from_row``) and pass it in. This keeps the worker hot
+    path free of DB imports and makes unit-testing trivial.
+    """
+
+    def __init__(self, bifrost_url: Optional[str] = None):
+        self.bifrost_url = (bifrost_url or _bifrost_url()).rstrip("/")
+
+    # ---- path selection (pure) -------------------------------------------
+
+    @staticmethod
+    def select_path(
+        provider: ProviderSpec, *, enable_thinking: bool = False
+    ) -> DispatchPath:
+        return select_path(provider, enable_thinking=enable_thinking)
+
+    # ---- dispatch --------------------------------------------------------
+
+    async def dispatch(
+        self,
+        *,
+        provider: ProviderSpec,
+        messages: List[Dict[str, Any]],
+        system_prompt: Optional[str] = None,
+        model: Optional[str] = None,
+        max_tokens: int = 4096,
+        temperature: Optional[float] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        enable_thinking: bool = False,
+        thinking_budget: int = 10000,
+    ) -> Dict[str, Any]:
+        """Send a chat completion via the appropriate path.
+
+        Returns a dict with at least ``content``, ``model``, ``input_tokens``,
+        ``output_tokens``, ``provider``, ``path``.
+        """
+        path = self.select_path(provider, enable_thinking=enable_thinking)
+        model = model or provider.default_model
+
+        if path == "anthropic_direct":
+            return await self._dispatch_anthropic(
+                provider=provider,
+                messages=messages,
+                system_prompt=system_prompt,
+                model=model,
+                max_tokens=max_tokens,
+                tools=tools,
+                enable_thinking=enable_thinking,
+                thinking_budget=thinking_budget,
+            )
+        return await self._dispatch_bifrost(
+            provider=provider,
+            messages=messages,
+            system_prompt=system_prompt,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tools=tools,
+        )
+
+    # ---- backends --------------------------------------------------------
+
+    async def _dispatch_bifrost(
+        self,
+        *,
+        provider: ProviderSpec,
+        messages: List[Dict[str, Any]],
+        system_prompt: Optional[str],
+        model: str,
+        max_tokens: int,
+        temperature: Optional[float],
+        tools: Optional[List[Dict[str, Any]]],
+    ) -> Dict[str, Any]:
+        from openai import AsyncOpenAI  # lazy — avoids hard dep for tests
+
+        oai_messages: List[Dict[str, Any]] = []
+        if system_prompt:
+            oai_messages.append({"role": "system", "content": system_prompt})
+        oai_messages.extend(messages)
+
+        client = AsyncOpenAI(
+            base_url=f"{self.bifrost_url}/v1",
+            api_key="bifrost",  # Bifrost ignores this; per-provider keys are in its config
+        )
+        kwargs: Dict[str, Any] = {
+            "model": f"{provider.provider_type}/{model}",
+            "messages": oai_messages,
+            "max_tokens": max_tokens,
+        }
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+        if tools:
+            kwargs["tools"] = tools
+
+        resp = await client.chat.completions.create(**kwargs)
+        choice = resp.choices[0].message
+        usage = getattr(resp, "usage", None)
+        return {
+            "content": choice.content or "",
+            "tool_calls": getattr(choice, "tool_calls", None),
+            "model": resp.model,
+            "input_tokens": getattr(usage, "prompt_tokens", 0) if usage else 0,
+            "output_tokens": getattr(usage, "completion_tokens", 0) if usage else 0,
+            "provider": provider.provider_type,
+            "path": "bifrost",
+        }
+
+    async def _dispatch_anthropic(
+        self,
+        *,
+        provider: ProviderSpec,
+        messages: List[Dict[str, Any]],
+        system_prompt: Optional[str],
+        model: str,
+        max_tokens: int,
+        tools: Optional[List[Dict[str, Any]]],
+        enable_thinking: bool,
+        thinking_budget: int,
+    ) -> Dict[str, Any]:
+        from anthropic import AsyncAnthropic  # lazy
+
+        api_key: Optional[str] = None
+        if provider.api_key_ref and get_secret is not None:
+            api_key = get_secret(provider.api_key_ref)
+        if not api_key:
+            # Fall back to common env names so local dev still works.
+            api_key = (
+                os.getenv("ANTHROPIC_API_KEY")
+                or os.getenv("CLAUDE_API_KEY")
+            )
+        if not api_key:
+            raise RuntimeError(
+                f"Anthropic provider '{provider.provider_id}' has no resolvable API key"
+            )
+
+        client = AsyncAnthropic(api_key=api_key, timeout=1800.0)
+        kwargs: Dict[str, Any] = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "messages": messages,
+        }
+        if system_prompt:
+            kwargs["system"] = system_prompt
+        if tools:
+            kwargs["tools"] = tools
+        if enable_thinking:
+            kwargs["thinking"] = {"type": "enabled", "budget_tokens": thinking_budget}
+
+        resp = await client.messages.create(**kwargs)
+        # Anthropic returns a list of content blocks (text, thinking, tool_use).
+        text_parts: List[str] = []
+        thinking_parts: List[str] = []
+        tool_uses: List[Dict[str, Any]] = []
+        for block in resp.content:
+            btype = getattr(block, "type", None)
+            if btype == "text":
+                text_parts.append(getattr(block, "text", ""))
+            elif btype == "thinking":
+                thinking_parts.append(getattr(block, "thinking", ""))
+            elif btype == "tool_use":
+                tool_uses.append({
+                    "id": getattr(block, "id", None),
+                    "name": getattr(block, "name", None),
+                    "input": getattr(block, "input", None),
+                })
+
+        usage = getattr(resp, "usage", None)
+        return {
+            "content": "".join(text_parts),
+            "thinking": "".join(thinking_parts) or None,
+            "tool_calls": tool_uses or None,
+            "model": resp.model,
+            "input_tokens": getattr(usage, "input_tokens", 0) if usage else 0,
+            "output_tokens": getattr(usage, "output_tokens", 0) if usage else 0,
+            "provider": provider.provider_type,
+            "path": "anthropic_direct",
+        }
+
+
+# ---------------------------------------------------------------------------
+# DB-facing helpers — importable without circular deps
+# ---------------------------------------------------------------------------
+
+
+def provider_spec_from_row(row) -> ProviderSpec:
+    """Convert an LLMProviderConfig ORM row into a ProviderSpec."""
+    return ProviderSpec(
+        provider_id=row.provider_id,
+        provider_type=row.provider_type,
+        base_url=row.base_url,
+        api_key_ref=row.api_key_ref,
+        default_model=row.default_model,
+        config=dict(row.config or {}),
+    )
+
+
+def get_provider_spec(provider_id: Optional[str]) -> Optional[ProviderSpec]:
+    """Load a provider by id (or the default Anthropic row if id is None).
+
+    Returns None if the DB is unavailable — callers should fall back to the
+    legacy ClaudeService path in that case.
+    """
+    try:
+        from database.connection import get_db_session
+        from database.models import LLMProviderConfig
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("provider spec DB lookup skipped: %s", exc)
+        return None
+
+    session = get_db_session()
+    try:
+        if provider_id:
+            row = session.get(LLMProviderConfig, provider_id)
+        else:
+            row = (
+                session.query(LLMProviderConfig)
+                .filter(
+                    LLMProviderConfig.provider_type == "anthropic",
+                    LLMProviderConfig.is_default.is_(True),
+                )
+                .first()
+            )
+        if row is None:
+            return None
+        return provider_spec_from_row(row)
+    finally:
+        session.close()

--- a/services/llm_worker.py
+++ b/services/llm_worker.py
@@ -65,15 +65,19 @@ async def llm_call(
     traceparent: str = "",
     agent_id: Optional[str] = None,
     investigation_id: Optional[str] = None,
+    provider_id: Optional[str] = None,
 ) -> Any:
     """Execute a single LLM call through the shared ClaudeService.
 
     This is the primary worker function.  It:
       1. Acquires the rate-limit semaphore
       2. Optionally loads session history from Redis
-      3. Calls the Anthropic API
+      3. Calls the Anthropic API (or Bifrost, if provider routes non-Anthropic)
       4. Saves updated session history
       5. Returns the response content
+
+    When ``provider_id`` is None, routing falls back to the existing
+    ClaudeService.chat() path (pre-#88 behavior).
     """
     rate_limiter: asyncio.Semaphore = ctx["rate_limiter"]
     claude_service = ctx["claude_service"]
@@ -102,27 +106,45 @@ async def llm_call(
         if history:
             messages = history + messages
 
-    await rate_limiter.acquire()
-    try:
-        response = await asyncio.to_thread(
-            _sync_claude_call,
-            claude_service,
-            messages=messages,
-            model=model,
-            max_tokens=max_tokens,
-            system_prompt=system_prompt,
-            enable_thinking=enable_thinking,
-            thinking_budget=thinking_budget,
-            tools=tools,
-            temperature=temperature,
-            session_id=session_id,
-            agent_id=agent_id,
-            investigation_id=investigation_id,
-        )
-    finally:
-        rate_limiter.release()
-
-    result = _extract_result(response)
+    # Multi-provider routing (GH #88): if a non-default provider_id is set
+    # and the router wants the Bifrost path, dispatch there instead of
+    # hitting ClaudeService directly. provider_id=None preserves the
+    # pre-#88 Anthropic-SDK path exactly.
+    router_result = await _maybe_dispatch_via_router(
+        ctx,
+        provider_id=provider_id,
+        messages=messages,
+        system_prompt=system_prompt,
+        model=model,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        tools=tools,
+        enable_thinking=enable_thinking,
+        thinking_budget=thinking_budget,
+    )
+    if router_result is not None:
+        result = router_result
+    else:
+        await rate_limiter.acquire()
+        try:
+            response = await asyncio.to_thread(
+                _sync_claude_call,
+                claude_service,
+                messages=messages,
+                model=model,
+                max_tokens=max_tokens,
+                system_prompt=system_prompt,
+                enable_thinking=enable_thinking,
+                thinking_budget=thinking_budget,
+                tools=tools,
+                temperature=temperature,
+                session_id=session_id,
+                agent_id=agent_id,
+                investigation_id=investigation_id,
+            )
+        finally:
+            rate_limiter.release()
+        result = _extract_result(response)
 
     if worker_span is not None:
         try:
@@ -132,8 +154,13 @@ async def llm_call(
 
     # Persist session
     if session_id:
+        # Bifrost results are always dicts; the legacy ClaudeService path
+        # can be a bare string, so guard against it.
+        assistant_content = (
+            result.get("content", "") if isinstance(result, dict) else result
+        )
         updated = messages + [
-            {"role": "assistant", "content": result.get("content", "")}
+            {"role": "assistant", "content": assistant_content}
         ]
         await session_store.save(session_id, updated)
 
@@ -152,6 +179,7 @@ async def llm_call_raw(
     traceparent: str = "",
     investigation_id: Optional[str] = None,
     agent_id: Optional[str] = None,
+    provider_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Execute a raw multi-turn LLM call (used by AgentRunner tool loop).
 
@@ -179,25 +207,39 @@ async def llm_call_raw(
     except Exception:
         worker_span = None
 
-    await rate_limiter.acquire()
-    try:
-        response = await asyncio.to_thread(
-            _sync_claude_raw,
-            claude_service,
-            messages=messages,
-            model=model,
-            max_tokens=max_tokens,
-            enable_thinking=enable_thinking,
-            thinking_budget=thinking_budget,
-            tools=tools,
-            temperature=temperature,
-            investigation_id=investigation_id,
-            agent_id=agent_id,
-        )
-    finally:
-        rate_limiter.release()
-
-    result = _serialize_raw_response(response)
+    router_result = await _maybe_dispatch_via_router(
+        ctx,
+        provider_id=provider_id,
+        messages=messages,
+        system_prompt=None,
+        model=model,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        tools=tools,
+        enable_thinking=enable_thinking,
+        thinking_budget=thinking_budget,
+    )
+    if router_result is not None:
+        result = _adapt_router_result_to_raw(router_result)
+    else:
+        await rate_limiter.acquire()
+        try:
+            response = await asyncio.to_thread(
+                _sync_claude_raw,
+                claude_service,
+                messages=messages,
+                model=model,
+                max_tokens=max_tokens,
+                enable_thinking=enable_thinking,
+                thinking_budget=thinking_budget,
+                tools=tools,
+                temperature=temperature,
+                investigation_id=investigation_id,
+                agent_id=agent_id,
+            )
+        finally:
+            rate_limiter.release()
+        result = _serialize_raw_response(response)
 
     if worker_span is not None:
         try:
@@ -213,6 +255,106 @@ async def llm_call_raw(
             pass
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Multi-provider routing (GH #88)
+# ---------------------------------------------------------------------------
+
+async def _maybe_dispatch_via_router(
+    ctx: Dict[str, Any],
+    *,
+    provider_id: Optional[str],
+    messages: List[Dict],
+    system_prompt: Optional[str],
+    model: str,
+    max_tokens: int,
+    temperature: Optional[float],
+    tools: Optional[List[Dict]],
+    enable_thinking: bool,
+    thinking_budget: int,
+) -> Optional[Dict[str, Any]]:
+    """Return a router result dict, or None if the caller should fall back
+    to the legacy ClaudeService path.
+
+    The router path is taken only when:
+      - provider_id is explicitly set (non-None), AND
+      - the resolved provider's path selection is "bifrost"
+    Anthropic + thinking resolves to "anthropic_direct" — we still return
+    None so the existing ClaudeService path handles it (that path is where
+    prompt caching and thinking work best).
+    """
+    if provider_id is None:
+        return None
+
+    router = ctx.get("llm_router")
+    if router is None:
+        logger.debug("llm_router not initialized; falling back to ClaudeService")
+        return None
+
+    try:
+        from services.llm_router import get_provider_spec
+        spec = get_provider_spec(provider_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to resolve provider %s: %s", provider_id, exc)
+        return None
+
+    if spec is None:
+        logger.warning("Provider %s not found; falling back to ClaudeService", provider_id)
+        return None
+
+    path = router.select_path(spec, enable_thinking=enable_thinking)
+    if path == "anthropic_direct":
+        # Let the existing ClaudeService path handle it (preserves caching,
+        # backend-tool loop, session management, etc.).
+        return None
+
+    rate_limiter: asyncio.Semaphore = ctx["rate_limiter"]
+    await rate_limiter.acquire()
+    try:
+        return await router.dispatch(
+            provider=spec,
+            messages=messages,
+            system_prompt=system_prompt,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tools=tools,
+            enable_thinking=enable_thinking,
+            thinking_budget=thinking_budget,
+        )
+    finally:
+        rate_limiter.release()
+
+
+def _adapt_router_result_to_raw(router_result: Dict[str, Any]) -> Dict[str, Any]:
+    """Shape an LLMRouter result to match _serialize_raw_response output.
+
+    AgentRunner expects a dict with ``content`` (list of blocks),
+    ``stop_reason``, ``input_tokens``, ``output_tokens``.
+    """
+    blocks: List[Dict[str, Any]] = []
+    text = router_result.get("content") or ""
+    if text:
+        blocks.append({"type": "text", "text": text})
+    thinking = router_result.get("thinking")
+    if thinking:
+        blocks.append({"type": "thinking", "thinking": thinking})
+    for tc in router_result.get("tool_calls") or []:
+        blocks.append({
+            "type": "tool_use",
+            "id": tc.get("id"),
+            "name": tc.get("name"),
+            "input": tc.get("input") or {},
+        })
+    return {
+        "content": blocks,
+        "stop_reason": "end_turn",
+        "input_tokens": router_result.get("input_tokens", 0),
+        "output_tokens": router_result.get("output_tokens", 0),
+        "provider": router_result.get("provider"),
+        "path": router_result.get("path"),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -406,6 +548,17 @@ async def on_startup(ctx: Dict[str, Any]):
     ctx["claude_service"] = claude_service
     ctx["rate_limiter"] = asyncio.Semaphore(MAX_CONCURRENT_LLM_CALLS)
     ctx["session_store"] = RedisSessionStore(ctx["redis"])
+
+    # Multi-provider routing (GH #88). Router is optional: if construction
+    # fails (e.g. openai not installed), worker continues in Anthropic-only
+    # mode and provider_id kwargs are silently ignored.
+    try:
+        from services.llm_router import LLMRouter
+        ctx["llm_router"] = LLMRouter()
+        logger.info("LLM router initialized (Bifrost URL=%s)", ctx["llm_router"].bifrost_url)
+    except Exception as _router_err:
+        ctx["llm_router"] = None
+        logger.warning("LLM router init skipped (non-fatal): %s", _router_err)
 
     logger.info(f"LLM worker started (max_concurrent={MAX_CONCURRENT_LLM_CALLS})")
 

--- a/services/llm_worker.py
+++ b/services/llm_worker.py
@@ -261,6 +261,30 @@ async def llm_call_raw(
 # Multi-provider routing (GH #88)
 # ---------------------------------------------------------------------------
 
+def _is_default_anthropic_spec(spec) -> bool:
+    """True when ``spec`` is the seeded Anthropic provider row whose key
+    lives under the legacy CLAUDE_API_KEY/ANTHROPIC_API_KEY env vars.
+
+    The shared ClaudeService in ctx resolves its key from exactly those env
+    names, so only this one provider row is safe to route through the
+    shared service. Any other Anthropic row (e.g. a second account added
+    through the Settings UI) carries its own api_key_ref and must dispatch
+    via LLMRouter so ``_dispatch_anthropic`` resolves that per-provider
+    secret.
+    """
+    if spec.provider_type != "anthropic":
+        return False
+    ref = spec.api_key_ref
+    if ref is None:
+        return True
+    return ref in {
+        "CLAUDE_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "claude_api_key",
+        "anthropic_api_key",
+    }
+
+
 async def _maybe_dispatch_via_router(
     ctx: Dict[str, Any],
     *,
@@ -277,12 +301,15 @@ async def _maybe_dispatch_via_router(
     """Return a router result dict, or None if the caller should fall back
     to the legacy ClaudeService path.
 
-    The router path is taken only when:
+    The router path is taken when:
       - provider_id is explicitly set (non-None), AND
-      - the resolved provider's path selection is "bifrost"
-    Anthropic + thinking resolves to "anthropic_direct" — we still return
-    None so the existing ClaudeService path handles it (that path is where
-    prompt caching and thinking work best).
+      - either the resolved provider's path is "bifrost",
+        or it's "anthropic_direct" but the provider is a non-default
+        Anthropic row (different api_key_ref than the shared ClaudeService).
+
+    For the bare "anthropic_direct" case on the default provider we still
+    return None so the existing ClaudeService path handles it (prompt
+    caching, backend-tool loop, session management all live there).
     """
     if provider_id is None:
         return None
@@ -305,9 +332,12 @@ async def _maybe_dispatch_via_router(
 
     path = router.select_path(spec, enable_thinking=enable_thinking)
     if path == "anthropic_direct":
-        # Let the existing ClaudeService path handle it (preserves caching,
-        # backend-tool loop, session management, etc.).
-        return None
+        # Only hand off to the shared ClaudeService when this is the default
+        # Anthropic account. A non-default Anthropic provider has its own
+        # api_key_ref and must dispatch through the router so _dispatch_anthropic
+        # resolves that per-provider secret (not CLAUDE_API_KEY).
+        if _is_default_anthropic_spec(spec):
+            return None
 
     rate_limiter: asyncio.Semaphore = ctx["rate_limiter"]
     await rate_limiter.acquire()

--- a/tests/test_bifrost_integration.py
+++ b/tests/test_bifrost_integration.py
@@ -1,0 +1,75 @@
+"""Bifrost sidecar smoke test (GH #88).
+
+Skipped by default. Runs only when BIFROST_URL is set and points at a
+live Bifrost instance. Use this as the end-to-end gate in the
+verification steps in docs/bifrost/README.md.
+
+Invoke with::
+
+    BIFROST_URL=http://localhost:8080 pytest -m integration \\
+        tests/test_bifrost_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("BIFROST_URL"),
+        reason="BIFROST_URL not set — Bifrost sidecar not running",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_bifrost_health_endpoint():
+    """Bifrost /health should return 200 when the sidecar is up."""
+    import httpx
+
+    url = os.environ["BIFROST_URL"].rstrip("/")
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        resp = await client.get(f"{url}/health")
+    assert resp.status_code == 200, (
+        f"Bifrost health check failed: {resp.status_code} {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_bifrost_chat_completion_via_ollama():
+    """A chat completion routed to Ollama through Bifrost should return content.
+
+    Requires a running Ollama with the model named in OLLAMA_DEFAULT_MODEL
+    (defaults to llama3.1:8b for the smoke test — smaller than the
+    env.example production default).
+    """
+    from services.llm_router import LLMRouter, ProviderSpec
+
+    model = os.getenv("OLLAMA_SMOKE_MODEL", "llama3.1:8b")
+    spec = ProviderSpec(
+        provider_id="ollama-smoke",
+        provider_type="ollama",
+        base_url=os.getenv("OLLAMA_URL", "http://localhost:11434"),
+        api_key_ref=None,
+        default_model=model,
+        config={},
+    )
+    router = LLMRouter(bifrost_url=os.environ["BIFROST_URL"])
+    result = await router.dispatch(
+        provider=spec,
+        messages=[{"role": "user", "content": "Say the single word 'ping'."}],
+        max_tokens=16,
+    )
+    assert result["path"] == "bifrost"
+    assert result["provider"] == "ollama"
+    assert isinstance(result.get("content"), str) and result["content"].strip(), (
+        "Bifrost→Ollama returned empty content"
+    )

--- a/tests/test_llm_providers_api.py
+++ b/tests/test_llm_providers_api.py
@@ -1,0 +1,259 @@
+"""Unit tests for the LLM provider CRUD API (GH #88).
+
+These tests mock the DB session and secrets_manager — no live Postgres
+required. CRUD semantics, secret persistence, and provider-type guards
+are exercised.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict, Optional
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "backend"))
+
+from backend.api.llm_providers import router as llm_providers_router
+from database.connection import get_db_session
+from database.models import LLMProviderConfig
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeQuery:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def order_by(self, *_a, **_kw):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeSession:
+    """Minimal SQLAlchemy-session stand-in backed by an in-memory dict."""
+
+    def __init__(self):
+        self._store: Dict[str, LLMProviderConfig] = {}
+        self._added = []
+        self.commits = 0
+
+    def query(self, _model):
+        return _FakeQuery(self._store.values())
+
+    def get(self, _model, pk):
+        return self._store.get(pk)
+
+    def add(self, row):
+        self._added.append(row)
+        self._store[row.provider_id] = row
+
+    def delete(self, row):
+        self._store.pop(row.provider_id, None)
+
+    def commit(self):
+        self.commits += 1
+
+    def refresh(self, _row):
+        return None
+
+    def execute(self, stmt):
+        # We approximate _clear_other_defaults by flipping is_default flags
+        # on rows of the same provider_type (except the keep_id). This is
+        # sufficient to cover the "one default per type" invariant.
+        try:
+            # stmt.whereclause is a ClauseList; walk elements for .right values
+            clauses = list(stmt.whereclause.clauses)
+            provider_type = clauses[0].right.value
+            keep_id = clauses[1].right.value
+        except Exception:
+            return None
+        for r in list(self._store.values()):
+            if r.provider_type == provider_type and r.provider_id != keep_id:
+                r.is_default = False
+        return None
+
+
+@pytest.fixture()
+def session() -> _FakeSession:
+    return _FakeSession()
+
+
+@pytest.fixture()
+def client(session):
+    app = FastAPI()
+    app.include_router(llm_providers_router, prefix="/api/llm/providers")
+
+    def _get_session():
+        return session
+
+    app.dependency_overrides[get_db_session] = _get_session
+    return TestClient(app)
+
+
+@pytest.fixture()
+def secrets_store():
+    store: Dict[str, str] = {}
+
+    def fake_set(key: str, value: str) -> bool:
+        store[key] = value
+        return True
+
+    def fake_get(key: str) -> Optional[str]:
+        return store.get(key)
+
+    def fake_delete(key: str) -> bool:
+        store.pop(key, None)
+        return True
+
+    with patch("backend.api.llm_providers.set_secret", side_effect=fake_set), \
+         patch("backend.api.llm_providers.get_secret", side_effect=fake_get), \
+         patch("backend.api.llm_providers.delete_secret", side_effect=fake_delete):
+        yield store
+
+
+def test_list_empty(client):
+    r = client.get("/api/llm/providers/")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_create_ollama_no_key(client, secrets_store):
+    r = client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_type": "ollama",
+            "name": "Local Ollama",
+            "base_url": "http://localhost:11434",
+            "default_model": "llama3.1:8b",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["provider_id"] == "local-ollama"
+    assert body["has_api_key"] is False
+    assert body["provider_type"] == "ollama"
+    assert secrets_store == {}
+
+
+def test_create_openai_persists_key(client, secrets_store):
+    r = client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_id": "openai-prod",
+            "provider_type": "openai",
+            "name": "OpenAI (prod)",
+            "default_model": "gpt-4o-mini",
+            "api_key": "sk-test-xyz",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["has_api_key"] is True
+    assert secrets_store["llm_provider_openai-prod_api_key"] == "sk-test-xyz"
+
+
+def test_create_rejects_unknown_type(client):
+    r = client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_type": "gemini",
+            "name": "x",
+            "default_model": "y",
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_create_rejects_duplicate_id(client, secrets_store):
+    payload = {
+        "provider_id": "dup",
+        "provider_type": "ollama",
+        "name": "a",
+        "default_model": "m",
+    }
+    assert client.post("/api/llm/providers/", json=payload).status_code == 201
+    assert client.post("/api/llm/providers/", json=payload).status_code == 409
+
+
+def test_update_rotates_key_and_clears(client, secrets_store):
+    client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_id": "openai-prod",
+            "provider_type": "openai",
+            "name": "OpenAI",
+            "default_model": "gpt-4o",
+            "api_key": "sk-old",
+        },
+    )
+    # Rotate
+    r = client.put(
+        "/api/llm/providers/openai-prod",
+        json={"api_key": "sk-new"},
+    )
+    assert r.status_code == 200
+    assert secrets_store["llm_provider_openai-prod_api_key"] == "sk-new"
+
+    # Clear (empty string)
+    r = client.put(
+        "/api/llm/providers/openai-prod",
+        json={"api_key": ""},
+    )
+    assert r.status_code == 200
+    assert r.json()["has_api_key"] is False
+    assert "llm_provider_openai-prod_api_key" not in secrets_store
+
+
+def test_delete_removes_secret(client, secrets_store):
+    client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_id": "openai-prod",
+            "provider_type": "openai",
+            "name": "OpenAI",
+            "default_model": "gpt-4o",
+            "api_key": "sk-bye",
+        },
+    )
+    assert "llm_provider_openai-prod_api_key" in secrets_store
+    r = client.delete("/api/llm/providers/openai-prod")
+    assert r.status_code == 200
+    assert "llm_provider_openai-prod_api_key" not in secrets_store
+
+
+def test_set_default_enforces_single_default(client, secrets_store, session):
+    client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_id": "ollama-a",
+            "provider_type": "ollama",
+            "name": "A",
+            "default_model": "m",
+            "is_default": True,
+        },
+    )
+    client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_id": "ollama-b",
+            "provider_type": "ollama",
+            "name": "B",
+            "default_model": "m",
+        },
+    )
+    r = client.post("/api/llm/providers/ollama-b/set-default")
+    assert r.status_code == 200
+    a = session.get(LLMProviderConfig, "ollama-a")
+    b = session.get(LLMProviderConfig, "ollama-b")
+    assert b.is_default is True
+    assert a.is_default is False

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -1,0 +1,212 @@
+"""Unit tests for services.llm_router (GH #88).
+
+Exercises the pure-logic path-selection rules and the dispatch wiring
+with mocked openai / anthropic clients.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from services.llm_router import (
+    LLMRouter,
+    ProviderSpec,
+    provider_spec_from_row,
+    select_path,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _anthropic_spec() -> ProviderSpec:
+    return ProviderSpec(
+        provider_id="anthropic-default",
+        provider_type="anthropic",
+        base_url=None,
+        api_key_ref="CLAUDE_API_KEY",
+        default_model="claude-sonnet-4-5-20250929",
+        config={},
+    )
+
+
+def _ollama_spec() -> ProviderSpec:
+    return ProviderSpec(
+        provider_id="ollama-local",
+        provider_type="ollama",
+        base_url="http://localhost:11434",
+        api_key_ref=None,
+        default_model="llama3.1:8b",
+        config={},
+    )
+
+
+def _openai_spec() -> ProviderSpec:
+    return ProviderSpec(
+        provider_id="openai-prod",
+        provider_type="openai",
+        base_url="https://api.openai.com/v1",
+        api_key_ref="llm_provider_openai-prod_api_key",
+        default_model="gpt-4o-mini",
+        config={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Path selection (pure logic)
+# ---------------------------------------------------------------------------
+
+
+def test_path_anthropic_with_thinking_is_direct():
+    assert select_path(_anthropic_spec(), enable_thinking=True) == "anthropic_direct"
+
+
+def test_path_anthropic_without_thinking_uses_bifrost():
+    assert select_path(_anthropic_spec(), enable_thinking=False) == "bifrost"
+
+
+def test_path_openai_always_uses_bifrost():
+    assert select_path(_openai_spec(), enable_thinking=False) == "bifrost"
+    assert select_path(_openai_spec(), enable_thinking=True) == "bifrost"
+
+
+def test_path_ollama_always_uses_bifrost():
+    assert select_path(_ollama_spec(), enable_thinking=True) == "bifrost"
+
+
+def test_router_class_method_matches_free_function():
+    spec = _anthropic_spec()
+    router = LLMRouter()
+    assert (
+        router.select_path(spec, enable_thinking=True)
+        == select_path(spec, enable_thinking=True)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — Bifrost branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_bifrost_for_ollama():
+    router = LLMRouter(bifrost_url="http://test-bifrost:8080")
+    fake_resp = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="hello", tool_calls=None)
+            )
+        ],
+        model="ollama/llama3.1:8b",
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=7),
+    )
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=fake_resp)
+
+    with patch("openai.AsyncOpenAI", return_value=mock_client) as oai_ctor:
+        out = await router.dispatch(
+            provider=_ollama_spec(),
+            messages=[{"role": "user", "content": "hi"}],
+            system_prompt="be terse",
+        )
+    oai_ctor.assert_called_once()
+    # base_url must be the Bifrost URL the router was constructed with
+    assert oai_ctor.call_args.kwargs["base_url"] == "http://test-bifrost:8080/v1"
+
+    kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert kwargs["model"] == "ollama/llama3.1:8b"
+    assert kwargs["messages"][0] == {"role": "system", "content": "be terse"}
+    assert kwargs["messages"][1] == {"role": "user", "content": "hi"}
+
+    assert out["path"] == "bifrost"
+    assert out["provider"] == "ollama"
+    assert out["content"] == "hello"
+    assert out["input_tokens"] == 5
+    assert out["output_tokens"] == 7
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — Anthropic direct branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_anthropic_direct_with_thinking():
+    router = LLMRouter()
+    thinking_block = SimpleNamespace(type="thinking", thinking="inner reasoning")
+    text_block = SimpleNamespace(type="text", text="the answer")
+    fake_resp = SimpleNamespace(
+        content=[thinking_block, text_block],
+        model="claude-sonnet-4-5-20250929",
+        usage=SimpleNamespace(input_tokens=12, output_tokens=34),
+    )
+    mock_client = MagicMock()
+    mock_client.messages.create = AsyncMock(return_value=fake_resp)
+
+    with patch("anthropic.AsyncAnthropic", return_value=mock_client) as ac_ctor, \
+         patch(
+             "services.llm_router.get_secret", return_value="sk-ant-fake"
+         ):
+        out = await router.dispatch(
+            provider=_anthropic_spec(),
+            messages=[{"role": "user", "content": "ponder"}],
+            enable_thinking=True,
+            thinking_budget=4096,
+        )
+
+    ac_ctor.assert_called_once_with(api_key="sk-ant-fake", timeout=1800.0)
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 4096}
+    assert kwargs["model"] == "claude-sonnet-4-5-20250929"
+    assert kwargs["messages"] == [{"role": "user", "content": "ponder"}]
+
+    assert out["path"] == "anthropic_direct"
+    assert out["provider"] == "anthropic"
+    assert out["content"] == "the answer"
+    assert out["thinking"] == "inner reasoning"
+    assert out["input_tokens"] == 12
+    assert out["output_tokens"] == 34
+
+
+@pytest.mark.asyncio
+async def test_anthropic_dispatch_raises_when_no_key():
+    router = LLMRouter()
+    with patch("services.llm_router.get_secret", return_value=None), \
+         patch.dict("os.environ", {"ANTHROPIC_API_KEY": "", "CLAUDE_API_KEY": ""}, clear=False):
+        with pytest.raises(RuntimeError, match="no resolvable API key"):
+            await router.dispatch(
+                provider=_anthropic_spec(),
+                messages=[{"role": "user", "content": "hi"}],
+                enable_thinking=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# provider_spec_from_row
+# ---------------------------------------------------------------------------
+
+
+def test_provider_spec_from_row_copies_fields():
+    row = SimpleNamespace(
+        provider_id="p",
+        provider_type="openai",
+        base_url="https://example.com",
+        api_key_ref="ref",
+        default_model="gpt-4o",
+        config={"organization": "o"},
+    )
+    spec = provider_spec_from_row(row)
+    assert spec.provider_id == "p"
+    assert spec.provider_type == "openai"
+    assert spec.base_url == "https://example.com"
+    assert spec.api_key_ref == "ref"
+    assert spec.default_model == "gpt-4o"
+    assert spec.config == {"organization": "o"}

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -194,6 +194,160 @@ async def test_anthropic_dispatch_raises_when_no_key():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Non-default Anthropic providers must route through the router so the
+# per-provider api_key_ref is resolved (regression for PR #103 review).
+# ---------------------------------------------------------------------------
+
+
+def test_is_default_anthropic_recognizes_legacy_refs():
+    from services.llm_worker import _is_default_anthropic_spec
+
+    default_key = ProviderSpec(
+        provider_id="anthropic-default",
+        provider_type="anthropic",
+        base_url=None,
+        api_key_ref="CLAUDE_API_KEY",
+        default_model="claude-sonnet-4-5-20250929",
+        config={},
+    )
+    legacy_key = ProviderSpec(
+        provider_id="anthropic-default",
+        provider_type="anthropic",
+        base_url=None,
+        api_key_ref="ANTHROPIC_API_KEY",
+        default_model="claude-sonnet-4-5-20250929",
+        config={},
+    )
+    per_provider = ProviderSpec(
+        provider_id="anthropic-team",
+        provider_type="anthropic",
+        base_url=None,
+        api_key_ref="llm_provider_anthropic-team_api_key",
+        default_model="claude-sonnet-4-5-20250929",
+        config={},
+    )
+    no_ref = ProviderSpec(
+        provider_id="anthropic-anon",
+        provider_type="anthropic",
+        base_url=None,
+        api_key_ref=None,
+        default_model="claude-sonnet-4-5-20250929",
+        config={},
+    )
+    openai = _openai_spec()
+    assert _is_default_anthropic_spec(default_key) is True
+    assert _is_default_anthropic_spec(legacy_key) is True
+    assert _is_default_anthropic_spec(no_ref) is True  # falls back to env
+    assert _is_default_anthropic_spec(per_provider) is False
+    assert _is_default_anthropic_spec(openai) is False
+
+
+@pytest.mark.asyncio
+async def test_non_default_anthropic_with_thinking_dispatches_via_router(monkeypatch):
+    """PR #103 review regression: a non-default Anthropic provider with
+    enable_thinking=True must be dispatched via LLMRouter so the
+    per-provider api_key_ref is used, NOT the shared ClaudeService
+    whose key is CLAUDE_API_KEY.
+    """
+    from services.llm_worker import _maybe_dispatch_via_router
+
+    per_provider = ProviderSpec(
+        provider_id="anthropic-team",
+        provider_type="anthropic",
+        base_url=None,
+        api_key_ref="llm_provider_anthropic-team_api_key",
+        default_model="claude-sonnet-4-5-20250929",
+        config={},
+    )
+
+    mock_router = MagicMock()
+    mock_router.select_path = MagicMock(return_value="anthropic_direct")
+    mock_router.dispatch = AsyncMock(return_value={
+        "content": "ok", "path": "anthropic_direct", "provider": "anthropic",
+        "input_tokens": 1, "output_tokens": 1, "model": "x",
+    })
+
+    import asyncio
+    ctx = {
+        "llm_router": mock_router,
+        "rate_limiter": asyncio.Semaphore(1),
+    }
+
+    with patch(
+        "services.llm_router.get_provider_spec",
+        return_value=per_provider,
+    ):
+        result = await _maybe_dispatch_via_router(
+            ctx,
+            provider_id="anthropic-team",
+            messages=[{"role": "user", "content": "think hard"}],
+            system_prompt=None,
+            model="claude-sonnet-4-5-20250929",
+            max_tokens=100,
+            temperature=None,
+            tools=None,
+            enable_thinking=True,
+            thinking_budget=4096,
+        )
+
+    # We MUST have dispatched via the router (not returned None which would
+    # fall back to the shared ClaudeService with the wrong key).
+    assert result is not None
+    mock_router.dispatch.assert_awaited_once()
+    dispatch_kwargs = mock_router.dispatch.call_args.kwargs
+    assert dispatch_kwargs["provider"].api_key_ref == (
+        "llm_provider_anthropic-team_api_key"
+    )
+    assert dispatch_kwargs["enable_thinking"] is True
+
+
+@pytest.mark.asyncio
+async def test_default_anthropic_with_thinking_still_falls_back():
+    """Default Anthropic row with thinking=True should keep using the
+    shared ClaudeService (return None), preserving prompt caching and
+    the tool-use loop that lives there.
+    """
+    from services.llm_worker import _maybe_dispatch_via_router
+
+    default_spec = ProviderSpec(
+        provider_id="anthropic-default",
+        provider_type="anthropic",
+        base_url=None,
+        api_key_ref="CLAUDE_API_KEY",
+        default_model="claude-sonnet-4-5-20250929",
+        config={},
+    )
+
+    mock_router = MagicMock()
+    mock_router.select_path = MagicMock(return_value="anthropic_direct")
+    mock_router.dispatch = AsyncMock()
+
+    import asyncio
+    ctx = {
+        "llm_router": mock_router,
+        "rate_limiter": asyncio.Semaphore(1),
+    }
+    with patch(
+        "services.llm_router.get_provider_spec",
+        return_value=default_spec,
+    ):
+        result = await _maybe_dispatch_via_router(
+            ctx,
+            provider_id="anthropic-default",
+            messages=[{"role": "user", "content": "think hard"}],
+            system_prompt=None,
+            model="claude-sonnet-4-5-20250929",
+            max_tokens=100,
+            temperature=None,
+            tools=None,
+            enable_thinking=True,
+            thinking_budget=4096,
+        )
+    assert result is None
+    mock_router.dispatch.assert_not_awaited()
+
+
 def test_provider_spec_from_row_copies_fields():
     row = SimpleNamespace(
         provider_id="p",

--- a/tests/unit/test_database_models.py
+++ b/tests/unit/test_database_models.py
@@ -91,6 +91,7 @@ class TestDatabaseMetadataRegistration:
             "custom_agents",
             "custom_workflows",
             "skills",
+            "llm_provider_configs",
         }
 
         registered = set(Base.metadata.tables.keys())


### PR DESCRIPTION
## Summary

Closes #88. Adds pluggable LLM backends (Anthropic + OpenAI + Ollama) via a [Bifrost](https://github.com/maximhq/bifrost) sidecar gateway, keeping the direct Anthropic SDK path for extended thinking / prompt caching.

- **Routing:** `services/llm_router.py` decides per-request whether traffic goes to Bifrost (OpenAI-format HTTP) or the Anthropic SDK. Rule: `anthropic + thinking` → direct; everything else → Bifrost.
- **Persistence:** new `llm_provider_configs` table (seeded with `anthropic-default`); keys stored in `secrets_manager` under generated `api_key_ref` names — never in the DB.
- **API:** `GET/POST/PUT/DELETE /api/llm/providers`, plus `/test`, `/models`, `/set-default`.
- **UI:** Settings "Claude" tab renamed "AI Config" (with `claude` alias), new providers table + 3-step add dialog (`LLMProvidersTab.tsx`, `LLMProviderDialog.tsx`).
- **Backwards-compat:** `LLMRequest.provider_id=None` routes through the existing `ClaudeService.chat()` path unchanged. Legacy `/config/claude` upserts the `anthropic-default` row so both surfaces stay in sync.
- **Bifrost container** runs under the `bifrost` docker-compose profile — default `docker compose up` is unaffected.

**Deferred follow-ups** (explicitly out of scope, tracked separately):
- Per-agent model assignment → [#89](https://github.com/Vigil-SOC/vigil/issues/89)
- Sonnet-pricing cost-tracking refactor (marked with `# TODO(#89)` in `daemon/agent_runner.py`) → #89
- Fallback chains, Ollama model-pull UI — can be filed as new issues if needed

## Review fixes

Second commit addresses four issues from the Claude Code review:

1. **services/llm_worker.py** — non-default Anthropic providers with thinking no longer silently use `CLAUDE_API_KEY`; they dispatch through `LLMRouter._dispatch_anthropic` which resolves the per-provider `api_key_ref`. New `_is_default_anthropic_spec` helper + 3 regression tests in `tests/test_llm_router.py`.
2. **frontend/.../LLMProviderDialog.tsx** — `draftProviderId` useState survives across Test→Save and Test-retry, so `finalSave` no longer loses the id and a failed-then-retried test updates the draft row instead of POSTing a duplicate (409).
3. **database/models.py** — partial unique index `llm_provider_default_per_type` is now declared in `__table_args__` so `create_all()` creates it for non-Docker deployments too.
4. **backend/api/llm_providers.py** — `test_provider` Anthropic branch uses `AsyncAnthropic + await` so a 15s ping cannot block the FastAPI event loop.

## Test plan
- [x] `pytest tests/test_llm_router.py tests/test_llm_providers_api.py tests/unit/test_database_models.py tests/unit/test_claude_service.py` → **75 passed, 0 regressions** (includes the 3 new regression tests for the routing fix)
- [x] `tests/test_bifrost_integration.py` skips cleanly when `BIFROST_URL` is unset
- [x] CI: Lint Backend/Frontend/Dockerfiles, Unit Tests Backend/Frontend, Integration Tests, Security Scan Python/NPM → **all green**
- [ ] Manual: `docker compose --profile bifrost up postgres redis bifrost backend llm-worker` → Settings → AI Config → add Ollama provider → test → set as default → send chat → confirm `docker compose logs bifrost` shows request while `LLMRouter dispatch → bifrost` appears in worker logs
- [ ] Manual: with default `anthropic-default`, run an investigation with `enable_thinking=true` → confirm Bifrost logs stay empty and worker logs show `LLMRouter dispatch → anthropic_direct`

🤖 Generated with [Claude Code](https://claude.com/claude-code)