### PR TITLE
Register secret fields for every password-typed integration

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -10,12 +10,14 @@ import os
 
 # Import new secrets manager
 import sys
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from secrets_manager import get_secret, set_secret, delete_secret, get_secrets_manager
 
 # Import database config service
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from database.config_service import get_config_service
+from services.integration_secrets import redact_secrets, split_secrets
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -23,11 +25,13 @@ logger = logging.getLogger(__name__)
 
 class ClaudeConfig(BaseModel):
     """Claude API configuration."""
+
     api_key: str
 
 
 class S3Config(BaseModel):
     """S3 configuration."""
+
     bucket_name: str
     region: str = "us-east-1"
     auth_method: str = "credentials"  # "credentials" or "profile"
@@ -40,23 +44,22 @@ class S3Config(BaseModel):
     parquet_prefix: str = ""
 
 
-
-
 class ThemeConfig(BaseModel):
     """Theme configuration."""
+
     theme: str = "dark"  # dark or light
-
-
 
 
 class IntegrationsConfig(BaseModel):
     """Integrations configuration."""
+
     enabled_integrations: list[str] = []
     integrations: dict = {}
 
 
 class GeneralConfig(BaseModel):
     """General application settings."""
+
     auto_start_sync: bool = False
     show_notifications: bool = True
     theme: str = "dark"
@@ -65,16 +68,19 @@ class GeneralConfig(BaseModel):
 
 class GitHubConfig(BaseModel):
     """GitHub integration configuration."""
+
     token: str
 
 
 class PostgreSQLConfig(BaseModel):
     """PostgreSQL database backend configuration."""
+
     connection_string: str
 
 
 class DemoModeConfig(BaseModel):
     """Demo mode configuration."""
+
     enabled: bool = False
 
 
@@ -82,21 +88,21 @@ class DemoModeConfig(BaseModel):
 async def get_demo_mode():
     """
     Get demo mode configuration.
-    
+
     Returns:
         Demo mode status
     """
     try:
         from core.config import is_demo_mode
         import os
-        
+
         demo_enabled = is_demo_mode()
-        env_value = os.getenv('DEMO_MODE', '')
-        
+        env_value = os.getenv("DEMO_MODE", "")
+
         return {
             "enabled": demo_enabled,
             "source": "environment" if env_value else "config",
-            "description": "Demo mode uses generated sample data instead of database"
+            "description": "Demo mode uses generated sample data instead of database",
         }
     except Exception as e:
         logger.error(f"Error getting demo mode: {e}")
@@ -107,36 +113,36 @@ async def get_demo_mode():
 async def set_demo_mode(config: DemoModeConfig):
     """
     Set demo mode configuration.
-    
+
     Note: Setting via API updates the config file. Environment variable takes precedence.
-    
+
     Args:
         config: Demo mode configuration
-    
+
     Returns:
         Success status
     """
     try:
-        config_file = Path.home() / '.deeptempo' / 'general_config.json'
+        config_file = Path.home() / ".deeptempo" / "general_config.json"
         config_file.parent.mkdir(parents=True, exist_ok=True)
-        
+
         # Load existing config
         existing = {}
         if config_file.exists():
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 existing = json.load(f)
-        
+
         # Update demo_mode setting
-        existing['demo_mode'] = config.enabled
-        
-        with open(config_file, 'w') as f:
+        existing["demo_mode"] = config.enabled
+
+        with open(config_file, "w") as f:
             json.dump(existing, f, indent=2)
-        
+
         return {
-            "success": True, 
+            "success": True,
             "enabled": config.enabled,
             "message": f"Demo mode {'enabled' if config.enabled else 'disabled'}. Restart the server for changes to take effect.",
-            "note": "Set DEMO_MODE=true environment variable for immediate effect without restart"
+            "note": "Set DEMO_MODE=true environment variable for immediate effect without restart",
         }
     except Exception as e:
         logger.error(f"Error setting demo mode: {e}")
@@ -147,25 +153,26 @@ async def set_demo_mode(config: DemoModeConfig):
 async def reset_demo_data():
     """
     Reset demo data to regenerate sample findings and cases.
-    
+
     Returns:
         Success status
     """
     try:
         from core.config import is_demo_mode
-        
+
         if not is_demo_mode():
             raise HTTPException(status_code=400, detail="Demo mode is not enabled")
-        
+
         from services.demo_data_service import get_demo_service
+
         demo_service = get_demo_service()
         demo_service.reset()
-        
+
         return {
             "success": True,
             "message": "Demo data regenerated",
             "findings_count": len(demo_service.get_findings()),
-            "cases_count": len(demo_service.get_cases())
+            "cases_count": len(demo_service.get_cases()),
         }
     except HTTPException:
         raise
@@ -178,22 +185,24 @@ async def reset_demo_data():
 async def get_claude_config():
     """
     Get Claude API configuration status.
-    
+
     Returns:
         Configuration status (without exposing the key)
     """
     try:
         # Try new key names first, then legacy names
-        api_key = (get_secret("CLAUDE_API_KEY") or 
-                   get_secret("ANTHROPIC_API_KEY") or
-                   get_secret("claude_api_key") or
-                   get_secret("anthropic_api_key"))
-        
+        api_key = (
+            get_secret("CLAUDE_API_KEY")
+            or get_secret("ANTHROPIC_API_KEY")
+            or get_secret("claude_api_key")
+            or get_secret("anthropic_api_key")
+        )
+
         has_key = bool(api_key)
-        
+
         return {
             "configured": has_key,
-            "key_preview": f"{api_key[:8]}..." if has_key else None
+            "key_preview": f"{api_key[:8]}..." if has_key else None,
         }
     except Exception as e:
         logger.error(f"Error getting Claude config: {e}")
@@ -264,44 +273,44 @@ async def set_claude_config(config: ClaudeConfig):
 async def get_s3_config():
     """
     Get S3 configuration status.
-    
+
     Returns:
         Configuration status
     """
     try:
         # Try database first
         config_service = get_config_service()
-        s3_integration = config_service.get_integration_config('s3')
-        
-        if s3_integration and s3_integration.get('config'):
-            config = s3_integration['config']
+        s3_integration = config_service.get_integration_config("s3")
+
+        if s3_integration and s3_integration.get("config"):
+            config = s3_integration["config"]
             return {
                 "configured": True,
-                "bucket_name": config.get('bucket_name'),
-                "region": config.get('region'),
-                "findings_path": config.get('findings_path'),
-                "cases_path": config.get('cases_path'),
-                "parquet_prefix": config.get('parquet_prefix', ''),
-                "auth_method": config.get('auth_method', 'credentials'),
-                "aws_profile": config.get('aws_profile', ''),
+                "bucket_name": config.get("bucket_name"),
+                "region": config.get("region"),
+                "findings_path": config.get("findings_path"),
+                "cases_path": config.get("cases_path"),
+                "parquet_prefix": config.get("parquet_prefix", ""),
+                "auth_method": config.get("auth_method", "credentials"),
+                "aws_profile": config.get("aws_profile", ""),
             }
-        
+
         # Fallback to file-based config
-        config_file = Path.home() / '.deeptempo' / 's3_config.json'
+        config_file = Path.home() / ".deeptempo" / "s3_config.json"
         if config_file.exists():
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 config = json.load(f)
                 return {
                     "configured": True,
-                    "bucket_name": config.get('bucket_name'),
-                    "region": config.get('region'),
-                    "findings_path": config.get('findings_path'),
-                    "cases_path": config.get('cases_path'),
-                    "parquet_prefix": config.get('parquet_prefix', ''),
-                    "auth_method": config.get('auth_method', 'credentials'),
-                    "aws_profile": config.get('aws_profile', ''),
+                    "bucket_name": config.get("bucket_name"),
+                    "region": config.get("region"),
+                    "findings_path": config.get("findings_path"),
+                    "cases_path": config.get("cases_path"),
+                    "parquet_prefix": config.get("parquet_prefix", ""),
+                    "auth_method": config.get("auth_method", "credentials"),
+                    "aws_profile": config.get("aws_profile", ""),
                 }
-        
+
         return {"configured": False}
     except Exception as e:
         logger.error(f"Error getting S3 config: {e}")
@@ -312,10 +321,10 @@ async def get_s3_config():
 async def set_s3_config(config: S3Config):
     """
     Set S3 configuration.
-    
+
     Args:
         config: S3 configuration
-    
+
     Returns:
         Success status
     """
@@ -324,17 +333,17 @@ async def set_s3_config(config: S3Config):
         parquet_prefix = config.parquet_prefix
 
         # Parse s3:// URIs: extract bucket name and use the path as prefix
-        if bucket_name.startswith('s3://'):
+        if bucket_name.startswith("s3://"):
             stripped = bucket_name[5:]
-            parts = stripped.split('/', 1)
+            parts = stripped.split("/", 1)
             bucket_name = parts[0]
             if len(parts) > 1 and parts[1]:
-                path = parts[1].rstrip('/')
+                path = parts[1].rstrip("/")
                 # If the path ends with a file extension, trim to the parent directory
-                last_segment = path.rsplit('/', 1)[-1] if '/' in path else path
-                if '.' in last_segment:
-                    path = path.rsplit('/', 1)[0] if '/' in path else ''
-                parquet_prefix = (path + '/') if path else ''
+                last_segment = path.rsplit("/", 1)[-1] if "/" in path else path
+                if "." in last_segment:
+                    path = path.rsplit("/", 1)[0] if "/" in path else ""
+                parquet_prefix = (path + "/") if path else ""
 
         config_data = {
             "bucket_name": bucket_name,
@@ -345,28 +354,30 @@ async def set_s3_config(config: S3Config):
             "auth_method": config.auth_method,
             "aws_profile": config.aws_profile,
         }
-        
+
         # Save to database
-        config_service = get_config_service(user_id='web_ui')
+        config_service = get_config_service(user_id="web_ui")
         success = config_service.set_integration_config(
-            integration_id='s3',
+            integration_id="s3",
             config=config_data,
             enabled=True,
-            integration_name='AWS S3',
-            integration_type='storage',
-            description='AWS S3 storage configuration',
-            change_reason='Updated via Settings UI'
+            integration_name="AWS S3",
+            integration_type="storage",
+            description="AWS S3 storage configuration",
+            change_reason="Updated via Settings UI",
         )
