### PR TITLE
Embed VStrike iframe in case dialog + event viz too

### DIFF
--- a/frontend/src/components/cases/CaseDetailDialog.tsx
+++ b/frontend/src/components/cases/CaseDetailDialog.tsx
@@ -53,7 +53,7 @@ import { casesApi, findingsApi, timelineApi, graphApi } from '../../services/api
 import ExportToTimesketchDialog from '../timesketch/ExportToTimesketchDialog'
 import JiraExportDialog from '../jira/JiraExportDialog'
 import EventTimeline from '../timeline/EventTimeline'
-import EntityGraph from '../graph/EntityGraph'
+import EntityVisualization from '../graph/EntityVisualization'
 import CaseComments from './CaseComments'
 import CaseEvidence from './CaseEvidence'
 import CaseIOCs from './CaseIOCs'
@@ -559,18 +559,19 @@ export default function CaseDetailDialog({
             <Grid item xs={12} md={6}>
               <Paper sx={{ p: 2, overflow: 'hidden' }}>
                 <Typography variant="h6" gutterBottom>Entity Graph</Typography>
-                {graphData.nodes.length > 0 ? (
-                  <Box sx={{ height: 400, width: '100%', overflow: 'hidden', position: 'relative' }}>
-                    <EntityGraph 
-                      nodes={graphData.nodes} 
-                      links={graphData.links} 
-                      height={400}
-                      showControls={false}
-                    />
-                  </Box>
-                ) : (
-                  <Typography color="text.secondary">No entities to display</Typography>
-                )}
+                <Box sx={{ height: 400, width: '100%', overflow: 'hidden', position: 'relative' }}>
+                  <EntityVisualization
+                    nodes={graphData.nodes}
+                    links={graphData.links}
+                    height={400}
+                    showControls={false}
+                    emptyState={
+                      <Typography color="text.secondary">
+                        No entities to display
+                      </Typography>
+                    }
+                  />
+                </Box>
               </Paper>
             </Grid>
             <Grid item xs={12}>

--- a/frontend/src/components/graph/EntityVisualization.tsx
+++ b/frontend/src/components/graph/EntityVisualization.tsx
@@ -19,7 +19,7 @@
  * to the legacy graph silently.
  */
 
-import { useEffect, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import { Box, CircularProgress } from '@mui/material'
 import { useQuery } from '@tanstack/react-query'
 import EntityGraph, { GraphLink, GraphNode } from './EntityGraph'
@@ -41,6 +41,12 @@ export interface EntityVisualizationProps {
   // VStrike-specific: when present, the iframe auto-loads this network
   // on mount (user can still override via the dropdown).
   vstrikeNetworkId?: string
+
+  // Rendered on the legacy (non-VStrike) path when `nodes.length === 0`.
+  // Lets call sites keep their existing empty-state copy without gating
+  // on node count themselves (which would skip the iframe path entirely
+  // when the case happens to have zero entities).
+  emptyState?: ReactNode
 }
 
 interface VStrikeReadiness {
@@ -73,6 +79,7 @@ export default function EntityVisualization(props: EntityVisualizationProps) {
   const {
     height = 500,
     vstrikeNetworkId,
+    emptyState,
     ...graphProps
   } = props
 
@@ -111,6 +118,10 @@ export default function EntityVisualization(props: EntityVisualizationProps) {
     return (
       <VStrikeIframe height={height} initialNetworkId={vstrikeNetworkId} />
     )
+  }
+
+  if (emptyState !== undefined && (!graphProps.nodes || graphProps.nodes.length === 0)) {
+    return <>{emptyState}</>
   }
 
   return <EntityGraph height={height} {...graphProps} />

--- a/frontend/src/components/timeline/EventVisualizationDialog.tsx
+++ b/frontend/src/components/timeline/EventVisualizationDialog.tsx
@@ -49,7 +49,7 @@ import {
 } from '@mui/icons-material'
 import { format } from 'date-fns'
 import { timelineApi } from '../../services/api'
-import EntityGraph from '../graph/EntityGraph'
+import EntityVisualization from '../graph/EntityVisualization'
 
 interface EventVisualizationDialogProps {
   open: boolean
@@ -342,18 +342,19 @@ export default function EventVisualizationDialog({
                     <Typography variant="h6" gutterBottom>
                       Entity Relationships
                     </Typography>
-                    {vizData.entity_graph && vizData.entity_graph.nodes?.length > 0 ? (
-                      <Box sx={{ height: 400, overflow: 'hidden', position: 'relative' }}>
-                        <EntityGraph 
-                          nodes={vizData.entity_graph.nodes || []} 
-                          links={vizData.entity_graph.links || []} 
-                          height={400}
-                          showControls={false}
-                        />
-                      </Box>
-                    ) : (
-                      <Typography color="textSecondary">No entity graph available</Typography>
-                    )}
+                    <Box sx={{ height: 400, overflow: 'hidden', position: 'relative' }}>
+                      <EntityVisualization
+                        nodes={vizData.entity_graph?.nodes || []}
+                        links={vizData.entity_graph?.links || []}
+                        height={400}
+                        showControls={false}
+                        emptyState={
+                          <Typography color="textSecondary">
+                            No entity graph available
+                          </Typography>
+                        }
+                      />
+                    </Box>
                   </Paper>
                 </Grid>
                 <Grid item xs={12} md={6}>


### PR DESCRIPTION
## Summary

Follow-up to #154. Only the `/investigation` page and Dashboard Tab 4 went through `EntityVisualization`; two more surfaces still rendered `<EntityGraph>` directly behind `if (nodes.length > 0)` guards, so a case with zero entities never reached the iframe path:

- `CaseDetailDialog` → Investigation tab → Entity Graph
- `EventVisualizationDialog` → Context tab → Entity Relationships

This routes both through `EntityVisualization` and adds an optional `emptyState` slot to the wrapper, so each call site keeps its existing empty-message copy on the non-VStrike path while the iframe path always renders regardless of node count.

## Test plan

- [x] ESLint clean on changed files (the 2 remaining warnings are pre-existing `exhaustive-deps` notes for `loadCase` / `loadVisualizationData`).
- [x] `tsc --noEmit` clean.
- [ ] With `VSTRIKE_USERNAME` / `VSTRIKE_PASSWORD` set in `.env`, open a case from the Cases list, switch to the Investigation tab — the VStrike iframe replaces the previous "No entities to display" message.
- [ ] Same case, open the timeline event viz dialog → Context tab — VStrike iframe shows in place of "No entity graph available".
- [ ] Without VStrike configured, both surfaces still display their original empty-state copy when there are zero entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)