### PR TITLE
Dynamic model discovery with single-source-of-truth refresh (#139)

### DIFF
--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -33,11 +33,13 @@ router = APIRouter()
 VALID_PROVIDER_TYPES = {"anthropic", "openai", "ollama"}
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
 
-# Single source of truth lives in services.model_registry. The Anthropic
-# SDK doesn't expose a /models endpoint, so this static list is what
-# drives the Providers UI's model dropdown.
-from services.model_registry import ANTHROPIC_STATIC_MODELS
-ANTHROPIC_MODELS = list(ANTHROPIC_STATIC_MODELS)
+# Anthropic's live /v1/models endpoint is consulted via
+# ``services.provider_model_discovery``; the fallback tuple here is the
+# cold-boot list used only when the live call fails (e.g. no API key
+# was provided at /discover-models time).
+from services.model_registry import _FALLBACK_MODELS_BY_PROVIDER
+
+ANTHROPIC_FALLBACK_MODELS = list(_FALLBACK_MODELS_BY_PROVIDER["anthropic"])
 
 
 def _slugify(name: str) -> str:
@@ -120,6 +122,28 @@ def _clear_other_defaults(db: Session, provider_type: str, keep_id: str) -> None
     )
 
 
+def _schedule_catalog_resync(reason: str) -> None:
+    """Invalidate the model-list cache and fire a background sync.
+
+    Called from provider CRUD so the UI dropdown and Bifrost's allow-list
+    reflect the change immediately, rather than waiting up to the next
+    scheduled refresh. Best-effort — never blocks the response.
+    """
+    import asyncio
+
+    from services.bifrost_admin import sync_all_provider_models
+    from services.model_registry import invalidate_model_cache
+
+    invalidate_model_cache()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is not None:
+        loop.create_task(sync_all_provider_models())
+    logger.info("Model catalog resync scheduled: %s", reason)
+
+
 @router.get("", response_model=List[LLMProviderResponse])
 @router.get("/", response_model=List[LLMProviderResponse])
 async def list_providers(db: Session = Depends(get_db_session)):
