### PR TITLE
Heartbeat last_activity_at inside the agent tool-use loop (#147)

### DIFF
--- a/daemon/agent_runner.py
+++ b/daemon/agent_runner.py
@@ -680,6 +680,14 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
             total_input += response.get("input_tokens", 0)
             total_output += response.get("output_tokens", 0)
 
+            # Heartbeat: an LLM turn just returned, so the agent is making
+            # progress even though the outer iteration hasn't finished. Without
+            # this, supervisor's stale_threshold (default 300s) can fire while
+            # a long multi-turn iteration is healthy. See issue #147.
+            self._update_db_record(
+                inv_id, {"last_activity_at": datetime.utcnow().isoformat()}
+            )
+
             stop_reason = response.get("stop_reason", "end_turn")
             if stop_reason == "end_turn" or stop_reason != "tool_use":
                 break
@@ -699,6 +707,12 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
 
                 self._update_db_record(inv_id, {"current_activity": f"Calling {tool_name}"})
                 result = await self._execute_tool(inv_id, tool_name, tool_input)
+                # Heartbeat after each tool — same reason as the post-LLM update
+                # above. A burst of slow MCP calls inside one iteration must
+                # not look like staleness to the supervisor (issue #147).
+                self._update_db_record(
+                    inv_id, {"last_activity_at": datetime.utcnow().isoformat()}
+                )
                 tool_results.append({
                     "type": "tool_result",
                     "tool_use_id": tool_block["id"],

--- a/daemon/orchestrator.py
+++ b/daemon/orchestrator.py
@@ -500,7 +500,15 @@ class Orchestrator:
                         idle_seconds = (now - last_activity).total_seconds()
                         if idle_seconds > self.config.stale_threshold:
                             logger.warning(
-                                f"{inv_id}: Stale for {idle_seconds:.0f}s, killing agent"
+                                "supervisor.kill stale inv_id=%s idle_s=%.0f "
+                                "iteration=%s current_activity=%r cost_usd=%.4f "
+                                "stale_threshold=%s",
+                                inv_id,
+                                idle_seconds,
+                                inv_dict.get("iteration_count"),
+                                inv_dict.get("current_activity"),
+                                inv_dict.get("cost_usd", 0.0),
+                                self.config.stale_threshold,
                             )
                             await self.agent_runner.stop_agent(inv_id)
                             self._update_investigation_status(
@@ -527,11 +535,20 @@ class Orchestrator:
                     )
                     if cost >= max_cost:
                         logger.warning(
-                            f"{inv_id}: Cost ${cost:.2f} exceeded limit ${max_cost:.2f}"
+                            "supervisor.kill cost inv_id=%s cost_usd=%.4f "
+                            "max_cost_usd=%.4f iteration=%s current_activity=%r",
+                            inv_id,
+                            cost,
+                            max_cost,
+                            inv_dict.get("iteration_count"),
+                            inv_dict.get("current_activity"),
                         )
                         await self.agent_runner.stop_agent(inv_id)
+                        # Match agent_runner's failure_reason vocabulary so
+                        # post-mortems treat both supervisor-side and
+                        # runner-side cost kills identically. (Issue #147)
                         self._update_investigation_status(
-                            inv_id, "failed", "Cost limit exceeded"
+                            inv_id, "failed", "Cost budget exceeded"
                         )
 
                 self._track_hourly_cost()


### PR DESCRIPTION
## Summary

Fixes [#147](https://github.com/Vigil-SOC/vigil/issues/147). Auto-investigations were being killed mid-flight by the supervisor and surfaced as "sits for a while and then fails."

**Root cause:** the supervisor's `stale_threshold` (default 300s) is checked against `last_activity_at`, but agent_runner only wrote that field once per outer iteration. A single iteration can legitimately span many minutes — `_call_claude`'s inner tool-use loop runs up to 25 LLM turns (timeout 180s each) interleaved with MCP tool calls (timeout 30s each). Healthy long iterations were tripping the stale check.

**Fix:** write `last_activity_at` after each LLM turn returns and after each tool execution. Now "stale" means actual lack of progress, not just a long iteration. Reuses the existing `_update_db_record` helper — no new infrastructure.

Bundled diagnosability cleanups in the same area:
- Structured `supervisor.kill` log lines including `inv_id`, `iteration`, `current_activity`, `idle_s`, `cost_usd` — the next time a kill fires it is diagnosable from logs alone.
- Align supervisor's cost-kill `failure_reason` with agent_runner's (`"Cost budget exceeded"`) so post-mortems group both paths together.

## Test plan
- [ ] Run the daemon against a synthetic finding that triggers a multi-tool-round investigation (high `enable_thinking` + several MCP calls).
- [ ] Confirm in the `investigations` table that `last_activity_at` advances mid-iteration, not only at iteration boundaries.
- [ ] Confirm no `Stale: no activity` failures fire for a healthy long investigation.
- [ ] Confirm a deliberately hung agent (force-block a tool) still gets killed once `stale_threshold` elapses with no real progress, and the new structured log line appears with the expected fields.
- [ ] Sanity-check pytest suite: `pytest tests/unit -x -q`.