### PR TITLE
feat(workflows): skills callable from playbooks + findings-table playbook action (#126)

### DIFF
--- a/frontend/src/components/findings/FindingsTable.tsx
+++ b/frontend/src/components/findings/FindingsTable.tsx
@@ -21,11 +21,12 @@ import {
   alpha,
   useTheme,
 } from '@mui/material'
-import { 
+import {
   Visibility as ViewIcon,
   Psychology as InvestigateIcon,
+  PlayCircleOutline as PlaybookIcon,
 } from '@mui/icons-material'
-import { findingsApi, agentsApi } from '../../services/api'
+import { findingsApi, agentsApi, workflowApi } from '../../services/api'
 import FindingDetailDialog from './FindingDetailDialog'
 import { notificationService } from '../../services/notifications'
 import { SeverityChip } from '../ui'
@@ -54,6 +55,11 @@ export default function FindingsTable({ filters = {}, searchQuery = '', limit, r
   const [agents, setAgents] = useState<Agent[]>([])
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [selectedFinding, setSelectedFinding] = useState<any>(null)
+  // Workflow (playbook) run picker — separate anchor from the agent menu.
+  const [workflows, setWorkflows] = useState<{ id: string; name: string; description?: string }[]>([])
+  const [workflowAnchorEl, setWorkflowAnchorEl] = useState<null | HTMLElement>(null)
+  const [workflowFinding, setWorkflowFinding] = useState<any>(null)
+  const [runningWorkflowId, setRunningWorkflowId] = useState<string | null>(null)
   const prevFindingsRef = useRef<Set<string>>(new Set())
   const [page, setPage] = useState(0)
   const [rowsPerPage, setRowsPerPage] = useState(10)
@@ -93,6 +99,11 @@ export default function FindingsTable({ filters = {}, searchQuery = '', limit, r
     agentsApi.listAgents()
       .then(res => setAgents(res.data.agents || []))
       .catch(() => {})
+    // Workflows are playbooks — keep the list cached alongside agents so
+    // the "Run Playbook" menu opens without a network roundtrip on click.
+    workflowApi.listAll()
+      .then(res => setWorkflows(res.data?.workflows || []))
+      .catch(() => setWorkflows([]))
   }, [])
 
   const loadFindings = async () => {
@@ -176,6 +187,55 @@ export default function FindingsTable({ filters = {}, searchQuery = '', limit, r
       console.error('Failed to start investigation:', error)
     } finally {
       handleCloseMenu()
+    }
+  }
+
+  // Playbook run — separate menu from the agent picker so the two
+  // actions stay conceptually distinct. A workflow is run as a playbook
+  // against the finding, not as a chat conversation.
+  const handleRunPlaybookClick = (event: React.MouseEvent<HTMLElement>, finding: any) => {
+    event.stopPropagation()
+    setWorkflowAnchorEl(event.currentTarget)
+    setWorkflowFinding(finding)
+  }
+
+  const handleCloseWorkflowMenu = () => {
+    setWorkflowAnchorEl(null)
+    setWorkflowFinding(null)
+  }
+
+  const handleWorkflowSelect = async (workflowId: string) => {
+    if (!workflowFinding) {
+      handleCloseWorkflowMenu()
+      return
+    }
+    const findingId = workflowFinding.finding_id
+    setRunningWorkflowId(workflowId)
+    handleCloseWorkflowMenu()
+    try {
+      const res = await workflowApi.execute(workflowId, { finding_id: findingId })
+      const body = res?.data || {}
+      if (body.success === false) {
+        notificationService.notifyGeneric(
+          'Playbook finished with errors',
+          `${body.workflow?.name || workflowId}: ${body.error || 'unknown error'}`,
+          { severity: 'error' }
+        )
+      } else {
+        notificationService.notifyGeneric(
+          'Playbook executed',
+          `${body.workflow?.name || workflowId} ran against ${findingId.substring(0, 12)}…`,
+          { severity: 'success' }
+        )
+      }
+    } catch (e: any) {
+      notificationService.notifyGeneric(
+        'Playbook execution failed',
+        e?.response?.data?.detail || e?.message || 'unknown error',
+        { severity: 'error' }
+      )
+    } finally {
+      setRunningWorkflowId(null)
     }
   }
 
@@ -519,6 +579,30 @@ export default function FindingsTable({ filters = {}, searchQuery = '', limit, r
                         </IconButton>
                       </Tooltip>
                     )}
+                    {workflows.length > 0 && (
+                      <Tooltip title="Run playbook against this finding">
+                        <span>
+                          <IconButton
+                            size="small"
+                            onClick={(e) => handleRunPlaybookClick(e, finding)}
+                            disabled={runningWorkflowId !== null}
+                            sx={{
+                              color: 'secondary.main',
+                              bgcolor: alpha(theme.palette.secondary.main, 0.1),
+                              '&:hover': {
+                                bgcolor: alpha(theme.palette.secondary.main, 0.2),
+                              },
+                            }}
+                          >
+                            {runningWorkflowId ? (
+                              <CircularProgress size={16} />
+                            ) : (
+                              <PlaybookIcon sx={{ fontSize: 18 }} />
+                            )}
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                    )}
                   </Box>
                 </TableCell>
               </TableRow>
@@ -563,6 +647,39 @@ export default function FindingsTable({ filters = {}, searchQuery = '', limit, r
             <ListItemText primary={agent.name} primaryTypographyProps={{ fontSize: '0.875rem' }} />
           </MenuItem>
         ))}
+      </Menu>
+
+      <Menu
+        anchorEl={workflowAnchorEl}
+        open={Boolean(workflowAnchorEl)}
+        onClose={handleCloseWorkflowMenu}
+      >
+        <MenuItem disabled sx={{ opacity: 1 }}>
+          <Typography variant="caption" color="text.secondary">
+            Run playbook:
+          </Typography>
+        </MenuItem>
+        {workflows.length === 0 ? (
+          <MenuItem disabled>
+            <Typography variant="caption" color="text.disabled">
+              No workflows configured
+            </Typography>
+          </MenuItem>
+        ) : (
+          workflows.map((wf) => (
+            <MenuItem key={wf.id} onClick={() => handleWorkflowSelect(wf.id)}>
+              <ListItemIcon sx={{ minWidth: 32 }}>
+                <PlaybookIcon sx={{ fontSize: 18, color: 'secondary.main' }} />
+              </ListItemIcon>
+              <ListItemText
+                primary={wf.name}
+                secondary={wf.description}
+                primaryTypographyProps={{ fontSize: '0.875rem' }}
+                secondaryTypographyProps={{ fontSize: '0.7rem', noWrap: true }}
+              />
+            </MenuItem>
+          ))
+        )}
       </Menu>
     </>
   )

--- a/services/workflows_service.py
+++ b/services/workflows_service.py
@@ -1,5 +1,6 @@
 """Workflows service for discovering, parsing, and executing WORKFLOW.md workflow definitions."""
 
+import asyncio
 import logging
 import re
 from typing import Dict, List, Optional, Any
@@ -474,7 +475,36 @@ For each phase:
         except Exception as e:
             logger.debug(f"Could not get MCP tools from registry: {e}")
 
+        # Include active DB-backed Skills as ``skill_<slug>`` tools so a
+        # workflow phase can invoke them (#126). Skills aren't MCP tools,
+        # they're backend tools generated at runtime from the `skills`
+        # table — without this step they'd be invisible to the execution
+        # engine even when the user had authored them.
+        skill_tool_names: List[str] = []
+        try:
+            from services.skill_tools_bridge import list_active_skill_tools
+
+            skill_defs, _ = list_active_skill_tools()
+            skill_tool_names = [t["name"] for t in skill_defs]
+            for name in skill_tool_names:
+                if name not in all_tools:
+                    all_tools.append(name)
+        except Exception as e:
+            logger.debug(f"Could not load active skill tools: {e}")
+
         # Build a composite system prompt incorporating all agent roles
+        skills_hint = ""
+        if skill_tool_names:
+            skills_hint = (
+                "\n<available_skills>\n"
+                "The following skill tools are available as reusable SOC "
+                "capabilities. Invoke by name whenever a phase's work "
+                "matches a skill's purpose — each call returns the "
+                "skill's rendered playbook text for you to act on.\n"
+                + "\n".join(f"- {name}" for name in skill_tool_names)
+                + "\n</available_skills>\n"
+            )
+
         system_prompt = f"""You are the Vigil SOC Workflow Engine executing the "{workflow.name}" workflow.
 
 You have access to all SOC tools and will execute a multi-phase workflow,
@@ -486,7 +516,7 @@ adopting different specialist agent roles for each phase.
 - IPs/domains/hashes: Use threat intel tools
 - NEVER access findings as files - use tools
 </entity_recognition>
-
+{skills_hint}
 <principles>
 - Always fetch data via tools before analyzing
 - Be evidence-based and document reasoning
@@ -496,34 +526,55 @@ adopting different specialist agent roles for each phase.
 </principles>
 """
 
-        # Execute via ClaudeService
+        # Workflow execution is a *playbook run*, not a chat session.
+        # We call ClaudeService.chat() as an internal Python primitive
+        # — no /api/claude/chat route, no conversation session, no
+        # session-history persistence. It's "run this composite prompt
+        # with access to backend + MCP tools (incl. skills) and hand me
+        # the structured result." The Agent SDK path used to live here
+        # (run_agent_task) but that branch doesn't see backend_tools, so
+        # skills would never resolve. See issue #126.
         claude_service = ClaudeService(
             use_backend_tools=True,
             use_mcp_tools=True,
-            use_agent_sdk=True,
+            use_agent_sdk=False,
             enable_thinking=True,
         )
 
         if not claude_service.has_api_key():
             return {"success": False, "error": "Claude API not configured"}
 
-        result = await claude_service.run_agent_task(
-            task=prompt,
-            agent_config={
-                "system_prompt": system_prompt,
-                "allowed_tools": all_tools if all_tools else None,
-                "max_turns": 25,  # More turns for multi-phase workflows
-                "model": "claude-sonnet-4-5-20250929",
-            }
-        )
+        # chat() is sync + has its own multi-iteration tool loop. Offload
+        # to a thread so we don't block the asyncio loop of the caller.
+        try:
+            response_text = await asyncio.to_thread(
+                claude_service.chat,
+                message=prompt,
+                system_prompt=system_prompt,
+                model="claude-sonnet-4-5-20250929",
+                max_tokens=8192,
+                recommended_tools=all_tools if all_tools else None,
+            )
+            success = response_text is not None
+            error = None if success else "Claude returned no response"
+        except Exception as exc:  # noqa: BLE001
+            response_text = ""
+            success = False
+            error = f"{type(exc).__name__}: {exc}"
+            logger.exception("Workflow execution failed for %s", workflow_id)
 
         return {
-            "success": result.get("success", False),
+            "success": success,
             "workflow": workflow.to_dict(include_body=False),
-            "result": result.get("final_result", ""),
-            "tool_calls": result.get("tool_calls", []),
-            "error": result.get("error"),
+            "result": response_text or "",
+            # Playbook runs don't yet stream intermediate tool calls back
+            # through this entry point; ClaudeService.chat captures them
+            # internally for reasoning-trace persistence. A structured
+            # per-phase output + tool_calls list is tracked as #127.
+            "tool_calls": [],
+            "error": error,
             "parameters": parameters,
+            "skill_tools_available": skill_tool_names,
             "executed_at": datetime.now().isoformat(),
         }
 

--- a/tests/unit/test_workflow_skill_wiring.py
+++ b/tests/unit/test_workflow_skill_wiring.py
@@ -1,0 +1,177 @@
+"""Unit tests for workflow execution seeing DB-backed skills as tools (#126).
+
+Workflows used to execute through ``ClaudeService.run_agent_task`` which
+drives the Claude Agent SDK. That path sees MCP tools only — our
+``backend_tools`` layer (where ``skill_<slug>`` tools live) was
+invisible, so workflows couldn't invoke user-authored skills.
+
+The fix: ``execute_workflow`` now calls ``ClaudeService.chat`` as an
+internal engine primitive. That entry point refreshes skill tools at
+the top of every invocation. These tests lock in the contract that
+skill tool names actually reach the executor + are mentioned in the
+system prompt.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from services.workflows_service import WorkflowDefinition, WorkflowsService
+
+
+def _make_workflow(agents=("investigator",), tools=("list_findings",)):
+    return WorkflowDefinition(
+        workflow_id="wf-test",
+        file_path=None,
+        metadata={
+            "name": "Test Workflow",
+            "description": "test",
+            "agents": list(agents),
+            "tools-used": list(tools),
+            "use-case": "test",
+            "trigger-examples": [],
+        },
+        body="Phase 1: investigate.\nPhase 2: report.\n",
+        source="file",
+    )
+
+
+def _fake_claude_service(response_text: str = "done"):
+    """MagicMock that satisfies the ClaudeService surface we call."""
+    svc = MagicMock()
+    svc.has_api_key.return_value = True
+    svc.chat = MagicMock(return_value=response_text)
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_execute_workflow_includes_skill_tools_in_allowed_list(monkeypatch):
+    """Skill tool names from skill_tools_bridge should be threaded
+    into the `recommended_tools` arg passed to chat()."""
+
+    service = WorkflowsService()
+    workflow = _make_workflow()
+
+    monkeypatch.setattr(
+        WorkflowsService, "get_workflow", lambda self, wid: workflow
+    )
+
+    fake = _fake_claude_service()
+
+    with patch(
+        "services.claude_service.ClaudeService", return_value=fake
+    ), patch(
+        "services.skill_tools_bridge.list_active_skill_tools",
+        return_value=(
+            [
+                {
+                    "name": "skill_cookie_recipe_generator",
+                    "description": "test",
+                    "input_schema": {"type": "object"},
+                }
+            ],
+            {},
+        ),
+    ):
+        result = await service.execute_workflow("wf-test", {})
+
+    assert result["success"] is True
+    # ``skill_tools_available`` is surfaced on the response envelope so
+    # the UI can tell the user which skills were in scope for this run.
+    assert "skill_cookie_recipe_generator" in result["skill_tools_available"]
+
+    # chat() was called once with recommended_tools containing the skill.
+    assert fake.chat.call_count == 1
+    kwargs = fake.chat.call_args.kwargs
+    rec_tools = kwargs.get("recommended_tools") or []
+    assert "skill_cookie_recipe_generator" in rec_tools
+    # Plus the originally-declared workflow tools.
+    assert "list_findings" in rec_tools
+    # system_prompt names the skill so the model knows it's available.
+    assert "skill_cookie_recipe_generator" in kwargs["system_prompt"]
+
+
+@pytest.mark.asyncio
+async def test_execute_workflow_no_skills_still_runs(monkeypatch):
+    """Empty skill registry shouldn't break workflow execution or add
+    an empty skills-hint block to the system prompt."""
+
+    service = WorkflowsService()
+    workflow = _make_workflow()
+    monkeypatch.setattr(
+        WorkflowsService, "get_workflow", lambda self, wid: workflow
+    )
+
+    fake = _fake_claude_service()
+    with patch(
+        "services.claude_service.ClaudeService", return_value=fake
+    ), patch(
+        "services.skill_tools_bridge.list_active_skill_tools",
+        return_value=([], {}),
+    ):
+        result = await service.execute_workflow("wf-test", {})
+
+    assert result["success"] is True
+    assert result["skill_tools_available"] == []
+    kwargs = fake.chat.call_args.kwargs
+    assert "<available_skills>" not in kwargs["system_prompt"]
+
+
+@pytest.mark.asyncio
+async def test_execute_workflow_does_not_use_agent_sdk(monkeypatch):
+    """Regression guard for #126: workflows must not take the Agent SDK
+    path, because that branch never sees backend_tools + skills."""
+
+    service = WorkflowsService()
+    workflow = _make_workflow()
+    monkeypatch.setattr(
+        WorkflowsService, "get_workflow", lambda self, wid: workflow
+    )
+
+    calls = []
+
+    def _record_svc(**kwargs):
+        calls.append(kwargs)
+        return _fake_claude_service()
+
+    with patch(
+        "services.claude_service.ClaudeService", side_effect=_record_svc
+    ), patch(
+        "services.skill_tools_bridge.list_active_skill_tools",
+        return_value=([], {}),
+    ):
+        await service.execute_workflow("wf-test", {})
+
+    assert len(calls) == 1
+    assert calls[0].get("use_agent_sdk") is False
+    # And backend_tools stays on (that's how skill tools load).
+    assert calls[0].get("use_backend_tools") is True
+
+
+@pytest.mark.asyncio
+async def test_execute_workflow_surfaces_chat_exception_as_error(monkeypatch):
+    """A raised exception from chat() should land as `success=False`
+    with a readable error, not a 500 up the stack."""
+
+    service = WorkflowsService()
+    workflow = _make_workflow()
+    monkeypatch.setattr(
+        WorkflowsService, "get_workflow", lambda self, wid: workflow
+    )
+
+    svc = MagicMock()
+    svc.has_api_key.return_value = True
+    svc.chat = MagicMock(side_effect=RuntimeError("boom"))
+
+    with patch(
+        "services.claude_service.ClaudeService", return_value=svc
+    ), patch(
+        "services.skill_tools_bridge.list_active_skill_tools",
+        return_value=([], {}),
+    ):
+        result = await service.execute_workflow("wf-test", {})
+
+    assert result["success"] is False
+    assert "RuntimeError" in (result["error"] or "")
+    assert "boom" in (result["error"] or "")


### PR DESCRIPTION
## Summary

Closes #126. Workflows couldn't invoke DB-backed skills because they executed through `ClaudeService.run_agent_task` → Claude Agent SDK, which only consumes MCP tools — our `backend_tools` layer (where `skill_<slug>` tools live) was invisible. This PR routes workflow execution through `ClaudeService.chat` as an internal Python primitive so the skill-tool refresh fires and skills become first-class inside a playbook run.

**Workflows remain playbooks, not chats.** `execute_workflow` still returns a structured `{success, result, workflow, skill_tools_available, error, ...}` envelope and does **not** route through the chat UI / `/api/claude/chat` endpoint. `chat()` is just a shared execution primitive invoked as a Python method.

Also includes a small UX piece asked for alongside: you can now run a playbook against a finding directly from the findings-table actions column.

## What changed

- **`services/workflows_service.py`** — `execute_workflow` collects active skill tool names via `skill_tools_bridge.list_active_skill_tools()`, threads them into `recommended_tools` passed to `chat()`, and names them in an `<available_skills>` block in the composite system prompt. Construction switches to `use_agent_sdk=False`; `chat()` runs on a worker thread via `asyncio.to_thread`. Exceptions surface as `{success: false, error}` instead of raising.
- **`tests/unit/test_workflow_skill_wiring.py`** — 4 new tests: skills reach `recommended_tools` + system prompt; empty skill registry doesn't add an empty hint block; regression guard that `use_agent_sdk=False`; exceptions come back as a structured error.
- **`frontend/src/components/findings/FindingsTable.tsx`** — new "Run playbook" action in the actions column. Menu lists configured workflows; picking one calls `workflowApi.execute(id, { finding_id })`. Result is surfaced via `notificationService.notifyGeneric(...)` — **no chat drawer opened**, no conversation threaded. Button hides when no workflows are configured.

## Test plan

- [x] `pytest tests/unit/test_workflow_skill_wiring.py` — 4 green.
- [x] `cd frontend && npx tsc --noEmit` — typecheck clean.
- [ ] Spin up the stack; create a skill in Settings → Skills; open a workflow that references any agent; run it — agent should invoke the `skill_*` tool and receive the rendered prompt.
- [ ] From the findings table, click the playbook action on a row — menu lists workflows, picking one fires an execute call, success snackbar appears.
- [ ] From the findings table, click the playbook action on a row when no workflows are configured — button is hidden (no empty menu).

## Stacked on #131

Base branch is `feat/soc-hardening-session` (PR #131). Once that merges, retarget to `main` — or keep as a stack; GitHub will auto-rebase.

## Related issues

- Closes #126
- #127 — persist workflow runs (`workflow_runs` table) — still open; intermediate tool_calls feedback lives inside ClaudeService today.
- #128 — enforce `approval_required` at workflow execution — still open; phase-by-phase execution is a prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
