### PR TITLE
feat(workflows): enforce phase approval_required at execution (#128)

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -13,6 +13,7 @@ from api.storage_status import router as storage_status_router
 from api.ai_decisions import router as ai_decisions_router
 from api.logs import router as logs_router
 from api.workflows import router as workflows_router
+from api.approvals import router as approvals_router
 from api.reasoning import router as reasoning_router
 from api.skills import router as skills_router
 from api.llm_providers import router as llm_providers_router
@@ -32,6 +33,7 @@ __all__ = [
     'ai_decisions_router',
     'logs_router',
     'workflows_router',
+    'approvals_router',
     'reasoning_router',
     'skills_router',
     'llm_providers_router',

--- a/backend/api/approvals.py
+++ b/backend/api/approvals.py
@@ -1,0 +1,208 @@
+"""Approvals API — list/approve/reject pending human-in-the-loop actions (#128).
+
+Workflow phase approvals surface here alongside any other pending
+action the ``ApprovalService`` is tracking (e.g. daemon-triggered
+containment actions). Approving a workflow-linked action auto-resumes
+the paused run; rejecting cancels it with the supplied reason.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class ApproveRequest(BaseModel):
+    approved_by: Optional[str] = Field(
+        default=None,
+        description="Identity of the approving analyst. Defaults to 'analyst'.",
+    )
+
+
+class RejectRequest(BaseModel):
+    reason: str = Field(..., description="Why the action is being rejected.")
+    rejected_by: Optional[str] = Field(
+        default=None,
+        description="Identity of the rejecting analyst. Defaults to 'analyst'.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pending_to_dict(action: Any) -> Dict[str, Any]:
+    """Normalise a ``PendingAction`` dataclass to a response dict."""
+    return {
+        "action_id": action.action_id,
+        "action_type": action.action_type,
+        "title": action.title,
+        "description": action.description,
+        "target": action.target,
+        "confidence": action.confidence,
+        "reason": action.reason,
+        "evidence": action.evidence,
+        "created_at": action.created_at,
+        "created_by": action.created_by,
+        "requires_approval": action.requires_approval,
+        "status": action.status,
+        "approved_at": action.approved_at,
+        "approved_by": action.approved_by,
+        "executed_at": action.executed_at,
+        "execution_result": action.execution_result,
+        "rejection_reason": action.rejection_reason,
+        "parameters": action.parameters,
+        "workflow_run_id": action.workflow_run_id,
+        "workflow_phase_id": action.workflow_phase_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/approvals")
+async def list_approvals(
+    status: Optional[str] = Query(
+        default=None,
+        description=(
+            "Filter by status: pending | approved | rejected | executed | failed."
+        ),
+    ),
+    workflow_run_id: Optional[str] = Query(
+        default=None,
+        description="Restrict to approvals linked to this workflow run.",
+    ),
+    limit: int = Query(default=100, ge=1, le=500),
+):
+    """List approval actions, newest first."""
+    from services.approval_service import (
+        ActionStatus,
+        get_approval_service,
+    )
+
+    status_enum: Optional[ActionStatus] = None
+    if status:
+        try:
+            status_enum = ActionStatus(status)
+        except ValueError:
+            raise HTTPException(status_code=400, detail=f"Invalid status: {status}")
+
+    service = get_approval_service()
+    actions = service.list_actions(
+        status=status_enum,
+        workflow_run_id=workflow_run_id,
+        limit=limit,
+    )
+    return {
+        "count": len(actions),
+        "actions": [_pending_to_dict(a) for a in actions],
+    }
+
+
+@router.get("/approvals/pending")
+async def list_pending_approvals() -> Dict[str, List[Dict[str, Any]]]:
+    """Shortcut: only actions with ``status=pending`` and
+    ``requires_approval=True``. Used by the AI Decisions approvals tab."""
+    from services.approval_service import get_approval_service
+
+    service = get_approval_service()
+    actions = service.list_pending_approvals()
+    return {"actions": [_pending_to_dict(a) for a in actions]}
+
+
+@router.get("/approvals/{action_id}")
+async def get_approval(action_id: str):
+    """Fetch a single approval action."""
+    from services.approval_service import get_approval_service
+
+    action = get_approval_service().get_action(action_id)
+    if action is None:
+        raise HTTPException(status_code=404, detail=f"Approval not found: {action_id}")
+    return _pending_to_dict(action)
+
+
+@router.post("/approvals/{action_id}/approve")
+async def approve_action(action_id: str, request: ApproveRequest):
+    """Approve a pending action.
+
+    If the action is linked to a paused workflow run, the run resumes
+    automatically and the resume result is included in the response.
+    """
+    from services.approval_service import get_approval_service
+    from services.workflows_service import get_workflows_service
+
+    service = get_approval_service()
+    action = service.get_action(action_id)
+    if action is None:
+        raise HTTPException(status_code=404, detail=f"Approval not found: {action_id}")
+
+    approved_by = request.approved_by or "analyst"
+    updated = service.approve_action(action_id, approved_by=approved_by)
+    if updated is None:
+        raise HTTPException(status_code=500, detail="Failed to approve action")
+
+    response: Dict[str, Any] = {
+        "action": _pending_to_dict(updated),
+        "resume_result": None,
+    }
+
+    if updated.workflow_run_id:
+        resume = await get_workflows_service().resume_workflow(
+            updated.workflow_run_id,
+            "approved",
+            approved_by=approved_by,
+        )
+        response["resume_result"] = resume
+
+    return response
+
+
+@router.post("/approvals/{action_id}/reject")
+async def reject_action(action_id: str, request: RejectRequest):
+    """Reject a pending action.
+
+    If the action is linked to a paused workflow run, the run is
+    cancelled with the supplied reason.
+    """
+    from services.approval_service import get_approval_service
+    from services.workflows_service import get_workflows_service
+
+    service = get_approval_service()
+    action = service.get_action(action_id)
+    if action is None:
+        raise HTTPException(status_code=404, detail=f"Approval not found: {action_id}")
+
+    rejected_by = request.rejected_by or "analyst"
+    updated = service.reject_action(
+        action_id, reason=request.reason, rejected_by=rejected_by
+    )
+    if updated is None:
+        raise HTTPException(status_code=500, detail="Failed to reject action")
+
+    response: Dict[str, Any] = {
+        "action": _pending_to_dict(updated),
+        "resume_result": None,
+    }
+
+    if updated.workflow_run_id:
+        resume = await get_workflows_service().resume_workflow(
+            updated.workflow_run_id,
+            "rejected",
+            rejection_reason=request.reason,
+            approved_by=rejected_by,
+        )
+        response["resume_result"] = resume
+
+    return response

--- a/backend/api/workflows.py
+++ b/backend/api/workflows.py
@@ -63,6 +63,19 @@ class WorkflowGenerateRequest(BaseModel):
     description: str
 
 
+class WorkflowRunResumeRequest(BaseModel):
+    """Optional payload when manually resuming a paused run."""
+
+    approved_by: Optional[str] = None
+
+
+class WorkflowRunCancelRequest(BaseModel):
+    """Payload when cancelling a paused / running run from the UI."""
+
+    reason: str
+    rejected_by: Optional[str] = None
+
+
 # -----------------------------------------------------------------------------
 # Read-only discovery endpoints (existing + extended)
 # -----------------------------------------------------------------------------
@@ -329,13 +342,126 @@ async def execute_workflow(workflow_id: str, request: WorkflowExecuteRequest):
 
 @router.get("/workflows/runs/{run_id}")
 async def get_workflow_run(run_id: str):
-    """Fetch a single workflow run by id, including its result summary."""
+    """Fetch a single workflow run by id.
+
+    Includes the full ``result_summary`` plus the list of phase rows
+    (``workflow_run_phases``) written by the phased execution loop
+    (#128). For one-shot runs with no phase rows, ``phases`` is just
+    an empty list.
+    """
     from services.workflow_run_service import get_workflow_run_service
 
-    row = get_workflow_run_service().get_run(run_id)
+    run_service = get_workflow_run_service()
+    row = run_service.get_run(run_id)
     if not row:
         raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+    row["phases"] = run_service.list_phases(run_id)
     return row
+
+
+@router.post("/workflows/runs/{run_id}/resume")
+async def resume_workflow_run(run_id: str, request: WorkflowRunResumeRequest):
+    """Resume a paused workflow run (#128).
+
+    Looks up the run's pending approval action, approves it, and
+    re-enters the phase loop. If there is no pending approval action
+    linked to the run, returns 409.
+    """
+    from services.approval_service import (
+        ActionStatus,
+        get_approval_service,
+    )
+    from services.workflow_run_service import get_workflow_run_service
+    from services.workflows_service import get_workflows_service
+
+    run_service = get_workflow_run_service()
+    run = run_service.get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+    if run.get("status") != "paused":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Run {run_id} is not paused (status={run.get('status')})",
+        )
+
+    approval_service = get_approval_service()
+    pending = [
+        a
+        for a in approval_service.list_actions(
+            status=ActionStatus.PENDING, workflow_run_id=run_id
+        )
+    ]
+    if pending:
+        approval_service.approve_action(
+            pending[0].action_id,
+            approved_by=request.approved_by or "analyst",
+        )
+
+    result = await get_workflows_service().resume_workflow(
+        run_id,
+        "approved",
+        approved_by=request.approved_by or "analyst",
+    )
+    return result
+
+
+@router.post("/workflows/runs/{run_id}/cancel")
+async def cancel_workflow_run(run_id: str, request: WorkflowRunCancelRequest):
+    """Cancel a paused or running workflow run (#128).
+
+    Rejects any pending approval action on the run and finalises it
+    as ``cancelled`` with the supplied reason.
+    """
+    from services.approval_service import (
+        ActionStatus,
+        get_approval_service,
+    )
+    from services.workflow_run_service import get_workflow_run_service
+    from services.workflows_service import get_workflows_service
+
+    run_service = get_workflow_run_service()
+    run = run_service.get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+
+    approval_service = get_approval_service()
+    pending = [
+        a
+        for a in approval_service.list_actions(
+            status=ActionStatus.PENDING, workflow_run_id=run_id
+        )
+    ]
+    for action in pending:
+        approval_service.reject_action(
+            action.action_id,
+            reason=request.reason,
+            rejected_by=request.rejected_by or "analyst",
+        )
+
+    if run.get("status") == "paused":
+        result = await get_workflows_service().resume_workflow(
+            run_id,
+            "rejected",
+            rejection_reason=request.reason,
+            approved_by=request.rejected_by or "analyst",
+        )
+        return result
+
+    # Running-but-not-paused runs: we can't interrupt the in-flight
+    # Claude call here, but we can mark the row cancelled so history
+    # reflects the user's intent. (Background-worker support would
+    # let us actually stop execution; that's out of scope for #128.)
+    run_service.finalize_run(
+        run_id,
+        status="cancelled",
+        error=f"Cancelled: {request.reason}",
+    )
+    return {
+        "success": True,
+        "status": "cancelled",
+        "run_id": run_id,
+        "rejection_reason": request.reason,
+    }
 
 
 @router.get("/workflows/{workflow_id}/runs")

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,6 +42,7 @@ from api import (
     ai_decisions_router,
     logs_router,
     workflows_router,
+    approvals_router,
     reasoning_router,
     skills_router,
     llm_providers_router,
@@ -211,6 +212,7 @@ app.include_router(detection_rules_router, prefix="/api/detection-rules", tags=[
 
 # Workflows engine
 app.include_router(workflows_router, prefix="/api", tags=["workflows"])
+app.include_router(approvals_router, prefix="/api", tags=["approvals"])
 
 # Autonomous orchestrator
 app.include_router(orchestrator_router, prefix="/api/orchestrator", tags=["orchestrator"])

--- a/database/init/13_approval_actions.sql
+++ b/database/init/13_approval_actions.sql
@@ -1,0 +1,68 @@
+-- Approval Actions — pending human-in-the-loop approvals (#128)
+--
+-- Before this migration, ApprovalService persisted pending actions to
+-- ``data/pending_actions.json``. That worked for the daemon's single-
+-- process orchestrator but was invisible to the API/UI and had no FK
+-- into workflow runs. Workflow phase-level approval gating (#128)
+-- needs a queryable, joinable surface with a direct link back to the
+-- paused workflow_run / phase.
+--
+-- This migration creates ``approval_actions`` (the DB home) and
+-- relaxes ``workflow_runs.status`` to include ``'paused'`` so a run
+-- blocked on approval has a dedicated terminal-ish state while it
+-- waits for the analyst.
+--
+-- Idempotent via IF NOT EXISTS / conditional constraint drops; safe
+-- to re-run.
+
+CREATE TABLE IF NOT EXISTS approval_actions (
+    action_id           VARCHAR(80)  PRIMARY KEY,                  -- action-YYYYMMDD-HHMMSS-ffffff
+    action_type         VARCHAR(40)  NOT NULL,                     -- ActionType enum value
+    title               TEXT         NOT NULL,
+    description         TEXT         NOT NULL,
+    target              TEXT         NOT NULL,                     -- IP, hostname, username, run_id, etc.
+    confidence          NUMERIC(4, 3) NOT NULL DEFAULT 0,          -- 0.000 - 1.000
+    reason              TEXT         NOT NULL,
+    evidence            JSONB        NOT NULL DEFAULT '[]'::jsonb, -- finding IDs / refs
+    created_at          TIMESTAMP    NOT NULL DEFAULT NOW(),
+    created_by          VARCHAR(100) NOT NULL,
+    requires_approval   BOOLEAN      NOT NULL DEFAULT TRUE,
+    status              VARCHAR(16)  NOT NULL
+        CHECK (status IN ('pending', 'approved', 'rejected', 'executed', 'failed')),
+    approved_at         TIMESTAMP,
+    approved_by         VARCHAR(100),
+    executed_at         TIMESTAMP,
+    execution_result    JSONB,
+    rejection_reason    TEXT,
+    parameters          JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    -- Workflow linkage (#128): null for non-workflow approvals (e.g.
+    -- daemon-triggered containment actions).
+    workflow_run_id     VARCHAR(80)  REFERENCES workflow_runs(run_id) ON DELETE SET NULL,
+    workflow_phase_id   TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_approval_actions_status_created
+    ON approval_actions(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_approval_actions_workflow_run
+    ON approval_actions(workflow_run_id)
+    WHERE workflow_run_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_approval_actions_pending
+    ON approval_actions(created_at DESC)
+    WHERE status = 'pending' AND requires_approval = TRUE;
+
+
+-- Extend workflow_runs.status to include 'paused'. A workflow run
+-- enters 'paused' when a phase with approval_required=TRUE blocks
+-- the loop; resume_workflow() transitions it back to 'running' on
+-- approve or 'cancelled' on reject.
+ALTER TABLE workflow_runs DROP CONSTRAINT IF EXISTS workflow_runs_status_check;
+ALTER TABLE workflow_runs ADD CONSTRAINT workflow_runs_status_check
+    CHECK (status IN ('running', 'paused', 'completed', 'failed', 'cancelled'));
+
+
+COMMENT ON TABLE  approval_actions IS 'Pending human-in-the-loop approvals. Workflow phase approvals link back via workflow_run_id + workflow_phase_id (#128).';
+COMMENT ON COLUMN approval_actions.workflow_run_id IS 'FK to workflow_runs — null for non-workflow approvals (e.g. daemon containment actions).';
+COMMENT ON COLUMN approval_actions.workflow_phase_id IS 'The phase_id inside the paused workflow run this approval gates.';
+
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON approval_actions TO deeptempo;

--- a/database/models.py
+++ b/database/models.py
@@ -1763,14 +1763,14 @@ class User(Base):
 
     # Failed-login tracking and account lockout
     failed_login_count: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default='0'
+        Integer, nullable=False, default=0, server_default="0"
     )
     locked_until: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
     # Password history — list of prior bcrypt hashes, newest first. Used
     # to reject reuse of the last N passwords. Capped in application code.
     password_history: Mapped[List[str]] = mapped_column(
-        JSONB, nullable=False, default=list, server_default='[]'
+        JSONB, nullable=False, default=list, server_default="[]"
     )
     password_changed_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime, nullable=True
@@ -2200,7 +2200,7 @@ class CustomWorkflow(Base):
     holds workflows created/edited via the Workflow Builder UI.
     """
 
-    __tablename__ = 'custom_workflows'
+    __tablename__ = "custom_workflows"
 
     workflow_id: Mapped[str] = mapped_column(String(100), primary_key=True)
 
@@ -2209,13 +2209,13 @@ class CustomWorkflow(Base):
     use_case: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     trigger_examples: Mapped[list] = mapped_column(
-        JSONB, nullable=False, default=list, server_default='[]'
+        JSONB, nullable=False, default=list, server_default="[]"
     )
     phases: Mapped[list] = mapped_column(
-        JSONB, nullable=False, default=list, server_default='[]'
+        JSONB, nullable=False, default=list, server_default="[]"
     )
     graph_layout: Mapped[dict] = mapped_column(
-        JSONB, nullable=False, default=dict, server_default='{}'
+        JSONB, nullable=False, default=dict, server_default="{}"
     )
 
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
@@ -2226,37 +2226,37 @@ class CustomWorkflow(Base):
         DateTime,
         nullable=False,
         default=datetime.utcnow,
-        server_default='now()',
+        server_default="now()",
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
         default=datetime.utcnow,
         onupdate=datetime.utcnow,
-        server_default='now()',
+        server_default="now()",
     )
 
     __table_args__ = (
-        Index('idx_custom_workflows_active', 'is_active'),
-        Index('idx_custom_workflows_created_by', 'created_by'),
-        Index('idx_custom_workflows_name', 'name'),
+        Index("idx_custom_workflows_active", "is_active"),
+        Index("idx_custom_workflows_created_by", "created_by"),
+        Index("idx_custom_workflows_name", "name"),
     )
 
     def to_dict(self) -> dict:
         """Convert custom workflow to dictionary."""
         return {
-            'workflow_id': self.workflow_id,
-            'name': self.name,
-            'description': self.description,
-            'use_case': self.use_case,
-            'trigger_examples': self.trigger_examples or [],
-            'phases': self.phases or [],
-            'graph_layout': self.graph_layout or {},
-            'is_active': self.is_active,
-            'created_by': self.created_by,
-            'version': self.version,
-            'created_at': self.created_at.isoformat() if self.created_at else None,
-            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+            "workflow_id": self.workflow_id,
+            "name": self.name,
+            "description": self.description,
+            "use_case": self.use_case,
+            "trigger_examples": self.trigger_examples or [],
+            "phases": self.phases or [],
+            "graph_layout": self.graph_layout or {},
+            "is_active": self.is_active,
+            "created_by": self.created_by,
+            "version": self.version,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
 
 
@@ -2268,63 +2268,63 @@ class WorkflowRun(Base):
     reserved for phase-by-phase execution (#128) and may be absent.
     """
 
-    __tablename__ = 'workflow_runs'
+    __tablename__ = "workflow_runs"
 
     run_id: Mapped[str] = mapped_column(String(80), primary_key=True)
     workflow_id: Mapped[str] = mapped_column(Text, nullable=False)
     workflow_version: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     workflow_source: Mapped[str] = mapped_column(
-        String(16), nullable=False, default='file', server_default='file'
+        String(16), nullable=False, default="file", server_default="file"
     )
     workflow_name: Mapped[str] = mapped_column(Text, nullable=False)
 
     status: Mapped[str] = mapped_column(String(16), nullable=False)
     triggered_by: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     trigger_context: Mapped[dict] = mapped_column(
-        JSONB, nullable=False, default=dict, server_default='{}'
+        JSONB, nullable=False, default=dict, server_default="{}"
     )
 
     started_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default='now()'
+        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
     )
     finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     duration_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
     total_cost_usd: Mapped[float] = mapped_column(
-        Numeric(10, 4), nullable=False, default=0, server_default='0'
+        Numeric(10, 4), nullable=False, default=0, server_default="0"
     )
     result_summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     skill_tools_available: Mapped[list] = mapped_column(
-        JSONB, nullable=False, default=list, server_default='[]'
+        JSONB, nullable=False, default=list, server_default="[]"
     )
     error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     __table_args__ = (
-        Index('idx_workflow_runs_workflow_id', 'workflow_id', 'started_at'),
-        Index('idx_workflow_runs_started_at', 'started_at'),
+        Index("idx_workflow_runs_workflow_id", "workflow_id", "started_at"),
+        Index("idx_workflow_runs_started_at", "started_at"),
     )
 
     def to_dict(self, include_result: bool = False) -> dict:
         """Serialise the run. ``include_result`` gates the potentially-large
         ``result_summary`` field so list endpoints stay light."""
         out: dict = {
-            'run_id': self.run_id,
-            'workflow_id': self.workflow_id,
-            'workflow_version': self.workflow_version,
-            'workflow_source': self.workflow_source,
-            'workflow_name': self.workflow_name,
-            'status': self.status,
-            'triggered_by': self.triggered_by,
-            'trigger_context': self.trigger_context or {},
-            'started_at': self.started_at.isoformat() if self.started_at else None,
-            'finished_at': self.finished_at.isoformat() if self.finished_at else None,
-            'duration_ms': self.duration_ms,
-            'total_cost_usd': float(self.total_cost_usd or 0),
-            'skill_tools_available': self.skill_tools_available or [],
-            'error': self.error,
+            "run_id": self.run_id,
+            "workflow_id": self.workflow_id,
+            "workflow_version": self.workflow_version,
+            "workflow_source": self.workflow_source,
+            "workflow_name": self.workflow_name,
+            "status": self.status,
+            "triggered_by": self.triggered_by,
+            "trigger_context": self.trigger_context or {},
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "duration_ms": self.duration_ms,
+            "total_cost_usd": float(self.total_cost_usd or 0),
+            "skill_tools_available": self.skill_tools_available or [],
+            "error": self.error,
         }
         if include_result:
-            out['result_summary'] = self.result_summary
+            out["result_summary"] = self.result_summary
         return out
 
 
@@ -2336,11 +2336,11 @@ class WorkflowRunPhase(Base):
     until phase-level execution lands.
     """
 
-    __tablename__ = 'workflow_run_phases'
+    __tablename__ = "workflow_run_phases"
 
     run_id: Mapped[str] = mapped_column(
         String(80),
-        ForeignKey('workflow_runs.run_id', ondelete='CASCADE'),
+        ForeignKey("workflow_runs.run_id", ondelete="CASCADE"),
         primary_key=True,
     )
     phase_id: Mapped[str] = mapped_column(Text, primary_key=True)
@@ -2353,36 +2353,110 @@ class WorkflowRunPhase(Base):
     duration_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
     input_context: Mapped[dict] = mapped_column(
-        JSONB, nullable=False, default=dict, server_default='{}'
+        JSONB, nullable=False, default=dict, server_default="{}"
     )
     output: Mapped[dict] = mapped_column(
-        JSONB, nullable=False, default=dict, server_default='{}'
+        JSONB, nullable=False, default=dict, server_default="{}"
     )
     approval_state: Mapped[Optional[str]] = mapped_column(String(16), nullable=True)
     cost_usd: Mapped[float] = mapped_column(
-        Numeric(10, 4), nullable=False, default=0, server_default='0'
+        Numeric(10, 4), nullable=False, default=0, server_default="0"
     )
     error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
+    __table_args__ = (Index("idx_workflow_run_phases_run_id", "run_id", "phase_order"),)
+
+    def to_dict(self) -> dict:
+        return {
+            "run_id": self.run_id,
+            "phase_id": self.phase_id,
+            "phase_order": self.phase_order,
+            "agent_id": self.agent_id,
+            "status": self.status,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "duration_ms": self.duration_ms,
+            "input_context": self.input_context or {},
+            "output": self.output or {},
+            "approval_state": self.approval_state,
+            "cost_usd": float(self.cost_usd or 0),
+            "error": self.error,
+        }
+
+
+class ApprovalAction(Base):
+    """Pending human-in-the-loop approval (#128).
+
+    Supersedes the JSON-file persistence that ApprovalService used to
+    do. Workflow phase-level approvals link back to the paused run via
+    ``workflow_run_id`` + ``workflow_phase_id``. Non-workflow approvals
+    (daemon containment actions, etc.) leave those columns null.
+    """
+
+    __tablename__ = "approval_actions"
+
+    action_id: Mapped[str] = mapped_column(String(80), primary_key=True)
+    action_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    target: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence: Mapped[float] = mapped_column(
+        Numeric(4, 3), nullable=False, default=0, server_default="0"
+    )
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    evidence: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+    )
+    created_by: Mapped[str] = mapped_column(String(100), nullable=False)
+    requires_approval: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    approved_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    approved_by: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    executed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    execution_result: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
+    rejection_reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    parameters: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default="{}"
+    )
+    workflow_run_id: Mapped[Optional[str]] = mapped_column(
+        String(80),
+        ForeignKey("workflow_runs.run_id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    workflow_phase_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
     __table_args__ = (
-        Index('idx_workflow_run_phases_run_id', 'run_id', 'phase_order'),
+        Index("idx_approval_actions_status_created", "status", "created_at"),
+        Index("idx_approval_actions_workflow_run", "workflow_run_id"),
     )
 
     def to_dict(self) -> dict:
         return {
-            'run_id': self.run_id,
-            'phase_id': self.phase_id,
-            'phase_order': self.phase_order,
-            'agent_id': self.agent_id,
-            'status': self.status,
-            'started_at': self.started_at.isoformat() if self.started_at else None,
-            'finished_at': self.finished_at.isoformat() if self.finished_at else None,
-            'duration_ms': self.duration_ms,
-            'input_context': self.input_context or {},
-            'output': self.output or {},
-            'approval_state': self.approval_state,
-            'cost_usd': float(self.cost_usd or 0),
-            'error': self.error,
+            "action_id": self.action_id,
+            "action_type": self.action_type,
+            "title": self.title,
+            "description": self.description,
+            "target": self.target,
+            "confidence": float(self.confidence or 0),
+            "reason": self.reason,
+            "evidence": self.evidence or [],
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "created_by": self.created_by,
+            "requires_approval": bool(self.requires_approval),
+            "status": self.status,
+            "approved_at": self.approved_at.isoformat() if self.approved_at else None,
+            "approved_by": self.approved_by,
+            "executed_at": self.executed_at.isoformat() if self.executed_at else None,
+            "execution_result": self.execution_result,
+            "rejection_reason": self.rejection_reason,
+            "parameters": self.parameters or {},
+            "workflow_run_id": self.workflow_run_id,
+            "workflow_phase_id": self.workflow_phase_id,
         }
 
 
@@ -2390,7 +2464,7 @@ class Skill(Base):
     """Skill model - reusable, parameterized SOC capability (detection,
     enrichment, response, reporting) that agents and workflows can invoke."""
 
-    __tablename__ = 'skills'
+    __tablename__ = "skills"
 
     skill_id: Mapped[str] = mapped_column(String(32), primary_key=True)
 
@@ -2400,88 +2474,88 @@ class Skill(Base):
 
     # JSON Schema for skill parameters (the inputs the skill accepts).
     input_schema: Mapped[dict] = mapped_column(
-        JSONB, nullable=False, default=dict, server_default='{}'
+        JSONB, nullable=False, default=dict, server_default="{}"
     )
     # JSON Schema for skill output.
     output_schema: Mapped[dict] = mapped_column(
-        JSONB, nullable=False, default=dict, server_default='{}'
+        JSONB, nullable=False, default=dict, server_default="{}"
     )
     # MCP tool names required by this skill
     # (e.g. ["splunk.search", "virustotal.hash_lookup"]).
     required_tools: Mapped[List[str]] = mapped_column(
-        JSONB, nullable=False, default=list, server_default='[]'
+        JSONB, nullable=False, default=list, server_default="[]"
     )
     # LLM instructions; may contain {{param}} placeholders.
     prompt_template: Mapped[str] = mapped_column(Text, nullable=False)
     # Ordered execution steps (tool calls / prompts / transforms) — interpreted
     # by the future skill-execution worker.
     execution_steps: Mapped[List[dict]] = mapped_column(
-        JSONB, nullable=False, default=list, server_default='[]'
+        JSONB, nullable=False, default=list, server_default="[]"
     )
 
     is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=True, server_default='true'
+        Boolean, nullable=False, default=True, server_default="true"
     )
     created_by: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     version: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=1, server_default='1'
+        Integer, nullable=False, default=1, server_default="1"
     )
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
         default=datetime.utcnow,
-        server_default='now()',
+        server_default="now()",
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
         default=datetime.utcnow,
         onupdate=datetime.utcnow,
-        server_default='now()',
+        server_default="now()",
     )
 
     __table_args__ = (
-        Index('idx_skill_category', 'category'),
-        Index('idx_skill_is_active', 'is_active'),
+        Index("idx_skill_category", "category"),
+        Index("idx_skill_is_active", "is_active"),
         Index(
-            'idx_skill_name_trgm',
-            'name',
-            postgresql_ops={'name': 'gin_trgm_ops'},
-            postgresql_using='gin',
+            "idx_skill_name_trgm",
+            "name",
+            postgresql_ops={"name": "gin_trgm_ops"},
+            postgresql_using="gin",
         ),
     )
 
     @staticmethod
     def generate_skill_id() -> str:
         """Generate a new skill_id in the form s-YYYYMMDD-XXXXXXXX."""
-        ts = datetime.utcnow().strftime('%Y%m%d')
+        ts = datetime.utcnow().strftime("%Y%m%d")
         return f"s-{ts}-{uuid.uuid4().hex[:8].upper()}"
 
     def to_dict(self) -> dict:
         """Convert skill to dictionary."""
         return {
-            'skill_id': self.skill_id,
-            'name': self.name,
-            'description': self.description,
-            'category': self.category,
-            'input_schema': self.input_schema or {},
-            'output_schema': self.output_schema or {},
-            'required_tools': self.required_tools or [],
-            'prompt_template': self.prompt_template,
-            'execution_steps': self.execution_steps or [],
-            'is_active': self.is_active,
-            'created_by': self.created_by,
-            'version': self.version,
-            'created_at': self.created_at.isoformat() if self.created_at else None,
-            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+            "skill_id": self.skill_id,
+            "name": self.name,
+            "description": self.description,
+            "category": self.category,
+            "input_schema": self.input_schema or {},
+            "output_schema": self.output_schema or {},
+            "required_tools": self.required_tools or [],
+            "prompt_template": self.prompt_template,
+            "execution_steps": self.execution_steps or [],
+            "is_active": self.is_active,
+            "created_by": self.created_by,
+            "version": self.version,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
 
 
 class CustomAgent(Base):
     """User-defined SOC agent created via the Agent Builder UI."""
 
-    __tablename__ = 'custom_agents'
+    __tablename__ = "custom_agents"
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
     name: Mapped[str] = mapped_column(Text, nullable=False)
@@ -2491,16 +2565,29 @@ class CustomAgent(Base):
     specialization: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     role: Mapped[str] = mapped_column(Text, nullable=False)
-    extra_principles: Mapped[str] = mapped_column(Text, nullable=False, default='', server_default='')
-    methodology: Mapped[str] = mapped_column(Text, nullable=False, default='', server_default='')
+    extra_principles: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=""
+    )
+    methodology: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=""
+    )
     system_prompt_override: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
-    recommended_tools: Mapped[list] = mapped_column(JSONB, nullable=False, default=list, server_default='[]')
-    max_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=4096, server_default='4096')
-    enable_thinking: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default='false')
+    recommended_tools: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]"
+    )
+    max_tokens: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=4096, server_default="4096"
+    )
+    enable_thinking: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
     model: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     component_category: Mapped[str] = mapped_column(
-        String(32), nullable=False, default='investigation', server_default='investigation'
+        String(32),
+        nullable=False,
+        default="investigation",
+        server_default="investigation",
     )
     # Origin agent ID this row was forked from (built-in id like "reporter" or
     # another custom id). Null for agents authored from scratch. Breadcrumb
