### PR TITLE
feat(auth): migrate to HttpOnly cookies + enable CSRF enforcement

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -7,10 +7,16 @@ Handles login, logout, token refresh, password management, and MFA.
 import logging
 from datetime import datetime
 from typing import Optional
-from fastapi import APIRouter, HTTPException, Depends, Header, Request, status
+from fastapi import APIRouter, HTTPException, Depends, Header, Request, Response, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
+from backend.services.auth_cookies import (
+    ACCESS_COOKIE_NAME,
+    REFRESH_COOKIE_NAME,
+    clear_auth_cookies,
+    set_auth_cookies,
+)
 from backend.services.auth_service import AccountLockedError, AuthService
 from backend.services.token_blacklist import (
     blacklist_jti,
@@ -50,8 +56,13 @@ class ChangePasswordRequest(BaseModel):
 
 
 class RefreshTokenRequest(BaseModel):
-    """Refresh token request."""
-    refresh_token: str
+    """Refresh token request.
+
+    refresh_token is optional because the primary transport is now the
+    HttpOnly refresh_token cookie. The body field stays for API/CLI
+    clients that haven't migrated to the cookie flow.
+    """
+    refresh_token: Optional[str] = None
 
 
 class MFASetupResponse(BaseModel):
@@ -69,14 +80,22 @@ class MFAVerifyRequest(BaseModel):
 @limiter.limit("5/minute")
 async def login(
     request: Request,
+    response: Response,
     payload: LoginRequest,
     session: Session = Depends(get_db_session)
 ):
     """
-    Authenticate user and return JWT tokens.
+    Authenticate user and issue tokens.
+
+    Tokens are delivered two ways:
+    - **HttpOnly cookies** (primary transport for the browser UI) — not
+      readable from JavaScript, protected against XSS exfiltration.
+    - **Response body** (for CLI/API clients) — these continue to send
+      the token as `Authorization: Bearer …`.
 
     Args:
         request: FastAPI request (used by the rate limiter).
+        response: FastAPI response, used to set auth cookies.
         payload: Login credentials
         session: Database session
 
@@ -124,6 +143,17 @@ async def login(
     access_token = AuthService.generate_jwt_token(user, "access")
     refresh_token = AuthService.generate_jwt_token(user, "refresh")
 
+    # Extract exp claims so the cookie Max-Age matches the JWT lifetime.
+    access_payload = AuthService.verify_jwt_token(access_token) or {}
+    refresh_payload = AuthService.verify_jwt_token(refresh_token) or {}
+    set_auth_cookies(
+        response,
+        access_token,
+        refresh_token,
+        access_exp=access_payload.get("exp"),
+        refresh_exp=refresh_payload.get("exp"),
+    )
+
     logger.info(f"User logged in: {user.username}")
 
     return LoginResponse(
@@ -135,45 +165,55 @@ async def login(
 
 @router.post("/logout")
 async def logout(
+    request: Request,
+    response: Response,
     current_user: User = Depends(get_current_active_user),
     authorization: Optional[str] = Header(None),
 ):
     """
     Logout user — blacklist the current access token's JTI so replaying it
-    returns 401 for the rest of its lifetime.
+    returns 401 for the rest of its lifetime, and clear the HttpOnly auth
+    cookies from the browser.
 
     Args:
-        current_user: Current authenticated user
-        authorization: Authorization header (used to extract the JTI)
+        request: FastAPI request (used to read the access_token cookie).
+        response: FastAPI response (used to clear auth cookies).
+        current_user: Current authenticated user.
+        authorization: Authorization header (used to extract the JTI for
+            Bearer-flow clients).
 
     Returns:
-        Success message
+        Success message.
     """
-    # Extract the current token's JTI from the Authorization header. The
-    # dependency above has already validated it, so decoding here just
-    # reads the claims we need.
-    if authorization:
+    # Prefer the cookie (browser flow). Fall back to Bearer for API clients.
+    raw_token: Optional[str] = request.cookies.get(ACCESS_COOKIE_NAME)
+    if not raw_token and authorization:
         parts = authorization.split()
         if len(parts) == 2 and parts[0].lower() == "bearer":
-            payload = AuthService.verify_jwt_token(parts[1])
-            if payload:
-                jti = payload.get("jti")
-                exp_ts = payload.get("exp")
-                exp_dt = (
-                    datetime.utcfromtimestamp(exp_ts) if exp_ts is not None else None
-                )
-                if jti:
-                    try:
-                        await blacklist_jti(jti, exp_dt)
-                    except Exception as exc:
-                        # Redis down — logout still "succeeds" client-side
-                        # (client discards the token), but we surface the
-                        # server-side failure so ops can see it.
-                        logger.error(
-                            "Failed to blacklist token for %s: %s",
-                            current_user.username,
-                            exc,
-                        )
+            raw_token = parts[1]
+
+    if raw_token:
+        payload = AuthService.verify_jwt_token(raw_token)
+        if payload:
+            jti = payload.get("jti")
+            exp_ts = payload.get("exp")
+            exp_dt = (
+                datetime.utcfromtimestamp(exp_ts) if exp_ts is not None else None
+            )
+            if jti:
+                try:
+                    await blacklist_jti(jti, exp_dt)
+                except Exception as exc:
+                    # Redis down — logout still "succeeds" client-side
+                    # (cookies cleared, client discards the Bearer token),
+                    # but we surface the server-side failure for ops.
+                    logger.error(
+                        "Failed to blacklist token for %s: %s",
+                        current_user.username,
+                        exc,
+                    )
+
+    clear_auth_cookies(response)
 
     logger.info(f"User logged out: {current_user.username}")
     return {"message": "Logged out successfully"}
@@ -183,22 +223,37 @@ async def logout(
 @limiter.limit("30/minute")
 async def refresh_token(
     request: Request,
-    body: RefreshTokenRequest,
+    response: Response,
+    body: Optional[RefreshTokenRequest] = None,
     session: Session = Depends(get_db_session)
 ):
     """
     Refresh access token using refresh token.
 
+    Token source priority:
+    1. `refresh_token` HttpOnly cookie (browser flow)
+    2. `refresh_token` field in the request body (Bearer-flow API clients)
+
     Args:
-        request: FastAPI request (used by the rate limiter).
-        body: Refresh token
-        session: Database session
+        request: FastAPI request (used by the rate limiter and to read
+            the refresh_token cookie).
+        response: FastAPI response (used to set the new auth cookies).
+        body: Optional refresh-token body for API clients.
+        session: Database session.
 
     Returns:
-        New access and refresh tokens
+        New access and refresh tokens.
     """
-    # Verify refresh token
-    payload = AuthService.verify_jwt_token(body.refresh_token)
+    raw_refresh: Optional[str] = request.cookies.get(REFRESH_COOKIE_NAME)
+    if not raw_refresh and body is not None:
+        raw_refresh = body.refresh_token
+    if not raw_refresh:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Refresh token missing",
+        )
+
+    payload = AuthService.verify_jwt_token(raw_refresh)
     if not payload or payload.get("token_type") != "refresh":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -210,7 +265,7 @@ async def refresh_token(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Refresh token has been revoked",
         )
-    
+
     # Get user
     user = session.query(User).filter(User.user_id == payload["user_id"]).first()
     if not user or not user.is_active:
@@ -218,11 +273,21 @@ async def refresh_token(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found or inactive",
         )
-    
+
     # Generate new tokens
     access_token = AuthService.generate_jwt_token(user, "access")
     refresh_token = AuthService.generate_jwt_token(user, "refresh")
-    
+
+    access_payload = AuthService.verify_jwt_token(access_token) or {}
+    refresh_payload = AuthService.verify_jwt_token(refresh_token) or {}
+    set_auth_cookies(
+        response,
+        access_token,
+        refresh_token,
+        access_exp=access_payload.get("exp"),
+        refresh_exp=refresh_payload.get("exp"),
+    )
+
     return LoginResponse(
         access_token=access_token,
         refresh_token=refresh_token,

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -9,9 +9,10 @@ import logging
 import os
 from typing import Optional, Callable
 from functools import wraps
-from fastapi import HTTPException, Header, Depends, status
+from fastapi import HTTPException, Header, Depends, Request, status
 from sqlalchemy.orm import Session
 
+from backend.services.auth_cookies import ACCESS_COOKIE_NAME
 from backend.services.auth_service import AuthService
 from backend.services.token_blacklist import is_token_revoked
 from database.models import User
@@ -70,47 +71,55 @@ def _get_dev_user(session: Session) -> User:
 
 
 async def get_current_user(
+    request: Request,
     authorization: Optional[str] = Header(None),
     session: Session = Depends(get_db_session)
 ) -> User:
     """
-    Dependency to get the current authenticated user from JWT token.
-    
+    Resolve the authenticated user from either the access_token HttpOnly
+    cookie (browser flow) or an Authorization: Bearer header (API clients).
+
+    Cookie is preferred when both are present.
+
     In DEV_MODE, authentication is bypassed and a mock admin user is returned.
-    
+
     Args:
-        authorization: Authorization header (Bearer token)
-        session: Database session
-    
+        request: FastAPI request (used to read the access_token cookie).
+        authorization: Authorization header (Bearer token fallback).
+        session: Database session.
+
     Returns:
-        Current User object
-    
+        Current User object.
+
     Raises:
-        HTTPException: If token is invalid or user not found (only in production)
+        HTTPException: If no token is present, validation fails, or the user
+            is not found (production only).
     """
     # DEV MODE: Bypass authentication and return mock user
     if DEV_MODE:
         logger.debug("DEV_MODE: Bypassing authentication")
         return _get_dev_user(session)
-    
-    # PRODUCTION MODE: Normal JWT authentication
-    if not authorization:
+
+    token: Optional[str] = request.cookies.get(ACCESS_COOKIE_NAME)
+
+    if not token and authorization:
+        # Bearer fallback for CLI / scripts / integrations that haven't
+        # migrated to the cookie flow.
+        parts = authorization.split()
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid authorization header format",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        token = parts[1]
+
+    if not token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authorization header missing",
+            detail="Not authenticated",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    
-    # Extract token from "Bearer <token>"
-    parts = authorization.split()
-    if len(parts) != 2 or parts[0].lower() != "bearer":
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid authorization header format",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    
-    token = parts[1]
     
     # Verify JWT token
     payload = AuthService.verify_jwt_token(token)
@@ -296,26 +305,30 @@ def require_role(role_name: str):
 
 # Optional authentication (doesn't raise error if no token)
 async def get_optional_user(
+    request: Request,
     authorization: Optional[str] = Header(None),
     session: Session = Depends(get_db_session)
 ) -> Optional[User]:
     """
     Dependency to optionally get the current user.
-    
-    Returns None if no valid token is provided.
-    
+
+    Returns None if no valid token is provided (either via cookie or
+    Authorization header).
+
     Args:
-        authorization: Authorization header (Bearer token)
+        request: FastAPI request (used to read the access_token cookie).
+        authorization: Authorization header (Bearer token fallback).
         session: Database session
-    
+
     Returns:
         User object or None
     """
-    if not authorization:
+    has_cookie = ACCESS_COOKIE_NAME in request.cookies
+    if not has_cookie and not authorization:
         return None
-    
+
     try:
-        return await get_current_user(authorization, session)
+        return await get_current_user(request, authorization, session)
     except HTTPException:
         return None
 

--- a/backend/middleware/csrf.py
+++ b/backend/middleware/csrf.py
@@ -72,7 +72,7 @@ class CSRFMiddleware(BaseHTTPMiddleware):
     ):
         super().__init__(app)
         self.enabled = (
-            _env_bool("VIGIL_CSRF_ENABLED", False) if enabled is None else enabled
+            _env_bool("VIGIL_CSRF_ENABLED", True) if enabled is None else enabled
         )
         self.report_only = (
             _env_bool("VIGIL_CSRF_REPORT_ONLY", True)
@@ -126,10 +126,11 @@ class CSRFMiddleware(BaseHTTPMiddleware):
 
         response = await call_next(request)
 
-        # Seed the csrf_token cookie on safe responses so the frontend has
-        # something to echo back on the next mutating request. Refresh if
-        # it's missing or on safe navigation responses.
-        if request.method not in UNSAFE_METHODS and CSRF_COOKIE_NAME not in request.cookies:
+        # Seed the csrf_token cookie on every response when the client
+        # doesn't already have one — including rejected POSTs (so the next
+        # attempt has something to echo) and error responses like 401
+        # (the frontend's loadUser flow gets a cookie from an unauth 401).
+        if CSRF_COOKIE_NAME not in request.cookies:
             response.set_cookie(
                 CSRF_COOKIE_NAME,
                 secrets.token_urlsafe(32),

--- a/backend/services/auth_cookies.py
+++ b/backend/services/auth_cookies.py
@@ -1,0 +1,107 @@
+"""
+Auth cookie helpers.
+
+Centralizes the HttpOnly / Secure / SameSite flags so every endpoint that
+sets or clears auth cookies agrees on the attributes. Reading attributes
+from env at call time means flipping `VIGIL_COOKIE_SECURE=false` in local
+dev doesn't require a restart cycle through the router.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import Response
+
+logger = logging.getLogger(__name__)
+
+
+ACCESS_COOKIE_NAME = "access_token"
+REFRESH_COOKIE_NAME = "refresh_token"
+
+# Path scoping: refresh cookie is only sent to the refresh endpoint so it
+# isn't exposed to every API call the browser makes.
+ACCESS_COOKIE_PATH = "/"
+REFRESH_COOKIE_PATH = "/api/auth/refresh"
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("true", "1", "yes", "on")
+
+
+def _cookie_secure() -> bool:
+    # Default true so a misconfiguration in prod fails safe. Local HTTP dev
+    # must explicitly set VIGIL_COOKIE_SECURE=false.
+    return _env_bool("VIGIL_COOKIE_SECURE", True)
+
+
+def _cookie_samesite() -> str:
+    raw = (os.getenv("VIGIL_COOKIE_SAMESITE") or "strict").strip().lower()
+    if raw not in ("strict", "lax", "none"):
+        logger.warning(
+            "Invalid VIGIL_COOKIE_SAMESITE=%r, falling back to 'strict'", raw
+        )
+        return "strict"
+    return raw
+
+
+def _ttl_seconds(exp_ts: Optional[int]) -> Optional[int]:
+    if exp_ts is None:
+        return None
+    ttl = exp_ts - int(datetime.now(tz=timezone.utc).timestamp())
+    return ttl if ttl > 0 else None
+
+
+def set_auth_cookies(
+    response: Response,
+    access_token: str,
+    refresh_token: str,
+    *,
+    access_exp: Optional[int] = None,
+    refresh_exp: Optional[int] = None,
+) -> None:
+    """Set both auth cookies with matching attributes."""
+    secure = _cookie_secure()
+    samesite = _cookie_samesite()
+
+    response.set_cookie(
+        ACCESS_COOKIE_NAME,
+        access_token,
+        max_age=_ttl_seconds(access_exp),
+        httponly=True,
+        secure=secure,
+        samesite=samesite,
+        path=ACCESS_COOKIE_PATH,
+    )
+    response.set_cookie(
+        REFRESH_COOKIE_NAME,
+        refresh_token,
+        max_age=_ttl_seconds(refresh_exp),
+        httponly=True,
+        secure=secure,
+        samesite=samesite,
+        path=REFRESH_COOKIE_PATH,
+    )
+
+
+def clear_auth_cookies(response: Response) -> None:
+    """Clear both auth cookies. Matching attributes required or browsers
+    won't recognize the clear."""
+    secure = _cookie_secure()
+    samesite = _cookie_samesite()
+    response.delete_cookie(
+        ACCESS_COOKIE_NAME,
+        path=ACCESS_COOKIE_PATH,
+        secure=secure,
+        samesite=samesite,
+    )
+    response.delete_cookie(
+        REFRESH_COOKIE_NAME,
+        path=REFRESH_COOKIE_PATH,
+        secure=secure,
+        samesite=samesite,
+    )

--- a/env.example
+++ b/env.example
@@ -87,21 +87,30 @@ VIGIL_CSP_ENABLED="true"
 VIGIL_CSP_POLICY=""
 
 # -----------------------------------------------------------------------------
-# CSRF Protection (enforced in a later PR — scaffold lives here now)
+# CSRF Protection
 # -----------------------------------------------------------------------------
-# Double-submit cookie pattern. The middleware is present but disabled until
-# the frontend migrates to HttpOnly auth cookies and echoes X-CSRF-Token.
-VIGIL_CSRF_ENABLED="false"
-# Report-only logs violations without rejecting. Flip to "false" after the
-# rollout window shows clean logs.
+# Double-submit cookie pattern, enabled by default alongside the cookie-based
+# auth migration. The frontend's axios interceptor reads csrf_token and
+# echoes it as the X-CSRF-Token header on mutating requests.
+VIGIL_CSRF_ENABLED="true"
+# Report-only logs violations without rejecting. Keep "true" for one rollout
+# window, then flip to "false" to enforce.
 VIGIL_CSRF_REPORT_ONLY="true"
-# Comma-separated path prefixes exempt from CSRF checks (e.g. webhooks that
+# Comma-separated path prefixes exempt from CSRF checks (webhooks that
 # authenticate themselves with HMAC, server-to-server ingestion endpoints).
 VIGIL_CSRF_EXEMPT_PATHS="/api/webhooks/,/api/ingest/"
-# Whether the csrf_token and future auth cookies should be set with Secure.
-# Leave "true" for anything served over HTTPS; set "false" only for local
+
+# -----------------------------------------------------------------------------
+# Auth Cookies (HttpOnly access_token + refresh_token)
+# -----------------------------------------------------------------------------
+# Whether the csrf_token and auth cookies should be set with Secure.
+# Leave "true" for anything served over HTTPS; set "false" ONLY for local
 # HTTP dev.
 VIGIL_COOKIE_SECURE="true"
+# SameSite attribute on auth cookies. "strict" is strongest; use "lax" if
+# the deployment has SSO redirects that need cookies on cross-site nav.
+# "none" requires Secure=true and is only sensible for cross-origin setups.
+VIGIL_COOKIE_SAMESITE="strict"
 
 # -----------------------------------------------------------------------------
 # MemPalace — Persistent AI Memory Layer

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -91,10 +91,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Load user from localStorage on mount
+  // Load user on mount. Auth cookies are HttpOnly so we can't read them
+  // from JS — we just call /auth/me and let the cookie (if present and
+  // valid) identify the user. A 401 means not logged in; show the login UI.
   useEffect(() => {
     const loadUser = async () => {
-      // DEV MODE: Skip authentication and use mock user
       if (DEV_MODE) {
         console.log('DEV_MODE: Using mock dev user');
         setUser(DEV_USER);
@@ -102,19 +103,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
         return;
       }
 
-      // PRODUCTION MODE: Normal authentication flow
-      const token = localStorage.getItem('access_token');
-      if (token) {
-        try {
-          // Verify token and get user info
-          const response = await api.get('/auth/me');
-          setUser(response.data);
-        } catch (error) {
-          console.error('Failed to load user:', error);
-          // Token is invalid, clear it
-          localStorage.removeItem('access_token');
-          localStorage.removeItem('refresh_token');
-        }
+      try {
+        const response = await api.get('/auth/me');
+        setUser(response.data);
+      } catch {
+        // Not logged in — AuthContext stays with user=null and the app
+        // renders the login page. /auth/me also seeds the csrf_token
+        // cookie as a side effect so the subsequent login POST works.
       }
       setIsLoading(false);
     };
@@ -142,7 +137,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return;
     }
 
-    // PRODUCTION MODE: Normal login flow
+    // PRODUCTION MODE: Normal login flow. The backend sets HttpOnly
+    // cookies for access_token and refresh_token; we just read the user
+    // from the response body.
     try {
       const response = await api.post('/auth/login', {
         username_or_email: usernameOrEmail,
@@ -150,16 +147,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
         mfa_code: mfaCode,
       });
 
-      const { access_token, refresh_token, user: userData } = response.data;
-
-      // Store tokens
-      localStorage.setItem('access_token', access_token);
-      localStorage.setItem('refresh_token', refresh_token);
-
-      // Set user
-      setUser(userData);
+      setUser(response.data.user);
     } catch (error: any) {
-      // Check if MFA is required (header or detail message)
       const isMfaRequired =
         error.response?.headers?.['x-mfa-required'] === 'true' ||
         error.response?.data?.detail === 'MFA code required';
@@ -178,41 +167,24 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return;
     }
 
-    // PRODUCTION MODE: Normal logout flow
+    // PRODUCTION MODE: Normal logout. Backend clears the auth cookies
+    // and blacklists the JTI; we just drop the user state.
     try {
       await api.post('/auth/logout');
     } catch (error) {
       console.error('Logout error:', error);
     } finally {
-      // Clear tokens and user
-      localStorage.removeItem('access_token');
-      localStorage.removeItem('refresh_token');
       setUser(null);
     }
   };
 
   const refreshToken = async () => {
     try {
-      const refreshTokenValue = localStorage.getItem('refresh_token');
-      if (!refreshTokenValue) {
-        throw new Error('No refresh token');
-      }
-
-      const response = await api.post('/auth/refresh', {
-        refresh_token: refreshTokenValue,
-      });
-
-      const { access_token, refresh_token: newRefreshToken, user: userData } = response.data;
-
-      // Update tokens
-      localStorage.setItem('access_token', access_token);
-      localStorage.setItem('refresh_token', newRefreshToken);
-
-      // Update user
-      setUser(userData);
+      // Refresh cookie is HttpOnly — the browser sends it automatically.
+      const response = await api.post('/auth/refresh');
+      setUser(response.data.user);
     } catch (error) {
       console.error('Token refresh failed:', error);
-      // Refresh failed, log out
       await logout();
     }
   };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,63 +1,68 @@
 import axios from 'axios'
 
+// Auth is cookie-based (HttpOnly access_token + refresh_token set by the
+// backend). withCredentials ensures axios sends those cookies on every
+// request, including via the Vite dev proxy.
 const api = axios.create({
   baseURL: '/api',
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
 })
 
-// Add auth token to requests
+// Read the csrf_token cookie set by the backend CSRF middleware. The
+// backend seeds this on any request that doesn't already have one, so
+// after the first /auth/me call it's always present.
+function readCookie(name: string): string | null {
+  const match = document.cookie.match(
+    new RegExp('(?:^|; )' + name.replace(/[.$?*|{}()[\]\\/+^]/g, '\\$&') + '=([^;]*)')
+  )
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+const MUTATING_METHODS = new Set(['post', 'put', 'patch', 'delete'])
+
+// Attach X-CSRF-Token on mutating requests. Double-submit cookie pattern —
+// a cross-site attacker can't read the cookie (same-origin policy) so
+// they can't forge a matching header.
 api.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('access_token')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
+    if (config.method && MUTATING_METHODS.has(config.method.toLowerCase())) {
+      const csrf = readCookie('csrf_token')
+      if (csrf) {
+        config.headers['X-CSRF-Token'] = csrf
+      }
     }
     return config
   },
-  (error) => {
-    return Promise.reject(error)
-  }
+  (error) => Promise.reject(error)
 )
 
-// Handle 401 errors (token expired)
+// Handle 401 by refreshing via the refresh_token cookie. The browser
+// carries the cookie automatically; we just POST to /auth/refresh.
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config
 
-    const isAuthEndpoint = originalRequest?.url?.startsWith('/auth/login')
+    const isAuthEndpoint =
+      originalRequest?.url?.startsWith('/auth/login') ||
+      originalRequest?.url?.startsWith('/auth/refresh')
 
     if (isAuthEndpoint) {
       return Promise.reject(error)
     }
 
-    // If 401 and we haven't retried yet, try to refresh token
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true
 
       try {
-        const refreshToken = localStorage.getItem('refresh_token')
-        if (refreshToken) {
-          const response = await axios.post('/api/auth/refresh', {
-            refresh_token: refreshToken,
-          })
-
-          const { access_token, refresh_token: newRefreshToken } = response.data
-
-          localStorage.setItem('access_token', access_token)
-          localStorage.setItem('refresh_token', newRefreshToken)
-
-          // Retry original request with new token
-          originalRequest.headers.Authorization = `Bearer ${access_token}`
-          return api(originalRequest)
-        }
+        await api.post('/auth/refresh')
+        // New cookies are set by the server; retry the original request.
+        return api(originalRequest)
       } catch (refreshError) {
-        // Refresh failed, redirect to login
-        localStorage.removeItem('access_token')
-        localStorage.removeItem('refresh_token')
-        window.location.href = '/login'
+        // Refresh failed — let the app's AuthContext react to the 401.
         return Promise.reject(refreshError)
       }
     }


