### PR TITLE
Surface mempalace health on Settings → General (#136)

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -1155,3 +1155,160 @@ async def set_darktrace_config(config: DarktraceConfig):
         logger.error(f"Error setting Darktrace config: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
+
+# ---------------------------------------------------------------------------
+# Mempalace health (#136)
+#
+# Mempalace is hidden from the MCP servers list because it's a core,
+# always-on dependency. This endpoint surfaces enough signal — connection
+# state, palace size, last write, entry counts — for operators to confirm
+# the memory store is actually healthy from the General tab in Settings.
+# ---------------------------------------------------------------------------
+
+
+def _format_size(num_bytes: int) -> str:
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(num_bytes)
+    for unit in units:
+        if size < 1024 or unit == units[-1]:
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TB"
+
+
+def _scan_palace(palace_path: Path) -> Dict[str, Any]:
+    """Walk the palace tree once and return size + last-modified.
+
+    Best-effort: any unreadable entry is skipped, not raised. Returns
+    ``palace_exists=False`` if the root doesn't exist.
+    """
+    if not palace_path.exists():
+        return {
+            "palace_exists": False,
+            "size_bytes": None,
+            "size_human": None,
+            "last_modified_iso": None,
+        }
+
+    total = 0
+    latest_mtime = 0.0
+    stack = [palace_path]
+    while stack:
+        current = stack.pop()
+        try:
+            for entry in os.scandir(current):
+                try:
+                    if entry.is_dir(follow_symlinks=False):
+                        stack.append(Path(entry.path))
+                    else:
+                        st = entry.stat(follow_symlinks=False)
+                        total += st.st_size
+                        if st.st_mtime > latest_mtime:
+                            latest_mtime = st.st_mtime
+                except OSError:
+                    continue
+        except OSError:
+            continue
+
+    from datetime import datetime, timezone
+    last_iso = (
+        datetime.fromtimestamp(latest_mtime, tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+        if latest_mtime > 0
+        else None
+    )
+    return {
+        "palace_exists": True,
+        "size_bytes": total,
+        "size_human": _format_size(total),
+        "last_modified_iso": last_iso,
+    }
+
+
+def _count_memories(palace_path: Path) -> Dict[str, Any]:
+    """Best-effort ChromaDB collection count.
+
+    Returns a dict with ``count`` (int|None) and ``source`` (one of
+    ``chromadb``, ``unavailable``). Never raises — a missing or
+    incompatible chromadb install just degrades to ``unavailable``.
+    """
+    try:
+        import chromadb  # type: ignore
+    except Exception:
+        return {"count": None, "source": "unavailable"}
+
+    try:
+        client = chromadb.PersistentClient(path=str(palace_path))
+        collections = client.list_collections()
+        total = 0
+        for coll in collections:
+            try:
+                total += coll.count()
+            except Exception:
+                continue
+        return {"count": total, "source": "chromadb"}
+    except Exception as e:
+        logger.debug("ChromaDB count failed for %s: %s", palace_path, e)
+        return {"count": None, "source": "unavailable"}
+
+
+@router.get("/mempalace/health")
+async def get_mempalace_health():
+    """Health snapshot for the mempalace memory store.
+
+    Aggregates MCP connection state with filesystem facts about the
+    palace directory so operators can sanity-check at a glance whether
+    memories are actually being persisted. Always returns 200 — failures
+    are surfaced via ``connected: false`` and ``error`` fields rather
+    than HTTP errors, so the panel can render even when mempalace is
+    completely down.
+    """
+    import asyncio
+
+    from services.mempalace_paths import (
+        get_closed_cases_dir,
+        get_palace_path,
+    )
+
+    # Connection state — reuse the same signal /api/mcp/connections/status uses.
+    connected = False
+    error: Optional[str] = None
+    try:
+        from services.mcp_client import get_mcp_client
+        mcp_client = get_mcp_client()
+        if mcp_client is not None:
+            statuses = mcp_client.get_connection_status() or {}
+            connected = bool(statuses.get("mempalace", False))
+            error = mcp_client.get_last_error("mempalace")
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Could not read mempalace MCP status: %s", e)
+        error = str(e)
+
+    palace_path = get_palace_path(ensure_exists=False)
+
+    fs_stats = await asyncio.to_thread(_scan_palace, palace_path)
+
+    closed_cases_count: Optional[int] = None
+    try:
+        closed_dir = get_closed_cases_dir(ensure_exists=False)
+        if closed_dir.exists():
+            closed_cases_count = await asyncio.to_thread(
+                lambda: len(list(closed_dir.glob("*.json")))
+            )
+        else:
+            closed_cases_count = 0
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Closed-cases count failed: %s", e)
+
+    memories = await asyncio.to_thread(_count_memories, palace_path)
+
+    return {
+        "connected": connected,
+        "error": error,
+        "palace_path": str(palace_path),
+        **fs_stats,
+        "closed_cases_count": closed_cases_count,
+        "memories_count": memories["count"],
+        "memories_count_source": memories["source"],
+    }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -38,6 +38,7 @@ import {
   LinearProgress,
   ToggleButtonGroup,
   ToggleButton,
+  Link,
 } from '@mui/material'
 import { useNotifications } from '../contexts/NotificationContext'
 import { notificationService } from '../services/notifications'
@@ -57,7 +58,7 @@ import {
   UploadFile as UploadFileIcon,
   DeleteSweep as DeleteSweepIcon,
 } from '@mui/icons-material'
-import { configApi, mcpApi, storageApi, localServicesApi, ingestionApi, findingsApi } from '../services/api'
+import { configApi, mcpApi, storageApi, localServicesApi, ingestionApi, findingsApi, MempalaceHealth } from '../services/api'
 import IntegrationWizard, { IntegrationMetadata } from '../components/settings/IntegrationWizard'
 import CustomIntegrationBuilder from '../components/settings/CustomIntegrationBuilder'
 import { getAllIntegrations, loadCustomIntegrations } from '../config/integrations'
@@ -187,11 +188,16 @@ export default function Settings() {
   const [detectionRulesOpen, setDetectionRulesOpen] = useState(false)
   const [splunkStatus, setSplunkStatus] = useState<any>(null)
   const [splunkLoading, setSplunkLoading] = useState(false)
+  const [mempalaceHealth, setMempalaceHealth] = useState<MempalaceHealth | null>(null)
+  const [mempalaceLoading, setMempalaceLoading] = useState(false)
+  const [mempalaceTestResult, setMempalaceTestResult] = useState<{ ok: boolean; msg: string } | null>(null)
+  const [mempalaceTesting, setMempalaceTesting] = useState(false)
 
   useEffect(() => { loadConfigs() }, [])
   useEffect(() => { setGeneralConfig(prev => ({ ...prev, show_notifications: notificationsEnabled })) }, [notificationsEnabled])
   useEffect(() => {
     if (currentTab === tabIndex['integrations']) { loadMcpServers() }
+    else if (currentTab === tabIndex['general']) { loadMempalaceHealth() }
     else if (IS_DEV_MODE && currentTab === tabIndex['dev']) { loadSplunkStatus(); loadStorageStatus() }
   }, [currentTab, tabIndex])
 
@@ -293,6 +299,39 @@ export default function Settings() {
       setStorageStatus(status.data)
       setStorageHealth(health.data)
     } catch { /* ignore */ }
+  }
+
+  const loadMempalaceHealth = async () => {
+    setMempalaceLoading(true)
+    try {
+      const response = await configApi.getMempalaceHealth()
+      setMempalaceHealth(response.data)
+    } catch {
+      setMempalaceHealth(null)
+    } finally {
+      setMempalaceLoading(false)
+    }
+  }
+
+  const handleTestMempalace = async () => {
+    setMempalaceTesting(true)
+    setMempalaceTestResult(null)
+    try {
+      const response = await mcpApi.testServer('mempalace')
+      const ok = !!(response.data?.success ?? response.data?.connected ?? response.data?.ok)
+      setMempalaceTestResult({
+        ok,
+        msg: response.data?.message || (ok ? 'Mempalace MCP server responded.' : 'Test returned a non-success status.'),
+      })
+    } catch (error: any) {
+      setMempalaceTestResult({
+        ok: false,
+        msg: error?.response?.data?.detail || error?.message || 'Test failed.',
+      })
+    } finally {
+      setMempalaceTesting(false)
+      loadMempalaceHealth()
+    }
   }
 
   // ---- Action handlers ----
@@ -1606,6 +1645,119 @@ export default function Settings() {
             <Box sx={{ mt: 4 }}>
               <Divider sx={{ mb: 3 }} />
               <CostAnalytics />
+            </Box>
+
+            {/* GH #136 — mempalace is hidden from MCP servers list because it's
+                 always-on, so its health surfaces here on General. */}
+            <Box sx={{ mt: 4, maxWidth: 900 }}>
+              <Divider sx={{ mb: 3 }} />
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 600, display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Box
+                    component="span"
+                    sx={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      bgcolor: mempalaceHealth?.connected ? 'success.main' : (mempalaceHealth ? 'error.main' : 'grey.500'),
+                    }}
+                  />
+                  Mempalace Health
+                </Typography>
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                  <Button size="small" startIcon={<RefreshIcon />} onClick={loadMempalaceHealth} disabled={mempalaceLoading}>
+                    {mempalaceLoading ? 'Refreshing...' : 'Refresh'}
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={handleTestMempalace}
+                    disabled={mempalaceTesting}
+                    startIcon={mempalaceTesting ? <CircularProgress size={14} color="inherit" /> : undefined}
+                  >
+                    {mempalaceTesting ? 'Testing...' : 'Test connection'}
+                  </Button>
+                </Box>
+              </Box>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                Persistent memory store used by every agent. Always on — not toggleable from the Integrations tab.
+              </Typography>
+              {mempalaceHealth ? (
+                <Card variant="outlined">
+                  <CardContent>
+                    <Box sx={{ display: 'grid', gridTemplateColumns: '180px 1fr', rowGap: 1.5, columnGap: 2 }}>
+                      <Typography variant="body2" color="text.secondary">Status</Typography>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Chip
+                          size="small"
+                          label={mempalaceHealth.connected ? 'Connected' : 'Disconnected'}
+                          color={mempalaceHealth.connected ? 'success' : 'error'}
+                          variant="outlined"
+                        />
+                        {mempalaceHealth.error && (
+                          <Typography variant="body2" color="error.main">{mempalaceHealth.error}</Typography>
+                        )}
+                      </Box>
+
+                      <Typography variant="body2" color="text.secondary">Palace path</Typography>
+                      <Typography variant="body2" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                        {mempalaceHealth.palace_path}
+                        {!mempalaceHealth.palace_exists && (
+                          <Typography component="span" variant="caption" color="error.main" sx={{ ml: 1 }}>
+                            (missing)
+                          </Typography>
+                        )}
+                      </Typography>
+
+                      <Typography variant="body2" color="text.secondary">Size on disk</Typography>
+                      <Typography variant="body2">{mempalaceHealth.size_human ?? '—'}</Typography>
+
+                      <Typography variant="body2" color="text.secondary">Last write</Typography>
+                      <Typography variant="body2">
+                        {mempalaceHealth.last_modified_iso
+                          ? new Date(mempalaceHealth.last_modified_iso).toLocaleString()
+                          : '—'}
+                      </Typography>
+
+                      <Typography variant="body2" color="text.secondary">Closed cases</Typography>
+                      <Typography variant="body2">{mempalaceHealth.closed_cases_count ?? '—'}</Typography>
+
+                      <Typography variant="body2" color="text.secondary">Stored memories</Typography>
+                      <Typography variant="body2">
+                        {mempalaceHealth.memories_count ?? '—'}
+                        {mempalaceHealth.memories_count_source === 'unavailable' && (
+                          <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                            (chromadb unavailable)
+                          </Typography>
+                        )}
+                      </Typography>
+                    </Box>
+                    <Box sx={{ mt: 2 }}>
+                      <Link
+                        href="https://github.com/Vigil-SOC/vigil/blob/main/docs/STATE.md"
+                        target="_blank"
+                        rel="noopener"
+                        variant="body2"
+                      >
+                        Backup &amp; recovery guidance →
+                      </Link>
+                    </Box>
+                  </CardContent>
+                </Card>
+              ) : (
+                <Alert severity={mempalaceLoading ? 'info' : 'warning'}>
+                  {mempalaceLoading ? 'Loading mempalace health...' : 'Could not load mempalace health.'}
+                </Alert>
+              )}
+              {mempalaceTestResult && (
+                <Alert
+                  severity={mempalaceTestResult.ok ? 'success' : 'error'}
+                  onClose={() => setMempalaceTestResult(null)}
+                  sx={{ mt: 2 }}
+                >
+                  {mempalaceTestResult.msg}
+                </Alert>
+              )}
             </Box>
           </TabPanel>
         )

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -750,6 +750,23 @@ export const configApi = {
     review_model: string
     workdir_base: string
   }) => api.post('/config/orchestrator', data),
+
+  getMempalaceHealth: () => api.get<MempalaceHealth>('/config/mempalace/health'),
+}
+
+// GH #136 — Mempalace is hidden from the MCP servers list because it's an
+// always-on core dependency, so its health surfaces on the General tab.
+export interface MempalaceHealth {
+  connected: boolean
+  error: string | null
+  palace_path: string
+  palace_exists: boolean
+  size_bytes: number | null
+  size_human: string | null
+  last_modified_iso: string | null
+  closed_cases_count: number | null
+  memories_count: number | null
+  memories_count_source: 'chromadb' | 'unavailable'
 }
 
 // LLM Provider API (GH #88 — multi-provider LLM config)