-        
+
         if not success:
-            raise HTTPException(status_code=500, detail="Failed to save S3 config to database")
-        
+            raise HTTPException(
+                status_code=500, detail="Failed to save S3 config to database"
+            )
+
         # Also save to file for backward compatibility
-        config_file = Path.home() / '.deeptempo' / 's3_config.json'
+        config_file = Path.home() / ".deeptempo" / "s3_config.json"
         config_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(config_file, 'w') as f:
+        with open(config_file, "w") as f:
             json.dump(config_data, f, indent=2)
-        
+
         # Only overwrite credentials if new values were provided
         if config.access_key_id:
             set_secret("AWS_ACCESS_KEY_ID", config.access_key_id)
@@ -377,7 +388,7 @@ async def set_s3_config(config: S3Config):
         elif config.access_key_id:
             # Clear session token when new non-STS credentials are provided
             set_secret("AWS_SESSION_TOKEN", "")
-        
+
         return {"success": True, "message": "S3 configuration saved"}
     except HTTPException:
         raise
@@ -390,38 +401,38 @@ async def set_s3_config(config: S3Config):
 async def test_s3_connection():
     """
     Test S3 connection with current configuration.
-    
+
     Returns:
         Connection test result
     """
     try:
         from services.s3_service import S3Service
-        
+
         # Load S3 config
         config_service = get_config_service()
-        s3_integration = config_service.get_integration_config('s3')
-        
+        s3_integration = config_service.get_integration_config("s3")
+
         if not s3_integration:
             # Fallback to file-based config
-            config_file = Path.home() / '.deeptempo' / 's3_config.json'
+            config_file = Path.home() / ".deeptempo" / "s3_config.json"
             if config_file.exists():
-                with open(config_file, 'r') as f:
+                with open(config_file, "r") as f:
                     s3_integration = json.load(f)
             else:
                 raise HTTPException(status_code=400, detail="S3 not configured")
-        
+
         # Unwrap nested config if present
         cfg = s3_integration
-        if isinstance(s3_integration.get('config'), dict):
-            cfg = s3_integration['config']
+        if isinstance(s3_integration.get("config"), dict):
+            cfg = s3_integration["config"]
 
-        auth_method = cfg.get('auth_method', 'credentials')
-        aws_profile = cfg.get('aws_profile', '')
+        auth_method = cfg.get("auth_method", "credentials")
+        aws_profile = cfg.get("aws_profile", "")
 
-        if auth_method == 'profile' and aws_profile:
+        if auth_method == "profile" and aws_profile:
             s3_service = S3Service(
-                bucket_name=cfg.get('bucket_name'),
-                region_name=cfg.get('region', 'us-east-1'),
+                bucket_name=cfg.get("bucket_name"),
+                region_name=cfg.get("region", "us-east-1"),
                 aws_profile=aws_profile,
             )
         else:
@@ -431,47 +442,47 @@ async def test_s3_connection():
             if not access_key_id or not secret_access_key:
                 raise HTTPException(
                     status_code=400,
-                    detail="S3 credentials not found. Please configure S3 in Settings."
+                    detail="S3 credentials not found. Please configure S3 in Settings.",
                 )
 
             s3_service = S3Service(
-                bucket_name=cfg.get('bucket_name'),
-                region_name=cfg.get('region', 'us-east-1'),
+                bucket_name=cfg.get("bucket_name"),
+                region_name=cfg.get("region", "us-east-1"),
                 aws_access_key_id=access_key_id,
                 aws_secret_access_key=secret_access_key,
             )
-        
+
         # Test connection
         success, message = s3_service.test_connection()
-        
+
         if success:
             # Try to list files as an additional test
-            findings_path = cfg.get('findings_path', 'findings.json')
-            cases_path = cfg.get('cases_path', 'cases.json')
-            
+            findings_path = cfg.get("findings_path", "findings.json")
+            cases_path = cfg.get("cases_path", "cases.json")
+
             files = s3_service.list_files()
             has_findings = findings_path in files
             has_cases = cases_path in files
-            
+
             return {
                 "success": True,
                 "message": message,
-                "bucket": cfg.get('bucket_name'),
-                "region": cfg.get('region', 'us-east-1'),
+                "bucket": cfg.get("bucket_name"),
+                "region": cfg.get("region", "us-east-1"),
                 "files_found": len(files),
                 "findings_file_exists": has_findings,
                 "cases_file_exists": has_cases,
                 "expected_findings_path": findings_path,
-                "expected_cases_path": cases_path
+                "expected_cases_path": cases_path,
             }
         else:
             return {
                 "success": False,
                 "message": message,
-                "bucket": cfg.get('bucket_name'),
-                "region": cfg.get('region', 'us-east-1')
+                "bucket": cfg.get("bucket_name"),
+                "region": cfg.get("region", "us-east-1"),
             }
-            
+
     except HTTPException:
         raise
     except Exception as e:
@@ -479,31 +490,29 @@ async def test_s3_connection():
         raise HTTPException(status_code=500, detail=f"S3 test failed: {str(e)}")
 
 
-
-
 @router.get("/theme")
 async def get_theme_config():
     """
     Get theme configuration.
-    
+
     Returns:
         Theme configuration
     """
     try:
         # Try database first
         config_service = get_config_service()
-        config_value = config_service.get_system_config('theme.current')
-        
+        config_value = config_service.get_system_config("theme.current")
+
         if config_value:
             return config_value
-        
+
         # Fallback to file-based config
-        config_file = Path.home() / '.deeptempo' / 'theme_config.json'
+        config_file = Path.home() / ".deeptempo" / "theme_config.json"
         if config_file.exists():
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 config = json.load(f)
-                return {"theme": config.get('theme', 'dark')}
-        
+                return {"theme": config.get("theme", "dark")}
+
         return {"theme": "dark"}
     except Exception as e:
         logger.error(f"Error getting theme config: {e}")
@@ -514,35 +523,37 @@ async def get_theme_config():
 async def set_theme_config(config: ThemeConfig):
     """
     Set theme configuration.
-    
+
     Args:
         config: Theme configuration
-    
+
     Returns:
         Success status
     """
     try:
         config_data = {"theme": config.theme}
-        
+
         # Save to database
-        config_service = get_config_service(user_id='web_ui')
+        config_service = get_config_service(user_id="web_ui")
         success = config_service.set_system_config(
-            key='theme.current',
+            key="theme.current",
             value=config_data,
-            description='Current UI theme',
-            config_type='theme',
-            change_reason='Updated via Settings UI'
+            description="Current UI theme",
+            config_type="theme",
+            change_reason="Updated via Settings UI",
         )
-        
+
         if not success:
-            raise HTTPException(status_code=500, detail="Failed to save theme to database")
-        
+            raise HTTPException(
+                status_code=500, detail="Failed to save theme to database"
+            )
+
         # Also save to file for backward compatibility
-        config_file = Path.home() / '.deeptempo' / 'theme_config.json'
+        config_file = Path.home() / ".deeptempo" / "theme_config.json"
         config_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(config_file, 'w') as f:
+        with open(config_file, "w") as f:
             json.dump(config_data, f, indent=2)
-        
+
         return {"success": True, "message": "Theme saved"}
     except HTTPException:
         raise
@@ -551,13 +562,11 @@ async def set_theme_config(config: ThemeConfig):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-
-
 @router.get("/integrations")
 async def get_integrations_config():
     """
     Get integrations configuration.
-    
+
     Returns:
         Configuration status and enabled integrations
     """
@@ -565,74 +574,112 @@ async def get_integrations_config():
         # Try database first
         config_service = get_config_service()
         integrations_list = config_service.list_integrations()
-        
+
         if integrations_list:
-            # Build response in the expected format
-            enabled_integrations = [i['integration_id'] for i in integrations_list if i['enabled']]
-            integrations = {i['integration_id']: i['config'] for i in integrations_list}
-            
+            enabled_integrations = [
+                i["integration_id"] for i in integrations_list if i["enabled"]
+            ]
+            # Redact registered secret fields so the frontend never receives
+            # plaintext credentials. Pre-secret-store rows may still contain
+            # them — strip on read so any legacy plaintext is sanitized.
+            integrations = {
+                i["integration_id"]: redact_secrets(
+                    i["integration_id"], i["config"] or {}
+                )
+                for i in integrations_list
+            }
             return {
                 "configured": True,
                 "enabled_integrations": enabled_integrations,
-                "integrations": integrations
+                "integrations": integrations,
             }
-        
+
         # Fallback to file-based config
-        config_file = Path.home() / '.deeptempo' / 'integrations_config.json'
+        config_file = Path.home() / ".deeptempo" / "integrations_config.json"
         if config_file.exists():
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 config = json.load(f)
+                redacted = {
+                    iid: redact_secrets(iid, cfg or {})
+                    for iid, cfg in (config.get("integrations") or {}).items()
+                }
                 return {
                     "configured": True,
-                    "enabled_integrations": config.get('enabled_integrations', []),
-                    "integrations": config.get('integrations', {})
+                    "enabled_integrations": config.get("enabled_integrations", []),
+                    "integrations": redacted,
                 }
-        
+
         return {"configured": False, "enabled_integrations": [], "integrations": {}}
     except Exception as e:
         logger.error(f"Error getting integrations config: {e}")
-        return {"configured": False, "enabled_integrations": [], "integrations": {}, "error": str(e)}
+        return {
+            "configured": False,
+            "enabled_integrations": [],
+            "integrations": {},
+            "error": str(e),
+        }
 
 
 @router.post("/integrations")
 async def set_integrations_config(config: IntegrationsConfig):
     """
     Set integrations configuration.
-    
+
+    Secret-typed fields (registered in ``services.integration_secrets``) are
+    routed to the encrypted secrets store via ``set_secret`` and stripped
+    from the dict that lands in the DB / JSON file. Empty strings are
+    treated as "keep existing secret" (matches the S3 endpoint convention)
+    so editing non-secret fields without re-typing the password doesn't
+    clobber stored credentials.
+
     Args:
         config: Integrations configuration
-    
+
     Returns:
         Success status
     """
     try:
-        config_service = get_config_service(user_id='web_ui')
-        
-        # Save each integration to database
-        for integration_id in config.integrations.keys():
-            integration_config = config.integrations[integration_id]
+        config_service = get_config_service(user_id="web_ui")
+
+        # Build a sanitized integrations dict (no secrets) for DB/JSON
+        # persistence. Apply secret writes to the encrypted store.
+        sanitized_integrations: dict = {}
+        for integration_id, raw_config in config.integrations.items():
+            secrets, non_secrets = split_secrets(integration_id, raw_config)
+
+            # Empty string ⇒ user didn't re-type the secret on edit; leave
+            # the existing encrypted value untouched. Non-empty ⇒ overwrite.
+            for env_key, value in secrets.items():
+                if value == "":
+                    continue
+                if not set_secret(env_key, value):
+                    logger.error(
+                        f"Failed to write secret '{env_key}' for "
+                        f"integration '{integration_id}'"
+                    )
+
+            sanitized_integrations[integration_id] = non_secrets
+
             enabled = integration_id in config.enabled_integrations
-            
             success = config_service.set_integration_config(
                 integration_id=integration_id,
-                config=integration_config,
+                config=non_secrets,
                 enabled=enabled,
-                change_reason='Updated via Settings UI'
+                change_reason="Updated via Settings UI",
             )
-            
             if not success:
                 logger.error(f"Failed to save integration '{integration_id}'")
-        
-        # Also save to file for backward compatibility
-        config_file = Path.home() / '.deeptempo' / 'integrations_config.json'
+
+        # Also save to file for backward compatibility — sanitized only.
+        config_file = Path.home() / ".deeptempo" / "integrations_config.json"
         config_file.parent.mkdir(parents=True, exist_ok=True)
         config_data = {
             "enabled_integrations": config.enabled_integrations,
-            "integrations": config.integrations
+            "integrations": sanitized_integrations,
         }
-        with open(config_file, 'w') as f:
+        with open(config_file, "w") as f:
             json.dump(config_data, f, indent=2)
-        
+
         return {"success": True, "message": "Integrations configuration saved"}
     except Exception as e:
         logger.error(f"Error setting integrations config: {e}")
@@ -643,7 +690,7 @@ async def set_integrations_config(config: IntegrationsConfig):
 async def get_integrations_status():
     """
     Get status of all integrations.
-    
+
     Returns:
         Status information for all integrations
     """
@@ -651,14 +698,11 @@ async def get_integrations_status():
         # Import here to avoid circular dependencies
         sys.path.insert(0, str(Path(__file__).parent.parent.parent))
         from services.integration_bridge_service import get_integration_bridge
-        
+
         bridge = get_integration_bridge()
         statuses = bridge.get_all_integration_statuses()
-        
-        return {
-            "success": True,
-            "statuses": statuses
-        }
+
+        return {"success": True, "statuses": statuses}
     except Exception as e:
         logger.error(f"Error getting integration statuses: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -668,10 +712,10 @@ async def get_integrations_status():
 async def test_integration(integration_id: str):
     """
     Test an integration connection.
-    
+
     Args:
         integration_id: Integration identifier
-    
+
     Returns:
         Test result with success/failure and message
     """
@@ -679,47 +723,49 @@ async def test_integration(integration_id: str):
         # Import here to avoid circular dependencies
         sys.path.insert(0, str(Path(__file__).parent.parent.parent))
         from services.integration_bridge_service import get_integration_bridge
-        
+
         bridge = get_integration_bridge()
         status = bridge.get_integration_status(integration_id)
-        
-        if not status['configured']:
+
+        if not status["configured"]:
             raise HTTPException(status_code=400, detail="Integration not configured")
-        
-        if not status['server_available']:
+
+        if not status["server_available"]:
             return {
                 "success": False,
                 "message": f"Integration server not yet implemented. The '{integration_id}' integration is planned but the backend MCP server needs to be created.",
                 "status": status,
-                "implementation_status": "pending"
+                "implementation_status": "pending",
             }
-        
-        if not status['enabled']:
+
+        if not status["enabled"]:
             return {
                 "success": False,
                 "message": "Integration is configured but not enabled. Please enable it in the integrations list.",
-                "status": status
+                "status": status,
             }
-        
+
         # TODO: Implement actual connection test using MCP client
         # For now, we just verify the configuration is complete
         integration_config = bridge.get_integration_config(integration_id)
-        
+
         # Check if required fields are present (basic validation)
         if not integration_config:
-            raise HTTPException(status_code=400, detail="Integration configuration is empty")
-        
+            raise HTTPException(
+                status_code=400, detail="Integration configuration is empty"
+            )
+
         # Prepare environment variables to verify they're being set correctly
         env_vars = bridge._config_to_env_vars(integration_id, integration_config)
-        
+
         return {
             "success": True,
             "message": f"Integration '{integration_id}' is configured and ready. Configuration will be passed to the MCP server as environment variables.",
             "status": status,
             "env_var_count": len(env_vars),
-            "server_name": status.get('server_name', 'unknown')
+            "server_name": status.get("server_name", "unknown"),
         }
-    
+
     except HTTPException:
         raise
     except Exception as e:
@@ -731,45 +777,45 @@ async def test_integration(integration_id: str):
 async def get_general_config():
     """
     Get general application settings.
-    
+
     Returns:
         General configuration
     """
     try:
         # Try database first
         config_service = get_config_service()
-        config_value = config_service.get_system_config('general.settings')
-        
+        config_value = config_service.get_system_config("general.settings")
+
         if config_value:
             return config_value
-        
+
         # Fallback to file-based config
-        config_file = Path.home() / '.deeptempo' / 'general_config.json'
-        
+        config_file = Path.home() / ".deeptempo" / "general_config.json"
+
         if config_file.exists():
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 config = json.load(f)
                 return {
-                    "auto_start_sync": config.get('auto_start_sync', False),
-                    "show_notifications": config.get('show_notifications', True),
-                    "theme": config.get('theme', 'dark'),
-                    "enable_keyring": config.get('enable_keyring', False)
+                    "auto_start_sync": config.get("auto_start_sync", False),
+                    "show_notifications": config.get("show_notifications", True),
+                    "theme": config.get("theme", "dark"),
+                    "enable_keyring": config.get("enable_keyring", False),
                 }
-        
+
         # Default values
         return {
-            "auto_start_sync": False, 
-            "show_notifications": True, 
+            "auto_start_sync": False,
+            "show_notifications": True,
             "theme": "dark",
-            "enable_keyring": False
+            "enable_keyring": False,
         }
     except Exception as e:
         logger.error(f"Error getting general config: {e}")
         return {
-            "auto_start_sync": False, 
-            "show_notifications": True, 
+            "auto_start_sync": False,
+            "show_notifications": True,
             "theme": "dark",
-            "enable_keyring": False
+            "enable_keyring": False,
         }
 
 
@@ -777,10 +823,10 @@ async def get_general_config():
 async def set_general_config(config: GeneralConfig):
     """
     Set general application settings.
-    
+
     Args:
         config: General configuration
-    
+
     Returns:
         Success status
     """
@@ -789,39 +835,45 @@ async def set_general_config(config: GeneralConfig):
             "auto_start_sync": config.auto_start_sync,
             "show_notifications": config.show_notifications,
             "theme": config.theme,
-            "enable_keyring": config.enable_keyring
+            "enable_keyring": config.enable_keyring,
         }
-        
+
         # Save to database
-        config_service = get_config_service(user_id='web_ui')
+        config_service = get_config_service(user_id="web_ui")
         success = config_service.set_system_config(
-            key='general.settings',
+            key="general.settings",
             value=config_data,
-            description='General application settings',
-            config_type='general',
-            change_reason='Updated via Settings UI'
+            description="General application settings",
+            config_type="general",
+            change_reason="Updated via Settings UI",
         )
-        
+
         if not success:
-            raise HTTPException(status_code=500, detail="Failed to save configuration to database")
-        
+            raise HTTPException(
+                status_code=500, detail="Failed to save configuration to database"
+            )
+
         # Also save to file for backward compatibility (during transition)
-        config_file = Path.home() / '.deeptempo' / 'general_config.json'
+        config_file = Path.home() / ".deeptempo" / "general_config.json"
         config_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(config_file, 'w') as f:
+        with open(config_file, "w") as f:
             json.dump(config_data, f, indent=2)
-        
+
         # Update the global secrets manager if keyring setting changed
         try:
             from secrets_manager import get_secrets_manager
+
             # Force reinitialize with new setting
             import secrets_manager as sm_module
+
             sm_module._secrets_manager = None  # Reset global instance
             get_secrets_manager(enable_keyring=config.enable_keyring)
-            logger.info(f"Secrets manager updated: enable_keyring={config.enable_keyring}")
+            logger.info(
+                f"Secrets manager updated: enable_keyring={config.enable_keyring}"
+            )
         except Exception as e:
             logger.warning(f"Could not update secrets manager: {e}")
-        
+
         return {"success": True, "message": "General settings saved"}
     except HTTPException:
         raise
@@ -834,17 +886,17 @@ async def set_general_config(config: GeneralConfig):
 async def get_github_config():
     """
     Get GitHub integration configuration status.
-    
+
     Returns:
         Configuration status (without exposing the token)
     """
     try:
         token = get_secret("GITHUB_TOKEN")
         has_token = bool(token)
-        
+
         return {
             "configured": has_token,
-            "token_preview": f"{token[:12]}..." if has_token else None
+            "token_preview": f"{token[:12]}..." if has_token else None,
         }
     except Exception as e:
         logger.error(f"Error getting GitHub config: {e}")
@@ -855,10 +907,10 @@ async def get_github_config():
 async def set_github_config(config: GitHubConfig):
     """
     Set GitHub integration configuration.
-    
+
     Args:
         config: GitHub configuration
-    
+
     Returns:
         Success status
     """
@@ -877,14 +929,14 @@ async def set_github_config(config: GitHubConfig):
 async def get_postgresql_config():
     """
     Get PostgreSQL database backend configuration status.
-    
+
     Returns:
         Configuration status
     """
     try:
         conn_str = get_secret("POSTGRESQL_CONNECTION_STRING")
         has_config = bool(conn_str)