### PR DESCRIPTION
## Summary

Fourth of five auth-hardening PRs tracked under #76. **The riskiest one** — touches backend + frontend and logs every currently-logged-in user out on deploy. After this, `localStorage` no longer holds tokens, so XSS can no longer exfiltrate them.

Both transports are now supported:
- **Browsers use HttpOnly cookies** (set by the backend, unreadable from JS)
- **CLI / scripts / API clients continue with `Authorization: Bearer …`**

## Backend changes

**Cookies.** New `backend/services/auth_cookies.py` centralizes the cookie attributes (`HttpOnly`, `Secure`, `SameSite`, `Path`) so every endpoint that sets or clears them agrees. Attributes read from env at call time:
- `VIGIL_COOKIE_SECURE` (default `true`; set `false` only for local HTTP dev)
- `VIGIL_COOKIE_SAMESITE` (default `strict`; `lax`/`none` for cross-origin setups)

`/auth/login` and `/auth/refresh` set both cookies in addition to returning the tokens in the response body. `access_token` is scoped to `Path=/`; `refresh_token` to `Path=/api/auth/refresh` so it isn't sent to every API call. Cookie `Max-Age` tracks each token's `exp` claim.

`/auth/logout` reads the current token from the cookie first (Bearer fallback), blacklists the JTI, and clears both cookies.