@@ -2509,39 +2596,40 @@ class CustomAgent(Base):
 
     created_by: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default='now()'
+        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow,
-        onupdate=datetime.utcnow, server_default='now()'
+        DateTime,
+        nullable=False,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        server_default="now()",
     )
 
-    __table_args__ = (
-        Index('idx_custom_agents_updated_at', 'updated_at'),
-    )
+    __table_args__ = (Index("idx_custom_agents_updated_at", "updated_at"),)
 
     def to_dict(self) -> dict:
         """Convert custom agent to dictionary."""
         return {
-            'id': self.id,
-            'name': self.name,
-            'description': self.description,
-            'icon': self.icon,
-            'color': self.color,
-            'specialization': self.specialization,
-            'role': self.role,
-            'extra_principles': self.extra_principles,
-            'methodology': self.methodology,
-            'system_prompt_override': self.system_prompt_override,
-            'recommended_tools': self.recommended_tools or [],
-            'max_tokens': self.max_tokens,
-            'enable_thinking': self.enable_thinking,
-            'model': self.model,
-            'component_category': self.component_category,
-            'forked_from': self.forked_from,
-            'created_by': self.created_by,
-            'created_at': self.created_at.isoformat() if self.created_at else None,
-            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "icon": self.icon,
+            "color": self.color,
+            "specialization": self.specialization,
+            "role": self.role,
+            "extra_principles": self.extra_principles,
+            "methodology": self.methodology,
+            "system_prompt_override": self.system_prompt_override,
+            "recommended_tools": self.recommended_tools or [],
+            "max_tokens": self.max_tokens,
+            "enable_thinking": self.enable_thinking,
+            "model": self.model,
+            "component_category": self.component_category,
+            "forked_from": self.forked_from,
+            "created_by": self.created_by,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
 
 
@@ -2552,7 +2640,7 @@ class LLMProviderConfig(Base):
     See database/init/09_llm_providers.sql for the table definition.
     """
 
-    __tablename__ = 'llm_provider_configs'
+    __tablename__ = "llm_provider_configs"
 
     provider_id: Mapped[str] = mapped_column(String(64), primary_key=True)
     provider_type: Mapped[str] = mapped_column(String(32), nullable=False)
@@ -2567,43 +2655,45 @@ class LLMProviderConfig(Base):
     last_test_success: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
     last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default='now()'
+        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default='now()'
+        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
     )
 
     __table_args__ = (
-        Index('idx_llm_provider_type', 'provider_type'),
-        Index('idx_llm_provider_active', 'is_active'),
+        Index("idx_llm_provider_type", "provider_type"),
+        Index("idx_llm_provider_active", "is_active"),
         # Partial unique index — enforces "one default per provider_type"
         # for non-Docker deployments too (Base.metadata.create_all path).
         # Mirrors the SQL in database/init/07_llm_providers.sql.
         Index(
-            'llm_provider_default_per_type',
-            'provider_type',
+            "llm_provider_default_per_type",
+            "provider_type",
             unique=True,
-            postgresql_where=text('is_default = TRUE'),
+            postgresql_where=text("is_default = TRUE"),
         ),
     )
 
     def to_dict(self, include_secrets: bool = False) -> dict:
         return {
-            'provider_id': self.provider_id,
-            'provider_type': self.provider_type,
-            'name': self.name,
-            'base_url': self.base_url,
-            'api_key_ref': self.api_key_ref if include_secrets else None,
-            'has_api_key': bool(self.api_key_ref),
-            'default_model': self.default_model,
-            'is_active': self.is_active,
-            'is_default': self.is_default,
-            'config': self.config or {},
-            'last_test_at': self.last_test_at.isoformat() if self.last_test_at else None,
-            'last_test_success': self.last_test_success,
-            'last_error': self.last_error,
-            'created_at': self.created_at.isoformat() if self.created_at else None,
-            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+            "provider_id": self.provider_id,
+            "provider_type": self.provider_type,
+            "name": self.name,
+            "base_url": self.base_url,
+            "api_key_ref": self.api_key_ref if include_secrets else None,
+            "has_api_key": bool(self.api_key_ref),
+            "default_model": self.default_model,
+            "is_active": self.is_active,
+            "is_default": self.is_default,
+            "config": self.config or {},
+            "last_test_at": (
+                self.last_test_at.isoformat() if self.last_test_at else None
+            ),
+            "last_test_success": self.last_test_success,
+            "last_error": self.last_error,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
 
 
@@ -2619,35 +2709,33 @@ class AIModelConfig(Base):
     See database/init/10_ai_model_configs.sql for the table definition.
     """
 
-    __tablename__ = 'ai_model_configs'
+    __tablename__ = "ai_model_configs"
 
     component: Mapped[str] = mapped_column(String(64), primary_key=True)
     provider_id: Mapped[str] = mapped_column(
         String(64),
-        ForeignKey('llm_provider_configs.provider_id', ondelete='RESTRICT'),
+        ForeignKey("llm_provider_configs.provider_id", ondelete="RESTRICT"),
         nullable=False,
     )
     model_id: Mapped[str] = mapped_column(String(200), nullable=False)
     settings: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     updated_by: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default='now()'
+        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default='now()'
+        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
     )
 
