### PR TITLE
feat: SOC platform hardening — MCP, agents, skills, secrets, workflows

### DIFF
--- a/backend/api/agents.py
+++ b/backend/api/agents.py
@@ -38,13 +38,17 @@ class InvestigationRequest(BaseModel):
 
 @router.get("/agents")
 async def list_agents():
-    """
-    Get list of all available SOC agents.
-    
-    Returns:
-        List of agents with their metadata
+    """Get list of all available SOC agents (built-ins + DB-backed customs).
+
+    Always refreshes the custom-agent side of the cache from the DB so
+    callers see rows created by other worker processes or external
+    tooling without having to restart. Built-ins are code-defined and
+    cached in-process.
     """
     try:
+        # Cheap best-effort refresh. Failures leave the existing cache in
+        # place — you'd still get the built-in list back.
+        agent_manager.refresh_custom_agents()
         agents = agent_manager.get_agent_list()
         return {
             "agents": agents,

--- a/backend/api/custom_agents.py
+++ b/backend/api/custom_agents.py
@@ -69,6 +69,13 @@ class CustomAgentUpdate(BaseModel):
     model: Optional[str] = None
 
 
+class ForkAgentRequest(BaseModel):
+    """Optional payload when forking. `new_name` lets the UI set the copy's
+    name up front instead of taking the default "<source> (copy)"."""
+
+    new_name: Optional[str] = None
+
+
 class GenerateAgentRequest(BaseModel):
     """Request body for AI-assisted agent generation (issue #80 Phase 2).
 
@@ -203,6 +210,41 @@ async def get_custom_agent(agent_id: str) -> Dict[str, Any]:
         raise
     except Exception as e:
         logger.error(f"Error getting custom agent {agent_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/agents/{source_agent_id}/fork", status_code=201)
+async def fork_agent(
+    source_agent_id: str, request: Optional[ForkAgentRequest] = None
+) -> Dict[str, Any]:
+    """Fork any agent (built-in or custom) into a new editable custom copy.
+
+    Built-ins remain static templates — the source is never modified. The
+    new row is a standalone custom agent that can be edited or deleted
+    without affecting the source.
+    """
+    try:
+        from backend.api.agents import agent_manager, _resolve_agent
+
+        source = _resolve_agent(source_agent_id)
+        if source is None:
+            raise HTTPException(
+                status_code=404, detail=f"Source agent not found: {source_agent_id}"
+            )
+        new_name = (request.new_name if request else None)
+        row = service.fork_from_profile(
+            source_profile=source,
+            source_id=source_agent_id,
+            new_name=new_name,
+        )
+        agent_manager.refresh_custom_agents()
+        return _with_effective_prompt(row)
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception("Error forking agent %s", source_agent_id)
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -25,6 +25,7 @@ from secrets_manager import delete_secret, get_secret, set_secret
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from database.connection import get_db_session
 from database.models import LLMProviderConfig
+from services.bifrost_admin import push_provider_key
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -32,13 +33,11 @@ router = APIRouter()
 VALID_PROVIDER_TYPES = {"anthropic", "openai", "ollama"}
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
 
-# Static list for Anthropic — the SDK doesn't expose a /models endpoint
-# for listing. Kept in sync with docker/bifrost/config.json.
-ANTHROPIC_MODELS = [
-    "claude-sonnet-4-20250514",
-    "claude-sonnet-4-5-20250929",
-    "claude-opus-4-20250514",
-]
+# Single source of truth lives in services.model_registry. The Anthropic
+# SDK doesn't expose a /models endpoint, so this static list is what
+# drives the Providers UI's model dropdown.
+from services.model_registry import ANTHROPIC_STATIC_MODELS
+ANTHROPIC_MODELS = list(ANTHROPIC_STATIC_MODELS)
 
 
 def _slugify(name: str) -> str:
@@ -144,6 +143,9 @@ async def create_provider(
         api_key_ref = _secret_ref_for(provider_id)
         if not set_secret(api_key_ref, payload.api_key):
             raise HTTPException(status_code=500, detail="Failed to persist API key")
+        # Push live to Bifrost so subsequent LLM calls use the new key
+        # without waiting for a container restart.
+        push_provider_key(payload.provider_type, payload.api_key)
 
     row = LLMProviderConfig(
         provider_id=provider_id,
@@ -193,10 +195,14 @@ async def update_provider(
         if payload.api_key == "":
             delete_secret(ref)
             row.api_key_ref = None
+            # Clearing the key: push an empty value to Bifrost so it stops
+            # trying to authenticate with a stale credential.
+            push_provider_key(row.provider_type, "")
         else:
             if not set_secret(ref, payload.api_key):
                 raise HTTPException(status_code=500, detail="Failed to persist API key")
             row.api_key_ref = ref
+            push_provider_key(row.provider_type, payload.api_key)
 
     if payload.is_default is True:
         row.is_default = True
@@ -220,6 +226,8 @@ async def delete_provider(provider_id: str, db: Session = Depends(get_db_session
             delete_secret(row.api_key_ref)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Failed to delete secret %s: %s", row.api_key_ref, exc)
+        # Wipe the corresponding value on Bifrost too.
+        push_provider_key(row.provider_type, "")
 
     db.delete(row)
     db.commit()

--- a/backend/api/mcp.py
+++ b/backend/api/mcp.py
@@ -1,13 +1,48 @@
 """MCP Server management API endpoints."""
 
-from typing import Dict, List
+import logging
+from typing import Dict, List, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from services.mcp_service import MCPService
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
-mcp_service = MCPService()
+
+
+def _service() -> MCPService:
+    """Return the process-wide MCPService instance.
+
+    Both the API endpoints and the MCPClient used to wrap in their own
+    ``MCPService()`` — two instances, two cached ``_enabled_servers``
+    dicts, so ``set_server_enabled`` on A was never visible to
+    ``connect_to_server`` on B. Centralising through ``get_mcp_client()``
+    ensures a single source of truth. Falls back to a local instance
+    if the MCP SDK isn't installed so the introspection endpoints
+    still work.
+    """
+    try:
+        from services.mcp_client import get_mcp_client
+
+        client = get_mcp_client()
+        if client is not None:
+            return client.mcp_service
+    except Exception:
+        pass
+    if not hasattr(_service, "_fallback"):
+        _service._fallback = MCPService()  # type: ignore[attr-defined]
+    return _service._fallback  # type: ignore[attr-defined]
+
+
+class _ServiceProxy:
+    """Back-compat alias so existing ``mcp_service.X`` call sites keep working."""
+
+    def __getattr__(self, name):
+        return getattr(_service(), name)
+
+
+mcp_service = _ServiceProxy()
 
 
 class ServerControl(BaseModel):
@@ -63,35 +98,73 @@ async def get_enabled_states():
 
 @router.put("/servers/{server_name}/enabled")
 async def set_server_enabled(server_name: str, request: ServerEnabledRequest):
-    """
-    Enable or disable an MCP server.
-    
-    When disabled, the server will not start via start-all and
-    cannot be started individually. If currently running and being
-    disabled, the server will be stopped.
-    
-    Args:
-        server_name: Name of the server
-        request: Body with enabled boolean
-    
-    Returns:
-        Success status
+    """Enable or disable an MCP server and apply the change at runtime.
+
+    Transactional: persisting the enabled bit also triggers an actual
+    connect (on enable) or disconnect (on disable), so the UI toggle
+    becomes the single lever users need. Before this was wired, toggling
+    only changed persisted state — the server didn't actually come online
+    until the next backend restart.
+
+    The response carries ``connected`` and ``error`` so the UI can flip
+    the toggle back off and surface the real reason (e.g. missing creds,
+    bad binary) when the connect attempt fails.
     """
     success = mcp_service.set_server_enabled(server_name, request.enabled)
     if not success:
         raise HTTPException(status_code=404, detail="Server not found")
-    
-    # If disabling a running server, stop it
-    if not request.enabled:
+
+    connected: Optional[bool] = None
+    error: Optional[str] = None
+    missing_credentials: Optional[List[str]] = None
+
+    try:
+        from services.mcp_client import get_mcp_client
+
+        mcp_client = get_mcp_client()
+    except Exception:
+        mcp_client = None
+
+    if request.enabled:
+        # Try to bring the server online now. Failures (missing creds,
+        # missing binary, unreachable remote MCP) surface via last_error.
+        # Missing-credentials case is dormancy-by-design, not an error —
+        # the UI treats it via the existing "Not Configured" chip.
+        if mcp_client is not None:
+            try:
+                connected = await mcp_client.connect_to_server(
+                    server_name, persistent=True
+                )
+                if not connected:
+                    error = mcp_client.get_last_error(server_name)
+                    missing_credentials = mcp_client.get_missing_credentials(
+                        server_name
+                    )
+            except Exception as exc:  # noqa: BLE001
+                connected = False
+                error = f"{type(exc).__name__}: {exc}"
+    else:
+        # Disable → stop any running monitor process + tear down the
+        # persistent MCP session so tools disappear from the pool.
         status = mcp_service.get_server_status(server_name)
         if status == "running":
             mcp_service.stop_server(server_name)
-    
+        if mcp_client is not None:
+            try:
+                await mcp_client.disconnect_from_server(server_name)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "Disconnect for %s failed (non-fatal): %s", server_name, exc
+                )
+
     return {
         "success": True,
         "server": server_name,
         "enabled": request.enabled,
-        "message": f"Server {server_name} {'enabled' if request.enabled else 'disabled'}"
+        "connected": connected,
+        "error": error,
+        "missing_credentials": missing_credentials,
+        "message": f"Server {server_name} {'enabled' if request.enabled else 'disabled'}",
     }
 
 
@@ -108,13 +181,32 @@ async def get_connections_status():
     mcp_client = get_mcp_client()
     if not mcp_client:
         return {"error": "MCP client not available", "connections": {}}
-    
+
+    # Auto-heal: if a previously-dormant server's required env vars have
+    # since resolved (user saved the credential via the integration
+    # wizard, or set it in the shell), retry the connect here so the
+    # next poll reflects the new state. Rate-limited per-server inside
+    # retry_dormant_if_ready to avoid connect storms.
+    try:
+        await mcp_client.retry_dormant_if_ready()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Dormant-retry sweep skipped: %s", exc)
+
     status = mcp_client.get_connection_status()
-    connections_list = [
-        {"name": name, "connected": connected}
-        for name, connected in status.items()
-    ]
-    
+    connections_list: List[Dict] = []
+    for name, connected in status.items():
+        entry: Dict = {"name": name, "connected": connected}
+        if not connected:
+            # Surface dormant-due-to-missing-creds so the UI can show the
+            # "Not Configured" chip without a second roundtrip.
+            missing = mcp_client.get_missing_credentials(name)
+            if missing:
+                entry["missing_credentials"] = missing
+            err = mcp_client.get_last_error(name)
+            if err:
+                entry["error"] = err
+        connections_list.append(entry)
+
     return {
         "connections": connections_list,
         "total": len(status),
@@ -140,73 +232,16 @@ async def get_server_status(server_name: str):
     return {"server": server_name, "status": status}
 
 
-@router.post("/servers/{server_name}/start")
-async def start_server(server_name: str):
-    """
-    Start an MCP server.
-    
-    Args:
-        server_name: Name of the server to start
-    
-    Returns:
-        Success status
-    """
-    success = mcp_service.start_server(server_name)
-    
-    if not success:
-        # Check if it's a stdio server
-        server = mcp_service.servers.get(server_name)
-        if server and server.server_type == "stdio":
-            return {
-                "success": False,
-                "message": "This server is stdio-based and designed for advanced MCP integration"
-            }
-        raise HTTPException(status_code=500, detail="Failed to start server")
-    
-    return {"success": True, "message": f"Server {server_name} started"}
+# NOTE: the former POST /servers/{name}/start + /stop endpoints were
+# removed when PUT /enabled became transactional. Every server in
+# mcp-config.json is stdio-based, which the old `start_server` path
+# explicitly refused (services/mcp_service.py), so those endpoints never
+# worked for users. The enable toggle is now the single lever.
 
 
-@router.post("/servers/{server_name}/stop")
-async def stop_server(server_name: str):
-    """
-    Stop an MCP server.
-    
-    Args:
-        server_name: Name of the server to stop
-    
-    Returns:
-        Success status
-    """
-    success = mcp_service.stop_server(server_name)
-    
-    if not success:
-        raise HTTPException(status_code=500, detail="Failed to stop server")
-    
-    return {"success": True, "message": f"Server {server_name} stopped"}
-
-
-@router.post("/servers/start-all")
-async def start_all_servers():
-    """
-    Start all MCP servers.
-    
-    Returns:
-        Results for each server
-    """
-    results = mcp_service.start_all()
-    return {"results": results}
-
-
-@router.post("/servers/stop-all")
-async def stop_all_servers():
-    """
-    Stop all MCP servers.
-    
-    Returns:
-        Results for each server
-    """
-    results = mcp_service.stop_all()
-    return {"results": results}
+# NOTE: the former /servers/start-all + /servers/stop-all endpoints were
+# removed alongside /start + /stop. They called the same stdio-hostile
+# service methods and nothing in the UI invoked them.
 
 
 @router.get("/servers/{server_name}/logs")
@@ -222,10 +257,22 @@ async def get_server_logs(server_name: str, lines: int = 100):
         Server logs
     """
     logs = mcp_service.get_server_log(server_name, lines=lines)
-    
+
     if logs == "":
         raise HTTPException(status_code=404, detail="Server not found")
-    
+
+    # Prepend the last connect-failure reason, if any — this is what
+    # actually tells the user why a server isn't reachable. The log file
+    # itself only exists for servers started via the monitor path.
+    try:
+        from services.mcp_client import get_mcp_client
+
+        last_err = get_mcp_client().get_last_error(server_name)
+        if last_err:
+            logs = f"[last connect error] {last_err}\n\n{logs}"
+    except Exception:
+        pass
+
     return {"server": server_name, "logs": logs}
 
 
@@ -251,40 +298,31 @@ async def test_server(server_name: str):
 
 @router.post("/servers/reload")
 async def reload_servers():
+    """Reload MCP server configurations from ``mcp-config.json`` and
+    the integration bridge, picking up newly enabled/disabled
+    integrations without restarting the backend.
+
+    Reinitialises the process-wide ``MCPService`` in place so both the
+    API and the ``MCPClient`` see the new catalog. Previously-enabled
+    servers are reconnected automatically; the old Popen-monitor path
+    is gone (#125), so there's nothing here analogous to "restart
+    running servers" — just enumerate new servers and let the enable
+    toggle drive connects.
     """
-    Reload MCP server configurations from integrations.
-    This picks up newly enabled/disabled integrations without restarting the backend.
-    
-    Returns:
-        Status of reload operation
-    """
-    global mcp_service
-    
     try:
-        # Store current running servers
-        running_servers = [
-            name for name, server in mcp_service.servers.items()
-            if server.is_running()
-        ]
-        
-        # Create new MCP service instance (reinitializes with latest config)
-        mcp_service = MCPService()
-        
-        # Try to restart previously running servers
-        restarted = []
-        for server_name in running_servers:
-            if server_name in mcp_service.servers:
-                if mcp_service.start_server(server_name):
-                    restarted.append(server_name)
-        
-        new_servers = list(mcp_service.servers.keys())
-        
+        svc = _service()
+        # Reinitialise servers dict in place so the MCPClient's reference
+        # to this same instance keeps seeing the new catalog.
+        svc.servers.clear()
+        svc._initialize_servers()
+
+        new_servers = list(svc.servers.keys())
+
         return {
             "success": True,
             "message": "MCP servers reloaded successfully",
             "total_servers": len(new_servers),
-            "restarted_servers": len(restarted),
-            "servers": new_servers
+            "servers": new_servers,
         }
     
     except Exception as e:

--- a/backend/api/orchestrator.py
+++ b/backend/api/orchestrator.py
@@ -69,7 +69,7 @@ async def get_orchestrator_status():
         # See services/config_service and backend/api/config.py.
         enabled = False
         try:
-            from services.config_service import get_config_service
+            from database.config_service import get_config_service
             settings = get_config_service().get_system_config('orchestrator.settings')
             if isinstance(settings, dict):
                 enabled = bool(settings.get("enabled", False))
@@ -84,7 +84,7 @@ async def get_orchestrator_status():
         
         max_agents = 3
         try:
-            from services.config_service import get_config_service
+            from database.config_service import get_config_service
             orch_cfg = get_config_service().get_system_config('orchestrator.settings')
             if orch_cfg and isinstance(orch_cfg, dict):
                 max_agents = int(orch_cfg.get('max_concurrent_agents', 3))
@@ -117,7 +117,7 @@ def _persist_orchestrator_enabled(enabled: bool) -> None:
     defaults defined in backend/api/config.py.
     """
     try:
-        from services.config_service import get_config_service
+        from database.config_service import get_config_service
         from backend.api.config import ORCHESTRATOR_DEFAULTS
 
         svc = get_config_service(user_id='web_ui')

--- a/backend/api/workflows.py
+++ b/backend/api/workflows.py
@@ -184,6 +184,8 @@ async def update_custom_workflow(workflow_id: str, payload: CustomWorkflowUpdate
         return updated
     except HTTPException:
         raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.exception("Error updating custom workflow")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/main.py
+++ b/backend/main.py
@@ -270,7 +270,17 @@ async def startup_event():
             
     except Exception as e:
         logger.warning(f"Error loading secrets for MCP servers: {e}")
-    
+
+    # Push LLM provider keys from the secrets manager to Bifrost so its
+    # configured keys reflect what's in the secret store, regardless of
+    # how the container was started or which shell env was loaded at the
+    # time. Best-effort — Bifrost may not be up yet in all environments.
+    try:
+        from services.bifrost_admin import sync_all_provider_keys
+        sync_all_provider_keys()
+    except Exception as e:
+        logger.warning(f"Bifrost provider sync skipped: {e}")
+
     # Initialize data storage backend
     logger.info("Initializing data storage...")
     try:
@@ -400,7 +410,22 @@ async def startup_event():
                         connected_count += 1
                         logger.info(f"✓ Persistent connection established: {server_name}")
                     else:
-                        logger.warning(f"Failed to connect to MCP server: {server_name}")
+                        # Dormant-by-design when the user hasn't supplied
+                        # credentials yet — log at info and name the vars
+                        # so ops has a single line to act on. Other failure
+                        # modes (bad binary, unreachable remote MCP) still
+                        # warn at warning-level because they're real.
+                        missing = mcp_client.get_missing_credentials(server_name)
+                        if missing:
+                            logger.info(
+                                "MCP server %s dormant — awaiting env vars: %s",
+                                server_name,
+                                ", ".join(missing),
+                            )
+                        else:
+                            logger.warning(
+                                f"Failed to connect to MCP server: {server_name}"
+                            )
                 except Exception as e:
                     logger.error(f"Error connecting to {server_name}: {e}")
             
@@ -475,16 +500,12 @@ async def shutdown_event():
 
         mcp_client = get_mcp_client()
         if mcp_client:
-            # Close all MCP sessions
+            # Close all MCP sessions — stdio child processes are owned by
+            # the MCP SDK's stdio_client contexts, which shut down as the
+            # persistent sessions close. No separate Popen pool to tear
+            # down since the legacy start_server path was removed (#125).
             await mcp_client.close_all()
             logger.info("All MCP connections closed")
-
-            # Stop all MCP server processes managed by MCPService
-            mcp_service = mcp_client.mcp_service
-            if mcp_service:
-                stop_results = mcp_service.stop_all()
-                stopped_count = sum(1 for success in stop_results.values() if success)
-                logger.info(f"Stopped {stopped_count} MCP server processes")
     except Exception as e:
         logger.error(f"Error during shutdown cleanup: {e}")
 

--- a/backend/secrets_manager.py
+++ b/backend/secrets_manager.py
@@ -2,20 +2,19 @@
 Secrets Manager for Vigil SOC
 
 Provides pluggable secrets storage backends with priority fallback:
-1. Environment variables (best for server deployments)
-2. .env file (good for local development)
-3. Keyring (fallback for desktop development)
+1. Encrypted local file at ``~/.vigil/secrets.enc`` (preferred; at-rest encrypted)
+2. Environment variables
+3. .env file (legacy / interoperability)
+4. Keyring (only when explicitly enabled)
 
 Usage:
     from backend.secrets_manager import get_secret, set_secret
-    
-    # Get a secret (tries all backends in order)
+
     api_key = get_secret("CLAUDE_API_KEY")
-    
-    # Set a secret (uses configured backend)
     set_secret("CLAUDE_API_KEY", "sk-ant-...")
 """
 
+import json
 import os
 import logging
 from pathlib import Path
@@ -281,59 +280,227 @@ class KeyringBackend(SecretsBackend):
         return self._available
 
 
+class EncryptedFileBackend(SecretsBackend):
+    """Project-local, at-rest encrypted secret store.
+
+    Secrets live in a Fernet-encrypted JSON blob at ``~/.vigil/secrets.enc``.
+    The symmetric key lives alongside it in ``~/.vigil/master.key`` (chmod
+    600, auto-generated on first write). Both files sit outside the repo
+    so ``.env`` rewrites, ``setup_dev.sh``, or resetting the project dir
+    never nuke stored credentials.
+
+    This is the preferred backend when running locally. Keys stored here
+    are never written to ``.env`` and are not exposed to other processes.
+    """
+
+    DEFAULT_DIR = Path.home() / ".vigil"
+    SECRETS_FILENAME = "secrets.enc"
+    MASTER_KEY_FILENAME = "master.key"
+
+    def __init__(self, data_dir: Optional[Path] = None):
+        self.data_dir = data_dir or self.DEFAULT_DIR
+        self.secrets_path = self.data_dir / self.SECRETS_FILENAME
+        self.master_key_path = self.data_dir / self.MASTER_KEY_FILENAME
+        self._fernet = None  # lazy
+        self._cache: Optional[Dict[str, str]] = None
+        # mtime of the last ``secrets.enc`` load. Used by ``_load_cache``
+        # to detect cross-process writes so the backend picks up secrets
+        # saved by sibling processes without a restart.
+        self._cache_mtime: float = 0.0
+        # `cryptography` is listed in requirements.txt; guard in case a
+        # slim deploy is missing it.
+        try:
+            from cryptography.fernet import Fernet  # noqa: F401
+            self._crypto_ok = True
+        except Exception as e:
+            logger.debug(f"EncryptedFileBackend disabled (cryptography missing): {e}")
+            self._crypto_ok = False
+
+    def _ensure_dir(self) -> None:
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(self.data_dir, 0o700)
+        except OSError:
+            pass
+
+    def _load_or_create_master_key(self) -> bytes:
+        """Return the Fernet key bytes, creating ``master.key`` on first use."""
+        from cryptography.fernet import Fernet
+
+        self._ensure_dir()
+        if self.master_key_path.exists():
+            return self.master_key_path.read_bytes().strip()
+        key = Fernet.generate_key()
+        # Atomic write
+        tmp = self.master_key_path.with_suffix(".tmp")
+        tmp.write_bytes(key)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, self.master_key_path)
+        logger.info(f"Generated new Vigil master key at {self.master_key_path}")
+        return key
+
+    def _get_fernet(self):
+        from cryptography.fernet import Fernet
+        if self._fernet is None:
+            self._fernet = Fernet(self._load_or_create_master_key())
+        return self._fernet
+
+    def _current_mtime(self) -> float:
+        """Return the secrets file's mtime, or 0 if it doesn't exist."""
+        try:
+            return self.secrets_path.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    def _load_cache(self) -> Dict[str, str]:
+        # Invalidate the in-memory cache if another process (or another
+        # instance in this process) has written to the file since we
+        # last read it. Without this, the backend couldn't see secrets
+        # saved by sibling processes (CLI tools, other workers, the MCP
+        # dormant-retry auto-reconnect path, etc.).
+        current_mtime = self._current_mtime()
+        if (
+            self._cache is not None
+            and current_mtime
+            and current_mtime != getattr(self, "_cache_mtime", 0.0)
+        ):
+            logger.debug("Secrets file changed on disk — reloading cache")
+            self._cache = None
+
+        if self._cache is not None:
+            return self._cache
+        if not self.secrets_path.exists():
+            self._cache = {}
+            self._cache_mtime = current_mtime
+            return self._cache
+        try:
+            from cryptography.fernet import InvalidToken  # noqa: F401
+            blob = self.secrets_path.read_bytes()
+            plaintext = self._get_fernet().decrypt(blob)
+            self._cache = json.loads(plaintext.decode("utf-8"))
+            self._cache_mtime = current_mtime
+            logger.debug(f"Loaded {len(self._cache)} secrets from {self.secrets_path}")
+        except Exception as e:
+            # Don't silently wipe: log and present an empty view, but leave
+            # the encrypted file untouched so a bad master key doesn't
+            # destroy data.
+            logger.error(
+                f"Could not decrypt {self.secrets_path} ({e}); "
+                f"treating as empty. If the master key changed, restore "
+                f"~/.vigil/master.key from a backup."
+            )
+            self._cache = {}
+            self._cache_mtime = current_mtime
+        return self._cache
+
+    def _write_cache(self) -> bool:
+        try:
+            self._ensure_dir()
+            plaintext = json.dumps(self._cache or {}, sort_keys=True).encode("utf-8")
+            blob = self._get_fernet().encrypt(plaintext)
+            tmp = self.secrets_path.with_suffix(".tmp")
+            tmp.write_bytes(blob)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, self.secrets_path)
+            # Keep our mtime tracker in sync so we don't needlessly
+            # re-read the file we just wrote.
+            self._cache_mtime = self._current_mtime()
+            return True
+        except Exception as e:
+            logger.error(f"Error writing encrypted secrets: {e}")
+            return False
+
+    def get(self, key: str) -> Optional[str]:
+        if not self._crypto_ok:
+            return None
+        value = self._load_cache().get(key)
+        if value:
+            logger.debug(f"Found secret '{key}' in encrypted store")
+        return value
+
+    def set(self, key: str, value: str) -> bool:
+        if not self._crypto_ok:
+            logger.error("EncryptedFileBackend unavailable (cryptography missing)")
+            return False
+        cache = self._load_cache()
+        cache[key] = value
+        if self._write_cache():
+            logger.info(f"Set secret '{key}' in encrypted store")
+            return True
+        return False
+
+    def delete(self, key: str) -> bool:
+        if not self._crypto_ok:
+            return False
+        cache = self._load_cache()
+        if key in cache:
+            del cache[key]
+            if self._write_cache():
+                logger.info(f"Deleted secret '{key}' from encrypted store")
+        return True
+
+    def is_available(self) -> bool:
+        return self._crypto_ok
+
+
 class SecretsManager:
     """
     Unified secrets manager that tries multiple backends in priority order.
-    
+
     Priority for reading:
-    1. Environment variables (process-level, ideal for containers/servers)
-    2. .env file (file-based, good for local dev)
-    3. Keyring (OS-level, only if explicitly enabled)
-    
-    Priority for writing (configurable):
-    - By default writes to .env file for server deployments
-    - Can be configured to write to keyring for desktop deployments
+    1. Encrypted local file (``~/.vigil/secrets.enc``; preferred)
+    2. Environment variables
+    3. .env file (legacy / interoperability)
+    4. Keyring (only when explicitly enabled)
+
+    Priority for writing: configurable via ``SECRETS_BACKEND``. Default is
+    ``encrypted`` when ``cryptography`` is available, otherwise ``dotenv``.
     """
-    
-    def __init__(self, write_backend: str = "dotenv", enable_keyring: bool = False):
-        """
-        Initialize secrets manager.
-        
+
+    def __init__(self, write_backend: str = "encrypted", enable_keyring: bool = False):
+        """Initialize secrets manager.
+
         Args:
-            write_backend: Backend to use for writing ("env", "dotenv", or "keyring")
-            enable_keyring: If True, include keyring in read backends. If False, only use
-                          keyring if it's the write_backend. This prevents keychain prompts
-                          on macOS unless explicitly needed.
+            write_backend: "encrypted", "env", "dotenv", or "keyring".
+            enable_keyring: Include keyring in read backends when True. Keyring
+                access triggers macOS keychain prompts, so off by default.
         """
+        self.encrypted_backend = EncryptedFileBackend()
         self.env_backend = EnvironmentBackend()
         self.dotenv_backend = DotEnvBackend()
         # Use lazy init to avoid triggering keychain prompts on startup
         self.keyring_backend = KeyringBackend(lazy_init=True)
         self.enable_keyring = enable_keyring or (write_backend == "keyring")
-        
-        # Read priority - only include keyring if explicitly enabled
+
+        # Graceful fallback if user asked for "encrypted" but cryptography
+        # isn't installed — prevents hard failure on slim deploys.
+        if write_backend == "encrypted" and not self.encrypted_backend.is_available():
+            logger.warning(
+                "EncryptedFileBackend unavailable; falling back to dotenv write backend"
+            )
+            write_backend = "dotenv"
+
+        # Read priority — encrypted first (preferred), then env, then dotenv,
+        # then keyring only when explicitly enabled.
+        self.read_backends = []
+        if self.encrypted_backend.is_available():
+            self.read_backends.append(self.encrypted_backend)
+        self.read_backends.extend([self.env_backend, self.dotenv_backend])
         if self.enable_keyring:
-            self.read_backends = [
-                self.env_backend,
-                self.dotenv_backend,
-                self.keyring_backend,
-            ]
+            self.read_backends.append(self.keyring_backend)
         else:
-            self.read_backends = [
-                self.env_backend,
-                self.dotenv_backend,
-            ]
             logger.debug("Keyring backend disabled - will not check keyring for secrets")
-        
+
         # Write backend (configurable based on deployment)
         self.write_backend_name = write_backend
         backend_map = {
+            "encrypted": self.encrypted_backend,
             "env": self.env_backend,
             "dotenv": self.dotenv_backend,
             "keyring": self.keyring_backend,
         }
-        self.write_backend = backend_map.get(write_backend, self.dotenv_backend)
-        
+        self.write_backend = backend_map.get(write_backend, self.encrypted_backend)
+
         logger.info(f"Secrets manager initialized (write backend: {write_backend})")
     
     def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
@@ -393,7 +560,12 @@ class SecretsManager:
             True if successful
         """
         success = True
-        for backend in [self.env_backend, self.dotenv_backend, self.keyring_backend]:
+        for backend in [
+            self.encrypted_backend,
+            self.env_backend,
+            self.dotenv_backend,
+            self.keyring_backend,
+        ]:
             if backend.is_available():
                 if not backend.delete(key):
                     success = False
@@ -402,6 +574,11 @@ class SecretsManager:
     def get_backend_status(self) -> Dict[str, Any]:
         """Get status of all backends."""
         return {
+            "encrypted": {
+                "available": self.encrypted_backend.is_available(),
+                "path": str(self.encrypted_backend.secrets_path),
+                "description": "Project-local encrypted file (preferred)"
+            },
             "environment": {
                 "available": self.env_backend.is_available(),
                 "description": "Environment variables (best for containers/servers)"
@@ -409,7 +586,7 @@ class SecretsManager:
             "dotenv": {
                 "available": self.dotenv_backend.is_available(),
                 "path": str(self.dotenv_backend.env_file),
-                "description": "File-based secrets (good for local development)"
+                "description": "File-based secrets (legacy)"
             },
             "keyring": {
                 "available": self.keyring_backend.is_available(),
@@ -439,7 +616,7 @@ def get_secrets_manager(write_backend: Optional[str] = None, enable_keyring: Opt
     if _secrets_manager is None:
         # Check environment variable for backend preference
         if write_backend is None:
-            write_backend = os.environ.get("SECRETS_BACKEND", "dotenv")
+            write_backend = os.environ.get("SECRETS_BACKEND", "encrypted")
         
         # Check if keyring should be enabled (priority order: arg > env var > config file)
         if enable_keyring is None:

--- a/backend/services/custom_agent_service.py
+++ b/backend/services/custom_agent_service.py
@@ -110,7 +110,7 @@ class CustomAgentService:
                     f"Custom agent already exists: {agent_id}"
                 )
 
-            agent = CustomAgent(
+            kwargs = dict(
                 id=agent_id,
                 name=name,
                 description=data.get("description"),
@@ -125,11 +125,72 @@ class CustomAgentService:
                 max_tokens=int(data.get("max_tokens") or 4096),
                 enable_thinking=bool(data.get("enable_thinking") or False),
                 model=data.get("model"),
+                forked_from=data.get("forked_from"),
                 created_by=created_by,
             )
+            if data.get("component_category"):
+                kwargs["component_category"] = data["component_category"]
+            agent = CustomAgent(**kwargs)
             session.add(agent)
             session.flush()
             return agent.to_dict()
+
+    def fork_from_profile(
+        self,
+        source_profile: Any,
+        source_id: str,
+        created_by: Optional[str] = None,
+        new_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create a custom agent by copying values from an ``AgentProfile``.
+
+        Works for both built-in and custom source agents. The new row is
+        an independent copy — the source is never touched. Appends "
+        (copy)" to the name unless ``new_name`` is supplied, and bumps
+        with a numeric suffix if the default ID collides.
+        """
+        base_name = new_name or f"{source_profile.name} (copy)"
+        # Find an unused ID by appending " 2", " 3", ... on collision.
+        db_manager = get_db_manager()
+        with db_manager.session_scope() as session:
+            name = base_name
+            counter = 2
+            while True:
+                candidate = build_agent_id(name)
+                exists = (
+                    session.query(CustomAgent)
+                    .filter(CustomAgent.id == candidate)
+                    .one_or_none()
+                )
+                if not exists:
+                    break
+                name = f"{base_name} {counter}"
+                counter += 1
+
+        # Extract fields off the AgentProfile. Some built-in fields
+        # (extra_principles, methodology) aren't on the profile — we
+        # capture the rendered system prompt as an override so the fork
+        # behaves exactly like the source on day one.
+        data = {
+            "name": name,
+            "role": getattr(source_profile, "role", "") or source_profile.name,
+            "description": getattr(source_profile, "description", None),
+            "icon": getattr(source_profile, "icon", None),
+            "color": getattr(source_profile, "color", None),
+            "specialization": getattr(source_profile, "specialization", None),
+            "extra_principles": getattr(source_profile, "extra_principles", "") or "",
+            "methodology": getattr(source_profile, "methodology", "") or "",
+            "system_prompt_override": getattr(source_profile, "system_prompt", None),
+            "recommended_tools": list(
+                getattr(source_profile, "recommended_tools", []) or []
+            ),
+            "max_tokens": getattr(source_profile, "max_tokens", 4096),
+            "enable_thinking": getattr(source_profile, "enable_thinking", False),
+            "model": getattr(source_profile, "model", None),
+            "component_category": getattr(source_profile, "component_category", None),
+            "forked_from": source_id,
+        }
+        return self.create_agent(data, created_by=created_by)
 
     def update_agent(
         self,

--- a/database/init/07_custom_agents.sql
+++ b/database/init/07_custom_agents.sql
@@ -18,10 +18,15 @@ CREATE TABLE IF NOT EXISTS custom_agents (
     max_tokens INTEGER NOT NULL DEFAULT 4096,
     enable_thinking BOOLEAN NOT NULL DEFAULT FALSE,
     model TEXT,
+    forked_from TEXT,
     created_by VARCHAR(100),
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+-- Idempotent migration for existing installs where this table predates the
+-- `forked_from` column. Safe to run repeatedly.
+ALTER TABLE custom_agents ADD COLUMN IF NOT EXISTS forked_from TEXT;
 
 CREATE INDEX IF NOT EXISTS idx_custom_agents_updated_at ON custom_agents(updated_at DESC);
 

--- a/database/models.py
+++ b/database/models.py
@@ -2376,6 +2376,10 @@ class CustomAgent(Base):
     component_category: Mapped[str] = mapped_column(
         String(32), nullable=False, default='investigation', server_default='investigation'
     )
+    # Origin agent ID this row was forked from (built-in id like "reporter" or
+    # another custom id). Null for agents authored from scratch. Breadcrumb
+    # only — no FK, because built-ins live in code, not a table.
+    forked_from: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     created_by: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
@@ -2408,6 +2412,7 @@ class CustomAgent(Base):
             'enable_thinking': self.enable_thinking,
             'model': self.model,
             'component_category': self.component_category,
+            'forked_from': self.forked_from,
             'created_by': self.created_by,
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None,

--- a/docker/bifrost/config.json
+++ b/docker/bifrost/config.json
@@ -8,9 +8,12 @@
           "weight": 1,
           "value": "env.ANTHROPIC_API_KEY",
           "models": [
-            "claude-sonnet-4-20250514",
+            "claude-opus-4-7",
+            "claude-sonnet-4-6",
             "claude-sonnet-4-5-20250929",
-            "claude-opus-4-20250514"
+            "claude-sonnet-4-20250514",
+            "claude-opus-4-20250514",
+            "claude-haiku-4-5-20251001"
           ]
         }
       ]

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,0 +1,136 @@
+# Where Vigil stores state
+
+This project grew with state scattered across several locations. This
+doc is the canonical map: where each kind of thing lives, which store
+is authoritative, and what's deprecated.
+
+## Secrets
+
+**Authoritative store: `~/.vigil/secrets.enc`** (Fernet-encrypted JSON,
+chmod 600). The symmetric key lives at `~/.vigil/master.key` (chmod 600,
+auto-generated on first write). Both files sit outside the repo, so
+`.env` rewrites, `setup_dev.sh`, resetting the project dir, or git
+checkouts don't nuke stored credentials.
+
+**Backend priority** (read order in `SecretsManager.read_backends`):
+
+1. `EncryptedFileBackend` — `~/.vigil/secrets.enc` (preferred)
+2. `EnvironmentBackend` — `os.environ`
+3. `DotEnvBackend` — `~/.deeptempo/.env` (**legacy, prefer migrate**)
+4. `KeyringBackend` — OS keychain, only when `ENABLE_KEYRING=true`
+
+**Default write backend:** `encrypted` (override with
+`SECRETS_BACKEND=env|dotenv|keyring`).
+
+**Editing a secret.** Use the LLM Providers UI (Settings → AI Config →
+Providers) or the `set_secret()` helper from `backend.secrets_manager`.
+Never write secrets into `.env` by hand; that file is for non-secret
+bootstrap flags only (see below).
+
+**Migrating legacy secrets.** Run once:
+
+    python scripts/migrate_secrets.py          # copy → encrypted store
+    python scripts/migrate_secrets.py --purge  # also strip from ~/.deeptempo/.env
+
+**Backup.** Back up `~/.vigil/` as a unit — both files are needed.
+Losing `master.key` means losing every secret in `secrets.enc`; there
+is no recovery.
+
+## Non-secret runtime config
+
+**Authoritative store: Postgres `system_config` table.** Runtime-editable
+settings (orchestrator tunables, AI operations, general/S3/Darktrace
+settings, feature flags, etc.) live here with a full audit trail in
+`config_audit_log`. Access via `backend.api.config` and the Settings UI.
+
+New runtime config should go here — not into `.env`.
+
+## `.env` (repo root)
+
+**Purpose: bootstrap only.** Values needed to start the backend before
+the DB is reachable. Nothing sensitive should live here.
+
+Safe to put in `.env`:
+- `DATABASE_URL`, `REDIS_URL`, `BIFROST_URL`
+- `BIND_HOST`, port numbers
+- `DEV_MODE`, `SECRETS_BACKEND`, `ENABLE_KEYRING`
+- `SENTRY_DSN` (non-secret in practice)
+- `LOG_LEVEL`, polling intervals, etc.
+
+**Do not put in `.env`:** API keys, tokens, passwords. Store via the UI
+or `set_secret()`; they land in `~/.vigil/secrets.enc`.
+
+Historical `ANTHROPIC_API_KEY` placeholder lines in `.env` are ignored
+when the encrypted store has a value.
+
+## `~/.deeptempo/.env` (deprecated)
+
+This was the old default write target of `DotEnvBackend`. It still
+*reads* for backward compatibility (position 3 in the backend chain)
+but nothing should write here anymore. `scripts/migrate_secrets.py`
+moves values from here into `~/.vigil/secrets.enc`; run with `--purge`
+to clear it.
+
+## `~/.deeptempo/general_config.json`
+
+Kept for one thing only: the `enable_keyring` flag. You can also set
+this via the `ENABLE_KEYRING` env var in `.env`. This file is benign
+and will likely be folded into `system_config` in a future cleanup.
+
+## Pointers (DB → secret store)
+
+| Table | Points to |
+|---|---|
+| `llm_provider_configs.api_key_ref` | a key in the secrets manager (e.g. `llm_provider_anthropic-default_api_key`) |
+| `integration_configs` | references secrets by name; values in secrets manager |
+
+Row + value are decoupled on purpose: the DB is safe to back up / copy,
+and secrets stay in the encrypted store at rest.
+
+## Bifrost
+
+Bifrost is a sidecar container that fronts all LLM traffic. It has its
+own internal state for provider config and cache. Vigil does **not**
+rely on Bifrost reading `env.ANTHROPIC_API_KEY` from its docker env
+anymore — that was the old flow and caused the "key lost on restart"
+problem. Instead:
+
+- On backend startup, `services.bifrost_admin.sync_all_provider_keys()`
+  pushes every key in the secrets manager to Bifrost via its admin API
+  (`PUT /api/providers/{name}`).
+- On provider create/update/delete in the UI, the corresponding endpoint
+  in `backend/api/llm_providers.py` pushes the new (or empty) value to
+  Bifrost in the same request.
+
+So the flow is: **UI → secrets_manager → bifrost_admin → Bifrost** in
+one synchronous chain. No container restart needed to rotate a key.
+
+The seed `docker/bifrost/config.json` still references `env.*` for
+first-boot provider/model definitions, but the actual key *values* are
+overwritten at runtime.
+
+## Workdirs and logs
+
+- `data/investigations/` — orchestrator working files (investigation
+  transcripts, context docs, agent output).
+- `data/mitre/`, `data/schemas/` — static reference data.
+- `logs/*.log`, `logs/*.pid` — runtime logs and process pids (started
+  via `start_web.sh`, `start_daemon.sh`).
+
+## Docker volumes
+
+- `deeptempo-postgres` — Postgres data.
+- `deeptempo-redis` — Redis (ARQ queue + rate limiting).
+- `deeptempo-bifrost` — Bifrost's internal state (if any persistent).
+
+## Quick reference
+
+| Thing | Where |
+|---|---|
+| API keys, tokens | `~/.vigil/secrets.enc` |
+| Runtime settings (UI-editable) | Postgres `system_config` |
+| Bootstrap flags (DB URL, ports, DEV_MODE) | repo `.env` |
+| Ephemeral runtime | Redis, Postgres |
+| Investigation files | `data/investigations/` |
+| Logs, PIDs | `logs/` |
+| Legacy secrets (migrate from) | `~/.deeptempo/.env` |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,25 +1,38 @@
+import { lazy, Suspense } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
-import { Box } from '@mui/material'
+import { Box, CircularProgress } from '@mui/material'
 import { AuthProvider } from './contexts/AuthContext'
 import ProtectedRoute from './components/auth/ProtectedRoute'
 import MainLayout from './components/layout/MainLayout'
-import Login from './pages/Login'
-import Dashboard from './pages/Dashboard'
-import Cases from './pages/Cases'
-import CaseMetrics from './pages/CaseMetrics'
-import Timesketch from './pages/Timesketch'
-import Settings from './pages/Settings'
-import AIDecisions from './pages/AIDecisions'
-import Investigation from './pages/Investigation'
-import Analytics from './pages/Analytics'
-import Skills from './pages/Skills'
-import Orchestrator from './pages/Orchestrator'
-import BuilderTool from './pages/BuilderTool'
+
+// Lazy-load every page so a refresh on any route only pulls that page's
+// module graph (plus shared deps). Previously every page was eagerly
+// imported, forcing ~1 MB of JS + all its MUI/recharts/x-data-grid deps
+// on every cold load.
+const Login = lazy(() => import('./pages/Login'))
+const Dashboard = lazy(() => import('./pages/Dashboard'))
+const Cases = lazy(() => import('./pages/Cases'))
+const CaseMetrics = lazy(() => import('./pages/CaseMetrics'))
+const Timesketch = lazy(() => import('./pages/Timesketch'))
+const Settings = lazy(() => import('./pages/Settings'))
+const AIDecisions = lazy(() => import('./pages/AIDecisions'))
+const Investigation = lazy(() => import('./pages/Investigation'))
+const Analytics = lazy(() => import('./pages/Analytics'))
+const Skills = lazy(() => import('./pages/Skills'))
+const Orchestrator = lazy(() => import('./pages/Orchestrator'))
+const BuilderTool = lazy(() => import('./pages/BuilderTool'))
+
+const PageFallback = () => (
+  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1, minHeight: 200 }}>
+    <CircularProgress size={24} />
+  </Box>
+)
 
 function App() {
   return (
     <AuthProvider>
       <Box sx={{ display: 'flex', height: '100vh' }}>
+        <Suspense fallback={<PageFallback />}>
         <Routes>
           {/* Public routes */}
           <Route path="/login" element={<Login />} />
@@ -77,6 +90,7 @@ function App() {
             />
           </Route>
         </Routes>
+        </Suspense>
       </Box>
     </AuthProvider>
   )

--- a/frontend/src/components/settings/AgentBuilderTab.tsx
+++ b/frontend/src/components/settings/AgentBuilderTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   Box,
   Typography,
@@ -20,9 +20,11 @@ import {
   Add as AddIcon,
   Edit as EditIcon,
   Delete as DeleteIcon,
+  ContentCopy as ForkIcon,
   SmartToy as AgentIcon,
+  Lock as LockIcon,
 } from '@mui/icons-material'
-import { agentsApi, type CustomAgent } from '../../services/api'
+import { agentsApi, type CustomAgent, type AgentSummary } from '../../services/api'
 import AgentBuilderDialog from './AgentBuilderDialog'
 
 interface Props {
@@ -30,21 +32,51 @@ interface Props {
   showConfirm: (title: string, msg: string, onConfirm: () => void) => void
 }
 
+type Row = AgentSummary & {
+  is_builtin: boolean
+  // Custom rows carry the extras; built-ins leave these undefined.
+  forked_from?: string | null
+  recommended_tools?: string[]
+  updated_at?: string
+}
+
+const CUSTOM_PREFIX = 'custom-'
+
 export default function AgentBuilderTab({ onMessage, showConfirm }: Props) {
-  const [agents, setAgents] = useState<CustomAgent[]>([])
+  const [rows, setRows] = useState<Row[]>([])
   const [loading, setLoading] = useState(true)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
+  const [busyId, setBusyId] = useState<string | null>(null)
 
-  const loadAgents = useCallback(async () => {
+  const load = useCallback(async () => {
     setLoading(true)
     try {
-      const res = await agentsApi.listCustom()
-      setAgents(res.data.agents || [])
+      // Pull both streams: the unified list for display, and the custom
+      // rows so we can surface updated_at + recommended_tools counts.
+      const [unifiedRes, customRes] = await Promise.all([
+        agentsApi.listAgents(),
+        agentsApi.listCustom().catch(() => ({ data: { agents: [] as CustomAgent[] } })),
+      ])
+      const unified: AgentSummary[] = unifiedRes.data?.agents || []
+      const customs: CustomAgent[] = customRes.data?.agents || []
+      const customById = new Map(customs.map((c) => [c.id, c]))
+      const merged: Row[] = unified.map((a) => {
+        const is_builtin = !a.id.startsWith(CUSTOM_PREFIX)
+        const custom = customById.get(a.id)
+        return {
+          ...a,
+          is_builtin,
+          forked_from: custom?.forked_from ?? null,
+          recommended_tools: custom?.recommended_tools ?? undefined,
+          updated_at: custom?.updated_at,
+        }
+      })
+      setRows(merged)
     } catch (err: any) {
       onMessage({
         type: 'error',
-        text: `Failed to load custom agents: ${err?.response?.data?.detail || err?.message || 'unknown error'}`,
+        text: `Failed to load agents: ${err?.response?.data?.detail || err?.message || 'unknown error'}`,
       })
     } finally {
       setLoading(false)
@@ -52,8 +84,11 @@ export default function AgentBuilderTab({ onMessage, showConfirm }: Props) {
   }, [onMessage])
 
   useEffect(() => {
-    loadAgents()
-  }, [loadAgents])
+    load()
+  }, [load])
+
+  const builtins = useMemo(() => rows.filter((r) => r.is_builtin), [rows])
+  const customs = useMemo(() => rows.filter((r) => !r.is_builtin), [rows])
 
   const handleNew = () => {
     setEditingId(null)
@@ -65,16 +100,40 @@ export default function AgentBuilderTab({ onMessage, showConfirm }: Props) {
     setDialogOpen(true)
   }
 
-  const handleDelete = (agent: CustomAgent) => {
+  const handleFork = async (row: Row) => {
+    setBusyId(row.id)
+    try {
+      const res = await agentsApi.forkAgent(row.id)
+      const newId: string = res.data?.id
+      onMessage({ type: 'success', text: `Forked "${row.name}" → opening editor` })
+      setTimeout(() => onMessage({ type: 'success', text: '' }), 2500)
+      await load()
+      // Drop the user straight into the editor so the fork feels like a
+      // "customize this template" flow, not a silent copy.
+      if (newId) {
+        setEditingId(newId)
+        setDialogOpen(true)
+      }
+    } catch (err: any) {
+      onMessage({
+        type: 'error',
+        text: `Fork failed: ${err?.response?.data?.detail || err?.message || 'unknown error'}`,
+      })
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const handleDelete = (row: Row) => {
     showConfirm(
       'Delete custom agent',
-      `Delete ${agent.name}? This cannot be undone.`,
+      `Delete ${row.name}? This cannot be undone. The built-in it was forked from (if any) is unaffected.`,
       async () => {
         try {
-          await agentsApi.deleteCustom(agent.id)
-          onMessage({ type: 'success', text: `Deleted ${agent.name}` })
+          await agentsApi.deleteCustom(row.id)
+          onMessage({ type: 'success', text: `Deleted ${row.name}` })
           setTimeout(() => onMessage({ type: 'success', text: '' }), 3000)
-          await loadAgents()
+          await load()
         } catch (err: any) {
           onMessage({
             type: 'error',
@@ -88,10 +147,120 @@ export default function AgentBuilderTab({ onMessage, showConfirm }: Props) {
   const handleDialogClose = (saved: boolean) => {
     setDialogOpen(false)
     setEditingId(null)
-    if (saved) {
-      loadAgents()
-    }
+    if (saved) load()
   }
+
+  const renderAvatar = (row: Row) => (
+    <Box
+      sx={{
+        width: 28,
+        height: 28,
+        borderRadius: '50%',
+        bgcolor: row.color || '#888',
+        color: '#fff',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '0.8rem',
+        fontWeight: 700,
+        flexShrink: 0,
+      }}
+    >
+      {row.icon || (row.is_builtin ? 'B' : 'C')}
+    </Box>
+  )
+
+  const renderRow = (row: Row) => (
+    <TableRow key={row.id} hover>
+      <TableCell>
+        <Stack direction="row" spacing={1.25} alignItems="center">
+          {renderAvatar(row)}
+          <Box>
+            <Stack direction="row" spacing={0.75} alignItems="center">
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                {row.name}
+              </Typography>
+              {row.is_builtin && (
+                <Chip
+                  size="small"
+                  label="Template"
+                  icon={<LockIcon sx={{ fontSize: 13 }} />}
+                  sx={{ height: 20, fontSize: '0.7rem' }}
+                />
+              )}
+              {row.forked_from && (
+                <Tooltip title={`Forked from ${row.forked_from}`} arrow>
+                  <Chip
+                    size="small"
+                    label={`⎇ ${row.forked_from}`}
+                    variant="outlined"
+                    sx={{ height: 20, fontSize: '0.7rem' }}
+                  />
+                </Tooltip>
+              )}
+            </Stack>
+            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+              {row.id}
+            </Typography>
+          </Box>
+        </Stack>
+      </TableCell>
+      <TableCell>{row.specialization || '—'}</TableCell>
+      <TableCell>
+        {row.recommended_tools ? (
+          <Chip size="small" label={`${row.recommended_tools.length} tool(s)`} />
+        ) : (
+          <Typography variant="caption" color="text.disabled">
+            —
+          </Typography>
+        )}
+      </TableCell>
+      <TableCell>
+        <Typography variant="caption" color="text.secondary">
+          {row.updated_at ? new Date(row.updated_at).toLocaleString() : '—'}
+        </Typography>
+      </TableCell>
+      <TableCell align="right">
+        {row.is_builtin ? (
+          <Tooltip title="Fork this template into an editable custom agent" arrow>
+            <span>
+              <IconButton
+                size="small"
+                onClick={() => handleFork(row)}
+                disabled={busyId === row.id}
+              >
+                {busyId === row.id ? <CircularProgress size={16} /> : <ForkIcon fontSize="small" />}
+              </IconButton>
+            </span>
+          </Tooltip>
+        ) : (
+          <>
+            <Tooltip title="Edit">
+              <IconButton size="small" onClick={() => handleEdit(row.id)}>
+                <EditIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Fork into a new copy">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={() => handleFork(row)}
+                  disabled={busyId === row.id}
+                >
+                  {busyId === row.id ? <CircularProgress size={16} /> : <ForkIcon fontSize="small" />}
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="Delete">
+              <IconButton size="small" onClick={() => handleDelete(row)}>
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </>
+        )}
+      </TableCell>
+    </TableRow>
+  )
 
   return (
     <Box>
@@ -101,7 +270,8 @@ export default function AgentBuilderTab({ onMessage, showConfirm }: Props) {
             SOC Agents
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            Create custom specialized agents in addition to the 13 built-in SOC agents.
+            Built-in agents are read-only templates. Fork one to create an
+            editable custom copy, or start from scratch with "New Agent".
           </Typography>
         </Box>
         <Button variant="contained" startIcon={<AddIcon />} onClick={handleNew}>
@@ -113,85 +283,57 @@ export default function AgentBuilderTab({ onMessage, showConfirm }: Props) {
         <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
           <CircularProgress size={28} />
         </Box>
-      ) : agents.length === 0 ? (
+      ) : rows.length === 0 ? (
         <Paper variant="outlined" sx={{ p: 4, textAlign: 'center' }}>
           <AgentIcon sx={{ fontSize: 40, color: 'text.disabled', mb: 1 }} />
           <Typography variant="body1" sx={{ mb: 0.5 }}>
-            No custom agents yet
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Click "New Agent" to create one. Custom agents appear in the Skills page alongside built-ins.
+            No agents available
           </Typography>
         </Paper>
       ) : (
-        <TableContainer component={Paper} variant="outlined">
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Name</TableCell>
-                <TableCell>Specialization</TableCell>
-                <TableCell>Tools</TableCell>
-                <TableCell>Updated</TableCell>
-                <TableCell align="right">Actions</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {agents.map((a) => (
-                <TableRow key={a.id} hover>
-                  <TableCell>
-                    <Stack direction="row" spacing={1} alignItems="center">
-                      <Box
-                        sx={{
-                          width: 24,
-                          height: 24,
-                          borderRadius: '50%',
-                          bgcolor: a.color || '#888',
-                          color: '#fff',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          fontSize: '0.75rem',
-                          fontWeight: 700,
-                        }}
-                      >
-                        {a.icon || 'C'}
-                      </Box>
-                      <Box>
-                        <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                          {a.name}
-                        </Typography>
-                        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
-                          {a.id}
-                        </Typography>
-                      </Box>
-                    </Stack>
-                  </TableCell>
-                  <TableCell>{a.specialization || '—'}</TableCell>
-                  <TableCell>
-                    <Chip size="small" label={`${(a.recommended_tools || []).length} tool(s)`} />
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="caption" color="text.secondary">
-                      {a.updated_at ? new Date(a.updated_at).toLocaleString() : '—'}
-                    </Typography>
-                  </TableCell>
-                  <TableCell align="right">
-                    <Tooltip title="Edit">
-                      <IconButton size="small" onClick={() => handleEdit(a.id)}>
-                        <EditIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                    <Tooltip title="Delete">
-                      <IconButton size="small" onClick={() => handleDelete(a)}>
-                        <DeleteIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
+        <Stack spacing={3}>
+          {customs.length > 0 && (
+            <Box>
+              <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                Your agents ({customs.length})
+              </Typography>
+              <TableContainer component={Paper} variant="outlined" sx={{ mt: 0.5 }}>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Name</TableCell>
+                      <TableCell>Specialization</TableCell>
+                      <TableCell>Tools</TableCell>
+                      <TableCell>Updated</TableCell>
+                      <TableCell align="right">Actions</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>{customs.map(renderRow)}</TableBody>
+                </Table>
+              </TableContainer>
+            </Box>
+          )}
+
+          <Box>
+            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+              Built-in templates ({builtins.length})
+            </Typography>
+            <TableContainer component={Paper} variant="outlined" sx={{ mt: 0.5 }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Name</TableCell>
+                    <TableCell>Specialization</TableCell>
+                    <TableCell>Tools</TableCell>
+                    <TableCell>Updated</TableCell>
+                    <TableCell align="right">Actions</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{builtins.map(renderRow)}</TableBody>
+              </Table>
+            </TableContainer>
+          </Box>
+        </Stack>
       )}
 
       <AgentBuilderDialog

--- a/frontend/src/components/settings/AutoInvestigateTab.tsx
+++ b/frontend/src/components/settings/AutoInvestigateTab.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Alert,
   Box,
   Button,
@@ -12,6 +15,7 @@ import {
   InputAdornment,
   InputLabel,
   MenuItem,
+  Paper,
   Select,
   Stack,
   Switch,
@@ -20,6 +24,8 @@ import {
   Typography,
 } from '@mui/material'
 import RestoreIcon from '@mui/icons-material/Restore'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import TuneIcon from '@mui/icons-material/Tune'
 import { aiConfigApi, AIModelInfo, configApi, orchestratorApi } from '../../services/api'
 
 interface OrchestratorConfig {
@@ -65,6 +71,68 @@ const DEFAULTS: OrchestratorConfig = {
 }
 
 const ALL_SEVERITIES = ['critical', 'high', 'medium', 'low']
+
+type PresetKey = 'conservative' | 'balanced' | 'aggressive'
+type PresetValues = Pick<
+  OrchestratorConfig,
+  | 'max_concurrent_agents'
+  | 'max_iterations_per_agent'
+  | 'max_runtime_per_investigation'
+  | 'max_cost_per_investigation'
+  | 'max_total_hourly_cost'
+  | 'max_total_daily_cost'
+>
+
+const PRESETS: Record<PresetKey, { label: string; summary: string; values: PresetValues }> = {
+  conservative: {
+    label: 'Conservative',
+    summary: 'Minimal spend · 2 agents · tight limits',
+    values: {
+      max_concurrent_agents: 2,
+      max_iterations_per_agent: 25,
+      max_runtime_per_investigation: 1800,
+      max_cost_per_investigation: 1.0,
+      max_total_hourly_cost: 5.0,
+      max_total_daily_cost: 25.0,
+    },
+  },
+  balanced: {
+    label: 'Balanced',
+    summary: 'Recommended · 3 agents · $20/hr · $100/day',
+    values: {
+      max_concurrent_agents: 3,
+      max_iterations_per_agent: 50,
+      max_runtime_per_investigation: 3600,
+      max_cost_per_investigation: 5.0,
+      max_total_hourly_cost: 20.0,
+      max_total_daily_cost: 100.0,
+    },
+  },
+  aggressive: {
+    label: 'Aggressive',
+    summary: 'Broad coverage · 5 agents · $60/hr · $300/day',
+    values: {
+      max_concurrent_agents: 5,
+      max_iterations_per_agent: 100,
+      max_runtime_per_investigation: 7200,
+      max_cost_per_investigation: 15.0,
+      max_total_hourly_cost: 60.0,
+      max_total_daily_cost: 300.0,
+    },
+  },
+}
+
+const matchesPreset = (cfg: OrchestratorConfig, key: PresetKey) =>
+  (Object.entries(PRESETS[key].values) as [keyof PresetValues, number][]).every(
+    ([k, v]) => cfg[k] === v,
+  )
+
+const detectActivePreset = (cfg: OrchestratorConfig): PresetKey | 'custom' => {
+  for (const key of Object.keys(PRESETS) as PresetKey[]) {
+    if (matchesPreset(cfg, key)) return key
+  }
+  return 'custom'
+}
 
 interface Props {
   onMessage: (msg: { type: 'success' | 'error'; text: string }) => void
@@ -121,6 +189,12 @@ export default function AutoInvestigateTab({ onMessage }: Props) {
     setConfig(next)
     persist(next)
   }
+
+  const applyPreset = (key: PresetKey) => {
+    applyAndSave(PRESETS[key].values)
+  }
+
+  const activePreset = detectActivePreset(config)
 
   const toggleSeverity = (sev: string) => {
     const current = config.auto_assign_severities
@@ -385,133 +459,210 @@ export default function AutoInvestigateTab({ onMessage }: Props) {
 
       <Divider sx={{ my: 3 }} />
 
-      {/* Agent Limits */}
-      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1.5 }}>
-        Agent Limits
+      {/* Investigation Profile — one-click preset for agent + cost limits */}
+      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+        Investigation profile
       </Typography>
-      <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={12} sm={4}>
-          {numField('Max concurrent agents', 'max_concurrent_agents', {
-            min: 1,
-            max: 10,
-            helperText: '1-10 simultaneous agents',
-            allowUnlimited: true,
-          })}
-        </Grid>
-        <Grid item xs={12} sm={4}>
-          {numField('Max iterations per agent', 'max_iterations_per_agent', {
-            min: 1,
-            max: 500,
-            helperText: 'Claude calls per investigation',
-            allowUnlimited: true,
-          })}
-        </Grid>
-        <Grid item xs={12} sm={4}>
-          {numField('Max runtime (seconds)', 'max_runtime_per_investigation', {
-            min: 60,
-            max: 86400,
-            suffix: 's',
-            helperText: `${Math.round(config.max_runtime_per_investigation / 60)} minutes`,
-            allowUnlimited: true,
-          })}
-        </Grid>
-      </Grid>
-
-      <Divider sx={{ my: 3 }} />
-
-      {/* Cost Guardrails */}
-      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1.5 }}>
-        Cost Guardrails
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
+        Pick a profile to set agent concurrency, runtime, and cost limits in one click.
+        Fine-tune any value in Advanced below.
       </Typography>
-      <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={12} sm={4}>
-          {numField('Per investigation limit', 'max_cost_per_investigation', {
-            min: 0.5,
-            max: 100,
-            prefix: '$',
-            helperText: 'Max spend per investigation',
-            allowUnlimited: true,
-          })}
-        </Grid>
-        <Grid item xs={12} sm={4}>
-          {numField('Hourly cost limit', 'max_total_hourly_cost', {
-            min: 1,
-            max: 500,
-            prefix: '$',
-            helperText: 'Pause intake if exceeded',
-            allowUnlimited: true,
-          })}
-        </Grid>
-        <Grid item xs={12} sm={4}>
-          {numField('Daily cost limit', 'max_total_daily_cost', {
-            min: 1,
-            max: 1000,
-            prefix: '$',
-            helperText: 'Hard daily ceiling',
-            allowUnlimited: true,
-          })}
-        </Grid>
+      <Grid container spacing={1.5} sx={{ mb: 3 }}>
+        {(Object.keys(PRESETS) as PresetKey[]).map((key) => {
+          const p = PRESETS[key]
+          const selected = activePreset === key
+          return (
+            <Grid key={key} item xs={12} sm={4}>
+              <Paper
+                variant="outlined"
+                onClick={() => applyPreset(key)}
+                sx={{
+                  p: 1.75,
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  cursor: 'pointer',
+                  borderColor: selected ? 'primary.main' : 'divider',
+                  borderWidth: selected ? 2 : 1,
+                  bgcolor: selected ? 'action.selected' : 'background.paper',
+                  transition: 'all 120ms ease',
+                  '&:hover': { borderColor: 'primary.main', bgcolor: 'action.hover' },
+                }}
+              >
+                <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    {p.label}
+                  </Typography>
+                  {selected && <Chip size="small" label="Active" color="primary" />}
+                </Stack>
+                <Typography variant="caption" color="text.secondary">
+                  {p.summary}
+                </Typography>
+              </Paper>
+            </Grid>
+          )
+        })}
       </Grid>
+      {activePreset === 'custom' && (
+        <Alert severity="info" icon={<TuneIcon fontSize="small" />} sx={{ mb: 3 }}>
+          Custom limits in effect — your values don’t match any profile. Pick one above
+          to restore a profile, or expand Advanced to review.
+        </Alert>
+      )}
 
-      <Divider sx={{ my: 3 }} />
+      {/* Advanced — everything power users may want to tune */}
+      <Accordion
+        disableGutters
+        elevation={0}
+        sx={{
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          mb: 2,
+          '&:before': { display: 'none' },
+        }}
+      >
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <TuneIcon fontSize="small" />
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              Advanced
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Fine-tune limits, timing, models
+            </Typography>
+          </Stack>
+        </AccordionSummary>
+        <AccordionDetails>
+          {/* Agent Limits */}
+          <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            Agent limits
+          </Typography>
+          <Grid container spacing={2} sx={{ mb: 3, mt: 0.5 }}>
+            <Grid item xs={12} sm={4}>
+              {numField('Max concurrent agents', 'max_concurrent_agents', {
+                min: 1,
+                max: 10,
+                helperText: '1-10 simultaneous agents',
+                allowUnlimited: true,
+              })}
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              {numField('Max iterations per agent', 'max_iterations_per_agent', {
+                min: 1,
+                max: 500,
+                helperText: 'Claude calls per investigation',
+                allowUnlimited: true,
+              })}
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              {numField('Max runtime (seconds)', 'max_runtime_per_investigation', {
+                min: 60,
+                max: 86400,
+                suffix: 's',
+                helperText: `${Math.round(config.max_runtime_per_investigation / 60)} minutes`,
+                allowUnlimited: true,
+              })}
+            </Grid>
+          </Grid>
 
-      {/* Timing & Advanced */}
-      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1.5 }}>
-        Timing &amp; Advanced
-      </Typography>
-      <Grid container spacing={2} sx={{ mb: 2 }}>
-        <Grid item xs={12} sm={4}>
-          {numField('Loop interval', 'loop_interval', {
-            min: 10,
-            max: 600,
-            suffix: 's',
-            helperText: 'Orchestrator check interval',
-          })}
-        </Grid>
-        <Grid item xs={12} sm={4}>
-          {numField('Agent loop delay', 'agent_loop_delay', {
-            min: 1,
-            max: 30,
-            suffix: 's',
-            helperText: 'Pause between agent iterations',
-          })}
-        </Grid>
-        <Grid item xs={12} sm={4}>
-          {numField('Stale threshold', 'stale_threshold', {
-            min: 60,
-            max: 3600,
-            suffix: 's',
-            helperText: 'Kill idle agents after this',
-          })}
-        </Grid>
-        <Grid item xs={12} sm={4}>
-          {numField('Dedup window', 'dedup_window_minutes', {
-            min: 5,
-            max: 1440,
-            suffix: 'min',
-            helperText: 'Overlap detection window',
-          })}
-        </Grid>
-        <Grid item xs={12} sm={4}>
-          {numField('Context max chars', 'context_max_chars', {
-            min: 1000,
-            max: 100000,
-            helperText: 'Max context.md in prompt',
-          })}
-        </Grid>
-      </Grid>
+          {/* Cost Guardrails */}
+          <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            Cost guardrails
+          </Typography>
+          <Grid container spacing={2} sx={{ mb: 3, mt: 0.5 }}>
+            <Grid item xs={12} sm={4}>
+              {numField('Per investigation limit', 'max_cost_per_investigation', {
+                min: 0.5,
+                max: 100,
+                prefix: '$',
+                helperText: 'Max spend per investigation',
+                allowUnlimited: true,
+              })}
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              {numField('Hourly cost limit', 'max_total_hourly_cost', {
+                min: 1,
+                max: 500,
+                prefix: '$',
+                helperText: 'Pause intake if exceeded',
+                allowUnlimited: true,
+              })}
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              {numField('Daily cost limit', 'max_total_daily_cost', {
+                min: 1,
+                max: 1000,
+                prefix: '$',
+                helperText: 'Hard daily ceiling',
+                allowUnlimited: true,
+              })}
+            </Grid>
+          </Grid>
 
-      <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={12} sm={4}>
-          {modelSelect('Plan model', 'plan_model', 'Model for agent planning')}
-        </Grid>
-        <Grid item xs={12} sm={4}>
-          {modelSelect('Review model', 'review_model', 'Model for master review')}
-        </Grid>
-        <Grid item xs={12} sm={4}>
-          {textField('Working directory', 'workdir_base', 'Base path for investigation files')}
-        </Grid>
-      </Grid>
+          {/* Timing */}
+          <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            Timing
+          </Typography>
+          <Grid container spacing={2} sx={{ mb: 3, mt: 0.5 }}>
+            <Grid item xs={12} sm={4}>
+              {numField('Loop interval', 'loop_interval', {
+                min: 10,
+                max: 600,
+                suffix: 's',
+                helperText: 'Orchestrator check interval',
+              })}
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              {numField('Agent loop delay', 'agent_loop_delay', {
+                min: 1,
+                max: 30,
+                suffix: 's',
+                helperText: 'Pause between agent iterations',
+              })}
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              {numField('Stale threshold', 'stale_threshold', {
+                min: 60,
+                max: 3600,
+                suffix: 's',
+                helperText: 'Kill idle agents after this',
+              })}
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              {numField('Dedup window', 'dedup_window_minutes', {
+                min: 5,
+                max: 1440,
+                suffix: 'min',
+                helperText: 'Overlap detection window',
+              })}
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              {numField('Context max chars', 'context_max_chars', {
+                min: 1000,
+                max: 100000,
+                helperText: 'Max context.md in prompt',
+              })}
+            </Grid>
+          </Grid>
+
+          {/* Models & workdir */}
+          <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            Models &amp; storage
+          </Typography>
+          <Grid container spacing={2} sx={{ mb: 1, mt: 0.5 }}>
+            <Grid item xs={12} sm={4}>
+              {modelSelect('Plan model', 'plan_model', 'Model for agent planning')}
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              {modelSelect('Review model', 'review_model', 'Model for master review')}
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              {textField('Working directory', 'workdir_base', 'Base path for investigation files')}
+            </Grid>
+          </Grid>
+        </AccordionDetails>
+      </Accordion>
 
       <Divider sx={{ my: 3 }} />
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -477,12 +477,41 @@ export default function Settings() {
 
   const handleToggleServer = async (serverName: string, enabled: boolean) => {
     try {
-      await mcpApi.setServerEnabled(serverName, enabled)
-      setMcpEnabled(prev => ({ ...prev, [serverName]: enabled }))
-      setMessage({ type: 'success', text: `${serverName} ${enabled ? 'enabled' : 'disabled'}` })
+      // Backend makes this transactional: the persist step also triggers
+      // a connect (on enable) or disconnect (on disable). If the connect
+      // fails — missing creds, missing binary, unreachable remote MCP —
+      // we flip the toggle back off so state stays honest and surface
+      // the actual reason in the snackbar.
+      const res = await mcpApi.setServerEnabled(serverName, enabled)
+      const { connected, error } = (res?.data || {}) as {
+        connected?: boolean | null
+        error?: string | null
+      }
+      if (enabled && connected === false) {
+        // Revert: persisted enabled=false on the backend too, to keep the
+        // UI and server in lockstep. Fire-and-forget — this is the
+        // "unhappy path" anyway.
+        mcpApi.setServerEnabled(serverName, false).catch(() => {})
+        setMcpEnabled(prev => ({ ...prev, [serverName]: false }))
+        setMessage({
+          type: 'error',
+          text: `Could not start ${serverName}${error ? `: ${error}` : ''}`,
+        })
+      } else {
+        setMcpEnabled(prev => ({ ...prev, [serverName]: enabled }))
+        setMessage({
+          type: 'success',
+          text: `${serverName} ${enabled ? 'enabled' : 'disabled'}`,
+        })
+      }
       loadMcpServers()
-    } catch { setMessage({ type: 'error', text: `Failed to ${enabled ? 'enable' : 'disable'} ${serverName}` }) }
-    setTimeout(() => setMessage(null), 3000)
+    } catch {
+      setMessage({
+        type: 'error',
+        text: `Failed to ${enabled ? 'enable' : 'disable'} ${serverName}`,
+      })
+    }
+    setTimeout(() => setMessage(null), 4500)
   }
 
   const handleSaveIntegration = async (integrationId: string, config: Record<string, any>) => {

--- a/frontend/src/pages/WorkflowBuilder.tsx
+++ b/frontend/src/pages/WorkflowBuilder.tsx
@@ -88,20 +88,13 @@ interface CustomWorkflowRecord {
 
 type View = 'list' | 'editor'
 
-// Known built-in agent IDs mapped to readable labels (matches soc_agents.py)
-const AGENT_OPTIONS: Array<{ id: string; label: string }> = [
-  { id: 'triage', label: 'Triage Agent' },
+// Agent options are fetched from /api/agents/agents at runtime so both
+// built-in templates and DB-backed custom agents (incl. forks) show up in
+// the phase picker. Shape: { id, label }. Seeded with the minimal fallback
+// so first render before the fetch resolves doesn't crash the Select.
+type AgentOption = { id: string; label: string }
+const FALLBACK_AGENT_OPTIONS: AgentOption[] = [
   { id: 'investigator', label: 'Investigation Agent' },
-  { id: 'threat_hunter', label: 'Threat Hunter' },
-  { id: 'correlator', label: 'Correlator' },
-  { id: 'responder', label: 'Responder' },
-  { id: 'reporter', label: 'Reporter' },
-  { id: 'mitre_analyst', label: 'MITRE Analyst' },
-  { id: 'forensics', label: 'Forensics' },
-  { id: 'threat_intel', label: 'Threat Intel' },
-  { id: 'compliance', label: 'Compliance' },
-  { id: 'malware_analyst', label: 'Malware Analyst' },
-  { id: 'network_analyst', label: 'Network Analyst' },
 ]
 
 const emptyPhase = (order: number): WorkflowPhase => ({
@@ -624,18 +617,27 @@ function EditorView({
   setSnackbar,
   isDark,
 }: EditorViewProps) {
-  const initialGraph = useMemo(() => buildGraph(editor.phases), [])
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Agent pool (built-ins + custom) fetched from the unified API. Seeded
+  // with the fallback so the first render before the fetch resolves still
+  // has a valid list for buildGraph and the Select.
+  const [agentOptions, setAgentOptions] = useState<AgentOption[]>(FALLBACK_AGENT_OPTIONS)
+  const initialGraph = useMemo(
+    () => buildGraph(editor.phases, agentOptions),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  )
   const [nodes, setNodes] = useState<Node[]>(initialGraph.nodes)
   const [edges, setEdges] = useState<Edge[]>(initialGraph.edges)
   const [edgeLabelEdit, setEdgeLabelEdit] = useState<{ edgeId: string; label: string } | null>(null)
 
   // Keep nodes in sync with editor.phases when phases are added/removed/renamed.
   // We preserve user-dragged positions for phases that still exist.
+  // Also re-runs when agentOptions arrive from the API so freshly-loaded
+  // labels replace the id-as-label fallback on node cards.
   useEffect(() => {
     setNodes((prev) => {
       const prevById = new Map(prev.map((n) => [n.id, n]))
-      const fresh = buildGraph(editor.phases).nodes
+      const fresh = buildGraph(editor.phases, agentOptions).nodes
       return fresh.map((n) => {
         const existing = prevById.get(n.id)
         return existing
@@ -652,10 +654,10 @@ function EditorView({
         (e) => validIds.has(e.source) && validIds.has(e.target),
       )
       // If there are no edges at all (first render or all invalid) seed from defaults.
-      if (keep.length === 0) return buildGraph(editor.phases).edges
+      if (keep.length === 0) return buildGraph(editor.phases, agentOptions).edges
       return keep
     })
-  }, [editor.phases])
+  }, [editor.phases, agentOptions])
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) => setNodes((nds) => applyNodeChanges(changes, nds)),
@@ -737,6 +739,21 @@ function EditorView({
       .getAvailableTools()
       .then((res) => setAvailableTools(res.data.tools || []))
       .catch(() => { /* non-fatal; falls back to free text */ })
+
+    // Unified agent pool — built-ins + custom agents (forks included).
+    agentsApi
+      .listAgents()
+      .then((res) => {
+        const agents = res.data?.agents || []
+        if (agents.length === 0) return
+        setAgentOptions(
+          agents.map((a: { id: string; name: string }) => ({
+            id: a.id,
+            label: a.name,
+          }))
+        )
+      })
+      .catch(() => { /* keep fallback list */ })
   }, [])
 
   const openPhase = (idx: number, isNew: boolean) => {
@@ -1011,6 +1028,7 @@ function EditorView({
                 phase={editor.phases[editPhaseIdx]}
                 onChange={(patch) => updatePhase(editPhaseIdx, patch)}
                 availableTools={availableTools}
+                agentOptions={agentOptions}
               />
             </DialogContent>
             <DialogActions>
@@ -1073,9 +1091,10 @@ interface PhaseFieldsProps {
   phase: WorkflowPhase
   onChange: (patch: Partial<WorkflowPhase>) => void
   availableTools: string[]
+  agentOptions: AgentOption[]
 }
 
-function PhaseFields({ phase, onChange, availableTools }: PhaseFieldsProps) {
+function PhaseFields({ phase, onChange, availableTools, agentOptions }: PhaseFieldsProps) {
   const allAccess = (phase.tools || []).length === 1 && phase.tools[0] === '*'
   const selectedTools = allAccess ? [] : phase.tools || []
   return (
@@ -1098,7 +1117,7 @@ function PhaseFields({ phase, onChange, availableTools }: PhaseFieldsProps) {
                 value={phase.agent_id}
                 onChange={(e) => onChange({ agent_id: e.target.value })}
               >
-                {AGENT_OPTIONS.map((a) => (
+                {agentOptions.map((a) => (
                   <MenuItem key={a.id} value={a.id}>
                     {a.label} ({a.id})
                   </MenuItem>
@@ -1227,11 +1246,14 @@ function PhaseFields({ phase, onChange, availableTools }: PhaseFieldsProps) {
 // Graph builder — linear left-to-right layout
 // -----------------------------------------------------------------------------
 
-function buildGraph(phases: WorkflowPhase[]): { nodes: Node[]; edges: Edge[] } {
+function buildGraph(
+  phases: WorkflowPhase[],
+  agentOptions: AgentOption[] = FALLBACK_AGENT_OPTIONS,
+): { nodes: Node[]; edges: Edge[] } {
   const NODE_WIDTH = 280
   const HORIZONTAL_GAP = 60
   const agentLabel = (id: string) =>
-    AGENT_OPTIONS.find((a) => a.id === id)?.label || id
+    agentOptions.find((a) => a.id === id)?.label || id
   const timeoutLabel = (s?: number) => {
     if (!s || s <= 0) return null
     if (s < 60) return `${s}s`

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -416,15 +416,13 @@ export const mcpApi = {
   getStatuses: () => api.get('/mcp/servers/status'),
   
   getServerStatus: (name: string) => api.get(`/mcp/servers/${name}/status`),
-  
-  startServer: (name: string) => api.post(`/mcp/servers/${name}/start`),
-  
-  stopServer: (name: string) => api.post(`/mcp/servers/${name}/stop`),
-  
-  startAll: () => api.post('/mcp/servers/start-all'),
-  
-  stopAll: () => api.post('/mcp/servers/stop-all'),
-  
+
+  // NOTE: startServer / stopServer / startAll / stopAll were removed —
+  // every server in mcp-config.json is stdio-based, and the old endpoints
+  // explicitly refused stdio. Runtime start/stop now lives on the enable
+  // toggle (setServerEnabled below) which actually triggers a connect
+  // attempt and returns its result.
+
   getLogs: (name: string, lines: number = 100) =>
     api.get(`/mcp/servers/${name}/logs`, { params: { lines } }),
   
@@ -589,6 +587,10 @@ export const agentsApi = {
     api.patch(`/agents/custom/${agent_id}`, data),
   deleteCustom: (agent_id: string) => api.delete(`/agents/custom/${agent_id}`),
   getAvailableTools: () => api.get('/agents/custom/_meta/tools'),
+  // Fork any agent (built-in or custom) into a new editable custom copy.
+  // Built-ins are never mutated; they're static templates.
+  forkAgent: (source_agent_id: string, new_name?: string) =>
+    api.post(`/agents/${source_agent_id}/fork`, { new_name }),
 
   // AI-assisted generation + iterative refinement (issue #80 Phase 2)
   generateCustom: (data: {
@@ -634,6 +636,17 @@ export interface CustomAgent extends CustomAgentPayload {
   created_at?: string
   updated_at?: string
   effective_prompt?: string
+  forked_from?: string | null
+}
+
+// Shape returned by /agents/agents (both built-ins and customs).
+export interface AgentSummary {
+  id: string
+  name: string
+  description?: string
+  icon?: string
+  color?: string
+  specialization?: string
 }
 
 // Config API

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,13 @@ alembic>=1.13.0
 # MCP SDK (for MCP tools)
 # Install with: pip install mcp
 
+# `uv` ships `uvx`, which several MCP server configs in mcp-config.json use
+# as their launcher (e.g. crowdstrike/falcon-mcp, sentinelone/purple-mcp,
+# pagerduty-mcp, gcp-* security tools). Installing it here means the venv
+# has `uvx` on PATH and those servers can connect at backend startup
+# instead of silently failing with FileNotFoundError.
+uv>=0.5.0
+
 # Authentication
 bcrypt>=4.2.0
 pyjwt>=2.10.0

--- a/scripts/migrate_secrets.py
+++ b/scripts/migrate_secrets.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Migrate legacy secrets into ``~/.vigil/secrets.enc``.
+
+Historically Vigil spread secrets across several places:
+
+- ``.env`` at the repo root
+- ``~/.deeptempo/.env`` (the ``DotEnvBackend`` default)
+- OS env vars
+- macOS Keychain (only if enabled)
+
+This script reads every well-known secret name from all of those stores,
+writes them to the new encrypted backend (``~/.vigil/secrets.enc``), and
+then reports on what was moved. It does **not** delete from the old
+stores by default — pass ``--purge`` to strip migrated values from
+``~/.deeptempo/.env`` (the root ``.env`` is never touched automatically;
+edit it by hand if you want to clean it up).
+
+Run from the repo root::
+
+    python scripts/migrate_secrets.py          # dry-run-ish: moves, leaves originals
+    python scripts/migrate_secrets.py --purge  # also clears originals
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Make `backend` importable when running from repo root
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from backend.secrets_manager import (  # noqa: E402
+    DotEnvBackend,
+    EncryptedFileBackend,
+    EnvironmentBackend,
+)
+
+# Secret names worth checking. Extend as new providers/integrations appear.
+LEGACY_NAMES = [
+    "CLAUDE_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GITHUB_TOKEN",
+    "POSTGRESQL_CONNECTION_STRING",
+    "VIRUSTOTAL_API_KEY",
+    "SHODAN_API_KEY",
+    "SPLUNK_TOKEN",
+    "SPLUNK_PASSWORD",
+    "CROWDSTRIKE_CLIENT_ID",
+    "CROWDSTRIKE_CLIENT_SECRET",
+    "SLACK_BOT_TOKEN",
+    "SLACK_WEBHOOK_URL",
+    "JIRA_API_TOKEN",
+    "DARKTRACE_WEBHOOK_SECRET",
+    # Provider-scoped refs. If you created providers via the UI their
+    # api_key_ref will look like ``llm_provider_<id>_api_key``.
+]
+
+
+def _scan_dotenv_for_provider_refs(dotenv: DotEnvBackend) -> list[str]:
+    """Return any ``llm_provider_*_api_key`` names present in the legacy dotenv."""
+    return [k for k in dotenv._cache.keys() if k.startswith("llm_provider_") and k.endswith("_api_key")]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--purge",
+        action="store_true",
+        help="Delete migrated values from ~/.deeptempo/.env after success.",
+    )
+    args = parser.parse_args()
+
+    encrypted = EncryptedFileBackend()
+    if not encrypted.is_available():
+        print("ERROR: EncryptedFileBackend unavailable (install `cryptography`).", file=sys.stderr)
+        return 2
+
+    env = EnvironmentBackend()
+    dotenv = DotEnvBackend()  # default path: ~/.deeptempo/.env
+
+    candidates = list(LEGACY_NAMES) + _scan_dotenv_for_provider_refs(dotenv)
+    moved: list[str] = []
+    already_in_encrypted: list[str] = []
+    not_found: list[str] = []
+
+    for name in candidates:
+        # Don't clobber an existing encrypted value.
+        if encrypted.get(name):
+            already_in_encrypted.append(name)
+            continue
+        value = env.get(name) or dotenv.get(name)
+        if not value:
+            not_found.append(name)
+            continue
+        if encrypted.set(name, value):
+            moved.append(name)
+
+    print(f"Migrated {len(moved)} secret(s) into {encrypted.secrets_path}")
+    for name in moved:
+        print(f"  + {name}")
+    if already_in_encrypted:
+        print(f"\nAlready in encrypted store (skipped): {len(already_in_encrypted)}")
+        for name in already_in_encrypted:
+            print(f"  = {name}")
+
+    # Bonus: if CLAUDE_API_KEY or ANTHROPIC_API_KEY moved but no
+    # llm_provider_anthropic-default_api_key exists, mirror the value
+    # so the UI-driven provider row can resolve it.
+    ref = "llm_provider_anthropic-default_api_key"
+    if not encrypted.get(ref):
+        value = encrypted.get("ANTHROPIC_API_KEY") or encrypted.get("CLAUDE_API_KEY")
+        if value:
+            encrypted.set(ref, value)
+            print(f"\nMirrored into {ref} for LLM Providers UI")
+
+    if args.purge and moved:
+        for name in moved:
+            if name in dotenv._cache:
+                dotenv.delete(name)
+        print(f"\nPurged {len(moved)} value(s) from {dotenv.env_file}")
+    elif moved:
+        print(
+            f"\nLeft originals in place. Rerun with --purge to clear "
+            f"{dotenv.env_file} after you verify the new store works."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/bifrost_admin.py
+++ b/services/bifrost_admin.py
@@ -1,0 +1,128 @@
+"""Bifrost management API helper.
+
+Bifrost exposes a REST admin API at ``${BIFROST_URL}/api/providers/{name}``
+that lets us update provider keys at runtime without a container restart.
+This module is the one place the backend talks to that API, so the flow
+is: user edits a key in the UI → ``llm_providers`` endpoint writes to the
+secrets manager → this module pushes the new value to Bifrost → Bifrost
+uses it for subsequent requests.
+
+The previous architecture had Bifrost read ``env.ANTHROPIC_API_KEY`` from
+its container env, which diverged from whatever the UI had written to the
+secrets manager under ``llm_provider_<id>_api_key``. Pushing via the API
+keeps a single source of truth in the secrets manager.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT = 5.0
+
+
+def _bifrost_base_url() -> str:
+    return os.getenv("BIFROST_URL", "http://localhost:8080").rstrip("/")
+
+
+def _get_provider(name: str, client: httpx.Client) -> Optional[Dict[str, Any]]:
+    try:
+        r = client.get(f"{_bifrost_base_url()}/api/providers/{name}", timeout=_DEFAULT_TIMEOUT)
+        if r.status_code == 404:
+            logger.debug("Bifrost: provider %s not configured", name)
+            return None
+        r.raise_for_status()
+        return r.json()
+    except Exception as e:
+        logger.warning("Bifrost: could not fetch provider %s: %s", name, e)
+        return None
+
+
+def push_provider_key(provider_name: str, key_value: str) -> bool:
+    """Update the first configured key on ``provider_name`` with ``key_value``.
+
+    We take the current provider document, replace the key value with a
+    literal (``from_env: false``), and PUT it back. This is idempotent —
+    pushing the same value twice is a no-op from Anthropic's perspective.
+
+    Returns True on success. Any failure is logged and returns False so
+    the caller's CRUD flow never breaks on a Bifrost hiccup.
+    """
+    if not provider_name:
+        return False
+    with httpx.Client() as client:
+        prov = _get_provider(provider_name, client)
+        if prov is None:
+            return False
+        keys = prov.get("keys") or []
+        if not keys:
+            logger.warning("Bifrost: provider %s has no keys slot to update", provider_name)
+            return False
+        # Update the first key. Bifrost's current config seeds exactly one
+        # key per provider; multi-key rotation is a separate feature.
+        keys[0]["value"] = {
+            "value": key_value,
+            "env_var": "",
+            "from_env": False,
+        }
+        try:
+            r = client.put(
+                f"{_bifrost_base_url()}/api/providers/{provider_name}",
+                json=prov,
+                timeout=_DEFAULT_TIMEOUT,
+            )
+            if r.status_code >= 400:
+                logger.warning(
+                    "Bifrost: PUT /api/providers/%s returned %s: %s",
+                    provider_name, r.status_code, r.text[:200],
+                )
+                return False
+            logger.info("Bifrost: pushed updated key for provider %s", provider_name)
+            return True
+        except Exception as e:
+            logger.warning("Bifrost: PUT /api/providers/%s failed: %s", provider_name, e)
+            return False
+
+
+def sync_all_provider_keys() -> Dict[str, bool]:
+    """Push every DB-configured provider's current secret value to Bifrost.
+
+    Run on backend startup so Bifrost picks up whatever is in the secrets
+    store regardless of how it was started or whether its container was
+    recreated. Best-effort — returns a per-provider dict of success flags.
+    """
+    # Deferred imports to keep this module import-cheap for code that only
+    # needs ``push_provider_key`` (e.g. llm_providers.py).
+    from backend.secrets_manager import get_secret
+    from database.connection import get_db_manager
+    from database.models import LLMProviderConfig
+
+    results: Dict[str, bool] = {}
+    db_manager = get_db_manager()
+    if db_manager._engine is None:
+        db_manager.initialize()
+    with db_manager.session_scope() as session:
+        rows = session.query(LLMProviderConfig).filter(
+            LLMProviderConfig.is_active.is_(True),
+        ).all()
+        for row in rows:
+            if not row.api_key_ref:
+                continue
+            value = get_secret(row.api_key_ref)
+            if not value:
+                logger.debug(
+                    "Bifrost sync: no value in secrets store for %s (ref=%s)",
+                    row.provider_id, row.api_key_ref,
+                )
+                results[row.provider_id] = False
+                continue
+            results[row.provider_id] = push_provider_key(row.provider_type, value)
+    if results:
+        ok = sum(1 for v in results.values() if v)
+        logger.info("Bifrost sync: pushed %d/%d provider keys", ok, len(results))
+    return results

--- a/services/claude_service.py
+++ b/services/claude_service.py
@@ -351,17 +351,70 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
             return False
 
     def _load_backend_tools(self):
-        """Load backend tools for Claude to use via function calling."""
+        """Load backend tools for Claude to use via function calling.
+
+        Also appends a tool per active DB-backed Skill so the model can
+        invoke user-created Skills directly (Issue #82 Phase 1 wiring).
+        Skill tool lookups happen via ``self._skill_tool_index`` set here.
+        """
         self.backend_tools = list(BACKEND_TOOLS)
-        logger.info(f"Loaded {len(self.backend_tools)} backend tools")
+        self._static_backend_tools_count = len(self.backend_tools)
+        self._skill_tool_index = {}
+        self._refresh_skill_tools()
         for tool in self.backend_tools:
             logger.debug(f"  - {tool['name']}: {tool['description'][:60]}...")
+
+    def _refresh_skill_tools(self) -> int:
+        """Reload DB-backed skill tools in place.
+
+        The chat path calls this at the start of every request so skills
+        created after the (shared, worker-pool) ClaudeService booted are
+        still visible. Trims any previously-loaded skill tools first so
+        deletes and renames propagate cleanly. Cheap: one DB query.
+
+        Returns the number of skill tools loaded.
+        """
+        # Reset to the static portion only.
+        if hasattr(self, "_static_backend_tools_count"):
+            self.backend_tools = self.backend_tools[: self._static_backend_tools_count]
+        self._skill_tool_index = {}
+        try:
+            from services.skill_tools_bridge import list_active_skill_tools
+
+            skill_tools, skill_index = list_active_skill_tools()
+            self.backend_tools.extend(skill_tools)
+            self._skill_tool_index = skill_index
+            if skill_tools:
+                logger.info(
+                    f"Backend tools refreshed: {len(self.backend_tools)} total "
+                    f"(incl. {len(skill_tools)} skill tool(s))"
+                )
+            return len(skill_tools)
+        except Exception as e:
+            logger.debug(f"Could not load skill tools: {e}")
+            return 0
 
     async def _execute_backend_tool(self, tool_name: str, tool_input: dict):
         """Execute a single backend tool by name. Used by the daemon agent runner."""
         from services.database_data_service import DatabaseDataService
 
         data_service = DatabaseDataService()
+
+        # DB-backed Skills get their own dispatch path so we don't bury
+        # every one of them in this long if/elif ladder.
+        try:
+            from services.skill_tools_bridge import execute_skill_tool, is_skill_tool_name
+
+            if is_skill_tool_name(tool_name):
+                return execute_skill_tool(
+                    tool_name,
+                    tool_input or {},
+                    skills_by_tool_name=getattr(self, "_skill_tool_index", None),
+                )
+        except Exception as e:
+            logger.warning(f"Skill tool dispatch failed for {tool_name}: {e}")
+            # Fall through to the regular backend-tool ladder in case the
+            # tool name coincidentally starts with "skill_" but is built-in.
 
         if tool_name == "list_findings":
             limit = tool_input.get("limit", 20)
@@ -1707,8 +1760,30 @@ Provide a structured summary preserving all critical context."""
                 try:
                     result = None
 
+                    # DB-backed Skills (Issue #82 wiring) get a dedicated
+                    # dispatch so we don't clutter the ladder below with
+                    # user-created entries. Falls through on failure so a
+                    # coincidental ``skill_`` prefix still tries the rest
+                    # of the chain.
+                    if tool_name and tool_name.startswith("skill_"):
+                        try:
+                            from services.skill_tools_bridge import execute_skill_tool
+
+                            result = execute_skill_tool(
+                                tool_name,
+                                arguments or {},
+                                skills_by_tool_name=getattr(
+                                    self, "_skill_tool_index", None
+                                ),
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"Skill tool dispatch failed for {tool_name}: {e}"
+                            )
+                            result = {"error": f"Skill execution failed: {e}"}
+
                     # Security detection tools
-                    if tool_name in [
+                    if result is None and tool_name in [
                         "analyze_coverage",
                         "search_detections",
                         "identify_gaps",
@@ -2045,7 +2120,10 @@ Provide a structured summary preserving all critical context."""
                         elif tool_name == "get_approval_stats":
                             result = approval_service.get_stats()
 
-                    else:
+                    elif result is None:
+                        # Only hit when no ladder branch set ``result`` and
+                        # the skill-tool pre-dispatch above didn't match
+                        # either — truly unknown tool.
                         logger.warning(f"Unknown backend tool: {tool_name}")
                         result = {"error": f"Unknown tool: {tool_name}"}
 
@@ -2249,6 +2327,11 @@ Provide a structured summary preserving all critical context."""
             raise ValueError(
                 "API key not configured. Please set your Anthropic API key."
             )
+
+        # Refresh DB-backed skill tools so this request sees skills
+        # created after the (potentially shared) ClaudeService booted.
+        if self.use_backend_tools and BACKEND_TOOLS_AVAILABLE:
+            self._refresh_skill_tools()
 
         try:
             messages = []
@@ -2842,6 +2925,11 @@ Provide a structured summary preserving all critical context."""
             raise ValueError(
                 "API key not configured. Please set your Anthropic API key."
             )
+
+        # Refresh DB-backed skill tools so this request sees skills
+        # created after the (potentially shared) ClaudeService booted.
+        if self.use_backend_tools and BACKEND_TOOLS_AVAILABLE:
+            self._refresh_skill_tools()
 
         try:
             messages = []

--- a/services/custom_workflow_service.py
+++ b/services/custom_workflow_service.py
@@ -33,6 +33,41 @@ def _generate_workflow_id(name: str) -> str:
     return f"wf-{_slugify(name)}-{uuid.uuid4().hex[:8]}"
 
 
+def _validate_agent_ids(phases: List[Dict[str, Any]]) -> None:
+    """Ensure every phase's agent_id resolves against the unified pool.
+
+    Avoids the silent-failure-at-execution-time pattern where a workflow
+    references a renamed/deleted custom agent. Built-ins + DB-backed
+    custom agents are both checked. Raises ``ValueError`` listing every
+    unknown id so the UI can surface all of them at once.
+    """
+    if not phases:
+        return
+    # Deferred to keep this service import-cheap for callers that only
+    # want a .get() and don't touch the AgentManager.
+    try:
+        from services.soc_agents import AgentManager
+
+        known = set(AgentManager().agents.keys())
+    except Exception as e:
+        # If the agent registry isn't available (e.g. DB down during a
+        # migration) we skip validation rather than block writes.
+        logger.warning("Skipping workflow agent validation: %s", e)
+        return
+
+    missing: List[str] = []
+    for idx, phase in enumerate(phases, start=1):
+        aid = (phase or {}).get("agent_id")
+        if aid and aid not in known:
+            missing.append(f"phase {idx}: '{aid}'")
+    if missing:
+        raise ValueError(
+            "Unknown agent_id(s) in workflow phases: "
+            + "; ".join(missing)
+            + ". Fork one of the built-in templates or pick an existing custom agent."
+        )
+
+
 class CustomWorkflowService:
     """Persistence service for database-backed custom workflows."""
 
@@ -52,6 +87,8 @@ class CustomWorkflowService:
             raise ValueError("name is required")
         if not payload.get("description"):
             raise ValueError("description is required")
+
+        _validate_agent_ids(payload.get("phases") or [])
 
         workflow_id = payload.get("workflow_id") or _generate_workflow_id(
             payload["name"]
@@ -117,6 +154,9 @@ class CustomWorkflowService:
             "graph_layout",
             "is_active",
         }
+        if "phases" in updates and updates["phases"] is not None:
+            _validate_agent_ids(updates["phases"])
+
         db = get_db_manager()
         with db.session_scope() as session:
             wf = session.get(CustomWorkflow, workflow_id)

--- a/services/llm_worker.py
+++ b/services/llm_worker.py
@@ -564,6 +564,23 @@ async def on_startup(ctx: Dict[str, Any]):
         )
         logger.warning("Telemetry init failed (non-fatal): %s", _tel_err)
 
+    # Initialize the SQLAlchemy DB manager so downstream code (skill tool
+    # loading, reasoning-trace persistence, provider-key resolution) can
+    # query the DB. The backend process does this in its FastAPI startup
+    # hook; the worker is a separate process and must do it itself.
+    try:
+        from database.connection import get_db_manager
+
+        db_manager = get_db_manager()
+        if db_manager._engine is None:
+            db_manager.initialize()
+            logger.info("LLM worker: DB manager initialized")
+    except Exception as _db_err:
+        logger.warning(
+            "LLM worker DB init failed (skill tools + reasoning traces will be disabled): %s",
+            _db_err,
+        )
+
     from services.claude_service import ClaudeService
 
     claude_service = ClaudeService(

--- a/services/mcp_client.py
+++ b/services/mcp_client.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import os
 from typing import Optional, Dict, List, Any, Tuple, TYPE_CHECKING
 from pathlib import Path
 import platform
@@ -167,7 +168,7 @@ class MCPClient:
     def __init__(self, mcp_service: MCPService):
         """
         Initialize MCP client with persistent connection support.
-        
+
         Args:
             mcp_service: MCPService instance for managing server processes
         """
@@ -175,41 +176,79 @@ class MCPClient:
         self.persistent_sessions: Dict[str, PersistentServerSession] = {}
         self.tools_cache: Dict[str, List[Dict]] = {}
         self._connection_locks: Dict[str, threading.Lock] = {}  # Locks per server to prevent concurrent connections
+        # Populated by connect_to_server — string reason on failure, and a
+        # structured list of env var names when credentials are missing.
+        self.last_errors: Dict[str, str] = {}
+        self.last_missing_credentials: Dict[str, List[str]] = {}
     
     async def connect_to_server(self, server_name: str, persistent: bool = True) -> bool:
         """
         Connect to an MCP server, cache its tools, and optionally maintain persistent connection.
-        
-        Only connects if the server is enabled in the MCP service.
-        
+
+        Only connects if the server is enabled in the MCP service. On failure, the
+        exception message is recorded on ``self.last_errors[server_name]`` so the
+        Settings → MCP UI can surface *why* a connection failed (missing binary,
+        credentials, package not installed) instead of a generic "Failed to connect".
+
         Args:
             server_name: Name of the server to connect to
             persistent: If True, maintain persistent connection for reuse
-            
+
         Returns:
             True if successful, False otherwise
         """
+        # Defensive init for deployments that upgraded without reinstantiating
+        # the client — keeps the legacy __init__ compatible.
+        if not hasattr(self, "last_errors"):
+            self.last_errors: Dict[str, str] = {}
+        if not hasattr(self, "last_missing_credentials"):
+            self.last_missing_credentials: Dict[str, List[str]] = {}
+        # Clear any stale state from a prior attempt so the UI always
+        # reflects the most recent connect.
+        self.last_errors.pop(server_name, None)
+        self.last_missing_credentials.pop(server_name, None)
+
         if not MCP_AVAILABLE:
             logger.error("MCP SDK not available")
+            self.last_errors[server_name] = "MCP SDK not installed in the backend venv"
             return False
-        
+
         if server_name not in self.mcp_service.servers:
             logger.error(f"Unknown server: {server_name}")
+            self.last_errors[server_name] = "Server not present in mcp-config.json"
             return False
-        
+
         # Skip disabled servers
         if not self.mcp_service.is_server_enabled(server_name):
             logger.debug(f"Server {server_name} is disabled, skipping connection")
             return False
-        
+
         # Check if already connected with cached tools
         if server_name in self.persistent_sessions and server_name in self.tools_cache:
             if self.persistent_sessions[server_name].is_connected:
                 logger.debug(f"Already connected to {server_name}")
                 return True
-        
+
         server = self.mcp_service.servers[server_name]
-        
+
+        # Credential gate: if the server declared ${VAR} placeholders in
+        # its mcp-config.json entry and those env vars resolve empty,
+        # short-circuit without spawning a child. This is dormancy by
+        # design — per #124's conclusion, pre-configuration is not a
+        # failure. The UI's existing "Not Configured" treatment takes
+        # over once it sees connected=false + a missing_credentials list.
+        missing = self._missing_credentials_for(server)
+        if missing:
+            msg = f"missing credentials: {', '.join(missing)}"
+            self.last_errors[server_name] = msg
+            self.last_missing_credentials[server_name] = missing
+            logger.info(
+                "MCP server %s dormant — waiting on env vars: %s",
+                server_name,
+                ", ".join(missing),
+            )
+            return False
+
         try:
             # Create stdio server parameters
             server_params = StdioServerParameters(
@@ -266,9 +305,112 @@ class MCPClient:
             return True
         
         except Exception as e:
+            # Preserve the exception text so the UI can surface the real
+            # reason (e.g. "FileNotFoundError: uvx", "ModuleNotFoundError:
+            # mempalace", "missing env var GITHUB_TOKEN") instead of a
+            # generic "Failed to connect".
+            self.last_errors[server_name] = f"{type(e).__name__}: {e}"
             logger.error(f"Failed to connect to {server_name}: {e}")
             return False
-    
+
+    def _missing_credentials_for(self, server) -> List[str]:
+        """Return the subset of a server's required_env_vars that resolve empty.
+
+        Checks both ``os.environ`` and the Vigil secrets manager, so a
+        user who saved a credential via the integration wizard (which
+        writes to the encrypted store, not the process env) isn't told
+        the server is still dormant.
+        """
+        required = getattr(server, "required_env_vars", None) or []
+        if not required:
+            return []
+        try:
+            from backend.secrets_manager import get_secret
+        except Exception:  # pragma: no cover — secrets module always present
+            get_secret = lambda _name: None  # type: ignore[assignment]
+
+        missing: List[str] = []
+        for var in required:
+            if os.environ.get(var):
+                continue
+            if get_secret(var):
+                continue
+            missing.append(var)
+        return missing
+
+    def get_missing_credentials(self, server_name: str) -> Optional[List[str]]:
+        """Return the list of unset required env vars from the last connect."""
+        return getattr(self, "last_missing_credentials", {}).get(server_name)
+
+    def get_last_error(self, server_name: str) -> Optional[str]:
+        """Return the most recent connect-failure reason for a server, if any."""
+        return getattr(self, "last_errors", {}).get(server_name)
+
+    # Per-server rate limit between auto-retry attempts. Prevents a
+    # misconfigured secret (wrong value, typo) from hammering the MCP
+    # child process with connect storms on every /connections/status
+    # poll. 15s balances "user saves key and sees it online quickly"
+    # with "don't spin up 20 subprocesses a minute on a stuck setup".
+    _RETRY_MIN_INTERVAL_S = 15.0
+
+    async def retry_dormant_if_ready(self) -> Dict[str, bool]:
+        """Re-attempt connect for any dormant server whose required env
+        vars have since resolved (e.g. user saved the credential via the
+        integration wizard). Safe to call from a read-path endpoint:
+        no-op when nothing's dormant or when creds are still missing.
+
+        Returns a dict ``{server_name: connected_bool}`` recording what
+        we actually tried this call — the common case is an empty dict.
+        """
+        # Defensive init — mirrors connect_to_server's compat shim.
+        if not hasattr(self, "_last_retry_at"):
+            self._last_retry_at: Dict[str, float] = {}
+        if not hasattr(self, "last_missing_credentials"):
+            return {}
+
+        import time
+
+        now = time.monotonic()
+        attempted: Dict[str, bool] = {}
+
+        # Snapshot the keys — ``last_missing_credentials`` is mutated
+        # by ``connect_to_server`` we're about to call.
+        candidates = [
+            name
+            for name, missing in list(self.last_missing_credentials.items())
+            if missing
+        ]
+        for server_name in candidates:
+            server = self.mcp_service.servers.get(server_name)
+            if server is None:
+                continue
+            # Cheap precheck — skip unless creds actually resolve now.
+            if self._missing_credentials_for(server):
+                continue
+            # Rate-limit: don't retry the same server more than once
+            # per _RETRY_MIN_INTERVAL_S seconds.
+            last = self._last_retry_at.get(server_name, 0.0)
+            if now - last < self._RETRY_MIN_INTERVAL_S:
+                continue
+            self._last_retry_at[server_name] = now
+            try:
+                attempted[server_name] = await self.connect_to_server(
+                    server_name, persistent=True
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Dormant-retry for %s raised: %s", server_name, exc
+                )
+                attempted[server_name] = False
+        if attempted:
+            connected = sum(1 for v in attempted.values() if v)
+            logger.info(
+                "Auto-reconnect: %d/%d dormant server(s) came online",
+                connected,
+                len(attempted),
+            )
+        return attempted
+
     async def list_tools(self, server_name: Optional[str] = None) -> Dict[str, List[Dict]]:
         """
         List available tools from MCP servers.

--- a/services/mcp_service.py
+++ b/services/mcp_service.py
@@ -4,6 +4,7 @@ import subprocess
 import platform
 import logging
 import json
+import re
 from pathlib import Path
 from typing import Optional, Dict, List
 from datetime import datetime
@@ -12,10 +13,55 @@ import os
 logger = logging.getLogger(__name__)
 
 
+# Matches ${VAR_NAME} placeholders in mcp-config.json values/args. Anchored
+# to uppercase+underscore+digits so we don't pick up things like
+# ${workspaceFolder} (filtered explicitly below regardless).
+_ENV_PLACEHOLDER_RE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)\}")
+
+# Placeholders that are path sentinels, not credentials — never treat as
+# required env vars.
+_PLACEHOLDER_BLACKLIST = {"workspaceFolder", "HOME", "PYTHONPATH"}
+
+
+def extract_required_env_vars(raw_env: Dict[str, str], raw_args: List[str]) -> List[str]:
+    """Collect every ``${VAR}`` placeholder referenced by a server config.
+
+    Scans the raw (pre-substitution) ``env`` values and ``args`` entries
+    from ``mcp-config.json``. Returns a deduplicated, sorted list of
+    placeholder names. These are treated as required by
+    ``mcp_client.connect_to_server`` — if any resolve to empty, the
+    server is considered dormant-by-design (not a connect failure).
+
+    Limitation (documented for follow-ups): this infers requirements
+    from the config file. A server whose process quietly needs a
+    credential that isn't referenced via ``${…}`` is invisible to us
+    and will fall through to the regular connect path.
+    """
+    found: set[str] = set()
+    for value in list((raw_env or {}).values()) + list(raw_args or []):
+        if not isinstance(value, str):
+            continue
+        for m in _ENV_PLACEHOLDER_RE.finditer(value):
+            name = m.group(1)
+            if name in _PLACEHOLDER_BLACKLIST:
+                continue
+            found.add(name)
+    return sorted(found)
+
+
 class MCPServer:
     """Represents an MCP server process."""
-    
-    def __init__(self, name: str, command: str, args: List[str], cwd: str, env: Dict[str, str], server_type: str = "unknown"):
+
+    def __init__(
+        self,
+        name: str,
+        command: str,
+        args: List[str],
+        cwd: str,
+        env: Dict[str, str],
+        server_type: str = "unknown",
+        required_env_vars: Optional[List[str]] = None,
+    ):
         self.name = name
         self.command = command
         self.args = args
@@ -25,6 +71,9 @@ class MCPServer:
         self.status = "stopped"
         self.start_time: Optional[datetime] = None
         self.server_type = server_type  # "fastmcp" or "stdio"
+        # Credential placeholders declared in mcp-config.json for this
+        # server. Read by mcp_client.connect_to_server at connect time.
+        self.required_env_vars: List[str] = list(required_env_vars or [])
     
     def start(self) -> bool:
         """Start the MCP server."""
@@ -312,27 +361,37 @@ class MCPService:
                         cwd = cwd.replace("${workspaceFolder}", project_path_str)
                     
                     # Get environment variables and substitute ${VAR_NAME} patterns
-                    raw_env = server_config.get("env", {})
-                    env = {}
-                    for env_key, env_val in raw_env.items():
-                        # Skip documentation keys (e.g., _note, _setup_note)
-                        if env_key.startswith("_"):
-                            continue
-                        env[env_key] = self._substitute_env_vars(str(env_val))
+                    raw_env_strs = {
+                        k: str(v)
+                        for k, v in (server_config.get("env") or {}).items()
+                        if not k.startswith("_")
+                    }
+                    env = {
+                        k: self._substitute_env_vars(v)
+                        for k, v in raw_env_strs.items()
+                    }
                     env["PYTHONPATH"] = project_path_str
-                    
+
                     # Get args and perform environment variable substitution
-                    args = server_config.get("args", [])
-                    # Substitute environment variables in args (e.g., ${VAR_NAME})
-                    args = [self._substitute_env_vars(arg) for arg in args]
-                    
+                    raw_args = list(server_config.get("args") or [])
+                    args = [self._substitute_env_vars(arg) for arg in raw_args]
+
+                    # Capture declared credential placeholders *before*
+                    # substitution collapses missing vars to empty strings
+                    # — used by mcp_client to short-circuit connect when
+                    # required credentials aren't set.
+                    required_env_vars = extract_required_env_vars(
+                        raw_env_strs, raw_args
+                    )
+
                     server_configs.append({
                         "name": server_name,
                         "command": command,
                         "args": args,
                         "cwd": cwd,
                         "env": env,
-                        "server_type": self._detect_server_type(args)
+                        "server_type": self._detect_server_type(args),
+                        "required_env_vars": required_env_vars,
                     })
                     
                 logger.info(f"Loaded {len(server_configs)} servers from mcp-config.json")
@@ -435,78 +494,28 @@ class MCPService:
             }
         ]
     
-    def start_server(self, server_name: str, ignore_enabled: bool = False) -> bool:
-        """
-        Start an MCP server.
-        
-        Args:
-            server_name: Name of the server to start.
-            ignore_enabled: If True, start regardless of enabled state (for internal use).
-        
-        Returns:
-            True if successful, False otherwise.
-        """
-        if server_name not in self.servers:
-            logger.error(f"Unknown server: {server_name}")
-            return False
-        
-        # Respect enabled state unless explicitly overridden
-        if not ignore_enabled and not self.is_server_enabled(server_name):
-            logger.info(f"Server {server_name} is disabled, skipping start")
-            return False
-        
-        server = self.servers[server_name]
-        
-        # Check if it's a stdio-based server
-        if server.server_type == "stdio":
-            logger.warning(f"Server {server_name} is stdio-based and designed for advanced MCP integration, not standalone monitoring")
-            return False
-        
-        return server.start()
-    
+    # NOTE: the former `start_server` / `start_all` / `stop_all` methods were
+    # removed when the MCP enable toggle became the single runtime lever.
+    # They were Popen-subprocess monitors that explicitly refused stdio
+    # servers (every server in mcp-config.json is stdio), so they never
+    # worked for users anyway. Runtime connect/disconnect is now owned by
+    # services.mcp_client.connect_to_server / disconnect_from_server.
+
     def stop_server(self, server_name: str) -> bool:
-        """
-        Stop an MCP server.
-        
-        Args:
-            server_name: Name of the server to stop.
-        
-        Returns:
-            True if successful, False otherwise.
+        """Stop a Popen-managed server if one was spawned.
+
+        Kept for completeness: a stdio server never gets a Popen child via
+        this class (it's driven by the MCP SDK's ``stdio_client`` through
+        ``mcp_client``), so for the current config this is effectively a
+        no-op. Still called defensively from ``PUT /enabled`` when a
+        non-stdio ``running`` status is observed.
         """
         if server_name not in self.servers:
             logger.error(f"Unknown server: {server_name}")
             return False
-        
         return self.servers[server_name].stop()
-    
-    def start_all(self) -> Dict[str, bool]:
-        """
-        Start all *enabled* MCP servers.
-        
-        Returns:
-            Dictionary mapping server names to success status.
-        """
-        results = {}
-        for name in self.servers:
-            if self.is_server_enabled(name):
-                results[name] = self.start_server(name)
-            else:
-                results[name] = False
-        return results
-    
-    def stop_all(self) -> Dict[str, bool]:
-        """
-        Stop all MCP servers.
-        
-        Returns:
-            Dictionary mapping server names to success status.
-        """
-        results = {}
-        for name in self.servers:
-            results[name] = self.stop_server(name)
-        return results
-    
+
+
     def get_server_status(self, server_name: str) -> Optional[str]:
         """
         Get the status of an MCP server.

--- a/services/model_registry.py
+++ b/services/model_registry.py
@@ -61,6 +61,24 @@ def is_valid_component(name: str) -> bool:
 
 _CATALOG: Dict[Tuple[str, str], Dict[str, Any]] = {
     # (provider_type, model_id) → metadata
+    ("anthropic", "claude-opus-4-7"): {
+        "display_name": "Claude Opus 4.7",
+        "context_window": 1_000_000,
+        "input_per_m": 15.0,
+        "output_per_m": 75.0,
+        "supports_tools": True,
+        "supports_thinking": True,
+        "supports_vision": True,
+    },
+    ("anthropic", "claude-sonnet-4-6"): {
+        "display_name": "Claude Sonnet 4.6",
+        "context_window": 200_000,
+        "input_per_m": 3.0,
+        "output_per_m": 15.0,
+        "supports_tools": True,
+        "supports_thinking": True,
+        "supports_vision": True,
+    },
     ("anthropic", "claude-sonnet-4-5-20250929"): {
         "display_name": "Claude Sonnet 4.5",
         "context_window": 200_000,
@@ -232,8 +250,12 @@ class _ProviderModelCache:
 _MODEL_LIST_CACHE = _ProviderModelCache()
 
 
-# Kept in sync with docker/bifrost/config.json and backend/api/llm_providers.py.
+# Single source of truth for the Anthropic model list. `backend/api/llm_providers.py`
+# imports this tuple; `docker/bifrost/config.json` must be kept in sync so Bifrost
+# accepts requests for these model IDs.
 ANTHROPIC_STATIC_MODELS: Tuple[str, ...] = (
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
     "claude-sonnet-4-5-20250929",
     "claude-sonnet-4-20250514",
     "claude-opus-4-20250514",

--- a/services/skill_tools_bridge.py
+++ b/services/skill_tools_bridge.py
@@ -1,0 +1,194 @@
+"""Bridge: expose DB-backed Skills as Anthropic tools at agent runtime.
+
+Issue #82 Phase 1 created the ``skills`` table + Skill Builder UI but deferred
+execution: agents couldn't actually invoke what the user saved. This module
+closes that gap by generating one Anthropic tool per active skill each time
+an agent runs. The model sees ``skill_<slug>`` tools alongside the regular
+backend and MCP toolset; when it picks one, ``execute_skill_tool`` expands
+the skill's ``prompt_template`` with the provided inputs and returns the
+rendered text as the tool result for the model to reason over.
+
+No execution of ``execution_steps`` yet — that's intentionally deferred to a
+later ARQ worker per the Skill MVP note. The prompt-fragment path is
+already enough to make skills usable in chat today.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Anthropic's hard limit on tool names is 64 characters.
+_TOOL_NAME_MAX = 64
+_TOOL_NAME_PREFIX = "skill_"
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+# Conservative placeholder pattern: {{param}} with optional whitespace.
+_PLACEHOLDER_RE = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
+
+
+def _slug_for_tool_name(name: str, skill_id: str) -> str:
+    """Derive a deterministic, Anthropic-safe tool name for a skill.
+
+    Prefer the human-readable name (so ``skill_cookie_recipe_generator``
+    is what agents see), but fall back to the skill_id if the name is
+    empty or slugifies to nothing.
+    """
+    base = _SLUG_RE.sub("_", (name or "").lower()).strip("_") or skill_id.lower()
+    base = _SLUG_RE.sub("_", base).strip("_") or "skill"
+    full = f"{_TOOL_NAME_PREFIX}{base}"
+    return full[:_TOOL_NAME_MAX]
+
+
+def _normalize_input_schema(schema: Any) -> Dict[str, Any]:
+    """Return a JSON Schema object safe to attach as a tool input_schema.
+
+    Anthropic requires ``type: object`` at the top level. Skills created
+    without an explicit schema get an empty permissive object so agents
+    can still invoke them.
+    """
+    if not isinstance(schema, dict) or not schema:
+        return {"type": "object", "properties": {}}
+    out = dict(schema)
+    out.setdefault("type", "object")
+    out.setdefault("properties", {})
+    return out
+
+
+def build_skill_tool(skill: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    """Build an Anthropic tool definition from a skill row.
+
+    Returns ``(tool_name, tool_def)`` where ``tool_name`` is the
+    prefixed slug the agent will call and ``tool_def`` is the Anthropic
+    tool object to append to ``backend_tools``.
+    """
+    tool_name = _slug_for_tool_name(skill.get("name", ""), skill.get("skill_id", ""))
+    desc_parts: List[str] = []
+    if skill.get("description"):
+        desc_parts.append(str(skill["description"]).strip())
+    if skill.get("category"):
+        desc_parts.append(f"Category: {skill['category']}.")
+    required = skill.get("required_tools") or []
+    if required:
+        desc_parts.append(
+            "Recommended upstream tools: " + ", ".join(str(t) for t in required[:6])
+        )
+    desc_parts.append(
+        "Calling this returns the skill's rendered prompt fragment — "
+        "use that as guidance for your next step."
+    )
+    description = " ".join(desc_parts)[:1024]
+
+    tool_def = {
+        "name": tool_name,
+        "description": description,
+        "input_schema": _normalize_input_schema(skill.get("input_schema")),
+    }
+    return tool_name, tool_def
+
+
+def list_active_skill_tools() -> Tuple[List[Dict[str, Any]], Dict[str, Dict[str, Any]]]:
+    """Fetch active skills from DB and return (tool_defs, skills_by_tool_name).
+
+    The second element is a reverse index the executor uses to map a
+    tool_name back to the original skill row without a DB round-trip.
+    Failures are logged and degraded to an empty list, so a DB hiccup
+    never breaks ClaudeService.
+    """
+    try:
+        from services.skill_service import SkillService
+
+        rows = SkillService().list_skills(is_active=True)
+    except Exception as e:
+        logger.debug("skill_tools_bridge: could not list skills (%s)", e)
+        return [], {}
+
+    tools: List[Dict[str, Any]] = []
+    by_name: Dict[str, Dict[str, Any]] = {}
+    for row in rows:
+        tool_name, tool_def = build_skill_tool(row)
+        # If two skill names collide, suffix the second with the id slug
+        # so both remain distinct and discoverable.
+        if tool_name in by_name:
+            suffix = _SLUG_RE.sub("_", row.get("skill_id", "")).strip("_")
+            tool_name = f"{tool_name}_{suffix}"[:_TOOL_NAME_MAX]
+            tool_def["name"] = tool_name
+        tools.append(tool_def)
+        by_name[tool_name] = row
+    return tools, by_name
+
+
+def is_skill_tool_name(name: str) -> bool:
+    return isinstance(name, str) and name.startswith(_TOOL_NAME_PREFIX)
+
+
+def _render_prompt(template: str, inputs: Dict[str, Any]) -> Tuple[str, List[str]]:
+    """Substitute ``{{param}}`` placeholders with values from ``inputs``.
+
+    Returns (rendered_text, list_of_missing_params). Placeholders whose
+    values aren't supplied are left in place so the agent can see what
+    was expected.
+    """
+    missing: List[str] = []
+
+    def repl(match: "re.Match[str]") -> str:
+        key = match.group(1)
+        if key in inputs and inputs[key] is not None:
+            return str(inputs[key])
+        missing.append(key)
+        return match.group(0)
+
+    rendered = _PLACEHOLDER_RE.sub(repl, template or "")
+    return rendered, sorted(set(missing))
+
+
+def execute_skill_tool(
+    tool_name: str,
+    tool_input: Dict[str, Any],
+    skills_by_tool_name: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Execute a skill tool call and return the result payload.
+
+    Pass ``skills_by_tool_name`` to skip a DB lookup; otherwise we fetch
+    fresh state (keeps this callable from the ARQ worker path where the
+    reverse index isn't readily available).
+    """
+    if not is_skill_tool_name(tool_name):
+        return {"error": f"Not a skill tool: {tool_name}"}
+
+    skill: Optional[Dict[str, Any]] = None
+    if skills_by_tool_name and tool_name in skills_by_tool_name:
+        skill = skills_by_tool_name[tool_name]
+    else:
+        _, fresh = list_active_skill_tools()
+        skill = fresh.get(tool_name)
+
+    if skill is None:
+        return {
+            "error": (
+                f"Skill tool '{tool_name}' not found or no longer active. "
+                "Ask the user to check the Skills page."
+            )
+        }
+
+    rendered, missing = _render_prompt(
+        skill.get("prompt_template") or "", dict(tool_input or {})
+    )
+    result = {
+        "skill_id": skill.get("skill_id"),
+        "skill_name": skill.get("name"),
+        "rendered_prompt": rendered,
+    }
+    if missing:
+        result["missing_inputs"] = missing
+    exec_steps = skill.get("execution_steps") or []
+    if exec_steps:
+        # Surface structured steps as a hint — actual orchestration is
+        # Issue #82 Phase 2 (ARQ worker). For now the agent can read the
+        # steps and drive them via its existing MCP tools.
+        result["execution_steps_hint"] = exec_steps
+    if skill.get("required_tools"):
+        result["required_tools"] = skill["required_tools"]
+    return result

--- a/services/soc_agents.py
+++ b/services/soc_agents.py
@@ -552,6 +552,11 @@ class AgentManager:
     def __init__(self):
         self.agents = SOCAgentLibrary.get_all_agents()
         self.current_agent_id = "investigator"
+        # Load DB-backed custom agents at startup so /agents/agents returns
+        # a unified list without waiting for a later CRUD call to trigger
+        # refresh. Failures (DB not ready) are logged inside the helper,
+        # so this remains safe when imported before the DB is initialised.
+        self.refresh_custom_agents()
 
     def refresh_custom_agents(self) -> int:
         """Reload custom agents from the DB.

--- a/tests/integration/test_mcp_enable_transactional.py
+++ b/tests/integration/test_mcp_enable_transactional.py
@@ -1,0 +1,147 @@
+"""API-contract integration tests for the transactional MCP enable toggle (#125).
+
+These tests verify that ``PUT /api/mcp/servers/{name}/enabled`` does more
+than persist a bit — it also triggers a connect/disconnect at runtime and
+returns the result in the response envelope. Without the transactional
+behavior, enabling a server was a no-op until the backend was restarted,
+which is the bug #125 exists to fix.
+
+The tests stub ``mcp_service`` and ``mcp_client`` so they don't spawn real
+MCP child processes or require credentials. See tests/integration/conftest.py
+for why DB-backed fixtures aren't available here; this is a contract check,
+not an end-to-end MCP spin-up.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Keep CSRF out of the way — exercised elsewhere.
+os.environ.setdefault("DEV_MODE", "true")
+os.environ.setdefault("VIGIL_CSRF_ENABLED", "false")
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="module")
+def client():
+    from backend.main import app
+
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def fake_server_known():
+    """Patch mcp_service so ``deeptempo-findings`` is a known, settable server."""
+    from backend.api import mcp as mcp_api
+
+    # Make set_server_enabled succeed (server exists); status is the stdio
+    # sentinel so the legacy stop_server branch doesn't fire.
+    with patch.object(
+        mcp_api.mcp_service, "set_server_enabled", return_value=True
+    ), patch.object(
+        mcp_api.mcp_service,
+        "get_server_status",
+        return_value="stdio (MCP integration)",
+    ):
+        yield
+
+
+@pytest.mark.integration
+class TestEnableTransactional:
+    """PUT /enabled should connect-on-enable and disconnect-on-disable."""
+
+    def test_enable_triggers_connect_and_reports_connected(
+        self, client, fake_server_known
+    ):
+        fake_client = MagicMock()
+        fake_client.connect_to_server = AsyncMock(return_value=True)
+        fake_client.get_last_error = MagicMock(return_value=None)
+        fake_client.disconnect_from_server = AsyncMock(return_value=True)
+
+        with patch(
+            "services.mcp_client.get_mcp_client", return_value=fake_client
+        ):
+            r = client.put(
+                "/api/mcp/servers/deeptempo-findings/enabled",
+                json={"enabled": True},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["enabled"] is True
+        assert body["connected"] is True
+        assert body["error"] is None
+        fake_client.connect_to_server.assert_awaited_once_with(
+            "deeptempo-findings", persistent=True
+        )
+        fake_client.disconnect_from_server.assert_not_called()
+
+    def test_enable_with_missing_creds_reports_error_not_raising(
+        self, client, fake_server_known
+    ):
+        # Simulate the credential-missing / FileNotFoundError / etc. case.
+        fake_client = MagicMock()
+        fake_client.connect_to_server = AsyncMock(return_value=False)
+        fake_client.get_last_error = MagicMock(
+            return_value="missing credentials: VIRUSTOTAL_API_KEY"
+        )
+        fake_client.disconnect_from_server = AsyncMock(return_value=True)
+
+        with patch(
+            "services.mcp_client.get_mcp_client", return_value=fake_client
+        ):
+            r = client.put(
+                "/api/mcp/servers/virustotal/enabled",
+                json={"enabled": True},
+            )
+
+        # Endpoint doesn't raise — it surfaces the reason so the UI can
+        # flip the toggle back off and show a snackbar.
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["enabled"] is True
+        assert body["connected"] is False
+        assert "VIRUSTOTAL_API_KEY" in (body["error"] or "")
+
+    def test_disable_triggers_disconnect(self, client, fake_server_known):
+        fake_client = MagicMock()
+        fake_client.connect_to_server = AsyncMock(return_value=True)
+        fake_client.disconnect_from_server = AsyncMock(return_value=True)
+
+        with patch(
+            "services.mcp_client.get_mcp_client", return_value=fake_client
+        ):
+            r = client.put(
+                "/api/mcp/servers/deeptempo-findings/enabled",
+                json={"enabled": False},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["enabled"] is False
+        # connected is None when disabling — we didn't attempt a connect.
+        assert body["connected"] is None
+        fake_client.disconnect_from_server.assert_awaited_once_with(
+            "deeptempo-findings"
+        )
+        fake_client.connect_to_server.assert_not_called()
+
+
+@pytest.mark.integration
+class TestDeadEndpointsGone:
+    """The broken /start + /stop paths should no longer exist."""
+
+    def test_start_endpoint_is_removed(self, client):
+        r = client.post("/api/mcp/servers/deeptempo-findings/start")
+        # Either 404 (route not registered) or 405 (method not allowed) is
+        # acceptable — just never a 500 or 200 from the old broken handler.
+        assert r.status_code in (404, 405), r.text
+
+    def test_start_all_endpoint_is_removed(self, client):
+        r = client.post("/api/mcp/servers/start-all")
+        assert r.status_code in (404, 405), r.text

--- a/tests/unit/test_mcp_required_env.py
+++ b/tests/unit/test_mcp_required_env.py
@@ -1,0 +1,249 @@
+"""Unit tests for the MCP required-env-var extractor + credential gate.
+
+These cover the dormancy-by-design path introduced with the #125 close:
+when a server's ``mcp-config.json`` entry declares ``${VAR}`` placeholders
+and those vars aren't set, we short-circuit before spawning the MCP
+child and record the missing var names so the UI can show "Not
+Configured" with specifics.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+from services.mcp_service import MCPServer, extract_required_env_vars
+
+
+class TestExtractRequiredEnvVars:
+    def test_scans_env_values(self):
+        assert extract_required_env_vars(
+            {"API_KEY": "${VIRUSTOTAL_API_KEY}"}, []
+        ) == ["VIRUSTOTAL_API_KEY"]
+
+    def test_scans_args(self):
+        assert extract_required_env_vars(
+            {}, ["-y", "mcp-remote", "${SPLUNK_MCP_URL}"]
+        ) == ["SPLUNK_MCP_URL"]
+
+    def test_scans_docker_style_args(self):
+        # okta's config: `-e OKTA_API_TOKEN=${OKTA_API_TOKEN}` inside an arg.
+        args = [
+            "run",
+            "-i",
+            "--rm",
+            "-e",
+            "OKTA_DOMAIN=${OKTA_DOMAIN}",
+            "-e",
+            "OKTA_API_TOKEN=${OKTA_API_TOKEN}",
+            "mcp/okta-mcp-fctr",
+        ]
+        result = extract_required_env_vars({}, args)
+        assert result == ["OKTA_API_TOKEN", "OKTA_DOMAIN"]
+
+    def test_deduplicates_across_env_and_args(self):
+        result = extract_required_env_vars(
+            {"URL": "${SPLUNK_MCP_URL}"}, ["-y", "mcp-remote", "${SPLUNK_MCP_URL}"]
+        )
+        assert result == ["SPLUNK_MCP_URL"]
+
+    def test_ignores_workspaceFolder(self):
+        # Not all ${...} references are credentials — path sentinels shouldn't be flagged.
+        assert extract_required_env_vars(
+            {"CWD": "${workspaceFolder}/data"}, []
+        ) == []
+
+    def test_returns_empty_when_no_placeholders(self):
+        assert extract_required_env_vars(
+            {"LITERAL_VALUE": "just-a-string"}, ["--flag", "value"]
+        ) == []
+
+    def test_returns_empty_on_none_inputs(self):
+        assert extract_required_env_vars({}, []) == []
+        assert extract_required_env_vars(None, None) == []  # type: ignore[arg-type]
+
+
+class TestMCPServerRequiredEnvVars:
+    def test_attribute_set_from_kwarg(self):
+        server = MCPServer(
+            name="test",
+            command="python",
+            args=[],
+            cwd=".",
+            env={},
+            required_env_vars=["FOO", "BAR"],
+        )
+        assert server.required_env_vars == ["FOO", "BAR"]
+
+    def test_default_is_empty_list(self):
+        server = MCPServer(
+            name="test",
+            command="python",
+            args=[],
+            cwd=".",
+            env={},
+        )
+        assert server.required_env_vars == []
+
+
+class TestCredentialGate:
+    """The short-circuit in MCPClient._missing_credentials_for()."""
+
+    def _build_client(self):
+        # Minimal stub: only _missing_credentials_for is exercised here,
+        # so we instantiate MCPClient with a MagicMock-y service.
+        from services.mcp_client import MCPClient
+
+        class _StubService:
+            servers: dict = {}
+
+        return MCPClient(_StubService())
+
+    def test_returns_missing_var_names(self):
+        client = self._build_client()
+        server = MCPServer(
+            name="virustotal",
+            command="npx",
+            args=[],
+            cwd=".",
+            env={},
+            required_env_vars=["VIRUSTOTAL_API_KEY"],
+        )
+        # Ensure env var + secrets manager both return falsy.
+        with patch("os.environ.get", return_value=None), patch(
+            "backend.secrets_manager.get_secret", return_value=None
+        ):
+            assert client._missing_credentials_for(server) == [
+                "VIRUSTOTAL_API_KEY"
+            ]
+
+    def test_secrets_manager_satisfies_requirement(self):
+        # A user who saved a credential via the integration wizard (which
+        # writes to the encrypted store, not os.environ) should not be
+        # told the server is dormant.
+        client = self._build_client()
+        server = MCPServer(
+            name="virustotal",
+            command="npx",
+            args=[],
+            cwd=".",
+            env={},
+            required_env_vars=["VIRUSTOTAL_API_KEY"],
+        )
+        with patch("os.environ.get", return_value=None), patch(
+            "backend.secrets_manager.get_secret", return_value="sk-ant-xyz"
+        ):
+            assert client._missing_credentials_for(server) == []
+
+    def test_no_required_env_vars_means_never_dormant(self):
+        client = self._build_client()
+        server = MCPServer(
+            name="builtin",
+            command="python",
+            args=[],
+            cwd=".",
+            env={},
+        )
+        assert client._missing_credentials_for(server) == []
+
+
+class TestRetryDormantIfReady:
+    """`retry_dormant_if_ready` should only retry servers whose creds now resolve."""
+
+    def _build_client_with_server(self, server: MCPServer):
+        from services.mcp_client import MCPClient
+
+        class _StubService:
+            def __init__(self, srv):
+                self.servers = {srv.name: srv}
+
+        return MCPClient(_StubService(server))
+
+    @pytest.mark.asyncio
+    async def test_noop_when_nothing_dormant(self):
+        server = MCPServer(
+            name="builtin",
+            command="python",
+            args=[],
+            cwd=".",
+            env={},
+        )
+        client = self._build_client_with_server(server)
+        # Nothing in last_missing_credentials → empty result, no retries.
+        result = await client.retry_dormant_if_ready()
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_skips_server_with_still_missing_creds(self):
+        server = MCPServer(
+            name="virustotal",
+            command="npx",
+            args=[],
+            cwd=".",
+            env={},
+            required_env_vars=["VIRUSTOTAL_API_KEY"],
+        )
+        client = self._build_client_with_server(server)
+        # Mark as dormant.
+        client.last_missing_credentials = {"virustotal": ["VIRUSTOTAL_API_KEY"]}
+        # Env and secrets both still empty.
+        with patch("os.environ.get", return_value=None), patch(
+            "backend.secrets_manager.get_secret", return_value=None
+        ):
+            result = await client.retry_dormant_if_ready()
+        assert result == {}
+        # Nothing was retried, so last_retry_at stays empty.
+        assert client._last_retry_at == {}
+
+    @pytest.mark.asyncio
+    async def test_retries_when_cred_becomes_available(self):
+        from unittest.mock import AsyncMock
+
+        server = MCPServer(
+            name="virustotal",
+            command="npx",
+            args=[],
+            cwd=".",
+            env={},
+            required_env_vars=["VIRUSTOTAL_API_KEY"],
+        )
+        client = self._build_client_with_server(server)
+        client.last_missing_credentials = {"virustotal": ["VIRUSTOTAL_API_KEY"]}
+        # Stub connect_to_server to record the call + simulate success.
+        client.connect_to_server = AsyncMock(return_value=True)
+        # Secrets manager now returns a key — creds resolve.
+        with patch("os.environ.get", return_value=None), patch(
+            "backend.secrets_manager.get_secret", return_value="vt-key-xyz"
+        ):
+            result = await client.retry_dormant_if_ready()
+        assert result == {"virustotal": True}
+        client.connect_to_server.assert_awaited_once_with(
+            "virustotal", persistent=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_rate_limits_repeated_retries(self):
+        from unittest.mock import AsyncMock
+
+        server = MCPServer(
+            name="virustotal",
+            command="npx",
+            args=[],
+            cwd=".",
+            env={},
+            required_env_vars=["VIRUSTOTAL_API_KEY"],
+        )
+        client = self._build_client_with_server(server)
+        client.last_missing_credentials = {"virustotal": ["VIRUSTOTAL_API_KEY"]}
+        client.connect_to_server = AsyncMock(return_value=False)
+        with patch("os.environ.get", return_value=None), patch(
+            "backend.secrets_manager.get_secret", return_value="vt-key-xyz"
+        ):
+            # First call: attempts retry.
+            r1 = await client.retry_dormant_if_ready()
+            # Second call, immediately after: rate-limited.
+            r2 = await client.retry_dormant_if_ready()
+        assert "virustotal" in r1
+        assert r2 == {}
+        # connect_to_server was called exactly once despite two sweeps.
+        assert client.connect_to_server.await_count == 1


### PR DESCRIPTION
## Summary

SOC platform hardening pass covering MCP, agents, skills, workflows, secrets, model catalog, and cold-load performance. Five thematic commits, each independently valid.

- **feat(secrets)** — project-local encrypted store at `~/.vigil/secrets.enc`, Bifrost admin-API live-sync on provider-key change, legacy-value migration script, mtime-based cache invalidation so cross-process writes propagate. `docs/STATE.md` documents where each kind of state lives.
- **fix(backend)** — orchestrator status endpoint silently returned `enabled=false` due to a wrong module path (`services.config_service` vs `database.config_service`) hiding the Auto Ops nav item. Also unifies the Anthropic model catalog and adds `claude-opus-4-7` (1M ctx) + `claude-sonnet-4-6`.
- **perf(frontend)** — lazy-load all 12 page routes via `React.lazy` + `Suspense`; cold-load on `/` no longer fetches Settings / Analytics / Orchestrator / AIDecisions / Skills up front. Auto-Investigate tab replaced with a three-card profile picker (Conservative / Balanced / Aggressive) + collapsed Advanced accordion.
- **feat(agents,skills,workflows)** — `POST /api/agents/{id}/fork` creates a custom copy of any template (built-in or custom); built-ins remain static read-only templates. `custom_agents` gains a `forked_from` breadcrumb column. Agents list now refreshes from the DB on every `/api/agents/agents` poll (fixes multi-worker stale-cache bug). Skills become callable as `skill_<slug>` Anthropic tools, refreshed at the top of every chat so DB changes propagate without a worker restart. Workflow saves validate agent IDs against the unified pool. `WorkflowBuilder` fetches agents from the API instead of a hardcoded 12-entry list.
- **feat(mcp)** — closes [#124](https://github.com/Vigil-SOC/vigil/issues/124) and [#125](https://github.com/Vigil-SOC/vigil/issues/125). `PUT /api/mcp/servers/{name}/enabled` now triggers an actual connect-on-enable / disconnect-on-disable with `{connected, error, missing_credentials}` in the response. Dead `/start` + `/start-all` endpoints (and their underlying service methods) removed. Credential-gating: servers with unset `${VAR}` placeholders stay dormant-by-design without spawning a child, and auto-heal on the next `/connections/status` poll once the credentials appear (rate-limited per server). `uv>=0.5.0` added to requirements so `uvx`-launched MCPs launch on fresh installs.

## Closed / referenced issues

Closes #124 and #125. The PR explicitly does **not** address the other open tracked issues:

- [#126](https://github.com/Vigil-SOC/vigil/issues/126) — workflows can't invoke skills (Agent SDK vs backend_tools gap)
- [#127](https://github.com/Vigil-SOC/vigil/issues/127) — persist workflow runs (`workflow_runs` table)
- [#128](https://github.com/Vigil-SOC/vigil/issues/128) — enforce `approval_required` at workflow execution
- [#129](https://github.com/Vigil-SOC/vigil/issues/129) — install + run `memory-palace` MCP as part of the Vigil stack
- [#130](https://github.com/Vigil-SOC/vigil/issues/130) — Skills `.zip` import (Claude Desktop-compatible)

## Test plan

- [ ] `pytest tests/unit/test_mcp_required_env.py tests/integration/test_mcp_enable_transactional.py` — 21 tests green (new).
- [ ] `pytest` full suite passes — no regressions in existing tests.
- [ ] `cd frontend && npx tsc --noEmit` — frontend typecheck clean.
- [ ] Spin up the stack, toggle `deeptempo-findings` off/on via Settings → MCP — server transitions `running → disconnected → running` without a backend restart.
- [ ] Enable a credential-gated server (e.g. `virustotal`) without the env var set — toggle flips back off, snackbar surfaces `missing credentials: VIRUSTOTAL_API_KEY`, no subprocess spawn.
- [ ] Save a credential via the integration wizard — next poll of the Settings page auto-reconnects the dormant server.
- [ ] Fork a built-in agent (e.g. `triage`) — editor opens on the new `custom-*` copy; the original `triage` still reports its original `name` and `specialization`.
- [ ] Ask the chat to use an active skill (e.g. the cookie-recipe demo skill) — agent invokes `skill_<slug>` and receives the rendered `prompt_template`.

## Migration notes

- If running locally with secrets in `~/.deeptempo/.env` (old DotEnvBackend default), run `python scripts/migrate_secrets.py` once to move them into the encrypted store. `--purge` clears the originals after verification.
- Fresh installs: `pip install -r requirements.txt` now pulls `uv`, which ships `uvx`.
- The `custom_agents.forked_from` column is added via an idempotent `ALTER TABLE IF NOT EXISTS` at the bottom of the existing migration (no manual DB work needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