`/auth/refresh` reads the refresh token from the cookie first; the body field stays **optional** (`RefreshTokenRequest.refresh_token: Optional[str] = None`) so Bearer clients keep working.

**Middleware.** `get_current_user` now reads `access_token` from the cookie first and falls back to `Authorization: Bearer`. Dual-mode.

**CSRF enforcement.** `VIGIL_CSRF_ENABLED` default flipped to `true`. `VIGIL_CSRF_REPORT_ONLY` stays `true` for one rollout release — violations are logged at WARNING without rejecting. Flip to `false` to enforce once logs are clean. The middleware now also seeds `csrf_token` on **any** response when missing (previously only safe methods), so even a rejected POST gives the client a cookie for its next attempt.

## Frontend changes

**`api.ts`.** `withCredentials: true` on the axios instance. All `localStorage` token reads and writes removed. New request interceptor reads `csrf_token` cookie and attaches `X-CSRF-Token` on `POST|PUT|PATCH|DELETE`. 401 response interceptor POSTs `/auth/refresh` with no body (cookie carries the token) and retries.

**`AuthContext.tsx`.** `loadUser` unconditionally calls `/auth/me` on mount — backend identifies the user from the cookie, and the call also seeds `csrf_token` so the next login POST has a cookie to echo. `login`, `logout`, `refreshToken` no longer touch tokens directly; the server-set cookies and the user payload are the only things the UI needs.

