### PR TITLE
Ignore .claude/ Claude Code per-user state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ cython_debug/
 .vscode/
 .idea/
 .cursor/
+.claude/
 *.swp
 *.swo
 *~


### PR DESCRIPTION
## Summary
- Add `.claude/` to root `.gitignore` so per-user Claude Code state (`settings.local.json`, `worktrees/`) stops surfacing as untracked.
- One-line addition in the existing `# IDEs` block alongside `.vscode/`, `.idea/`, `.cursor/`.
- No tracked files affected — `git ls-files | grep '^\.claude'` is empty before and after.

## Test plan
- [x] `git check-ignore -v .claude/` matches the new line.
- [x] `git status` no longer lists `.claude/` as untracked on a working tree that contains it.
- [x] No tracked files removed (`git ls-files` count unchanged for `.claude` paths: 0 → 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)