-    __table_args__ = (
-        Index('idx_ai_model_configs_provider', 'provider_id'),
-    )
+    __table_args__ = (Index("idx_ai_model_configs_provider", "provider_id"),)
 
     def to_dict(self) -> dict:
         return {
-            'component': self.component,
-            'provider_id': self.provider_id,
-            'model_id': self.model_id,
-            'settings': self.settings or {},
-            'updated_by': self.updated_by,
-            'created_at': self.created_at.isoformat() if self.created_at else None,
-            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+            "component": self.component,
+            "provider_id": self.provider_id,
+            "model_id": self.model_id,
+            "settings": self.settings or {},
+            "updated_by": self.updated_by,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/frontend/src/pages/AIDecisions.tsx
+++ b/frontend/src/pages/AIDecisions.tsx
@@ -26,6 +26,11 @@ import {
   alpha,
   useTheme,
   Link,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
 } from '@mui/material'
 import {
   Feedback as FeedbackIcon,
@@ -34,8 +39,10 @@ import {
   Analytics as AnalyticsIcon,
   TrendingUp as TrendingUpIcon,
   Timer as TimerIcon,
+  ThumbUp as ThumbUpIcon,
+  ThumbDown as ThumbDownIcon,
 } from '@mui/icons-material'
-import { aiDecisionsApi } from '../services/api'
+import { aiDecisionsApi, approvalsApi } from '../services/api'
 import AIDecisionFeedback from '../components/ai/AIDecisionFeedback'
 import { StatCard, StatusBadge } from '../components/ui'
 import { severityColors } from '../theme'
@@ -71,6 +78,15 @@ export default function AIDecisionsPage() {
   const [hoveredRow, setHoveredRow] = useState<string | null>(null)
   const [investigationFilter, setInvestigationFilter] = useState<string | null>(null)
 
+  // #128 — pending workflow phase / daemon-action approvals
+  const [pendingApprovals, setPendingApprovals] = useState<any[]>([])
+  const [approvalActing, setApprovalActing] = useState<string | null>(null)
+  const [rejectDialog, setRejectDialog] = useState<{ open: boolean; action: any | null }>({
+    open: false,
+    action: null,
+  })
+  const [rejectReason, setRejectReason] = useState('')
+
   useEffect(() => {
     const agentParam = searchParams.get('agent_id')
     const invParam = searchParams.get('investigation_id')
@@ -102,10 +118,58 @@ export default function AIDecisionsPage() {
       const statsParams = filterAgent !== 'all' ? { agent_id: filterAgent } : {}
       const statsResponse = await aiDecisionsApi.getStats(statsParams)
       setStats(statsResponse.data)
+      const approvalsResponse = await approvalsApi.listPending()
+      setPendingApprovals(approvalsResponse.data?.actions || [])
     } catch (err: any) {
       setError(err.response?.data?.detail || 'Failed to load AI decisions')
     } finally {
       setLoading(false)
+    }
+  }
+
+  const reloadApprovals = async () => {
+    try {
+      const response = await approvalsApi.listPending()
+      setPendingApprovals(response.data?.actions || [])
+    } catch (err: any) {
+      setError(err.response?.data?.detail || 'Failed to reload approvals')
+    }
+  }
+
+  const handleApprove = async (action: any) => {
+    setApprovalActing(action.action_id)
+    try {
+      await approvalsApi.approve(action.action_id)
+      await reloadApprovals()
+    } catch (err: any) {
+      setError(err.response?.data?.detail || 'Failed to approve action')
+    } finally {
+      setApprovalActing(null)
+    }
+  }
+
+  const openRejectDialog = (action: any) => {
+    setRejectDialog({ open: true, action })
+    setRejectReason('')
+  }
+
+  const closeRejectDialog = () => {
+    setRejectDialog({ open: false, action: null })
+    setRejectReason('')
+  }
+
+  const submitReject = async () => {
+    const action = rejectDialog.action
+    if (!action || !rejectReason.trim()) return
+    setApprovalActing(action.action_id)
+    try {
+      await approvalsApi.reject(action.action_id, rejectReason.trim())
+      closeRejectDialog()
+      await reloadApprovals()
+    } catch (err: any) {
+      setError(err.response?.data?.detail || 'Failed to reject action')
+    } finally {
+      setApprovalActing(null)
     }
   }
 
@@ -220,6 +284,10 @@ export default function AIDecisionsPage() {
             <Tab label={`Pending (${pendingDecisions.length})`} sx={{ minHeight: 48 }} />
             <Tab label="All Decisions" sx={{ minHeight: 48 }} />
             <Tab label="Analytics" sx={{ minHeight: 48 }} />
+            <Tab
+              label={`Pending Approvals (${pendingApprovals.length})`}
+              sx={{ minHeight: 48 }}
+            />
           </Tabs>
         </Box>
 
@@ -430,6 +498,145 @@ export default function AIDecisionsPage() {
             </TableContainer>
           </TabPanel>
 
+          <TabPanel value={tabValue} index={3}>
+            {pendingApprovals.length === 0 ? (
+              <Box sx={{ py: 6, textAlign: 'center' }}>
+                <CheckIcon sx={{ fontSize: 48, color: 'success.main', mb: 1 }} />
+                <Typography color="text.secondary">
+                  No pending approvals. Workflow phases that require approval will appear here.
+                </Typography>
+              </Box>
+            ) : (
+              <TableContainer>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Action</TableCell>
+                      <TableCell>Target / Run</TableCell>
+                      <TableCell>Phase</TableCell>
+                      <TableCell>Reason</TableCell>
+                      <TableCell>Created</TableCell>
+                      <TableCell align="right" sx={{ width: 200 }}>
+                        Decision
+                      </TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {pendingApprovals.map((action) => (
+                      <TableRow key={action.action_id}>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                            {action.title}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ display: 'block', maxWidth: 320 }}
+                          >
+                            {action.description}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          {action.workflow_run_id ? (
+                            <Tooltip title="View workflow run">
+                              <Link
+                                component="button"
+                                variant="body2"
+                                sx={{
+                                  fontFamily: 'monospace',
+                                  fontSize: '0.7rem',
+                                  cursor: 'pointer',
+                                }}
+                                onClick={() =>
+                                  navigate(
+                                    `/workflows?run_id=${action.workflow_run_id}`,
+                                  )
+                                }
+                              >
+                                {action.workflow_run_id}
+                              </Link>
+                            </Tooltip>
+                          ) : (
+                            <Typography
+                              variant="caption"
+                              sx={{ fontFamily: 'monospace' }}
+                            >
+                              {action.target}
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {action.workflow_phase_id ? (
+                            <Chip
+                              label={action.workflow_phase_id}
+                              size="small"
+                              variant="outlined"
+                            />
+                          ) : (
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                            >
+                              —
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Tooltip title={action.reason}>
+                            <Typography
+                              variant="body2"
+                              noWrap
+                              sx={{ maxWidth: 220 }}
+                            >
+                              {action.reason}
+                            </Typography>
+                          </Tooltip>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="caption" color="text.secondary">
+                            {formatDateTime(action.created_at)}
+                          </Typography>
+                        </TableCell>
+                        <TableCell align="right">
+                          <Stack
+                            direction="row"
+                            spacing={1}
+                            justifyContent="flex-end"
+                          >
+                            <Button
+                              size="small"
+                              variant="contained"
+                              color="success"
+                              startIcon={
+                                <ThumbUpIcon sx={{ fontSize: 16 }} />
+                              }
+                              disabled={approvalActing === action.action_id}
+                              onClick={() => handleApprove(action)}
+                            >
+                              Approve
+                            </Button>
+                            <Button
+                              size="small"
+                              variant="outlined"
+                              color="error"
+                              startIcon={
+                                <ThumbDownIcon sx={{ fontSize: 16 }} />
+                              }
+                              disabled={approvalActing === action.action_id}
+                              onClick={() => openRejectDialog(action)}
+                            >
+                              Reject
+                            </Button>
+                          </Stack>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            )}
+          </TabPanel>
+
           <TabPanel value={tabValue} index={2}>
             <Grid container spacing={3}>
               <Grid item xs={12} md={6}>
@@ -488,6 +695,41 @@ export default function AIDecisionsPage() {
         decision={selectedDecision}
         onFeedbackSubmitted={loadData}
       />
+
+      <Dialog
+        open={rejectDialog.open}
+        onClose={closeRejectDialog}
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle>Reject action</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {rejectDialog.action?.title}
+          </Typography>
+          <TextField
+            autoFocus
+            fullWidth
+            multiline
+            minRows={3}
+            label="Rejection reason"
+            value={rejectReason}
+            onChange={(e) => setRejectReason(e.target.value)}
+            helperText="Required. This is recorded on the workflow run's audit trail."
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeRejectDialog}>Cancel</Button>
+          <Button
+            variant="contained"
+            color="error"
+            disabled={!rejectReason.trim() || !!approvalActing}
+            onClick={submitReject}
+          >
+            Reject
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   )
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -113,8 +113,28 @@ export const aiDecisionsApi = {
     days?: number
   }) => api.get('/ai/decisions/stats', { params }),
   
-  getPendingFeedback: (limit?: number) => 
+  getPendingFeedback: (limit?: number) =>
     api.get('/ai/decisions/pending-feedback', { params: { limit } }),
+}
+
+// Approvals API (#128) — pending human-in-the-loop actions, including
+// workflow phase approvals that pause execution until a decision is made.
+export const approvalsApi = {
+  list: (params?: {
+    status?: string
+    workflow_run_id?: string
+    limit?: number
+  }) => api.get('/approvals', { params }),
+
+  listPending: () => api.get('/approvals/pending'),
+
+  getById: (actionId: string) => api.get(`/approvals/${actionId}`),
+
+  approve: (actionId: string, approved_by?: string) =>
+    api.post(`/approvals/${actionId}/approve`, { approved_by }),
+
+  reject: (actionId: string, reason: string, rejected_by?: string) =>
+    api.post(`/approvals/${actionId}/reject`, { reason, rejected_by }),
 }
 
 // Findings API

--- a/helm/vigil/files/database-init/13_approval_actions.sql
+++ b/helm/vigil/files/database-init/13_approval_actions.sql
@@ -1,0 +1,68 @@
+-- Approval Actions — pending human-in-the-loop approvals (#128)
+--
+-- Before this migration, ApprovalService persisted pending actions to
+-- ``data/pending_actions.json``. That worked for the daemon's single-
+-- process orchestrator but was invisible to the API/UI and had no FK
+-- into workflow runs. Workflow phase-level approval gating (#128)
+-- needs a queryable, joinable surface with a direct link back to the
+-- paused workflow_run / phase.
+--
+-- This migration creates ``approval_actions`` (the DB home) and
+-- relaxes ``workflow_runs.status`` to include ``'paused'`` so a run
+-- blocked on approval has a dedicated terminal-ish state while it
+-- waits for the analyst.
+--
+-- Idempotent via IF NOT EXISTS / conditional constraint drops; safe
+-- to re-run.
+
+CREATE TABLE IF NOT EXISTS approval_actions (
+    action_id           VARCHAR(80)  PRIMARY KEY,                  -- action-YYYYMMDD-HHMMSS-ffffff
+    action_type         VARCHAR(40)  NOT NULL,                     -- ActionType enum value
+    title               TEXT         NOT NULL,
+    description         TEXT         NOT NULL,
+    target              TEXT         NOT NULL,                     -- IP, hostname, username, run_id, etc.
+    confidence          NUMERIC(4, 3) NOT NULL DEFAULT 0,          -- 0.000 - 1.000
+    reason              TEXT         NOT NULL,
+    evidence            JSONB        NOT NULL DEFAULT '[]'::jsonb, -- finding IDs / refs
+    created_at          TIMESTAMP    NOT NULL DEFAULT NOW(),
+    created_by          VARCHAR(100) NOT NULL,
+    requires_approval   BOOLEAN      NOT NULL DEFAULT TRUE,
+    status              VARCHAR(16)  NOT NULL
+        CHECK (status IN ('pending', 'approved', 'rejected', 'executed', 'failed')),
+    approved_at         TIMESTAMP,
+    approved_by         VARCHAR(100),
+    executed_at         TIMESTAMP,
+    execution_result    JSONB,
+    rejection_reason    TEXT,
+    parameters          JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    -- Workflow linkage (#128): null for non-workflow approvals (e.g.
+    -- daemon-triggered containment actions).
+    workflow_run_id     VARCHAR(80)  REFERENCES workflow_runs(run_id) ON DELETE SET NULL,
+    workflow_phase_id   TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_approval_actions_status_created
+    ON approval_actions(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_approval_actions_workflow_run
+    ON approval_actions(workflow_run_id)
+    WHERE workflow_run_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_approval_actions_pending
+    ON approval_actions(created_at DESC)
+    WHERE status = 'pending' AND requires_approval = TRUE;
+
+
+-- Extend workflow_runs.status to include 'paused'. A workflow run
+-- enters 'paused' when a phase with approval_required=TRUE blocks
+-- the loop; resume_workflow() transitions it back to 'running' on
+-- approve or 'cancelled' on reject.
+ALTER TABLE workflow_runs DROP CONSTRAINT IF EXISTS workflow_runs_status_check;
+ALTER TABLE workflow_runs ADD CONSTRAINT workflow_runs_status_check
+    CHECK (status IN ('running', 'paused', 'completed', 'failed', 'cancelled'));
+
+
+COMMENT ON TABLE  approval_actions IS 'Pending human-in-the-loop approvals. Workflow phase approvals link back via workflow_run_id + workflow_phase_id (#128).';
+COMMENT ON COLUMN approval_actions.workflow_run_id IS 'FK to workflow_runs — null for non-workflow approvals (e.g. daemon containment actions).';
+COMMENT ON COLUMN approval_actions.workflow_phase_id IS 'The phase_id inside the paused workflow run this approval gates.';
+
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON approval_actions TO deeptempo;

--- a/services/approval_service.py
+++ b/services/approval_service.py
@@ -1,34 +1,53 @@
-"""Approval service for managing pending autonomous actions."""
+"""Approval service for managing pending autonomous actions.
 
-import json
+Actions are persisted in the ``approval_actions`` table (#128). Prior
+to that migration, pending actions lived in ``data/pending_actions.json``
+— fine for the daemon's single-process loop but invisible to the API
+and with no FK into workflow runs. The DB move gives us a queryable,
+joinable surface that links workflow phase approvals back to the run
+they paused.
+
+Public API (``create_action``, ``approve_action``, ``reject_action``,
+``mark_executed``, ``mark_failed``, ``list_actions``, ``get_action``)
+is intentionally preserved so ``daemon/orchestrator.py`` (and any
+other existing callers) keep working.
+"""
+
 import logging
-from typing import Dict, List, Optional
-from pathlib import Path
+from dataclasses import dataclass
 from datetime import datetime
-from dataclasses import dataclass, asdict
 from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional
 import sys
 
-# Add path for database imports
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from database.config_service import get_config_service
+from database.connection import get_db_manager
+from database.models import ApprovalAction as ApprovalActionRow
 
 logger = logging.getLogger(__name__)
 
 
 class ActionType(Enum):
     """Types of actions that can be approved."""
+
     ISOLATE_HOST = "isolate_host"
     BLOCK_IP = "block_ip"
     BLOCK_DOMAIN = "block_domain"
     QUARANTINE_FILE = "quarantine_file"
     DISABLE_USER = "disable_user"
     EXECUTE_SPL_QUERY = "execute_spl_query"
+    WORKFLOW_PHASE = "workflow_phase"  # #128 — phase with approval_required=True
     CUSTOM = "custom"
 
 
 class ActionStatus(Enum):
     """Status of pending actions."""
+
     PENDING = "pending"
     APPROVED = "approved"
     REJECTED = "rejected"
@@ -38,7 +57,12 @@ class ActionStatus(Enum):
 
 @dataclass
 class PendingAction:
-    """Represents a pending action awaiting approval."""
+    """Represents a pending action awaiting approval.
+
+    Kept as a dataclass for API-stable serialisation; populated from
+    ``ApprovalAction`` ORM rows by ``_row_to_pending``.
+    """
+
     action_id: str
     action_type: str  # ActionType value
     title: str
@@ -46,9 +70,9 @@ class PendingAction:
     target: str  # IP, hostname, username, etc.
     confidence: float
     reason: str
-    evidence: List[str]  # Finding IDs or evidence references
+    evidence: List[str]
     created_at: str
-    created_by: str  # "auto_responder", "investigator", etc.
+    created_by: str
     requires_approval: bool
     status: str  # ActionStatus value
     approved_at: Optional[str] = None
@@ -56,242 +80,164 @@ class PendingAction:
     executed_at: Optional[str] = None
     execution_result: Optional[Dict] = None
     rejection_reason: Optional[str] = None
-    
-    # Action-specific parameters
     parameters: Optional[Dict] = None
+    # #128 — workflow phase approvals link back here.
+    workflow_run_id: Optional[str] = None
+    workflow_phase_id: Optional[str] = None
+
+
+def _row_to_pending(row: ApprovalActionRow) -> PendingAction:
+    return PendingAction(
+        action_id=row.action_id,
+        action_type=row.action_type,
+        title=row.title,
+        description=row.description,
+        target=row.target,
+        confidence=float(row.confidence or 0),
+        reason=row.reason,
+        evidence=list(row.evidence or []),
+        created_at=row.created_at.isoformat() if row.created_at else "",
+        created_by=row.created_by,
+        requires_approval=bool(row.requires_approval),
+        status=row.status,
+        approved_at=row.approved_at.isoformat() if row.approved_at else None,
+        approved_by=row.approved_by,
+        executed_at=row.executed_at.isoformat() if row.executed_at else None,
+        execution_result=row.execution_result,
+        rejection_reason=row.rejection_reason,
+        parameters=dict(row.parameters or {}),
+        workflow_run_id=row.workflow_run_id,
+        workflow_phase_id=row.workflow_phase_id,
+    )
 
 
 class ApprovalService:
     """Service for managing approval workflow for autonomous actions."""
-    
+
     def __init__(self, data_dir: Optional[Path] = None, dry_run: bool = False):
         """
         Initialize approval service.
-        
+
         Args:
-            data_dir: Directory for storing pending actions (default: ./data)
+            data_dir: retained for backwards compatibility with callers
+                that previously passed a data directory; ignored now
+                that storage lives in Postgres.
             dry_run: If True, don't execute actions, just log them
         """
-        if data_dir is None:
-            data_dir = Path(__file__).parent.parent / "data"
-        
-        self.data_dir = Path(data_dir)
-        self.data_dir.mkdir(parents=True, exist_ok=True)
-        self.actions_file = self.data_dir / "pending_actions.json"
-        self.config_file = self.data_dir / "approval_config.json"
         self.dry_run = dry_run
-        
-        # Create file if it doesn't exist
-        if not self.actions_file.exists():
-            self._save_actions([])
-        
-        # Load configuration
+        # data_dir retained as attribute so any caller introspecting
+        # it doesn't break; no filesystem I/O is performed anymore.
+        self.data_dir = data_dir
         self._load_config()
-    
-    def _load_actions(self) -> List[PendingAction]:
-        """Load all actions from file."""
-        try:
-            with open(self.actions_file, 'r') as f:
-                data = json.load(f)
-                return [PendingAction(**action) for action in data]
-        except FileNotFoundError:
-            return []
-        except Exception as e:
-            logger.error(f"Error loading actions: {e}")
-            return []
-    
-    def _save_actions(self, actions: List[PendingAction]):
-        """Save all actions to file."""
-        try:
-            with open(self.actions_file, 'w') as f:
-                json.dump([asdict(action) for action in actions], f, indent=2)
-        except Exception as e:
-            logger.error(f"Error saving actions: {e}")
-    
+
+    # ------------------------------------------------------------------
+    # Config (force_manual_approval) — unchanged, still db/config-backed
+    # ------------------------------------------------------------------
+
     def _load_config(self):
-        """Load approval configuration from database with file fallback."""
+        """Load approval configuration from database."""
         try:
-            # Try database first
             config_service = get_config_service()
-            config_value = config_service.get_system_config('approval.force_manual_approval')
-            
+            config_value = config_service.get_system_config(
+                "approval.force_manual_approval"
+            )
             if config_value:
-                self.force_manual_approval = config_value.get('enabled', False)
-                logger.debug(f"Loaded approval config from database: force_manual_approval={self.force_manual_approval}")
-                return
-            
-            # Fallback to file-based config
-            if self.config_file.exists():
-                with open(self.config_file, 'r') as f:
-                    config = json.load(f)
-                    self.force_manual_approval = config.get("force_manual_approval", False)
-                    logger.debug(f"Loaded approval config from file: force_manual_approval={self.force_manual_approval}")
+                self.force_manual_approval = config_value.get("enabled", False)
+                logger.debug(
+                    "Loaded approval config: force_manual_approval=%s",
+                    self.force_manual_approval,
+                )
             else:
                 self.force_manual_approval = False
                 self._save_config()
-        except Exception as e:
-            logger.error(f"Error loading approval config: {e}")
+        except Exception as e:  # noqa: BLE001
+            logger.error("Error loading approval config: %s", e)
             self.force_manual_approval = False
-    
+
     def _save_config(self):
-        """Save approval configuration to database and file."""
+        """Save approval configuration to database."""
         try:
-            config_value = {
-                "enabled": self.force_manual_approval
-            }
-            
-            # Save to database
-            config_service = get_config_service(user_id='approval_service')
-            success = config_service.set_system_config(
-                key='approval.force_manual_approval',
+            config_value = {"enabled": self.force_manual_approval}
+            config_service = get_config_service(user_id="approval_service")
+            config_service.set_system_config(
+                key="approval.force_manual_approval",
                 value=config_value,
-                description='Force manual approval for all actions',
-                config_type='approval',
-                change_reason='Updated by approval service'
+                description="Force manual approval for all actions",
+                config_type="approval",
+                change_reason="Updated by approval service",
             )
-            
-            if success:
-                logger.debug("Saved approval config to database")
-            else:
-                logger.warning("Failed to save approval config to database")
-            
-            # Also save to file for backward compatibility
-            config = {
-                "force_manual_approval": self.force_manual_approval
-            }
-            with open(self.config_file, 'w') as f:
-                json.dump(config, f, indent=2)
-                logger.debug("Saved approval config to file")
-                
-        except Exception as e:
-            logger.error(f"Error saving approval config: {e}")
-    
+        except Exception as e:  # noqa: BLE001
+            logger.error("Error saving approval config: %s", e)
+
     def set_force_manual_approval(self, force: bool):
-        """
-        Set whether to force manual approval for all actions.
-        
-        Args:
-            force: If True, all actions require approval regardless of confidence
-        """
+        """Set whether to force manual approval for all actions."""
         self.force_manual_approval = force
         self._save_config()
-        logger.info(f"Force manual approval set to: {force}")
-    
+        logger.info("Force manual approval set to: %s", force)
+
     def get_force_manual_approval(self) -> bool:
         """Get the current force manual approval setting."""
         return self.force_manual_approval
-    
+
     def should_auto_approve(
-        self, 
-        action: Dict, 
-        threshold: float = 0.90, 
-        force_manual: bool = False
+        self,
+        action: Dict,
+        threshold: float = 0.90,
+        force_manual: bool = False,
     ) -> bool:
-        """
-        Determine if an action should be auto-approved based on confidence.
-        
-        Args:
-            action: Action dict with 'confidence' key
-            threshold: Confidence threshold for auto-approval (default 0.90)
-            force_manual: If True, never auto-approve
-            
-        Returns:
-            True if action should be auto-approved, False otherwise
-        """
+        """Decide if an action should auto-approve based on confidence."""
         if force_manual or self.get_force_manual_approval():
             return False
-        
         confidence = action.get("confidence", 0.0)
-        
-        # Auto-approve if confidence >= threshold
         if confidence >= threshold:
             return True
-        
-        # Auto-approve with flag if confidence between 0.85-0.89
         if confidence >= 0.85:
             return True
-        
-        # Require manual approval for confidence < 0.85
         return False
-    
+
     def needs_flag(self, confidence: float) -> bool:
-        """
-        Check if an action needs a flag (confidence 0.85-0.89).
-        
-        Args:
-            confidence: Confidence score
-            
-        Returns:
-            True if action needs a flag, False otherwise
-        """
+        """Check if an action needs a flag (confidence 0.85-0.89)."""
         return 0.85 <= confidence < 0.90
-    
+
     def get_action_decision(self, action: Dict, threshold: float = 0.90) -> str:
-        """
-        Get the decision for an action based on confidence.
-        
-        Args:
-            action: Action dict with 'confidence' key
-            threshold: Confidence threshold
-            
-        Returns:
-            Decision string: "auto_approve", "manual_approval", or "monitor_only"
-        """
+        """Get the decision for an action based on confidence."""
         confidence = action.get("confidence", 0.0)
-        
         if confidence < 0.70:
             return "monitor_only"
         elif confidence < 0.85:
             return "manual_approval"
         else:
             return "auto_approve"
-    
+
     def is_valid_action_type(self, action_type: str) -> bool:
-        """
-        Check if an action type is valid.
-        
-        Args:
-            action_type: Action type string
-            
-        Returns:
-            True if valid, False otherwise
-        """
+        """Check if an action type is valid."""
         try:
             ActionType(action_type)
             return True
         except ValueError:
             return False
-    
+
     def validate_action(self, action: Dict) -> tuple[bool, List[str]]:
-        """
-        Validate an action payload.
-        
-        Args:
-            action: Action dictionary
-            
-        Returns:
-            Tuple of (is_valid, list_of_errors)
-        """
+        """Validate an action payload."""
         errors = []
-        
-        # Check required fields
         required_fields = ["type", "target", "confidence"]
         for field in required_fields:
             if field not in action:
                 errors.append(f"Missing required field: {field}")
-        
-        # Validate action type
         if "type" in action and not self.is_valid_action_type(action["type"]):
             errors.append(f"Invalid action type: {action['type']}")
-        
-        # Validate confidence range
         if "confidence" in action:
             confidence = action.get("confidence", 0.0)
             if not (0.0 <= confidence <= 1.0):
-                errors.append(f"Confidence must be between 0.0 and 1.0, got {confidence}")
-        
+                errors.append(
+                    f"Confidence must be between 0.0 and 1.0, got {confidence}"
+                )
         return (len(errors) == 0, errors)
-    
+
+    # ------------------------------------------------------------------
+    # CRUD — DB-backed
+    # ------------------------------------------------------------------
+
     def create_action(
         self,
         action_type: ActionType,
@@ -302,404 +248,375 @@ class ApprovalService:
         reason: str,
         evidence: List[str],
         created_by: str = "system",
-        parameters: Optional[Dict] = None
+        parameters: Optional[Dict] = None,
+        workflow_run_id: Optional[str] = None,
+        workflow_phase_id: Optional[str] = None,
     ) -> PendingAction:
+        """Create a new pending action.
+
+        Workflow phase approvals pass ``workflow_run_id`` and
+        ``workflow_phase_id`` so the approvals UI / resume endpoint can
+        link back to the paused run.
         """
-        Create a new pending action.
-        
-        Args:
-            action_type: Type of action
-            title: Short title
-            description: Detailed description
-            target: Target (IP, hostname, etc.)
-            confidence: Confidence score (0.0-1.0)
-            reason: Reason for action
-            evidence: List of evidence/finding IDs
-            created_by: Who created the action
-            parameters: Action-specific parameters
-        
-        Returns:
-            Created PendingAction
-        """
-        # Determine if approval is required based on confidence and override setting
         if self.force_manual_approval:
-            # Override: Force all actions to require approval
             requires_approval = True
         else:
-            # Normal behavior: Auto-execute if >= 0.90
             requires_approval = confidence < 0.90
-        
-        action = PendingAction(
-            action_id=f"action-{datetime.now().strftime('%Y%m%d-%H%M%S-%f')}",
-            action_type=action_type.value,
-            title=title,
-            description=description,
-            target=target,
-            confidence=confidence,
-            reason=reason,
-            evidence=evidence,
-            created_at=datetime.now().isoformat(),
-            created_by=created_by,
-            requires_approval=requires_approval,
-            status=ActionStatus.PENDING.value if requires_approval else ActionStatus.APPROVED.value,
-            parameters=parameters or {}
+
+        action_id = f"action-{datetime.now().strftime('%Y%m%d-%H%M%S-%f')}"
+        status = (
+            ActionStatus.PENDING.value
+            if requires_approval
+            else ActionStatus.APPROVED.value
         )
-        
-        # Save
-        actions = self._load_actions()
-        actions.append(action)
-        self._save_actions(actions)
-        
-        logger.info(f"Created action {action.action_id}: {title} (confidence: {confidence})")
-        return action
-    
+
+        try:
+            db = get_db_manager()
+            with db.session_scope() as session:
+                row = ApprovalActionRow(
+                    action_id=action_id,
+                    action_type=action_type.value,
+                    title=title,
+                    description=description,
+                    target=target,
+                    confidence=float(confidence),
+                    reason=reason,
+                    evidence=list(evidence or []),
+                    created_at=datetime.utcnow(),
+                    created_by=created_by,
+                    requires_approval=requires_approval,
+                    status=status,
+                    parameters=dict(parameters or {}),
+                    workflow_run_id=workflow_run_id,
+                    workflow_phase_id=workflow_phase_id,
+                )
+                session.add(row)
+                session.flush()
+                pending = _row_to_pending(row)
+            logger.info(
+                "Created action %s: %s (confidence: %s)",
+                action_id,
+                title,
+                confidence,
+            )
+            return pending
+        except SQLAlchemyError as e:
+            logger.error("DB error creating action: %s", e)
+            raise
+
     def get_action(self, action_id: str) -> Optional[PendingAction]:
         """Get a specific action by ID."""
-        actions = self._load_actions()
-        for action in actions:
-            if action.action_id == action_id:
-                return action
-        return None
-    
+        try:
+            db = get_db_manager()
+            with db.session_scope() as session:
+                row = session.get(ApprovalActionRow, action_id)
+                return _row_to_pending(row) if row else None
+        except SQLAlchemyError as e:
+            logger.error("DB error fetching action %s: %s", action_id, e)
+            return None
+
     def list_actions(
         self,
         status: Optional[ActionStatus] = None,
         action_type: Optional[ActionType] = None,
-        requires_approval: Optional[bool] = None
+        requires_approval: Optional[bool] = None,
+        workflow_run_id: Optional[str] = None,
+        limit: int = 500,
     ) -> List[PendingAction]:
-        """
-        List actions with optional filters.
-        
-        Args:
-            status: Filter by status
-            action_type: Filter by action type
-            requires_approval: Filter by approval requirement
-        
-        Returns:
-            List of matching actions
-        """
-        actions = self._load_actions()
-        
-        # Apply filters
-        if status:
-            actions = [a for a in actions if a.status == status.value]
-        if action_type:
-            actions = [a for a in actions if a.action_type == action_type.value]
-        if requires_approval is not None:
-            actions = [a for a in actions if a.requires_approval == requires_approval]
-        
-        # Sort by created_at descending
-        actions.sort(key=lambda x: x.created_at, reverse=True)
-        
-        return actions
-    
+        """List actions with optional filters, newest first."""
+        try:
+            db = get_db_manager()
+            with db.session_scope() as session:
+                stmt = select(ApprovalActionRow)
+                if status:
+                    stmt = stmt.where(ApprovalActionRow.status == status.value)
+                if action_type:
+                    stmt = stmt.where(
+                        ApprovalActionRow.action_type == action_type.value
+                    )
+                if requires_approval is not None:
+                    stmt = stmt.where(
+                        ApprovalActionRow.requires_approval == requires_approval
+                    )
+                if workflow_run_id:
+                    stmt = stmt.where(
+                        ApprovalActionRow.workflow_run_id == workflow_run_id
+                    )
+                stmt = stmt.order_by(ApprovalActionRow.created_at.desc()).limit(limit)
+                rows = session.execute(stmt).scalars().all()
+                return [_row_to_pending(r) for r in rows]
+        except SQLAlchemyError as e:
+            logger.error("DB error listing actions: %s", e)
+            return []
+
     def approve_action(
         self,
         action_id: str,
-        approved_by: str = "analyst"
+        approved_by: str = "analyst",
     ) -> Optional[PendingAction]:
-        """
-        Approve a pending action.
-        
-        Args:
-            action_id: Action ID to approve
-            approved_by: Who approved it
-        
-        Returns:
-            Updated action or None if not found
-        """
-        actions = self._load_actions()
-        
-        for action in actions:
-            if action.action_id == action_id:
-                if action.status == ActionStatus.PENDING.value:
-                    action.status = ActionStatus.APPROVED.value
-                    action.approved_at = datetime.now().isoformat()
-                    action.approved_by = approved_by
-                    self._save_actions(actions)
-                    logger.info(f"Action {action_id} approved by {approved_by}")
-                    return action
-                else:
-                    logger.warning(f"Action {action_id} is not pending (status: {action.status})")
-                    return action
-        
-        logger.warning(f"Action {action_id} not found")
-        return None
-    
+        """Approve a pending action."""
+        try:
+            db = get_db_manager()
+            with db.session_scope() as session:
+                row = session.get(ApprovalActionRow, action_id)
+                if row is None:
+                    logger.warning("Action %s not found", action_id)
+                    return None
+                if row.status != ActionStatus.PENDING.value:
+                    logger.warning(
+                        "Action %s is not pending (status: %s)",
+                        action_id,
+                        row.status,
+                    )
+                    return _row_to_pending(row)
+                row.status = ActionStatus.APPROVED.value
+                row.approved_at = datetime.utcnow()
+                row.approved_by = approved_by
+                session.flush()
+                pending = _row_to_pending(row)
+            logger.info("Action %s approved by %s", action_id, approved_by)
+            return pending
+        except SQLAlchemyError as e:
+            logger.error("DB error approving action %s: %s", action_id, e)
+            return None
+
     def reject_action(
         self,
         action_id: str,
         reason: str,
-        rejected_by: str = "analyst"
+        rejected_by: str = "analyst",
     ) -> Optional[PendingAction]:
-        """
-        Reject a pending action.
-        
-        Args:
-            action_id: Action ID to reject
-            reason: Reason for rejection
-            rejected_by: Who rejected it
-        
-        Returns:
-            Updated action or None if not found
-        """
-        actions = self._load_actions()
-        
-        for action in actions:
-            if action.action_id == action_id:
-                if action.status == ActionStatus.PENDING.value:
-                    action.status = ActionStatus.REJECTED.value
-                    action.rejection_reason = reason
-                    action.approved_by = rejected_by  # Track who rejected
-                    action.approved_at = datetime.now().isoformat()
-                    self._save_actions(actions)
-                    logger.info(f"Action {action_id} rejected by {rejected_by}: {reason}")
-                    return action
-                else:
-                    logger.warning(f"Action {action_id} is not pending (status: {action.status})")
-                    return action
-        
-        logger.warning(f"Action {action_id} not found")
-        return None
-    
+        """Reject a pending action."""
+        try:
+            db = get_db_manager()
+            with db.session_scope() as session:
+                row = session.get(ApprovalActionRow, action_id)
+                if row is None:
+                    logger.warning("Action %s not found", action_id)
+                    return None
+                if row.status != ActionStatus.PENDING.value:
+                    logger.warning(
+                        "Action %s is not pending (status: %s)",
+                        action_id,
+                        row.status,
+                    )
+                    return _row_to_pending(row)
+                row.status = ActionStatus.REJECTED.value
+                row.rejection_reason = reason
+                row.approved_by = rejected_by
+                row.approved_at = datetime.utcnow()
+                session.flush()
+                pending = _row_to_pending(row)
+            logger.info(
+                "Action %s rejected by %s: %s",
+                action_id,
+                rejected_by,
+                reason,
+            )
+            return pending
+        except SQLAlchemyError as e:
+            logger.error("DB error rejecting action %s: %s", action_id, e)
+            return None
+
     def mark_executed(
         self,
         action_id: str,
-        result: Dict
+        result: Dict,
     ) -> Optional[PendingAction]:
-        """
-        Mark an action as executed.
-        
-        Args:
-            action_id: Action ID
-            result: Execution result
-        
-        Returns:
-            Updated action or None if not found
-        """
-        actions = self._load_actions()
-        
-        for action in actions:
-            if action.action_id == action_id:
-                if action.status == ActionStatus.APPROVED.value:
-                    action.status = ActionStatus.EXECUTED.value
-                    action.executed_at = datetime.now().isoformat()
-                    action.execution_result = result
-                    self._save_actions(actions)
-                    logger.info(f"Action {action_id} marked as executed")
-                    return action
-                else:
-                    logger.warning(f"Action {action_id} is not approved (status: {action.status})")
+        """Mark an action as executed."""
+        try:
+            db = get_db_manager()
+            with db.session_scope() as session:
+                row = session.get(ApprovalActionRow, action_id)
+                if row is None:
                     return None
-        
-        logger.warning(f"Action {action_id} not found")
-        return None
-    
+                if row.status != ActionStatus.APPROVED.value:
+                    logger.warning(
+                        "Action %s is not approved (status: %s)",
+                        action_id,
+                        row.status,
+                    )
+                    return _row_to_pending(row)
+                row.status = ActionStatus.EXECUTED.value
+                row.executed_at = datetime.utcnow()
+                row.execution_result = result
+                session.flush()
+                return _row_to_pending(row)
+        except SQLAlchemyError as e:
+            logger.error("DB error marking action %s executed: %s", action_id, e)
+            return None
+
     def mark_failed(
         self,
         action_id: str,
-        error: str
+        error: str,
     ) -> Optional[PendingAction]:
-        """
-        Mark an action as failed.
-        
-        Args:
-            action_id: Action ID
-            error: Error message
-        
-        Returns:
-            Updated action or None if not found
-        """
-        actions = self._load_actions()
-        
-        for action in actions:
-            if action.action_id == action_id:
-                action.status = ActionStatus.FAILED.value
-                action.executed_at = datetime.now().isoformat()
-                action.execution_result = {"error": error}
-                self._save_actions(actions)
-                logger.error(f"Action {action_id} failed: {error}")
-                return action
-        
-        return None
-    
+        """Mark an action as failed."""
+        try:
+            db = get_db_manager()
+            with db.session_scope() as session:
+                row = session.get(ApprovalActionRow, action_id)
+                if row is None:
+                    return None
+                row.status = ActionStatus.FAILED.value
+                row.executed_at = datetime.utcnow()
+                row.execution_result = {"error": error}
+                session.flush()
+                logger.error("Action %s failed: %s", action_id, error)
+                return _row_to_pending(row)
+        except SQLAlchemyError as e:
+            logger.error("DB error marking action %s failed: %s", action_id, e)
+            return None
+
     def get_pending_count(self) -> int:
         """Get count of pending actions requiring approval."""
-        actions = self.list_actions(status=ActionStatus.PENDING)
-        return len([a for a in actions if a.requires_approval])
-    
+        return len(self.list_pending_approvals())
+
     def get_stats(self) -> Dict:
         """Get statistics about actions."""
-        actions = self._load_actions()
-        
+        actions = self.list_actions()
         return {
             "total": len(actions),
-            "pending": len([a for a in actions if a.status == ActionStatus.PENDING.value]),
-            "approved": len([a for a in actions if a.status == ActionStatus.APPROVED.value]),
-            "rejected": len([a for a in actions if a.status == ActionStatus.REJECTED.value]),
-            "executed": len([a for a in actions if a.status == ActionStatus.EXECUTED.value]),
-            "failed": len([a for a in actions if a.status == ActionStatus.FAILED.value]),
+            "pending": len(
+                [a for a in actions if a.status == ActionStatus.PENDING.value]
+            ),
+            "approved": len(
+                [a for a in actions if a.status == ActionStatus.APPROVED.value]
+            ),
+            "rejected": len(
+                [a for a in actions if a.status == ActionStatus.REJECTED.value]
+            ),
+            "executed": len(
+                [a for a in actions if a.status == ActionStatus.EXECUTED.value]
+            ),
+            "failed": len(
+                [a for a in actions if a.status == ActionStatus.FAILED.value]
+            ),
             "requires_approval": len([a for a in actions if a.requires_approval]),
-            "by_type": self._count_by_type(actions)
+            "by_type": self._count_by_type(actions),
         }
-    
+
     def _count_by_type(self, actions: List[PendingAction]) -> Dict[str, int]:
         """Count actions by type."""
-        counts = {}
+        counts: Dict[str, int] = {}
         for action in actions:
             counts[action.action_type] = counts.get(action.action_type, 0) + 1
         return counts
-    
+
     def list_pending_approvals(self) -> List[PendingAction]:
-        """
-        List all pending actions requiring approval.
-        
-        Returns:
-            List of pending actions
-        """
+        """List all pending actions requiring approval."""
         return self.list_actions(status=ActionStatus.PENDING, requires_approval=True)
-    
+
     def get_audit_trail(self, action_id: str) -> List[Dict]:
-        """
-        Get audit trail for a specific action.
-        
-        Args:
-            action_id: Action ID to get audit trail for
-            
-        Returns:
-            List of audit events for the action
-        """
+        """Get audit trail for a specific action."""
         action = self.get_action(action_id)
         if not action:
             return []
-        
-        # Build audit trail from action lifecycle
-        trail = []
-        
-        # Created event
-        trail.append({
-            "event": "created",
-            "timestamp": action.created_at,
-            "user": action.created_by,
-            "details": {
-                "action_type": action.action_type,
-                "target": action.target,
-                "confidence": action.confidence
-            }
-        })
-        
-        # Approval/rejection event - check if approved_at exists AND if status was changed
-        if action.approved_at:
-            if action.status in [ActionStatus.APPROVED.value, ActionStatus.EXECUTED.value]:
-                trail.append({
-                    "event": "approved",
-                    "timestamp": action.approved_at,
-                    "user": action.approved_by,
-                    "details": {}
-                })
-            elif action.status == ActionStatus.REJECTED.value:
-                trail.append({
-                    "event": "rejected",
-                    "timestamp": action.approved_at,
-                    "user": action.approved_by,
-                    "details": {
-                        "reason": action.rejection_reason
-                    }
-                })
-        
-        # Execution event
-        if action.executed_at:
-            trail.append({
-                "event": "executed" if action.status == ActionStatus.EXECUTED.value else "failed",
-                "timestamp": action.executed_at,
-                "user": "system",
+
+        trail = [
+            {
+                "event": "created",
+                "timestamp": action.created_at,
+                "user": action.created_by,
                 "details": {
-                    "result": action.execution_result
+                    "action_type": action.action_type,
+                    "target": action.target,
+                    "confidence": action.confidence,
+                },
+            }
+        ]
+
+        if action.approved_at:
+            if action.status in [
+                ActionStatus.APPROVED.value,
+                ActionStatus.EXECUTED.value,
+            ]:
+                trail.append(
+                    {
+                        "event": "approved",
+                        "timestamp": action.approved_at,
+                        "user": action.approved_by,
+                        "details": {},
+                    }
+                )
+            elif action.status == ActionStatus.REJECTED.value:
+                trail.append(
+                    {
+                        "event": "rejected",
+                        "timestamp": action.approved_at,
+                        "user": action.approved_by,
+                        "details": {"reason": action.rejection_reason},
+                    }
+                )
+
+        if action.executed_at:
+            trail.append(
+                {
+                    "event": (
+                        "executed"
+                        if action.status == ActionStatus.EXECUTED.value
+                        else "failed"
+                    ),
+                    "timestamp": action.executed_at,
+                    "user": "system",
+                    "details": {"result": action.execution_result},
                 }
-            })
-        
+            )
+
         return trail
-    
+
     def execute_action(self, action: Dict) -> Dict:
-        """
-        Execute an action (with dry run support).
-        
-        Args:
-            action: Action dictionary with type, target, etc.
-            
-        Returns:
-            Execution result dictionary
-        """
+        """Execute an action (with dry run support)."""
         if self.dry_run:
-            # In dry run mode, just log and return mock result
-            logger.info(f"DRY RUN: Would execute {action.get('type')} on {action.get('target')}")
+            logger.info(
+                "DRY RUN: Would execute %s on %s",
+                action.get("type"),
+                action.get("target"),
+            )
             return {
                 "status": "dry_run",
                 "would_execute": True,
-                "action": action
+                "action": action,
             }
-        
-        # In real execution mode, this would call actual service integrations
-        # For now, return a mock result indicating execution is not yet implemented
-        logger.warning(f"Action execution not yet fully implemented: {action.get('type')}")
+        logger.warning(
+            "Action execution not yet fully implemented: %s",
+            action.get("type"),
+        )
         return {
             "status": "not_implemented",
             "message": "Action execution requires service integration",
-            "action": action
+            "action": action,
         }
-    
+
     def execute_approved_action(self, action_id: str) -> Dict:
-        """
-        Execute an approved action by ID.
-        
-        Args:
-            action_id: Action ID to execute
-            
-        Returns:
-            Execution result
-        """
+        """Execute an approved action by ID."""
         action = self.get_action(action_id)
         if not action:
             return {"error": f"Action {action_id} not found"}
-        
         if action.status != ActionStatus.APPROVED.value:
-            return {"error": f"Action {action_id} is not approved (status: {action.status})"}
-        
-        # Convert PendingAction to dict for execute_action
+            return {
+                "error": (
+                    f"Action {action_id} is not approved " f"(status: {action.status})"
+                )
+            }
         action_dict = {
             "type": action.action_type,
             "target": action.target,
             "confidence": action.confidence,
-            "parameters": action.parameters
+            "parameters": action.parameters,
         }
-        
-        # Execute the action
         result = self.execute_action(action_dict)
-        
-        # Update action status based on result
         if result.get("status") == "success":
             self.mark_executed(action_id, result)
         elif result.get("status") not in ["dry_run", "not_implemented"]:
             self.mark_failed(action_id, result.get("error", "Unknown error"))
-        
         return result
-    
+
     def add_to_queue(self, action: Dict) -> str:
-        """
-        Add an action to the approval queue. Wrapper for create_action().
-        
-        Args:
-            action: Action dictionary with type, target, confidence, etc.
-            
-        Returns:
-            Action ID
-        """
-        # Validate action
+        """Add an action to the approval queue (wraps create_action)."""
         is_valid, errors = self.validate_action(action)
         if not is_valid:
             raise ValueError(f"Invalid action: {', '.join(errors)}")
-        
-        # Create the action
         pending_action = self.create_action(
             action_type=ActionType(action["type"]),
             title=action.get("title", f"{action['type']}: {action['target']}"),
@@ -709,30 +626,20 @@ class ApprovalService:
             reason=action.get("reasoning", action.get("reason", "")),
             evidence=action.get("evidence", []),
             created_by=action.get("created_by", "system"),
-            parameters=action.get("parameters")
+            parameters=action.get("parameters"),
+            workflow_run_id=action.get("workflow_run_id"),
+            workflow_phase_id=action.get("workflow_phase_id"),
         )
-        
         return pending_action.action_id
-    
+
     def log_approval_decision(
         self,
         action: Dict,
         decision: str,
         user: str,
-        reasoning: Optional[str] = None
+        reasoning: Optional[str] = None,
     ) -> Dict:
-        """
-        Log an approval decision.
-        
-        Args:
-            action: Action dictionary
-            decision: Decision made ("auto_approved", "approved", "rejected")
-            user: User who made the decision
-            reasoning: Optional reasoning for the decision
-            
-        Returns:
-            Log entry dictionary
-        """
+        """Log an approval decision."""
         log_entry = {
             "timestamp": datetime.now().isoformat(),
             "action_type": action.get("type"),
@@ -741,58 +648,48 @@ class ApprovalService:
             "decision": decision,
             "user": user,
             "reasoning": reasoning or action.get("reasoning", ""),
-            "dry_run": self.dry_run
+            "dry_run": self.dry_run,
         }
-        
-        logger.info(f"Approval decision logged: {decision} by {user} for {action.get('type')}")
-        
+        logger.info(
+            "Approval decision logged: %s by %s for %s",
+            decision,
+            user,
+            action.get("type"),
+        )
         return log_entry
-    
+
     def log_execution(
         self,
         action_id: str,
         status: str,
         result: Optional[Dict] = None,
-        error: Optional[str] = None
+        error: Optional[str] = None,
     ) -> Dict:
-        """
-        Log action execution result.
-        
-        Args:
-            action_id: Action ID
-            status: Execution status ("success", "failed", "skipped")
-            result: Execution result data
-            error: Error message if failed
-            
-        Returns:
-            Log entry dictionary
-        """
+        """Log action execution result."""
         log_entry = {
             "timestamp": datetime.now().isoformat(),
             "action_id": action_id,
             "status": status,
             "result": result,
             "error": error,
-            "dry_run": self.dry_run
+            "dry_run": self.dry_run,
         }
-        
         if status == "success":
-            logger.info(f"Action {action_id} executed successfully")
+            logger.info("Action %s executed successfully", action_id)
             if not self.dry_run:
-                # Update action status
                 self.mark_executed(action_id, result or {})
         elif status == "failed":
-            logger.error(f"Action {action_id} failed: {error}")
+            logger.error("Action %s failed: %s", action_id, error)
             if not self.dry_run:
-                # Update action status
                 self.mark_failed(action_id, error or "Unknown error")
         else:
-            logger.info(f"Action {action_id} execution skipped (dry run or other reason)")
-        
+            logger.info(
+                "Action %s execution skipped (dry run or other reason)",
+                action_id,
+            )
         return log_entry
 
 
-# Singleton instance
 _approval_service: Optional[ApprovalService] = None
 
 
@@ -802,4 +699,3 @@ def get_approval_service() -> ApprovalService:
     if _approval_service is None:
         _approval_service = ApprovalService()
     return _approval_service
-

--- a/services/workflow_run_service.py
+++ b/services/workflow_run_service.py
@@ -24,7 +24,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
 from database.connection import get_db_manager
-from database.models import WorkflowRun
+from database.models import WorkflowRun, WorkflowRunPhase
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +77,25 @@ class WorkflowRunService:
         except SQLAlchemyError as e:
             logger.warning("Could not persist workflow run start: %s", e)
             return None
+
+    def set_status(self, run_id: str, status: str) -> bool:
+        """Update only ``workflow_runs.status`` without touching terminal
+        fields. Used by the phase loop to flip running→paused when a
+        phase blocks on approval (#128)."""
+        if status not in ("running", "paused"):
+            logger.error("set_status: invalid non-terminal status %r", status)
+            return False
+        try:
+            db = get_db_manager()
+            with db.session_scope() as session:
+                row = session.get(WorkflowRun, run_id)
+                if row is None:
+                    return False
+                row.status = status
+            return True
+        except SQLAlchemyError as e:
+            logger.warning("Could not set run status %s: %s", run_id, e)
+            return False
 
     def finalize_run(
         self,
@@ -156,6 +175,97 @@ class WorkflowRunService:
         except SQLAlchemyError as e:
             logger.warning("Error fetching workflow run %s: %s", run_id, e)
             return None
+
+    # ------------------------------------------------------------------
+    # Phase-level helpers (#128)
+    # ------------------------------------------------------------------
+
+    def upsert_phase(
+        self,
+        run_id: str,
+        phase_id: str,
+        *,
+        phase_order: int,
+        agent_id: str,
+        status: str,
+        input_context: Optional[Dict[str, Any]] = None,
+        output: Optional[Dict[str, Any]] = None,
+        approval_state: Optional[str] = None,
+        error: Optional[str] = None,
+        started_at: Optional[datetime] = None,
+        finished_at: Optional[datetime] = None,
+    ) -> bool:
+        """Insert or update a ``workflow_run_phases`` row.
+
+        The phase loop in ``WorkflowsService.execute_workflow`` calls
+        this at each state transition (pending → running → completed
+        / failed / pending_approval). ``upsert`` semantics keep the
+        call sites simple — they don't need to know whether a prior
+        row exists on retry/resume.
+        """
+        try:
+            db = get_db_manager()
+            with db.session_scope() as session:
+                row = session.get(WorkflowRunPhase, (run_id, phase_id))
+                if row is None:
+                    row = WorkflowRunPhase(
+                        run_id=run_id,
+                        phase_id=phase_id,
+                        phase_order=phase_order,
+                        agent_id=agent_id,
+                        status=status,
+                        input_context=dict(input_context or {}),
+                        output=dict(output or {}),
+                        approval_state=approval_state,
+                        error=error,
+                        started_at=started_at,
+                        finished_at=finished_at,
+                    )
+                    session.add(row)
+                else:
+                    row.phase_order = phase_order
+                    row.agent_id = agent_id
+                    row.status = status
+                    if input_context is not None:
+                        row.input_context = dict(input_context)
+                    if output is not None:
+                        row.output = dict(output)
+                    if approval_state is not None:
+                        row.approval_state = approval_state
+                    if error is not None:
+                        row.error = error
+                    if started_at is not None:
+                        row.started_at = started_at
+                    if finished_at is not None:
+                        row.finished_at = finished_at
+                        if row.started_at:
+                            delta = finished_at - row.started_at
+                            row.duration_ms = int(delta.total_seconds() * 1000)
+            return True
+        except SQLAlchemyError as e:
+            logger.warning(
+                "Could not upsert phase %s/%s: %s",
+                run_id,
+                phase_id,
+                e,
+            )
+            return False
+
+    def list_phases(self, run_id: str) -> List[Dict[str, Any]]:
+        """Return all phase rows for a run, ordered by ``phase_order``."""
+        try:
+            db = get_db_manager()
+            with db.session_scope() as session:
+                stmt = (
+                    select(WorkflowRunPhase)
+                    .where(WorkflowRunPhase.run_id == run_id)
+                    .order_by(WorkflowRunPhase.phase_order)
+                )
+                rows = session.execute(stmt).scalars().all()
+                return [r.to_dict() for r in rows]
+        except SQLAlchemyError as e:
+            logger.warning("Error listing phases for run %s: %s", run_id, e)
+            return []
 
 
 _service: Optional[WorkflowRunService] = None

--- a/services/workflows_service.py
+++ b/services/workflows_service.py
@@ -18,7 +18,7 @@ def _parse_yaml_frontmatter(content: str) -> Dict[str, Any]:
     Handles strings, lists (both inline [...] and indented - item).
     """
     # Match frontmatter block: --- ... --- followed by newline, EOF, or content
-    match = re.match(r'^---\s*\n(.*?)\n---\s*(?:\n|$)', content, re.DOTALL)
+    match = re.match(r"^---\s*\n(.*?)\n---\s*(?:\n|$)", content, re.DOTALL)
     if not match:
         return {}
 
@@ -27,21 +27,21 @@ def _parse_yaml_frontmatter(content: str) -> Dict[str, Any]:
     current_key = None
     current_list = None
 
-    for line in frontmatter_text.split('\n'):
+    for line in frontmatter_text.split("\n"):
         # Skip empty lines and comments
         stripped = line.strip()
-        if not stripped or stripped.startswith('#'):
+        if not stripped or stripped.startswith("#"):
             continue
 
         # Check for list continuation (indented "- item")
-        if current_key and current_list is not None and re.match(r'^\s+-\s+', line):
-            item = re.sub(r'^\s+-\s+', '', line).strip().strip('"').strip("'")
+        if current_key and current_list is not None and re.match(r"^\s+-\s+", line):
+            item = re.sub(r"^\s+-\s+", "", line).strip().strip('"').strip("'")
             current_list.append(item)
             result[current_key] = current_list
             continue
 
         # Key-value pair
-        kv_match = re.match(r'^(\S+):\s*(.*)', line)
+        kv_match = re.match(r"^(\S+):\s*(.*)", line)
         if kv_match:
             key = kv_match.group(1)
             value = kv_match.group(2).strip()
@@ -52,10 +52,12 @@ def _parse_yaml_frontmatter(content: str) -> Dict[str, Any]:
                 # Might be start of a list
                 current_list = []
                 result[key] = current_list
-            elif value.startswith('[') and value.endswith(']'):
+            elif value.startswith("[") and value.endswith("]"):
                 # Inline list: [item1, item2, ...]
-                items = value[1:-1].split(',')
-                result[key] = [i.strip().strip('"').strip("'") for i in items if i.strip()]
+                items = value[1:-1].split(",")
+                result[key] = [
+                    i.strip().strip('"').strip("'") for i in items if i.strip()
+                ]
                 current_list = None
             elif value.startswith('"') and value.endswith('"'):
                 result[key] = value[1:-1]
@@ -72,7 +74,7 @@ def _parse_yaml_frontmatter(content: str) -> Dict[str, Any]:
 
 def _get_frontmatter_end(content: str) -> int:
     """Get the character index where frontmatter ends and body begins."""
-    match = re.match(r'^---\s*\n(.*?)\n---\s*(?:\n|$)', content, re.DOTALL)
+    match = re.match(r"^---\s*\n(.*?)\n---\s*(?:\n|$)", content, re.DOTALL)
     if match:
         return match.end()
     return 0
@@ -97,33 +99,33 @@ class WorkflowDefinition:
 
     @property
     def name(self) -> str:
-        return self.metadata.get('name', self.id)
+        return self.metadata.get("name", self.id)
 
     @property
     def description(self) -> str:
-        return self.metadata.get('description', '')
+        return self.metadata.get("description", "")
 
     @property
     def agents(self) -> List[str]:
-        agents = self.metadata.get('agents', [])
+        agents = self.metadata.get("agents", [])
         if isinstance(agents, str):
-            return [a.strip() for a in agents.split(',')]
+            return [a.strip() for a in agents.split(",")]
         return agents
 
     @property
     def tools_used(self) -> List[str]:
-        tools = self.metadata.get('tools-used', [])
+        tools = self.metadata.get("tools-used", [])
         if isinstance(tools, str):
-            return [t.strip() for t in tools.split(',')]
+            return [t.strip() for t in tools.split(",")]
         return tools
 
     @property
     def use_case(self) -> str:
-        return self.metadata.get('use-case', '')
+        return self.metadata.get("use-case", "")
 
     @property
     def trigger_examples(self) -> List[str]:
-        examples = self.metadata.get('trigger-examples', [])
+        examples = self.metadata.get("trigger-examples", [])
         if isinstance(examples, str):
             return [examples]
         return examples
@@ -185,7 +187,9 @@ def _custom_workflow_to_definition(wf: Dict[str, Any]) -> WorkflowDefinition:
     )
 
 
-def _render_custom_workflow_body(wf: Dict[str, Any], phases: List[Dict[str, Any]]) -> str:
+def _render_custom_workflow_body(
+    wf: Dict[str, Any], phases: List[Dict[str, Any]]
+) -> str:
     """Render a markdown body from structured phases, compatible with
     build_execution_prompt()'s template."""
     lines: List[str] = []
@@ -261,7 +265,7 @@ class WorkflowsService:
                 continue
 
             try:
-                content = workflow_file.read_text(encoding='utf-8')
+                content = workflow_file.read_text(encoding="utf-8")
                 metadata = _parse_yaml_frontmatter(content)
                 body_start = _get_frontmatter_end(content)
                 body = content[body_start:].strip()
@@ -316,7 +320,9 @@ class WorkflowsService:
         Return metadata for all discovered workflows, merging file-based and
         database-backed custom workflows. Custom workflows are listed first.
         """
-        custom = [wf.to_dict(include_body=False) for wf in self._list_custom_workflows()]
+        custom = [
+            wf.to_dict(include_body=False) for wf in self._list_custom_workflows()
+        ]
         file_based = [wf.to_dict(include_body=False) for wf in self._cache.values()]
         return custom + file_based
 
@@ -327,7 +333,9 @@ class WorkflowsService:
             return custom
         return self._cache.get(workflow_id)
 
-    def get_workflow_dict(self, workflow_id: str, include_body: bool = True) -> Optional[Dict[str, Any]]:
+    def get_workflow_dict(
+        self, workflow_id: str, include_body: bool = True
+    ) -> Optional[Dict[str, Any]]:
         """Get a specific workflow as a dictionary."""
         workflow = self.get_workflow(workflow_id)
         if workflow:
@@ -359,7 +367,9 @@ class WorkflowsService:
         if agent_profiles:
             agent_section = "\n\n## Agent Methodologies\n\n"
             agent_section += "You will be executing this workflow by embodying each agent in sequence. "
-            agent_section += "Here are the methodologies for each agent you will use:\n\n"
+            agent_section += (
+                "Here are the methodologies for each agent you will use:\n\n"
+            )
 
             for agent_id in workflow.agents:
                 profile = agent_profiles.get(agent_id)
@@ -369,12 +379,14 @@ class WorkflowsService:
                     agent_section += f"**Description:** {profile.description}\n"
                     # Extract methodology from system prompt
                     methodology_match = re.search(
-                        r'<methodology>(.*?)</methodology>',
+                        r"<methodology>(.*?)</methodology>",
                         profile.system_prompt,
-                        re.DOTALL
+                        re.DOTALL,
                     )
                     if methodology_match:
-                        agent_section += f"**Methodology:**\n{methodology_match.group(1).strip()}\n"
+                        agent_section += (
+                            f"**Methodology:**\n{methodology_match.group(1).strip()}\n"
+                        )
                     agent_section += "\n"
 
         prompt = f"""# Execute Workflow: {workflow.name}
@@ -417,151 +429,206 @@ For each phase:
         parameters: Dict[str, Any],
         triggered_by: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Execute a workflow as a playbook run (not a chat session).
+        """Execute a workflow as a playbook run.
 
-        Per #126, the execution path delegates to ``ClaudeService.chat``
-        as an internal Python primitive so backend_tools (including
-        ``skill_<slug>`` generated from the ``skills`` table) are in
-        scope for the model. Per #127, the run is persisted to
-        ``workflow_runs`` for history/audit — the row starts with
-        ``status='running'`` and is finalised with the terminal status
-        + result summary or error.
+        Custom workflows with a structured ``phases`` list run phase-
+        by-phase so ``approval_required`` can actually block execution
+        (#128). File-based workflows without structured phases fall
+        back to the legacy one-shot composite prompt — there's nothing
+        to gate on.
 
-        Args:
-            workflow_id: The workflow ID to execute
-            parameters: Execution parameters:
-                - finding_id: Optional finding to investigate
-                - case_id: Optional case to investigate
-                - context: Optional freeform context string
-                - hypothesis: Optional hunt hypothesis (for threat-hunt)
-            triggered_by: Identifier of what initiated the run
-                (user id, "daemon", "api", …). Persisted for audit.
-
-        Returns:
-            Execution result dict, including ``run_id`` so callers can
-            retrieve the persisted run via /api/workflows/runs/{run_id}.
+        Returns an execution result dict. If a phase pauses on
+        approval, the response shape is
+        ``{success: True, status: "paused", run_id,
+           pending_approval_action_id, paused_at_phase}`` and the caller
+        (or the Approvals UI) must call ``resume_workflow`` once a
+        decision is made.
         """
-        from services.claude_service import ClaudeService
-        from services.soc_agents import SOCAgentLibrary
-        from services.workflow_run_service import get_workflow_run_service
-
         workflow = self.get_workflow(workflow_id)
         if not workflow:
             return {"success": False, "error": f"Workflow not found: {workflow_id}"}
 
-        # Build target context from parameters
-        target_context = self._build_target_context(parameters)
+        phases = workflow.metadata.get("phases") or []
+        if not phases:
+            # No structured phases → legacy one-shot path. There's no
+            # phase to gate on, so approval_required has no meaning.
+            return await self._execute_oneshot(workflow, parameters, triggered_by)
 
-        # Get agent profiles for methodology embedding
+        return await self._execute_phased(workflow, phases, parameters, triggered_by)
+
+    async def resume_workflow(
+        self,
+        run_id: str,
+        decision: str,
+        *,
+        rejection_reason: Optional[str] = None,
+        approved_by: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Resume a paused workflow run after an approval decision (#128).
+
+        Called from the approvals endpoint (or the workflow-run resume
+        endpoint). ``decision`` is ``"approved"`` or ``"rejected"``.
+        On approve, re-enters the phase loop at the paused phase. On
+        reject, finalises the run as ``cancelled``.
+        """
+        from services.workflow_run_service import get_workflow_run_service
+
+        if decision not in ("approved", "rejected"):
+            return {"success": False, "error": f"Invalid decision: {decision}"}
+
+        run_service = get_workflow_run_service()
+        run = run_service.get_run(run_id)
+        if run is None:
+            return {"success": False, "error": f"Run not found: {run_id}"}
+        if run.get("status") != "paused":
+            return {
+                "success": False,
+                "error": (f"Run {run_id} is not paused (status={run.get('status')})"),
+            }
+
+        phases_rows = run_service.list_phases(run_id)
+        paused = next(
+            (p for p in phases_rows if p["status"] == "pending_approval"),
+            None,
+        )
+        if paused is None:
+            return {
+                "success": False,
+                "error": f"No pending_approval phase found on run {run_id}",
+            }
+
+        workflow = self.get_workflow(run["workflow_id"])
+        if not workflow:
+            run_service.finalize_run(
+                run_id,
+                status="failed",
+                error=f"Workflow {run['workflow_id']} no longer exists",
+            )
+            return {
+                "success": False,
+                "error": f"Workflow not found: {run['workflow_id']}",
+            }
+
+        phases = workflow.metadata.get("phases") or []
+        phase_index = next(
+            (
+                i
+                for i, p in enumerate(phases)
+                if (p.get("phase_id") or f"phase-{p.get('order', i + 1)}")
+                == paused["phase_id"]
+            ),
+            None,
+        )
+        if phase_index is None:
+            run_service.finalize_run(
+                run_id,
+                status="failed",
+                error=(
+                    f"Paused phase {paused['phase_id']} no longer in "
+                    f"workflow definition"
+                ),
+            )
+            return {
+                "success": False,
+                "error": "Paused phase missing from workflow definition",
+            }
+
+        if decision == "rejected":
+            reason = rejection_reason or "Rejected by analyst"
+            run_service.upsert_phase(
+                run_id,
+                paused["phase_id"],
+                phase_order=paused["phase_order"],
+                agent_id=paused["agent_id"],
+                status="failed",
+                approval_state="rejected",
+                error=reason,
+                finished_at=datetime.utcnow(),
+            )
+            run_service.finalize_run(
+                run_id, status="cancelled", error=f"Rejected: {reason}"
+            )
+            return {
+                "success": True,
+                "status": "cancelled",
+                "run_id": run_id,
+                "rejection_reason": reason,
+                "rejected_by": approved_by,
+            }
+
+        # Approved — mark the approval state and re-enter the loop.
+        run_service.upsert_phase(
+            run_id,
+            paused["phase_id"],
+            phase_order=paused["phase_order"],
+            agent_id=paused["agent_id"],
+            status="pending",
+            approval_state="approved",
+        )
+        run_service.set_status(run_id, "running")
+
+        # Rebuild accumulated context from completed prior phases.
+        accumulated: Dict[str, Any] = {}
+        for p in phases_rows:
+            if p["status"] == "completed":
+                accumulated[p["phase_id"]] = p.get("output") or {}
+
+        return await self._run_phase_loop(
+            workflow=workflow,
+            phases=phases,
+            start_index=phase_index,
+            run_id=run_id,
+            parameters=dict(run.get("trigger_context") or {}),
+            accumulated=accumulated,
+            triggered_by=run.get("triggered_by"),
+            skill_tools_available=list(run.get("skill_tools_available") or []),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal execution helpers
+    # ------------------------------------------------------------------
+
+    async def _execute_oneshot(
+        self,
+        workflow: "WorkflowDefinition",
+        parameters: Dict[str, Any],
+        triggered_by: Optional[str],
+    ) -> Dict[str, Any]:
+        """Legacy composite-prompt path for file-based workflows that
+        don't have structured phases. No approval gating possible —
+        there's no phase_id to attach an approval to."""
+        from services.claude_service import ClaudeService
+        from services.soc_agents import SOCAgentLibrary
+        from services.workflow_run_service import get_workflow_run_service
+
+        target_context = self._build_target_context(parameters)
         all_agents = SOCAgentLibrary.get_all_agents()
         agent_profiles = {
             agent_id: all_agents[agent_id]
             for agent_id in workflow.agents
             if agent_id in all_agents
         }
-
-        # Build the composite execution prompt
         prompt = self.build_execution_prompt(
             workflow=workflow,
             target_context=target_context,
             agent_profiles=agent_profiles,
         )
+        all_tools, skill_tool_names = self._collect_tools(workflow, agent_profiles)
+        system_prompt = self._build_system_prompt(workflow, skill_tool_names)
 
-        # Collect all tools needed across all agents in the workflow
-        all_tools = list(workflow.tools_used)
-        for agent_id in workflow.agents:
-            profile = agent_profiles.get(agent_id)
-            if profile and profile.recommended_tools:
-                for tool in profile.recommended_tools:
-                    if tool not in all_tools:
-                        all_tools.append(tool)
-
-        # Add MCP tools if available
-        try:
-            from services.mcp_registry import get_mcp_registry
-            registry = get_mcp_registry()
-            mcp_tool_names = registry.get_tool_names()
-            if mcp_tool_names:
-                all_tools.extend(mcp_tool_names)
-        except Exception as e:
-            logger.debug(f"Could not get MCP tools from registry: {e}")
-
-        # Include active DB-backed Skills as ``skill_<slug>`` tools so a
-        # workflow phase can invoke them (#126). Skills aren't MCP tools,
-        # they're backend tools generated at runtime from the `skills`
-        # table — without this step they'd be invisible to the execution
-        # engine even when the user had authored them.
-        skill_tool_names: List[str] = []
-        try:
-            from services.skill_tools_bridge import list_active_skill_tools
-
-            skill_defs, _ = list_active_skill_tools()
-            skill_tool_names = [t["name"] for t in skill_defs]
-            for name in skill_tool_names:
-                if name not in all_tools:
-                    all_tools.append(name)
-        except Exception as e:
-            logger.debug(f"Could not load active skill tools: {e}")
-
-        # Build a composite system prompt incorporating all agent roles
-        skills_hint = ""
-        if skill_tool_names:
-            skills_hint = (
-                "\n<available_skills>\n"
-                "The following skill tools are available as reusable SOC "
-                "capabilities. Invoke by name whenever a phase's work "
-                "matches a skill's purpose — each call returns the "
-                "skill's rendered playbook text for you to act on.\n"
-                + "\n".join(f"- {name}" for name in skill_tool_names)
-                + "\n</available_skills>\n"
-            )
-
-        system_prompt = f"""You are the Vigil SOC Workflow Engine executing the "{workflow.name}" workflow.
-
-You have access to all SOC tools and will execute a multi-phase workflow,
-adopting different specialist agent roles for each phase.
-
-<entity_recognition>
-- Finding IDs (f-YYYYMMDD-XXXXXXXX): Use get_finding tool
-- Case IDs (case-YYYYMMDD-XXXXXXXX): Use get_case tool
-- IPs/domains/hashes: Use threat intel tools
-- NEVER access findings as files - use tools
-</entity_recognition>
-{skills_hint}
-<principles>
-- Always fetch data via tools before analyzing
-- Be evidence-based and document reasoning
-- Use parallel tool calls for independent queries
-- Follow each workflow phase in sequence
-- Pass context between phases
-</principles>
-"""
-
-        # Workflow execution is a *playbook run*, not a chat session.
-        # We call ClaudeService.chat() as an internal Python primitive
-        # — no /api/claude/chat route, no conversation session, no
-        # session-history persistence. It's "run this composite prompt
-        # with access to backend + MCP tools (incl. skills) and hand me
-        # the structured result." The Agent SDK path used to live here
-        # (run_agent_task) but that branch doesn't see backend_tools, so
-        # skills would never resolve. See issue #126.
         claude_service = ClaudeService(
             use_backend_tools=True,
             use_mcp_tools=True,
             use_agent_sdk=False,
             enable_thinking=True,
         )
-
         if not claude_service.has_api_key():
             return {"success": False, "error": "Claude API not configured"}
 
-        # Persist run start so history/audit reflects this invocation
-        # even if the chat() call below crashes. Best-effort: a DB
-        # hiccup yields ``run_id is None`` and the workflow still runs.
         workflow_dict = workflow.to_dict(include_body=False)
         run_service = get_workflow_run_service()
         run_id = run_service.begin_run(
-            workflow_id=workflow_id,
+            workflow_id=workflow.id,
             workflow_name=workflow.name,
             workflow_source=workflow_dict.get("source", "file"),
             workflow_version=workflow_dict.get("version"),
@@ -570,8 +637,6 @@ adopting different specialist agent roles for each phase.
             skill_tools_available=skill_tool_names,
         )
 
-        # chat() is sync + has its own multi-iteration tool loop. Offload
-        # to a thread so we don't block the asyncio loop of the caller.
         try:
             response_text = await asyncio.to_thread(
                 claude_service.chat,
@@ -587,10 +652,8 @@ adopting different specialist agent roles for each phase.
             response_text = ""
             success = False
             error = f"{type(exc).__name__}: {exc}"
-            logger.exception("Workflow execution failed for %s", workflow_id)
+            logger.exception("Workflow execution failed for %s", workflow.id)
 
-        # Finalize the run record regardless of outcome so the row never
-        # dangles in ``status='running'``.
         if run_id:
             run_service.finalize_run(
                 run_id,
@@ -601,19 +664,436 @@ adopting different specialist agent roles for each phase.
 
         return {
             "success": success,
+            "status": "completed" if success else "failed",
             "run_id": run_id,
             "workflow": workflow_dict,
             "result": response_text or "",
-            # Playbook runs don't yet stream intermediate tool calls back
-            # through this entry point; ClaudeService.chat captures them
-            # internally for reasoning-trace persistence. A structured
-            # per-phase output + tool_calls feed is tracked as #128.
             "tool_calls": [],
             "error": error,
             "parameters": parameters,
             "skill_tools_available": skill_tool_names,
             "executed_at": datetime.now().isoformat(),
         }
+
+    async def _execute_phased(
+        self,
+        workflow: "WorkflowDefinition",
+        phases: List[Dict[str, Any]],
+        parameters: Dict[str, Any],
+        triggered_by: Optional[str],
+    ) -> Dict[str, Any]:
+        """Phase-by-phase execution path for custom workflows (#128)."""
+        from services.claude_service import ClaudeService
+        from services.workflow_run_service import get_workflow_run_service
+
+        if not ClaudeService(
+            use_backend_tools=False, use_mcp_tools=False, use_agent_sdk=False
+        ).has_api_key():
+            return {"success": False, "error": "Claude API not configured"}
+
+        _, skill_tool_names = self._collect_tools(workflow, {})
+
+        workflow_dict = workflow.to_dict(include_body=False)
+        run_service = get_workflow_run_service()
+        run_id = run_service.begin_run(
+            workflow_id=workflow.id,
+            workflow_name=workflow.name,
+            workflow_source=workflow_dict.get("source", "custom"),
+            workflow_version=workflow_dict.get("version"),
+            trigger_context=dict(parameters or {}),
+            triggered_by=triggered_by,
+            skill_tools_available=skill_tool_names,
+        )
+
+        if not run_id:
+            return {
+                "success": False,
+                "error": "Could not persist run (DB unavailable)",
+            }
+
+        return await self._run_phase_loop(
+            workflow=workflow,
+            phases=phases,
+            start_index=0,
+            run_id=run_id,
+            parameters=parameters,
+            accumulated={},
+            triggered_by=triggered_by,
+            skill_tools_available=skill_tool_names,
+        )
+
+    async def _run_phase_loop(
+        self,
+        *,
+        workflow: "WorkflowDefinition",
+        phases: List[Dict[str, Any]],
+        start_index: int,
+        run_id: str,
+        parameters: Dict[str, Any],
+        accumulated: Dict[str, Any],
+        triggered_by: Optional[str],
+        skill_tools_available: List[str],
+    ) -> Dict[str, Any]:
+        """Shared phase-loop body used by both initial execute and
+        resume. Walks phases from ``start_index``; pauses or completes
+        the run as appropriate."""
+        from services.claude_service import ClaudeService
+        from services.soc_agents import SOCAgentLibrary
+        from services.approval_service import (
+            ActionType,
+            get_approval_service,
+        )
+        from services.workflow_run_service import get_workflow_run_service
+
+        run_service = get_workflow_run_service()
+        approval_service = get_approval_service()
+        all_agents = SOCAgentLibrary.get_all_agents()
+        workflow_dict = workflow.to_dict(include_body=False)
+
+        target_context = self._build_target_context(parameters)
+
+        claude_service = ClaudeService(
+            use_backend_tools=True,
+            use_mcp_tools=True,
+            use_agent_sdk=False,
+            enable_thinking=True,
+        )
+
+        phase_outputs: List[Dict[str, Any]] = []
+        last_response_text = ""
+
+        # Existing phase rows (populated on resume) let us detect a
+        # phase that was already approved and must not re-prompt.
+        existing_phases = {p["phase_id"]: p for p in run_service.list_phases(run_id)}
+
+        for idx in range(start_index, len(phases)):
+            phase = phases[idx]
+            phase_id = phase.get("phase_id") or f"phase-{phase.get('order', idx + 1)}"
+            phase_order = int(phase.get("order", idx + 1))
+            agent_id = phase.get("agent_id") or ""
+
+            prior_row = existing_phases.get(phase_id)
+            already_approved = (
+                prior_row is not None
+                and prior_row.get("approval_state") == "approved"
+            )
+
+            # Pre-phase approval gate (#128). Skipped if the phase row
+            # already carries approval_state='approved' (resume path).
+            if phase.get("approval_required") and not already_approved:
+                run_service.upsert_phase(
+                    run_id,
+                    phase_id,
+                    phase_order=phase_order,
+                    agent_id=agent_id,
+                    status="pending_approval",
+                    input_context={"prior_outputs": accumulated},
+                    approval_state="pending",
+                )
+                action = approval_service.create_action(
+                    action_type=ActionType.WORKFLOW_PHASE,
+                    title=(
+                        f"Approve phase '{phase.get('name', phase_id)}' "
+                        f"in {workflow.name}"
+                    ),
+                    description=(
+                        phase.get("purpose")
+                        or f"Phase {phase_order} of {workflow.name}"
+                    ),
+                    target=run_id,
+                    confidence=0.0,
+                    reason="Workflow phase marked approval_required=True",
+                    evidence=[run_id],
+                    created_by=triggered_by or "workflow_engine",
+                    parameters={
+                        "phase_id": phase_id,
+                        "phase_order": phase_order,
+                        "agent_id": agent_id,
+                        "phase_inputs": accumulated,
+                        "workflow_name": workflow.name,
+                    },
+                    workflow_run_id=run_id,
+                    workflow_phase_id=phase_id,
+                )
+                run_service.set_status(run_id, "paused")
+                return {
+                    "success": True,
+                    "status": "paused",
+                    "run_id": run_id,
+                    "workflow": workflow_dict,
+                    "pending_approval_action_id": action.action_id,
+                    "paused_at_phase": phase_id,
+                    "parameters": parameters,
+                    "skill_tools_available": skill_tools_available,
+                    "executed_at": datetime.now().isoformat(),
+                }
+
+            # Run the phase.
+            run_service.upsert_phase(
+                run_id,
+                phase_id,
+                phase_order=phase_order,
+                agent_id=agent_id,
+                status="running",
+                input_context={"prior_outputs": accumulated},
+                started_at=datetime.utcnow(),
+            )
+
+            profile = all_agents.get(agent_id)
+            phase_prompt = self._build_phase_prompt(
+                workflow=workflow,
+                phase=phase,
+                target_context=target_context,
+                prior_outputs=accumulated,
+            )
+            system_prompt = self._build_system_prompt(
+                workflow, skill_tools_available, single_phase=phase
+            )
+            phase_tools = self._tools_for_phase(phase, profile, skill_tools_available)
+
+            try:
+                response_text = await asyncio.to_thread(
+                    claude_service.chat,
+                    message=phase_prompt,
+                    system_prompt=system_prompt,
+                    model="claude-sonnet-4-5-20250929",
+                    max_tokens=8192,
+                    recommended_tools=phase_tools or None,
+                )
+                phase_ok = response_text is not None
+                phase_error = None if phase_ok else "Claude returned no response"
+            except Exception as exc:  # noqa: BLE001
+                response_text = ""
+                phase_ok = False
+                phase_error = f"{type(exc).__name__}: {exc}"
+                logger.exception(
+                    "Workflow phase %s failed for run %s", phase_id, run_id
+                )
+
+            finished = datetime.utcnow()
+            if phase_ok:
+                output = {"text": response_text or ""}
+                run_service.upsert_phase(
+                    run_id,
+                    phase_id,
+                    phase_order=phase_order,
+                    agent_id=agent_id,
+                    status="completed",
+                    output=output,
+                    finished_at=finished,
+                )
+                accumulated[phase_id] = output
+                phase_outputs.append(
+                    {"phase_id": phase_id, "output": response_text or ""}
+                )
+                last_response_text = response_text or last_response_text
+            else:
+                run_service.upsert_phase(
+                    run_id,
+                    phase_id,
+                    phase_order=phase_order,
+                    agent_id=agent_id,
+                    status="failed",
+                    error=phase_error,
+                    finished_at=finished,
+                )
+                run_service.finalize_run(
+                    run_id,
+                    status="failed",
+                    result_summary=self._combine_summary(phase_outputs),
+                    error=phase_error,
+                )
+                return {
+                    "success": False,
+                    "status": "failed",
+                    "run_id": run_id,
+                    "workflow": workflow_dict,
+                    "result": self._combine_summary(phase_outputs),
+                    "tool_calls": [],
+                    "error": phase_error,
+                    "parameters": parameters,
+                    "skill_tools_available": skill_tools_available,
+                    "executed_at": datetime.now().isoformat(),
+                }
+
+        summary = self._combine_summary(phase_outputs) or last_response_text
+        run_service.finalize_run(
+            run_id,
+            status="completed",
+            result_summary=summary or None,
+        )
+        return {
+            "success": True,
+            "status": "completed",
+            "run_id": run_id,
+            "workflow": workflow_dict,
+            "result": summary or "",
+            "tool_calls": [],
+            "error": None,
+            "parameters": parameters,
+            "skill_tools_available": skill_tools_available,
+            "executed_at": datetime.now().isoformat(),
+        }
+
+    # ------------------------------------------------------------------
+    # Prompt / tool helpers
+    # ------------------------------------------------------------------
+
+    def _collect_tools(
+        self,
+        workflow: "WorkflowDefinition",
+        agent_profiles: Dict[str, Any],
+    ) -> tuple[List[str], List[str]]:
+        """Collect workflow + agent + MCP + skill tools. Returns
+        ``(all_tools, skill_tool_names)``."""
+        all_tools = list(workflow.tools_used)
+        for agent_id in workflow.agents:
+            profile = agent_profiles.get(agent_id)
+            if profile and getattr(profile, "recommended_tools", None):
+                for tool in profile.recommended_tools:
+                    if tool not in all_tools:
+                        all_tools.append(tool)
+        try:
+            from services.mcp_registry import get_mcp_registry
+
+            registry = get_mcp_registry()
+            for name in registry.get_tool_names() or []:
+                if name not in all_tools:
+                    all_tools.append(name)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Could not get MCP tools from registry: %s", e)
+
+        skill_tool_names: List[str] = []
+        try:
+            from services.skill_tools_bridge import list_active_skill_tools
+
+            skill_defs, _ = list_active_skill_tools()
+            skill_tool_names = [t["name"] for t in skill_defs]
+            for name in skill_tool_names:
+                if name not in all_tools:
+                    all_tools.append(name)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Could not load active skill tools: %s", e)
+
+        return all_tools, skill_tool_names
+
+    def _tools_for_phase(
+        self,
+        phase: Dict[str, Any],
+        profile: Optional[Any],
+        skill_tool_names: List[str],
+    ) -> List[str]:
+        """Narrow the tool list to what this phase actually needs."""
+        tools = list(phase.get("tools") or [])
+        if profile and getattr(profile, "recommended_tools", None):
+            for t in profile.recommended_tools:
+                if t not in tools:
+                    tools.append(t)
+        try:
+            from services.mcp_registry import get_mcp_registry
+
+            registry = get_mcp_registry()
+            for name in registry.get_tool_names() or []:
+                if name not in tools:
+                    tools.append(name)
+        except Exception:  # noqa: BLE001
+            pass
+        for name in skill_tool_names:
+            if name not in tools:
+                tools.append(name)
+        return tools
+
+    def _build_system_prompt(
+        self,
+        workflow: "WorkflowDefinition",
+        skill_tool_names: List[str],
+        single_phase: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """System prompt shared by oneshot and per-phase execution."""
+        skills_hint = ""
+        if skill_tool_names:
+            skills_hint = (
+                "\n<available_skills>\n"
+                "The following skill tools are available as reusable SOC "
+                "capabilities. Invoke by name whenever the phase's work "
+                "matches a skill's purpose — each call returns the "
+                "skill's rendered playbook text for you to act on.\n"
+                + "\n".join(f"- {name}" for name in skill_tool_names)
+                + "\n</available_skills>\n"
+            )
+        scope = (
+            f'phase "{single_phase.get("name", single_phase.get("phase_id"))}"'
+            if single_phase
+            else "multi-phase workflow"
+        )
+        header = (
+            f'You are the Vigil SOC Workflow Engine executing the '
+            f'"{workflow.name}" {scope}.'
+        )
+        return f"""{header}
+
+You have access to SOC tools and must ground every conclusion in tool output.
+
+<entity_recognition>
+- Finding IDs (f-YYYYMMDD-XXXXXXXX): Use get_finding tool
+- Case IDs (case-YYYYMMDD-XXXXXXXX): Use get_case tool
+- IPs/domains/hashes: Use threat intel tools
+- NEVER access findings as files - use tools
+</entity_recognition>
+{skills_hint}
+<principles>
+- Always fetch data via tools before analyzing
+- Be evidence-based and document reasoning
+- Use parallel tool calls for independent queries
+- Return a concise, structured summary suitable as input to the next phase
+</principles>
+"""
+
+    def _build_phase_prompt(
+        self,
+        workflow: "WorkflowDefinition",
+        phase: Dict[str, Any],
+        target_context: str,
+        prior_outputs: Dict[str, Any],
+    ) -> str:
+        """Focused prompt for a single phase. Includes accumulated
+        outputs from prior phases so context carries forward."""
+        lines: List[str] = [
+            f"# Phase {phase.get('order', '?')}: {phase.get('name', '')}",
+            "",
+            f"**Workflow:** {workflow.name}",
+            f"**Agent role:** {phase.get('agent_id', '')}",
+        ]
+        if phase.get("purpose"):
+            lines += ["", f"**Purpose:** {phase['purpose']}"]
+        lines += ["", "## Target Context", target_context]
+        if prior_outputs:
+            lines += ["", "## Prior Phase Outputs"]
+            for pid, out in prior_outputs.items():
+                text = (out or {}).get("text") if isinstance(out, dict) else str(out)
+                if text:
+                    lines += [f"### {pid}", text.strip()]
+        steps = phase.get("steps") or []
+        if steps:
+            lines += ["", "## Steps"]
+            for i, step in enumerate(steps, start=1):
+                lines.append(f"{i}. {step}")
+        if phase.get("expected_output"):
+            lines += ["", f"**Expected output:** {phase['expected_output']}"]
+        lines += [
+            "",
+            "Execute this phase using the tools available, grounding "
+            "every claim in tool results. Conclude with a structured "
+            "summary suitable as input for the next phase.",
+        ]
+        return "\n".join(lines)
+
+    def _combine_summary(self, phase_outputs: List[Dict[str, Any]]) -> str:
+        """Concatenate per-phase outputs into a single run summary."""
+        parts: List[str] = []
+        for p in phase_outputs:
+            parts.append(f"### {p['phase_id']}\n{p.get('output', '')}")
+        return "\n\n".join(parts)
 
     def _build_target_context(self, parameters: Dict[str, Any]) -> str:
         """Build a context string from execution parameters."""
@@ -627,11 +1107,16 @@ adopting different specialist agent roles for each phase.
         if finding_id:
             try:
                 from services.database_data_service import DatabaseDataService
+
                 data_service = DatabaseDataService()
                 finding = data_service.get_finding(finding_id)
                 if finding:
-                    techniques = finding.get('predicted_techniques', [])
-                    technique_str = ', '.join([t.get('technique_id', '') for t in techniques]) if techniques else 'None'
+                    techniques = finding.get("predicted_techniques", [])
+                    technique_str = (
+                        ", ".join([t.get("technique_id", "") for t in techniques])
+                        if techniques
+                        else "None"
+                    )
                     parts.append(f"""**Target Finding:**
 - Finding ID: {finding.get('finding_id')}
 - Severity: {finding.get('severity')}
@@ -641,13 +1126,18 @@ adopting different specialist agent roles for each phase.
 - Description: {finding.get('description', 'N/A')}
 - MITRE ATT&CK Techniques: {technique_str}""")
                 else:
-                    parts.append(f"**Target Finding ID:** {finding_id} (details will be retrieved during execution)")
+                    parts.append(
+                        f"**Target Finding ID:** {finding_id} (details will be retrieved during execution)"
+                    )
             except Exception:
-                parts.append(f"**Target Finding ID:** {finding_id} (use get_finding to retrieve details)")
+                parts.append(
+                    f"**Target Finding ID:** {finding_id} (use get_finding to retrieve details)"
+                )
 
         if case_id:
             try:
                 from services.database_data_service import DatabaseDataService
+
                 data_service = DatabaseDataService()
                 case = data_service.get_case(case_id)
                 if case:
@@ -659,9 +1149,13 @@ adopting different specialist agent roles for each phase.
 - Description: {case.get('description', 'N/A')}
 - Finding Count: {len(case.get('finding_ids', []))}""")
                 else:
-                    parts.append(f"**Target Case ID:** {case_id} (details will be retrieved during execution)")
+                    parts.append(
+                        f"**Target Case ID:** {case_id} (details will be retrieved during execution)"
+                    )
             except Exception:
-                parts.append(f"**Target Case ID:** {case_id} (use get_case to retrieve details)")
+                parts.append(
+                    f"**Target Case ID:** {case_id} (use get_case to retrieve details)"
+                )
 
         if hypothesis:
             parts.append(f"**Hunt Hypothesis:** {hypothesis}")
@@ -670,7 +1164,9 @@ adopting different specialist agent roles for each phase.
             parts.append(f"**Additional Context:** {context}")
 
         if not parts:
-            parts.append("No specific target provided. Use available tools to identify relevant findings and cases.")
+            parts.append(
+                "No specific target provided. Use available tools to identify relevant findings and cases."
+            )
 
         return "\n\n".join(parts)
 

--- a/tests/unit/test_workflow_phase_approval.py
+++ b/tests/unit/test_workflow_phase_approval.py
@@ -1,0 +1,312 @@
+"""Unit tests for phase-by-phase workflow execution + approval gating (#128).
+
+These exercise the full pause→approve/reject→resume state machine
+against a real Postgres. ``ClaudeService.chat`` is patched to return
+canned per-phase text so we don't spend API credits and tests stay
+deterministic.
+
+Skips cleanly if no DB is reachable — same pattern as
+``test_workflow_run_service.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+
+def _db_available() -> bool:
+    try:
+        from database.connection import get_db_manager
+
+        m = get_db_manager()
+        if m._engine is None:
+            m.initialize()
+        with m.session_scope() as s:
+            s.execute(__import__("sqlalchemy").text("SELECT 1"))
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _db_available(), reason="Postgres not reachable; skipping DB-backed tests"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_tables():
+    """Wipe the tables we touch before + after each test."""
+    from database.connection import get_db_manager
+    from sqlalchemy import text
+
+    def _clear():
+        with get_db_manager().session_scope() as s:
+            s.execute(
+                text(
+                    "DELETE FROM approval_actions WHERE workflow_run_id IN "
+                    "(SELECT run_id FROM workflow_runs "
+                    "WHERE workflow_id LIKE 'test-phase-%')"
+                )
+            )
+            s.execute(
+                text(
+                    "DELETE FROM workflow_run_phases WHERE run_id IN "
+                    "(SELECT run_id FROM workflow_runs "
+                    "WHERE workflow_id LIKE 'test-phase-%')"
+                )
+            )
+            s.execute(
+                text("DELETE FROM workflow_runs WHERE workflow_id LIKE 'test-phase-%'")
+            )
+
+    _clear()
+    yield
+    _clear()
+
+
+def _make_workflow(approval_on_phase_2: bool = True):
+    """Build an in-memory WorkflowDefinition with 2 phases."""
+    from services.workflows_service import WorkflowDefinition
+
+    phases: List[Dict[str, Any]] = [
+        {
+            "order": 1,
+            "phase_id": "phase-1",
+            "name": "Triage",
+            "agent_id": "triage",
+            "purpose": "Initial triage",
+            "tools": [],
+            "steps": ["Check severity"],
+            "expected_output": "triage summary",
+            "approval_required": False,
+        },
+        {
+            "order": 2,
+            "phase_id": "phase-2",
+            "name": "Respond",
+            "agent_id": "auto_responder",
+            "purpose": "Contain threat",
+            "tools": [],
+            "steps": ["Isolate host"],
+            "expected_output": "response result",
+            "approval_required": approval_on_phase_2,
+        },
+    ]
+    metadata = {
+        "name": "Test Phased Workflow",
+        "description": "phase-by-phase execution test",
+        "agents": ["triage", "auto_responder"],
+        "tools-used": [],
+        "use-case": "",
+        "trigger-examples": [],
+        "phases": phases,
+    }
+    return WorkflowDefinition(
+        workflow_id="test-phase-001",
+        file_path=None,
+        metadata=metadata,
+        body="",
+        source="custom",
+    )
+
+
+class _FakeClaudeService:
+    """Test double that skips the real Claude call but keeps the
+    interface ``WorkflowsService`` depends on."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def has_api_key(self) -> bool:  # noqa: D401
+        return True
+
+    def chat(
+        self, *, message, system_prompt, model, max_tokens, recommended_tools=None
+    ):
+        # Return a deterministic per-phase summary so we can assert on it.
+        if "phase-1" in message or "Phase 1" in message:
+            return "phase-1 output: triage complete"
+        if "phase-2" in message or "Phase 2" in message:
+            return "phase-2 output: contained"
+        return "ok"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPhasedExecutionPauseResume:
+    def _patched_service(self, workflow):
+        """Return a WorkflowsService wired so .get_workflow yields our
+        in-memory fixture and ClaudeService is the fake."""
+        from services import workflows_service as ws
+
+        svc = ws.WorkflowsService()
+        svc.get_workflow = lambda wid: workflow  # type: ignore[method-assign]
+        return svc
+
+    def test_pauses_before_phase_requiring_approval(self, clean_tables):
+        from services import claude_service as cs_module
+        from services.workflow_run_service import get_workflow_run_service
+
+        workflow = _make_workflow(approval_on_phase_2=True)
+        svc = self._patched_service(workflow)
+
+        with patch.object(cs_module, "ClaudeService", _FakeClaudeService):
+            result = asyncio.run(
+                svc.execute_workflow(
+                    workflow.id,
+                    parameters={"context": "test"},
+                    triggered_by="pytest",
+                )
+            )
+
+        assert result["success"] is True
+        assert result["status"] == "paused"
+        assert result["run_id"]
+        assert result["pending_approval_action_id"]
+        assert result["paused_at_phase"] == "phase-2"
+
+        run = get_workflow_run_service().get_run(result["run_id"])
+        assert run["status"] == "paused"
+        phases = get_workflow_run_service().list_phases(result["run_id"])
+        by_id = {p["phase_id"]: p for p in phases}
+        assert by_id["phase-1"]["status"] == "completed"
+        assert by_id["phase-2"]["status"] == "pending_approval"
+        assert by_id["phase-2"]["approval_state"] == "pending"
+
+    def test_resume_approved_completes_run(self, clean_tables):
+        from services import claude_service as cs_module
+        from services.approval_service import get_approval_service
+        from services.workflow_run_service import get_workflow_run_service
+
+        workflow = _make_workflow(approval_on_phase_2=True)
+        svc = self._patched_service(workflow)
+
+        with patch.object(cs_module, "ClaudeService", _FakeClaudeService):
+            paused = asyncio.run(
+                svc.execute_workflow(workflow.id, parameters={}, triggered_by="pytest")
+            )
+            assert paused["status"] == "paused"
+            run_id = paused["run_id"]
+            action_id = paused["pending_approval_action_id"]
+
+            get_approval_service().approve_action(action_id, approved_by="tester")
+            result = asyncio.run(
+                svc.resume_workflow(run_id, "approved", approved_by="tester")
+            )
+
+        assert result["success"] is True
+        assert result["status"] == "completed"
+        assert result["run_id"] == run_id
+
+        run = get_workflow_run_service().get_run(run_id)
+        assert run["status"] == "completed"
+        phases = get_workflow_run_service().list_phases(run_id)
+        statuses = {p["phase_id"]: p["status"] for p in phases}
+        approval_states = {p["phase_id"]: p["approval_state"] for p in phases}
+        assert statuses == {"phase-1": "completed", "phase-2": "completed"}
+        assert approval_states["phase-2"] == "approved"
+
+    def test_resume_rejected_cancels_run(self, clean_tables):
+        from services import claude_service as cs_module
+        from services.approval_service import get_approval_service
+        from services.workflow_run_service import get_workflow_run_service
+
+        workflow = _make_workflow(approval_on_phase_2=True)
+        svc = self._patched_service(workflow)
+
+        with patch.object(cs_module, "ClaudeService", _FakeClaudeService):
+            paused = asyncio.run(
+                svc.execute_workflow(workflow.id, parameters={}, triggered_by="pytest")
+            )
+            run_id = paused["run_id"]
+            action_id = paused["pending_approval_action_id"]
+
+            get_approval_service().reject_action(
+                action_id, reason="not safe", rejected_by="tester"
+            )
+            result = asyncio.run(
+                svc.resume_workflow(
+                    run_id,
+                    "rejected",
+                    rejection_reason="not safe",
+                    approved_by="tester",
+                )
+            )
+
+        assert result["success"] is True
+        assert result["status"] == "cancelled"
+        assert "not safe" in result["rejection_reason"]
+
+        run = get_workflow_run_service().get_run(run_id)
+        assert run["status"] == "cancelled"
+        assert "not safe" in (run["error"] or "")
+        phases = get_workflow_run_service().list_phases(run_id)
+        by_id = {p["phase_id"]: p for p in phases}
+        assert by_id["phase-2"]["status"] == "failed"
+        assert by_id["phase-2"]["approval_state"] == "rejected"
+
+    def test_no_approval_required_runs_straight_through(self, clean_tables):
+        from services import claude_service as cs_module
+        from services.workflow_run_service import get_workflow_run_service
+
+        workflow = _make_workflow(approval_on_phase_2=False)
+        svc = self._patched_service(workflow)
+
+        with patch.object(cs_module, "ClaudeService", _FakeClaudeService):
+            result = asyncio.run(
+                svc.execute_workflow(workflow.id, parameters={}, triggered_by="pytest")
+            )
+
+        assert result["success"] is True
+        assert result["status"] == "completed"
+        run = get_workflow_run_service().get_run(result["run_id"])
+        assert run["status"] == "completed"
+
+
+class TestApprovalActionWorkflowLinkage:
+    def test_create_action_persists_workflow_linkage(self, clean_tables):
+        from services.approval_service import (
+            ActionType,
+            get_approval_service,
+        )
+        from services.workflow_run_service import get_workflow_run_service
+
+        run_id = get_workflow_run_service().begin_run(
+            workflow_id="test-phase-linkage",
+            workflow_name="Linkage",
+        )
+        assert run_id is not None
+        svc = get_approval_service()
+        action = svc.create_action(
+            action_type=ActionType.WORKFLOW_PHASE,
+            title="phase approval",
+            description="t",
+            target=run_id,
+            confidence=0.0,
+            reason="approval_required",
+            evidence=[run_id],
+            created_by="pytest",
+            workflow_run_id=run_id,
+            workflow_phase_id="phase-2",
+        )
+        assert action.workflow_run_id == run_id
+        assert action.workflow_phase_id == "phase-2"
+
+        fetched = svc.get_action(action.action_id)
+        assert fetched is not None
+        assert fetched.workflow_run_id == run_id
+
+        listed = svc.list_actions(workflow_run_id=run_id)
+        assert any(a.action_id == action.action_id for a in listed)


### PR DESCRIPTION
## Summary

Closes #128.

Workflow phases already carried an `approval_required: bool` field (set in the builder UI, persisted in `custom_workflows.phases` JSONB), but `WorkflowsService.execute_workflow()` ignored it — the whole workflow ran as a single composite Claude prompt with no pause point. This PR wires the flag up end-to-end: execution pauses before any phase marked approval-required, surfaces an approval action in the UI, and resumes or cancels the run based on the analyst's decision.

## What changed

**Execution model** — `execute_workflow` now runs phase-by-phase for custom workflows (file-based ones without structured phases keep the legacy one-shot path; there's no phase_id to gate on). Each phase gets a focused prompt with accumulated outputs from prior phases fed in as `input_context`. A new `resume_workflow(run_id, decision)` re-enters the loop at the paused phase.

**State machine** —
- `workflow_runs.status`: `running → paused → completed | cancelled | failed`
- `workflow_run_phases.status`: `pending → running → completed | failed | pending_approval`
- `paused` added to the `workflow_runs.status` CHECK constraint; `pending_approval` was already allowed from #127's schema.

**Approvals migrated to Postgres** — `ApprovalService` previously wrote to `data/pending_actions.json`, which had no API surface and no workflow linkage. New `approval_actions` table (migration `13_approval_actions.sql`) with FK to `workflow_runs` + `workflow_phase_id`. Public service API is preserved so `daemon/orchestrator.py` still works; new `workflow_run_id` / `workflow_phase_id` kwargs on `create_action`.

**New endpoints**
- `GET /api/approvals` (with status / workflow_run_id filters), `/api/approvals/pending`, `/api/approvals/{id}`
- `POST /api/approvals/{id}/approve` and `/reject` — auto-resume or cancel the linked workflow run
- `POST /api/workflows/runs/{run_id}/resume` and `/cancel` for direct control
- `GET /api/workflows/runs/{run_id}` now includes a `phases` array

**Frontend** — new "Pending Approvals" tab on the AI Decisions page lists pending actions with a workflow run link + phase chip; Approve button and Reject-with-reason dialog call the new endpoints.

## Files

| Area | Key files |
|---|---|
| Migration | `database/init/13_approval_actions.sql` (+ helm copy) |
| Models | `database/models.py` — `ApprovalAction` |
| Services | `services/approval_service.py` (DB-backed rewrite), `services/workflow_run_service.py` (+ `upsert_phase`, `list_phases`, `set_status`), `services/workflows_service.py` (phase loop + `resume_workflow`) |
| API | `backend/api/approvals.py` (new), `backend/api/workflows.py` (resume/cancel + phases in detail) |
| Frontend | `frontend/src/services/api.ts` (`approvalsApi`), `frontend/src/pages/AIDecisions.tsx` (Pending Approvals tab) |
| Tests | `tests/unit/test_workflow_phase_approval.py` |

## Test plan

- [ ] `pytest tests/unit/test_workflow_phase_approval.py tests/unit/test_workflow_run_service.py tests/unit/test_approval_workflow.py` — all pass locally (14 + 27 = 41 tests, DB-backed tests skip cleanly without Postgres).
- [ ] In WorkflowBuilder, create a 2-phase custom workflow with `approval_required: true` on phase 2.
- [ ] Execute it from the UI → response should be `{status: "paused", run_id, pending_approval_action_id}`.
- [ ] Open **AI Decisions → Pending Approvals** tab → confirm the new action shows up with the run link + phase chip.
- [ ] Click **Approve** → run should resume and finalise as `completed`; Workflow History shows both phase rows as `completed`.
- [ ] Repeat the flow with **Reject** (with a reason) → run finalises as `cancelled`; rejection reason appears in the run's error field and phase 2's `approval_state=rejected`.
- [ ] Confirm a workflow with NO `approval_required` phases runs straight through (no regression).
- [ ] Confirm `daemon/orchestrator.py` containment approval creation still works (ApprovalService public API preserved).
- [ ] Apply migration `13_approval_actions.sql` to any existing databases — the schema init runs on fresh installs automatically.

## Notes for reviewers

- Phase-by-phase execution is new. The per-phase prompt is in `WorkflowsService._build_phase_prompt` and stitches target context + prior phase outputs + the phase's own steps. Review the tradeoff vs the old "one composite prompt letting Claude flow between phases" approach — the old style may have produced more natural inter-phase reasoning, but is structurally unable to pause.
- No background worker was introduced. The execute endpoint returns early with `status: paused` and the resume endpoint re-enters the loop synchronously on click. If a future phase approval can take hours, we'd want to move to ARQ — out of scope here.
- `workflow_runs` history entries from before this PR have `workflow_run_phases` rows that may be missing; the UI handles empty arrays gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)