### PR TITLE
Fix Timeline crash loop when switching to Timeline tab

### DIFF
--- a/frontend/src/components/timeline/EventTimeline.tsx
+++ b/frontend/src/components/timeline/EventTimeline.tsx
@@ -273,6 +273,7 @@ const EventTimeline = memo(function EventTimeline({
     if (!timelineRef.current || filteredEvents.length === 0) return
 
     setLoading(true)
+    let fitTimeoutId: ReturnType<typeof setTimeout> | null = null
 
     // Cleanup existing instance
     if (timelineInstance.current) {
@@ -308,8 +309,15 @@ const EventTimeline = memo(function EventTimeline({
       timelineInstance.current = timeline
 
       // Fit timeline to show all events
-      setTimeout(() => {
-        timeline.fit()
+      fitTimeoutId = setTimeout(() => {
+        fitTimeoutId = null
+        if (timelineInstance.current === timeline) {
+          try {
+            timeline.fit()
+          } catch (err) {
+            console.error('Error fitting timeline:', err)
+          }
+        }
         setLoading(false)
       }, 100)
     } catch (error) {
@@ -318,6 +326,10 @@ const EventTimeline = memo(function EventTimeline({
     }
 
     return () => {
+      if (fitTimeoutId !== null) {
+        clearTimeout(fitTimeoutId)
+        fitTimeoutId = null
+      }
       if (timelineInstance.current) {
         timelineInstance.current.destroy()
         timelineInstance.current = null


### PR DESCRIPTION
## Summary
- `EventTimeline.tsx` schedules `timeline.fit()` via `setTimeout(..., 100)`. If the effect re-ran (or the component unmounted) inside that 100ms window, the cleanup destroyed the Timeline — nulling its `itemsData` — and `fit()` crashed reading `.length` on null. StrictMode's double-invoke produced a cascade of identical uncaught `TypeError`s when clicking the Dashboard's Timeline tab.
- Track the `setTimeout` id, clear it in the effect cleanup, and guard `fit()` against being called on a replaced instance. `try/catch` around `fit()` as a belt-and-suspenders guard for any remaining vis-timeline internal races.

## Test plan
- [ ] Open Dashboard → click Timeline tab → no `Uncaught TypeError: Cannot read properties of null (reading 'length')` in console.
- [ ] Switch between Findings ↔ Timeline rapidly — no error cascade.
- [ ] Timeline still auto-fits on initial render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)