### PR TITLE
feat(skills): import Claude Desktop .zip bundles (#130)

### DIFF
--- a/backend/api/skills.py
+++ b/backend/api/skills.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
@@ -17,8 +17,14 @@ from backend.schemas.skill import (  # noqa: E402
     SkillCreate,
     SkillGenerateRequest,
     SkillGenerateResponse,
+    SkillImportResponse,
     SkillResponse,
     SkillUpdate,
+)
+from services.skill_importer import (  # noqa: E402
+    MAX_ZIP_BYTES,
+    SkillImportError,
+    import_skill_zip,
 )
 from services.skill_service import SkillService  # noqa: E402
 
@@ -60,6 +66,45 @@ async def generate_skill(request: SkillGenerateRequest):
         raise
     except Exception as e:
         logger.error("Error generating skill: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/import", response_model=SkillImportResponse, status_code=201)
+async def import_skill(
+    file: UploadFile = File(...),
+    created_by: Optional[str] = Form(None),
+):
+    """Import a Claude Desktop-compatible skill ``.zip`` bundle (Issue #130).
+
+    The zip must contain a ``SKILL.md`` (YAML frontmatter + markdown body).
+    If a skill with the same name already exists, it is overwritten and its
+    version bumped; otherwise a new row is created.
+    """
+    try:
+        zip_bytes = await file.read()
+        if len(zip_bytes) > MAX_ZIP_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail={
+                    "message": (
+                        f"Zip exceeds {MAX_ZIP_BYTES // (1024 * 1024)} MB limit"
+                    ),
+                    "details": {
+                        "size_bytes": len(zip_bytes),
+                        "limit_bytes": MAX_ZIP_BYTES,
+                    },
+                },
+            )
+        return import_skill_zip(zip_bytes, created_by=created_by)
+    except SkillImportError as err:
+        raise HTTPException(
+            status_code=err.status_code,
+            detail={"message": err.message, "details": err.details},
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Error importing skill zip: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/backend/schemas/skill.py
+++ b/backend/schemas/skill.py
@@ -94,3 +94,16 @@ class SkillGenerateResponse(BaseModel):
     conversation_history: Optional[List[Dict[str, str]]] = None
     skill: Optional[SkillDraft] = None
     error: Optional[str] = None
+
+
+class SkillImportResponse(BaseModel):
+    """Response from `POST /api/skills/import` (Issue #130).
+
+    ``replaced`` is True when an existing skill with the same name was
+    overwritten (and its version bumped); False when a new row was created.
+    """
+
+    skill_id: str
+    name: str
+    version: int
+    replaced: bool

--- a/frontend/src/components/settings/SkillsTab.tsx
+++ b/frontend/src/components/settings/SkillsTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   Alert,
   Box,
@@ -27,6 +27,7 @@ import {
   AutoAwesome as SparkIcon,
   Delete as DeleteIcon,
   Refresh as RefreshIcon,
+  UploadFile as UploadFileIcon,
 } from '@mui/icons-material'
 
 import {
@@ -49,9 +50,12 @@ export default function SkillsTab() {
   const [skills, setSkills] = useState<Skill[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [importInfo, setImportInfo] = useState<string | null>(null)
+  const [importing, setImporting] = useState(false)
   const [categoryFilter, setCategoryFilter] = useState<SkillCategory | ''>('')
   const [builderOpen, setBuilderOpen] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState<Skill | null>(null)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   const load = async () => {
     setLoading(true)
@@ -96,6 +100,40 @@ export default function SkillsTab() {
     }
   }
 
+  const handleImportClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleImportChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    // Reset the input so the same file can be re-picked after an error.
+    e.target.value = ''
+    if (!file) return
+    setImporting(true)
+    setError(null)
+    setImportInfo(null)
+    try {
+      const result = await skillsApi.importZip(file)
+      const verb = result.replaced ? 'updated' : 'imported'
+      setImportInfo(`Successfully ${verb} "${result.name}" (v${result.version}).`)
+      await load()
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail
+      const message =
+        typeof detail === 'string'
+          ? detail
+          : detail?.message || err.message || 'Failed to import skill zip'
+      const rejected: string[] | undefined = detail?.details?.rejected_paths
+      setError(
+        rejected && rejected.length > 0
+          ? `${message} (offending paths: ${rejected.join(', ')})`
+          : message
+      )
+    } finally {
+      setImporting(false)
+    }
+  }
+
   return (
     <Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2, flexWrap: 'wrap' }}>
@@ -133,6 +171,21 @@ export default function SkillsTab() {
           Refresh
         </Button>
         <Button
+          variant="outlined"
+          startIcon={<UploadFileIcon />}
+          onClick={handleImportClick}
+          disabled={importing}
+        >
+          {importing ? 'Importing…' : 'Import Zip'}
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".zip,application/zip"
+          hidden
+          onChange={handleImportChange}
+        />
+        <Button
           variant="contained"
           startIcon={<SparkIcon />}
           onClick={() => setBuilderOpen(true)}
@@ -140,6 +193,12 @@ export default function SkillsTab() {
           Build Skill
         </Button>
       </Box>
+
+      {importInfo && (
+        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setImportInfo(null)}>
+          {importInfo}
+        </Alert>
+      )}
 
       {error && (
         <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>

--- a/frontend/src/components/settings/__tests__/SkillsTab.test.tsx
+++ b/frontend/src/components/settings/__tests__/SkillsTab.test.tsx
@@ -15,6 +15,7 @@ vi.mock('../../../services/skillsApi', async () => {
       update: vi.fn(),
       remove: vi.fn(),
       generate: vi.fn(),
+      importZip: vi.fn(),
     },
   }
 })

--- a/frontend/src/services/skillsApi.ts
+++ b/frontend/src/services/skillsApi.ts
@@ -53,6 +53,13 @@ export interface SkillGenerateResponse {
   error?: string
 }
 
+export interface SkillImportResult {
+  skill_id: string
+  name: string
+  version: number
+  replaced: boolean
+}
+
 const client = axios.create({
   baseURL: '/api/skills',
   headers: { 'Content-Type': 'application/json' },
@@ -84,4 +91,14 @@ export const skillsApi = {
 
   remove: (skillId: string) =>
     client.delete<{ success: boolean; skill_id: string }>(`/${skillId}`).then((r) => r.data),
+
+  importZip: (file: File) => {
+    const form = new FormData()
+    form.append('file', file)
+    return client
+      .post<SkillImportResult>('/import', form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+      .then((r) => r.data)
+  },
 }

--- a/services/skill_importer.py
+++ b/services/skill_importer.py
@@ -1,0 +1,300 @@
+"""Import Claude Desktop-compatible skill ``.zip`` bundles (Issue #130).
+
+A Claude Desktop skill ships as a zip containing ``SKILL.md`` — YAML
+frontmatter plus a markdown body. The frontmatter maps 1:1 to the
+``skills`` table (``name``, ``description``, ``category``,
+``input_schema``, ``output_schema``, ``required_tools``) and the body
+becomes ``prompt_template``.
+
+This module parses the zip, normalizes fields, and upserts via
+:class:`SkillService`. A name collision updates the existing row and
+bumps its version; a fresh name creates a new row.
+
+v1 scope: only ``SKILL.md`` is accepted. Any other zip entry is
+rejected with ``400`` and the offending paths listed in ``details``.
+Attachment storage is left to a follow-up.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import zipfile
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from services import skill_service as _skill_service_mod
+
+logger = logging.getLogger(__name__)
+
+
+MAX_ZIP_BYTES = 5 * 1024 * 1024
+MAX_ENTRIES = 32
+MAX_SKILL_MD_BYTES = 1 * 1024 * 1024
+
+ALLOWED_CATEGORIES = {
+    "detection",
+    "enrichment",
+    "response",
+    "reporting",
+    "custom",
+}
+
+_FRONTMATTER_RE = re.compile(
+    r"\A---\s*\n(?P<front>.*?)\n---\s*\n?(?P<body>.*)\Z",
+    re.DOTALL,
+)
+
+
+class SkillImportError(Exception):
+    """Validation failure during import. Carries an HTTP status code."""
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        details: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+        self.details = details or {}
+
+
+def import_skill_zip(
+    zip_bytes: bytes,
+    created_by: Optional[str] = None,
+    service: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Parse a Claude Desktop skill zip and upsert into the ``skills`` table.
+
+    Returns a dict with ``skill_id``, ``name``, ``version``, ``replaced``.
+    Raises :class:`SkillImportError` on any validation failure.
+    """
+    if len(zip_bytes) > MAX_ZIP_BYTES:
+        raise SkillImportError(
+            413,
+            f"Zip exceeds {MAX_ZIP_BYTES // (1024 * 1024)} MB limit",
+            {"size_bytes": len(zip_bytes), "limit_bytes": MAX_ZIP_BYTES},
+        )
+
+    skill_md_text = _extract_skill_md(zip_bytes)
+    name, patch = _parse_skill_md(skill_md_text)
+
+    svc = service or _skill_service_mod.SkillService()
+    existing = _find_by_name(svc, name)
+
+    if existing is not None:
+        updated = svc.update_skill(existing["skill_id"], patch)
+        if not updated:
+            raise SkillImportError(
+                500,
+                "Failed to update existing skill",
+                {"skill_id": existing["skill_id"]},
+            )
+        return {
+            "skill_id": updated["skill_id"],
+            "name": updated["name"],
+            "version": updated["version"],
+            "replaced": True,
+        }
+
+    created = svc.create_skill(patch, created_by=created_by)
+    return {
+        "skill_id": created["skill_id"],
+        "name": created["name"],
+        "version": created["version"],
+        "replaced": False,
+    }
+
+
+def _extract_skill_md(zip_bytes: bytes) -> str:
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile as exc:
+        raise SkillImportError(400, f"Not a valid zip file: {exc}")
+
+    with zf:
+        infos = [i for i in zf.infolist() if not i.is_dir()]
+        if len(infos) > MAX_ENTRIES:
+            raise SkillImportError(
+                400,
+                f"Zip has more than {MAX_ENTRIES} entries",
+                {"entry_count": len(infos), "limit": MAX_ENTRIES},
+            )
+
+        top_level = _detect_top_level_prefix(infos)
+        skill_md_name = f"{top_level}SKILL.md" if top_level else "SKILL.md"
+
+        rejected: List[str] = []
+        skill_md_info: Optional[zipfile.ZipInfo] = None
+        for info in infos:
+            if info.filename == skill_md_name:
+                skill_md_info = info
+            else:
+                rejected.append(info.filename)
+
+        if skill_md_info is None:
+            raise SkillImportError(
+                400,
+                (
+                    "Zip must contain a SKILL.md at the root or under a "
+                    "single top-level folder"
+                ),
+                {"entries": [i.filename for i in infos]},
+            )
+
+        if rejected:
+            raise SkillImportError(
+                400,
+                (
+                    "Zip contains files other than SKILL.md; attachments "
+                    "are not supported in v1"
+                ),
+                {"rejected_paths": rejected},
+            )
+
+        if skill_md_info.file_size > MAX_SKILL_MD_BYTES:
+            raise SkillImportError(
+                400,
+                f"SKILL.md exceeds {MAX_SKILL_MD_BYTES // (1024 * 1024)} MB limit",
+                {
+                    "size_bytes": skill_md_info.file_size,
+                    "limit_bytes": MAX_SKILL_MD_BYTES,
+                },
+            )
+
+        raw = zf.read(skill_md_info)
+
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw.decode("latin-1")
+
+
+def _detect_top_level_prefix(infos: List[zipfile.ZipInfo]) -> str:
+    """Return a single top-level directory prefix (with trailing ``/``) or ``""``.
+
+    Claude Desktop bundles sometimes nest SKILL.md under a single folder
+    named after the skill. If every entry shares the same first path
+    segment, treat that segment as the prefix.
+    """
+    prefixes = set()
+    for info in infos:
+        head, sep, _ = info.filename.partition("/")
+        if sep:
+            prefixes.add(head + "/")
+        else:
+            return ""
+    if len(prefixes) == 1:
+        return next(iter(prefixes))
+    return ""
+
+
+def _parse_skill_md(text: str) -> tuple[str, Dict[str, Any]]:
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        raise SkillImportError(
+            400,
+            "SKILL.md must begin with YAML frontmatter delimited by '---' lines",
+        )
+
+    try:
+        front = yaml.safe_load(match.group("front")) or {}
+    except yaml.YAMLError as exc:
+        raise SkillImportError(400, f"Invalid YAML in SKILL.md frontmatter: {exc}")
+
+    if not isinstance(front, dict):
+        raise SkillImportError(
+            400,
+            "SKILL.md frontmatter must be a YAML mapping",
+        )
+
+    body = match.group("body").strip()
+    if not body:
+        raise SkillImportError(
+            400,
+            "SKILL.md body is empty; it becomes the prompt_template and is required",
+        )
+
+    missing = [k for k in ("name", "category") if not front.get(k)]
+    if missing:
+        raise SkillImportError(
+            400,
+            "SKILL.md frontmatter is missing required fields",
+            {"missing_fields": missing},
+        )
+
+    name = str(front["name"]).strip()
+    category = str(front["category"]).strip().lower()
+    if category not in ALLOWED_CATEGORIES:
+        raise SkillImportError(
+            400,
+            f"Unknown category '{category}'",
+            {"allowed": sorted(ALLOWED_CATEGORIES)},
+        )
+
+    required_tools = _coerce_required_tools(front.get("required_tools"))
+    input_schema = _coerce_mapping(front.get("input_schema"), "input_schema")
+    output_schema = _coerce_mapping(front.get("output_schema"), "output_schema")
+
+    description = front.get("description")
+    if description is not None and not isinstance(description, str):
+        description = str(description)
+
+    patch = {
+        "name": name,
+        "description": description,
+        "category": category,
+        "input_schema": input_schema,
+        "output_schema": output_schema,
+        "required_tools": required_tools,
+        "prompt_template": body,
+        "execution_steps": [],
+        "is_active": True,
+    }
+    return name, patch
+
+
+def _coerce_required_tools(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        out: List[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                raise SkillImportError(
+                    400,
+                    "required_tools must be a list of strings",
+                    {"offending_value": repr(item)},
+                )
+            out.append(item)
+        return out
+    raise SkillImportError(
+        400,
+        "required_tools must be a string or a list of strings",
+        {"got_type": type(value).__name__},
+    )
+
+
+def _coerce_mapping(value: Any, field: str) -> Dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    raise SkillImportError(
+        400,
+        f"{field} must be a YAML mapping",
+        {"got_type": type(value).__name__},
+    )
+
+
+def _find_by_name(service: Any, name: str) -> Optional[Dict[str, Any]]:
+    for row in service.list_skills():
+        if row.get("name") == name:
+            return row
+    return None

--- a/tests/test_skill_importer.py
+++ b/tests/test_skill_importer.py
@@ -1,0 +1,361 @@
+"""Unit tests for the Claude Desktop skill zip importer (Issue #130).
+
+Exercises ``services.skill_importer.import_skill_zip`` against an
+in-memory fake service. No DB or HTTP involved.
+"""
+
+import io
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from services.skill_importer import (  # noqa: E402
+    MAX_ENTRIES,
+    MAX_SKILL_MD_BYTES,
+    MAX_ZIP_BYTES,
+    SkillImportError,
+    import_skill_zip,
+)
+
+# --------------------------------------------------------------------------- #
+# In-memory fake SkillService matching the subset of the API the importer uses
+# --------------------------------------------------------------------------- #
+
+
+class FakeSkillService:
+    def __init__(self) -> None:
+        self._store: Dict[str, Dict[str, Any]] = {}
+        self._next = 1
+
+    def list_skills(
+        self,
+        category: Optional[str] = None,
+        is_active: Optional[bool] = None,
+    ) -> List[Dict[str, Any]]:
+        return list(self._store.values())
+
+    def create_skill(
+        self,
+        data: Dict[str, Any],
+        created_by: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        skill_id = f"s-20260423-{self._next:08X}"
+        self._next += 1
+        row = {
+            "skill_id": skill_id,
+            "version": 1,
+            "created_by": created_by,
+            **data,
+        }
+        self._store[skill_id] = row
+        return row
+
+    def update_skill(
+        self,
+        skill_id: str,
+        patch: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        row = self._store.get(skill_id)
+        if not row:
+            return None
+        content_fields = {
+            "name",
+            "description",
+            "category",
+            "input_schema",
+            "output_schema",
+            "required_tools",
+            "prompt_template",
+            "execution_steps",
+        }
+        bumped = False
+        for k, v in patch.items():
+            if v is None:
+                continue
+            if k in content_fields and row.get(k) != v:
+                bumped = True
+            row[k] = v
+        if bumped:
+            row["version"] = row.get("version", 1) + 1
+        return row
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_zip(entries: Dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, body in entries.items():
+            zf.writestr(name, body)
+    return buf.getvalue()
+
+
+VALID_SKILL_MD = b"""---
+name: Detect Lateral RDP
+description: Finds unusual RDP sessions.
+category: detection
+required_tools:
+  - splunk.search
+input_schema:
+  type: object
+  properties:
+    hours:
+      type: integer
+---
+Look for suspicious RDP logons in the last {{hours}} hours."""
+
+
+# --------------------------------------------------------------------------- #
+# Happy paths
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_happy_path_creates_new_skill():
+    svc = FakeSkillService()
+    zip_bytes = _make_zip({"SKILL.md": VALID_SKILL_MD})
+
+    result = import_skill_zip(zip_bytes, created_by="alice", service=svc)
+
+    assert result["replaced"] is False
+    assert result["name"] == "Detect Lateral RDP"
+    assert result["version"] == 1
+    row = svc._store[result["skill_id"]]
+    assert row["category"] == "detection"
+    assert row["required_tools"] == ["splunk.search"]
+    assert row["prompt_template"].startswith("Look for suspicious RDP")
+    assert row["input_schema"]["properties"]["hours"]["type"] == "integer"
+    assert row["created_by"] == "alice"
+
+
+@pytest.mark.unit
+def test_happy_path_accepts_nested_top_level_folder():
+    svc = FakeSkillService()
+    zip_bytes = _make_zip({"detect-rdp/SKILL.md": VALID_SKILL_MD})
+
+    result = import_skill_zip(zip_bytes, service=svc)
+
+    assert result["replaced"] is False
+    assert result["name"] == "Detect Lateral RDP"
+
+
+@pytest.mark.unit
+def test_replace_bumps_version_when_name_collides():
+    svc = FakeSkillService()
+    zip_bytes_v1 = _make_zip({"SKILL.md": VALID_SKILL_MD})
+    first = import_skill_zip(zip_bytes_v1, service=svc)
+    assert first["version"] == 1
+
+    updated_md = VALID_SKILL_MD.replace(
+        b"Finds unusual RDP sessions.",
+        b"Finds unusual RDP sessions on domain controllers.",
+    )
+    zip_bytes_v2 = _make_zip({"SKILL.md": updated_md})
+    second = import_skill_zip(zip_bytes_v2, service=svc)
+
+    assert second["replaced"] is True
+    assert second["skill_id"] == first["skill_id"]
+    assert second["version"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# Validation failures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_missing_skill_md_is_400():
+    svc = FakeSkillService()
+    zip_bytes = _make_zip({"README.md": b"not a skill"})
+
+    with pytest.raises(SkillImportError) as excinfo:
+        import_skill_zip(zip_bytes, service=svc)
+    assert excinfo.value.status_code == 400
+    assert "SKILL.md" in excinfo.value.message
+
+
+@pytest.mark.unit
+def test_extra_files_alongside_skill_md_are_rejected():
+    svc = FakeSkillService()
+    zip_bytes = _make_zip(
+        {
+            "SKILL.md": VALID_SKILL_MD,
+            "scripts/helper.py": b"print('hi')",
+            "notes.txt": b"hello",
+        }
+    )
+
+    with pytest.raises(SkillImportError) as excinfo:
+        import_skill_zip(zip_bytes, service=svc)
+    assert excinfo.value.status_code == 400
+    rejected = excinfo.value.details.get("rejected_paths") or []
+    assert "scripts/helper.py" in rejected
+    assert "notes.txt" in rejected
+
+
+@pytest.mark.unit
+def test_not_a_zip_is_400():
+    svc = FakeSkillService()
+    with pytest.raises(SkillImportError) as excinfo:
+        import_skill_zip(b"totally not a zip file", service=svc)
+    assert excinfo.value.status_code == 400
+
+
+@pytest.mark.unit
+def test_missing_frontmatter_is_400():
+    svc = FakeSkillService()
+    zip_bytes = _make_zip({"SKILL.md": b"# Just markdown, no frontmatter"})
+
+    with pytest.raises(SkillImportError) as excinfo:
+        import_skill_zip(zip_bytes, service=svc)
+    assert excinfo.value.status_code == 400
+    assert "frontmatter" in excinfo.value.message.lower()
+
+
+@pytest.mark.unit
+def test_missing_required_field_is_400():
+    svc = FakeSkillService()
+    # Missing 'category'
+    md = b"""---
+name: Has No Category
+---
+Body here."""
+    zip_bytes = _make_zip({"SKILL.md": md})
+
+    with pytest.raises(SkillImportError) as excinfo:
+        import_skill_zip(zip_bytes, service=svc)
+    assert excinfo.value.status_code == 400
+    assert "category" in excinfo.value.details.get("missing_fields", [])
+
+
+@pytest.mark.unit
+def test_invalid_category_is_400():
+    svc = FakeSkillService()
+    md = b"""---
+name: Bad Category
+category: banana
+---
+Body here."""
+    zip_bytes = _make_zip({"SKILL.md": md})
+
+    with pytest.raises(SkillImportError) as excinfo:
+        import_skill_zip(zip_bytes, service=svc)
+    assert excinfo.value.status_code == 400
+    assert "banana" in excinfo.value.message
+
+
+@pytest.mark.unit
+def test_empty_body_is_400():
+    svc = FakeSkillService()
+    md = b"""---
+name: No Body
+category: detection
+---
+"""
+    zip_bytes = _make_zip({"SKILL.md": md})
+
+    with pytest.raises(SkillImportError) as excinfo:
+        import_skill_zip(zip_bytes, service=svc)
+    assert excinfo.value.status_code == 400
+    assert "body" in excinfo.value.message.lower()
+
+
+@pytest.mark.unit
+def test_required_tools_scalar_string_coerced_to_list():
+    svc = FakeSkillService()
+    md = b"""---
+name: Scalar Tool
+category: enrichment
+required_tools: virustotal.hash
+---
+Enrich it."""
+    zip_bytes = _make_zip({"SKILL.md": md})
+
+    result = import_skill_zip(zip_bytes, service=svc)
+    row = svc._store[result["skill_id"]]
+    assert row["required_tools"] == ["virustotal.hash"]
+
+
+@pytest.mark.unit
+def test_required_tools_wrong_type_is_400():
+    svc = FakeSkillService()
+    md = b"""---
+name: Bad Tools
+category: enrichment
+required_tools:
+  nested: wrong
+---
+Body."""
+    zip_bytes = _make_zip({"SKILL.md": md})
+
+    with pytest.raises(SkillImportError) as excinfo:
+        import_skill_zip(zip_bytes, service=svc)
+    assert excinfo.value.status_code == 400
+
+
+@pytest.mark.unit
+def test_oversize_zip_is_413():
+    svc = FakeSkillService()
+    oversized = b"x" * (MAX_ZIP_BYTES + 1)
+
+    with pytest.raises(SkillImportError) as excinfo:
+        import_skill_zip(oversized, service=svc)
+    assert excinfo.value.status_code == 413
+
+
+@pytest.mark.unit
+def test_too_many_entries_is_400():
+    svc = FakeSkillService()
+    entries = {"SKILL.md": VALID_SKILL_MD}
+    for i in range(MAX_ENTRIES):
+        entries[f"extra_{i}.txt"] = b"x"
+    zip_bytes = _make_zip(entries)
+
+    with pytest.raises(SkillImportError) as excinfo:
+        import_skill_zip(zip_bytes, service=svc)
+    assert excinfo.value.status_code == 400
+    # Message differentiates between entry-count and extra-file rejection
+    assert "entries" in excinfo.value.message.lower()
+
+
+@pytest.mark.unit
+def test_router_path_uses_module_level_service(monkeypatch):
+    """The importer looks up SkillService at call time so router-level
+    patches propagate. Regression guard: if someone replaces the import
+    with `from services.skill_service import SkillService`, this breaks.
+    """
+    import services.skill_importer as importer_mod
+
+    captured: Dict[str, Any] = {}
+
+    class SpyService(FakeSkillService):
+        def create_skill(self, data, created_by=None):
+            captured["data"] = data
+            captured["created_by"] = created_by
+            return super().create_skill(data, created_by=created_by)
+
+    monkeypatch.setattr(importer_mod._skill_service_mod, "SkillService", SpyService)
+
+    zip_bytes = _make_zip({"SKILL.md": VALID_SKILL_MD})
+    # No `service=` argument: importer must resolve SkillService at call time.
+    result = import_skill_zip(zip_bytes, created_by="bob")
+
+    assert result["replaced"] is False
+    assert captured["created_by"] == "bob"
+    assert captured["data"]["name"] == "Detect Lateral RDP"
+
+
+# Silence unused-import warnings for constants used in assertions above.
+_ = MAX_SKILL_MD_BYTES
+_ = patch

--- a/tests/test_skills_api.py
+++ b/tests/test_skills_api.py
@@ -6,7 +6,9 @@ by whether Postgres is running.
 """
 
 import importlib.util
+import io
 import sys
+import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -247,6 +249,105 @@ def test_generate_passes_through_clarification(client):
     assert body["needs_clarification"] is True
     assert "which SIEM" in body["message"]
     assert body["conversation_history"][-1]["role"] == "assistant"
+
+
+# ---------------------------------------------------------------------------
+# Import endpoint — Claude Desktop .zip bundles (Issue #130)
+# ---------------------------------------------------------------------------
+
+
+IMPORT_SKILL_MD = b"""---
+name: Imported Enrich IOC
+description: Enrich an IOC via VirusTotal.
+category: enrichment
+required_tools:
+  - virustotal.hash
+---
+Given {{ioc}}, query VirusTotal and summarize."""
+
+
+def _zip_bytes(entries):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, body in entries.items():
+            zf.writestr(name, body)
+    return buf.getvalue()
+
+
+@pytest.mark.api
+def test_import_creates_new_skill(client):
+    buf = _zip_bytes({"SKILL.md": IMPORT_SKILL_MD})
+    r = client.post(
+        "/api/skills/import",
+        files={"file": ("skill.zip", buf, "application/zip")},
+        data={"created_by": "alice"},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["name"] == "Imported Enrich IOC"
+    assert body["replaced"] is False
+    assert body["version"] == 1
+
+    # Round-trip: the imported skill shows up in the list.
+    r = client.get("/api/skills")
+    names = [s["name"] for s in r.json()]
+    assert "Imported Enrich IOC" in names
+
+
+@pytest.mark.api
+def test_import_replaces_and_bumps_version_on_name_collision(client):
+    buf1 = _zip_bytes({"SKILL.md": IMPORT_SKILL_MD})
+    r1 = client.post(
+        "/api/skills/import",
+        files={"file": ("skill.zip", buf1, "application/zip")},
+    )
+    assert r1.status_code == 201
+    first_id = r1.json()["skill_id"]
+
+    # Second import with same name but tweaked body → replace + bump.
+    tweaked = IMPORT_SKILL_MD.replace(
+        b"Given {{ioc}}, query VirusTotal and summarize.",
+        b"Given {{ioc}}, query VirusTotal, Shodan, and summarize.",
+    )
+    buf2 = _zip_bytes({"SKILL.md": tweaked})
+    r2 = client.post(
+        "/api/skills/import",
+        files={"file": ("skill.zip", buf2, "application/zip")},
+    )
+    assert r2.status_code == 201, r2.text
+    body = r2.json()
+    assert body["replaced"] is True
+    assert body["skill_id"] == first_id
+    assert body["version"] == 2
+
+
+@pytest.mark.api
+def test_import_missing_skill_md_is_400(client):
+    buf = _zip_bytes({"README.md": b"not a skill"})
+    r = client.post(
+        "/api/skills/import",
+        files={"file": ("skill.zip", buf, "application/zip")},
+    )
+    assert r.status_code == 400
+    detail = r.json()["detail"]
+    assert "SKILL.md" in detail["message"]
+
+
+@pytest.mark.api
+def test_import_extra_files_rejected_with_paths(client):
+    buf = _zip_bytes(
+        {
+            "SKILL.md": IMPORT_SKILL_MD,
+            "scripts/helper.py": b"x",
+        }
+    )
+    r = client.post(
+        "/api/skills/import",
+        files={"file": ("skill.zip", buf, "application/zip")},
+    )
+    assert r.status_code == 400
+    detail = r.json()["detail"]
+    assert "scripts/helper.py" in detail["details"]["rejected_paths"]
 
 
 @pytest.mark.api


### PR DESCRIPTION
## Summary
- Adds `POST /api/skills/import` for multipart `.zip` uploads. Parses `SKILL.md` (YAML frontmatter + markdown body), normalizes to the existing `skills` schema, and upserts via `SkillService` — same-name imports bump `version` on the existing row.
- Surfaces the flow as an **Import Zip** button in Builder > Skills (top toolbar, next to Build Skill). Success / error are shown inline.
- v1 rejects any non-`SKILL.md` entries in the zip with a clear 400 listing offending paths; attachment storage is deferred to a follow-up.

Closes #130.

## Files
- Backend: [services/skill_importer.py](services/skill_importer.py) (new), [backend/api/skills.py](backend/api/skills.py), [backend/schemas/skill.py](backend/schemas/skill.py)
- Frontend: [frontend/src/services/skillsApi.ts](frontend/src/services/skillsApi.ts), [frontend/src/components/settings/SkillsTab.tsx](frontend/src/components/settings/SkillsTab.tsx)
- Tests: [tests/test_skill_importer.py](tests/test_skill_importer.py) (new), [tests/test_skills_api.py](tests/test_skills_api.py), [frontend/src/components/settings/__tests__/SkillsTab.test.tsx](frontend/src/components/settings/__tests__/SkillsTab.test.tsx)

## Test plan
- [x] `pytest tests/test_skill_importer.py tests/test_skills_api.py -v` — 26 passed locally
- [x] `black` + `flake8` clean on changed Python files
- [ ] Frontend `npm run lint` + `npm run test:run` (running in CI)
- [ ] Manual end-to-end: `curl -F file=@skill.zip http://localhost:6987/api/skills/import` → expect 201, re-run → expect 201 with `replaced=true, version=2`
- [ ] Builder > Skills → Import Zip → pick a valid bundle → verify success banner and skill card appears; verify agents pick up the skill without restart

## Scope decisions
- **Name collision**: upsert by name, bump `version`. Matches Claude Desktop's install-over behavior.
- **Attachments**: v1 accepts only `SKILL.md`; other files rejected. Follow-up issue can cover embedded scripts/prompt partials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)