### PR TITLE
Remove duplicate Cases tab from Dashboard (#138)

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -30,7 +30,6 @@ import {
 } from '@mui/icons-material'
 import { findingsApi, casesApi, configApi, timelineApi, graphApi } from '../services/api'
 import FindingsTable from '../components/findings/FindingsTable'
-import CasesTable from '../components/cases/CasesTable'
 import AttackChart from '../components/attack/AttackChart'
 import ExportToTimesketchDialog from '../components/timesketch/ExportToTimesketchDialog'
 import EventTimeline from '../components/timeline/EventTimeline'
@@ -77,9 +76,9 @@ export default function Dashboard() {
   }, [])
 
   useEffect(() => {
-    if (currentTab === 3) {
+    if (currentTab === 2) {
       loadTimelineData()
-    } else if (currentTab === 4) {
+    } else if (currentTab === 3) {
       loadGraphData()
     }
   }, [currentTab])
@@ -270,7 +269,7 @@ export default function Dashboard() {
             subtitle={`${stats?.cases?.by_status?.open || 0} open`}
             icon={<FolderIcon />}
             color={theme.palette.primary.main}
-            onClick={() => setCurrentTab(1)}
+            onClick={() => navigate('/cases')}
           />
         </Grid>
         <Grid item xs={12} sm={6} md={3}>
@@ -297,7 +296,6 @@ export default function Dashboard() {
         <Box sx={{ borderBottom: 1, borderColor: 'divider', px: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <Tabs value={currentTab} onChange={(_, v) => setCurrentTab(v)}>
             <Tab label="Findings" sx={{ minHeight: 48 }} />
-            <Tab label="Cases" sx={{ minHeight: 48 }} />
             <Tab label="ATT&CK" sx={{ minHeight: 48 }} />
             <Tab label="Timeline" sx={{ minHeight: 48 }} />
             <Tab label="Entity Graph" sx={{ minHeight: 48 }} />
@@ -346,9 +344,8 @@ export default function Dashboard() {
               />
             </>
           )}
-          {currentTab === 1 && <CasesTable limit={10} />}
-          {currentTab === 2 && <AttackChart />}
-          {currentTab === 3 && (
+          {currentTab === 1 && <AttackChart />}
+          {currentTab === 2 && (
             loadingTimeline ? (
               <Box display="flex" justifyContent="center" p={3}>
                 <CircularProgress />
@@ -362,7 +359,7 @@ export default function Dashboard() {
               />
             )
           )}
-          {currentTab === 4 && (
+          {currentTab === 3 && (
             loadingGraph ? (
               <Box display="flex" justifyContent="center" p={3}>
                 <CircularProgress />


### PR DESCRIPTION
Closes #138.

## Summary
- Drop the `<Tab label="Cases" />` entry on Dashboard and the `CasesTable limit={10}` block it rendered — cases are now only reachable via the sidebar `/cases` route (the canonical, permission-gated view).
- "Active Cases" KPI card now navigates to `/cases` instead of switching to the removed tab.
- Renumber the remaining tabs (ATT&CK, Timeline, Entity Graph shift from 2/3/4 → 1/2/3) and update the `useEffect` guards that trigger timeline/graph data loads.
- Drop the now-unused `CasesTable` import from Dashboard. `CasesTable` itself stays — it's still used by `pages/Cases.tsx`.

Grepped for other deep links into the old tab index (`setCurrentTab(1)`); nothing else referenced it.

## Test plan
- [ ] Dashboard no longer shows a "Cases" tab; four tabs remain (Findings, ATT&CK, Timeline, Entity Graph).
- [ ] Clicking the "Active Cases" stat card routes to `/cases`.
- [ ] Timeline tab still triggers `loadTimelineData()` and Entity Graph tab still triggers `loadGraphData()` (indexes renumbered).
- [ ] Sidebar Cases page (`/cases`) still renders with full filters + pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)