@@ -136,7 +160,9 @@ async def create_provider(
 
     provider_id = payload.provider_id or _slugify(payload.name)
     if db.get(LLMProviderConfig, provider_id) is not None:
-        raise HTTPException(status_code=409, detail=f"provider_id '{provider_id}' already exists")
+        raise HTTPException(
+            status_code=409, detail=f"provider_id '{provider_id}' already exists"
+        )
 
     api_key_ref: Optional[str] = None
     if payload.api_key:
@@ -165,6 +191,7 @@ async def create_provider(
 
     db.commit()
     db.refresh(row)
+    _schedule_catalog_resync(f"created provider {provider_id}")
     return _to_response(row)
 
 
@@ -212,6 +239,7 @@ async def update_provider(
 
     db.commit()
     db.refresh(row)
+    _schedule_catalog_resync(f"updated provider {provider_id}")
     return _to_response(row)
 
 
@@ -231,13 +259,12 @@ async def delete_provider(provider_id: str, db: Session = Depends(get_db_session
 
     db.delete(row)
     db.commit()
+    _schedule_catalog_resync(f"deleted provider {provider_id}")
     return {"success": True, "provider_id": provider_id}
 
 
 @router.post("/{provider_id}/set-default", response_model=LLMProviderResponse)
-async def set_default_provider(
-    provider_id: str, db: Session = Depends(get_db_session)
-):
+async def set_default_provider(provider_id: str, db: Session = Depends(get_db_session)):
     row = db.get(LLMProviderConfig, provider_id)
     if row is None:
         raise HTTPException(status_code=404, detail="provider not found")
@@ -331,51 +358,52 @@ class DiscoverModelsRequest(BaseModel):
 
 @router.post("/discover-models")
 async def discover_models(req: DiscoverModelsRequest):
+    """Pre-save model discovery for the Add Provider dialog.
+
+    Delegates to ``services.provider_model_discovery``. Returns a flat
+    list of model IDs (unchanged contract). For Anthropic, falls back
+    to the hard-coded cold-boot list when no key is supplied so the
+    dialog still has something to render.
+    """
     if req.provider_type not in VALID_PROVIDER_TYPES:
         raise HTTPException(
             status_code=400,
             detail=f"unsupported provider_type: {req.provider_type}",
         )
 
-    if req.provider_type == "anthropic":
-        return {"models": ANTHROPIC_MODELS}
+    from services import provider_model_discovery as discovery
 
-    if req.provider_type == "ollama":
-        base_url = req.base_url or "http://localhost:11434"
-        try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                resp = await client.get(f"{base_url.rstrip('/')}/api/tags")
-                resp.raise_for_status()
-                data = resp.json()
-        except httpx.HTTPError as e:
-            raise HTTPException(status_code=502, detail=f"ollama: {e}")
-        return {
-            "models": [m.get("name") for m in data.get("models", []) if m.get("name")]
-        }
-
-    # openai / openai-compatible
-    base_url = req.base_url or "https://api.openai.com/v1"
-    if not req.api_key:
-        raise HTTPException(
-            status_code=400, detail="api_key is required to discover OpenAI models"
-        )
-    headers = {"Authorization": f"Bearer {req.api_key}"}
-    if req.organization:
-        headers["OpenAI-Organization"] = req.organization
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.get(f"{base_url.rstrip('/')}/models", headers=headers)
-            resp.raise_for_status()
-            data = resp.json()
+        if req.provider_type == "anthropic":
+            if not req.api_key:
+                return {"models": ANTHROPIC_FALLBACK_MODELS}
+            meta = await discovery.fetch_anthropic_models(req.api_key)
+        elif req.provider_type == "openai":
+            if not req.api_key:
+                raise HTTPException(
+                    status_code=400,
+                    detail="api_key is required to discover OpenAI models",
+                )
+            meta = await discovery.fetch_openai_models(
+                req.api_key,
+                base_url=req.base_url,
+                organization=req.organization,
+            )
+        else:  # ollama
+            meta = await discovery.fetch_ollama_models(req.base_url)
     except httpx.HTTPStatusError as e:
-        # Surface auth errors cleanly so the dialog can show them
         raise HTTPException(
             status_code=e.response.status_code,
             detail=f"upstream error: {e.response.text[:200]}",
         )
     except httpx.HTTPError as e:
-        raise HTTPException(status_code=502, detail=f"openai: {e}")
-    return {"models": [m.get("id") for m in data.get("data", []) if m.get("id")]}
+        raise HTTPException(status_code=502, detail=f"{req.provider_type}: {e}")
+    except HTTPException:
+        raise
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=str(e))
+
+    return {"models": [m.id for m in meta]}
 
 
 @router.get("/{provider_id}/models")
@@ -384,29 +412,61 @@ async def list_models(provider_id: str, db: Session = Depends(get_db_session)):
     if row is None:
         raise HTTPException(status_code=404, detail="provider not found")
 
-    if row.provider_type == "anthropic":
-        return {"models": ANTHROPIC_MODELS}
+    from services.model_registry import fetch_provider_models
 
-    if row.provider_type == "ollama":
-        base_url = row.base_url or "http://localhost:11434"
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(f"{base_url.rstrip('/')}/api/tags")
-            resp.raise_for_status()
-            data = resp.json()
-        return {"models": [m.get("name") for m in data.get("models", []) if m.get("name")]}
+    # ``fetch_provider_models`` delegates to the discovery module and
+    # falls back to the cold-boot list on any error, so callers always
+    # get a usable payload.
+    try:
+        models = await fetch_provider_models(row)
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"models": models}
 
-    if row.provider_type == "openai":
-        base_url = row.base_url or "https://api.openai.com/v1"
-        key = await _resolve_api_key(row)
-        if not key:
-            raise HTTPException(status_code=400, detail="no api key configured")
-        headers = {"Authorization": f"Bearer {key}"}
-        if row.config and row.config.get("organization"):
-            headers["OpenAI-Organization"] = row.config["organization"]
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.get(f"{base_url.rstrip('/')}/models", headers=headers)
-            resp.raise_for_status()
-            data = resp.json()
-        return {"models": [m.get("id") for m in data.get("data", []) if m.get("id")]}
 
-    raise HTTPException(status_code=400, detail=f"unsupported provider_type: {row.provider_type}")
+@router.post("/{provider_id}/refresh-models")
+async def refresh_provider_models(
+    provider_id: str, db: Session = Depends(get_db_session)
+):
+    """Force a live rediscovery for one provider and push the union of
+    same-type providers' models to Bifrost's allow-list. Invalidates the
+    registry's TTL cache so the next dropdown fetch sees fresh data.
+    """
+    row = db.get(LLMProviderConfig, provider_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="provider not found")
+
+    from services.bifrost_admin import sync_all_provider_models
+    from services.model_registry import invalidate_model_cache
+
+    invalidate_model_cache()
+    # Run the same union-of-same-type sync used at startup so Bifrost
+    # sees the new state too, not just the backend's cache.
+    sync_results = await sync_all_provider_models()
+
+    from services.model_registry import fetch_provider_models
+
+    try:
+        models = await fetch_provider_models(row)
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=str(e))
+    return {
+        "provider_id": provider_id,
+        "provider_type": row.provider_type,
+        "models": models,
+        "bifrost_sync": sync_results.get(row.provider_type, False),
+    }
+
+
+@router.post("/refresh-models")
+async def refresh_all_provider_models():
+    """Force live rediscovery across every active provider and push the
+    resulting allow-lists to Bifrost. Useful after enabling a new
+    provider or rotating keys in bulk.
+    """
+    from services.bifrost_admin import sync_all_provider_models
+    from services.model_registry import invalidate_model_cache
+
+    invalidate_model_cache()
+    sync_results = await sync_all_provider_models()
+    return {"bifrost_sync": sync_results}

--- a/backend/main.py
+++ b/backend/main.py
@@ -283,6 +283,38 @@ async def startup_event():
     except Exception as e:
         logger.warning(f"Bifrost provider sync skipped: {e}")
 
+    # Discover live model catalogs upstream (Anthropic /v1/models, OpenAI
+    # /v1/models, Ollama /api/tags) and push the union per provider-type
+    # to Bifrost's allow-list. Single source of truth — one call populates
+    # both the UI dropdown cache and Bifrost's allow-list, so they can't
+    # drift. Scheduler loop refreshes every
+    # MODEL_CATALOG_REFRESH_INTERVAL_S (default 300s). Runs as a
+    # background task so startup isn't blocked on upstream reachability.
+    try:
+        import asyncio
+
+        from services.bifrost_admin import sync_all_provider_models
+
+        refresh_interval_s = int(
+            os.getenv("MODEL_CATALOG_REFRESH_INTERVAL_S", "300")
+        )
+
+        async def _model_catalog_refresher():
+            while True:
+                try:
+                    await sync_all_provider_models()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "Model catalog refresh iteration failed: %s", exc,
+                    )
+                if refresh_interval_s <= 0:
+                    break
+                await asyncio.sleep(refresh_interval_s)
+
+        asyncio.create_task(_model_catalog_refresher())
+    except Exception as e:
+        logger.warning(f"Model catalog refresher skipped: {e}")
+
     # Initialize data storage backend
     logger.info("Initializing data storage...")
     try:

--- a/docker/bifrost/README.md
+++ b/docker/bifrost/README.md
@@ -46,6 +46,34 @@ Health check: `curl http://localhost:8080/health`.
 
 `docker/bifrost/config.json` declares the providers, the models Bifrost will expose, and the cache backend. API keys are **not** written into the config file — they are injected as environment variables at container start time (`env.ANTHROPIC_API_KEY`, `env.OPENAI_API_KEY`, `env.OLLAMA_URL`). Vigil's backend reads per-provider keys from its own `secrets_manager`; what's in Bifrost's env are the fallback/default keys used when a provider row in `llm_provider_configs` doesn't override them.
 
+### Model allow-list: runtime sync, not the config file
+
+The `models` array under each `providers.<name>.keys[0]` in `config.json` is a **cold-boot bootstrap list only**. The backend runs `sync_all_provider_models()` ([services/bifrost_admin.py](../../services/bifrost_admin.py)) which:
+
+1. Queries each upstream provider's live catalog (Anthropic `/v1/models`, OpenAI `/v1/models`, Ollama `/api/tags`) via [services/provider_model_discovery.py](../../services/provider_model_discovery.py).
+2. Writes the per-row list into the backend's dropdown cache (`_MODEL_LIST_CACHE` in [services/model_registry.py](../../services/model_registry.py)).
+3. Unions the model IDs across all active providers of the same type and PUTs that union to Bifrost's admin API (`PUT /api/providers/{name}` with `keys[0].models` updated).
+
+**Single source of truth.** `sync_all_provider_models()` is the only writer to both caches — the UI dropdown and Bifrost's allow-list come from the same call over the same upstream fetch, so they cannot drift. `fetch_provider_models()` on the read path is a pure cache lookup that falls back to a lazy sync on a cold-start miss.
+
+**When it runs:**
+- At backend startup — launched as a background task ([backend/main.py](../../backend/main.py) startup handler).
+- **Periodically** — `MODEL_CATALOG_REFRESH_INTERVAL_S` (default 300s / 5min). Set to `0` to disable the loop and only sync once at startup.
+- On demand — `POST /api/llm-providers/refresh-models` (all) or `POST /api/llm-providers/{id}/refresh-models` (one).
+- Whenever a provider is added, updated, or deleted via the Providers UI — CRUD handlers invalidate the cache and schedule a background resync.
+
+The bootstrap list in `config.json` only matters for the cold-start window (seconds) before the first sync iteration completes, or for environments where the backend can't reach upstream at startup.
+
+### Legacy / non-listed models (extras)
+
+Some upstream providers drop older model IDs from their `/v1/models` listing even when those IDs are still callable (Anthropic did this with the Claude 3.x family). To surface those in the UI and let Bifrost route traffic for them, the backend unions a configurable "extras" set into both the dropdown and Bifrost's allow-list. Extras are flagged `deprecated=True` in the API response so the UI can badge them.
+
+The defaults live in [services/model_registry.py](../../services/model_registry.py) (`_DEFAULT_EXTRA_MODELS`) and currently cover Claude 3.5 Haiku, 3.5 Sonnet v2, and 3 Haiku. Override per deployment via env:
+
+- `ANTHROPIC_EXTRA_MODELS="id1,id2,..."` — replaces the default list.
+- `ANTHROPIC_EXTRA_MODELS=""` — disables extras for Anthropic entirely.
+- `OPENAI_EXTRA_MODELS="..."` — same mechanism for OpenAI if you need it.
+
 ### Caching — two layers
 
 Vigil benefits from two independent caching layers. They're **complementary**, not redundant:

--- a/env.example
+++ b/env.example
@@ -25,6 +25,21 @@ DEV_MODE=true
 # -----------------------------------------------------------------------------
 ANTHROPIC_API_KEY="sk-ant-api03-..."
 
+# Extra model IDs to always include in the Settings dropdown, on top of
+# whatever upstream /v1/models returns. Intended for IDs the provider
+# removed from their listing endpoint but that are still callable (e.g.
+# Claude 3.x family). Shown with a "deprecated" flag so users know they
+# aren't the preferred path. Comma-separated; leave empty to disable.
+# Defaults: claude-3-5-haiku-20241022, claude-3-5-sonnet-20241022,
+# claude-3-haiku-20240307. Set to "" to disable all extras.
+# ANTHROPIC_EXTRA_MODELS="claude-3-5-haiku-20241022,claude-3-5-sonnet-20241022,claude-3-haiku-20240307"
+# OPENAI_EXTRA_MODELS=""
+
+# How often the backend re-discovers provider model catalogs and syncs
+# Bifrost's allow-list. Seconds. Default 300 (5 min). Set to 0 to run
+# only the initial sync at startup (no scheduled refresh).
+# MODEL_CATALOG_REFRESH_INTERVAL_S=300
+
 # -----------------------------------------------------------------------------
 # Database
 # -----------------------------------------------------------------------------

--- a/services/bifrost_admin.py
+++ b/services/bifrost_admin.py
@@ -15,15 +15,23 @@ keeps a single source of truth in the secrets manager.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 5.0
+
+# In-flight future used to coalesce concurrent ``sync_all_provider_models``
+# calls. If a sync is running and a second caller arrives (e.g. a cold
+# dropdown lazy-sync landing during the scheduled refresher's iteration),
+# the second caller awaits the same future instead of issuing a duplicate
+# round of upstream fetches. None when idle.
+_sync_in_flight: Optional["asyncio.Future[Dict[str, Any]]"] = None
 
 
 def _bifrost_base_url() -> str:
@@ -32,7 +40,9 @@ def _bifrost_base_url() -> str:
 
 def _get_provider(name: str, client: httpx.Client) -> Optional[Dict[str, Any]]:
     try:
-        r = client.get(f"{_bifrost_base_url()}/api/providers/{name}", timeout=_DEFAULT_TIMEOUT)
+        r = client.get(
+            f"{_bifrost_base_url()}/api/providers/{name}", timeout=_DEFAULT_TIMEOUT
+        )
         if r.status_code == 404:
             logger.debug("Bifrost: provider %s not configured", name)
             return None
@@ -61,7 +71,9 @@ def push_provider_key(provider_name: str, key_value: str) -> bool:
             return False
         keys = prov.get("keys") or []
         if not keys:
-            logger.warning("Bifrost: provider %s has no keys slot to update", provider_name)
+            logger.warning(
+                "Bifrost: provider %s has no keys slot to update", provider_name
+            )
             return False
         # Update the first key. Bifrost's current config seeds exactly one
         # key per provider; multi-key rotation is a separate feature.
@@ -79,13 +91,17 @@ def push_provider_key(provider_name: str, key_value: str) -> bool:
             if r.status_code >= 400:
                 logger.warning(
                     "Bifrost: PUT /api/providers/%s returned %s: %s",
-                    provider_name, r.status_code, r.text[:200],
+                    provider_name,
+                    r.status_code,
+                    r.text[:200],
                 )
                 return False
             logger.info("Bifrost: pushed updated key for provider %s", provider_name)
             return True
         except Exception as e:
-            logger.warning("Bifrost: PUT /api/providers/%s failed: %s", provider_name, e)
+            logger.warning(
+                "Bifrost: PUT /api/providers/%s failed: %s", provider_name, e
+            )
             return False
 
 
@@ -107,9 +123,13 @@ def sync_all_provider_keys() -> Dict[str, bool]:
     if db_manager._engine is None:
         db_manager.initialize()
     with db_manager.session_scope() as session:
-        rows = session.query(LLMProviderConfig).filter(
-            LLMProviderConfig.is_active.is_(True),
-        ).all()
+        rows = (
+            session.query(LLMProviderConfig)
+            .filter(
+                LLMProviderConfig.is_active.is_(True),
+            )
+            .all()
+        )
         for row in rows:
             if not row.api_key_ref:
                 continue
@@ -117,7 +137,8 @@ def sync_all_provider_keys() -> Dict[str, bool]:
             if not value:
                 logger.debug(
                     "Bifrost sync: no value in secrets store for %s (ref=%s)",
-                    row.provider_id, row.api_key_ref,
+                    row.provider_id,
+                    row.api_key_ref,
                 )
                 results[row.provider_id] = False
                 continue
@@ -126,3 +147,307 @@ def sync_all_provider_keys() -> Dict[str, bool]:
         ok = sum(1 for v in results.values() if v)
         logger.info("Bifrost sync: pushed %d/%d provider keys", ok, len(results))
     return results
+
+
+def sync_provider_models(provider_type: str, model_ids: list[str]) -> bool:
+    """Update Bifrost's allow-list of routable models for ``provider_type``.
+
+    GETs the provider document, replaces ``keys[0].models`` with
+    ``model_ids``, and PUTs the result back. Empty lists are skipped —
+    wiping the allow-list to ``[]`` would cause Bifrost to reject every
+    subsequent LLM call for that provider, which we never want just
+    because an upstream API had a momentary hiccup.
+    """
+    if not provider_type:
+        return False
+    if not model_ids:
+        logger.info(
+            "Bifrost sync: skipping empty model list for provider %s "
+            "(refusing to wipe allow-list)",
+            provider_type,
+        )
+        return False
+    # Normalize + dedupe while preserving order.
+    seen: set = set()
+    normalized: list[str] = []
+    for mid in model_ids:
+        if not mid or mid in seen:
+            continue
+        seen.add(mid)
+        normalized.append(mid)
+
+    with httpx.Client() as client:
+        prov = _get_provider(provider_type, client)
+        if prov is None:
+            return False
+        keys = prov.get("keys") or []
+        if not keys:
+            logger.warning(
+                "Bifrost: provider %s has no keys slot to update",
+                provider_type,
+            )
+            return False
+        keys[0]["models"] = normalized
+        try:
+            r = client.put(
+                f"{_bifrost_base_url()}/api/providers/{provider_type}",
+                json=prov,
+                timeout=_DEFAULT_TIMEOUT,
+            )
+            if r.status_code >= 400:
+                logger.warning(
+                    "Bifrost: PUT /api/providers/%s (models) returned %s: %s",
+                    provider_type,
+                    r.status_code,
+                    r.text[:200],
+                )
+                return False
+            logger.info(
+                "Bifrost: synced %d models for provider %s",
+                len(normalized),
+                provider_type,
+            )
+            return True
+        except Exception as e:
+            logger.warning(
+                "Bifrost: PUT /api/providers/%s (models) failed: %s",
+                provider_type,
+                e,
+            )
+            return False
+
+
+async def sync_all_provider_models() -> Dict[str, Any]:
+    """Canonical refresh for every active LLM provider.
+
+    Single source of truth — called at startup, on a schedule, from the
+    refresh endpoints, and lazily on a dropdown cache miss. One call
+    does everything:
+
+    1. Fetches each provider's live upstream catalog via
+       ``services.provider_model_discovery``.
+    2. Applies the configured extras (IDs upstream dropped from
+       /v1/models but that still route — e.g. Claude 3.x).
+    3. Populates ``_MODEL_LIST_CACHE[provider_id]`` in
+       ``services.model_registry`` so the UI dropdown reads the same
+       list the sync just computed.
+    4. Unions per-provider-type across rows and PUTs that to Bifrost's
+       allow-list via the admin API, so LLM traffic routes for every
+       model the dropdown shows.
+
+    Because all three surfaces (dropdown cache, live-meta cache, Bifrost
+    allow-list) are written in the same pass, they cannot drift.
+
+    Concurrent calls are coalesced — if a sync is already running (e.g.
+    the scheduled refresher kicked off at the same time as a dropdown
+    cold-load), the second caller awaits the same future rather than
+    issuing a duplicate round of upstream fetches.
+
+    Best-effort — never raises. Returns a dict with per-provider-type
+    Bifrost sync flags under ``bifrost`` and the computed per-row model
+    lists under ``models_by_provider`` for observability.
+    """
+    global _sync_in_flight
+    if _sync_in_flight is not None and not _sync_in_flight.done():
+        logger.debug("sync_all_provider_models: joining in-flight sync")
+        return await _sync_in_flight
+
+    loop = asyncio.get_running_loop()
+    _sync_in_flight = loop.create_future()
+    try:
+        result = await _do_sync_all_provider_models()
+        _sync_in_flight.set_result(result)
+        return result
+    except Exception as exc:
+        _sync_in_flight.set_exception(exc)
+        raise
+    finally:
+        # Release the slot so the next scheduled tick or CRUD event can
+        # start a fresh sync.
+        _sync_in_flight = None
+
+
+async def _do_sync_all_provider_models() -> Dict[str, Any]:
+    # Deferred imports to keep module load cheap.
+    from database.connection import get_db_manager
+    from database.models import LLMProviderConfig
+    from services import provider_model_discovery as discovery
+    from services.model_registry import (
+        _FALLBACK_MODELS_BY_PROVIDER,
+        _MODEL_LIST_CACHE,
+        _register_extras,
+        get_extra_model_ids,
+        record_live_meta,
+    )
+
+    db_manager = get_db_manager()
+    if db_manager._engine is None:
+        db_manager.initialize()
+
+    # Group active providers by type and collect the rows we need to
+    # fetch (we don't hold the session open across awaits).
+    rows_by_type: Dict[str, list] = {}
+    with db_manager.session_scope() as session:
+        rows = (
+            session.query(LLMProviderConfig)
+            .filter(
+                LLMProviderConfig.is_active.is_(True),
+            )
+            .all()
+        )
+        for row in rows:
+            # Detach enough state from the row so we can use it after the
+            # session closes. The ORM row becomes unusable post-scope.
+            rows_by_type.setdefault(row.provider_type, []).append(
+                {
+                    "provider_id": row.provider_id,
+                    "provider_type": row.provider_type,
+                    "base_url": row.base_url,
+                    "api_key_ref": row.api_key_ref,
+                    "config": dict(row.config or {}),
+                }
+            )
+
+    bifrost_results: Dict[str, bool] = {}
+    per_row_models: Dict[str, List[str]] = {}
+
+    for provider_type, provider_rows in rows_by_type.items():
+        # Extras are per-provider-type; apply to every row of this type.
+        extras = get_extra_model_ids(provider_type)
+        _register_extras(provider_type, extras)
+
+        type_union: List[str] = []
+        type_seen: set = set()
+
+        for row_dict in provider_rows:
+            row_ids: List[str] = []
+            row_seen: set = set()
+            upstream_ok = False
+
+            try:
+                meta = await _fetch_meta_for_row(row_dict, discovery)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "sync_all_provider_models: discovery failed for %s (%s): %s",
+                    row_dict["provider_id"],
+                    provider_type,
+                    exc,
+                )
+                meta = None
+
+            if meta is not None:
+                upstream_ok = True
+                record_live_meta(provider_type, meta)
+                for m in meta:
+                    if m.id in row_seen:
+                        continue
+                    row_seen.add(m.id)
+                    row_ids.append(m.id)
+
+            # Upstream failed: union the bootstrap list so the dropdown
+            # isn't empty while still carrying the extras below.
+            if not upstream_ok:
+                for mid in _FALLBACK_MODELS_BY_PROVIDER.get(provider_type, ()):
+                    if mid not in row_seen:
+                        row_seen.add(mid)
+                        row_ids.append(mid)
+
+            # Extras are unioned into the row list so the dropdown shows
+            # them and the Bifrost allow-list contains them — same list,
+            # same source.
+            for mid in extras:
+                if mid not in row_seen:
+                    row_seen.add(mid)
+                    row_ids.append(mid)
+
+            # Single-writer: populate the dropdown cache with this row's
+            # list. ``fetch_provider_models`` reads this same key.
+            _MODEL_LIST_CACHE.set(row_dict["provider_id"], row_ids)
+            per_row_models[row_dict["provider_id"]] = row_ids
+
+            # Contribute to the per-type union for Bifrost.
+            for mid in row_ids:
+                if mid in type_seen:
+                    continue
+                type_seen.add(mid)
+                type_union.append(mid)
+
+        if not type_union:
+            # Preserve bootstrap: don't overwrite Bifrost's allow-list
+            # with an empty list if every row failed and there are no
+            # extras or fallback.
+            bifrost_results[provider_type] = False
+            continue
+
+        bifrost_results[provider_type] = sync_provider_models(provider_type, type_union)
+
+    if bifrost_results:
+        ok = sum(1 for v in bifrost_results.values() if v)
+        logger.info(
+            "Model catalog sync: pushed model lists for %d/%d provider types",
+            ok,
+            len(bifrost_results),
+        )
+
+    return {
+        "bifrost": bifrost_results,
+        "models_by_provider": per_row_models,
+    }
+
+
+async def _fetch_meta_for_row(row_dict: Dict[str, Any], discovery) -> Optional[list]:
+    """Call the appropriate discovery function for one provider row.
+
+    Returns ``None`` when the row isn't usable (e.g. no API key). The
+    caller logs and skips.
+    """
+    from backend.secrets_manager import get_secret
+
+    provider_type = row_dict["provider_type"]
+    base_url = row_dict.get("base_url")
+    api_key_ref = row_dict.get("api_key_ref")
+    config = row_dict.get("config") or {}
+
+    def _resolve_key() -> Optional[str]:
+        if api_key_ref:
+            try:
+                val = get_secret(api_key_ref)
+                if val:
+                    return val
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("secret lookup for %s failed: %s", api_key_ref, exc)
+        if provider_type == "anthropic":
+            return os.getenv("ANTHROPIC_API_KEY") or os.getenv("CLAUDE_API_KEY")
+        if provider_type == "openai":
+            return os.getenv("OPENAI_API_KEY")
+        return None
+
+    if provider_type == "anthropic":
+        key = _resolve_key()
+        if not key:
+            logger.info(
+                "Bifrost sync: no Anthropic key available for %s — skipping",
+                row_dict["provider_id"],
+            )
+            return None
+        return await discovery.fetch_anthropic_models(key)
+
+    if provider_type == "openai":
+        key = _resolve_key()
+        if not key:
+            logger.info(
+                "Bifrost sync: no OpenAI key available for %s — skipping",
+                row_dict["provider_id"],
+            )
+            return None
+        return await discovery.fetch_openai_models(
+            key,
+            base_url=base_url,
+            organization=config.get("organization"),
+        )
+
+    if provider_type == "ollama":
+        return await discovery.fetch_ollama_models(base_url)
+
+    logger.debug("Bifrost sync: unsupported provider_type %s", provider_type)
+    return None

