### PR TITLE
feat(agents): AI-assisted Agent Builder — iterative NL → draft (#80 Phase 2)

### DIFF
--- a/backend/api/custom_agents.py
+++ b/backend/api/custom_agents.py
@@ -69,6 +69,18 @@ class CustomAgentUpdate(BaseModel):
     model: Optional[str] = None
 
 
+class GenerateAgentRequest(BaseModel):
+    """Request body for AI-assisted agent generation (issue #80 Phase 2).
+
+    First call: pass ``description`` only.
+    Refinement: also pass ``current_draft`` and ``feedback``.
+    """
+
+    description: str = Field(..., min_length=1)
+    current_draft: Optional[Dict[str, Any]] = None
+    feedback: Optional[str] = None
+
+
 def _with_effective_prompt(row: Dict[str, Any]) -> Dict[str, Any]:
     """Attach the rendered effective prompt to an agent row dict."""
     row = dict(row)
@@ -112,6 +124,36 @@ async def list_available_tools() -> Dict[str, Any]:
         "tools": tools,
         "grouped": grouped,
     }
+
+
+@router.post("/agents/custom/generate")
+async def generate_custom_agent(payload: GenerateAgentRequest) -> Dict[str, Any]:
+    """
+    AI-assisted agent generation / refinement (issue #80 Phase 2).
+
+    Does NOT save. Frontend takes the returned draft, lets the user tweak it,
+    and POSTs to /agents/custom to create. Pass ``current_draft`` + ``feedback``
+    to iteratively refine a prior draft.
+    """
+    try:
+        from services.agent_ai_generator import get_agent_ai_generator
+
+        result = await get_agent_ai_generator().generate(
+            description=payload.description,
+            current_draft=payload.current_draft,
+            feedback=payload.feedback,
+        )
+        if not result.get("success"):
+            raise HTTPException(
+                status_code=502,
+                detail=result.get("error") or "Agent generation failed",
+            )
+        return {"draft": result["draft"]}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Error generating custom agent")
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.get("/agents/custom/{agent_id}")

--- a/frontend/src/components/settings/AgentBuilderDialog.tsx
+++ b/frontend/src/components/settings/AgentBuilderDialog.tsx
@@ -14,15 +14,22 @@ import {
   Switch,
   Autocomplete,
   Chip,
-  Tooltip,
   Accordion,
   AccordionSummary,
   AccordionDetails,
   Alert,
   CircularProgress,
 } from '@mui/material'
