### PR TITLE
feat(agents): Agent Builder MVP — custom SOC agents via UI (#80)

### DIFF
--- a/backend/api/agents.py
+++ b/backend/api/agents.py
@@ -5,13 +5,28 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 import logging
 
-from services.soc_agents import SOCAgentLibrary, AgentManager
+from services.soc_agents import SOCAgentLibrary, AgentManager, CUSTOM_AGENT_ID_PREFIX
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 # Global agent manager instance
 agent_manager = AgentManager()
+
+
+def _resolve_agent(agent_id: str):
+    """Resolve an agent_id to an AgentProfile, lazy-loading custom agents on miss.
+
+    Built-in agents are served from the in-memory dict with zero DB calls.
+    Only misses for IDs prefixed with custom- trigger a refresh and retry.
+    """
+    agent = agent_manager.agents.get(agent_id)
+    if agent is not None:
+        return agent
+    if agent_id and agent_id.startswith(CUSTOM_AGENT_ID_PREFIX):
+        agent_manager.refresh_custom_agents()
+        return agent_manager.agents.get(agent_id)
+    return None
 
 
 class InvestigationRequest(BaseModel):
@@ -52,10 +67,10 @@ async def get_agent(agent_id: str):
         Agent details
     """
     try:
-        agent = agent_manager.agents.get(agent_id)
+        agent = _resolve_agent(agent_id)
         if not agent:
             raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
-        
+
         return {
             "id": agent.id,
             "name": agent.name,
@@ -123,7 +138,7 @@ async def start_investigation(request: InvestigationRequest):
             raise HTTPException(status_code=404, detail=f"Finding not found: {request.finding_id}")
         
         # Get the agent
-        agent = agent_manager.agents.get(request.agent_id)
+        agent = _resolve_agent(request.agent_id)
         if not agent:
             raise HTTPException(status_code=404, detail=f"Agent not found: {request.agent_id}")
         
@@ -191,10 +206,10 @@ async def run_agent(request: AgentRunRequest):
     from services.claude_service import ClaudeService
     
     try:
-        agent = agent_manager.agents.get(request.agent_id)
+        agent = _resolve_agent(request.agent_id)
         if not agent:
             raise HTTPException(status_code=404, detail=f"Agent not found: {request.agent_id}")
-        
+
         # Build task from finding/case if not explicitly provided
         task = request.task
         context_data = {}

--- a/backend/api/custom_agents.py
+++ b/backend/api/custom_agents.py
@@ -1,0 +1,196 @@
+"""Custom SOC Agent CRUD endpoints (Agent Builder).
+
+Built-in agents remain hardcoded in services/soc_agents.py. This module only
+manages the DB-backed custom agents, prefixed with "custom-".
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from backend.services.custom_agent_service import (
+    CustomAgentAlreadyExists,
+    CustomAgentNotFound,
+    CustomAgentService,
+)
+from services.soc_agents import CUSTOM_AGENT_ID_PREFIX
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+service = CustomAgentService()
+
+
+def _refresh_manager() -> None:
+    """Refresh the global AgentManager so changes are visible to /agents/* routes."""
+    try:
+        from backend.api.agents import agent_manager
+
+        agent_manager.refresh_custom_agents()
+    except Exception as e:
+        logger.warning(f"Failed to refresh AgentManager after custom agent change: {e}")
+
+
+class CustomAgentCreate(BaseModel):
+    """Request body for creating a custom agent."""
+
+    name: str = Field(..., min_length=1)
+    role: str = Field(..., min_length=1)
+    description: Optional[str] = None
+    icon: Optional[str] = None
+    color: Optional[str] = None
+    specialization: Optional[str] = None
+    extra_principles: Optional[str] = ""
+    methodology: Optional[str] = ""
+    system_prompt_override: Optional[str] = None
+    recommended_tools: List[str] = Field(default_factory=list)
+    max_tokens: int = 4096
+    enable_thinking: bool = False
+    model: Optional[str] = None
+
+
+class CustomAgentUpdate(BaseModel):
+    """Partial update for an existing custom agent. All fields optional."""
+
+    name: Optional[str] = None
+    role: Optional[str] = None
+    description: Optional[str] = None
+    icon: Optional[str] = None
+    color: Optional[str] = None
+    specialization: Optional[str] = None
+    extra_principles: Optional[str] = None
+    methodology: Optional[str] = None
+    system_prompt_override: Optional[str] = None
+    recommended_tools: Optional[List[str]] = None
+    max_tokens: Optional[int] = None
+    enable_thinking: Optional[bool] = None
+    model: Optional[str] = None
+
+
+def _with_effective_prompt(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Attach the rendered effective prompt to an agent row dict."""
+    row = dict(row)
+    row["effective_prompt"] = service.get_effective_prompt(row)
+    return row
+
+
+@router.get("/agents/custom")
+async def list_custom_agents() -> Dict[str, Any]:
+    try:
+        agents = service.list_agents()
+        return {"agents": agents}
+    except Exception as e:
+        logger.error(f"Error listing custom agents: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/agents/custom/_meta/tools")
+async def list_available_tools() -> Dict[str, Any]:
+    """Return MCP tool names grouped by server prefix for the UI multiselect."""
+    tools: List[str] = []
+    try:
+        from services.mcp_registry import get_mcp_registry
+
+        registry = get_mcp_registry()
+        names = registry.get_tool_names() or []
+        tools = sorted(set(names))
+    except Exception as e:
+        logger.warning(f"Could not load MCP tool names from registry: {e}")
+
+    grouped: Dict[str, List[str]] = {}
+    for name in tools:
+        # Names follow "{server}_{tool}"; group by prefix before the first underscore
+        if "_" in name:
+            server, _rest = name.split("_", 1)
+        else:
+            server = "other"
+        grouped.setdefault(server, []).append(name)
+
+    return {
+        "tools": tools,
+        "grouped": grouped,
+    }
+
+
+@router.get("/agents/custom/{agent_id}")
+async def get_custom_agent(agent_id: str) -> Dict[str, Any]:
+    try:
+        row = service.get_agent(agent_id)
+        if not row:
+            raise HTTPException(
+                status_code=404, detail=f"Custom agent not found: {agent_id}"
+            )
+        return _with_effective_prompt(row)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting custom agent {agent_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/agents/custom", status_code=201)
+async def create_custom_agent(request: CustomAgentCreate) -> Dict[str, Any]:
+    try:
+        row = service.create_agent(request.model_dump(exclude_unset=False))
+        _refresh_manager()
+        return _with_effective_prompt(row)
+    except CustomAgentAlreadyExists as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error creating custom agent: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.patch("/agents/custom/{agent_id}")
+async def update_custom_agent(
+    agent_id: str, request: CustomAgentUpdate
+) -> Dict[str, Any]:
+    if not agent_id.startswith(CUSTOM_AGENT_ID_PREFIX):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Refusing to update built-in agent: {agent_id}",
+        )
+    try:
+        updates = request.model_dump(exclude_unset=True)
+        row = service.update_agent(agent_id, updates)
+        _refresh_manager()
+        return _with_effective_prompt(row)
+    except CustomAgentNotFound:
+        raise HTTPException(
+            status_code=404, detail=f"Custom agent not found: {agent_id}"
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating custom agent {agent_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete("/agents/custom/{agent_id}", status_code=204)
+async def delete_custom_agent(agent_id: str):
+    if not agent_id.startswith(CUSTOM_AGENT_ID_PREFIX):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Refusing to delete built-in agent: {agent_id}",
+        )
+    try:
+        deleted = service.delete_agent(agent_id)
+        if not deleted:
+            raise HTTPException(
+                status_code=404, detail=f"Custom agent not found: {agent_id}"
+            )
+        _refresh_manager()
+        return None
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting custom agent {agent_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/main.py
+++ b/backend/main.py
@@ -48,6 +48,7 @@ from api.ingestion import router as ingestion_router
 from api.timeline import router as timeline_router
 from api.graph import router as graph_router
 from api.vstrike import router as vstrike_router
+from api.custom_agents import router as custom_agents_router
 
 # Enhanced case management routers
 from api.case_templates import router as case_templates_router
@@ -178,6 +179,7 @@ app.include_router(mcp_router, prefix="/api/mcp", tags=["mcp"])
 app.include_router(claude_router, prefix="/api/claude", tags=["claude"], dependencies=[Depends(rate_limit_dependency)])
 app.include_router(config_router, prefix="/api/config", tags=["config"])
 app.include_router(attack_router, prefix="/api/attack", tags=["attack"])
+app.include_router(custom_agents_router, prefix="/api", tags=["custom-agents"])
 app.include_router(agents_router, prefix="/api/agents", tags=["agents"])
 app.include_router(compatibility_router, prefix="/api/integrations", tags=["integrations"])
 app.include_router(custom_integrations_router, prefix="/api/custom-integrations", tags=["custom-integrations"])
@@ -428,6 +430,16 @@ async def startup_event():
             logger.warning("MCP client not available - MCP SDK may not be installed")
     except Exception as e:
         logger.error(f"Error during MCP initialization: {e}")
+
+    # Load custom agents from DB into the AgentManager so built-in + custom
+    # agents are visible in one merged list. Lookup misses for "custom-*" IDs
+    # also trigger a refresh at request time, so this is a convenience preload.
+    try:
+        from backend.api.agents import agent_manager
+        loaded = agent_manager.refresh_custom_agents()
+        logger.info(f"Loaded {loaded} custom agent(s) from database")
+    except Exception as e:
+        logger.warning(f"Could not preload custom agents: {e}")
 
 
 @app.on_event("shutdown")

--- a/backend/services/custom_agent_service.py
+++ b/backend/services/custom_agent_service.py
@@ -1,0 +1,178 @@
+"""Service layer for custom SOC agents (Agent Builder)."""
+
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+from database.connection import get_db_manager
+from database.models import CustomAgent
+from services.soc_agents import CUSTOM_AGENT_ID_PREFIX, render_base_prompt
+
+logger = logging.getLogger(__name__)
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def slugify(name: str) -> str:
+    """Convert a display name to a URL-safe slug."""
+    slug = _SLUG_RE.sub("-", (name or "").lower()).strip("-")
+    return slug or "agent"
+
+
+def build_agent_id(name: str) -> str:
+    """Build a prefixed custom agent ID from a display name."""
+    return f"{CUSTOM_AGENT_ID_PREFIX}{slugify(name)}"
+
+
+class CustomAgentAlreadyExists(Exception):
+    """Raised when attempting to create a custom agent whose ID already exists."""
+
+
+class CustomAgentNotFound(Exception):
+    """Raised when a custom agent is requested but does not exist."""
+
+
+# Fields that can be updated via PATCH. Kept in sync with CustomAgent columns
+# that belong to the editable agent definition (not audit fields).
+UPDATABLE_FIELDS = {
+    "name",
+    "description",
+    "icon",
+    "color",
+    "specialization",
+    "role",
+    "extra_principles",
+    "methodology",
+    "system_prompt_override",
+    "recommended_tools",
+    "max_tokens",
+    "enable_thinking",
+    "model",
+}
+
+
+class CustomAgentService:
+    """CRUD service for custom SOC agents."""
+
+    def list_agents(self) -> List[Dict[str, Any]]:
+        db_manager = get_db_manager()
+        with db_manager.session_scope() as session:
+            rows = (
+                session.query(CustomAgent).order_by(CustomAgent.updated_at.desc()).all()
+            )
+            return [row.to_dict() for row in rows]
+
+    def get_agent(self, agent_id: str) -> Optional[Dict[str, Any]]:
+        db_manager = get_db_manager()
+        with db_manager.session_scope() as session:
+            row = (
+                session.query(CustomAgent)
+                .filter(CustomAgent.id == agent_id)
+                .one_or_none()
+            )
+            return row.to_dict() if row else None
+
+    def get_effective_prompt(self, agent_row: Dict[str, Any]) -> str:
+        """Return the system prompt that will actually be sent to Claude."""
+        override = agent_row.get("system_prompt_override")
+        if override:
+            return override
+        return render_base_prompt(
+            role=agent_row.get("role", ""),
+            extra_principles=agent_row.get("extra_principles", ""),
+            methodology=agent_row.get("methodology", ""),
+        )
+
+    def create_agent(
+        self,
+        data: Dict[str, Any],
+        created_by: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        name = (data.get("name") or "").strip()
+        if not name:
+            raise ValueError("name is required")
+        role = (data.get("role") or "").strip()
+        if not role:
+            raise ValueError("role is required")
+
+        agent_id = build_agent_id(name)
+
+        db_manager = get_db_manager()
+        with db_manager.session_scope() as session:
+            existing = (
+                session.query(CustomAgent)
+                .filter(CustomAgent.id == agent_id)
+                .one_or_none()
+            )
+            if existing:
+                raise CustomAgentAlreadyExists(
+                    f"Custom agent already exists: {agent_id}"
+                )
+
+            agent = CustomAgent(
+                id=agent_id,
+                name=name,
+                description=data.get("description"),
+                icon=data.get("icon"),
+                color=data.get("color"),
+                specialization=data.get("specialization"),
+                role=role,
+                extra_principles=data.get("extra_principles") or "",
+                methodology=data.get("methodology") or "",
+                system_prompt_override=data.get("system_prompt_override"),
+                recommended_tools=list(data.get("recommended_tools") or []),
+                max_tokens=int(data.get("max_tokens") or 4096),
+                enable_thinking=bool(data.get("enable_thinking") or False),
+                model=data.get("model"),
+                created_by=created_by,
+            )
+            session.add(agent)
+            session.flush()
+            return agent.to_dict()
+
+    def update_agent(
+        self,
+        agent_id: str,
+        updates: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        db_manager = get_db_manager()
+        with db_manager.session_scope() as session:
+            agent = (
+                session.query(CustomAgent)
+                .filter(CustomAgent.id == agent_id)
+                .one_or_none()
+            )
+            if not agent:
+                raise CustomAgentNotFound(agent_id)
+
+            for key, value in updates.items():
+                if key not in UPDATABLE_FIELDS:
+                    continue
+                if value is None and key in {"role"}:
+                    # Required field cannot be set to null via PATCH
+                    continue
+                if key == "recommended_tools":
+                    setattr(agent, key, list(value or []))
+                elif key == "max_tokens":
+                    setattr(agent, key, int(value))
+                elif key == "enable_thinking":
+                    setattr(agent, key, bool(value))
+                else:
+                    setattr(agent, key, value)
+
+            session.flush()
+            return agent.to_dict()
+
+    def delete_agent(self, agent_id: str) -> bool:
+        db_manager = get_db_manager()
+        with db_manager.session_scope() as session:
+            agent = (
+                session.query(CustomAgent)
+                .filter(CustomAgent.id == agent_id)
+                .one_or_none()
+            )
+            if not agent:
+                return False
+            session.delete(agent)
+            return True

--- a/database/init/07_custom_agents.sql
+++ b/database/init/07_custom_agents.sql
@@ -1,0 +1,51 @@
+-- Custom SOC Agents Table
+-- Stores user-defined agents created via the Agent Builder UI.
+-- Built-in agents remain hardcoded in services/soc_agents.py; this table
+-- only holds custom agents. IDs are prefixed "custom-" to disambiguate.
+
+CREATE TABLE IF NOT EXISTS custom_agents (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    icon TEXT,
+    color TEXT,
+    specialization TEXT,
+    role TEXT NOT NULL,
+    extra_principles TEXT NOT NULL DEFAULT '',
+    methodology TEXT NOT NULL DEFAULT '',
+    system_prompt_override TEXT,
+    recommended_tools JSONB NOT NULL DEFAULT '[]'::jsonb,
+    max_tokens INTEGER NOT NULL DEFAULT 4096,
+    enable_thinking BOOLEAN NOT NULL DEFAULT FALSE,
+    model TEXT,
+    created_by VARCHAR(100),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_custom_agents_updated_at ON custom_agents(updated_at DESC);
+
+CREATE OR REPLACE FUNCTION update_custom_agents_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_custom_agents_updated_at ON custom_agents;
+CREATE TRIGGER trigger_custom_agents_updated_at
+    BEFORE UPDATE ON custom_agents
+    FOR EACH ROW
+    EXECUTE FUNCTION update_custom_agents_timestamp();
+
+COMMENT ON TABLE custom_agents IS 'User-defined SOC agents created via the Agent Builder UI';
+COMMENT ON COLUMN custom_agents.id IS 'Agent identifier, format "custom-<slug>"';
+COMMENT ON COLUMN custom_agents.role IS 'Injected into BASE_PROMPT {role} placeholder';
+COMMENT ON COLUMN custom_agents.extra_principles IS 'Injected into BASE_PROMPT {extra_principles} placeholder';
+COMMENT ON COLUMN custom_agents.methodology IS 'Injected into BASE_PROMPT {methodology} placeholder';
+COMMENT ON COLUMN custom_agents.system_prompt_override IS 'When set, bypasses BASE_PROMPT and uses this text verbatim';
+COMMENT ON COLUMN custom_agents.recommended_tools IS 'Array of MCP tool names (full {server}_{tool} format)';
+COMMENT ON COLUMN custom_agents.model IS 'Reserved for per-agent model override (issue #89); null = use caller default';
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON custom_agents TO deeptempo;

--- a/database/models.py
+++ b/database/models.py
@@ -2105,3 +2105,61 @@ class CaseNotification(Base):
             'created_at': self.created_at.isoformat() if self.created_at else None,
         }
 
+
+class CustomAgent(Base):
+    """User-defined SOC agent created via the Agent Builder UI."""
+
+    __tablename__ = 'custom_agents'
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    icon: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    color: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    specialization: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    role: Mapped[str] = mapped_column(Text, nullable=False)
+    extra_principles: Mapped[str] = mapped_column(Text, nullable=False, default='', server_default='')
+    methodology: Mapped[str] = mapped_column(Text, nullable=False, default='', server_default='')
+    system_prompt_override: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    recommended_tools: Mapped[list] = mapped_column(JSONB, nullable=False, default=list, server_default='[]')
+    max_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=4096, server_default='4096')
+    enable_thinking: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default='false')
+    model: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    created_by: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, server_default='now()'
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow,
+        onupdate=datetime.utcnow, server_default='now()'
+    )
+
+    __table_args__ = (
+        Index('idx_custom_agents_updated_at', 'updated_at'),
+    )
+
+    def to_dict(self) -> dict:
+        """Convert custom agent to dictionary."""
+        return {
+            'id': self.id,
+            'name': self.name,
+            'description': self.description,
+            'icon': self.icon,
+            'color': self.color,
+            'specialization': self.specialization,
+            'role': self.role,
+            'extra_principles': self.extra_principles,
+            'methodology': self.methodology,
+            'system_prompt_override': self.system_prompt_override,
+            'recommended_tools': self.recommended_tools or [],
+            'max_tokens': self.max_tokens,
+            'enable_thinking': self.enable_thinking,
+            'model': self.model,
+            'created_by': self.created_by,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }
+

--- a/frontend/src/components/settings/AgentBuilderDialog.tsx
+++ b/frontend/src/components/settings/AgentBuilderDialog.tsx
@@ -1,0 +1,381 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  Box,
+  Typography,
+  Stack,
+  Grid,
+  FormControlLabel,
+  Switch,
+  Autocomplete,
+  Chip,
+  Tooltip,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Alert,
+  CircularProgress,
+} from '@mui/material'
+import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material'
+import { agentsApi, type CustomAgent, type CustomAgentPayload } from '../../services/api'
+
+interface Props {
+  open: boolean
+  agentId: string | null
+  onClose: (saved: boolean) => void
+  onMessage: (msg: { type: 'success' | 'error'; text: string }) => void
+}
+
+const EMPTY_FORM: CustomAgentPayload = {
+  name: '',
+  role: '',
+  description: '',
+  icon: 'C',
+  color: '#888888',
+  specialization: '',
+  extra_principles: '',
+  methodology: '',
+  system_prompt_override: '',
+  recommended_tools: [],
+  max_tokens: 4096,
+  enable_thinking: false,
+}
+
+export default function AgentBuilderDialog({ open, agentId, onClose, onMessage }: Props) {
+  const [form, setForm] = useState<CustomAgentPayload>(EMPTY_FORM)
+  const [availableTools, setAvailableTools] = useState<string[]>([])
+  const [effectivePrompt, setEffectivePrompt] = useState<string>('')
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [useOverride, setUseOverride] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const isEdit = Boolean(agentId)
+
+  useEffect(() => {
+    if (!open) return
+    setError(null)
+    // Load tool list once per open
+    agentsApi
+      .getAvailableTools()
+      .then((res) => setAvailableTools(res.data.tools || []))
+      .catch(() => {
+        /* non-fatal; multi-select still accepts free text */
+      })
+    if (agentId) {
+      setLoading(true)
+      agentsApi
+        .getCustom(agentId)
+        .then((res) => {
+          const a: CustomAgent = res.data
+          setForm({
+            name: a.name,
+            role: a.role,
+            description: a.description || '',
+            icon: a.icon || 'C',
+            color: a.color || '#888888',
+            specialization: a.specialization || '',
+            extra_principles: a.extra_principles || '',
+            methodology: a.methodology || '',
+            system_prompt_override: a.system_prompt_override || '',
+            recommended_tools: a.recommended_tools || [],
+            max_tokens: a.max_tokens ?? 4096,
+            enable_thinking: a.enable_thinking ?? false,
+          })
+          setUseOverride(Boolean(a.system_prompt_override))
+          setEffectivePrompt(a.effective_prompt || '')
+        })
+        .catch((err) => {
+          setError(err?.response?.data?.detail || err?.message || 'Failed to load agent')
+        })
+        .finally(() => setLoading(false))
+    } else {
+      setForm(EMPTY_FORM)
+      setUseOverride(false)
+      setEffectivePrompt('')
+    }
+  }, [open, agentId])
+
+  const handleChange = <K extends keyof CustomAgentPayload>(key: K, value: CustomAgentPayload[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const validate = (): string | null => {
+    if (!form.name?.trim()) return 'Name is required'
+    if (!form.role?.trim()) return 'Role is required'
+    if (useOverride && !form.system_prompt_override?.trim()) {
+      return 'Advanced override is enabled but the override text is empty'
+    }
+    return null
+  }
+
+  const handleSave = async () => {
+    const v = validate()
+    if (v) {
+      setError(v)
+      return
+    }
+    setError(null)
+    setSaving(true)
+    try {
+      const payload: CustomAgentPayload = {
+        ...form,
+        // When override toggle is off, send explicit null so server clears any prior override
+        system_prompt_override: useOverride ? form.system_prompt_override || '' : null,
+        // Coerce numeric field
+        max_tokens: Number(form.max_tokens) || 4096,
+      }
+      if (isEdit && agentId) {
+        await agentsApi.updateCustom(agentId, payload)
+        onMessage({ type: 'success', text: `Updated ${form.name}` })
+      } else {
+        await agentsApi.createCustom(payload)
+        onMessage({ type: 'success', text: `Created ${form.name}` })
+      }
+      setTimeout(() => onMessage({ type: 'success', text: '' }), 3000)
+      onClose(true)
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail || err?.message || 'Save failed'
+      setError(detail)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={() => onClose(false)} maxWidth="md" fullWidth>
+      <DialogTitle>{isEdit ? `Edit Agent: ${form.name || agentId}` : 'New Custom Agent'}</DialogTitle>
+      <DialogContent dividers>
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+            <CircularProgress size={28} />
+          </Box>
+        ) : (
+          <Stack spacing={2}>
+            {error && <Alert severity="error">{error}</Alert>}
+
+            {/* Phase 2 placeholder: NL-to-agent generator */}
+            <Tooltip title="Coming in Phase 2: describe the agent in natural language and we generate the configuration.">
+              <span>
+                <TextField
+                  label="Describe your agent (AI-assisted — coming soon)"
+                  multiline
+                  rows={2}
+                  fullWidth
+                  disabled
+                  placeholder="e.g. detects impossible-travel logins by correlating auth events across geographies"
+                />
+              </span>
+            </Tooltip>
+
+            <Typography variant="subtitle2" sx={{ mt: 1 }}>
+              Identity
+            </Typography>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="Name"
+                  fullWidth
+                  required
+                  value={form.name}
+                  onChange={(e) => handleChange('name', e.target.value)}
+                  disabled={isEdit}
+                  helperText={isEdit ? 'Agent ID is derived from the name and cannot be changed' : 'The agent ID will be "custom-<slug>"'}
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="Specialization"
+                  fullWidth
+                  value={form.specialization || ''}
+                  onChange={(e) => handleChange('specialization', e.target.value)}
+                  placeholder="e.g. Phishing Analysis"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  label="Description"
+                  fullWidth
+                  multiline
+                  rows={2}
+                  value={form.description || ''}
+                  onChange={(e) => handleChange('description', e.target.value)}
+                />
+              </Grid>
+              <Grid item xs={6} sm={3}>
+                <TextField
+                  label="Icon (1 char)"
+                  fullWidth
+                  inputProps={{ maxLength: 2 }}
+                  value={form.icon || ''}
+                  onChange={(e) => handleChange('icon', e.target.value)}
+                />
+              </Grid>
+              <Grid item xs={6} sm={3}>
+                <TextField
+                  label="Color"
+                  type="color"
+                  fullWidth
+                  value={form.color || '#888888'}
+                  onChange={(e) => handleChange('color', e.target.value)}
+                />
+              </Grid>
+            </Grid>
+
+            <Typography variant="subtitle2" sx={{ mt: 1 }}>
+              Prompt fragments
+              <Typography variant="caption" component="span" color="text.secondary" sx={{ ml: 1 }}>
+                Rendered into the Vigil base prompt (preserves mempalace + entity-recognition directives)
+              </Typography>
+            </Typography>
+            <TextField
+              label="Role"
+              required
+              fullWidth
+              value={form.role}
+              onChange={(e) => handleChange('role', e.target.value)}
+              placeholder="e.g. phishing specialist"
+              helperText='Renders as: "You are a SOC {role} in the Vigil SOC platform."'
+              disabled={useOverride}
+            />
+            <TextField
+              label="Extra principles"
+              multiline
+              rows={3}
+              fullWidth
+              value={form.extra_principles || ''}
+              onChange={(e) => handleChange('extra_principles', e.target.value)}
+              placeholder="- Verify sender reputation before classifying..."
+              disabled={useOverride}
+            />
+            <TextField
+              label="Methodology"
+              multiline
+              rows={4}
+              fullWidth
+              value={form.methodology || ''}
+              onChange={(e) => handleChange('methodology', e.target.value)}
+              placeholder="1. Enrich sender IP with threat intel...\n2. Check for lookalike domains...\n3. ..."
+              disabled={useOverride}
+            />
+
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={useOverride}
+                  onChange={(e) => setUseOverride(e.target.checked)}
+                />
+              }
+              label="Advanced: bypass base template (write the full system prompt yourself)"
+            />
+            {useOverride && (
+              <TextField
+                label="System prompt (verbatim — replaces the base template)"
+                multiline
+                rows={10}
+                fullWidth
+                value={form.system_prompt_override || ''}
+                onChange={(e) => handleChange('system_prompt_override', e.target.value)}
+                InputProps={{ sx: { fontFamily: 'monospace', fontSize: '0.85rem' } }}
+              />
+            )}
+
+            <Typography variant="subtitle2" sx={{ mt: 1 }}>
+              Tools & behavior
+            </Typography>
+            <Autocomplete
+              multiple
+              freeSolo
+              options={availableTools}
+              groupBy={(opt) => (opt.includes('_') ? opt.split('_', 1)[0] : 'other')}
+              value={form.recommended_tools || []}
+              onChange={(_, newValue) => handleChange('recommended_tools', newValue as string[])}
+              renderTags={(value, getTagProps) =>
+                value.map((tool, index) => (
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    label={tool}
+                    {...getTagProps({ index })}
+                    key={tool}
+                  />
+                ))
+              }
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Recommended MCP tools"
+                  placeholder="Start typing to filter..."
+                  helperText={`${availableTools.length} tools available — free text accepted if a tool isn't in the registry yet`}
+                />
+              )}
+            />
+            <Grid container spacing={2}>
+              <Grid item xs={6} sm={4}>
+                <TextField
+                  label="Max tokens"
+                  type="number"
+                  fullWidth
+                  value={form.max_tokens ?? 4096}
+                  onChange={(e) => handleChange('max_tokens', Number(e.target.value))}
+                  inputProps={{ min: 256, max: 32768, step: 256 }}
+                />
+              </Grid>
+              <Grid item xs={6} sm={4}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={form.enable_thinking ?? false}
+                      onChange={(e) => handleChange('enable_thinking', e.target.checked)}
+                    />
+                  }
+                  label="Enable thinking"
+                />
+              </Grid>
+            </Grid>
+
+            {isEdit && effectivePrompt && (
+              <Accordion variant="outlined" disableGutters>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="body2">Preview effective prompt</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Box
+                    sx={{
+                      fontFamily: 'monospace',
+                      fontSize: '0.8rem',
+                      whiteSpace: 'pre-wrap',
+                      bgcolor: (t) => (t.palette.mode === 'dark' ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)'),
+                      p: 2,
+                      borderRadius: 1,
+                      maxHeight: '40vh',
+                      overflow: 'auto',
+                    }}
+                  >
+                    {effectivePrompt}
+                  </Box>
+                  <Typography variant="caption" color="text.secondary">
+                    This is the exact system prompt Claude receives. Re-save to refresh.
+                  </Typography>
+                </AccordionDetails>
+              </Accordion>
+            )}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => onClose(false)} disabled={saving}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={handleSave} disabled={saving || loading}>
+          {saving ? 'Saving…' : isEdit ? 'Save Changes' : 'Create Agent'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/settings/AgentBuilderTab.tsx
+++ b/frontend/src/components/settings/AgentBuilderTab.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Box,
+  Typography,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton,
+  Chip,
+  CircularProgress,
+  Tooltip,
+  Stack,
+} from '@mui/material'
+import {
+  Add as AddIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+  SmartToy as AgentIcon,
+} from '@mui/icons-material'
+import { agentsApi, type CustomAgent } from '../../services/api'
+import AgentBuilderDialog from './AgentBuilderDialog'
+
+interface Props {
+  onMessage: (msg: { type: 'success' | 'error'; text: string }) => void
+  showConfirm: (title: string, msg: string, onConfirm: () => void) => void
+}
+
+export default function AgentBuilderTab({ onMessage, showConfirm }: Props) {
+  const [agents, setAgents] = useState<CustomAgent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+
+  const loadAgents = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await agentsApi.listCustom()
+      setAgents(res.data.agents || [])
+    } catch (err: any) {
+      onMessage({
+        type: 'error',
+        text: `Failed to load custom agents: ${err?.response?.data?.detail || err?.message || 'unknown error'}`,
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [onMessage])
+
+  useEffect(() => {
+    loadAgents()
+  }, [loadAgents])
+
+  const handleNew = () => {
+    setEditingId(null)
+    setDialogOpen(true)
+  }
+
+  const handleEdit = (id: string) => {
+    setEditingId(id)
+    setDialogOpen(true)
+  }
+
+  const handleDelete = (agent: CustomAgent) => {
+    showConfirm(
+      'Delete custom agent',
+      `Delete ${agent.name}? This cannot be undone.`,
+      async () => {
+        try {
+          await agentsApi.deleteCustom(agent.id)
+          onMessage({ type: 'success', text: `Deleted ${agent.name}` })
+          setTimeout(() => onMessage({ type: 'success', text: '' }), 3000)
+          await loadAgents()
+        } catch (err: any) {
+          onMessage({
+            type: 'error',
+            text: `Delete failed: ${err?.response?.data?.detail || err?.message || 'unknown error'}`,
+          })
+        }
+      }
+    )
+  }
+
+  const handleDialogClose = (saved: boolean) => {
+    setDialogOpen(false)
+    setEditingId(null)
+    if (saved) {
+      loadAgents()
+    }
+  }
+
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+        <Box>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+            SOC Agents
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Create custom specialized agents in addition to the 13 built-in SOC agents.
+          </Typography>
+        </Box>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={handleNew}>
+          New Agent
+        </Button>
+      </Stack>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+          <CircularProgress size={28} />
+        </Box>
+      ) : agents.length === 0 ? (
+        <Paper variant="outlined" sx={{ p: 4, textAlign: 'center' }}>
+          <AgentIcon sx={{ fontSize: 40, color: 'text.disabled', mb: 1 }} />
+          <Typography variant="body1" sx={{ mb: 0.5 }}>
+            No custom agents yet
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Click "New Agent" to create one. Custom agents appear in the Skills page alongside built-ins.
+          </Typography>
+        </Paper>
+      ) : (
+        <TableContainer component={Paper} variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Specialization</TableCell>
+                <TableCell>Tools</TableCell>
+                <TableCell>Updated</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {agents.map((a) => (
+                <TableRow key={a.id} hover>
+                  <TableCell>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Box
+                        sx={{
+                          width: 24,
+                          height: 24,
+                          borderRadius: '50%',
+                          bgcolor: a.color || '#888',
+                          color: '#fff',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontSize: '0.75rem',
+                          fontWeight: 700,
+                        }}
+                      >
+                        {a.icon || 'C'}
+                      </Box>
+                      <Box>
+                        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                          {a.name}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                          {a.id}
+                        </Typography>
+                      </Box>
+                    </Stack>
+                  </TableCell>
+                  <TableCell>{a.specialization || '—'}</TableCell>
+                  <TableCell>
+                    <Chip size="small" label={`${(a.recommended_tools || []).length} tool(s)`} />
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="caption" color="text.secondary">
+                      {a.updated_at ? new Date(a.updated_at).toLocaleString() : '—'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">
+                    <Tooltip title="Edit">
+                      <IconButton size="small" onClick={() => handleEdit(a.id)}>
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete">
+                      <IconButton size="small" onClick={() => handleDelete(a)}>
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <AgentBuilderDialog
+        open={dialogOpen}
+        agentId={editingId}
+        onClose={handleDialogClose}
+        onMessage={onMessage}
+      />
+    </Box>
+  )
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -62,6 +62,7 @@ import IntegrationWizard, { IntegrationMetadata } from '../components/settings/I
 import CustomIntegrationBuilder from '../components/settings/CustomIntegrationBuilder'
 import { getAllIntegrations, loadCustomIntegrations } from '../config/integrations'
 import UserManagementTab from '../components/settings/UserManagementTab'
+import AgentBuilderTab from '../components/settings/AgentBuilderTab'
 import DetectionRulesTab from '../components/settings/DetectionRulesTab'
 import AutoInvestigateTab from '../components/settings/AutoInvestigateTab'
 import KafkaTab from '../components/settings/KafkaTab'
@@ -94,6 +95,7 @@ const TAB_DEFS: { key: string; label: string; devOnly: boolean }[] = [
   { key: 's3', label: 'S3 Storage', devOnly: false },
   { key: 'integrations', label: 'Integrations / MCP', devOnly: false },
   { key: 'users', label: 'Users', devOnly: false },
+  { key: 'agents', label: 'SOC Agents', devOnly: false },
   { key: 'autoinvestigate', label: 'Auto Investigate', devOnly: false },
   { key: 'kafka', label: 'Kafka', devOnly: false },
   { key: 'general', label: 'General', devOnly: false },
@@ -1393,6 +1395,13 @@ export default function Settings() {
         return (
           <TabPanel value={currentTab} index={idx} key={tabKey}>
             <UserManagementTab />
+          </TabPanel>
+        )
+
+      case 'agents':
+        return (
+          <TabPanel value={currentTab} index={idx} key={tabKey}>
+            <AgentBuilderTab onMessage={setMessage} showConfirm={showConfirm} />
           </TabPanel>
         )
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -575,6 +575,39 @@ export const agentsApi = {
     agent_id?: string
     use_agent_sdk?: boolean
   }) => api.post('/agents/agents/run', data),
+
+  // Custom Agent Builder (issue #80)
+  listCustom: () => api.get('/agents/custom'),
+  getCustom: (agent_id: string) => api.get(`/agents/custom/${agent_id}`),
+  createCustom: (data: CustomAgentPayload) => api.post('/agents/custom', data),
+  updateCustom: (agent_id: string, data: Partial<CustomAgentPayload>) =>
+    api.patch(`/agents/custom/${agent_id}`, data),
+  deleteCustom: (agent_id: string) => api.delete(`/agents/custom/${agent_id}`),
+  getAvailableTools: () => api.get('/agents/custom/_meta/tools'),
+}
+
+export interface CustomAgentPayload {
+  name: string
+  role: string
+  description?: string | null
+  icon?: string | null
+  color?: string | null
+  specialization?: string | null
+  extra_principles?: string | null
+  methodology?: string | null
+  system_prompt_override?: string | null
+  recommended_tools?: string[]
+  max_tokens?: number
+  enable_thinking?: boolean
+  model?: string | null
+}
+
+export interface CustomAgent extends CustomAgentPayload {
+  id: string
+  created_by?: string | null
+  created_at?: string
+  updated_at?: string
+  effective_prompt?: string
 }
 
 // Config API

--- a/services/soc_agents.py
+++ b/services/soc_agents.py
@@ -415,6 +415,17 @@ Confidence scoring:
 }
 
 
+def render_base_prompt(
+    role: str, extra_principles: str = "", methodology: str = ""
+) -> str:
+    """Render BASE_PROMPT with the given fragments. Shared by built-in + custom."""
+    return BASE_PROMPT.format(
+        role=role,
+        extra_principles=extra_principles or "",
+        methodology=methodology or "",
+    )
+
+
 class SOCAgentLibrary:
     @staticmethod
     def get_all_agents() -> Dict[str, AgentProfile]:
@@ -422,7 +433,7 @@ class SOCAgentLibrary:
 
     @staticmethod
     def _build_agent(agent_id: str, cfg: dict) -> AgentProfile:
-        prompt = BASE_PROMPT.format(
+        prompt = render_base_prompt(
             role=cfg["role"],
             extra_principles=cfg.get("extra_principles", ""),
             methodology=cfg.get("methodology", ""),
@@ -441,15 +452,83 @@ class SOCAgentLibrary:
         )
 
     @staticmethod
+    def _build_from_custom(row: dict) -> AgentProfile:
+        """Build an AgentProfile from a custom_agents row dict.
+
+        Uses system_prompt_override verbatim when set; otherwise renders BASE_PROMPT
+        with the row's role/extra_principles/methodology fragments.
+        """
+        override = row.get("system_prompt_override")
+        if override:
+            prompt = override
+        else:
+            prompt = render_base_prompt(
+                role=row.get("role", ""),
+                extra_principles=row.get("extra_principles", ""),
+                methodology=row.get("methodology", ""),
+            )
+        return AgentProfile(
+            id=row["id"],
+            name=row.get("name") or row["id"],
+            description=row.get("description") or "",
+            system_prompt=prompt,
+            icon=row.get("icon") or "C",
+            color=row.get("color") or "#888888",
+            specialization=row.get("specialization") or "Custom",
+            recommended_tools=list(row.get("recommended_tools") or []),
+            max_tokens=int(row.get("max_tokens") or 4096),
+            enable_thinking=bool(row.get("enable_thinking") or False),
+        )
+
+    @staticmethod
     def get_agent(agent_id: str) -> Optional[AgentProfile]:
         agents = SOCAgentLibrary.get_all_agents()
         return agents.get(agent_id)
+
+
+CUSTOM_AGENT_ID_PREFIX = "custom-"
 
 
 class AgentManager:
     def __init__(self):
         self.agents = SOCAgentLibrary.get_all_agents()
         self.current_agent_id = "investigator"
+
+    def refresh_custom_agents(self) -> int:
+        """Reload custom agents from the DB.
+
+        Clears only entries with the custom- prefix so built-ins are never touched.
+        Returns the number of custom agents loaded. Failures (e.g. DB unavailable
+        at import time) are logged and swallowed so the built-in set remains usable.
+        """
+        # Drop existing custom agents first
+        custom_keys = [k for k in self.agents if k.startswith(CUSTOM_AGENT_ID_PREFIX)]
+        for k in custom_keys:
+            del self.agents[k]
+
+        try:
+            from database.connection import get_db_manager
+            from database.models import CustomAgent
+        except Exception as e:
+            logger.warning(f"CustomAgent model unavailable, skipping refresh: {e}")
+            return 0
+
+        try:
+            db_manager = get_db_manager()
+            with db_manager.session_scope() as session:
+                rows = session.query(CustomAgent).all()
+                loaded = 0
+                for row in rows:
+                    try:
+                        profile = SOCAgentLibrary._build_from_custom(row.to_dict())
+                        self.agents[profile.id] = profile
+                        loaded += 1
+                    except Exception as e:
+                        logger.error(f"Failed to load custom agent {row.id}: {e}")
+                return loaded
+        except Exception as e:
+            logger.warning(f"Unable to refresh custom agents from DB: {e}")
+            return 0
 
     def get_current_agent(self) -> AgentProfile:
         return self.agents.get(self.current_agent_id, self.agents["investigator"])


### PR DESCRIPTION
## Summary
- Phase 1 of [#80](https://github.com/Vigil-SOC/vigil/issues/80): users can create, edit, and delete custom SOC agents from Settings → **SOC Agents** without editing code.
- Built-in 13 agents stay hardcoded; custom agents live in a new \`custom_agents\` table with IDs prefixed \`custom-\`. \`AgentManager\` merges both into one in-memory dict and self-heals on lookup miss, so built-in performance is unchanged.
- Custom agents inherit the load-bearing \`BASE_PROMPT\` (mempalace / entity-recognition directives) via template fragments (role / extra_principles / methodology); power users can bypass via an Advanced override field.

## What's here (Phase 1 / MVP)
**Backend**
- \`database/init/07_custom_agents.sql\` + \`CustomAgent\` model in \`database/models.py\`
- \`services/soc_agents.py\` — \`render_base_prompt()\`, \`SOCAgentLibrary._build_from_custom()\`, \`AgentManager.refresh_custom_agents()\`
- \`backend/services/custom_agent_service.py\` — CRUD + slugified ID build
- \`backend/api/custom_agents.py\` — \`GET/POST/PATCH/DELETE /api/agents/custom\`, \`GET /api/agents/custom/_meta/tools\`
- \`backend/api/agents.py\` — \`_resolve_agent()\` helper wired into all 3 lookup sites
- \`backend/main.py\` — custom router registered **before** the built-in agents router so \`/agents/custom\` isn't swallowed by \`/agents/{agent_id}\`; preload at startup

**Frontend**
- New Settings tab with \`AgentBuilderTab\` (table + delete) and \`AgentBuilderDialog\` (identity, prompt fragments, advanced override, MCP tools multi-select grouped by server prefix, effective-prompt preview)
- \`agentsApi\` extended with \`listCustom/getCustom/createCustom/updateCustom/deleteCustom/getAvailableTools\` + TS types
- Custom agents show up in the existing Skills page automatically — no change to \`Skills.tsx\` needed

## What's deferred (tracked in plan)
- **Phase 2:** AI-assisted prompt generation (NL → agent config)
- **Phase 3:** versioning + rollback
- **Phase 4:** sandbox test-run (tier-filtered tool access)
- **#89 hook:** \`model\` column already in schema/Pydantic/payload so per-component model selection can wire up without another migration

## Design decisions
- **Namespace:** \`custom-<slug>\` prefix; only prefix misses hit the DB
- **Prompt shape:** fragments rendered into \`BASE_PROMPT\` (preserves mempalace directives); Advanced toggle for raw \`system_prompt_override\`
- **Tool selection:** individual \`{server}_{tool}\` names (matches \`recommended_tools\` + MCP registry); no new resolver layer
- **Route precedence:** custom router mounted before built-in so specific \`/agents/custom/...\` wins over \`/agents/{agent_id}\`
- **Deletion guard:** \`DELETE /agents/custom/{id}\` returns 400 if the ID doesn't start with \`custom-\`

## Test plan
- [ ] \`docker compose down -v && docker compose up -d postgres\` — \`07_custom_agents.sql\` applies cleanly
- [ ] \`./start_web.sh\` — backend + frontend start; log shows \`Loaded N custom agent(s) from database\`
- [ ] \`curl -X POST localhost:6987/api/agents/custom -d '{"name":"Phish Triage","role":"phishing specialist","specialization":"Email threats","icon":"P","color":"#8e44ad","recommended_tools":["list_findings","get_finding"]}'\` — returns 201 with \`id: "custom-phish-triage"\`
- [ ] \`curl localhost:6987/api/agents\` — returns 14 agents (13 built-in + custom)
- [ ] \`curl localhost:6987/api/agents/custom/custom-phish-triage\` — \`effective_prompt\` contains \`"phishing specialist"\` inside BASE_PROMPT
- [ ] \`curl -X POST localhost:6987/api/agents/run -d '{"agent_id":"custom-phish-triage","task":"test"}'\` — runs with custom system_prompt + MCP tools
- [ ] UI: Settings → SOC Agents → New → fill form → save → row appears; Skills page shows the new agent
- [ ] UI: edit → save → \`Preview effective prompt\` shows the updated rendering
- [ ] Guards: \`DELETE /api/agents/triage\` → 400; \`DELETE /api/agents/custom-phish-triage\` → 204
- [ ] Regression: existing built-in agents still run (\`investigator\`, \`triage\`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)