--- a/services/model_registry.py
+++ b/services/model_registry.py
@@ -3,11 +3,12 @@
 Sits on top of the multi-provider layer introduced in #88:
   - Reads `ai_model_configs` (component → provider+model) for assignments.
   - Reads `llm_provider_configs` for provider info.
-  - Live-queries providers for their current model lists (Anthropic static,
-    Ollama /api/tags, OpenAI /v1/models), with a short TTL cache so the
-    Settings UI feels responsive without hammering external APIs.
-  - Owns the static cost/capability catalog used for dollar-per-token math
-    and the capability chips shown in the UI.
+  - Live-queries providers for their current model lists via
+    ``services.provider_model_discovery`` (Anthropic /v1/models, OpenAI
+    /v1/models, Ollama /api/tags + /api/show), with a short TTL cache.
+  - Owns a layered cost/capability catalog: live upstream meta first, then
+    a static override dict for known-exact values, then a provider-specific
+    tier heuristic keyed by model-id prefix, then a safe (0, 0) default.
 
 The registry is intentionally decoupled from the DB hot path: all DB access
 goes through short-lived sessions that are closed before returning.
@@ -17,8 +18,8 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sys
-import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -52,12 +53,24 @@ def is_valid_component(name: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Static pricing + capability catalog (per-million-token USD rates)
+# Layered catalog — live meta → static override → tier heuristic → default
 # ---------------------------------------------------------------------------
+#
+# 1. Live meta: populated by ``services.provider_model_discovery`` when the
+#    dynamic-discovery path runs. Holds display_name, context_window and
+#    capability flags scraped from upstream APIs. Does NOT hold pricing —
+#    no provider publishes pricing in their /models endpoint.
+# 2. Static overrides (``_CATALOG``): exact-known values we've hand-verified
+#    against provider pricing pages. Takes precedence over tier heuristics
+#    so cost math stays precise for the models we actually use a lot.
+# 3. Tier heuristic (``_TIER_HEURISTIC``): prefix-regex fallback. Ensures a
+#    new model (e.g. a future Haiku or Sonnet variant) gets a reasonable
+#    cost estimate the moment upstream exposes it, without a code change.
+# 4. Default: (0, 0) for cost, 0 for context, all-False capabilities.
 
-# Values sourced from provider public pricing pages as of 2025-Q4. Ollama
-# models are self-hosted so rates are $0. When a model isn't in the catalog
-# we return (0, 0) and log a warning so cost data degrades gracefully.
+
+# Exact overrides — per-million-token USD rates. Sourced from provider
+# public pricing pages as of 2025-Q4. Ollama models are self-hosted → $0.
 
 _CATALOG: Dict[Tuple[str, str], Dict[str, Any]] = {
     # (provider_type, model_id) → metadata
@@ -115,6 +128,36 @@ _CATALOG: Dict[Tuple[str, str], Dict[str, Any]] = {
         "supports_thinking": False,
         "supports_vision": True,
     },
+    # Legacy 3.x — kept so the extras-mechanism (see _DEFAULT_EXTRA_MODELS)
+    # renders correct context/pricing instead of "0K ctx · $0". Anthropic
+    # pulled these from /v1/models but they're still callable.
+    ("anthropic", "claude-3-5-sonnet-20241022"): {
+        "display_name": "Claude Sonnet 3.5 v2",
+        "context_window": 200_000,
+        "input_per_m": 3.0,
+        "output_per_m": 15.0,
+        "supports_tools": True,
+        "supports_thinking": False,
+        "supports_vision": True,
+    },
+    ("anthropic", "claude-3-5-haiku-20241022"): {
+        "display_name": "Claude Haiku 3.5",
+        "context_window": 200_000,
+        "input_per_m": 0.80,
+        "output_per_m": 4.0,
+        "supports_tools": True,
+        "supports_thinking": False,
+        "supports_vision": False,
+    },
+    ("anthropic", "claude-3-haiku-20240307"): {
+        "display_name": "Claude Haiku 3",
+        "context_window": 200_000,
+        "input_per_m": 0.25,
+        "output_per_m": 1.25,
+        "supports_tools": True,
+        "supports_thinking": False,
+        "supports_vision": True,
+    },
     ("openai", "gpt-4o"): {
         "display_name": "GPT-4o",
         "context_window": 128_000,
@@ -145,26 +188,96 @@ _CATALOG: Dict[Tuple[str, str], Dict[str, Any]] = {
 }
 
 
-def _catalog_entry(provider_type: str, model_id: str) -> Dict[str, Any]:
-    """Return catalog entry or a safe default."""
-    entry = _CATALOG.get((provider_type, model_id))
-    if entry is not None:
-        return entry
-    if provider_type == "ollama":
-        return {
-            "display_name": model_id,
-            "context_window": 0,  # unknown — depends on ollama modelfile
-            "input_per_m": 0.0,
-            "output_per_m": 0.0,
-            "supports_tools": False,
-            "supports_thinking": False,
-            "supports_vision": False,
+# ---------------------------------------------------------------------------
+# Tier heuristic — last-resort pricing by model-id prefix regex
+# ---------------------------------------------------------------------------
+# Order matters: more specific patterns first. Each entry gives the
+# per-million-token USD rate pair. Context window / capabilities are left
+# at defaults when a tier heuristic is all we have; live meta (layer 1)
+# is expected to fill those in for any model worth routing to.
+#
+# NOTE: these are estimates. Exact rates belong in ``_CATALOG`` above.
+
+_TierPattern = Tuple[str, float, float]
+
+_ANTHROPIC_TIERS: Tuple[_TierPattern, ...] = (
+    (r"opus", 15.0, 75.0),
+    (r"sonnet", 3.0, 15.0),
+    (r"haiku", 0.80, 4.0),
+)
+
+_OPENAI_TIERS: Tuple[_TierPattern, ...] = (
+    (r"gpt-4o-mini", 0.15, 0.60),
+    (r"gpt-4o", 2.50, 10.0),
+    (r"gpt-4\.1-mini", 0.40, 1.60),
+    (r"gpt-4\.1", 2.0, 8.0),
+    (r"gpt-4-turbo", 10.0, 30.0),
+    (r"gpt-4", 30.0, 60.0),
+    (r"o3-mini", 1.10, 4.40),
+    (r"o3", 10.0, 40.0),
+    (r"o1-mini", 1.10, 4.40),
+    (r"o1", 15.0, 60.0),
+)
+
+_TIER_HEURISTIC: Dict[str, Tuple[_TierPattern, ...]] = {
+    "anthropic": _ANTHROPIC_TIERS,
+    "openai": _OPENAI_TIERS,
+    "ollama": (),  # always $0 — handled as a separate branch
+}
+
+
+def _match_tier(provider_type: str, model_id: str) -> Optional[Tuple[float, float]]:
+    for pattern, in_rate, out_rate in _TIER_HEURISTIC.get(provider_type, ()):
+        if re.search(pattern, model_id, re.IGNORECASE):
+            return (in_rate, out_rate)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Live-meta cache — populated by the discovery module
+# ---------------------------------------------------------------------------
+
+# Maps (provider_type, model_id) → catalog-shape dict with the meta we
+# got from upstream. Populated by ``record_live_meta`` after
+# ``services.provider_model_discovery.fetch_*`` succeeds. Cleared when
+# discovery cache is invalidated.
+
+_LIVE_META: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+
+def record_live_meta(provider_type: str, meta_list: List[Any]) -> None:
+    """Absorb a list of ``ModelMeta`` objects from the discovery module.
+
+    Called by ``fetch_provider_models`` after a successful upstream call
+    so subsequent cost/catalog lookups see the live display_name, context,
+    and capability data.
+    """
+    for m in meta_list:
+        caps = getattr(m, "capabilities", {}) or {}
+        _LIVE_META[(provider_type, m.id)] = {
+            "display_name": getattr(m, "display_name", m.id),
+            "context_window": int(getattr(m, "context_window", 0) or 0),
+            "supports_tools": bool(caps.get("supports_tools", False)),
+            "supports_thinking": bool(caps.get("supports_thinking", False)),
+            "supports_vision": bool(caps.get("supports_vision", False)),
         }
-    logger.warning(
-        "No catalog entry for %s/%s — defaulting cost to $0 and capabilities to false",
-        provider_type,
-        model_id,
-    )
+
+
+def clear_live_meta(provider_type: Optional[str] = None) -> None:
+    if provider_type is None:
+        _LIVE_META.clear()
+        return
+    for key in list(_LIVE_META.keys()):
+        if key[0] == provider_type:
+            _LIVE_META.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# Layered lookup
+# ---------------------------------------------------------------------------
+
+
+def _default_entry(provider_type: str, model_id: str) -> Dict[str, Any]:
     return {
         "display_name": model_id,
         "context_window": 0,
@@ -173,7 +286,64 @@ def _catalog_entry(provider_type: str, model_id: str) -> Dict[str, Any]:
         "supports_tools": False,
         "supports_thinking": False,
         "supports_vision": False,
+        "pricing_source": "unknown",
     }
+
+
+def _catalog_entry(provider_type: str, model_id: str) -> Dict[str, Any]:
+    """Return a merged catalog entry using the four-layer lookup.
+
+    Precedence: static override (``_CATALOG``) > live upstream meta
+    (``_LIVE_META``) > tier heuristic + provider default > safe default.
+    The static override wins over live meta so hand-verified pricing
+    isn't clobbered by zero-pricing from an upstream response — the API
+    doesn't carry price data anyway, so the merge strategy is: take
+    context/caps from live meta, take pricing from the layer that has
+    it, with ``_CATALOG`` winning ties on display_name.
+    """
+    entry = dict(_default_entry(provider_type, model_id))
+    static = _CATALOG.get((provider_type, model_id))
+    live = _LIVE_META.get((provider_type, model_id))
+
+    # Context / capabilities: prefer live meta (upstream source of truth),
+    # fall back to static override, then default.
+    for source in (live, static):
+        if not source:
+            continue
+        for field_name in (
+            "display_name",
+            "context_window",
+            "supports_tools",
+            "supports_thinking",
+            "supports_vision",
+        ):
+            if field_name in source and source[field_name]:
+                entry[field_name] = source[field_name]
+
+    # Pricing: static override → tier heuristic → provider-specific default.
+    if static and ("input_per_m" in static or "output_per_m" in static):
+        entry["input_per_m"] = float(static.get("input_per_m", 0.0))
+        entry["output_per_m"] = float(static.get("output_per_m", 0.0))
+        entry["pricing_source"] = "exact"
+    elif provider_type == "ollama":
+        entry["input_per_m"] = 0.0
+        entry["output_per_m"] = 0.0
+        entry["pricing_source"] = "zero"
+    else:
+        tier = _match_tier(provider_type, model_id)
+        if tier is not None:
+            entry["input_per_m"], entry["output_per_m"] = tier
+            entry["pricing_source"] = "heuristic"
+        else:
+            entry["pricing_source"] = "unknown"
+            logger.warning(
+                "No catalog entry for %s/%s — defaulting cost to $0 and "
+                "capabilities to false",
+                provider_type,
+                model_id,
+            )
+
+    return entry
 
 
 # ---------------------------------------------------------------------------
@@ -193,6 +363,14 @@ class ModelInfo:
     supports_tools: bool
     supports_thinking: bool
     supports_vision: bool
+    # One of: "exact" (from _CATALOG), "heuristic" (tier regex),
+    # "zero" (ollama self-hosted), "unknown" (no data — treated as $0).
+    # Logged at discovery time; frontend can use it to badge estimates.
+    pricing_source: str = "exact"
+    # True when the model was pinned to a component via ai_model_configs
+    # but is no longer advertised by the upstream API. Kept in the UI
+    # list so a user's saved selection doesn't silently disappear.
+    deprecated: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -206,6 +384,8 @@ class ModelInfo:
             "supports_tools": self.supports_tools,
             "supports_thinking": self.supports_thinking,
             "supports_vision": self.supports_vision,
+            "pricing_source": self.pricing_source,
+            "deprecated": self.deprecated,
         }
 
 
@@ -218,27 +398,25 @@ class ComponentAssignment:
 
 
 # ---------------------------------------------------------------------------
-# Provider model lists — live-query with a per-provider TTL cache
+# Per-provider model list cache — no TTL
 # ---------------------------------------------------------------------------
-
-_MODEL_LIST_CACHE_TTL_S = 60.0
+# Entries are valid until ``invalidate()`` is called (CRUD) or overwritten
+# by ``sync_all_provider_models`` (scheduled refresh, manual refresh, or
+# a lazy-sync on cold cache). The scheduled refresher — running every
+# MODEL_CATALOG_REFRESH_INTERVAL_S (default 300s) — is the source of
+# freshness. A time-based TTL here would just guarantee a latency spike
+# on whichever page load falls on the expiry boundary.
 
 
 class _ProviderModelCache:
     def __init__(self):
-        self._entries: Dict[str, Tuple[float, List[str]]] = {}
+        self._entries: Dict[str, List[str]] = {}
 
     def get(self, provider_id: str) -> Optional[List[str]]:
-        hit = self._entries.get(provider_id)
-        if not hit:
-            return None
-        ts, models = hit
-        if time.time() - ts > _MODEL_LIST_CACHE_TTL_S:
-            return None
-        return models
+        return self._entries.get(provider_id)
 
     def set(self, provider_id: str, models: List[str]) -> None:
-        self._entries[provider_id] = (time.time(), models)
+        self._entries[provider_id] = models
 
     def invalidate(self, provider_id: Optional[str] = None) -> None:
         if provider_id is None:
@@ -250,65 +428,125 @@ class _ProviderModelCache:
 _MODEL_LIST_CACHE = _ProviderModelCache()
 
 
-# Single source of truth for the Anthropic model list. `backend/api/llm_providers.py`
-# imports this tuple; `docker/bifrost/config.json` must be kept in sync so Bifrost
-# accepts requests for these model IDs.
-ANTHROPIC_STATIC_MODELS: Tuple[str, ...] = (
-    "claude-opus-4-7",
-    "claude-sonnet-4-6",
-    "claude-sonnet-4-5-20250929",
-    "claude-sonnet-4-20250514",
-    "claude-opus-4-20250514",
-    "claude-haiku-4-5-20251001",
-)
+# Cold-boot fallback lists — used only when the live upstream API is
+# unreachable at the exact moment a caller needs a list. Each entry is
+# a small safe set; it is NOT the UI dropdown. Real model discovery
+# runs through ``services.provider_model_discovery`` and populates the
+# layered catalog above.
+
+_FALLBACK_MODELS_BY_PROVIDER: Dict[str, Tuple[str, ...]] = {
+    "anthropic": (
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5-20251001",
+    ),
+    "openai": (
+        "gpt-4o",
+        "gpt-4o-mini",
+    ),
+    "ollama": (),
+}
+
+
+# Extra model IDs that are NOT returned by the upstream /v1/models listing
+# but are still callable. Unioned with the live list and rendered with
+# ``deprecated=True`` so users get a visual cue that these aren't the
+# preferred path. Default covers Anthropic's 3.x family which was pulled
+# from the listing endpoint but remains routable. Override per deployment
+# via env: ``ANTHROPIC_EXTRA_MODELS`` / ``OPENAI_EXTRA_MODELS`` (CSV).
+# Set to empty string to disable for a provider.
+
+_DEFAULT_EXTRA_MODELS: Dict[str, Tuple[str, ...]] = {
+    "anthropic": (
+        "claude-3-5-haiku-20241022",
+        "claude-3-5-sonnet-20241022",
+        "claude-3-haiku-20240307",
+    ),
+    "openai": (),
+    "ollama": (),
+}
+
+
+def get_extra_model_ids(provider_type: str) -> Tuple[str, ...]:
+    """Return the extra model IDs for a provider type, honoring env
+    overrides. Empty string disables; missing env falls back to defaults."""
+    env_name = f"{provider_type.upper()}_EXTRA_MODELS"
+    raw = os.getenv(env_name)
+    if raw is None:
+        return _DEFAULT_EXTRA_MODELS.get(provider_type, ())
+    # Present but empty → explicitly disabled.
+    parts = tuple(s.strip() for s in raw.split(",") if s.strip())
+    return parts
+
+
+# Tracks (provider_type, model_id) pairs added via the extras mechanism so
+# ``list_available_models`` can tag them as deprecated in the UI response.
+_EXTRA_IDS: set = set()
+
+
+def _register_extras(provider_type: str, ids: Tuple[str, ...]) -> None:
+    for mid in ids:
+        _EXTRA_IDS.add((provider_type, mid))
+
+
+def is_extra_model(provider_type: str, model_id: str) -> bool:
+    return (provider_type, model_id) in _EXTRA_IDS
 
 
 async def fetch_provider_models(row) -> List[str]:
-    """Live-query a provider for its available model IDs.
+    """Return the cached model list for a provider.
 
-    ``row`` is an LLMProviderConfig ORM row. Raises on unrecoverable errors;
-    callers should catch and degrade gracefully (e.g. fall back to
-    [row.default_model]).
+    Cache reader only — the sole writer is
+    ``services.bifrost_admin.sync_all_provider_models`` which populates
+    this cache at the same time it pushes to Bifrost. That shared-writer
+    design is what prevents drift between the UI dropdown and Bifrost's
+    allow-list.
+
+    Cold start: if the cache is empty (e.g. startup sync hasn't completed
+    or this row was added after the last scheduled refresh), trigger the
+    canonical sync and re-read. If upstream is unreachable, fall back to
+    the provider-type bootstrap list + extras so callers always get
+    something to render.
     """
-    import httpx  # lazy
+    cached = _MODEL_LIST_CACHE.get(row.provider_id)
+    if cached is not None:
+        return cached
+
+    # Cold: run the canonical refresh. This populates the cache for every
+    # active provider, so concurrent lazy-syncs for other rows are free.
+    try:
+        from services.bifrost_admin import sync_all_provider_models
+
+        await sync_all_provider_models()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "fetch_provider_models(%s/%s): lazy sync failed: %s",
+            row.provider_type,
+            row.provider_id,
+            exc,
+        )
 
     cached = _MODEL_LIST_CACHE.get(row.provider_id)
     if cached is not None:
         return cached
 
+    # Hard fallback: upstream unreachable AND sync didn't cache this row
+    # (e.g. no API key configured). Populate with bootstrap + extras so
+    # we don't keep retrying upstream on every dropdown open.
     provider_type = row.provider_type
-    models: List[str]
+    fallback = list(_FALLBACK_MODELS_BY_PROVIDER.get(provider_type, ()))
+    extras = get_extra_model_ids(provider_type)
+    _register_extras(provider_type, extras)
+    for mid in extras:
+        if mid not in fallback:
+            fallback.append(mid)
+    _MODEL_LIST_CACHE.set(row.provider_id, fallback)
+    return fallback
 
-    if provider_type == "anthropic":
-        models = list(ANTHROPIC_STATIC_MODELS)
 
-    elif provider_type == "ollama":
-        base_url = (row.base_url or "http://localhost:11434").rstrip("/")
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(f"{base_url}/api/tags")
-            resp.raise_for_status()
-            data = resp.json()
-        models = [m.get("name") for m in data.get("models", []) if m.get("name")]
-
-    elif provider_type == "openai":
-        base_url = (row.base_url or "https://api.openai.com/v1").rstrip("/")
-        api_key = await _resolve_provider_key(row)
-        if not api_key:
-            raise RuntimeError(f"openai provider {row.provider_id}: no api key")
-        headers = {"Authorization": f"Bearer {api_key}"}
-        if row.config and row.config.get("organization"):
-            headers["OpenAI-Organization"] = row.config["organization"]
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.get(f"{base_url}/models", headers=headers)
-            resp.raise_for_status()
-            data = resp.json()
-        models = [m.get("id") for m in data.get("data", []) if m.get("id")]
-
-    else:
-        raise RuntimeError(f"unsupported provider_type: {provider_type}")
-
-    _MODEL_LIST_CACHE.set(row.provider_id, models)
-    return models
+# Backward-compat alias — kept so existing imports don't break.
+# Prefer ``_FALLBACK_MODELS_BY_PROVIDER['anthropic']`` for new code.
+ANTHROPIC_STATIC_MODELS: Tuple[str, ...] = _FALLBACK_MODELS_BY_PROVIDER["anthropic"]
 
 
 async def _resolve_provider_key(row) -> Optional[str]:
@@ -359,7 +597,11 @@ class ModelRegistry:
 
     @staticmethod
     def get_model_info(
-        provider_id: str, provider_type: str, model_id: str
+        provider_id: str,
+        provider_type: str,
+        model_id: str,
+        *,
+        deprecated: bool = False,
     ) -> ModelInfo:
         entry = _catalog_entry(provider_type, model_id)
         return ModelInfo(
@@ -373,6 +615,8 @@ class ModelRegistry:
             supports_tools=entry["supports_tools"],
             supports_thinking=entry["supports_thinking"],
             supports_vision=entry["supports_vision"],
+            pricing_source=entry.get("pricing_source", "exact"),
+            deprecated=deprecated,
         )
 
     # ---- assignments -----------------------------------------------------
@@ -490,7 +734,10 @@ class ModelRegistry:
         """Aggregate live model lists across all active providers.
 
         Each provider is queried independently; a provider failure is
-        logged but never blocks the overall list.
+        logged but never blocks the overall list. Models pinned via
+        ``ai_model_configs`` that no longer appear in the live list are
+        still returned with ``deprecated=True`` so users don't see their
+        saved selection silently disappear.
         """
         try:
             from database.connection import get_db_session
@@ -509,6 +756,15 @@ class ModelRegistry:
         finally:
             session.close()
 
+        # Collect pinned (provider_id, model_id) pairs so we can keep
+        # orphaned selections visible.
+        pinned: Dict[Tuple[str, str], str] = {}
+        for asn in self.get_all_assignments().values():
+            pinned[(asn.provider_id, asn.model_id)] = (
+                # provider_type is filled in below when the row exists.
+                ""
+            )
+
         out: List[ModelInfo] = []
         seen: set = set()
 
@@ -525,16 +781,50 @@ class ModelRegistry:
                 )
                 model_ids = [p.default_model] if p.default_model else []
 
+            provider_live: set = set()
             for mid in model_ids:
                 key = (p.provider_id, mid)
                 if key in seen:
                     continue
                 seen.add(key)
+                provider_live.add(mid)
+                # Models added via the extras mechanism are deprecated —
+                # they're still callable but upstream dropped them from
+                # /v1/models, so the UI should badge them.
+                is_deprecated = is_extra_model(p.provider_type, mid)
                 out.append(
                     self.get_model_info(
                         provider_id=p.provider_id,
                         provider_type=p.provider_type,
                         model_id=mid,
+                        deprecated=is_deprecated,
+                    )
+                )
+
+            # Orphaned pins: a user has this provider+model pinned, but
+            # upstream no longer advertises it. Preserve the entry so
+            # the dropdown still renders the saved selection.
+            for pin_provider_id, pin_model_id in pinned:
+                if pin_provider_id != p.provider_id:
+                    continue
+                if pin_model_id in provider_live:
+                    continue
+                key = (pin_provider_id, pin_model_id)
+                if key in seen:
+                    continue
+                seen.add(key)
+                logger.info(
+                    "Pinned model %s/%s is no longer advertised by upstream "
+                    "— keeping in list as deprecated",
+                    p.provider_type,
+                    pin_model_id,
+                )
+                out.append(
+                    self.get_model_info(
+                        provider_id=p.provider_id,
+                        provider_type=p.provider_type,
+                        model_id=pin_model_id,
+                        deprecated=True,
                     )
                 )
 
@@ -557,5 +847,17 @@ def get_registry() -> ModelRegistry:
 
 def invalidate_model_cache(provider_id: Optional[str] = None) -> None:
     """Callers that change provider config (add/update/delete) can drop
-    the per-provider model-list cache so the UI sees fresh data."""
+    the per-provider model-list cache + the discovery module's meta cache
+    so the UI sees fresh data."""
     _MODEL_LIST_CACHE.invalidate(provider_id)
+    # Provider-scoped live meta / discovery cache invalidation — best
+    # effort. ``provider_id`` is a DB id, not a provider_type, so we can't
+    # surgically drop a single entry; clear all meta + discovery cache
+    # when any provider changes.
+    try:
+        from services import provider_model_discovery as discovery
+
+        discovery.invalidate_cache()
+    except Exception:  # noqa: BLE001
+        pass
+    clear_live_meta()

--- a/services/provider_model_discovery.py
+++ b/services/provider_model_discovery.py
@@ -1,0 +1,311 @@
+"""Per-provider live model discovery.
+
+One module, three providers, one normalized return shape. Each provider's
+public catalog endpoint is queried directly (not through Bifrost — this is
+capability discovery, not LLM traffic, so the "single LLM routing path"
+policy doesn't apply: the same carve-out already applies to
+``backend/api/llm_providers.py::test_provider`` which validates user keys
+against upstream).
+
+Returned shape — ``ModelMeta``:
+
+    {
+        "id": "<model-id>",
+        "display_name": "<human-readable>",
+        "context_window": <int, 0 when unknown>,
+        "capabilities": {
+            "supports_tools": bool,
+            "supports_thinking": bool,
+            "supports_vision": bool,
+        },
+    }
+
+Each function retries on transient connection failures, TTL-caches on the
+tuple ``(provider_type, base_url, key_hash)``, and returns ``[]`` when the
+upstream is reachable but returns nothing so the caller can distinguish
+"no models" from "discovery failed" (latter raises).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_CACHE_TTL_S = 60.0
+_RETRIES = 3
+_RETRY_BACKOFF_S = 2.0
+_ANTHROPIC_API_URL = "https://api.anthropic.com/v1/models"
+_ANTHROPIC_VERSION = "2023-06-01"
+
+
+@dataclass(frozen=True)
+class ModelMeta:
+    id: str
+    display_name: str
+    context_window: int = 0
+    capabilities: Dict[str, bool] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "display_name": self.display_name,
+            "context_window": self.context_window,
+            "capabilities": dict(self.capabilities),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+
+class _MetaCache:
+    def __init__(self) -> None:
+        self._entries: Dict[str, Tuple[float, List[ModelMeta]]] = {}
+
+    def get(self, key: str) -> Optional[List[ModelMeta]]:
+        hit = self._entries.get(key)
+        if not hit:
+            return None
+        ts, models = hit
+        if time.time() - ts > _CACHE_TTL_S:
+            return None
+        return models
+
+    def set(self, key: str, models: List[ModelMeta]) -> None:
+        self._entries[key] = (time.time(), models)
+
+    def invalidate(self, key: Optional[str] = None) -> None:
+        if key is None:
+            self._entries.clear()
+        else:
+            self._entries.pop(key, None)
+
+
+_META_CACHE = _MetaCache()
+
+
+def _cache_key(provider_type: str, base_url: str, secret: str) -> str:
+    material = f"{provider_type}|{base_url}|{secret}".encode("utf-8")
+    return hashlib.sha256(material).hexdigest()
+
+
+def invalidate_cache(key: Optional[str] = None) -> None:
+    """Drop cached meta. Called from refresh endpoints and when provider
+    config changes."""
+    _META_CACHE.invalidate(key)
+
+
+# ---------------------------------------------------------------------------
+# Retry helper
+# ---------------------------------------------------------------------------
+
+
+async def _with_retry(label: str, coro_factory) -> Any:
+    """Run ``coro_factory()`` with 3 tries and 2s backoff on ConnectionError /
+    httpx transient errors. Non-connection HTTP errors pass through immediately."""
+    last: Optional[Exception] = None
+    for attempt in range(1, _RETRIES + 1):
+        try:
+            return await coro_factory()
+        except (
+            httpx.ConnectError,
+            httpx.ReadTimeout,
+            httpx.RemoteProtocolError,
+        ) as exc:
+            last = exc
+            logger.debug("%s: attempt %d/%d failed (%s)", label, attempt, _RETRIES, exc)
+            if attempt < _RETRIES:
+                await asyncio.sleep(_RETRY_BACKOFF_S)
+    assert last is not None
+    raise last
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+def _anthropic_caps(api_caps: Dict[str, Any]) -> Dict[str, bool]:
+    """Map the Anthropic /v1/models capability block onto our flat booleans."""
+    thinking = api_caps.get("thinking") or {}
+    image = api_caps.get("image_input") or {}
+    # All current Claude models support tool-use. The API doesn't expose a
+    # per-model flag for it (there's no ``tools`` sub-object in the response),
+    # so we default to True for every Claude id.
+    return {
+        "supports_tools": True,
+        "supports_thinking": bool(thinking.get("supported", False)),
+        "supports_vision": bool(image.get("supported", False)),
+    }
+
+
+async def fetch_anthropic_models(api_key: str) -> List[ModelMeta]:
+    """Fetch the live Anthropic model catalog.
+
+    Raises on unrecoverable error so the caller can fall back to the
+    hard-coded bootstrap list. A non-200 from Anthropic (e.g. invalid
+    key) raises ``httpx.HTTPStatusError``.
+    """
+    if not api_key:
+        raise RuntimeError("fetch_anthropic_models: api_key required")
+
+    cache_key = _cache_key("anthropic", _ANTHROPIC_API_URL, api_key)
+    cached = _META_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": _ANTHROPIC_VERSION,
+    }
+
+    async def _call() -> List[ModelMeta]:
+        out: List[ModelMeta] = []
+        after_id: Optional[str] = None
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            while True:
+                params: Dict[str, Any] = {"limit": 1000}
+                if after_id:
+                    params["after_id"] = after_id
+                resp = await client.get(
+                    _ANTHROPIC_API_URL, headers=headers, params=params
+                )
+                resp.raise_for_status()
+                payload = resp.json()
+                for m in payload.get("data", []):
+                    mid = m.get("id")
+                    if not mid:
+                        continue
+                    out.append(
+                        ModelMeta(
+                            id=mid,
+                            display_name=m.get("display_name") or mid,
+                            context_window=int(m.get("max_input_tokens") or 0),
+                            capabilities=_anthropic_caps(m.get("capabilities") or {}),
+                        )
+                    )
+                if not payload.get("has_more"):
+                    break
+                after_id = payload.get("last_id")
+                if not after_id:
+                    break
+        return out
+
+    models = await _with_retry("anthropic model fetch", _call)
+    _META_CACHE.set(cache_key, models)
+    return models
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+async def fetch_openai_models(
+    api_key: str,
+    base_url: Optional[str] = None,
+    organization: Optional[str] = None,
+) -> List[ModelMeta]:
+    """Fetch the live OpenAI (or OpenAI-compatible) model catalog.
+
+    OpenAI's /v1/models returns only ``id``/``created``/``owned_by``; no
+    display name, context, or capability data. The model_registry tier
+    heuristic fills in pricing — context/capabilities stay at their
+    (0/False) defaults unless an override is registered in the static
+    catalog.
+    """
+    if not api_key:
+        raise RuntimeError("fetch_openai_models: api_key required")
+
+    base = (base_url or "https://api.openai.com/v1").rstrip("/")
+    cache_key = _cache_key("openai", base, api_key + "|" + (organization or ""))
+    cached = _META_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    if organization:
+        headers["OpenAI-Organization"] = organization
+
+    async def _call() -> List[ModelMeta]:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(f"{base}/models", headers=headers)
+            resp.raise_for_status()
+            payload = resp.json()
+        out: List[ModelMeta] = []
+        for m in payload.get("data", []):
+            mid = m.get("id")
+            if not mid:
+                continue
+            out.append(ModelMeta(id=mid, display_name=mid))
+        return out
+
+    models = await _with_retry("openai model fetch", _call)
+    _META_CACHE.set(cache_key, models)
+    return models
+
+
+# ---------------------------------------------------------------------------
+# Ollama
+# ---------------------------------------------------------------------------
+
+
+def _ollama_context_from_show(show_payload: Dict[str, Any]) -> int:
+    """Extract a context window from the ``/api/show`` response.
+
+    Ollama nests context under ``model_info`` with architecture-specific keys
+    like ``llama.context_length`` or ``qwen2.context_length``. We scan for the
+    first key ending in ``.context_length``.
+    """
+    info = show_payload.get("model_info") or {}
+    for key, value in info.items():
+        if key.endswith(".context_length"):
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return 0
+    return 0
+
+
+async def fetch_ollama_models(base_url: Optional[str] = None) -> List[ModelMeta]:
+    """Fetch the Ollama library with a best-effort ``/api/show`` probe for
+    context windows. A failed per-model probe doesn't abort the batch."""
+    base = (base_url or "http://localhost:11434").rstrip("/")
+    cache_key = _cache_key("ollama", base, "")
+    cached = _META_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    async def _list() -> List[str]:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(f"{base}/api/tags")
+            resp.raise_for_status()
+            payload = resp.json()
+        return [m.get("name") for m in payload.get("models", []) if m.get("name")]
+
+    names = await _with_retry("ollama tags fetch", _list)
+
+    async def _show(client: httpx.AsyncClient, name: str) -> ModelMeta:
+        try:
+            resp = await client.post(f"{base}/api/show", json={"name": name})
+            resp.raise_for_status()
+            ctx = _ollama_context_from_show(resp.json())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("ollama /api/show %s failed: %s", name, exc)
+            ctx = 0
+        return ModelMeta(id=name, display_name=name, context_window=ctx)
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        models = await asyncio.gather(*(_show(client, n) for n in names))
+
+    _META_CACHE.set(cache_key, list(models))
+    return list(models)

--- a/tests/test_bifrost_admin.py
+++ b/tests/test_bifrost_admin.py
@@ -1,0 +1,423 @@
+"""Unit tests for services.bifrost_admin sync helpers (GH #139).
+
+Verifies the new ``sync_provider_models`` path: empty-list guard, dedup,
+GET-modify-PUT flow, and error handling. httpx is monkeypatched via a
+fake client so tests don't depend on a running Bifrost.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from services import bifrost_admin  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeResp:
+    def __init__(self, status: int, payload: Any = None, text: str = ""):
+        self.status_code = status
+        self._payload = payload
+        self.text = text
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class _RecordingClient:
+    """Mimic ``httpx.Client`` as a context manager with recorded calls."""
+
+    def __init__(self, get_payload=None, get_status=200, put_status=200):
+        self._get_payload = get_payload
+        self._get_status = get_status
+        self._put_status = put_status
+        self.calls: List[Dict[str, Any]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, **kwargs):
+        self.calls.append({"method": "GET", "url": url, "kwargs": kwargs})
+        return _FakeResp(self._get_status, self._get_payload)
+
+    def put(self, url, **kwargs):
+        self.calls.append({"method": "PUT", "url": url, "kwargs": kwargs})
+        return _FakeResp(self._put_status, None, "")
+
+
+def test_sync_provider_models_skips_empty_list():
+    # Must not even hit the admin API — refuses to wipe the allow-list.
+    with patch.object(bifrost_admin.httpx, "Client", lambda: _RecordingClient()):
+        assert bifrost_admin.sync_provider_models("anthropic", []) is False
+
+
+def test_sync_provider_models_dedupes_and_preserves_order():
+    provider_doc = {
+        "keys": [
+            {
+                "value": {"value": "sk-...", "env_var": "", "from_env": False},
+                "models": ["old"],
+            }
+        ]
+    }
+    rec = _RecordingClient(get_payload=provider_doc)
+
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        ok = bifrost_admin.sync_provider_models(
+            "anthropic",
+            [
+                "claude-opus-4-7",
+                "claude-sonnet-4-6",
+                "claude-opus-4-7",
+                "",
+                "claude-haiku-3-5",
+            ],
+        )
+    assert ok is True
+
+    put = [c for c in rec.calls if c["method"] == "PUT"][0]
+    body = put["kwargs"]["json"]
+    assert body["keys"][0]["models"] == [
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-3-5",
+    ]
+
+
+def test_sync_provider_models_returns_false_when_provider_missing():
+    rec = _RecordingClient(get_status=404, get_payload=None)
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        ok = bifrost_admin.sync_provider_models("anthropic", ["claude-opus-4-7"])
+    assert ok is False
+    # No PUT was attempted.
+    assert not any(c["method"] == "PUT" for c in rec.calls)
+
+
+def test_sync_provider_models_returns_false_on_put_error():
+    provider_doc = {"keys": [{"models": []}]}
+    rec = _RecordingClient(get_payload=provider_doc, put_status=500)
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        ok = bifrost_admin.sync_provider_models("openai", ["gpt-4o"])
+    assert ok is False
+
+
+def test_sync_provider_models_returns_false_when_no_keys_slot():
+    # A provider without any keys slot can't be updated.
+    rec = _RecordingClient(get_payload={"keys": []})
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        ok = bifrost_admin.sync_provider_models("anthropic", ["claude-opus-4-7"])
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# sync_all_provider_models — canonical single-writer path
+# ---------------------------------------------------------------------------
+
+
+class _FakeProviderRow:
+    def __init__(self, provider_id, provider_type):
+        self.provider_id = provider_id
+        self.provider_type = provider_type
+        self.base_url = None
+        self.api_key_ref = None
+        self.config = {}
+        self.is_active = True
+
+
+class _FakeSessionScope:
+    """Stand-in for db_manager.session_scope() context manager."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __enter__(self):
+        class _S:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def query(self, model):
+                class _Q:
+                    def __init__(self, rows):
+                        self._rows = rows
+
+                    def filter(self, *_):
+                        return self
+
+                    def all(self):
+                        return self._rows
+
+                return _Q(self._rows)
+
+        return _S(self._rows)
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeDBManager:
+    def __init__(self, rows):
+        self._rows = rows
+        self._engine = object()  # truthy so initialize() isn't called
+
+    def initialize(self):
+        self._engine = object()
+
+    def session_scope(self):
+        return _FakeSessionScope(self._rows)
+
+
+class _M:
+    def __init__(self, mid):
+        self.id = mid
+        self.display_name = mid
+        self.context_window = 0
+        self.capabilities = {}
+
+
+def _patch_db(monkeypatch, rows):
+    fake_db = _FakeDBManager(rows)
+    monkeypatch.setattr(
+        "database.connection.get_db_manager",
+        lambda: fake_db,
+        raising=False,
+    )
+
+
+def _reset_registry():
+    from services import model_registry
+
+    model_registry._MODEL_LIST_CACHE.invalidate()
+    model_registry._EXTRA_IDS.clear()
+    model_registry.clear_live_meta()
+
+
+def test_sync_all_populates_dropdown_cache_and_bifrost_allowlist(monkeypatch):
+    """The whole point of the refactor: one call writes the dropdown cache
+    AND Bifrost's allow-list — they can't drift because they come from
+    the same iteration over the same upstream fetch."""
+    from services import bifrost_admin as ba
+
+    _reset_registry()
+
+    rows = [_FakeProviderRow("ant-default", "anthropic")]
+    _patch_db(monkeypatch, rows)
+
+    # Stub the discovery fetch — returns two live models.
+    async def fake_fetch_row(row_dict, discovery):
+        return [_M("claude-opus-4-7"), _M("claude-haiku-4-5-20251001")]
+
+    monkeypatch.setattr(ba, "_fetch_meta_for_row", fake_fetch_row)
+
+    # Capture Bifrost PUTs.
+    pushed = {}
+
+    def fake_push(provider_type, model_ids):
+        pushed[provider_type] = list(model_ids)
+        return True
+
+    monkeypatch.setattr(ba, "sync_provider_models", fake_push)
+    monkeypatch.setenv("ANTHROPIC_EXTRA_MODELS", "claude-3-5-haiku-20241022")
+
+    import asyncio
+
+    result = asyncio.run(ba.sync_all_provider_models())
+
+    # Bifrost allow-list — live list + extras, unioned.
+    assert pushed["anthropic"] == [
+        "claude-opus-4-7",
+        "claude-haiku-4-5-20251001",
+        "claude-3-5-haiku-20241022",
+    ]
+    # Dropdown cache — same list, same row, same call.
+    from services.model_registry import _MODEL_LIST_CACHE
+
+    assert _MODEL_LIST_CACHE.get("ant-default") == [
+        "claude-opus-4-7",
+        "claude-haiku-4-5-20251001",
+        "claude-3-5-haiku-20241022",
+    ]
+    # Return shape includes both views.
+    assert result["bifrost"]["anthropic"] is True
+    assert result["models_by_provider"]["ant-default"] == [
+        "claude-opus-4-7",
+        "claude-haiku-4-5-20251001",
+        "claude-3-5-haiku-20241022",
+    ]
+    _reset_registry()
+
+
+def test_sync_all_unions_across_same_type_providers(monkeypatch):
+    """Two anthropic providers with different keys — per-row caches hold
+    each row's own list; Bifrost allow-list is the union."""
+    from services import bifrost_admin as ba
+
+    _reset_registry()
+
+    rows = [
+        _FakeProviderRow("ant-dev", "anthropic"),
+        _FakeProviderRow("ant-prod", "anthropic"),
+    ]
+    _patch_db(monkeypatch, rows)
+
+    async def fake_fetch_row(row_dict, discovery):
+        if row_dict["provider_id"] == "ant-dev":
+            return [_M("claude-opus-4-7"), _M("claude-haiku-4-5-20251001")]
+        return [_M("claude-opus-4-7"), _M("claude-sonnet-4-6")]
+
+    monkeypatch.setattr(ba, "_fetch_meta_for_row", fake_fetch_row)
+
+    pushed = {}
+
+    def fake_push(provider_type, model_ids):
+        pushed[provider_type] = list(model_ids)
+        return True
+
+    monkeypatch.setattr(ba, "sync_provider_models", fake_push)
+    monkeypatch.setenv("ANTHROPIC_EXTRA_MODELS", "")  # no extras for this test
+
+    import asyncio
+
+    asyncio.run(ba.sync_all_provider_models())
+
+    from services.model_registry import _MODEL_LIST_CACHE
+
+    assert _MODEL_LIST_CACHE.get("ant-dev") == [
+        "claude-opus-4-7",
+        "claude-haiku-4-5-20251001",
+    ]
+    assert _MODEL_LIST_CACHE.get("ant-prod") == [
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+    ]
+    # Union for Bifrost (order preserved, deduped).
+    assert pushed["anthropic"] == [
+        "claude-opus-4-7",
+        "claude-haiku-4-5-20251001",
+        "claude-sonnet-4-6",
+    ]
+    _reset_registry()
+
+
+def test_sync_all_falls_back_when_all_fetches_fail(monkeypatch):
+    """Every row's fetch failing → per-row cache gets bootstrap + extras,
+    Bifrost allow-list gets the union."""
+    from services import bifrost_admin as ba
+
+    _reset_registry()
+
+    rows = [_FakeProviderRow("ant-default", "anthropic")]
+    _patch_db(monkeypatch, rows)
+
+    async def fake_fetch_row(row_dict, discovery):
+        raise RuntimeError("upstream down")
+
+    monkeypatch.setattr(ba, "_fetch_meta_for_row", fake_fetch_row)
+
+    pushed = {}
+
+    def fake_push(provider_type, model_ids):
+        pushed[provider_type] = list(model_ids)
+        return True
+
+    monkeypatch.setattr(ba, "sync_provider_models", fake_push)
+    monkeypatch.setenv("ANTHROPIC_EXTRA_MODELS", "legacy-1")
+
+    import asyncio
+
+    asyncio.run(ba.sync_all_provider_models())
+
+    from services.model_registry import _MODEL_LIST_CACHE
+
+    row_list = _MODEL_LIST_CACHE.get("ant-default")
+    assert "claude-opus-4-7" in row_list  # from bootstrap
+    assert "legacy-1" in row_list  # extras applied even on failure
+    assert "legacy-1" in pushed["anthropic"]
+    _reset_registry()
+
+
+def test_sync_all_coalesces_concurrent_callers(monkeypatch):
+    """Two simultaneous callers should share a single upstream fetch pass.
+
+    Prevents a dropdown cold-load from doubling upstream load when it
+    races the scheduled refresher's first tick.
+    """
+    from services import bifrost_admin as ba
+
+    _reset_registry()
+
+    rows = [_FakeProviderRow("ant-default", "anthropic")]
+    _patch_db(monkeypatch, rows)
+
+    import asyncio
+
+    fetch_calls = {"n": 0}
+    gate = asyncio.Event()
+
+    async def slow_fake_fetch_row(row_dict, discovery):
+        fetch_calls["n"] += 1
+        # Hold the sync open long enough for the second caller to join.
+        await gate.wait()
+        return [_M("claude-opus-4-7")]
+
+    monkeypatch.setattr(ba, "_fetch_meta_for_row", slow_fake_fetch_row)
+    monkeypatch.setattr(ba, "sync_provider_models", lambda *a, **kw: True)
+    monkeypatch.setenv("ANTHROPIC_EXTRA_MODELS", "")
+
+    async def _race():
+        task_a = asyncio.create_task(ba.sync_all_provider_models())
+        # Yield so task_a enters the critical section and claims the slot.
+        await asyncio.sleep(0)
+        task_b = asyncio.create_task(ba.sync_all_provider_models())
+        # Let task_b also start and try to join the in-flight future.
+        await asyncio.sleep(0)
+        gate.set()
+        return await asyncio.gather(task_a, task_b)
+
+    results = asyncio.run(_race())
+
+    # Exactly one upstream fetch despite two callers.
+    assert fetch_calls["n"] == 1
+    # Both callers see the same result shape.
+    assert results[0]["models_by_provider"] == results[1]["models_by_provider"]
+    _reset_registry()
+
+
+def test_cache_has_no_ttl(monkeypatch):
+    """Cache entries are valid indefinitely until overwritten/invalidated.
+
+    Before the drift-prevention refactor this had a 60s TTL that caused
+    periodic latency spikes when the UI hit an expired entry.
+    """
+    from services.model_registry import _MODEL_LIST_CACHE
+
+    _MODEL_LIST_CACHE.invalidate()
+    _MODEL_LIST_CACHE.set("p1", ["a", "b"])
+
+    # Pretend a long time has passed. Cache should still return the entry.
+    import time as _time
+
+    original = _time.time
+
+    try:
+        # Shift time far into the future. If a TTL lingered, .get() would
+        # drop the entry.
+        _time.time = lambda: original() + 10_000_000  # type: ignore[assignment]
+        assert _MODEL_LIST_CACHE.get("p1") == ["a", "b"]
+    finally:
+        _time.time = original  # type: ignore[assignment]
+    _MODEL_LIST_CACHE.invalidate()

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -16,8 +16,8 @@ import pytest
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO))
 
+from services.model_registry import COMPONENTS  # noqa: E402
 from services.model_registry import (  # noqa: E402
-    COMPONENTS,
     ComponentAssignment,
     ModelRegistry,
     _catalog_entry,
@@ -93,6 +93,145 @@ def test_catalog_entry_ollama_has_no_tools():
     entry = _catalog_entry("ollama", "llama3.1:8b")
     assert entry["supports_tools"] is False
     assert entry["input_per_m"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Layered catalog — tier heuristic + live meta + pricing_source (GH #139)
+# ---------------------------------------------------------------------------
+
+
+def test_tier_heuristic_anthropic_haiku_future():
+    """A model NOT in the exact catalog should fall to the heuristic
+    layer and get tier pricing, not $0. Uses a hypothetical future
+    Haiku variant so the test survives _CATALOG additions."""
+    entry = _catalog_entry("anthropic", "claude-haiku-9-9-hypothetical")
+    assert entry["input_per_m"] == pytest.approx(0.80)
+    assert entry["output_per_m"] == pytest.approx(4.0)
+    assert entry["pricing_source"] == "heuristic"
+
+
+def test_tier_heuristic_openai_gpt4o_mini():
+    entry = _catalog_entry("openai", "gpt-4o-mini-2024-07-18")
+    assert entry["input_per_m"] == pytest.approx(0.15)
+    assert entry["output_per_m"] == pytest.approx(0.60)
+    assert entry["pricing_source"] == "heuristic"
+
+
+def test_tier_heuristic_openai_o3_mini_orders_before_o1():
+    """Regex order matters: o3-mini should NOT match o3 first."""
+    entry = _catalog_entry("openai", "o3-mini")
+    assert entry["input_per_m"] == pytest.approx(1.10)
+    assert entry["pricing_source"] == "heuristic"
+
+
+def test_exact_catalog_wins_over_heuristic():
+    # claude-sonnet-4-5 is in _CATALOG → "exact", even though it also
+    # matches the sonnet tier.
+    entry = _catalog_entry("anthropic", "claude-sonnet-4-5-20250929")
+    assert entry["pricing_source"] == "exact"
+    assert entry["input_per_m"] == pytest.approx(3.0)
+
+
+def test_pricing_source_unknown_for_unrecognized_model():
+    entry = _catalog_entry("openai", "completely-unknown-xyz")
+    assert entry["pricing_source"] == "unknown"
+    assert entry["input_per_m"] == 0.0
+
+
+def test_live_meta_populates_context_window(monkeypatch):
+    """record_live_meta should feed display_name / context / caps into
+    the catalog lookup for models not in the static _CATALOG."""
+    from services import model_registry
+
+    class _M:
+        id = "claude-haiku-3-5-20241022"
+        display_name = "Claude Haiku 3.5 (live)"
+        context_window = 200_000
+        capabilities = {
+            "supports_tools": True,
+            "supports_thinking": False,
+            "supports_vision": True,
+        }
+
+    try:
+        model_registry.record_live_meta("anthropic", [_M()])
+        entry = _catalog_entry("anthropic", "claude-haiku-3-5-20241022")
+        assert entry["context_window"] == 200_000
+        assert entry["display_name"] == "Claude Haiku 3.5 (live)"
+        assert entry["supports_vision"] is True
+        # Pricing still comes from the tier heuristic for this id.
+        assert entry["pricing_source"] == "heuristic"
+    finally:
+        model_registry.clear_live_meta("anthropic")
+
+
+def test_get_model_info_deprecated_flag():
+    info = ModelRegistry.get_model_info(
+        provider_id="anthropic-default",
+        provider_type="anthropic",
+        model_id="claude-sonnet-4-5-20250929",
+        deprecated=True,
+    )
+    assert info.deprecated is True
+    d = info.to_dict()
+    assert d["deprecated"] is True
+    assert d["pricing_source"] == "exact"
+
+
+# ---------------------------------------------------------------------------
+# Extras mechanism — force-include IDs upstream dropped from /v1/models
+# ---------------------------------------------------------------------------
+
+
+def test_default_extras_include_anthropic_3x(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_EXTRA_MODELS", raising=False)
+    from services.model_registry import get_extra_model_ids
+
+    ids = get_extra_model_ids("anthropic")
+    assert "claude-3-5-haiku-20241022" in ids
+    assert "claude-3-5-sonnet-20241022" in ids
+    assert "claude-3-haiku-20240307" in ids
+
+
+def test_env_override_replaces_defaults(monkeypatch):
+    from services.model_registry import get_extra_model_ids
+
+    monkeypatch.setenv("ANTHROPIC_EXTRA_MODELS", "foo-1, bar-2 ,, baz-3")
+    ids = get_extra_model_ids("anthropic")
+    assert ids == ("foo-1", "bar-2", "baz-3")
+
+
+def test_env_empty_string_disables_extras(monkeypatch):
+    from services.model_registry import get_extra_model_ids
+
+    monkeypatch.setenv("ANTHROPIC_EXTRA_MODELS", "")
+    assert get_extra_model_ids("anthropic") == ()
+
+
+def test_extras_catalog_entry_has_exact_pricing():
+    """3.x entries were added to _CATALOG so they render with correct
+    context/pricing instead of the tier heuristic fallback."""
+    entry = _catalog_entry("anthropic", "claude-3-5-haiku-20241022")
+    assert entry["pricing_source"] == "exact"
+    assert entry["context_window"] == 200_000
+    assert entry["input_per_m"] == pytest.approx(0.80)
+
+    entry = _catalog_entry("anthropic", "claude-3-haiku-20240307")
+    assert entry["input_per_m"] == pytest.approx(0.25)
+    assert entry["output_per_m"] == pytest.approx(1.25)
+
+
+def test_is_extra_model_flips_after_registration():
+    from services import model_registry
+
+    provider_type = "anthropic"
+    mid = "test-extra-registration-xyz"
+    assert model_registry.is_extra_model(provider_type, mid) is False
+    model_registry._register_extras(provider_type, (mid,))
+    try:
+        assert model_registry.is_extra_model(provider_type, mid) is True
+    finally:
+        model_registry._EXTRA_IDS.discard((provider_type, mid))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_provider_model_discovery.py
+++ b/tests/test_provider_model_discovery.py
@@ -1,0 +1,379 @@
+"""Unit tests for services.provider_model_discovery (GH #139).
+
+Focus: per-provider fetch behavior, retry, cache TTL, fallback on
+transient error. httpx is monkeypatched so tests never hit the network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from services import provider_model_discovery as discovery  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Isolation: drop the module cache before each test."""
+    discovery._META_CACHE.invalidate()
+    yield
+    discovery._META_CACHE.invalidate()
+
+
+# ---------------------------------------------------------------------------
+# Fake httpx.AsyncClient helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status: int, payload: Dict[str, Any]):
+        self.status_code = status
+        self._payload = payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"status {self.status_code}",
+                request=httpx.Request("GET", "https://example/"),
+                response=httpx.Response(self.status_code),
+            )
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    """Minimal async-context-manager stand-in for ``httpx.AsyncClient``.
+
+    ``get_handler`` and ``post_handler`` return ``_FakeResponse`` based on
+    the URL; tests pass in whichever they need.
+    """
+
+    def __init__(self, *, get_handler=None, post_handler=None):
+        self._get = get_handler or (lambda url, **kw: _FakeResponse(404, {}))
+        self._post = post_handler or (lambda url, **kw: _FakeResponse(404, {}))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, **kwargs):
+        return self._get(url, **kwargs)
+
+    async def post(self, url, **kwargs):
+        return self._post(url, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+def _anthropic_page(
+    models: List[Dict[str, Any]], has_more: bool = False, last_id: str = ""
+) -> Dict[str, Any]:
+    return {"data": models, "has_more": has_more, "last_id": last_id}
+
+
+def test_anthropic_requires_key():
+    with pytest.raises(RuntimeError):
+        asyncio.run(discovery.fetch_anthropic_models(""))
+
+
+def test_anthropic_single_page_parses_fields():
+    pages = [
+        _anthropic_page(
+            [
+                {
+                    "id": "claude-haiku-3-5-20241022",
+                    "display_name": "Claude Haiku 3.5",
+                    "max_input_tokens": 200000,
+                    "capabilities": {
+                        "image_input": {"supported": True},
+                        "thinking": {"supported": False},
+                    },
+                },
+                {
+                    "id": "claude-opus-4-7",
+                    "display_name": "Claude Opus 4.7",
+                    "max_input_tokens": 1000000,
+                    "capabilities": {
+                        "image_input": {"supported": True},
+                        "thinking": {"supported": True},
+                    },
+                },
+            ]
+        )
+    ]
+    calls = {"n": 0}
+
+    def _get(url, **kw):
+        calls["n"] += 1
+        return _FakeResponse(200, pages[0])
+
+    with patch.object(
+        discovery.httpx, "AsyncClient", lambda **kw: _FakeClient(get_handler=_get)
+    ):
+        out = asyncio.run(discovery.fetch_anthropic_models("sk-test"))
+
+    assert [m.id for m in out] == ["claude-haiku-3-5-20241022", "claude-opus-4-7"]
+    haiku = out[0]
+    assert haiku.display_name == "Claude Haiku 3.5"
+    assert haiku.context_window == 200000
+    assert haiku.capabilities["supports_vision"] is True
+    assert haiku.capabilities["supports_thinking"] is False
+    # Tool support is True for every Claude id (API doesn't expose a flag).
+    assert haiku.capabilities["supports_tools"] is True
+    assert calls["n"] == 1
+
+
+def test_anthropic_paginates():
+    page1 = _anthropic_page(
+        [{"id": "a", "display_name": "A", "max_input_tokens": 1}], True, "a"
+    )
+    page2 = _anthropic_page(
+        [{"id": "b", "display_name": "B", "max_input_tokens": 2}], False, ""
+    )
+
+    responses = iter([page1, page2])
+
+    def _get(url, **kw):
+        return _FakeResponse(200, next(responses))
+
+    with patch.object(
+        discovery.httpx, "AsyncClient", lambda **kw: _FakeClient(get_handler=_get)
+    ):
+        out = asyncio.run(discovery.fetch_anthropic_models("sk-test"))
+
+    assert [m.id for m in out] == ["a", "b"]
+
+
+def test_anthropic_retries_on_connect_error(monkeypatch):
+    monkeypatch.setattr(discovery, "_RETRY_BACKOFF_S", 0.0)
+    calls = {"n": 0}
+
+    def _get(url, **kw):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise httpx.ConnectError("boom")
+        return _FakeResponse(
+            200,
+            _anthropic_page([{"id": "x", "display_name": "X", "max_input_tokens": 1}]),
+        )
+
+    with patch.object(
+        discovery.httpx, "AsyncClient", lambda **kw: _FakeClient(get_handler=_get)
+    ):
+        out = asyncio.run(discovery.fetch_anthropic_models("sk-test"))
+    assert [m.id for m in out] == ["x"]
+    assert calls["n"] == 2
+
+
+def test_anthropic_gives_up_after_retries(monkeypatch):
+    monkeypatch.setattr(discovery, "_RETRY_BACKOFF_S", 0.0)
+
+    def _get(url, **kw):
+        raise httpx.ConnectError("down")
+
+    with patch.object(
+        discovery.httpx, "AsyncClient", lambda **kw: _FakeClient(get_handler=_get)
+    ):
+        with pytest.raises(httpx.ConnectError):
+            asyncio.run(discovery.fetch_anthropic_models("sk-test"))
+
+
+def test_anthropic_cache_hit_skips_httpx():
+    pages = [_anthropic_page([{"id": "a", "display_name": "A", "max_input_tokens": 1}])]
+    calls = {"n": 0}
+
+    def _get(url, **kw):
+        calls["n"] += 1
+        return _FakeResponse(200, pages[0])
+
+    with patch.object(
+        discovery.httpx, "AsyncClient", lambda **kw: _FakeClient(get_handler=_get)
+    ):
+        asyncio.run(discovery.fetch_anthropic_models("sk-test"))
+        asyncio.run(discovery.fetch_anthropic_models("sk-test"))
+    assert calls["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+def test_openai_requires_key():
+    with pytest.raises(RuntimeError):
+        asyncio.run(discovery.fetch_openai_models(""))
+
+
+def test_openai_parses_flat_id_list():
+    payload = {"data": [{"id": "gpt-4o"}, {"id": "gpt-4o-mini"}, {"id": None}]}
+
+    def _get(url, **kw):
+        assert url.endswith("/models")
+        return _FakeResponse(200, payload)
+
+    with patch.object(
+        discovery.httpx, "AsyncClient", lambda **kw: _FakeClient(get_handler=_get)
+    ):
+        out = asyncio.run(discovery.fetch_openai_models("sk-test"))
+
+    assert [m.id for m in out] == ["gpt-4o", "gpt-4o-mini"]
+    # OpenAI endpoint doesn't carry meta, so context defaults to 0.
+    assert out[0].context_window == 0
+    assert out[0].display_name == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# Ollama
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_extracts_context_from_show():
+    tags = {"models": [{"name": "llama3.1:8b"}, {"name": "qwen2.5:7b"}]}
+    show_llama = {"model_info": {"llama.context_length": 131072}}
+    show_qwen = {"model_info": {"qwen2.context_length": 32768}}
+
+    def _get(url, **kw):
+        assert url.endswith("/api/tags")
+        return _FakeResponse(200, tags)
+
+    def _post(url, **kw):
+        name = kw["json"]["name"]
+        if name == "llama3.1:8b":
+            return _FakeResponse(200, show_llama)
+        return _FakeResponse(200, show_qwen)
+
+    with patch.object(
+        discovery.httpx,
+        "AsyncClient",
+        lambda **kw: _FakeClient(get_handler=_get, post_handler=_post),
+    ):
+        out = asyncio.run(discovery.fetch_ollama_models("http://localhost:11434"))
+
+    by_id = {m.id: m for m in out}
+    assert by_id["llama3.1:8b"].context_window == 131072
+    assert by_id["qwen2.5:7b"].context_window == 32768
+
+
+def test_ollama_context_defaults_to_zero_when_show_fails():
+    tags = {"models": [{"name": "unknown-model"}]}
+
+    def _get(url, **kw):
+        return _FakeResponse(200, tags)
+
+    def _post(url, **kw):
+        raise httpx.ReadTimeout("slow")
+
+    with patch.object(
+        discovery.httpx,
+        "AsyncClient",
+        lambda **kw: _FakeClient(get_handler=_get, post_handler=_post),
+    ):
+        out = asyncio.run(discovery.fetch_ollama_models())
+
+    assert out[0].id == "unknown-model"
+    assert out[0].context_window == 0
+
+
+# ---------------------------------------------------------------------------
+# fetch_provider_models — cache reader backed by sync_all_provider_models
+# ---------------------------------------------------------------------------
+
+
+class _FakeRow:
+    def __init__(self, provider_type, provider_id="p1", base_url=None, config=None):
+        self.provider_type = provider_type
+        self.provider_id = provider_id
+        self.base_url = base_url
+        self.config = config or {}
+        self.api_key_ref = None
+
+
+def _reset_registry_state():
+    from services import model_registry
+
+    model_registry._MODEL_LIST_CACHE.invalidate()
+    model_registry._EXTRA_IDS.clear()
+    model_registry.clear_live_meta()
+
+
+def test_fetch_provider_models_reads_cache():
+    """Populated cache is returned without any lazy sync."""
+    from services import model_registry
+
+    _reset_registry_state()
+    model_registry._MODEL_LIST_CACHE.set(
+        "p1",
+        ["model-a", "model-b", "model-c"],
+    )
+    result = asyncio.run(model_registry.fetch_provider_models(_FakeRow("anthropic")))
+    assert result == ["model-a", "model-b", "model-c"]
+    _reset_registry_state()
+
+
+def test_fetch_provider_models_lazy_sync_on_miss(monkeypatch):
+    """Cache miss triggers sync_all_provider_models; result is the cache
+    entry that sync wrote."""
+    from services import model_registry
+
+    _reset_registry_state()
+    call_count = {"n": 0}
+
+    async def fake_sync():
+        call_count["n"] += 1
+        # Simulate the sync populating the cache.
+        model_registry._MODEL_LIST_CACHE.set(
+            "p1",
+            ["from-sync-a", "from-sync-b"],
+        )
+        return {"bifrost": {}, "models_by_provider": {}}
+
+    # The lazy-sync import is inside the function, so patch the attribute
+    # where the caller looks it up.
+    import services.bifrost_admin as bifrost_admin
+
+    monkeypatch.setattr(bifrost_admin, "sync_all_provider_models", fake_sync)
+
+    result = asyncio.run(model_registry.fetch_provider_models(_FakeRow("anthropic")))
+    assert result == ["from-sync-a", "from-sync-b"]
+    assert call_count["n"] == 1
+    _reset_registry_state()
+
+
+def test_fetch_provider_models_hard_fallback_when_sync_fails(monkeypatch):
+    """If sync raises AND cache remains empty, return bootstrap + extras."""
+    from services import model_registry
+
+    _reset_registry_state()
+
+    async def fake_sync_fails():
+        raise RuntimeError("no db")
+
+    import services.bifrost_admin as bifrost_admin
+
+    monkeypatch.setattr(bifrost_admin, "sync_all_provider_models", fake_sync_fails)
+    monkeypatch.setenv("ANTHROPIC_EXTRA_MODELS", "legacy-only-1")
+
+    result = asyncio.run(model_registry.fetch_provider_models(_FakeRow("anthropic")))
+
+    # Extras still appear in hard-fallback mode.
+    assert "legacy-only-1" in result
+    # Bootstrap list is preserved.
+    assert "claude-opus-4-7" in result
+    _reset_registry_state()


### PR DESCRIPTION
## Summary

Resolves [#139](https://github.com/Vigil-SOC/vigil/issues/139). Replaces three hand-maintained Anthropic model lists with **live discovery** and a **runtime push to Bifrost's admin API**. Generalizes to OpenAI and Ollama. The UI dropdown cache and Bifrost's allow-list are populated by one function in one pass — they can't drift.

- **Dynamic discovery** — Anthropic `/v1/models` (paginated), OpenAI `/v1/models`, Ollama `/api/tags` + `/api/show`. See [services/provider_model_discovery.py](services/provider_model_discovery.py).
- **Single source of truth** — `sync_all_provider_models()` writes both the dropdown cache and Bifrost's allow-list in the same pass. Concurrent callers coalesce on an in-flight future so a cold dropdown load racing the scheduler tick doesn't double upstream load.
- **Scheduled refresh** — background task every `MODEL_CATALOG_REFRESH_INTERVAL_S` (default 300s). CRUD on a provider (add/update/delete) schedules an immediate resync.
- **Extras mechanism** (`ANTHROPIC_EXTRA_MODELS` env) — force-include IDs upstream dropped from `/v1/models` but that still route (e.g. Claude 3.x family). Shown with `deprecated=True` so the UI can badge them. Defaults cover Claude 3.5 Haiku, 3.5 Sonnet v2, 3 Haiku.
- **Layered pricing/catalog** — exact static overrides > live meta > tier-heuristic by model-id prefix > safe default. New models get reasonable cost estimates without code changes; `pricing_source` annotation tells the frontend which layer it came from.
- **No-TTL cache** — freshness comes from the scheduler, not from expiry timers. Fixes the periodic latency spikes the previous 60s TTL caused.

## Test plan

- [ ] Backend starts cleanly; logs `sync_all_provider_models` completing.
- [ ] Settings → Model Assignments dropdown shows the 4.x lineup plus the 3.x extras (badged where the frontend renders `deprecated`).
- [ ] `curl http://localhost:8080/anthropic/v1/models` shows the same list Bifrost will route for.
- [ ] Send a message to a 3.x model (e.g. `claude-3-5-haiku-20241022`) through Bifrost — routes without "no keys found".
- [ ] Add a new provider in the UI; dropdown reflects it within seconds without manual refresh.
- [ ] `POST /api/llm-providers/refresh-models` returns 200 with per-type sync flags.
- [ ] `scripts/bifrost_capability_probe.py` still passes.
- [ ] `pytest tests/test_model_registry.py tests/test_provider_model_discovery.py tests/test_bifrost_admin.py -v` → 53 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)