--- a/tests/test_backend_mempalace_health.py
+++ b/tests/test_backend_mempalace_health.py
@@ -1,0 +1,151 @@
+"""Tests for the mempalace health endpoint (#136).
+
+The endpoint must never raise — it's a status probe and the UI relies on
+it returning shape even when mempalace is completely down. These tests
+exercise the major degraded-path branches.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Mirror backend/main.py's sys.path setup so intra-package imports resolve
+# without pulling in the entire backend/api/__init__.py chain.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_BACKEND_DIR = _REPO_ROOT / "backend"
+for p in (str(_REPO_ROOT), str(_BACKEND_DIR)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+def _load_config_module():
+    spec = importlib.util.spec_from_file_location(
+        "config_under_test", _BACKEND_DIR / "api" / "config.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["config_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def palace_dir(tmp_path, monkeypatch):
+    """Point MEMPALACE_PALACE_PATH at a fresh tmp directory."""
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(palace))
+    return palace
+
+
+@pytest.fixture()
+def client(palace_dir):
+    config_mod = _load_config_module()
+    app = FastAPI()
+    app.include_router(config_mod.router, prefix="/api/config")
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_health_returns_shape_when_no_mcp_client(client, palace_dir, monkeypatch):
+    """No MCP client wired in → connected=false, no error, palace facts populated."""
+    import services.mcp_client as mcp_client_mod
+
+    monkeypatch.setattr(mcp_client_mod, "get_mcp_client", lambda: None)
+
+    resp = client.get("/api/config/mempalace/health")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["connected"] is False
+    assert data["palace_path"] == str(palace_dir)
+    assert data["palace_exists"] is True
+    assert data["size_bytes"] == 0
+    assert data["closed_cases_count"] == 0
+    # chromadb isn't installed in dev — the endpoint must degrade gracefully.
+    assert data["memories_count_source"] in ("chromadb", "unavailable")
+
+
+@pytest.mark.unit
+def test_health_counts_closed_cases(client, palace_dir, monkeypatch):
+    """JSON files dropped in investigations/closed-cases/ should be counted."""
+    import services.mcp_client as mcp_client_mod
+
+    monkeypatch.setattr(mcp_client_mod, "get_mcp_client", lambda: None)
+
+    closed = palace_dir / "investigations" / "closed-cases"
+    closed.mkdir(parents=True)
+    for i in range(3):
+        (closed / f"case-{i}.json").write_text(json.dumps({"i": i}))
+    # A non-json file must be ignored.
+    (closed / "README.txt").write_text("ignore me")
+
+    resp = client.get("/api/config/mempalace/health")
+    data = resp.json()
+    assert data["closed_cases_count"] == 3
+    assert data["size_bytes"] > 0
+    assert data["last_modified_iso"] is not None
+
+
+@pytest.mark.unit
+def test_health_handles_missing_palace(client, tmp_path, monkeypatch):
+    """If the palace path is unreachable, palace_exists must be False, not raise."""
+    missing = tmp_path / "does-not-exist-xyz"
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(missing))
+    import services.mcp_client as mcp_client_mod
+
+    monkeypatch.setattr(mcp_client_mod, "get_mcp_client", lambda: None)
+
+    resp = client.get("/api/config/mempalace/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["palace_exists"] is False
+    assert data["size_bytes"] is None
+    assert data["last_modified_iso"] is None
+    assert data["closed_cases_count"] == 0
+
+
+@pytest.mark.unit
+def test_health_surfaces_mcp_error(client, palace_dir, monkeypatch):
+    """When the MCP client reports mempalace as connected with no error,
+    the endpoint should reflect that. When disconnected with a last_error
+    the error string must propagate so operators see the real failure."""
+    import services.mcp_client as mcp_client_mod
+
+    class FakeClient:
+        def get_connection_status(self):
+            return {"mempalace": False, "splunk": True}
+
+        def get_last_error(self, name):
+            return "stdio process exited with code 1" if name == "mempalace" else None
+
+    monkeypatch.setattr(mcp_client_mod, "get_mcp_client", lambda: FakeClient())
+
+    resp = client.get("/api/config/mempalace/health")
+    data = resp.json()
+    assert data["connected"] is False
+    assert data["error"] == "stdio process exited with code 1"
+
+
+@pytest.mark.unit
+def test_health_connected_path(client, palace_dir, monkeypatch):
+    """Happy path — MCP says connected, no error string surfaced."""
+    import services.mcp_client as mcp_client_mod
+
+    class FakeClient:
+        def get_connection_status(self):
+            return {"mempalace": True}
+
+        def get_last_error(self, name):
+            return None
+
+    monkeypatch.setattr(mcp_client_mod, "get_mcp_client", lambda: FakeClient())
+
+    resp = client.get("/api/config/mempalace/health")
+    data = resp.json()
+    assert data["connected"] is True
+    assert data["error"] is None


### PR DESCRIPTION
## Summary

- Adds a Mempalace Health panel to the **General** tab in Settings, showing connection status, palace path, on-disk size, last write timestamp, closed-cases count, and stored-memories count.
- New `GET /api/config/mempalace/health` endpoint that aggregates MCP connection state (reusing the same signal `/api/mcp/connections/status` uses) with filesystem facts about the palace dir, plus a best-effort ChromaDB collection count.
- Includes a "Test connection" button wired to the existing `mcpApi.testServer('mempalace')` endpoint and a link to `docs/STATE.md` backup guidance.

Closes #136.

## Why

Mempalace was made an always-on Vigil dependency in #129 and is intentionally hidden from the MCP servers list (`HIDDEN_MCP_SERVERS` in `Settings.tsx`) because it isn't user-toggleable. The downside: operators had **no way to confirm it was actually working** — exactly the silent-failure mode #129 was meant to prevent. This panel surfaces enough signal to confirm at a glance: is it connected, where's the data, how big is it, and are entries actually accumulating.

## Files

| File | Change |
|---|---|
| `backend/api/config.py` | New `GET /mempalace/health` endpoint + filesystem/ChromaDB helpers |
| `frontend/src/services/api.ts` | New `configApi.getMempalaceHealth` + `MempalaceHealth` type |
| `frontend/src/pages/Settings.tsx` | Health panel rendered after `<CostAnalytics />` on the General tab |
| `tests/test_backend_mempalace_health.py` | 5 unit tests covering happy path + degraded paths |

## Design notes

- The endpoint **always returns 200** — failures surface in the response JSON (`connected: false`, `error: "..."`, `palace_exists: false`) rather than as HTTP errors. This way the UI panel renders even when mempalace is completely down, which is when operators most need it.
- ChromaDB is queried opportunistically: if `chromadb` isn't importable the response sets `memories_count_source: "unavailable"` and the UI shows a small caption rather than a broken count.
- Polling/auto-refresh deliberately omitted — single-shot fetch on tab open + manual Refresh button is enough; the panel is glanceable, not a live dashboard.

## Test plan

- [x] `pytest tests/test_backend_mempalace_health.py` — 5/5 pass
- [x] `tsc --noEmit` clean on `Settings.tsx` and `api.ts`
- [x] `eslint` clean on changed lines (no new warnings/errors)
- [x] `black` + `flake8` clean on new Python (existing whitespace issues elsewhere in `config.py` left untouched)
- [ ] Manual: open `http://localhost:6988/settings?tab=general`, verify status dot/chip, path, size, counts populate; click Test connection; click Refresh
- [ ] Manual disconnected case: set `MEMPALACE_PALACE_PATH=/tmp/does-not-exist-xyz`, restart backend, confirm UI shows red dot + error string + `(missing)` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)