### PR TITLE
Declare reportlab as a required dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,11 @@ redis>=5.0.0
 # Kafka ingestion (optional; only used when KAFKA_ENABLED=true)
 aiokafka>=0.10.0
 
+# PDF report generation (chat reports, case reports). The feature ships in
+# backend/api/claude.py → /generate-chat-report; without this dep the endpoint
+# returns 503 even though the feature is wired into the UI.
+reportlab>=4.0.0
+
 # Monitoring & Observability
 sentry-sdk>=1.40.0
 prometheus-client>=0.19.0


### PR DESCRIPTION
## Summary
The `/api/claude/generate-chat-report` endpoint guards on a soft optional-import of `reportlab` and returns **503** when it's missing. `reportlab` isn't in `requirements.txt`, so fresh checkouts hit this on the first Generate PDF click.

```python
# backend/api/claude.py:1209
if not REPORTLAB_AVAILABLE:
    raise HTTPException(
        status_code=503,
        detail="Report generation requires reportlab. Install with: pip install reportlab",
    )
```

`reportlab` isn't truly optional — the endpoint is wired into the frontend chat report flow and `services/report_service.py` imports it unconditionally. Promoting it to a declared dep matches actual usage.

## Test plan
- [ ] `pip install -r requirements.txt` in a fresh venv installs reportlab.
- [ ] POST `/api/claude/generate-chat-report` returns 200 with a PDF path (not 503).

🤖 Generated with [Claude Code](https://claude.com/claude-code)