**Dev environment.** `frontend/vite.config.ts` already has `server.proxy` for `/api`, so `SameSite=Strict` works in dev without changes — everything is same-origin through the proxy.

## Operator notes

- **Every currently-logged-in user session is invalidated on deploy.** Unavoidable: frontend no longer reads `localStorage`, and backend tokens predate the `jti`/`iat` claims from #97. One forced re-login.
- **For local HTTP dev: set `VIGIL_COOKIE_SECURE=false`.** Otherwise the browser discards the cookies and login silently fails.
- **For cross-origin SPA/API deployments:** set `VIGIL_COOKIE_SAMESITE=lax` (or `none` with `Secure=true`) and update `VIGIL_CORS_ORIGINS`.
- **CSRF is in report-only mode by default.** Monitor `grep "CSRF violation" backend.log` for a release before flipping `VIGIL_CSRF_REPORT_ONLY=false`.
- Bearer flow remains supported indefinitely — no deprecation planned.

## Test plan

- [ ] Fresh login in browser sets HttpOnly `access_token` and `refresh_token` cookies
- [ ] `document.cookie` does NOT expose `access_token` (HttpOnly)
- [ ] `document.cookie` DOES expose `csrf_token` (JS-readable by design)
- [ ] `localStorage.getItem('access_token')` returns null after login
- [ ] After cookie-based login, a page reload stays authenticated without any JS intervention
- [ ] `/auth/logout` clears both cookies; next `/auth/me` returns 401
- [ ] Let the access token expire (reduce `JWT_EXPIRATION_HOURS` for testing): the axios 401 interceptor auto-refreshes via the refresh cookie and retries
- [ ] POST without `X-CSRF-Token`: `VIGIL_CSRF_REPORT_ONLY=true` logs WARNING and proceeds; `false` returns 403
- [ ] Bearer flow still works: `curl -H "Authorization: Bearer …" /api/auth/me`
- [ ] Local HTTP dev: `VIGIL_COOKIE_SECURE=false` — cookies stick
- [ ] Local HTTPS / prod: `VIGIL_COOKIE_SECURE=true` — cookies stick
- [ ] SSO / cross-site redirect flows (if any) still work with `SameSite=strict` — otherwise flip to `lax`

## Scope boundaries

- Password policy / reset flow / broken test repair — #99 (last PR)
- This is the last breaking change in the auth hardening series

Closes #98. Part of #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)