-        
+
         # Extract host from connection string for preview (if exists)
         preview = None
         if conn_str and "postgresql://" in conn_str:
@@ -897,11 +949,8 @@ async def get_postgresql_config():
             except Exception as e:
                 logger.debug(f"Error parsing connection string preview: {e}")
                 preview = "postgresql://***:***@***/***"
-        
-        return {
-            "configured": has_config,
-            "connection_preview": preview
-        }
+
+        return {"configured": has_config, "connection_preview": preview}
     except Exception as e:
         logger.error(f"Error getting PostgreSQL config: {e}")
         return {"configured": False, "error": str(e)}
@@ -911,19 +960,24 @@ async def get_postgresql_config():
 async def set_postgresql_config(config: PostgreSQLConfig):
     """
     Set PostgreSQL database backend configuration.
-    
+
     Args:
         config: PostgreSQL configuration
-    
+
     Returns:
         Success status
     """
     try:
         success = set_secret("POSTGRESQL_CONNECTION_STRING", config.connection_string)
         if success:
-            return {"success": True, "message": "PostgreSQL connection string saved securely"}
+            return {
+                "success": True,
+                "message": "PostgreSQL connection string saved securely",
+            }
         else:
-            raise HTTPException(status_code=500, detail="Failed to save PostgreSQL connection string")
+            raise HTTPException(
+                status_code=500, detail="Failed to save PostgreSQL connection string"
+            )
     except Exception as e:
         logger.error(f"Error setting PostgreSQL config: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -938,6 +992,7 @@ class AIOperationsSettingsConfig(BaseModel):
     (AI Config → AI Operations) so operators can flip values live
     without restarting the backend / daemon / llm-worker.
     """
+
     prompt_cache_enabled: bool = True
     history_window: int = 20
     tool_response_budget_default: int = 8000
@@ -984,6 +1039,7 @@ async def set_ai_operations_config(config: AIOperationsSettingsConfig):
         # (default 60s) — acceptable since these are rarely-flipped toggles.
         try:
             from services.runtime_config import clear_cache
+
             clear_cache()
         except Exception as exc:  # noqa: BLE001
             logger.debug(f"runtime_config cache clear skipped: {exc}")
@@ -997,6 +1053,7 @@ async def set_ai_operations_config(config: AIOperationsSettingsConfig):
 
 class OrchestratorSettingsConfig(BaseModel):
     """Orchestrator configuration for autonomous investigations."""
+
     enabled: bool = True
     dry_run: bool = False
     auto_assign_findings: bool = True
@@ -1025,7 +1082,7 @@ async def get_orchestrator_config():
     """Get orchestrator configuration."""
     try:
         config_service = get_config_service()
-        config_value = config_service.get_system_config('orchestrator.settings')
+        config_value = config_service.get_system_config("orchestrator.settings")
 
         if config_value:
             merged = {**ORCHESTRATOR_DEFAULTS, **config_value}
@@ -1046,17 +1103,19 @@ async def set_orchestrator_config(config: OrchestratorSettingsConfig):
     try:
         config_data = config.model_dump()
 
-        config_service = get_config_service(user_id='web_ui')
+        config_service = get_config_service(user_id="web_ui")
         success = config_service.set_system_config(
-            key='orchestrator.settings',
+            key="orchestrator.settings",
             value=config_data,
-            description='Autonomous orchestrator settings',
-            config_type='orchestrator',
-            change_reason='Updated via Settings UI'
+            description="Autonomous orchestrator settings",
+            config_type="orchestrator",
+            change_reason="Updated via Settings UI",
         )
 
         if not success:
-            raise HTTPException(status_code=500, detail="Failed to save orchestrator config to database")
+            raise HTTPException(
+                status_code=500, detail="Failed to save orchestrator config to database"
+            )
 
         # Poke the in-process orchestrator (if the API happens to share one)
         # so a running daemon reacts immediately. No-op in backend-only
@@ -1064,6 +1123,7 @@ async def set_orchestrator_config(config: OrchestratorSettingsConfig):
         # seconds.
         try:
             from backend.api.orchestrator import _get_orchestrator
+
             orch = _get_orchestrator()
             if orch is not None:
                 if config_data.get("enabled"):
@@ -1211,6 +1271,7 @@ def _scan_palace(palace_path: Path) -> Dict[str, Any]:
             continue
 
     from datetime import datetime, timezone
+
     last_iso = (
         datetime.fromtimestamp(latest_mtime, tz=timezone.utc)
         .isoformat()
@@ -1276,6 +1337,7 @@ async def get_mempalace_health():
     error: Optional[str] = None
     try:
         from services.mcp_client import get_mcp_client
+
         mcp_client = get_mcp_client()
         if mcp_client is not None:
             statuses = mcp_client.get_connection_status() or {}

--- a/frontend/src/components/cases/CaseDetailDialog.tsx
+++ b/frontend/src/components/cases/CaseDetailDialog.tsx
@@ -53,7 +53,7 @@ import { casesApi, findingsApi, timelineApi, graphApi } from '../../services/api
 import ExportToTimesketchDialog from '../timesketch/ExportToTimesketchDialog'
 import JiraExportDialog from '../jira/JiraExportDialog'
 import EventTimeline from '../timeline/EventTimeline'
-import EntityGraph from '../graph/EntityGraph'
+import EntityVisualization from '../graph/EntityVisualization'
 import CaseComments from './CaseComments'
 import CaseEvidence from './CaseEvidence'
 import CaseIOCs from './CaseIOCs'
@@ -559,18 +559,19 @@ export default function CaseDetailDialog({
             <Grid item xs={12} md={6}>
               <Paper sx={{ p: 2, overflow: 'hidden' }}>
                 <Typography variant="h6" gutterBottom>Entity Graph</Typography>
-                {graphData.nodes.length > 0 ? (
-                  <Box sx={{ height: 400, width: '100%', overflow: 'hidden', position: 'relative' }}>
-                    <EntityGraph 
-                      nodes={graphData.nodes} 
-                      links={graphData.links} 
-                      height={400}
-                      showControls={false}
-                    />
-                  </Box>
-                ) : (
-                  <Typography color="text.secondary">No entities to display</Typography>
-                )}
+                <Box sx={{ height: 400, width: '100%', overflow: 'hidden', position: 'relative' }}>
+                  <EntityVisualization
+                    nodes={graphData.nodes}
+                    links={graphData.links}
+                    height={400}
+                    showControls={false}
+                    emptyState={
+                      <Typography color="text.secondary">
+                        No entities to display
+                      </Typography>
+                    }
+                  />
+                </Box>
               </Paper>
             </Grid>
             <Grid item xs={12}>

--- a/frontend/src/components/graph/EntityVisualization.tsx
+++ b/frontend/src/components/graph/EntityVisualization.tsx
@@ -19,7 +19,7 @@
  * to the legacy graph silently.
  */
 
-import { useEffect, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import { Box, CircularProgress } from '@mui/material'
 import { useQuery } from '@tanstack/react-query'
 import EntityGraph, { GraphLink, GraphNode } from './EntityGraph'
@@ -41,6 +41,12 @@ export interface EntityVisualizationProps {
   // VStrike-specific: when present, the iframe auto-loads this network
   // on mount (user can still override via the dropdown).
   vstrikeNetworkId?: string
+
+  // Rendered on the legacy (non-VStrike) path when `nodes.length === 0`.
+  // Lets call sites keep their existing empty-state copy without gating
+  // on node count themselves (which would skip the iframe path entirely
+  // when the case happens to have zero entities).
+  emptyState?: ReactNode
 }
 
 interface VStrikeReadiness {
@@ -73,6 +79,7 @@ export default function EntityVisualization(props: EntityVisualizationProps) {
   const {
     height = 500,
     vstrikeNetworkId,
+    emptyState,
     ...graphProps
   } = props
 
@@ -111,6 +118,10 @@ export default function EntityVisualization(props: EntityVisualizationProps) {
     return (
       <VStrikeIframe height={height} initialNetworkId={vstrikeNetworkId} />
     )
+  }
+
+  if (emptyState !== undefined && (!graphProps.nodes || graphProps.nodes.length === 0)) {
+    return <>{emptyState}</>
   }
 
   return <EntityGraph height={height} {...graphProps} />

--- a/frontend/src/components/timeline/EventVisualizationDialog.tsx
+++ b/frontend/src/components/timeline/EventVisualizationDialog.tsx
@@ -49,7 +49,7 @@ import {
 } from '@mui/icons-material'
 import { format } from 'date-fns'
 import { timelineApi } from '../../services/api'
-import EntityGraph from '../graph/EntityGraph'
+import EntityVisualization from '../graph/EntityVisualization'
 
 interface EventVisualizationDialogProps {
   open: boolean
@@ -342,18 +342,19 @@ export default function EventVisualizationDialog({
                     <Typography variant="h6" gutterBottom>
                       Entity Relationships
                     </Typography>
-                    {vizData.entity_graph && vizData.entity_graph.nodes?.length > 0 ? (
-                      <Box sx={{ height: 400, overflow: 'hidden', position: 'relative' }}>
-                        <EntityGraph 
-                          nodes={vizData.entity_graph.nodes || []} 
-                          links={vizData.entity_graph.links || []} 
-                          height={400}
-                          showControls={false}
-                        />
-                      </Box>
-                    ) : (
-                      <Typography color="textSecondary">No entity graph available</Typography>
-                    )}
+                    <Box sx={{ height: 400, overflow: 'hidden', position: 'relative' }}>
+                      <EntityVisualization
+                        nodes={vizData.entity_graph?.nodes || []}
+                        links={vizData.entity_graph?.links || []}
+                        height={400}
+                        showControls={false}
+                        emptyState={
+                          <Typography color="textSecondary">
+                            No entity graph available
+                          </Typography>
+                        }
+                      />
+                    </Box>
                   </Paper>
                 </Grid>
                 <Grid item xs={12} md={6}>

--- a/services/integration_secrets.py
+++ b/services/integration_secrets.py
@@ -1,0 +1,94 @@
+"""Per-integration registry of secret-typed configuration fields.
+
+Vigil's persistence story for integration credentials is split:
+
+- **Non-secret config** (URLs, regions, verify_ssl flags, paths) goes into the
+  ``IntegrationConfig`` database table via ``database.config_service`` and is
+  mirrored to ``~/.deeptempo/integrations_config.json`` for back-compat.
+- **Secret credentials** (API keys, passwords, bearer tokens) go into the
+  encrypted secrets store at ``~/.vigil/secrets.enc`` via
+  ``backend.secrets_manager.set_secret`` / ``get_secret``.
+
+This module exposes the mapping from frontend form-field name → environment
+variable name (which is also the secrets-store key) for each integration's
+secret-typed fields. The generic ``POST /config/integrations`` save handler
+uses it to:
+
+1. Route the value of each registered secret field through ``set_secret`` so
+   the credential lands in the encrypted store (and ``os.environ`` for the
+   in-process backend, see ``SecretsManager.set``).
+2. Strip the field from the dict that gets persisted to the DB / JSON, so we
+   never write plaintext credentials to those stores.
+3. On read, redact the same fields from the response so secrets don't leak
+   back to the frontend.
+
+When you add a new integration that has password-typed fields in
+``frontend/src/config/integrations.ts``, add a matching entry here.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping
+
+# integration_id → {form_field_name: secrets_manager_key}
+INTEGRATION_SECRET_FIELDS: Mapping[str, Mapping[str, str]] = {
+    "vstrike": {
+        "api_key": "VSTRIKE_API_KEY",
+        "inbound_api_key": "VSTRIKE_INBOUND_API_KEY",
+        "username": "VSTRIKE_USERNAME",
+        "password": "VSTRIKE_PASSWORD",
+    },
+}
+
+
+def secret_fields_for(integration_id: str) -> Mapping[str, str]:
+    """Return the secret-field map for an integration, empty if unregistered."""
+    return INTEGRATION_SECRET_FIELDS.get(integration_id, {})
+
+
+def split_secrets(
+    integration_id: str, config: Dict[str, object]
+) -> tuple[Dict[str, str], Dict[str, object]]:
+    """Partition a config dict into (secrets, non_secrets).
+
+    `secrets` maps secrets-store key → value (ready to feed `set_secret`).
+    Empty-string and `None` values are kept in `secrets` so the caller can
+    decide whether to apply or skip them (the convention is "empty means
+    don't overwrite an existing secret").
+
+    The returned non_secrets dict is a fresh copy with secret fields
+    removed — safe to persist to the DB / JSON.
+    """
+    mapping = secret_fields_for(integration_id)
+    if not mapping:
+        return {}, dict(config)
+
+    secrets: Dict[str, str] = {}
+    non_secrets: Dict[str, object] = {}
+    for field, value in config.items():
+        env_key = mapping.get(field)
+        if env_key is None:
+            non_secrets[field] = value
+            continue
+        # Coerce to string so callers don't have to. Non-string values for
+        # secret fields are pathological — log via the redact step if needed.
+        secrets[env_key] = "" if value is None else str(value)
+    return secrets, non_secrets
+
+
+def redact_secrets(integration_id: str, config: Dict[str, object]) -> Dict[str, object]:
+    """Return a copy of ``config`` with registered secret fields removed.
+
+    Used by the GET handler so the frontend never receives plaintext
+    credentials. The form will treat absent secret fields as "leave existing
+    value untouched" on the next save.
+    """
+    mapping = secret_fields_for(integration_id)
+    if not mapping:
+        return dict(config)
+    return {k: v for k, v in config.items() if k not in mapping}
+
+
+def secret_field_names(integration_id: str) -> Iterable[str]:
+    """Iterable over the form-field names that are secrets for an integration."""
+    return secret_fields_for(integration_id).keys()

--- a/services/integration_secrets.py
+++ b/services/integration_secrets.py
@@ -23,22 +23,191 @@ uses it to:
    back to the frontend.
 
 When you add a new integration that has password-typed fields in
-``frontend/src/config/integrations.ts``, add a matching entry here.
+``frontend/src/config/integrations.ts``, add a tuple entry to
+``_SECRET_FIELDS`` below. The default ``<INTEGRATION_ID>_<FIELD>``
+convention is built automatically; add an ``_ENV_VAR_OVERRIDES`` entry
+only when the consumer reads the secret under a non-canonical name
+(e.g. CrowdStrike's official MCP server reads ``FALCON_*``).
 """
 
 from __future__ import annotations
 
 from typing import Dict, Iterable, Mapping
 
-# integration_id → {form_field_name: secrets_manager_key}
-INTEGRATION_SECRET_FIELDS: Mapping[str, Mapping[str, str]] = {
-    "vstrike": {
-        "api_key": "VSTRIKE_API_KEY",
-        "inbound_api_key": "VSTRIKE_INBOUND_API_KEY",
-        "username": "VSTRIKE_USERNAME",
-        "password": "VSTRIKE_PASSWORD",
-    },
+# Default form-field → env-var-suffix translations. Mirrors
+# ``services.integration_bridge_service.IntegrationBridgeService.FIELD_TO_ENV_MAP``
+# so credentials saved via the Settings UI land under the same env-var
+# names that the bridge service uses when injecting env vars into MCP
+# server child processes.
+_DEFAULT_FIELD_SUFFIX: Mapping[str, str] = {
+    "api_key": "API_KEY",
+    "api_token": "API_TOKEN",
+    "api_secret": "API_SECRET",
+    "access_key": "ACCESS_KEY",
+    "secret_key": "SECRET_KEY",
+    "client_id": "CLIENT_ID",
+    "client_secret": "CLIENT_SECRET",
+    "username": "USERNAME",
+    "password": "PASSWORD",
+    "token": "TOKEN",
+    "bot_token": "BOT_TOKEN",
+    "auth_token": "AUTH_TOKEN",
+    "webhook_url": "WEBHOOK_URL",
+    "integration_key": "INTEGRATION_KEY",
+    "credentials_json": "CREDENTIALS_JSON",
+    "secret_access_key": "SECRET_ACCESS_KEY",
+    "smtp_password": "SMTP_PASSWORD",
+    "sec_token": "SEC_TOKEN",
+    "api_key_secret": "API_KEY_SECRET",
+    "inbound_api_key": "INBOUND_API_KEY",
 }
+
+
+def _default_env_var(integration_id: str, field_name: str) -> str:
+    """Build the canonical env-var name for a given integration + field.
+
+    Convention: ``<UPPER_SNAKE_INTEGRATION_ID>_<FIELD_SUFFIX>`` where the
+    suffix comes from ``_DEFAULT_FIELD_SUFFIX`` if known, otherwise the
+    upper-snake-cased field name. Matches ``IntegrationBridgeService``'s
+    convention for env-var injection into MCP server child processes.
+    """
+    prefix = integration_id.upper().replace("-", "_")
+    suffix = _DEFAULT_FIELD_SUFFIX.get(field_name, field_name.upper())
+    return f"{prefix}_{suffix}"
+
+
+# Form-field names per integration that are sensitive (mirrors `type:
+# 'password'` entries in ``frontend/src/config/integrations.ts``). The
+# values get routed through the secrets manager rather than persisted
+# plaintext to the DB / JSON file.
+_SECRET_FIELDS: Mapping[str, tuple[str, ...]] = {
+    "github": ("token",),
+    "virustotal": ("api_key",),
+    "alienvault-otx": ("api_key",),
+    "shodan": ("api_key",),
+    "misp": ("api_key",),
+    "gcp-threat-intel": ("api_key",),
+    "url-analysis": ("api_key",),
+    "ip-geolocation": ("api_key",),
+    "crowdstrike": ("client_secret",),
+    "sentinelone": ("api_token",),
+    "carbon-black": ("api_key",),
+    "microsoft-defender": ("client_secret",),
+    "cortex-xdr": ("api_key",),
+    "trend-micro-vision-one": ("api_token",),
+    "sophos-intercept-x": ("client_secret",),
+    "cybereason": ("password",),
+    "trellix": ("client_secret", "api_key"),
+    "tanium": ("password",),
+    "cynet": ("api_key",),
+    "eset": ("password",),
+    "bitdefender-gravityzone": ("api_key",),
+    "fortinet-fortiedr": ("api_token",),
+    "kaspersky": ("password",),
+    "cisco-secure-endpoint": ("api_key",),
+    "symantec-edr": ("client_secret",),
+    "splunk": ("password",),
+    "cribl-stream": ("password",),
+    "elastic-siem": ("api_key", "password"),
+    "azure-sentinel": ("client_secret",),
+    "qradar": ("sec_token",),
+    "arcsight": ("password",),
+    "logrhythm": ("api_token",),
+    "exabeam": ("password",),
+    "securonix": ("password",),
+    "sumo-logic": ("access_key",),
+    "graylog": ("api_token",),
+    "aws-security-hub": ("secret_access_key",),
+    "aws-guardduty": ("secret_access_key",),
+    "gcp-security": ("credentials_json",),
+    "azure-defender": ("client_secret",),
+    "prisma-cloud": ("secret_key",),
+    "orca-security": ("api_token",),
+    "wiz": ("client_secret",),
+    "lacework": ("api_secret",),
+    "aqua-security": ("password",),
+    "snyk": ("api_token",),
+    "okta": ("api_token",),
+    "azure-ad": ("client_secret",),
+    "ping-identity": ("client_secret",),
+    "auth0": ("client_secret",),
+    "onelogin": ("client_secret",),
+    "duo-security": ("secret_key",),
+    "jumpcloud": ("api_key",),
+    "sailpoint": ("client_secret",),
+    "cyberark": ("password",),
+    "beyond-trust": ("api_key",),
+    "palo-alto": ("api_key",),
+    "cisco-firepower": ("password",),
+    "fortinet": ("api_key",),
+    "checkpoint": ("password",),
+    "zscaler": ("api_key", "password"),
+    "sophos": ("api_token",),
+    "cloudflare": ("api_token",),
+    "cloudforce_one": ("api_token",),
+    "juniper-srx": ("password",),
+    "jira": ("api_token",),
+    "servicenow": ("password",),
+    "thehive": ("api_key",),
+    "cortex-xsoar": ("api_key",),
+    "swimlane": ("password",),
+    "ibm-resilient": ("api_key_secret",),
+    "opsgenie": ("api_key",),
+    "slack": ("bot_token",),
+    "pagerduty": ("api_token", "integration_key"),
+    "microsoft-teams": ("webhook_url",),
+    "email": ("smtp_password",),
+    "webhook": ("auth_token",),
+    "discord": ("webhook_url",),
+    "mattermost": ("webhook_url",),
+    "hybrid-analysis": ("api_key",),
+    "joe-sandbox": ("api_key",),
+    "anyrun": ("api_key",),
+    "timesketch": ("password", "api_token"),
+    "velociraptor": ("api_key",),
+    "grr": ("password",),
+    "autopsy": ("password",),
+    "osquery": ("api_token",),
+    "cuckoo": ("api_token",),
+    "vstrike": ("api_key", "inbound_api_key", "username", "password"),
+}
+
+
+# Per-integration overrides where the consumer reads the secret under a
+# name that doesn't match the default ``<ID>_<FIELD>`` convention.
+# Anything NOT listed here uses ``_default_env_var(integration_id, field)``.
+#
+# Each entry is keyed by integration_id; values are partial maps from
+# form-field name → env-var name. Missing fields fall back to the default.
+_ENV_VAR_OVERRIDES: Mapping[str, Mapping[str, str]] = {
+    # CrowdStrike's official MCP server (falcon-mcp) reads FALCON_*
+    # rather than CROWDSTRIKE_*. Match the upstream so secrets saved
+    # via the Settings UI flow straight into the MCP server.
+    "crowdstrike": {"client_secret": "FALCON_CLIENT_SECRET"},
+    # mcp-config.json's PagerDuty server reads ${PAGERDUTY_API_KEY},
+    # not PAGERDUTY_API_TOKEN.
+    "pagerduty": {"api_token": "PAGERDUTY_API_KEY"},
+}
+
+
+def _resolve_env_var(integration_id: str, field_name: str) -> str:
+    """Resolve the secrets-store key for one integration field."""
+    overrides = _ENV_VAR_OVERRIDES.get(integration_id, {})
+    return overrides.get(field_name) or _default_env_var(integration_id, field_name)
+
+
+def _build_registry() -> Dict[str, Dict[str, str]]:
+    """Materialize the per-integration secret registry from the field list."""
+    return {
+        integration_id: {
+            field: _resolve_env_var(integration_id, field) for field in fields
+        }
+        for integration_id, fields in _SECRET_FIELDS.items()
+    }
+
+
+# integration_id → {form_field_name: secrets_manager_key}
+INTEGRATION_SECRET_FIELDS: Mapping[str, Mapping[str, str]] = _build_registry()
 
 
 def secret_fields_for(integration_id: str) -> Mapping[str, str]:

--- a/services/vstrike_service.py
+++ b/services/vstrike_service.py
@@ -450,27 +450,44 @@ def get_vstrike_service() -> Optional[VStrikeService]:
       - username + password (`VSTRIKE_USERNAME` / `VSTRIKE_PASSWORD`) —
         enables the MCP UI-control plane (iframe auto-login + ui-network-load).
 
-    Either or both modes may be configured. Within each, env vars take
-    precedence over the integration config persisted by the Settings UI.
+    Either or both modes may be configured. Credential lookups go through
+    Vigil's secrets manager, which checks (in priority order) the encrypted
+    store at ``~/.vigil/secrets.enc``, process env vars, ``.env`` file, and
+    the keyring (if enabled). The non-secret ``url`` and ``verify_ssl``
+    values are read from ``IntegrationConfig`` (DB) or its JSON
+    back-compat mirror via ``core.config.get_integration_config``.
     """
-    base_url = os.environ.get("VSTRIKE_BASE_URL")
-    api_key = os.environ.get("VSTRIKE_API_KEY")
-    username = os.environ.get("VSTRIKE_USERNAME")
-    password = os.environ.get("VSTRIKE_PASSWORD")
-    verify_ssl_env = os.environ.get("VSTRIKE_VERIFY_SSL", "true").lower() != "false"
+    try:
+        from backend.secrets_manager import get_secret
+    except Exception as e:  # pragma: no cover - import-time fallback
+        logger.debug("Secrets manager unavailable, using os.environ: %s", e)
 
+        def get_secret(name: str) -> Optional[str]:  # type: ignore[misc]
+            return os.environ.get(name)
+
+    base_url = get_secret("VSTRIKE_BASE_URL")
+    api_key = get_secret("VSTRIKE_API_KEY")
+    username = get_secret("VSTRIKE_USERNAME")
+    password = get_secret("VSTRIKE_PASSWORD")
+    verify_ssl_value = get_secret("VSTRIKE_VERIFY_SSL")
+    verify_ssl_env: Optional[bool] = None
+    if verify_ssl_value is not None:
+        verify_ssl_env = verify_ssl_value.lower() != "false"
+
+    # Non-secret fields (and any legacy plaintext credentials) may still
+    # live in the integration config — read it once for back-compat.
     config: Optional[Dict[str, Any]] = None
-    needs_config_lookup = not base_url or not (api_key or (username and password))
-    if needs_config_lookup:
-        try:
-            from core.config import get_integration_config
+    try:
+        from core.config import get_integration_config
 
-            config = get_integration_config("vstrike")
-        except Exception as e:
-            logger.debug("VStrike integration config not loaded: %s", e)
-            config = None
+        config = get_integration_config("vstrike")
+    except Exception as e:
+        logger.debug("VStrike integration config not loaded: %s", e)
+        config = None
 
     base_url = base_url or _config_value("url", config)
+    # Credentials should normally come from the secrets store; fall back to
+    # the integration config only for legacy installs that haven't migrated.
     api_key = api_key or _config_value("api_key", config)
     username = username or _config_value("username", config)
     password = password or _config_value("password", config)
@@ -480,9 +497,12 @@ def get_vstrike_service() -> Optional[VStrikeService]:
     if not (api_key or (username and password)):
         return None
 
-    verify_ssl = verify_ssl_env
-    if config is not None and "verify_ssl" in config:
+    if verify_ssl_env is not None:
+        verify_ssl = verify_ssl_env
+    elif config is not None and "verify_ssl" in config:
         verify_ssl = bool(config.get("verify_ssl", True))
+    else:
+        verify_ssl = True
 
     return VStrikeService(
         base_url=base_url,

--- a/tests/integration/test_integration_secrets_api.py
+++ b/tests/integration/test_integration_secrets_api.py
@@ -1,0 +1,174 @@
+"""Integration tests for the integration-config endpoints' secret handling.
+
+The generic ``POST /config/integrations`` endpoint must route registered
+secret fields through ``set_secret`` (so they land in the encrypted
+secrets store) and strip them from the dict that gets persisted to the
+database / JSON file. The matching ``GET`` endpoint must redact those
+fields on read so plaintext credentials never leak to the frontend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (ROOT, ROOT / "backend"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+os.environ.setdefault("DEV_MODE", "true")
+
+
+def _post_payload():
+    """Realistic VStrike save payload from the Settings UI."""
+    from backend.api.config import IntegrationsConfig
+
+    return IntegrationsConfig(
+        enabled_integrations=["vstrike"],
+        integrations={
+            "vstrike": {
+                "url": "https://vstrike.net",
+                "verify_ssl": False,
+                "api_key": "outbound-bearer",
+                "inbound_api_key": "inbound-bearer",
+                "username": "deeptempo_manager",
+                "password": "shh-secret",
+            }
+        },
+    )
+
+
+def _invoke_post(payload, *, set_secret=None, config_service=None, tmp_home=None):
+    """Run the async handler with patched secrets writer + config service."""
+    from backend.api import config as config_module
+
+    set_secret = set_secret or MagicMock(return_value=True)
+    config_service = config_service or MagicMock()
+    config_service.set_integration_config.return_value = True
+
+    patches = [
+        patch.object(config_module, "set_secret", set_secret),
+        patch.object(config_module, "get_config_service", return_value=config_service),
+    ]
+    if tmp_home is not None:
+        patches.append(patch.object(Path, "home", return_value=tmp_home))
+
+    for p in patches:
+        p.start()
+    try:
+        result = asyncio.run(config_module.set_integrations_config(payload))
+    finally:
+        for p in reversed(patches):
+            p.stop()
+    return result, set_secret, config_service
+
+
+def test_post_routes_secrets_to_set_secret(tmp_path):
+    payload = _post_payload()
+    result, set_secret, config_service = _invoke_post(payload, tmp_home=tmp_path)
+
+    assert result["success"] is True
+
+    # Each registered secret field should go through set_secret with the
+    # secrets-store key from services.integration_secrets.
+    written = {call.args[0]: call.args[1] for call in set_secret.call_args_list}
+    assert written["VSTRIKE_API_KEY"] == "outbound-bearer"
+    assert written["VSTRIKE_INBOUND_API_KEY"] == "inbound-bearer"
+    assert written["VSTRIKE_USERNAME"] == "deeptempo_manager"
+    assert written["VSTRIKE_PASSWORD"] == "shh-secret"
+
+    # The DB write should contain ONLY non-secret fields.
+    saved_config = config_service.set_integration_config.call_args.kwargs["config"]
+    assert saved_config == {"url": "https://vstrike.net", "verify_ssl": False}
+    assert "api_key" not in saved_config
+    assert "password" not in saved_config
+
+
+def test_post_strips_secrets_from_json_mirror(tmp_path):
+    payload = _post_payload()
+    _invoke_post(payload, tmp_home=tmp_path)
+
+    json_path = tmp_path / ".deeptempo" / "integrations_config.json"
+    assert json_path.exists()
+    import json
+
+    on_disk = json.loads(json_path.read_text())
+    assert on_disk["enabled_integrations"] == ["vstrike"]
+    persisted = on_disk["integrations"]["vstrike"]
+    assert persisted == {"url": "https://vstrike.net", "verify_ssl": False}
+    # No secrets in plaintext
+    for forbidden in ("api_key", "inbound_api_key", "username", "password"):
+        assert forbidden not in persisted
+
+
+def test_post_skips_empty_secret_means_keep_existing(tmp_path):
+    """Empty-string secret fields must NOT call set_secret (overwrite-skip)."""
+    from backend.api.config import IntegrationsConfig
+
+    payload = IntegrationsConfig(
+        enabled_integrations=["vstrike"],
+        integrations={
+            "vstrike": {
+                "url": "https://vstrike.net",
+                "verify_ssl": True,
+                "api_key": "",
+                "username": "alice",
+                "password": "",
+            }
+        },
+    )
+    _result, set_secret, _ = _invoke_post(payload, tmp_home=tmp_path)
+
+    written = {call.args[0]: call.args[1] for call in set_secret.call_args_list}
+    # Only the non-empty username should have been written.
+    assert written == {"VSTRIKE_USERNAME": "alice"}
+
+
+def test_post_unregistered_integration_pass_through(tmp_path):
+    """Integrations without a secret-field registry retain old behavior."""
+    from backend.api.config import IntegrationsConfig
+
+    payload = IntegrationsConfig(
+        enabled_integrations=["brand-new-thing"],
+        integrations={"brand-new-thing": {"foo": "bar", "verify_ssl": True}},
+    )
+    _result, set_secret, config_service = _invoke_post(payload, tmp_home=tmp_path)
+
+    # No secrets routed to the secrets store...
+    assert set_secret.call_args_list == []
+    # ...and the full config still reaches the DB write.
+    saved = config_service.set_integration_config.call_args.kwargs["config"]
+    assert saved == {"foo": "bar", "verify_ssl": True}
+
+
+def test_get_redacts_registered_secret_fields(tmp_path):
+    """GET handler must strip registered secret fields on read."""
+    from backend.api import config as config_module
+
+    fake_service = MagicMock()
+    fake_service.list_integrations.return_value = [
+        {
+            "integration_id": "vstrike",
+            "enabled": True,
+            "config": {
+                # Pretend a legacy plaintext row still exists in DB.
+                "url": "https://vstrike.net",
+                "verify_ssl": True,
+                "api_key": "leaked-from-db",
+                "username": "alice",
+                "password": "wonderland",
+            },
+        }
+    ]
+
+    with patch.object(config_module, "get_config_service", return_value=fake_service):
+        result = asyncio.run(config_module.get_integrations_config())
+
+    cfg = result["integrations"]["vstrike"]
+    assert cfg == {"url": "https://vstrike.net", "verify_ssl": True}
+    for forbidden in ("api_key", "username", "password"):
+        assert forbidden not in cfg

--- a/tests/unit/test_integration_secrets.py
+++ b/tests/unit/test_integration_secrets.py
@@ -112,3 +112,193 @@ def test_registry_is_a_mapping_not_a_dict_alias():
     assert len(secret_fields_for("vstrike")) == original_size
     # And the registry export is keyed by integration_id
     assert "vstrike" in INTEGRATION_SECRET_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Coverage of every password-typed integration in integrations.ts
+# ---------------------------------------------------------------------------
+
+
+def test_every_audited_integration_is_registered():
+    """Sweep test: every integration with password-typed fields in the
+    frontend metadata must have a corresponding registry entry, otherwise
+    its credentials would still flow through the plaintext path on save.
+
+    The list below was derived by parsing
+    ``frontend/src/config/integrations.ts`` for ``type: 'password'`` fields
+    grouped by their parent integration ``id``. If a new integration with
+    password-typed fields is added to the frontend, add it here AND to
+    ``_SECRET_FIELDS`` in services.integration_secrets.
+    """
+    expected = {
+        "github",
+        "virustotal",
+        "alienvault-otx",
+        "shodan",
+        "misp",
+        "gcp-threat-intel",
+        "url-analysis",
+        "ip-geolocation",
+        "crowdstrike",
+        "sentinelone",
+        "carbon-black",
+        "microsoft-defender",
+        "cortex-xdr",
+        "trend-micro-vision-one",
+        "sophos-intercept-x",
+        "cybereason",
+        "trellix",
+        "tanium",
+        "cynet",
+        "eset",
+        "bitdefender-gravityzone",
+        "fortinet-fortiedr",
+        "kaspersky",
+        "cisco-secure-endpoint",
+        "symantec-edr",
+        "splunk",
+        "cribl-stream",
+        "elastic-siem",
+        "azure-sentinel",
+        "qradar",
+        "arcsight",
+        "logrhythm",
+        "exabeam",
+        "securonix",
+        "sumo-logic",
+        "graylog",
+        "aws-security-hub",
+        "aws-guardduty",
+        "gcp-security",
+        "azure-defender",
+        "prisma-cloud",
+        "orca-security",
+        "wiz",
+        "lacework",
+        "aqua-security",
+        "snyk",
+        "okta",
+        "azure-ad",
+        "ping-identity",
+        "auth0",
+        "onelogin",
+        "duo-security",
+        "jumpcloud",
+        "sailpoint",
+        "cyberark",
+        "beyond-trust",
+        "palo-alto",
+        "cisco-firepower",
+        "fortinet",
+        "checkpoint",
+        "zscaler",
+        "sophos",
+        "cloudflare",
+        "cloudforce_one",
+        "juniper-srx",
+        "jira",
+        "servicenow",
+        "thehive",
+        "cortex-xsoar",
+        "swimlane",
+        "ibm-resilient",
+        "opsgenie",
+        "slack",
+        "pagerduty",
+        "microsoft-teams",
+        "email",
+        "webhook",
+        "discord",
+        "mattermost",
+        "hybrid-analysis",
+        "joe-sandbox",
+        "anyrun",
+        "timesketch",
+        "velociraptor",
+        "grr",
+        "autopsy",
+        "osquery",
+        "cuckoo",
+        "vstrike",
+    }
+    missing = expected - set(INTEGRATION_SECRET_FIELDS.keys())
+    assert not missing, f"Integrations missing from registry: {sorted(missing)}"
+
+
+def test_default_naming_convention_for_well_known_integrations():
+    """Sample of integrations that should follow ``<ID>_<FIELD>`` exactly."""
+    cases = [
+        ("virustotal", "api_key", "VIRUSTOTAL_API_KEY"),
+        ("shodan", "api_key", "SHODAN_API_KEY"),
+        ("github", "token", "GITHUB_TOKEN"),
+        ("splunk", "password", "SPLUNK_PASSWORD"),
+        ("sentinelone", "api_token", "SENTINELONE_API_TOKEN"),
+        ("aws-security-hub", "secret_access_key", "AWS_SECURITY_HUB_SECRET_ACCESS_KEY"),
+        ("microsoft-defender", "client_secret", "MICROSOFT_DEFENDER_CLIENT_SECRET"),
+        ("cribl-stream", "password", "CRIBL_STREAM_PASSWORD"),
+        ("cloudforce_one", "api_token", "CLOUDFORCE_ONE_API_TOKEN"),
+    ]
+    for integration_id, field, expected_env in cases:
+        actual = INTEGRATION_SECRET_FIELDS[integration_id][field]
+        assert (
+            actual == expected_env
+        ), f"{integration_id}.{field} expected {expected_env}, got {actual}"
+
+
+def test_overrides_take_precedence_over_default_naming():
+    """CrowdStrike's MCP server reads FALCON_*, not CROWDSTRIKE_*."""
+    assert (
+        INTEGRATION_SECRET_FIELDS["crowdstrike"]["client_secret"]
+        == "FALCON_CLIENT_SECRET"
+    )
+    # PagerDuty mcp-config.json source placeholder is PAGERDUTY_API_KEY.
+    assert INTEGRATION_SECRET_FIELDS["pagerduty"]["api_token"] == "PAGERDUTY_API_KEY"
+    # The other PagerDuty secret falls back to the default convention.
+    assert (
+        INTEGRATION_SECRET_FIELDS["pagerduty"]["integration_key"]
+        == "PAGERDUTY_INTEGRATION_KEY"
+    )
+
+
+def test_multi_secret_integrations_register_each_field():
+    """Integrations with multiple password fields must register every one."""
+    assert set(INTEGRATION_SECRET_FIELDS["trellix"].keys()) == {
+        "client_secret",
+        "api_key",
+    }
+    assert set(INTEGRATION_SECRET_FIELDS["zscaler"].keys()) == {
+        "api_key",
+        "password",
+    }
+    assert set(INTEGRATION_SECRET_FIELDS["timesketch"].keys()) == {
+        "password",
+        "api_token",
+    }
+    assert set(INTEGRATION_SECRET_FIELDS["pagerduty"].keys()) == {
+        "api_token",
+        "integration_key",
+    }
+    assert set(INTEGRATION_SECRET_FIELDS["vstrike"].keys()) == {
+        "api_key",
+        "inbound_api_key",
+        "username",
+        "password",
+    }
+
+
+def test_no_env_var_collisions_across_integrations():
+    """No two registered (integration, field) pairs may share an env-var
+    name unless that's an explicit override (e.g. shared keys across
+    integrations would collide silently in the secrets store)."""
+    seen: dict[str, tuple[str, str]] = {}
+    collisions: list[str] = []
+    for integration_id, fields in INTEGRATION_SECRET_FIELDS.items():
+        for field, env_var in fields.items():
+            if env_var in seen:
+                prior = seen[env_var]
+                collisions.append(
+                    f"{env_var}: {prior[0]}.{prior[1]} vs {integration_id}.{field}"
+                )
+            else:
+                seen[env_var] = (integration_id, field)
+    assert not collisions, "Env-var name collisions: " + ", ".join(collisions)

--- a/tests/unit/test_integration_secrets.py
+++ b/tests/unit/test_integration_secrets.py
@@ -1,0 +1,114 @@
+"""Unit tests for the per-integration secret-field registry."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from services.integration_secrets import (  # noqa: E402
+    INTEGRATION_SECRET_FIELDS,
+    redact_secrets,
+    secret_field_names,
+    secret_fields_for,
+    split_secrets,
+)
+
+
+def test_vstrike_secret_fields_registered():
+    """The four VStrike secret fields must round-trip to env-var keys."""
+    fields = secret_fields_for("vstrike")
+    assert fields["api_key"] == "VSTRIKE_API_KEY"
+    assert fields["inbound_api_key"] == "VSTRIKE_INBOUND_API_KEY"
+    assert fields["username"] == "VSTRIKE_USERNAME"
+    assert fields["password"] == "VSTRIKE_PASSWORD"
+
+
+def test_secret_fields_for_unregistered_returns_empty():
+    assert secret_fields_for("not-a-real-integration") == {}
+
+
+def test_split_secrets_partitions_correctly():
+    raw = {
+        "url": "https://vstrike.net",
+        "verify_ssl": True,
+        "username": "alice",
+        "password": "wonderland",
+        "api_key": "bearer-token",
+    }
+    secrets, non_secrets = split_secrets("vstrike", raw)
+    # Secrets keyed by env-var name, ready for set_secret().
+    assert secrets == {
+        "VSTRIKE_USERNAME": "alice",
+        "VSTRIKE_PASSWORD": "wonderland",
+        "VSTRIKE_API_KEY": "bearer-token",
+    }
+    # Non-secrets retain original field names; no plaintext credentials.
+    assert non_secrets == {
+        "url": "https://vstrike.net",
+        "verify_ssl": True,
+    }
+
+
+def test_split_secrets_keeps_empty_secret_values():
+    """Empty strings must reach the caller so it can choose 'don't overwrite'."""
+    raw = {
+        "url": "https://vstrike.net",
+        "username": "",
+        "password": "",
+    }
+    secrets, _non_secrets = split_secrets("vstrike", raw)
+    assert secrets["VSTRIKE_USERNAME"] == ""
+    assert secrets["VSTRIKE_PASSWORD"] == ""
+
+
+def test_split_secrets_unregistered_integration_passthrough():
+    """Unregistered integrations get an empty secrets dict + a copy of input."""
+    raw = {"foo": "bar", "baz": 42}
+    secrets, non_secrets = split_secrets("brand-new", raw)
+    assert secrets == {}
+    assert non_secrets == raw
+    assert non_secrets is not raw  # copy, not alias
+
+
+def test_redact_secrets_removes_registered_fields():
+    raw = {
+        "url": "https://vstrike.net",
+        "api_key": "leaked-bearer",
+        "username": "alice",
+        "password": "wonderland",
+        "verify_ssl": True,
+    }
+    redacted = redact_secrets("vstrike", raw)
+    assert "api_key" not in redacted
+    assert "username" not in redacted
+    assert "password" not in redacted
+    assert redacted["url"] == "https://vstrike.net"
+    assert redacted["verify_ssl"] is True
+
+
+def test_redact_secrets_unregistered_integration_passthrough():
+    raw = {"foo": "bar"}
+    redacted = redact_secrets("brand-new", raw)
+    assert redacted == raw
+
+
+def test_secret_field_names_returns_form_field_names():
+    names = list(secret_field_names("vstrike"))
+    assert set(names) == {"api_key", "inbound_api_key", "username", "password"}
+
+
+def test_registry_is_a_mapping_not_a_dict_alias():
+    """Sanity: callers shouldn't be able to mutate the registry by accident."""
+    # `secret_fields_for` returns the registry's inner mapping by reference.
+    # We don't enforce immutability here, but flag it if a caller mutates.
+    fields = secret_fields_for("vstrike")
+    original_size = len(fields)
+    # Constructing a new dict from it is fine; the registry stays intact.
+    {**fields, "extra": "ENV"}
+    assert len(secret_fields_for("vstrike")) == original_size
+    # And the registry export is keyed by integration_id
+    assert "vstrike" in INTEGRATION_SECRET_FIELDS

--- a/tests/unit/test_vstrike_service.py
+++ b/tests/unit/test_vstrike_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -25,6 +26,26 @@ def _clear_jwt_cache():
     _jwt_cache.clear()
     yield
     _jwt_cache.clear()
+
+
+@pytest.fixture
+def isolate_secrets(monkeypatch):
+    """Force the factory's `get_secret` lookups to consult only os.environ.
+
+    The real secrets manager reads from encrypted store + env + dotenv +
+    keyring. On a developer machine that store may already contain
+    VSTRIKE_* values (e.g. saved via a live Settings UI test), which would
+    leak into tests that expect those keys to be unset. This fixture
+    patches the factory's get_secret import to a thin wrapper that only
+    looks at os.environ — which the test then controls via monkeypatch.
+    """
+    import backend.secrets_manager as sm
+
+    def _env_only(key, default=None):
+        return os.environ.get(key, default)
+
+    monkeypatch.setattr(sm, "get_secret", _env_only)
+    return monkeypatch
 
 
 def _service(**kwargs) -> VStrikeService:
@@ -199,22 +220,24 @@ def test_get_vstrike_service_with_only_ui_credentials(monkeypatch):
     assert svc.has_ui_credentials is True
 
 
-def test_get_vstrike_service_returns_none_with_only_username(monkeypatch):
-    monkeypatch.setenv("VSTRIKE_BASE_URL", "https://vstrike.example.com")
-    monkeypatch.delenv("VSTRIKE_API_KEY", raising=False)
-    monkeypatch.setenv("VSTRIKE_USERNAME", "deeptempo_manager")
-    monkeypatch.delenv("VSTRIKE_PASSWORD", raising=False)
+def test_get_vstrike_service_returns_none_with_only_username(isolate_secrets):
+    isolate_secrets.setenv("VSTRIKE_BASE_URL", "https://vstrike.example.com")
+    isolate_secrets.delenv("VSTRIKE_API_KEY", raising=False)
+    isolate_secrets.setenv("VSTRIKE_USERNAME", "deeptempo_manager")
+    isolate_secrets.delenv("VSTRIKE_PASSWORD", raising=False)
     with patch("core.config.get_integration_config", return_value={}):
         svc = get_vstrike_service()
     # Username alone is not enough.
     assert svc is None
 
 
-def test_get_vstrike_service_ui_credentials_from_integration_config(monkeypatch):
-    monkeypatch.delenv("VSTRIKE_BASE_URL", raising=False)
-    monkeypatch.delenv("VSTRIKE_API_KEY", raising=False)
-    monkeypatch.delenv("VSTRIKE_USERNAME", raising=False)
-    monkeypatch.delenv("VSTRIKE_PASSWORD", raising=False)
+def test_get_vstrike_service_ui_credentials_from_integration_config(
+    isolate_secrets,
+):
+    isolate_secrets.delenv("VSTRIKE_BASE_URL", raising=False)
+    isolate_secrets.delenv("VSTRIKE_API_KEY", raising=False)
+    isolate_secrets.delenv("VSTRIKE_USERNAME", raising=False)
+    isolate_secrets.delenv("VSTRIKE_PASSWORD", raising=False)
     with patch(
         "core.config.get_integration_config",
         return_value={


### PR DESCRIPTION
## Summary

Follow-up to #156, which added the secret-routing infrastructure but only registered VStrike. Every other integration's password-typed fields still flowed through the plaintext path on save — defeating the point of the secrets store unless the integration was VStrike.

This sweeps [frontend/src/config/integrations.ts](frontend/src/config/integrations.ts) for every entry with `type: 'password'` fields (87 integrations, ~95 distinct secret fields) and registers them all. Each form-field name maps to a secrets-store key built from the canonical convention `<UPPER_SNAKE_INTEGRATION_ID>_<FIELD>` — mirrors the env-var naming the [IntegrationBridgeService.FIELD_TO_ENV_MAP](services/integration_bridge_service.py) already uses when injecting env vars into MCP server child processes, so the Settings UI write path and the MCP env-injection path agree on names.

Two consumer-driven overrides are explicit:
- **`crowdstrike.client_secret` → `FALCON_CLIENT_SECRET`** — the official `falcon-mcp` server reads `FALCON_*`, not `CROWDSTRIKE_*`.
- **`pagerduty.api_token` → `PAGERDUTY_API_KEY`** — [mcp-config.json](mcp-config.json) sources its `${PAGERDUTY_API_KEY}` placeholder.

The registry is built from a flat `_SECRET_FIELDS` tuple-per-integration map plus a small `_ENV_VAR_OVERRIDES` table. Adding a new integration is one tuple entry, not a hand-typed mapping.

## Test plan

- [x] `pytest tests/unit/test_integration_secrets.py tests/integration/test_integration_secrets_api.py tests/unit/test_vstrike_service.py tests/integration/test_vstrike_ui_routes.py tests/integration/test_vstrike_ingest.py` — 68 passed.
- [x] **Coverage sweep**: every integration_id from the frontend audit must be in the registry. Catches frontend additions that forget the backend registration.
- [x] **Naming-convention spot-checks**: `virustotal.api_key → VIRUSTOTAL_API_KEY`, `splunk.password → SPLUNK_PASSWORD`, `sentinelone.api_token → SENTINELONE_API_TOKEN`, `aws-security-hub.secret_access_key → AWS_SECURITY_HUB_SECRET_ACCESS_KEY`, etc.
- [x] **Override precedence**: `crowdstrike.client_secret → FALCON_CLIENT_SECRET`. `pagerduty.api_token → PAGERDUTY_API_KEY` while `pagerduty.integration_key` falls back to default.
- [x] **Multi-secret integrations** register every field (trellix, zscaler, timesketch, pagerduty, vstrike).
- [x] **No env-var collisions** across the full registry.
- [x] **Test hermeticity**: new `isolate_secrets` pytest fixture stubs `backend.secrets_manager.get_secret` to consult only `os.environ`, so a developer's actual encrypted store doesn't leak into unit tests that monkeypatch env vars. Two pre-existing flaky tests (introduced by PR #156's switch to the read chain) are now stable.
- [x] `black` clean on all changed files.
- [ ] Manual: enter credentials for any integration via Settings → Integrations / MCP, save, then `cat ~/.deeptempo/integrations_config.json` — confirm only non-secret fields persisted.

## Notes for review

- 87 integrations is a lot; mistakes are possible in env-var name choices for less-common services. The default `<ID>_<FIELD>` convention is *consistent with* the bridge service today; if a specific integration's consumer reads under a non-canonical name, it'll surface as "I configured it but the service can't find the credential" — fix is to add an `_ENV_VAR_OVERRIDES` entry. The structure makes that a one-line change.
- The sweep does NOT touch any non-secret form fields. Those continue to land in the DB / JSON exactly as before. Pure additive change to the secrets routing.
- Builds on top of #156 (which is on `main`). No conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)