-import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material'
-import { agentsApi, type CustomAgent, type CustomAgentPayload } from '../../services/api'
+import {
+  ExpandMore as ExpandMoreIcon,
+  AutoAwesome as AutoAwesomeIcon,
+} from '@mui/icons-material'
+import {
+  agentsApi,
+  type CustomAgent,
+  type CustomAgentPayload,
+  type GeneratedAgentDraft,
+} from '../../services/api'
 
 interface Props {
   open: boolean
@@ -46,6 +53,8 @@ const EMPTY_FORM: CustomAgentPayload = {
   enable_thinking: false,
 }
 
+type AIHistoryEntry = { kind: 'describe' | 'refine'; text: string }
+
 export default function AgentBuilderDialog({ open, agentId, onClose, onMessage }: Props) {
   const [form, setForm] = useState<CustomAgentPayload>(EMPTY_FORM)
   const [availableTools, setAvailableTools] = useState<string[]>([])
@@ -54,6 +63,14 @@ export default function AgentBuilderDialog({ open, agentId, onClose, onMessage }
   const [saving, setSaving] = useState(false)
   const [useOverride, setUseOverride] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // AI Assist state (issue #80 Phase 2) — iterative NL → draft refinement
+  const [aiDescription, setAiDescription] = useState('')
+  const [aiFeedback, setAiFeedback] = useState('')
+  const [aiDraft, setAiDraft] = useState<GeneratedAgentDraft | null>(null)
+  const [aiHistory, setAiHistory] = useState<AIHistoryEntry[]>([])
+  const [aiBusy, setAiBusy] = useState(false)
+  const [aiError, setAiError] = useState<string | null>(null)
 
   const isEdit = Boolean(agentId)
 
@@ -99,10 +116,84 @@ export default function AgentBuilderDialog({ open, agentId, onClose, onMessage }
       setUseOverride(false)
       setEffectivePrompt('')
     }
+    // Reset AI Assist state whenever the dialog opens or the target changes.
+    setAiDescription('')
+    setAiFeedback('')
+    setAiDraft(null)
+    setAiHistory([])
+    setAiBusy(false)
+    setAiError(null)
   }, [open, agentId])
 
   const handleChange = <K extends keyof CustomAgentPayload>(key: K, value: CustomAgentPayload[K]) => {
     setForm((prev) => ({ ...prev, [key]: value }))
+  }
+
+  // Merge an AI-generated draft into the form. Preserves a manually-typed name
+  // (and always preserves it in edit mode since the ID is locked there);
+  // everything else is replaced because that's what the AI is for.
+  const mergeDraftIntoForm = (d: GeneratedAgentDraft) => {
+    setForm((prev) => ({
+      ...prev,
+      name: isEdit || prev.name?.trim() ? prev.name : d.name,
+      description: d.description || prev.description,
+      specialization: d.specialization || prev.specialization,
+      icon: d.icon || prev.icon,
+      color: d.color || prev.color,
+      role: d.role || prev.role,
+      extra_principles: d.extra_principles || prev.extra_principles,
+      methodology: d.methodology || prev.methodology,
+      recommended_tools: d.recommended_tools?.length
+        ? d.recommended_tools
+        : prev.recommended_tools,
+      max_tokens: d.max_tokens || prev.max_tokens,
+      enable_thinking: d.enable_thinking ?? prev.enable_thinking,
+    }))
+  }
+
+  const handleAIGenerate = async () => {
+    if (!aiDescription.trim()) {
+      setAiError('Please describe your agent first.')
+      return
+    }
+    setAiBusy(true)
+    setAiError(null)
+    try {
+      const res = await agentsApi.generateCustom({ description: aiDescription })
+      const draft = res.data.draft
+      setAiDraft(draft)
+      setAiHistory((h) => [...h, { kind: 'describe', text: aiDescription }])
+      mergeDraftIntoForm(draft)
+    } catch (err: any) {
+      setAiError(err?.response?.data?.detail || err?.message || 'Generation failed')
+    } finally {
+      setAiBusy(false)
+    }
+  }
+
+  const handleAIRefine = async () => {
+    if (!aiFeedback.trim()) {
+      setAiError('Describe what to change in the feedback box.')
+      return
+    }
+    setAiBusy(true)
+    setAiError(null)
+    try {
+      const res = await agentsApi.generateCustom({
+        description: aiDescription || form.role || 'custom SOC agent',
+        current_draft: aiDraft,
+        feedback: aiFeedback,
+      })
+      const draft = res.data.draft
+      setAiDraft(draft)
+      setAiHistory((h) => [...h, { kind: 'refine', text: aiFeedback }])
+      setAiFeedback('')
+      mergeDraftIntoForm(draft)
+    } catch (err: any) {
+      setAiError(err?.response?.data?.detail || err?.message || 'Refinement failed')
+    } finally {
+      setAiBusy(false)
+    }
   }
 
   const validate = (): string | null => {
@@ -159,19 +250,137 @@ export default function AgentBuilderDialog({ open, agentId, onClose, onMessage }
           <Stack spacing={2}>
             {error && <Alert severity="error">{error}</Alert>}
 
-            {/* Phase 2 placeholder: NL-to-agent generator */}
-            <Tooltip title="Coming in Phase 2: describe the agent in natural language and we generate the configuration.">
-              <span>
-                <TextField
-                  label="Describe your agent (AI-assisted — coming soon)"
-                  multiline
-                  rows={2}
-                  fullWidth
-                  disabled
-                  placeholder="e.g. detects impossible-travel logins by correlating auth events across geographies"
-                />
-              </span>
-            </Tooltip>
+            {/* AI Assist — NL → draft with iterative refinement (issue #80 Phase 2) */}
+            <Accordion variant="outlined" disableGutters defaultExpanded={!isEdit}>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <AutoAwesomeIcon fontSize="small" color="primary" />
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    AI Assist
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Describe your agent and iterate with feedback
+                  </Typography>
+                </Stack>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Stack spacing={1.5}>
+                  {aiError && (
+                    <Alert severity="error" onClose={() => setAiError(null)}>
+                      {aiError}
+                    </Alert>
+                  )}
+                  <TextField
+                    label="Describe your agent"
+                    multiline
+                    rows={2}
+                    fullWidth
+                    value={aiDescription}
+                    onChange={(e) => setAiDescription(e.target.value)}
+                    placeholder="e.g. detects impossible-travel logins by correlating auth events across geographies"
+                    disabled={aiBusy}
+                    helperText="The draft fills the fields below. Your typed values are preserved where possible."
+                  />
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Button
+                      variant="contained"
+                      size="small"
+                      startIcon={
+                        aiBusy && !aiDraft ? (
+                          <CircularProgress size={14} />
+                        ) : (
+                          <AutoAwesomeIcon />
+                        )
+                      }
+                      onClick={handleAIGenerate}
+                      disabled={aiBusy || !aiDescription.trim()}
+                    >
+                      {aiDraft ? 'Regenerate' : 'Generate'}
+                    </Button>
+                    {aiDraft && (
+                      <Typography variant="caption" color="text.secondary">
+                        Draft applied. Refine below or edit fields directly.
+                      </Typography>
+                    )}
+                  </Stack>
+
+                  {aiDraft && (
+                    <>
+                      <TextField
+                        label="Refinement feedback"
+                        multiline
+                        rows={2}
+                        fullWidth
+                        value={aiFeedback}
+                        onChange={(e) => setAiFeedback(e.target.value)}
+                        placeholder="e.g. add VirusTotal lookups; tighten methodology to 3 steps; enable thinking"
+                        disabled={aiBusy}
+                      />
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Button
+                          variant="outlined"
+                          size="small"
+                          startIcon={
+                            aiBusy && aiDraft ? (
+                              <CircularProgress size={14} />
+                            ) : (
+                              <AutoAwesomeIcon />
+                            )
+                          }
+                          onClick={handleAIRefine}
+                          disabled={aiBusy || !aiFeedback.trim()}
+                        >
+                          Refine
+                        </Button>
+                        <Typography variant="caption" color="text.secondary">
+                          Keeps what's good; changes what you ask for.
+                        </Typography>
+                      </Stack>
+                    </>
+                  )}
+
+                  {aiHistory.length > 0 && (
+                    <Box
+                      sx={{
+                        mt: 0.5,
+                        p: 1,
+                        borderRadius: 1,
+                        bgcolor: (t) =>
+                          t.palette.mode === 'dark'
+                            ? 'rgba(255,255,255,0.03)'
+                            : 'rgba(0,0,0,0.03)',
+                      }}
+                    >
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ display: 'block', mb: 0.5 }}
+                      >
+                        Conversation
+                      </Typography>
+                      <Stack spacing={0.5}>
+                        {aiHistory.map((h, i) => (
+                          <Stack key={i} direction="row" spacing={1}>
+                            <Chip
+                              size="small"
+                              label={h.kind === 'describe' ? 'describe' : 'refine'}
+                              color={h.kind === 'describe' ? 'primary' : 'default'}
+                              variant="outlined"
+                            />
+                            <Typography
+                              variant="caption"
+                              sx={{ whiteSpace: 'pre-wrap' }}
+                            >
+                              {h.text}
+                            </Typography>
+                          </Stack>
+                        ))}
+                      </Stack>
+                    </Box>
+                  )}
+                </Stack>
+              </AccordionDetails>
+            </Accordion>
 
             <Typography variant="subtitle2" sx={{ mt: 1 }}>
               Identity

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -589,6 +589,27 @@ export const agentsApi = {
     api.patch(`/agents/custom/${agent_id}`, data),
   deleteCustom: (agent_id: string) => api.delete(`/agents/custom/${agent_id}`),
   getAvailableTools: () => api.get('/agents/custom/_meta/tools'),
+
+  // AI-assisted generation + iterative refinement (issue #80 Phase 2)
+  generateCustom: (data: {
+    description: string
+    current_draft?: GeneratedAgentDraft | null
+    feedback?: string
+  }) => api.post<{ draft: GeneratedAgentDraft }>('/agents/custom/generate', data),
+}
+
+export interface GeneratedAgentDraft {
+  name: string
+  description: string
+  specialization: string
+  icon: string
+  color: string
+  role: string
+  extra_principles: string
+  methodology: string
+  recommended_tools: string[]
+  max_tokens: number
+  enable_thinking: boolean
 }
 
 export interface CustomAgentPayload {
@@ -666,6 +687,14 @@ export const configApi = {
     tool_response_budget_default: number
     thinking_budget: number
   }) => api.post('/config/ai-operations', data),
+
+  getDarktrace: () => api.get('/config/darktrace'),
+  setDarktrace: (data: {
+    enabled: boolean
+    url: string
+    max_body_kb: number
+    webhook_secret?: string
+  }) => api.post('/config/darktrace', data),
 
   getOrchestrator: () => api.get('/config/orchestrator'),
   setOrchestrator: (data: {

--- a/services/agent_ai_generator.py
+++ b/services/agent_ai_generator.py
@@ -1,0 +1,330 @@
+"""
+AI-assisted custom SOC agent generator (issue #80, Phase 2).
+
+Takes a natural-language description of an agent's purpose — and optionally a
+current draft plus user feedback — and produces a draft agent configuration by
+prompting Claude with context about the platform's existing agents, available
+MCP tools, and the shape of the Vigil base prompt.
+
+Routes through ClaudeService, which flows through Bifrost per GH #84.
+"""
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class AgentAIGenerator:
+    """Generates / refines draft custom agent configurations from natural language."""
+
+    def __init__(self) -> None:
+        self._mcp_tool_names_cache: Optional[List[str]] = None
+
+    async def generate(
+        self,
+        description: str,
+        current_draft: Optional[Dict[str, Any]] = None,
+        feedback: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Generate or refine a draft agent config.
+
+        - First call: pass ``description`` only.
+        - Refinement: pass the prior ``current_draft`` plus ``feedback`` describing
+          the changes the user wants. ``description`` carries forward so the model
+          keeps the original intent in view.
+
+        Returns:
+            {
+                "success": bool,
+                "draft": {...agent config...} | None,
+                "error": str | None,
+                "raw": str,  # raw model response, for debugging
+            }
+        """
+        if not description or not description.strip():
+            return {
+                "success": False,
+                "draft": None,
+                "error": "description is required",
+                "raw": "",
+            }
+
+        from services.claude_service import ClaudeService
+
+        claude = ClaudeService(use_backend_tools=False, use_mcp_tools=False)
+        if not claude.has_api_key():
+            return {
+                "success": False,
+                "draft": None,
+                "error": "Claude API is not configured.",
+                "raw": "",
+            }
+
+        system_prompt = self._build_system_prompt()
+        user_prompt = self._build_user_prompt(description, current_draft, feedback)
+
+        try:
+            raw = claude.chat(
+                message=user_prompt,
+                system_prompt=system_prompt,
+                max_tokens=4096,
+                enable_thinking=False,
+            )
+        except Exception as e:
+            logger.exception("Agent generation call failed")
+            return {"success": False, "draft": None, "error": str(e), "raw": ""}
+
+        if not raw:
+            return {
+                "success": False,
+                "draft": None,
+                "error": "Empty response from Claude.",
+                "raw": "",
+            }
+
+        draft = self._extract_json(raw)
+        if not draft:
+            return {
+                "success": False,
+                "draft": None,
+                "error": "Could not parse agent JSON from model response.",
+                "raw": raw,
+            }
+
+        normalized = self._normalize_draft(draft)
+        return {"success": True, "draft": normalized, "error": None, "raw": raw}
+
+    # --- Prompt building ---------------------------------------------------
+
+    def _build_system_prompt(self) -> str:
+        return (
+            "You are a SOC agent designer for the Vigil SOC platform. "
+            "Given a plain-English description of an agent's purpose, design a "
+            "specialized SOC agent by writing its role, extra principles, "
+            "methodology, and a list of recommended MCP tools drawn only from "
+            "the provided catalog. Return STRICT JSON only \u2014 no prose, "
+            "no markdown, no code fences."
+        )
+
+    def _build_user_prompt(
+        self,
+        description: str,
+        current_draft: Optional[Dict[str, Any]],
+        feedback: Optional[str],
+    ) -> str:
+        agents_block = self._agents_context()
+        tools_block = self._tools_context()
+        base_prompt_shape = self._base_prompt_shape()
+
+        schema = {
+            "name": "Short Title Case agent name",
+            "description": "One-line description of what the agent does",
+            "specialization": "Short specialization area, e.g. 'Phishing Analysis'",
+            "icon": "Single uppercase letter (e.g. 'P')",
+            "color": "Hex color like '#8e44ad'",
+            "role": (
+                "Short role phrase for BASE_PROMPT "
+                "(e.g. 'phishing specialist')"
+            ),
+            "extra_principles": (
+                "Bullet list of additional principles, one per line prefixed "
+                "with '- '. Rendered inside <principles>."
+            ),
+            "methodology": (
+                "Numbered methodology (1., 2., ...) describing how the agent "
+                "operates. Rendered after the principles block."
+            ),
+            "recommended_tools": ["tool_name_1", "tool_name_2"],
+            "max_tokens": 4096,
+            "enable_thinking": False,
+        }
+
+        parts: List[str] = [f"## Agent Purpose\n{description.strip()}"]
+
+        if current_draft and feedback and feedback.strip():
+            parts.append(
+                "## Current Draft\n"
+                "```json\n"
+                f"{json.dumps(current_draft, indent=2)}\n"
+                "```\n\n"
+                "## Refinement Request\n"
+                f"{feedback.strip()}\n\n"
+                "Revise the draft to address the refinement request. Keep what is "
+                "already good; change only what the request asks for."
+            )
+        elif current_draft:
+            parts.append(
+                "## Current Draft (for context)\n"
+                "```json\n"
+                f"{json.dumps(current_draft, indent=2)}\n"
+                "```"
+            )
+
+        parts.extend(
+            [
+                f"## Existing Agents (do not duplicate)\n{agents_block}",
+                f"## Available MCP Tools (choose only from this list)\n{tools_block}",
+                (
+                    "## Base Prompt Shape\n"
+                    "Your `role`, `extra_principles`, and `methodology` fields are "
+                    "rendered into this template (Vigil preserves the "
+                    "entity-recognition and memory-palace directives):\n\n"
+                    f"{base_prompt_shape}"
+                ),
+                (
+                    "## Requirements\n"
+                    "- `role` is a short noun phrase. It renders as "
+                    "\"You are a SOC {role} in the Vigil SOC platform.\"\n"
+                    "- `extra_principles` is added AFTER Vigil's baseline "
+                    "principles. Use '- ' bullets, one per line.\n"
+                    "- `methodology` is a numbered step list (1., 2., 3., ...) "
+                    "describing how the agent should operate end-to-end.\n"
+                    "- `recommended_tools` MUST be chosen from the Available MCP "
+                    "Tools list above. Prefer 3-8 tools.\n"
+                    "- `icon` is exactly ONE uppercase letter.\n"
+                    "- `color` is a hex color like '#8e44ad'.\n"
+                    "- `max_tokens` between 2048 and 16384 (4096 is a reasonable "
+                    "default).\n"
+                    "- `enable_thinking` should be true ONLY for agents that need "
+                    "deep multi-step reasoning (e.g. forensics, correlation)."
+                ),
+                (
+                    "## Output Schema\n"
+                    "Return ONE JSON object matching this schema exactly:\n"
+                    f"{json.dumps(schema, indent=2)}"
+                ),
+            ]
+        )
+
+        return "\n\n".join(parts)
+
+    def _agents_context(self) -> str:
+        try:
+            from services.soc_agents import SOCAgentLibrary
+
+            agents = SOCAgentLibrary.get_all_agents()
+        except Exception as e:
+            logger.warning(f"Could not load agent library: {e}")
+            return "(agent library unavailable)"
+
+        lines: List[str] = []
+        for agent_id, profile in agents.items():
+            lines.append(
+                f"- `{agent_id}` \u2014 {profile.name}: "
+                f"{profile.specialization or profile.description}"
+            )
+        return "\n".join(lines) or "(no existing agents)"
+
+    def _tools_context(self) -> str:
+        tool_names = self._get_mcp_tool_names()
+        if not tool_names:
+            return (
+                "(MCP registry unavailable; leave `recommended_tools` empty "
+                "and the user can add tools manually)"
+            )
+        # Group by server prefix so the model sees the shape of each integration.
+        grouped: Dict[str, List[str]] = {}
+        for name in sorted(tool_names):
+            server = name.split("_", 1)[0] if "_" in name else "other"
+            grouped.setdefault(server, []).append(name)
+        lines: List[str] = []
+        for server, names in grouped.items():
+            lines.append(f"- **{server}**: {', '.join(names)}")
+        return "\n".join(lines)
+
+    def _get_mcp_tool_names(self) -> List[str]:
+        if self._mcp_tool_names_cache is not None:
+            return self._mcp_tool_names_cache
+        try:
+            from services.mcp_registry import get_mcp_registry
+
+            registry = get_mcp_registry()
+            names = list(registry.get_tool_names() or [])
+        except Exception as e:
+            logger.debug(f"MCP registry unavailable: {e}")
+            names = []
+        self._mcp_tool_names_cache = names
+        return names
+
+    def _base_prompt_shape(self) -> str:
+        return (
+            "You are a SOC {role} in the Vigil SOC platform.\n"
+            "\n"
+            "<entity_recognition> ... </entity_recognition>  (preserved by Vigil)\n"
+            "<available_tools> ... </available_tools>       (preserved by Vigil)\n"
+            "<memory_operations> ... </memory_operations>   (preserved by Vigil)\n"
+            "\n"
+            "<principles>\n"
+            "- Always fetch data via tools before analyzing\n"
+            "- Be evidence-based and document reasoning\n"
+            "- Use parallel tool calls for independent queries\n"
+            "{extra_principles}\n"
+            "</principles>\n"
+            "\n"
+            "{methodology}"
+        )
+
+    # --- Response parsing --------------------------------------------------
+
+    def _extract_json(self, text: str) -> Optional[Dict[str, Any]]:
+        """Extract the first valid JSON object from the response."""
+        fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+        if fence:
+            candidate = fence.group(1)
+        else:
+            match = re.search(r"\{.*\}", text, re.DOTALL)
+            candidate = match.group(0) if match else text
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            return None
+
+    def _normalize_draft(self, draft: Dict[str, Any]) -> Dict[str, Any]:
+        """Fill in defaults and sanitize values so the draft is safe to save."""
+        name = (draft.get("name") or "").strip() or "Untitled Agent"
+        icon_raw = (draft.get("icon") or "C").strip()
+        icon = (icon_raw[:1] or "C").upper()
+        color = (draft.get("color") or "#888888").strip()
+        if not re.match(r"^#[0-9A-Fa-f]{6}$", color):
+            color = "#888888"
+
+        try:
+            max_tokens = int(draft.get("max_tokens") or 4096)
+        except (TypeError, ValueError):
+            max_tokens = 4096
+        max_tokens = max(2048, min(16384, max_tokens))
+
+        tools_raw = draft.get("recommended_tools") or []
+        tools = [str(t).strip() for t in tools_raw if str(t).strip()]
+        # Deduplicate while preserving order.
+        seen: set = set()
+        tools = [t for t in tools if not (t in seen or seen.add(t))]
+
+        return {
+            "name": name,
+            "description": (draft.get("description") or "").strip(),
+            "specialization": (draft.get("specialization") or "").strip(),
+            "icon": icon,
+            "color": color,
+            "role": (draft.get("role") or "").strip(),
+            "extra_principles": (draft.get("extra_principles") or "").strip(),
+            "methodology": (draft.get("methodology") or "").strip(),
+            "recommended_tools": tools,
+            "max_tokens": max_tokens,
+            "enable_thinking": bool(draft.get("enable_thinking") or False),
+        }
+
+
+_generator: Optional[AgentAIGenerator] = None
+
+
+def get_agent_ai_generator() -> AgentAIGenerator:
+    """Return the singleton AgentAIGenerator instance."""
+    global _generator
+    if _generator is None:
+        _generator = AgentAIGenerator()
+    return _generator


### PR DESCRIPTION
## Summary

Implements **Phase 2 of [#80](https://github.com/Vigil-SOC/vigil/issues/80)**: AI-assisted agent creation. Users describe an agent in natural language, get a generated draft, then iteratively refine it with feedback until they're happy — the draft merges into the existing Agent Builder form so users can still hand-edit anything before saving.

Phase 1 shipped in [#105](https://github.com/Vigil-SOC/vigil/pull/105) (merged). Phase 3 (versioning + rollback) and Phase 4 (sandbox test-run) remain deferred.

## What's here

**Backend**
- `services/agent_ai_generator.py` — `AgentAIGenerator.generate(description, current_draft?, feedback?)`. Routes through `ClaudeService.chat()` so the call flows via Bifrost ([#84](https://github.com/Vigil-SOC/vigil/pull/84)). Context supplied to the model:
  - Existing agent list (so it doesn't duplicate a built-in)
  - Available MCP tool catalog, grouped by server prefix
  - The `BASE_PROMPT` shape so the model writes `role` / `extra_principles` / `methodology` fragments that slot in cleanly
  - Strict-JSON output, with fence-stripping + a normalizer that clamps `max_tokens` and validates `icon` / `color`
- `backend/api/custom_agents.py` — `POST /api/agents/custom/generate`. Does NOT save; returns `{draft}`. Mounted before the parameterized `/agents/custom/{agent_id}` getter so the path isn't captured. Same request payload handles both initial generation (`description` only) and iterative refinement (add `current_draft` + `feedback`).

**Frontend**
- `frontend/src/services/api.ts` — `agentsApi.generateCustom()` + `GeneratedAgentDraft` type.
- `frontend/src/components/settings/AgentBuilderDialog.tsx` — replaces the disabled \"coming soon\" placeholder with a live **AI Assist** accordion:
  - Describe → **Generate** button → draft auto-applied to form fields
  - After the first draft: a **Refine** textbox + button lets the user iterate (\"add VirusTotal lookups\", \"tighten methodology to 3 steps\", etc.)
  - Conversation history renders as chips so users see what they've asked for
  - Merge helper preserves a manually-typed name so the AI draft doesn't clobber user input

## Design notes

- **Single endpoint for generate + refine.** Server is stateless; client sends the full prior `current_draft` each refinement turn. Keeps the API simple and avoids session storage.
- **Bifrost routing preserved.** `ClaudeService.chat()` already flows via the Bifrost Anthropic passthrough per [#84](https://github.com/Vigil-SOC/vigil/pull/84), so no direct-SDK bypass.
- **Mirrors the Workflow Builder generator.** `services/workflow_ai_generator.py` (shipped in [#108](https://github.com/Vigil-SOC/vigil/pull/108)) uses the same structure — prompt builder, JSON extractor with fence stripping, singleton accessor — so the two stay consistent.
- **Issue #80 mentioned `data/mitre_attack_taxonomy.json`** as a context source; that file doesn't exist in the repo (only `data/taxonomy/capability-taxonomy.yaml` does). I followed the Workflow Builder precedent and injected agents + tools only. MITRE context can be added later if useful.

## Deferred (tracked on the original issue)

- **Phase 3** — versioning + rollback
- **Phase 4** — sandbox test-run (tier-filtered tool access)

## Test plan

- [ ] Backend boots and `Loaded N custom agent(s) from database` still appears
- [ ] `curl -X POST localhost:6987/api/agents/custom/generate -H 'Content-Type: application/json' -d '{\"description\":\"detects impossible-travel logins\"}'` returns `{draft: {...}}` with all expected fields
- [ ] Refine call: same endpoint with `current_draft` + `feedback` returns an updated draft that reflects the feedback
- [ ] Missing/empty `description` → 502 with useful error
- [ ] No `ANTHROPIC_API_KEY` → 502 \"Claude API is not configured\"
- [ ] UI: Builder Tool → Agents → New → expand **AI Assist** → describe → Generate — form fields populate
- [ ] UI: type refinement feedback → Refine — fields update, feedback chip appears in history
- [ ] UI: regenerate with new description while a draft exists — form updates, previous refine input cleared
- [ ] UI: user-typed Name is preserved across generate (and editing an existing agent keeps the locked name)
- [ ] Save → agent appears in the list; effective prompt reflects AI-generated `role` / `extra_principles` / `methodology`

🤖 Generated with [Claude Code](https://claude.com/claude-code)