### PR TITLE
feat(ai): per-component model selection via AI Config (#89)

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -16,6 +16,7 @@ from api.workflows import router as workflows_router
 from api.reasoning import router as reasoning_router
 from api.skills import router as skills_router
 from api.llm_providers import router as llm_providers_router
+from api.ai_config import router as ai_config_router
 
 __all__ = [
     'findings_router',
@@ -34,4 +35,5 @@ __all__ = [
     'reasoning_router',
     'skills_router',
     'llm_providers_router',
+    'ai_config_router',
 ]

--- a/backend/api/ai_config.py
+++ b/backend/api/ai_config.py
@@ -1,0 +1,187 @@
+"""Per-component AI model assignment API (GH #89).
+
+Endpoints (registered under /api/ai):
+  GET    /config                 — all component → model assignments
+  PUT    /config/{component}     — upsert one assignment
+  DELETE /config/{component}     — clear one assignment (falls back to chat_default)
+  GET    /models                 — aggregated model list across active providers
+  GET    /models/{model_id}/info — capability + pricing detail for one model
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+from database.connection import get_db_session  # noqa: E402
+from database.models import AIModelConfig, LLMProviderConfig  # noqa: E402
+from services.model_registry import (  # noqa: E402
+    COMPONENTS,
+    ModelInfo,
+    get_registry,
+    is_valid_component,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class ComponentAssignmentResponse(BaseModel):
+    component: str
+    provider_id: str
+    model_id: str
+    settings: Dict[str, Any] = Field(default_factory=dict)
+    updated_by: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class ComponentAssignmentUpdate(BaseModel):
+    provider_id: str
+    model_id: str
+    settings: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AIConfigResponse(BaseModel):
+    components: List[str]
+    assignments: Dict[str, ComponentAssignmentResponse]
+
+
+class ModelInfoResponse(BaseModel):
+    model_id: str
+    provider_id: str
+    provider_type: str
+    display_name: str
+    context_window: int
+    input_cost_per_1k: float
+    output_cost_per_1k: float
+    supports_tools: bool
+    supports_thinking: bool
+    supports_vision: bool
+
+
+class ModelsListResponse(BaseModel):
+    models: List[ModelInfoResponse]
+
+
+# ---------------------------------------------------------------------------
+# Endpoints — config CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.get("/config", response_model=AIConfigResponse)
+def get_ai_config(db: Session = Depends(get_db_session)):
+    rows = db.query(AIModelConfig).all()
+    assignments = {
+        r.component: ComponentAssignmentResponse(
+            component=r.component,
+            provider_id=r.provider_id,
+            model_id=r.model_id,
+            settings=r.settings or {},
+            updated_by=r.updated_by,
+            updated_at=r.updated_at.isoformat() if r.updated_at else None,
+        )
+        for r in rows
+    }
+    return AIConfigResponse(components=list(COMPONENTS), assignments=assignments)
+
+
+@router.put("/config/{component}", response_model=ComponentAssignmentResponse)
+def set_component_assignment(
+    component: str,
+    payload: ComponentAssignmentUpdate,
+    db: Session = Depends(get_db_session),
+):
+    if not is_valid_component(component):
+        raise HTTPException(status_code=400, detail=f"unknown component: {component}")
+
+    provider = db.get(LLMProviderConfig, payload.provider_id)
+    if provider is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"provider not found: {payload.provider_id}",
+        )
+    if not provider.is_active:
+        raise HTTPException(
+            status_code=400,
+            detail=f"provider {payload.provider_id} is not active",
+        )
+
+    row = db.get(AIModelConfig, component)
+    if row is None:
+        row = AIModelConfig(
+            component=component,
+            provider_id=payload.provider_id,
+            model_id=payload.model_id,
+            settings=payload.settings,
+        )
+        db.add(row)
+    else:
+        row.provider_id = payload.provider_id
+        row.model_id = payload.model_id
+        row.settings = payload.settings
+    db.commit()
+    db.refresh(row)
+
+    return ComponentAssignmentResponse(
+        component=row.component,
+        provider_id=row.provider_id,
+        model_id=row.model_id,
+        settings=row.settings or {},
+        updated_by=row.updated_by,
+        updated_at=row.updated_at.isoformat() if row.updated_at else None,
+    )
+
+
+@router.delete("/config/{component}")
+def clear_component_assignment(component: str, db: Session = Depends(get_db_session)):
+    if not is_valid_component(component):
+        raise HTTPException(status_code=400, detail=f"unknown component: {component}")
+    row = db.get(AIModelConfig, component)
+    if row is None:
+        return {"component": component, "cleared": False}
+    db.delete(row)
+    db.commit()
+    return {"component": component, "cleared": True}
+
+
+# ---------------------------------------------------------------------------
+# Endpoints — model discovery
+# ---------------------------------------------------------------------------
+
+
+@router.get("/models", response_model=ModelsListResponse)
+async def list_models():
+    registry = get_registry()
+    models: List[ModelInfo] = await registry.list_available_models()
+    return ModelsListResponse(models=[ModelInfoResponse(**m.to_dict()) for m in models])
+
+
+@router.get("/models/{model_id}/info", response_model=ModelInfoResponse)
+async def get_model_info(model_id: str, provider_id: Optional[str] = None):
+    registry = get_registry()
+    # Find the provider for this model. If provider_id is given, trust it;
+    # otherwise pick the first active provider that offers the model in its
+    # live list (or matches a catalog entry).
+    all_models = await registry.list_available_models()
+    match: Optional[ModelInfo] = None
+    for m in all_models:
+        if m.model_id == model_id and (
+            provider_id is None or m.provider_id == provider_id
+        ):
+            match = m
+            break
+    if match is None:
+        raise HTTPException(status_code=404, detail=f"model not found: {model_id}")
+    return ModelInfoResponse(**match.to_dict())

--- a/backend/api/claude.py
+++ b/backend/api/claude.py
@@ -16,9 +16,53 @@ import logging
 import base64
 
 from services.claude_service import ClaudeService
+from services.model_registry import get_registry
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+def _resolve_model_for_request(
+    requested_model: Optional[str], agent_id: Optional[str]
+) -> str:
+    """Resolve the effective chat model (GH #89).
+
+    Precedence:
+      1. Explicit request.model (caller opt-in)
+      2. AgentProfile.model (per-agent override)
+      3. ai_model_configs[agent.component_category] (triage/investigation/reporting)
+      4. ai_model_configs['chat_default']
+      5. Default Anthropic provider's default_model
+      6. Historical default 'claude-sonnet-4-5-20250929'
+    """
+    if requested_model:
+        return requested_model
+
+    registry = get_registry()
+    agent_override: Optional[str] = None
+    category: str = "chat_default"
+
+    if agent_id:
+        try:
+            from services.soc_agents import AgentManager
+
+            agent = AgentManager().agents.get(agent_id)
+            if agent is not None:
+                agent_override = getattr(agent, "model", None)
+                category = getattr(agent, "component_category", None) or "investigation"
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("agent lookup in model resolution failed: %s", exc)
+
+    if agent_override:
+        resolved = registry.resolve_model_for_component(
+            category, agent_override=agent_override
+        )
+    else:
+        resolved = registry.resolve_model_for_component(category)
+
+    if resolved is not None:
+        return resolved[1]
+    return "claude-sonnet-4-5-20250929"
 
 
 class ContentBlock(BaseModel):
@@ -50,7 +94,9 @@ class ChatRequest(BaseModel):
 
     messages: List[ChatMessage]
     system_prompt: Optional[str] = None
-    model: str = "claude-sonnet-4-20250514"
+    # None means "resolve via ai_model_configs" (GH #89). Callers may still
+    # override with an explicit model id.
+    model: Optional[str] = None
     max_tokens: int = 4096
     enable_thinking: bool = False
     thinking_budget: int = 10000
@@ -69,7 +115,7 @@ class AgentTaskRequest(BaseModel):
     system_prompt: Optional[str] = None
     allowed_tools: Optional[List[str]] = None
     max_turns: int = 10
-    model: str = "claude-sonnet-4-20250514"
+    model: Optional[str] = None  # GH #89 — resolved via ai_model_configs if omitted
     session_id: Optional[str] = None
     agent_id: Optional[str] = None
 
@@ -94,6 +140,9 @@ async def chat(request: ChatRequest):
     # Generate unique request ID for tracking
     request_id = str(uuid.uuid4())[:8]
     start_time = time.time()
+
+    # GH #89: resolve model via ai_model_configs if caller didn't specify one.
+    request.model = _resolve_model_for_request(request.model, request.agent_id)
 
     logger.info(
         f"📨 Chat request received - RequestID: {request_id}, Model: {request.model}, Thinking: {request.enable_thinking}, Budget: {request.thinking_budget}, Agent: {request.agent_id}"
@@ -335,6 +384,9 @@ async def chat_stream(request: ChatRequest):
     # Generate unique request ID for tracking
     request_id = str(uuid.uuid4())[:8]
     start_time = time.time()
+
+    # GH #89: resolve model via ai_model_configs if caller didn't specify one.
+    request.model = _resolve_model_for_request(request.model, request.agent_id)
 
     logger.info(
         f"🌊 Stream request received - RequestID: {request_id}, Model: {request.model}, Thinking: {request.enable_thinking}, Budget: {request.thinking_budget}, Agent: {request.agent_id}"
@@ -586,7 +638,10 @@ async def websocket_chat(websocket: WebSocket):
 
             messages = data.get("messages", [])
             system_prompt = data.get("system_prompt")
-            model = data.get("model", "claude-sonnet-4-20250514")
+            # GH #89: resolve via ai_model_configs when caller omits model.
+            model = data.get("model") or _resolve_model_for_request(
+                None, data.get("agent_id")
+            )
             max_tokens = data.get("max_tokens", 4096)
             enable_thinking = data.get("enable_thinking", False)
             thinking_budget = data.get("thinking_budget", 10000)
@@ -636,29 +691,54 @@ async def websocket_chat(websocket: WebSocket):
 
 @router.get("/models")
 async def get_models():
-    """
-    Get list of available Claude models.
+    """List available models.
 
-    Returns:
-        List of model names
+    Backward-compatible alias for `/api/ai/models` (GH #89). Returns the
+    Anthropic subset so the existing Chat UI model picker continues to
+    show only Claude models even when Ollama/OpenAI providers are active.
     """
+    registry = get_registry()
+    try:
+        all_models = await registry.list_available_models()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("get_models: registry lookup failed: %s", exc)
+        all_models = []
+
+    anthropic_only = [m for m in all_models if m.provider_type == "anthropic"]
+    if not anthropic_only:
+        # Fallback — ensures the Chat UI still has something to render if the
+        # provider registry isn't reachable (e.g. fresh install, no DB).
+        return {
+            "models": [
+                {
+                    "id": "claude-sonnet-4-5-20250929",
+                    "name": "Claude Sonnet 4.5",
+                    "description": "Most intelligent model, best for complex tasks",
+                },
+                {
+                    "id": "claude-sonnet-4-20250514",
+                    "name": "Claude Sonnet 4",
+                    "description": "Balanced speed and intelligence",
+                },
+                {
+                    "id": "claude-haiku-4-5-20251001",
+                    "name": "Claude Haiku 4.5",
+                    "description": "Fastest model, good for simple tasks",
+                },
+            ]
+        }
+
     return {
         "models": [
             {
-                "id": "claude-sonnet-4-20250514",
-                "name": "Claude 4.5 Sonnet",
-                "description": "Most intelligent model, best for complex tasks",
-            },
-            {
-                "id": "claude-3-5-sonnet-20241022",
-                "name": "Claude 3.5 Sonnet",
-                "description": "Previous generation, good balance of speed and intelligence",
-            },
-            {
-                "id": "claude-3-5-haiku-20241022",
-                "name": "Claude 3.5 Haiku",
-                "description": "Fastest model, good for simple tasks",
-            },
+                "id": m.model_id,
+                "name": m.display_name,
+                "description": (
+                    f"{m.context_window // 1000}K context, "
+                    f"${m.input_cost_per_1k:.4f}/1K in / ${m.output_cost_per_1k:.4f}/1K out"
+                ),
+            }
+            for m in anthropic_only
         ]
     }
 
@@ -667,7 +747,8 @@ class SummarizeRequest(BaseModel):
     """Request to summarize a conversation."""
 
     messages: List[ChatMessage]
-    model: str = "claude-sonnet-4-20250514"
+    # GH #89: None means "use ai_model_configs['summarization']".
+    model: Optional[str] = None
 
 
 @router.post("/summarize")
@@ -729,10 +810,16 @@ Provide a structured summary that captures all essential context for continuing 
     try:
         from services.llm_gateway import get_llm_gateway
 
+        # GH #89: resolve summarization model via ai_model_configs.
+        model = request.model or _resolve_model_for_request(None, None)
+        resolved = get_registry().resolve_model_for_component("summarization")
+        if request.model is None and resolved is not None:
+            model = resolved[1]
+
         gateway = await get_llm_gateway()
         response = await gateway.submit_chat(
             messages=[{"role": "user", "content": summary_prompt}],
-            model=request.model,
+            model=model,
             max_tokens=4096,
             system_prompt="You are a precise conversation summarizer. Preserve all actionable details, entity IDs, and investigation context.",
         )
@@ -802,6 +889,9 @@ async def run_agent_task(request: AgentTaskRequest):
                 allowed_tools = agent.recommended_tools
             logger.info(f"Using agent: {agent.name}")
 
+    # GH #89: resolve model via ai_model_configs if caller didn't specify one.
+    request.model = _resolve_model_for_request(request.model, request.agent_id)
+
     claude_service = ClaudeService(use_backend_tools=True, use_agent_sdk=True)
 
     if not claude_service.has_api_key():
@@ -860,6 +950,9 @@ async def stream_agent_task(request: AgentTaskRequest):
             system_prompt = system_prompt or agent.system_prompt
             if not allowed_tools:
                 allowed_tools = agent.recommended_tools
+
+    # GH #89: resolve model via ai_model_configs if caller didn't specify one.
+    request.model = _resolve_model_for_request(request.model, request.agent_id)
 
     claude_service = ClaudeService(use_backend_tools=True, use_agent_sdk=True)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -45,6 +45,7 @@ from api import (
     reasoning_router,
     skills_router,
     llm_providers_router,
+    ai_config_router,
 )
 from api.local_services import router as local_services_router
 from api.integrations_compatibility import router as compatibility_router
@@ -191,6 +192,7 @@ app.include_router(claude_router, prefix="/api/claude", tags=["claude"], depende
 app.include_router(reasoning_router, prefix="/api/reasoning", tags=["reasoning"])
 app.include_router(config_router, prefix="/api/config", tags=["config"])
 app.include_router(llm_providers_router, prefix="/api/llm/providers", tags=["llm-providers"])
+app.include_router(ai_config_router, prefix="/api/ai", tags=["ai-config"])
 app.include_router(attack_router, prefix="/api/attack", tags=["attack"])
 app.include_router(custom_agents_router, prefix="/api", tags=["custom-agents"])
 app.include_router(agents_router, prefix="/api/agents", tags=["agents"])

--- a/daemon/agent_runner.py
+++ b/daemon/agent_runner.py
@@ -28,12 +28,33 @@ try:
 except Exception:
     _tracer = None  # type: ignore[assignment]
 
-# TODO(#89): Sonnet price constants assume Anthropic. With multi-provider
-# support (#88) landing, cost tracking should resolve per-provider rates
-# from a model registry instead of a single global constant. Update
-# together with the per-agent model assignment work in #89.
+# Deprecated legacy aliases — retained so out-of-tree imports don't crash.
+# New code should use `compute_call_cost()` below, which resolves per-provider
+# rates via services.model_registry (GH #89).
 SONNET_INPUT_COST = 3.0 / 1_000_000
 SONNET_OUTPUT_COST = 15.0 / 1_000_000
+
+
+def compute_call_cost(
+    model_id: Optional[str],
+    provider_type: Optional[str],
+    input_tokens: int,
+    output_tokens: int,
+) -> float:
+    """Compute USD cost of a single LLM call (GH #89).
+
+    Looks up per-token rates from services.model_registry.get_cost_rates().
+    Falls back to Sonnet pricing when the model/provider can't be determined
+    so daemon cost tracking never silently zeroes out for known Anthropic usage.
+    """
+    if model_id and provider_type:
+        try:
+            from services.model_registry import get_registry
+            in_rate, out_rate = get_registry().get_cost_rates(model_id, provider_type)
+            return input_tokens * in_rate + output_tokens * out_rate
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("cost lookup fell through to Sonnet defaults: %s", exc)
+    return input_tokens * SONNET_INPUT_COST + output_tokens * SONNET_OUTPUT_COST
 
 TOOL_TIERS = {
     "safe": [
@@ -371,7 +392,15 @@ class AgentRunner:
 
                 in_tokens = result.get("input_tokens", 0)
                 out_tokens = result.get("output_tokens", 0)
-                cost = in_tokens * SONNET_INPUT_COST + out_tokens * SONNET_OUTPUT_COST
+                # GH #89: provider_type defaults to "anthropic" since the
+                # plan_model used here is resolved from ai_model_configs or
+                # the default Anthropic provider.
+                cost = compute_call_cost(
+                    self.config.plan_model,
+                    result.get("provider") or "anthropic",
+                    in_tokens,
+                    out_tokens,
+                )
                 total_input_tokens += in_tokens
                 total_output_tokens += out_tokens
                 total_cost += cost

--- a/daemon/config.py
+++ b/daemon/config.py
@@ -274,6 +274,28 @@ class DaemonConfig:
         except Exception as e:
             logger.debug(f"Could not load orchestrator config from DB (using env/defaults): {e}")
 
+        # GH #89 — ai_model_configs takes precedence over orchestrator.settings
+        # for plan_model/review_model. This is the same override layer that
+        # powers the "Model Assignment" section of the AI Config tab.
+        try:
+            from services.model_registry import get_registry
+            registry = get_registry()
+            plan_pick = registry.resolve_model_for_component('orchestrator_plan')
+            review_pick = registry.resolve_model_for_component('orchestrator_review')
+            if plan_pick is not None:
+                config.orchestrator.plan_model = plan_pick[1]
+            if review_pick is not None:
+                config.orchestrator.review_model = review_pick[1]
+            if plan_pick or review_pick:
+                logger.info(
+                    "Orchestrator models resolved from ai_model_configs: "
+                    "plan=%s review=%s",
+                    config.orchestrator.plan_model,
+                    config.orchestrator.review_model,
+                )
+        except Exception as e:
+            logger.debug(f"ai_model_configs override skipped: {e}")
+
         # Kafka: merge non-secret DB settings on top of env defaults
         try:
             from database.config_service import get_config_service

--- a/database/init/10_ai_model_configs.sql
+++ b/database/init/10_ai_model_configs.sql
@@ -1,0 +1,46 @@
+-- Per-Component AI Model Assignments (GH #89)
+-- Maps system components (chat, triage, investigation, orchestrator_plan,
+-- orchestrator_review, summarization, reporting) to a (provider, model) pair.
+-- When a row is absent, the component falls back to `chat_default`.
+
+CREATE TABLE IF NOT EXISTS ai_model_configs (
+    component VARCHAR(64) PRIMARY KEY,
+    provider_id VARCHAR(64) NOT NULL REFERENCES llm_provider_configs(provider_id) ON DELETE RESTRICT,
+    model_id VARCHAR(200) NOT NULL,
+    settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+    updated_by VARCHAR(64),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_model_configs_provider ON ai_model_configs(provider_id);
+
+CREATE OR REPLACE FUNCTION update_ai_model_configs_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_ai_model_configs_updated_at ON ai_model_configs;
+CREATE TRIGGER trigger_ai_model_configs_updated_at
+    BEFORE UPDATE ON ai_model_configs
+    FOR EACH ROW
+    EXECUTE FUNCTION update_ai_model_configs_timestamp();
+
+COMMENT ON TABLE ai_model_configs IS 'Per-component AI model assignments (GH #89)';
+COMMENT ON COLUMN ai_model_configs.component IS
+    'chat_default | triage | investigation | orchestrator_plan | orchestrator_review | summarization | reporting';
+COMMENT ON COLUMN ai_model_configs.settings IS
+    'Component-specific overrides (max_tokens, thinking_budget, temperature)';
+
+-- Seed chat_default from the existing default Anthropic provider so upgrades
+-- behave identically to the previous hardcoded default.
+INSERT INTO ai_model_configs (component, provider_id, model_id, settings)
+SELECT 'chat_default', provider_id, default_model, '{}'::jsonb
+FROM llm_provider_configs
+WHERE provider_type = 'anthropic' AND is_default = TRUE
+ON CONFLICT (component) DO NOTHING;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ai_model_configs TO deeptempo;

--- a/database/init/11_custom_agent_component_category.sql
+++ b/database/init/11_custom_agent_component_category.sql
@@ -1,0 +1,10 @@
+-- Add component_category to custom_agents (GH #89)
+-- Lets custom agents inherit a per-component model assignment (triage,
+-- investigation, reporting) from ai_model_configs when no per-agent
+-- `model` override is set.
+
+ALTER TABLE custom_agents
+    ADD COLUMN IF NOT EXISTS component_category VARCHAR(32) NOT NULL DEFAULT 'investigation';
+
+COMMENT ON COLUMN custom_agents.component_category IS
+    'triage | investigation | reporting — maps to ai_model_configs components';

--- a/database/models.py
+++ b/database/models.py
@@ -2373,6 +2373,9 @@ class CustomAgent(Base):
     max_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=4096, server_default='4096')
     enable_thinking: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default='false')
     model: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    component_category: Mapped[str] = mapped_column(
+        String(32), nullable=False, default='investigation', server_default='investigation'
+    )
 
     created_by: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
@@ -2404,6 +2407,7 @@ class CustomAgent(Base):
             'max_tokens': self.max_tokens,
             'enable_thinking': self.enable_thinking,
             'model': self.model,
+            'component_category': self.component_category,
             'created_by': self.created_by,
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None,
@@ -2467,6 +2471,52 @@ class LLMProviderConfig(Base):
             'last_test_at': self.last_test_at.isoformat() if self.last_test_at else None,
             'last_test_success': self.last_test_success,
             'last_error': self.last_error,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+class AIModelConfig(Base):
+    """Per-component AI model assignment (GH #89).
+
+    Each row maps a logical component (chat_default, triage, investigation,
+    orchestrator_plan, orchestrator_review, summarization, reporting) to a
+    (provider, model) pair. Components without a row fall back to the
+    `chat_default` row; if that is missing, callers fall back to the
+    default Anthropic provider's default_model.
+
+    See database/init/10_ai_model_configs.sql for the table definition.
+    """
+
+    __tablename__ = 'ai_model_configs'
+
+    component: Mapped[str] = mapped_column(String(64), primary_key=True)
+    provider_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey('llm_provider_configs.provider_id', ondelete='RESTRICT'),
+        nullable=False,
+    )
+    model_id: Mapped[str] = mapped_column(String(200), nullable=False)
+    settings: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    updated_by: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, server_default='now()'
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, server_default='now()'
+    )
+
+    __table_args__ = (
+        Index('idx_ai_model_configs_provider', 'provider_id'),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            'component': self.component,
+            'provider_id': self.provider_id,
+            'model_id': self.model_id,
+            'settings': self.settings or {},
+            'updated_by': self.updated_by,
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/frontend/src/components/settings/ModelAssignmentTab.tsx
+++ b/frontend/src/components/settings/ModelAssignmentTab.tsx
@@ -1,0 +1,375 @@
+/**
+ * ModelAssignmentTab — per-component AI model picker (GH #89).
+ *
+ * Renders one row per component (chat_default, triage, investigation,
+ * orchestrator_plan, orchestrator_review, summarization, reporting). Each
+ * row has a provider + model selector populated from /api/ai/models.
+ * "Inherit from Chat Default" clears the assignment so the component
+ * falls back through the chain in services/model_registry.py.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Box,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Select,
+  MenuItem,
+  Chip,
+  Button,
+  CircularProgress,
+  Checkbox,
+  FormControlLabel,
+  Stack,
+} from '@mui/material'
+import SaveIcon from '@mui/icons-material/Save'
+import PsychologyIcon from '@mui/icons-material/Psychology'
+import BuildIcon from '@mui/icons-material/Build'
+import ImageIcon from '@mui/icons-material/Image'
+import {
+  aiConfigApi,
+  AIModelInfo,
+  ComponentAssignment,
+} from '../../services/api'
+
+interface Props {
+  setMessage: (m: { type: 'success' | 'error'; text: string } | null) => void
+}
+
+const COMPONENT_LABELS: Record<string, { label: string; description: string }> = {
+  chat_default: {
+    label: 'Chat (Default)',
+    description: 'Fallback for interactive chat and every component below when unset.',
+  },
+  triage: {
+    label: 'Triage Agent',
+    description: 'Automated alert triage — cheaper/faster models work well here.',
+  },
+  investigation: {
+    label: 'Investigation Agents',
+    description: 'Investigator, Threat Hunter, Correlator, etc. — the heavy lifters.',
+  },
+  orchestrator_plan: {
+    label: 'Orchestrator — Planning',
+    description: 'Generates the investigation plan from the initial finding.',
+  },
+  orchestrator_review: {
+    label: 'Orchestrator — Review',
+    description: 'Reviews and approves sub-agent output at the end of an investigation.',
+  },
+  summarization: {
+    label: 'Context Summarization',
+    description: 'Compresses long conversations — a cheap model is usually fine.',
+  },
+  reporting: {
+    label: 'Report Generation',
+    description: 'Reporter agent output — clarity and structure matter more than depth.',
+  },
+}
+
+const CHAT_DEFAULT_KEY = 'chat_default'
+
+type RowState = {
+  inherit: boolean
+  providerId: string
+  modelId: string
+}
+
+export default function ModelAssignmentTab({ setMessage }: Props) {
+  const [components, setComponents] = useState<string[]>([])
+  const [initialAssignments, setInitialAssignments] = useState<Record<string, ComponentAssignment>>({})
+  const [rows, setRows] = useState<Record<string, RowState>>({})
+  const [models, setModels] = useState<AIModelInfo[]>([])
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  const modelsByProvider = useMemo(() => {
+    const grouped: Record<string, AIModelInfo[]> = {}
+    for (const m of models) {
+      if (!grouped[m.provider_id]) grouped[m.provider_id] = []
+      grouped[m.provider_id].push(m)
+    }
+    return grouped
+  }, [models])
+
+  const providerIds = useMemo(() => Object.keys(modelsByProvider).sort(), [modelsByProvider])
+
+  const load = async () => {
+    setLoading(true)
+    try {
+      const [cfgResp, modelsResp] = await Promise.all([
+        aiConfigApi.getConfig(),
+        aiConfigApi.listModels(),
+      ])
+      setComponents(cfgResp.data.components)
+      setInitialAssignments(cfgResp.data.assignments)
+      setModels(modelsResp.data.models)
+
+      const nextRows: Record<string, RowState> = {}
+      for (const c of cfgResp.data.components) {
+        const a = cfgResp.data.assignments[c]
+        if (a) {
+          nextRows[c] = {
+            inherit: false,
+            providerId: a.provider_id,
+            modelId: a.model_id,
+          }
+        } else {
+          nextRows[c] = {
+            inherit: c !== CHAT_DEFAULT_KEY,
+            providerId: '',
+            modelId: '',
+          }
+        }
+      }
+      setRows(nextRows)
+    } catch (e: any) {
+      setMessage({
+        type: 'error',
+        text: e?.response?.data?.detail || 'Failed to load AI config',
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const updateRow = (component: string, patch: Partial<RowState>) => {
+    setRows((prev) => ({ ...prev, [component]: { ...prev[component], ...patch } }))
+  }
+
+  const hasChanges = useMemo(() => {
+    for (const c of components) {
+      const row = rows[c]
+      const initial = initialAssignments[c]
+      if (!row) continue
+      if (row.inherit) {
+        if (initial !== undefined) return true
+      } else {
+        if (!initial) return true
+        if (initial.provider_id !== row.providerId || initial.model_id !== row.modelId) {
+          return true
+        }
+      }
+    }
+    return false
+  }, [rows, initialAssignments, components])
+
+  const handleSave = async () => {
+    setSaving(true)
+    try {
+      for (const c of components) {
+        const row = rows[c]
+        const initial = initialAssignments[c]
+        if (!row) continue
+        if (row.inherit) {
+          if (initial !== undefined) {
+            await aiConfigApi.clearComponent(c)
+          }
+          continue
+        }
+        if (!row.providerId || !row.modelId) continue
+        if (
+          !initial ||
+          initial.provider_id !== row.providerId ||
+          initial.model_id !== row.modelId
+        ) {
+          await aiConfigApi.setComponent(c, {
+            provider_id: row.providerId,
+            model_id: row.modelId,
+          })
+        }
+      }
+      setMessage({ type: 'success', text: 'Model assignments saved' })
+      await load()
+    } catch (e: any) {
+      setMessage({
+        type: 'error',
+        text: e?.response?.data?.detail || 'Failed to save assignments',
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const renderModelMenuItem = (m: AIModelInfo) => {
+    const ctx = m.context_window ? `${Math.round(m.context_window / 1000)}K` : '?'
+    const cost =
+      m.input_cost_per_1k > 0 || m.output_cost_per_1k > 0
+        ? `$${m.input_cost_per_1k.toFixed(4)} in / $${m.output_cost_per_1k.toFixed(4)} out (per 1K)`
+        : 'self-hosted'
+    return (
+      <MenuItem value={m.model_id} key={`${m.provider_id}-${m.model_id}`}>
+        <Stack>
+          <Typography variant="body2">{m.display_name || m.model_id}</Typography>
+          <Typography variant="caption" color="text.secondary">
+            {ctx} ctx · {cost}
+          </Typography>
+        </Stack>
+      </MenuItem>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, p: 2 }}>
+        <CircularProgress size={16} />
+        <Typography variant="body2">Loading AI config…</Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box>
+      <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
+        Model Assignment
+      </Typography>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
+        Pick a provider + model for each system component. Unassigned rows fall back to
+        the <code>chat_default</code> assignment. Model list is live-queried from each
+        provider.
+      </Typography>
+
+      {providerIds.length === 0 ? (
+        <Typography variant="body2" color="warning.main" sx={{ mb: 2 }}>
+          No models discovered — add at least one active provider below before
+          assigning models.
+        </Typography>
+      ) : null}
+
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>Component</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Provider</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Model</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Capabilities</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Inherit</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {components.map((c) => {
+              const meta = COMPONENT_LABELS[c] || { label: c, description: '' }
+              const row = rows[c] || { inherit: true, providerId: '', modelId: '' }
+              const isChatDefault = c === CHAT_DEFAULT_KEY
+              const providerModels = row.providerId
+                ? modelsByProvider[row.providerId] || []
+                : []
+              const selectedModel =
+                providerModels.find((m) => m.model_id === row.modelId) || null
+
+              return (
+                <TableRow key={c}>
+                  <TableCell sx={{ verticalAlign: 'top' }}>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      {meta.label}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {meta.description}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Select
+                      size="small"
+                      fullWidth
+                      disabled={row.inherit}
+                      value={row.providerId}
+                      displayEmpty
+                      onChange={(e) =>
+                        updateRow(c, {
+                          providerId: e.target.value as string,
+                          modelId: '',
+                        })
+                      }
+                    >
+                      <MenuItem value="" disabled>
+                        <em>Select provider</em>
+                      </MenuItem>
+                      {providerIds.map((pid) => (
+                        <MenuItem value={pid} key={pid}>
+                          {pid}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </TableCell>
+                  <TableCell>
+                    <Select
+                      size="small"
+                      fullWidth
+                      disabled={row.inherit || !row.providerId}
+                      value={row.modelId}
+                      displayEmpty
+                      onChange={(e) => updateRow(c, { modelId: e.target.value as string })}
+                    >
+                      <MenuItem value="" disabled>
+                        <em>Select model</em>
+                      </MenuItem>
+                      {providerModels.map(renderModelMenuItem)}
+                    </Select>
+                  </TableCell>
+                  <TableCell>
+                    <Stack direction="row" spacing={0.5}>
+                      {selectedModel?.supports_tools ? (
+                        <Chip size="small" label="Tools" icon={<BuildIcon sx={{ fontSize: 14 }} />} />
+                      ) : null}
+                      {selectedModel?.supports_thinking ? (
+                        <Chip
+                          size="small"
+                          label="Thinking"
+                          icon={<PsychologyIcon sx={{ fontSize: 14 }} />}
+                        />
+                      ) : null}
+                      {selectedModel?.supports_vision ? (
+                        <Chip size="small" label="Vision" icon={<ImageIcon sx={{ fontSize: 14 }} />} />
+                      ) : null}
+                    </Stack>
+                  </TableCell>
+                  <TableCell sx={{ verticalAlign: 'top' }}>
+                    <FormControlLabel
+                      disabled={isChatDefault}
+                      control={
+                        <Checkbox
+                          size="small"
+                          checked={row.inherit}
+                          onChange={(e) =>
+                            updateRow(c, {
+                              inherit: e.target.checked,
+                              ...(e.target.checked ? { providerId: '', modelId: '' } : {}),
+                            })
+                          }
+                        />
+                      }
+                      label={<Typography variant="caption">From Chat Default</Typography>}
+                    />
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Box sx={{ mt: 2, display: 'flex', gap: 1 }}>
+        <Button
+          variant="contained"
+          startIcon={<SaveIcon />}
+          disabled={!hasChanges || saving}
+          onClick={handleSave}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -68,6 +68,7 @@ import AutoInvestigateTab from '../components/settings/AutoInvestigateTab'
 import SkillsTab from '../components/settings/SkillsTab'
 import KafkaTab from '../components/settings/KafkaTab'
 import LLMProvidersTab from '../components/settings/LLMProvidersTab'
+import ModelAssignmentTab from '../components/settings/ModelAssignmentTab'
 
 interface TabPanelProps {
   children?: React.ReactNode
@@ -879,6 +880,9 @@ export default function Settings() {
               </Box>
               <TextField fullWidth label="API Key" type="password" value={claudeConfig.api_key} onChange={(e) => setClaudeConfig({ ...claudeConfig, api_key: e.target.value })} sx={{ mb: 2 }} />
               <Button variant="contained" startIcon={<SaveIcon />} onClick={handleSaveClaude}>Save</Button>
+            </Box>
+            <Box sx={{ mt: 4, maxWidth: 1100 }}>
+              <ModelAssignmentTab setMessage={setMessage} />
             </Box>
             <Box sx={{ mt: 4 }}>
               <LLMProvidersTab setMessage={setMessage} />

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -737,6 +737,49 @@ export const llmProviderApi = {
     api.post<LLMProvider>(`/llm/providers/${providerId}/set-default`),
 }
 
+// AI Config API (GH #89 — per-component model assignments)
+export interface AIModelInfo {
+  model_id: string
+  provider_id: string
+  provider_type: 'anthropic' | 'openai' | 'ollama' | string
+  display_name: string
+  context_window: number
+  input_cost_per_1k: number
+  output_cost_per_1k: number
+  supports_tools: boolean
+  supports_thinking: boolean
+  supports_vision: boolean
+}
+
+export interface ComponentAssignment {
+  component: string
+  provider_id: string
+  model_id: string
+  settings: Record<string, any>
+  updated_by: string | null
+  updated_at: string | null
+}
+
+export interface AIConfigResponse {
+  components: string[]
+  assignments: Record<string, ComponentAssignment>
+}
+
+export const aiConfigApi = {
+  getConfig: () => api.get<AIConfigResponse>('/ai/config'),
+  setComponent: (
+    component: string,
+    payload: { provider_id: string; model_id: string; settings?: Record<string, any> },
+  ) => api.put<ComponentAssignment>(`/ai/config/${component}`, payload),
+  clearComponent: (component: string) =>
+    api.delete<{ component: string; cleared: boolean }>(`/ai/config/${component}`),
+  listModels: () => api.get<{ models: AIModelInfo[] }>('/ai/models'),
+  getModelInfo: (modelId: string, providerId?: string) =>
+    api.get<AIModelInfo>(`/ai/models/${encodeURIComponent(modelId)}/info`, {
+      params: providerId ? { provider_id: providerId } : undefined,
+    }),
+}
+
 // Ingestion API
 export const ingestionApi = {
   listS3Files: (prefix?: string) =>

--- a/services/claude_service.py
+++ b/services/claude_service.py
@@ -14,6 +14,28 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Union
 sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
 from secrets_manager import get_secret, set_secret
 
+# GH #89 — resolve the summarization model via ai_model_configs with a safe
+# fallback to the historical hardcoded default. Defined at module scope so
+# the registry import stays lazy and tests can monkeypatch it trivially.
+_SUMMARIZATION_DEFAULT = "claude-sonnet-4-20250514"
+
+
+def _resolve_summarization_model() -> str:
+    try:
+        from services.model_registry import get_registry
+
+        resolved = get_registry().resolve_model_for_component("summarization")
+        if resolved is not None:
+            return resolved[1]
+    except (
+        Exception
+    ) as exc:  # noqa: BLE001 — never let model resolution break summarization
+        logging.getLogger(__name__).debug(
+            "summarization model resolution failed, using default: %s", exc
+        )
+    return _SUMMARIZATION_DEFAULT
+
+
 # Import backend tool support
 try:
     sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -997,10 +1019,11 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
             tool_results_in = self._extract_prior_tool_results(request_messages)
 
             try:
-                from daemon.agent_runner import SONNET_INPUT_COST, SONNET_OUTPUT_COST
+                # GH #89: use the model registry for per-provider pricing.
+                from daemon.agent_runner import compute_call_cost
 
-                cost_usd = (input_tokens * SONNET_INPUT_COST) + (
-                    output_tokens * SONNET_OUTPUT_COST
+                cost_usd = compute_call_cost(
+                    model, "anthropic", int(input_tokens or 0), int(output_tokens or 0)
                 )
             except Exception:
                 cost_usd = 0.0
@@ -1228,7 +1251,7 @@ CONVERSATION ({len(conversation_text)} chars):
 Provide a structured summary preserving all critical context."""
 
     def _summarize_messages_sync(
-        self, messages: List[Dict], model: str = "claude-sonnet-4-20250514"
+        self, messages: List[Dict], model: Optional[str] = None
     ) -> Optional[str]:
         """
         Synchronously summarize a list of messages using a lightweight Claude call.
@@ -1244,6 +1267,9 @@ Provide a structured summary preserving all critical context."""
             return None
 
         prompt = self._build_summary_prompt(conversation_text)
+
+        # GH #89: use ai_model_configs['summarization'] when caller didn't pin one.
+        model = model or _resolve_summarization_model()
 
         try:
             logger.info(
@@ -1269,7 +1295,7 @@ Provide a structured summary preserving all critical context."""
             return None
 
     async def _summarize_messages_async(
-        self, messages: List[Dict], model: str = "claude-sonnet-4-20250514"
+        self, messages: List[Dict], model: Optional[str] = None
     ) -> Optional[str]:
         """
         Asynchronously summarize a list of messages using a lightweight Claude call.
@@ -1285,6 +1311,9 @@ Provide a structured summary preserving all critical context."""
             return None
 
         prompt = self._build_summary_prompt(conversation_text)
+
+        # GH #89: use ai_model_configs['summarization'] when caller didn't pin one.
+        model = model or _resolve_summarization_model()
 
         try:
             logger.info(
@@ -1361,7 +1390,9 @@ Provide a structured summary preserving all critical context."""
 
         threading.Thread(target=_archive_overflow, daemon=True).start()
 
-        summary = self._summarize_messages_sync(to_summarize, model=model)
+        # GH #89: pass model=None so summarization resolves to its own
+        # component in ai_model_configs, independent of the chat model.
+        summary = self._summarize_messages_sync(to_summarize, model=None)
 
         if summary:
             summary_msg = {
@@ -1444,7 +1475,9 @@ Provide a structured summary preserving all critical context."""
 
         threading.Thread(target=_archive_overflow_async, daemon=True).start()
 
-        summary = await self._summarize_messages_async(to_summarize, model=model)
+        # GH #89: pass model=None so summarization resolves to its own
+        # component in ai_model_configs, independent of the chat model.
+        summary = await self._summarize_messages_async(to_summarize, model=None)
 
         if summary:
             summary_msg = {
@@ -2216,12 +2249,12 @@ Provide a structured summary preserving all critical context."""
                     _cs_genai_metrics["llm_tokens"].add(
                         _out_tok, {**_labels, "gen_ai.token.type": "output"}
                     )
-                    from daemon.agent_runner import (
-                        SONNET_INPUT_COST,
-                        SONNET_OUTPUT_COST,
-                    )
+                    # GH #89: use the model registry for per-provider pricing.
+                    from daemon.agent_runner import compute_call_cost
 
-                    _cost = _in_tok * SONNET_INPUT_COST + _out_tok * SONNET_OUTPUT_COST
+                    _cost = compute_call_cost(
+                        model, "anthropic", int(_in_tok or 0), int(_out_tok or 0)
+                    )
                     _cs_genai_metrics["llm_cost_usd"].add(_cost, _labels)
                 except Exception:
                     pass

--- a/services/model_registry.py
+++ b/services/model_registry.py
@@ -1,0 +1,539 @@
+"""Model registry — aggregates model metadata and resolves per-component assignments.
+
+Sits on top of the multi-provider layer introduced in #88:
+  - Reads `ai_model_configs` (component → provider+model) for assignments.
+  - Reads `llm_provider_configs` for provider info.
+  - Live-queries providers for their current model lists (Anthropic static,
+    Ollama /api/tags, OpenAI /v1/models), with a short TTL cache so the
+    Settings UI feels responsive without hammering external APIs.
+  - Owns the static cost/capability catalog used for dollar-per-token math
+    and the capability chips shown in the UI.
+
+The registry is intentionally decoupled from the DB hot path: all DB access
+goes through short-lived sessions that are closed before returning.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_REPO = Path(__file__).resolve().parent.parent
+if str(_REPO / "backend") not in sys.path:
+    sys.path.insert(0, str(_REPO / "backend"))
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+
+# ---------------------------------------------------------------------------
+# Component enum (mirrors ai_model_configs.component values)
+# ---------------------------------------------------------------------------
+
+COMPONENTS: Tuple[str, ...] = (
+    "chat_default",
+    "triage",
+    "investigation",
+    "orchestrator_plan",
+    "orchestrator_review",
+    "summarization",
+    "reporting",
+)
+
+
+def is_valid_component(name: str) -> bool:
+    return name in COMPONENTS
+
+
+# ---------------------------------------------------------------------------
+# Static pricing + capability catalog (per-million-token USD rates)
+# ---------------------------------------------------------------------------
+
+# Values sourced from provider public pricing pages as of 2025-Q4. Ollama
+# models are self-hosted so rates are $0. When a model isn't in the catalog
+# we return (0, 0) and log a warning so cost data degrades gracefully.
+
+_CATALOG: Dict[Tuple[str, str], Dict[str, Any]] = {
+    # (provider_type, model_id) → metadata
+    ("anthropic", "claude-sonnet-4-5-20250929"): {
+        "display_name": "Claude Sonnet 4.5",
+        "context_window": 200_000,
+        "input_per_m": 3.0,
+        "output_per_m": 15.0,
+        "supports_tools": True,
+        "supports_thinking": True,
+        "supports_vision": True,
+    },
+    ("anthropic", "claude-sonnet-4-20250514"): {
+        "display_name": "Claude Sonnet 4",
+        "context_window": 200_000,
+        "input_per_m": 3.0,
+        "output_per_m": 15.0,
+        "supports_tools": True,
+        "supports_thinking": True,
+        "supports_vision": True,
+    },
+    ("anthropic", "claude-opus-4-20250514"): {
+        "display_name": "Claude Opus 4",
+        "context_window": 200_000,
+        "input_per_m": 15.0,
+        "output_per_m": 75.0,
+        "supports_tools": True,
+        "supports_thinking": True,
+        "supports_vision": True,
+    },
+    ("anthropic", "claude-haiku-4-5-20251001"): {
+        "display_name": "Claude Haiku 4.5",
+        "context_window": 200_000,
+        "input_per_m": 0.80,
+        "output_per_m": 4.0,
+        "supports_tools": True,
+        "supports_thinking": False,
+        "supports_vision": True,
+    },
+    ("openai", "gpt-4o"): {
+        "display_name": "GPT-4o",
+        "context_window": 128_000,
+        "input_per_m": 2.50,
+        "output_per_m": 10.0,
+        "supports_tools": True,
+        "supports_thinking": False,
+        "supports_vision": True,
+    },
+    ("openai", "gpt-4o-mini"): {
+        "display_name": "GPT-4o mini",
+        "context_window": 128_000,
+        "input_per_m": 0.15,
+        "output_per_m": 0.60,
+        "supports_tools": True,
+        "supports_thinking": False,
+        "supports_vision": True,
+    },
+    ("openai", "gpt-4-turbo"): {
+        "display_name": "GPT-4 Turbo",
+        "context_window": 128_000,
+        "input_per_m": 10.0,
+        "output_per_m": 30.0,
+        "supports_tools": True,
+        "supports_thinking": False,
+        "supports_vision": True,
+    },
+}
+
+
+def _catalog_entry(provider_type: str, model_id: str) -> Dict[str, Any]:
+    """Return catalog entry or a safe default."""
+    entry = _CATALOG.get((provider_type, model_id))
+    if entry is not None:
+        return entry
+    if provider_type == "ollama":
+        return {
+            "display_name": model_id,
+            "context_window": 0,  # unknown — depends on ollama modelfile
+            "input_per_m": 0.0,
+            "output_per_m": 0.0,
+            "supports_tools": False,
+            "supports_thinking": False,
+            "supports_vision": False,
+        }
+    logger.warning(
+        "No catalog entry for %s/%s — defaulting cost to $0 and capabilities to false",
+        provider_type,
+        model_id,
+    )
+    return {
+        "display_name": model_id,
+        "context_window": 0,
+        "input_per_m": 0.0,
+        "output_per_m": 0.0,
+        "supports_tools": False,
+        "supports_thinking": False,
+        "supports_vision": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    model_id: str
+    provider_id: str
+    provider_type: str
+    display_name: str
+    context_window: int
+    input_cost_per_1k: float  # USD — per 1,000 tokens
+    output_cost_per_1k: float
+    supports_tools: bool
+    supports_thinking: bool
+    supports_vision: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "provider_id": self.provider_id,
+            "provider_type": self.provider_type,
+            "display_name": self.display_name,
+            "context_window": self.context_window,
+            "input_cost_per_1k": self.input_cost_per_1k,
+            "output_cost_per_1k": self.output_cost_per_1k,
+            "supports_tools": self.supports_tools,
+            "supports_thinking": self.supports_thinking,
+            "supports_vision": self.supports_vision,
+        }
+
+
+@dataclass(frozen=True)
+class ComponentAssignment:
+    component: str
+    provider_id: str
+    model_id: str
+    settings: Dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Provider model lists — live-query with a per-provider TTL cache
+# ---------------------------------------------------------------------------
+
+_MODEL_LIST_CACHE_TTL_S = 60.0
+
+
+class _ProviderModelCache:
+    def __init__(self):
+        self._entries: Dict[str, Tuple[float, List[str]]] = {}
+
+    def get(self, provider_id: str) -> Optional[List[str]]:
+        hit = self._entries.get(provider_id)
+        if not hit:
+            return None
+        ts, models = hit
+        if time.time() - ts > _MODEL_LIST_CACHE_TTL_S:
+            return None
+        return models
+
+    def set(self, provider_id: str, models: List[str]) -> None:
+        self._entries[provider_id] = (time.time(), models)
+
+    def invalidate(self, provider_id: Optional[str] = None) -> None:
+        if provider_id is None:
+            self._entries.clear()
+        else:
+            self._entries.pop(provider_id, None)
+
+
+_MODEL_LIST_CACHE = _ProviderModelCache()
+
+
+# Kept in sync with docker/bifrost/config.json and backend/api/llm_providers.py.
+ANTHROPIC_STATIC_MODELS: Tuple[str, ...] = (
+    "claude-sonnet-4-5-20250929",
+    "claude-sonnet-4-20250514",
+    "claude-opus-4-20250514",
+    "claude-haiku-4-5-20251001",
+)
+
+
+async def fetch_provider_models(row) -> List[str]:
+    """Live-query a provider for its available model IDs.
+
+    ``row`` is an LLMProviderConfig ORM row. Raises on unrecoverable errors;
+    callers should catch and degrade gracefully (e.g. fall back to
+    [row.default_model]).
+    """
+    import httpx  # lazy
+
+    cached = _MODEL_LIST_CACHE.get(row.provider_id)
+    if cached is not None:
+        return cached
+
+    provider_type = row.provider_type
+    models: List[str]
+
+    if provider_type == "anthropic":
+        models = list(ANTHROPIC_STATIC_MODELS)
+
+    elif provider_type == "ollama":
+        base_url = (row.base_url or "http://localhost:11434").rstrip("/")
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(f"{base_url}/api/tags")
+            resp.raise_for_status()
+            data = resp.json()
+        models = [m.get("name") for m in data.get("models", []) if m.get("name")]
+
+    elif provider_type == "openai":
+        base_url = (row.base_url or "https://api.openai.com/v1").rstrip("/")
+        api_key = await _resolve_provider_key(row)
+        if not api_key:
+            raise RuntimeError(f"openai provider {row.provider_id}: no api key")
+        headers = {"Authorization": f"Bearer {api_key}"}
+        if row.config and row.config.get("organization"):
+            headers["OpenAI-Organization"] = row.config["organization"]
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(f"{base_url}/models", headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        models = [m.get("id") for m in data.get("data", []) if m.get("id")]
+
+    else:
+        raise RuntimeError(f"unsupported provider_type: {provider_type}")
+
+    _MODEL_LIST_CACHE.set(row.provider_id, models)
+    return models
+
+
+async def _resolve_provider_key(row) -> Optional[str]:
+    """Resolve a provider's API key via secrets_manager with env fallbacks."""
+    try:
+        from secrets_manager import get_secret  # type: ignore
+    except Exception:
+        get_secret = None  # type: ignore
+
+    if row.api_key_ref and get_secret is not None:
+        try:
+            key = get_secret(row.api_key_ref)
+            if key:
+                return key
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("secret lookup for %s failed: %s", row.api_key_ref, exc)
+
+    if row.provider_type == "anthropic":
+        return os.getenv("ANTHROPIC_API_KEY") or os.getenv("CLAUDE_API_KEY")
+    if row.provider_type == "openai":
+        return os.getenv("OPENAI_API_KEY")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# ModelRegistry
+# ---------------------------------------------------------------------------
+
+
+class ModelRegistry:
+    """Per-component model resolution + aggregated model listings.
+
+    Safe to instantiate directly; the module-level ``get_registry()``
+    returns a shared default instance.
+    """
+
+    # ---- cost lookup (pure) ----------------------------------------------
+
+    @staticmethod
+    def get_cost_rates(model_id: str, provider_type: str) -> Tuple[float, float]:
+        """Return (input_cost_per_token, output_cost_per_token) in USD.
+
+        Returns (0.0, 0.0) for unknown models and logs a warning (handled
+        inside ``_catalog_entry``).
+        """
+        entry = _catalog_entry(provider_type, model_id)
+        return (entry["input_per_m"] / 1_000_000, entry["output_per_m"] / 1_000_000)
+
+    @staticmethod
+    def get_model_info(
+        provider_id: str, provider_type: str, model_id: str
+    ) -> ModelInfo:
+        entry = _catalog_entry(provider_type, model_id)
+        return ModelInfo(
+            model_id=model_id,
+            provider_id=provider_id,
+            provider_type=provider_type,
+            display_name=entry["display_name"],
+            context_window=entry["context_window"],
+            input_cost_per_1k=entry["input_per_m"] / 1000,
+            output_cost_per_1k=entry["output_per_m"] / 1000,
+            supports_tools=entry["supports_tools"],
+            supports_thinking=entry["supports_thinking"],
+            supports_vision=entry["supports_vision"],
+        )
+
+    # ---- assignments -----------------------------------------------------
+
+    def get_component_assignment(self, component: str) -> Optional[ComponentAssignment]:
+        """Load a single `ai_model_configs` row. Returns None on cache miss."""
+        try:
+            from database.connection import get_db_session
+            from database.models import AIModelConfig
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("AIModelConfig lookup skipped: %s", exc)
+            return None
+
+        session = get_db_session()
+        try:
+            row = session.get(AIModelConfig, component)
+            if row is None:
+                return None
+            return ComponentAssignment(
+                component=row.component,
+                provider_id=row.provider_id,
+                model_id=row.model_id,
+                settings=dict(row.settings or {}),
+            )
+        finally:
+            session.close()
+
+    def get_all_assignments(self) -> Dict[str, ComponentAssignment]:
+        """Return every configured assignment keyed by component."""
+        try:
+            from database.connection import get_db_session
+            from database.models import AIModelConfig
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("AIModelConfig listing skipped: %s", exc)
+            return {}
+
+        session = get_db_session()
+        try:
+            rows = session.query(AIModelConfig).all()
+            return {
+                r.component: ComponentAssignment(
+                    component=r.component,
+                    provider_id=r.provider_id,
+                    model_id=r.model_id,
+                    settings=dict(r.settings or {}),
+                )
+                for r in rows
+            }
+        finally:
+            session.close()
+
+    def resolve_model_for_component(
+        self, component: str, *, agent_override: Optional[str] = None
+    ) -> Optional[Tuple[str, str]]:
+        """Return (provider_id, model_id) using the fallback chain.
+
+        Chain:
+          agent_override (if set) resolves through the default Anthropic provider,
+            since we don't know which provider owns a raw model id
+          → ai_model_configs[component]
+          → ai_model_configs['chat_default']
+          → default Anthropic provider's default_model
+
+        Returns None only if no DB is reachable and there's no Anthropic default.
+        """
+        if agent_override:
+            # agent-level overrides carry only a model id. Attach it to the
+            # default Anthropic provider — this is the historical assumption
+            # and matches how per-agent models worked before #89.
+            default_anthropic = self._default_anthropic_provider()
+            if default_anthropic is not None:
+                return (default_anthropic["provider_id"], agent_override)
+
+        assignments = self.get_all_assignments()
+        if component in assignments:
+            a = assignments[component]
+            return (a.provider_id, a.model_id)
+        if "chat_default" in assignments:
+            a = assignments["chat_default"]
+            return (a.provider_id, a.model_id)
+
+        default_anthropic = self._default_anthropic_provider()
+        if default_anthropic is not None:
+            return (
+                default_anthropic["provider_id"],
+                default_anthropic["default_model"],
+            )
+        return None
+
+    # ---- provider helpers ------------------------------------------------
+
+    def _default_anthropic_provider(self) -> Optional[Dict[str, str]]:
+        try:
+            from database.connection import get_db_session
+            from database.models import LLMProviderConfig
+        except Exception:
+            return None
+        session = get_db_session()
+        try:
+            row = (
+                session.query(LLMProviderConfig)
+                .filter(
+                    LLMProviderConfig.provider_type == "anthropic",
+                    LLMProviderConfig.is_default.is_(True),
+                )
+                .first()
+            )
+            if row is None:
+                return None
+            return {"provider_id": row.provider_id, "default_model": row.default_model}
+        finally:
+            session.close()
+
+    async def list_available_models(self) -> List[ModelInfo]:
+        """Aggregate live model lists across all active providers.
+
+        Each provider is queried independently; a provider failure is
+        logged but never blocks the overall list.
+        """
+        try:
+            from database.connection import get_db_session
+            from database.models import LLMProviderConfig
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("list_available_models: DB unreachable: %s", exc)
+            return []
+
+        session = get_db_session()
+        try:
+            providers = (
+                session.query(LLMProviderConfig)
+                .filter(LLMProviderConfig.is_active.is_(True))
+                .all()
+            )
+        finally:
+            session.close()
+
+        out: List[ModelInfo] = []
+        seen: set = set()
+
+        for p in providers:
+            try:
+                model_ids = await fetch_provider_models(p)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to fetch models for provider %s (%s): %s — "
+                    "falling back to default_model",
+                    p.provider_id,
+                    p.provider_type,
+                    exc,
+                )
+                model_ids = [p.default_model] if p.default_model else []
+
+            for mid in model_ids:
+                key = (p.provider_id, mid)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(
+                    self.get_model_info(
+                        provider_id=p.provider_id,
+                        provider_type=p.provider_type,
+                        model_id=mid,
+                    )
+                )
+
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton accessor
+# ---------------------------------------------------------------------------
+
+_registry_singleton: Optional[ModelRegistry] = None
+
+
+def get_registry() -> ModelRegistry:
+    global _registry_singleton
+    if _registry_singleton is None:
+        _registry_singleton = ModelRegistry()
+    return _registry_singleton
+
+
+def invalidate_model_cache(provider_id: Optional[str] = None) -> None:
+    """Callers that change provider config (add/update/delete) can drop
+    the per-provider model-list cache so the UI sees fresh data."""
+    _MODEL_LIST_CACHE.invalidate(provider_id)

--- a/services/soc_agents.py
+++ b/services/soc_agents.py
@@ -17,6 +17,13 @@ class AgentProfile:
     recommended_tools: List[str]
     max_tokens: int = 4096
     enable_thinking: bool = False
+    # GH #89 — per-agent model override. None = inherit from
+    # ai_model_configs[component_category] → ai_model_configs['chat_default'].
+    model: Optional[str] = None
+    # GH #89 — which ai_model_configs row to consult when `model` is None.
+    # One of: 'triage', 'investigation', 'reporting'. Custom agents default
+    # to 'investigation' unless the user picks otherwise in the builder.
+    component_category: str = "investigation"
 
 
 BASE_PROMPT = """You are a SOC {role} in the Vigil SOC platform.
@@ -86,6 +93,26 @@ Memory tool quick reference:
 </principles>
 
 {methodology}"""
+
+
+# GH #89 — maps each built-in agent id to the ai_model_configs component it
+# inherits its model from. Kept outside AGENT_CONFIGS so the per-agent dicts
+# stay focused on prompt content.
+_BUILTIN_COMPONENT_CATEGORY: Dict[str, str] = {
+    "triage": "triage",
+    "investigator": "investigation",
+    "threat_hunter": "investigation",
+    "correlator": "investigation",
+    "responder": "investigation",
+    "reporter": "reporting",
+    "mitre_analyst": "investigation",
+    "forensics": "investigation",
+    "threat_intel": "investigation",
+    "compliance": "investigation",
+    "malware_analyst": "investigation",
+    "network_analyst": "investigation",
+    "auto_responder": "investigation",
+}
 
 
 AGENT_CONFIGS = {
@@ -449,6 +476,13 @@ class SOCAgentLibrary:
             recommended_tools=cfg["tools"],
             max_tokens=cfg.get("max_tokens", 4096),
             enable_thinking=cfg.get("thinking", False),
+            # GH #89 — built-ins don't ship with a pinned model; they inherit
+            # from ai_model_configs[component_category] with chat_default as
+            # the ultimate fallback.
+            model=None,
+            component_category=_BUILTIN_COMPONENT_CATEGORY.get(
+                agent_id, "investigation"
+            ),
         )
 
     @staticmethod
@@ -478,6 +512,10 @@ class SOCAgentLibrary:
             recommended_tools=list(row.get("recommended_tools") or []),
             max_tokens=int(row.get("max_tokens") or 4096),
             enable_thinking=bool(row.get("enable_thinking") or False),
+            # GH #89 — custom agents can pin a model; falling back to the
+            # component_category (default 'investigation') if not set.
+            model=(row.get("model") or None),
+            component_category=(row.get("component_category") or "investigation"),
         )
 
     @staticmethod

--- a/tests/test_ai_config_api.py
+++ b/tests/test_ai_config_api.py
@@ -1,0 +1,267 @@
+"""Unit tests for the per-component AI config API (GH #89).
+
+DB access is mocked with an in-memory fake session so the tests don't
+require a live Postgres. Model-listing endpoints are exercised with the
+registry stubbed to avoid hitting external provider APIs.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict, List
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "backend"))
+
+from backend.api.ai_config import router as ai_config_router  # noqa: E402
+from database.connection import get_db_session  # noqa: E402
+from database.models import AIModelConfig, LLMProviderConfig  # noqa: E402
+from services.model_registry import ModelInfo  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeSession:
+    def __init__(self):
+        self.assignments: Dict[str, AIModelConfig] = {}
+        self.providers: Dict[str, LLMProviderConfig] = {}
+
+    # --- get (PK lookup) ---
+    def get(self, model, pk):
+        if model is AIModelConfig:
+            return self.assignments.get(pk)
+        if model is LLMProviderConfig:
+            return self.providers.get(pk)
+        return None
+
+    # --- query().all() ---
+    class _Query:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def all(self):
+            return list(self.rows)
+
+    def query(self, model):
+        if model is AIModelConfig:
+            return _FakeSession._Query(self.assignments.values())
+        if model is LLMProviderConfig:
+            return _FakeSession._Query(self.providers.values())
+        return _FakeSession._Query([])
+
+    def add(self, row):
+        if isinstance(row, AIModelConfig):
+            self.assignments[row.component] = row
+
+    def delete(self, row):
+        if isinstance(row, AIModelConfig):
+            self.assignments.pop(row.component, None)
+
+    def commit(self):
+        pass
+
+    def refresh(self, row):
+        # to_dict() reads updated_at — populate so response serialization works.
+        import datetime
+
+        if hasattr(row, "updated_at") and row.updated_at is None:
+            row.updated_at = datetime.datetime.utcnow()
+
+
+@pytest.fixture()
+def session() -> _FakeSession:
+    s = _FakeSession()
+    s.providers["anthropic-default"] = LLMProviderConfig(
+        provider_id="anthropic-default",
+        provider_type="anthropic",
+        name="Anthropic (default)",
+        default_model="claude-sonnet-4-5-20250929",
+        is_active=True,
+        is_default=True,
+        config={},
+    )
+    s.providers["ollama-local"] = LLMProviderConfig(
+        provider_id="ollama-local",
+        provider_type="ollama",
+        name="Local Ollama",
+        base_url="http://localhost:11434",
+        default_model="llama3:latest",
+        is_active=True,
+        is_default=True,
+        config={},
+    )
+    return s
+
+
+@pytest.fixture()
+def client(session):
+    app = FastAPI()
+    app.include_router(ai_config_router, prefix="/api/ai")
+
+    def _get_session():
+        return session
+
+    app.dependency_overrides[get_db_session] = _get_session
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/ai/config
+# ---------------------------------------------------------------------------
+
+
+def test_get_config_empty(client):
+    r = client.get("/api/ai/config")
+    assert r.status_code == 200
+    body = r.json()
+    assert "components" in body
+    assert body["assignments"] == {}
+    assert "chat_default" in body["components"]
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/ai/config/{component}
+# ---------------------------------------------------------------------------
+
+
+def test_put_component_creates_assignment(client, session):
+    r = client.put(
+        "/api/ai/config/triage",
+        json={"provider_id": "ollama-local", "model_id": "llama3:latest"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["component"] == "triage"
+    assert body["provider_id"] == "ollama-local"
+    assert body["model_id"] == "llama3:latest"
+    assert "triage" in session.assignments
+
+
+def test_put_component_rejects_unknown_component(client):
+    r = client.put(
+        "/api/ai/config/totally-not-real",
+        json={"provider_id": "anthropic-default", "model_id": "x"},
+    )
+    assert r.status_code == 400
+
+
+def test_put_component_rejects_unknown_provider(client):
+    r = client.put(
+        "/api/ai/config/triage",
+        json={"provider_id": "does-not-exist", "model_id": "x"},
+    )
+    assert r.status_code == 400
+
+
+def test_put_component_rejects_inactive_provider(client, session):
+    session.providers["anthropic-default"].is_active = False
+    r = client.put(
+        "/api/ai/config/summarization",
+        json={"provider_id": "anthropic-default", "model_id": "x"},
+    )
+    assert r.status_code == 400
+
+
+def test_put_component_updates_existing(client, session):
+    # seed
+    client.put(
+        "/api/ai/config/summarization",
+        json={"provider_id": "anthropic-default", "model_id": "a"},
+    )
+    # update
+    r = client.put(
+        "/api/ai/config/summarization",
+        json={"provider_id": "anthropic-default", "model_id": "b"},
+    )
+    assert r.status_code == 200
+    assert session.assignments["summarization"].model_id == "b"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/ai/config/{component}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_clears_assignment(client, session):
+    client.put(
+        "/api/ai/config/summarization",
+        json={"provider_id": "anthropic-default", "model_id": "x"},
+    )
+    r = client.delete("/api/ai/config/summarization")
+    assert r.status_code == 200
+    assert r.json()["cleared"] is True
+    assert "summarization" not in session.assignments
+
+
+def test_delete_missing_is_idempotent(client):
+    r = client.delete("/api/ai/config/triage")
+    assert r.status_code == 200
+    assert r.json()["cleared"] is False
+
+
+# ---------------------------------------------------------------------------
+# GET /api/ai/models — registry stubbed so no external calls happen
+# ---------------------------------------------------------------------------
+
+
+def test_list_models(client):
+    stub_models: List[ModelInfo] = [
+        ModelInfo(
+            model_id="claude-sonnet-4-5-20250929",
+            provider_id="anthropic-default",
+            provider_type="anthropic",
+            display_name="Claude Sonnet 4.5",
+            context_window=200_000,
+            input_cost_per_1k=0.003,
+            output_cost_per_1k=0.015,
+            supports_tools=True,
+            supports_thinking=True,
+            supports_vision=True,
+        ),
+        ModelInfo(
+            model_id="llama3:latest",
+            provider_id="ollama-local",
+            provider_type="ollama",
+            display_name="llama3:latest",
+            context_window=0,
+            input_cost_per_1k=0.0,
+            output_cost_per_1k=0.0,
+            supports_tools=False,
+            supports_thinking=False,
+            supports_vision=False,
+        ),
+    ]
+
+    async def fake_list():
+        return stub_models
+
+    with patch(
+        "services.model_registry.ModelRegistry.list_available_models",
+        side_effect=fake_list,
+    ):
+        r = client.get("/api/ai/models")
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["models"]) == 2
+    assert {m["provider_type"] for m in body["models"]} == {"anthropic", "ollama"}
+
+
+def test_model_info_404_when_missing(client):
+    async def fake_list():
+        return []
+
+    with patch(
+        "services.model_registry.ModelRegistry.list_available_models",
+        side_effect=fake_list,
+    ):
+        r = client.get("/api/ai/models/nothing/info")
+
+    assert r.status_code == 404

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,191 @@
+"""Unit tests for services.model_registry (GH #89).
+
+Focus: pure logic (cost catalog, capability lookup) and fallback resolution.
+DB-backed paths are exercised via monkeypatching the DB accessors so the
+tests don't require a live Postgres.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict, Optional
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from services.model_registry import (  # noqa: E402
+    COMPONENTS,
+    ComponentAssignment,
+    ModelRegistry,
+    _catalog_entry,
+    is_valid_component,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Catalog / cost lookups (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_components_enum_includes_all_seven():
+    expected = {
+        "chat_default",
+        "triage",
+        "investigation",
+        "orchestrator_plan",
+        "orchestrator_review",
+        "summarization",
+        "reporting",
+    }
+    assert set(COMPONENTS) == expected
+
+
+def test_is_valid_component():
+    assert is_valid_component("chat_default") is True
+    assert is_valid_component("nope") is False
+
+
+def test_cost_rates_known_anthropic_model():
+    input_rate, output_rate = ModelRegistry.get_cost_rates(
+        "claude-sonnet-4-5-20250929", "anthropic"
+    )
+    # Catalog says $3/$15 per 1M tokens.
+    assert input_rate == pytest.approx(3.0 / 1_000_000)
+    assert output_rate == pytest.approx(15.0 / 1_000_000)
+
+
+def test_cost_rates_ollama_is_zero():
+    # Ollama is self-hosted → zero cost by design.
+    input_rate, output_rate = ModelRegistry.get_cost_rates("llama3.1:8b", "ollama")
+    assert input_rate == 0.0
+    assert output_rate == 0.0
+
+
+def test_cost_rates_unknown_cloud_model_degrades_gracefully():
+    # Unknown models return (0, 0) and log a warning — we're asserting the
+    # fallback behavior is safe (no exception).
+    input_rate, output_rate = ModelRegistry.get_cost_rates(
+        "does-not-exist-1.0", "openai"
+    )
+    assert input_rate == 0.0
+    assert output_rate == 0.0
+
+
+def test_get_model_info_populates_capabilities():
+    info = ModelRegistry.get_model_info(
+        provider_id="anthropic-default",
+        provider_type="anthropic",
+        model_id="claude-sonnet-4-5-20250929",
+    )
+    assert info.model_id == "claude-sonnet-4-5-20250929"
+    assert info.provider_id == "anthropic-default"
+    assert info.supports_tools is True
+    assert info.supports_thinking is True
+    assert info.context_window == 200_000
+
+
+def test_catalog_entry_ollama_has_no_tools():
+    entry = _catalog_entry("ollama", "llama3.1:8b")
+    assert entry["supports_tools"] is False
+    assert entry["input_per_m"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Fallback resolution — DB mocked via registry internals
+# ---------------------------------------------------------------------------
+
+
+class _StubRegistry(ModelRegistry):
+    """ModelRegistry that returns canned DB responses without touching a DB."""
+
+    def __init__(
+        self,
+        *,
+        assignments: Optional[Dict[str, ComponentAssignment]] = None,
+        default_anthropic: Optional[Dict[str, str]] = None,
+    ):
+        super().__init__()
+        self._assignments = assignments or {}
+        self._default_anthropic = default_anthropic
+
+    def get_all_assignments(  # type: ignore[override]
+        self,
+    ) -> Dict[str, ComponentAssignment]:
+        return self._assignments
+
+    def _default_anthropic_provider(self):  # type: ignore[override]
+        return self._default_anthropic
+
+
+def test_resolve_uses_explicit_component_assignment():
+    reg = _StubRegistry(
+        assignments={
+            "triage": ComponentAssignment(
+                component="triage",
+                provider_id="ollama-local",
+                model_id="llama3:latest",
+            ),
+            "chat_default": ComponentAssignment(
+                component="chat_default",
+                provider_id="anthropic-default",
+                model_id="claude-sonnet-4-5-20250929",
+            ),
+        },
+    )
+    provider, model = reg.resolve_model_for_component("triage")
+    assert provider == "ollama-local"
+    assert model == "llama3:latest"
+
+
+def test_resolve_falls_back_to_chat_default():
+    reg = _StubRegistry(
+        assignments={
+            "chat_default": ComponentAssignment(
+                component="chat_default",
+                provider_id="anthropic-default",
+                model_id="claude-sonnet-4-5-20250929",
+            ),
+        },
+    )
+    # summarization has no explicit row → chat_default wins.
+    provider, model = reg.resolve_model_for_component("summarization")
+    assert provider == "anthropic-default"
+    assert model == "claude-sonnet-4-5-20250929"
+
+
+def test_resolve_falls_back_to_default_anthropic_when_db_empty():
+    reg = _StubRegistry(
+        assignments={},
+        default_anthropic={
+            "provider_id": "anthropic-default",
+            "default_model": "claude-sonnet-4-5-20250929",
+        },
+    )
+    provider, model = reg.resolve_model_for_component("investigation")
+    assert provider == "anthropic-default"
+    assert model == "claude-sonnet-4-5-20250929"
+
+
+def test_resolve_returns_none_when_no_db_and_no_anthropic():
+    reg = _StubRegistry(assignments={}, default_anthropic=None)
+    assert reg.resolve_model_for_component("chat_default") is None
+
+
+def test_agent_override_pins_model_but_uses_default_provider():
+    reg = _StubRegistry(
+        assignments={},
+        default_anthropic={
+            "provider_id": "anthropic-default",
+            "default_model": "claude-sonnet-4-5-20250929",
+        },
+    )
+    provider, model = reg.resolve_model_for_component(
+        "triage", agent_override="claude-opus-4-20250514"
+    )
+    assert provider == "anthropic-default"
+    assert model == "claude-opus-4-20250514"

--- a/tests/test_soc_agents_models.py
+++ b/tests/test_soc_agents_models.py
@@ -1,0 +1,86 @@
+"""Unit tests for AgentProfile model/component_category fields (GH #89)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from services.soc_agents import (  # noqa: E402
+    AgentProfile,
+    SOCAgentLibrary,
+    _BUILTIN_COMPONENT_CATEGORY,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_agent_profile_has_new_fields_with_safe_defaults():
+    p = AgentProfile(
+        id="x",
+        name="x",
+        description="x",
+        system_prompt="x",
+        icon="x",
+        color="#000",
+        specialization="x",
+        recommended_tools=[],
+    )
+    assert p.model is None
+    assert p.component_category == "investigation"
+
+
+def test_builtin_categories_cover_all_built_ins():
+    agents = SOCAgentLibrary.get_all_agents()
+    for agent_id, agent in agents.items():
+        assert agent.component_category in {
+            "triage",
+            "investigation",
+            "reporting",
+        }, f"{agent_id} has an invalid category: {agent.component_category}"
+        assert agent.component_category == _BUILTIN_COMPONENT_CATEGORY.get(
+            agent_id, "investigation"
+        )
+
+
+def test_triage_agent_is_categorized_as_triage():
+    agents = SOCAgentLibrary.get_all_agents()
+    assert agents["triage"].component_category == "triage"
+
+
+def test_reporter_agent_is_categorized_as_reporting():
+    agents = SOCAgentLibrary.get_all_agents()
+    assert agents["reporter"].component_category == "reporting"
+
+
+def test_custom_agent_builder_reads_model_and_category():
+    row = {
+        "id": "custom-test",
+        "name": "Custom Test",
+        "description": "",
+        "role": "tester",
+        "recommended_tools": [],
+        "max_tokens": 4096,
+        "enable_thinking": False,
+        "model": "claude-haiku-4-5-20251001",
+        "component_category": "triage",
+    }
+    profile = SOCAgentLibrary._build_from_custom(row)
+    assert profile.model == "claude-haiku-4-5-20251001"
+    assert profile.component_category == "triage"
+
+
+def test_custom_agent_builder_defaults_category_when_missing():
+    row = {
+        "id": "custom-default",
+        "name": "Custom Default",
+        "role": "tester",
+        "recommended_tools": [],
+    }
+    profile = SOCAgentLibrary._build_from_custom(row)
+    assert profile.model is None
+    assert profile.component_category == "investigation"


### PR DESCRIPTION
## Summary

Closes #89.

Adds granular, per-component AI model selection on top of the multi-provider foundation from #88. Each system component (chat, triage, investigation, orchestrator plan/review, summarization, reporting) can now be assigned its own provider + model through a new **Model Assignment** section in the **AI Config** settings tab.

- **New table** `ai_model_configs` mapping component → (provider, model, settings), seeded from the default Anthropic provider on fresh installs
- **New service** `services/model_registry.py` owns the resolution chain (agent override → component → chat_default → default Anthropic), a static pricing catalog, and 60s-TTL live model discovery across Anthropic/Ollama/OpenAI
- **New endpoints** `GET/PUT/DELETE /api/ai/config/{component}` + `GET /api/ai/models`
- **Runtime wiring**: chat endpoints, `_summarize_messages_*`, `daemon/config.py`, and `daemon/agent_runner.py` all resolve their model through the registry; per-agent overrides via new `AgentProfile.model` and `component_category` fields (13 built-ins tagged)
- **Dynamic cost tracking**: new `compute_call_cost()` replaces the hardcoded `SONNET_INPUT_COST` / `SONNET_OUTPUT_COST` constants across the daemon and `claude_service.py`
- **Frontend**: new `ModelAssignmentTab` with per-component provider/model selectors, capability chips (Tools / Thinking / Vision), cost captions, and "inherit from Chat Default" checkbox
- **Backward compat**: `/api/claude/models` kept as an alias that delegates to the new aggregated registry; `ChatRequest.model` is still accepted explicitly

## Test plan

- [x] Backend unit tests — 28 new tests, all passing (`pytest tests/test_model_registry.py tests/test_ai_config_api.py tests/test_soc_agents_models.py`)
- [x] Existing #88 tests still pass (`pytest tests/test_llm_router.py tests/test_llm_providers_api.py`)
- [x] `black --check` clean on all new files
- [x] `flake8` clean on all new files (line length 88)
- [x] `tsc --noEmit` clean on new frontend files
- [x] `eslint` clean on new frontend files
- [ ] End-to-end smoke test in a local stack:
  - [ ] Fresh DB: confirm `chat_default` seeded from `anthropic-default` provider
  - [ ] Add Ollama provider → model list populates in the dropdown
  - [ ] Assign summarization to an Ollama model → trigger long conversation → verify logs show Bifrost/Ollama path
  - [ ] Assign orchestrator_plan to Sonnet 4.5 → kick off autonomous investigation → verify logs
  - [ ] Clear a component → confirm fallback to `chat_default`
  - [ ] Verify existing Chat UI model picker still shows Anthropic models

## Migration safety

- `IF NOT EXISTS` + `ON CONFLICT DO NOTHING` — idempotent on fresh + existing databases
- No breaking API changes (chat requests without `model` now resolve via the registry; requests that pass `model` continue to work unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)