### PR TITLE
Land secrets in the encrypted store by default

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -1374,3 +1374,88 @@ async def get_mempalace_health():
         "memories_count": memories["count"],
         "memories_count_source": memories["source"],
     }
+
+
+# ---------------------------------------------------------------------------
+# Secrets manager status / reinit / migration
+# ---------------------------------------------------------------------------
+
+
+class _SecretsReinitRequest(BaseModel):
+    """Optional override for the reinit endpoint.
+
+    The running process's ``os.environ`` may have a stale
+    ``SECRETS_BACKEND`` from launch time. ``write_backend`` here lets an
+    admin force the rebuilt singleton onto a specific backend without
+    bouncing uvicorn.
+    """
+
+    write_backend: Optional[str] = None
+
+
+class _SecretsMigrateRequest(BaseModel):
+    keys: Optional[List[str]] = None
+    remove_from_dotenv: bool = True
+
+
+@router.get("/secrets/status")
+async def secrets_status() -> Dict[str, Any]:
+    """Report which backend the secrets manager is using and why.
+
+    Used by the Settings UI (and `curl` debugging) to answer "why are my
+    creds not landing in ~/.vigil/secrets.enc?". Includes the chosen
+    write backend, what was expected per ``SECRETS_BACKEND`` env, whether
+    cryptography imported, and where each backend lives on disk.
+    """
+    from backend.secrets_manager import get_secrets_manager
+
+    mgr = get_secrets_manager()
+    return mgr.get_backend_status()
+
+
+@router.post("/secrets/reinit")
+async def secrets_reinit(
+    request: Optional[_SecretsReinitRequest] = None,
+) -> Dict[str, Any]:
+    """Drop the cached secrets-manager singleton and rebuild it.
+
+    Useful when the long-running process picked the wrong write backend
+    on first init (e.g. ``SECRETS_BACKEND`` was stale in os.environ when
+    the very first ``set_secret`` call ran during startup). After this
+    call the manager re-evaluates backend availability fresh.
+
+    Pass ``{"write_backend": "encrypted"}`` to force a specific backend
+    regardless of what's currently in ``os.environ`` — useful when you
+    just edited ``.env`` to switch from dotenv to encrypted but haven't
+    bounced the process.
+    """
+    from backend.secrets_manager import get_secrets_manager
+
+    write_backend = request.write_backend if request else None
+    mgr = get_secrets_manager(write_backend=write_backend, force_reload=True)
+    return {
+        "reloaded": True,
+        "status": mgr.get_backend_status(),
+    }
+
+
+@router.post("/secrets/migrate-to-encrypted")
+async def secrets_migrate_to_encrypted(
+    request: Optional[_SecretsMigrateRequest] = None,
+) -> Dict[str, Any]:
+    """Move secrets from ``~/.deeptempo/.env`` to ``~/.vigil/secrets.enc``.
+
+    Encrypted store is authoritative on conflicts: if a key exists in
+    both with different values, the dotenv entry is left in place and
+    the conflict is reported so an operator can resolve it manually.
+
+    Body is optional. Pass ``{"keys": ["FOO_BAR"]}`` to migrate only a
+    subset, or ``{"remove_from_dotenv": false}`` for a dry-copy that
+    leaves the source file alone.
+    """
+    from backend.secrets_manager import get_secrets_manager
+
+    mgr = get_secrets_manager()
+    keys = request.keys if request else None
+    remove = request.remove_from_dotenv if request else True
+    return mgr.migrate_dotenv_secrets_to_encrypted(keys=keys, remove_from_dotenv=remove)

--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -10,12 +10,14 @@ import os
 
 # Import new secrets manager
 import sys
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from secrets_manager import get_secret, set_secret, delete_secret, get_secrets_manager
 
 # Import database config service
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from database.config_service import get_config_service
+from services.integration_secrets import redact_secrets, split_secrets
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -23,11 +25,13 @@ logger = logging.getLogger(__name__)
 
 class ClaudeConfig(BaseModel):
     """Claude API configuration."""
+
     api_key: str
 
 
 class S3Config(BaseModel):
     """S3 configuration."""
+
     bucket_name: str
     region: str = "us-east-1"
     auth_method: str = "credentials"  # "credentials" or "profile"
@@ -40,23 +44,22 @@ class S3Config(BaseModel):
     parquet_prefix: str = ""
 
 
-
-
 class ThemeConfig(BaseModel):
     """Theme configuration."""
+
     theme: str = "dark"  # dark or light
-
-
 
 
 class IntegrationsConfig(BaseModel):
     """Integrations configuration."""
+
     enabled_integrations: list[str] = []
     integrations: dict = {}
 
 
 class GeneralConfig(BaseModel):
     """General application settings."""
+
     auto_start_sync: bool = False
     show_notifications: bool = True
     theme: str = "dark"
@@ -65,16 +68,19 @@ class GeneralConfig(BaseModel):
 
 class GitHubConfig(BaseModel):
     """GitHub integration configuration."""
+
     token: str
 
 
 class PostgreSQLConfig(BaseModel):
     """PostgreSQL database backend configuration."""
+
     connection_string: str
 
 
 class DemoModeConfig(BaseModel):
     """Demo mode configuration."""
+
     enabled: bool = False
 
 
@@ -82,21 +88,21 @@ class DemoModeConfig(BaseModel):
 async def get_demo_mode():
     """
     Get demo mode configuration.
-    
+
     Returns:
         Demo mode status
     """
     try:
         from core.config import is_demo_mode
         import os
-        
+
         demo_enabled = is_demo_mode()
-        env_value = os.getenv('DEMO_MODE', '')
-        
+        env_value = os.getenv("DEMO_MODE", "")
+
         return {
             "enabled": demo_enabled,
             "source": "environment" if env_value else "config",
-            "description": "Demo mode uses generated sample data instead of database"
+            "description": "Demo mode uses generated sample data instead of database",
         }
     except Exception as e:
         logger.error(f"Error getting demo mode: {e}")
@@ -107,36 +113,36 @@ async def get_demo_mode():
 async def set_demo_mode(config: DemoModeConfig):
     """
     Set demo mode configuration.
-    
+
     Note: Setting via API updates the config file. Environment variable takes precedence.
-    
+
     Args:
         config: Demo mode configuration
-    
+
     Returns:
         Success status
     """
     try:
-        config_file = Path.home() / '.deeptempo' / 'general_config.json'
+        config_file = Path.home() / ".deeptempo" / "general_config.json"
         config_file.parent.mkdir(parents=True, exist_ok=True)
-        
+
         # Load existing config
         existing = {}
         if config_file.exists():
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 existing = json.load(f)
-        
+
         # Update demo_mode setting
-        existing['demo_mode'] = config.enabled
-        
-        with open(config_file, 'w') as f:
+        existing["demo_mode"] = config.enabled
+
+        with open(config_file, "w") as f:
             json.dump(existing, f, indent=2)
-        
+
         return {
-            "success": True, 
+            "success": True,
             "enabled": config.enabled,
             "message": f"Demo mode {'enabled' if config.enabled else 'disabled'}. Restart the server for changes to take effect.",
-            "note": "Set DEMO_MODE=true environment variable for immediate effect without restart"
+            "note": "Set DEMO_MODE=true environment variable for immediate effect without restart",
         }
     except Exception as e:
         logger.error(f"Error setting demo mode: {e}")
@@ -147,25 +153,26 @@ async def set_demo_mode(config: DemoModeConfig):
 async def reset_demo_data():
     """
     Reset demo data to regenerate sample findings and cases.
-    
+
     Returns:
         Success status
     """
     try:
         from core.config import is_demo_mode
-        
+
         if not is_demo_mode():
             raise HTTPException(status_code=400, detail="Demo mode is not enabled")
-        
+
         from services.demo_data_service import get_demo_service
+
         demo_service = get_demo_service()
         demo_service.reset()
-        
+
         return {
             "success": True,
             "message": "Demo data regenerated",
             "findings_count": len(demo_service.get_findings()),
-            "cases_count": len(demo_service.get_cases())
+            "cases_count": len(demo_service.get_cases()),
         }
     except HTTPException:
         raise
@@ -178,22 +185,24 @@ async def reset_demo_data():
 async def get_claude_config():
     """
     Get Claude API configuration status.
-    
+
     Returns:
         Configuration status (without exposing the key)
     """
     try:
         # Try new key names first, then legacy names
-        api_key = (get_secret("CLAUDE_API_KEY") or 
-                   get_secret("ANTHROPIC_API_KEY") or
-                   get_secret("claude_api_key") or
-                   get_secret("anthropic_api_key"))
-        
+        api_key = (
+            get_secret("CLAUDE_API_KEY")
+            or get_secret("ANTHROPIC_API_KEY")
+            or get_secret("claude_api_key")
+            or get_secret("anthropic_api_key")
+        )
+
         has_key = bool(api_key)
-        
+
         return {
             "configured": has_key,
-            "key_preview": f"{api_key[:8]}..." if has_key else None
+            "key_preview": f"{api_key[:8]}..." if has_key else None,
         }
     except Exception as e:
         logger.error(f"Error getting Claude config: {e}")
@@ -264,44 +273,44 @@ async def set_claude_config(config: ClaudeConfig):
 async def get_s3_config():
     """
     Get S3 configuration status.
-    
+
     Returns:
         Configuration status
     """
     try:
         # Try database first
         config_service = get_config_service()
-        s3_integration = config_service.get_integration_config('s3')
-        
-        if s3_integration and s3_integration.get('config'):
-            config = s3_integration['config']
+        s3_integration = config_service.get_integration_config("s3")
+
+        if s3_integration and s3_integration.get("config"):
+            config = s3_integration["config"]
             return {
                 "configured": True,
-                "bucket_name": config.get('bucket_name'),
-                "region": config.get('region'),
-                "findings_path": config.get('findings_path'),
-                "cases_path": config.get('cases_path'),
-                "parquet_prefix": config.get('parquet_prefix', ''),
-                "auth_method": config.get('auth_method', 'credentials'),
-                "aws_profile": config.get('aws_profile', ''),
+                "bucket_name": config.get("bucket_name"),
+                "region": config.get("region"),
+                "findings_path": config.get("findings_path"),
+                "cases_path": config.get("cases_path"),
+                "parquet_prefix": config.get("parquet_prefix", ""),
+                "auth_method": config.get("auth_method", "credentials"),
+                "aws_profile": config.get("aws_profile", ""),
             }
-        
+
         # Fallback to file-based config
-        config_file = Path.home() / '.deeptempo' / 's3_config.json'
+        config_file = Path.home() / ".deeptempo" / "s3_config.json"
         if config_file.exists():
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 config = json.load(f)
                 return {
                     "configured": True,
-                    "bucket_name": config.get('bucket_name'),
-                    "region": config.get('region'),
-                    "findings_path": config.get('findings_path'),
-                    "cases_path": config.get('cases_path'),
-                    "parquet_prefix": config.get('parquet_prefix', ''),
-                    "auth_method": config.get('auth_method', 'credentials'),
-                    "aws_profile": config.get('aws_profile', ''),
+                    "bucket_name": config.get("bucket_name"),
+                    "region": config.get("region"),
+                    "findings_path": config.get("findings_path"),
+                    "cases_path": config.get("cases_path"),
+                    "parquet_prefix": config.get("parquet_prefix", ""),
+                    "auth_method": config.get("auth_method", "credentials"),
+                    "aws_profile": config.get("aws_profile", ""),
                 }
-        
+
         return {"configured": False}
     except Exception as e:
         logger.error(f"Error getting S3 config: {e}")
@@ -312,10 +321,10 @@ async def get_s3_config():
 async def set_s3_config(config: S3Config):
     """
     Set S3 configuration.
-    
+
     Args:
         config: S3 configuration
-    
+
     Returns:
         Success status
     """
@@ -324,17 +333,17 @@ async def set_s3_config(config: S3Config):
         parquet_prefix = config.parquet_prefix
 
         # Parse s3:// URIs: extract bucket name and use the path as prefix
-        if bucket_name.startswith('s3://'):
+        if bucket_name.startswith("s3://"):
             stripped = bucket_name[5:]
-            parts = stripped.split('/', 1)
+            parts = stripped.split("/", 1)
             bucket_name = parts[0]
             if len(parts) > 1 and parts[1]:
-                path = parts[1].rstrip('/')
+                path = parts[1].rstrip("/")
                 # If the path ends with a file extension, trim to the parent directory
-                last_segment = path.rsplit('/', 1)[-1] if '/' in path else path
-                if '.' in last_segment:
-                    path = path.rsplit('/', 1)[0] if '/' in path else ''
-                parquet_prefix = (path + '/') if path else ''
+                last_segment = path.rsplit("/", 1)[-1] if "/" in path else path
+                if "." in last_segment:
+                    path = path.rsplit("/", 1)[0] if "/" in path else ""
+                parquet_prefix = (path + "/") if path else ""
 
         config_data = {
             "bucket_name": bucket_name,
@@ -345,28 +354,30 @@ async def set_s3_config(config: S3Config):
             "auth_method": config.auth_method,
             "aws_profile": config.aws_profile,
         }
-        
+
         # Save to database
-        config_service = get_config_service(user_id='web_ui')
+        config_service = get_config_service(user_id="web_ui")
         success = config_service.set_integration_config(
-            integration_id='s3',
+            integration_id="s3",
             config=config_data,
             enabled=True,
-            integration_name='AWS S3',
-            integration_type='storage',
-            description='AWS S3 storage configuration',
-            change_reason='Updated via Settings UI'
+            integration_name="AWS S3",
+            integration_type="storage",
+            description="AWS S3 storage configuration",
+            change_reason="Updated via Settings UI",
         )
-        
+
         if not success:
-            raise HTTPException(status_code=500, detail="Failed to save S3 config to database")
-        
+            raise HTTPException(
+                status_code=500, detail="Failed to save S3 config to database"
+            )
+
         # Also save to file for backward compatibility
-        config_file = Path.home() / '.deeptempo' / 's3_config.json'
+        config_file = Path.home() / ".deeptempo" / "s3_config.json"
         config_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(config_file, 'w') as f:
+        with open(config_file, "w") as f:
             json.dump(config_data, f, indent=2)
-        
+
         # Only overwrite credentials if new values were provided
         if config.access_key_id:
             set_secret("AWS_ACCESS_KEY_ID", config.access_key_id)
@@ -377,7 +388,7 @@ async def set_s3_config(config: S3Config):
         elif config.access_key_id:
             # Clear session token when new non-STS credentials are provided
             set_secret("AWS_SESSION_TOKEN", "")
-        
+
         return {"success": True, "message": "S3 configuration saved"}
     except HTTPException:
         raise
@@ -390,38 +401,38 @@ async def set_s3_config(config: S3Config):
 async def test_s3_connection():
     """
     Test S3 connection with current configuration.
-    
+
     Returns:
         Connection test result
     """
     try:
         from services.s3_service import S3Service
-        
+
         # Load S3 config
         config_service = get_config_service()
-        s3_integration = config_service.get_integration_config('s3')
-        
+        s3_integration = config_service.get_integration_config("s3")
+
         if not s3_integration:
             # Fallback to file-based config
-            config_file = Path.home() / '.deeptempo' / 's3_config.json'
+            config_file = Path.home() / ".deeptempo" / "s3_config.json"
             if config_file.exists():
-                with open(config_file, 'r') as f:
+                with open(config_file, "r") as f:
                     s3_integration = json.load(f)
             else:
                 raise HTTPException(status_code=400, detail="S3 not configured")
-        
+
         # Unwrap nested config if present
         cfg = s3_integration
-        if isinstance(s3_integration.get('config'), dict):
-            cfg = s3_integration['config']
+        if isinstance(s3_integration.get("config"), dict):
+            cfg = s3_integration["config"]
 
-        auth_method = cfg.get('auth_method', 'credentials')
-        aws_profile = cfg.get('aws_profile', '')
+        auth_method = cfg.get("auth_method", "credentials")
+        aws_profile = cfg.get("aws_profile", "")
 
-        if auth_method == 'profile' and aws_profile:
+        if auth_method == "profile" and aws_profile:
             s3_service = S3Service(
-                bucket_name=cfg.get('bucket_name'),
-                region_name=cfg.get('region', 'us-east-1'),
+                bucket_name=cfg.get("bucket_name"),
+                region_name=cfg.get("region", "us-east-1"),
                 aws_profile=aws_profile,
             )
         else:
@@ -431,47 +442,47 @@ async def test_s3_connection():
             if not access_key_id or not secret_access_key:
                 raise HTTPException(
                     status_code=400,
-                    detail="S3 credentials not found. Please configure S3 in Settings."
+                    detail="S3 credentials not found. Please configure S3 in Settings.",
                 )
 
             s3_service = S3Service(
-                bucket_name=cfg.get('bucket_name'),
-                region_name=cfg.get('region', 'us-east-1'),
+                bucket_name=cfg.get("bucket_name"),
+                region_name=cfg.get("region", "us-east-1"),
                 aws_access_key_id=access_key_id,
                 aws_secret_access_key=secret_access_key,
             )
-        
+
         # Test connection
         success, message = s3_service.test_connection()
-        
+
         if success:
             # Try to list files as an additional test
-            findings_path = cfg.get('findings_path', 'findings.json')
-            cases_path = cfg.get('cases_path', 'cases.json')
-            
+            findings_path = cfg.get("findings_path", "findings.json")
+            cases_path = cfg.get("cases_path", "cases.json")
+
             files = s3_service.list_files()
             has_findings = findings_path in files
             has_cases = cases_path in files
-            
+
             return {
                 "success": True,
                 "message": message,
-                "bucket": cfg.get('bucket_name'),
-                "region": cfg.get('region', 'us-east-1'),
+                "bucket": cfg.get("bucket_name"),
+                "region": cfg.get("region", "us-east-1"),
                 "files_found": len(files),
                 "findings_file_exists": has_findings,
                 "cases_file_exists": has_cases,
                 "expected_findings_path": findings_path,
-                "expected_cases_path": cases_path
+                "expected_cases_path": cases_path,
             }
         else:
             return {
                 "success": False,
                 "message": message,
-                "bucket": cfg.get('bucket_name'),
-                "region": cfg.get('region', 'us-east-1')
+                "bucket": cfg.get("bucket_name"),
+                "region": cfg.get("region", "us-east-1"),
             }
-            
+
     except HTTPException:
         raise
     except Exception as e:
@@ -479,31 +490,29 @@ async def test_s3_connection():
         raise HTTPException(status_code=500, detail=f"S3 test failed: {str(e)}")
 
 
-
-
 @router.get("/theme")
 async def get_theme_config():
     """
     Get theme configuration.
-    
+
     Returns:
         Theme configuration
     """
     try:
         # Try database first
         config_service = get_config_service()
-        config_value = config_service.get_system_config('theme.current')
-        
+        config_value = config_service.get_system_config("theme.current")
+
         if config_value:
             return config_value
-        
+
         # Fallback to file-based config
-        config_file = Path.home() / '.deeptempo' / 'theme_config.json'
+        config_file = Path.home() / ".deeptempo" / "theme_config.json"
         if config_file.exists():
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 config = json.load(f)
-                return {"theme": config.get('theme', 'dark')}
-        
+                return {"theme": config.get("theme", "dark")}
+
         return {"theme": "dark"}
     except Exception as e:
         logger.error(f"Error getting theme config: {e}")
@@ -514,35 +523,37 @@ async def get_theme_config():
 async def set_theme_config(config: ThemeConfig):
     """
     Set theme configuration.
-    
+
     Args:
         config: Theme configuration
-    
+
     Returns:
         Success status
     """
     try:
         config_data = {"theme": config.theme}
-        
+
         # Save to database
-        config_service = get_config_service(user_id='web_ui')
+        config_service = get_config_service(user_id="web_ui")
         success = config_service.set_system_config(
-            key='theme.current',
+            key="theme.current",
             value=config_data,
-            description='Current UI theme',
-            config_type='theme',
-            change_reason='Updated via Settings UI'
+            description="Current UI theme",
+            config_type="theme",
+            change_reason="Updated via Settings UI",
         )
-        
+
         if not success:
-            raise HTTPException(status_code=500, detail="Failed to save theme to database")
-        
+            raise HTTPException(
+                status_code=500, detail="Failed to save theme to database"
+            )
+
         # Also save to file for backward compatibility
-        config_file = Path.home() / '.deeptempo' / 'theme_config.json'
+        config_file = Path.home() / ".deeptempo" / "theme_config.json"
         config_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(config_file, 'w') as f:
+        with open(config_file, "w") as f:
             json.dump(config_data, f, indent=2)
-        
+
         return {"success": True, "message": "Theme saved"}
     except HTTPException:
         raise
@@ -551,13 +562,11 @@ async def set_theme_config(config: ThemeConfig):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-
-
 @router.get("/integrations")
 async def get_integrations_config():
     """
     Get integrations configuration.
-    
+
     Returns:
         Configuration status and enabled integrations
     """
@@ -565,74 +574,112 @@ async def get_integrations_config():
         # Try database first
         config_service = get_config_service()
         integrations_list = config_service.list_integrations()
-        
+
         if integrations_list:
-            # Build response in the expected format
-            enabled_integrations = [i['integration_id'] for i in integrations_list if i['enabled']]
-            integrations = {i['integration_id']: i['config'] for i in integrations_list}
-            
+            enabled_integrations = [
+                i["integration_id"] for i in integrations_list if i["enabled"]
+            ]
+            # Redact registered secret fields so the frontend never receives
+            # plaintext credentials. Pre-secret-store rows may still contain
+            # them — strip on read so any legacy plaintext is sanitized.
+            integrations = {
+                i["integration_id"]: redact_secrets(
+                    i["integration_id"], i["config"] or {}
+                )
+                for i in integrations_list
+            }
             return {
                 "configured": True,
                 "enabled_integrations": enabled_integrations,
-                "integrations": integrations
+                "integrations": integrations,
             }
-        
+
         # Fallback to file-based config
-        config_file = Path.home() / '.deeptempo' / 'integrations_config.json'
+        config_file = Path.home() / ".deeptempo" / "integrations_config.json"
         if config_file.exists():
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 config = json.load(f)
+                redacted = {
+                    iid: redact_secrets(iid, cfg or {})
+                    for iid, cfg in (config.get("integrations") or {}).items()
+                }
                 return {
                     "configured": True,
-                    "enabled_integrations": config.get('enabled_integrations', []),
-                    "integrations": config.get('integrations', {})
+                    "enabled_integrations": config.get("enabled_integrations", []),
+                    "integrations": redacted,
                 }
-        
+
         return {"configured": False, "enabled_integrations": [], "integrations": {}}
     except Exception as e:
         logger.error(f"Error getting integrations config: {e}")
-        return {"configured": False, "enabled_integrations": [], "integrations": {}, "error": str(e)}
+        return {
+            "configured": False,
+            "enabled_integrations": [],
+            "integrations": {},
+            "error": str(e),
+        }
 
 
 @router.post("/integrations")
 async def set_integrations_config(config: IntegrationsConfig):
     """
     Set integrations configuration.
-    
+
+    Secret-typed fields (registered in ``services.integration_secrets``) are
+    routed to the encrypted secrets store via ``set_secret`` and stripped
+    from the dict that lands in the DB / JSON file. Empty strings are
+    treated as "keep existing secret" (matches the S3 endpoint convention)
+    so editing non-secret fields without re-typing the password doesn't
+    clobber stored credentials.
+
     Args:
         config: Integrations configuration
-    
+
     Returns:
         Success status
     """
     try:
-        config_service = get_config_service(user_id='web_ui')
-        
-        # Save each integration to database
-        for integration_id in config.integrations.keys():
-            integration_config = config.integrations[integration_id]
+        config_service = get_config_service(user_id="web_ui")
+
+        # Build a sanitized integrations dict (no secrets) for DB/JSON
+        # persistence. Apply secret writes to the encrypted store.
+        sanitized_integrations: dict = {}
+        for integration_id, raw_config in config.integrations.items():
+            secrets, non_secrets = split_secrets(integration_id, raw_config)
+
+            # Empty string ⇒ user didn't re-type the secret on edit; leave
+            # the existing encrypted value untouched. Non-empty ⇒ overwrite.
+            for env_key, value in secrets.items():
+                if value == "":
+                    continue
+                if not set_secret(env_key, value):
+                    logger.error(
+                        f"Failed to write secret '{env_key}' for "
+                        f"integration '{integration_id}'"
+                    )
+
+            sanitized_integrations[integration_id] = non_secrets
+
             enabled = integration_id in config.enabled_integrations
-            
             success = config_service.set_integration_config(
                 integration_id=integration_id,
-                config=integration_config,
+                config=non_secrets,
                 enabled=enabled,
-                change_reason='Updated via Settings UI'
+                change_reason="Updated via Settings UI",
             )
-            
             if not success:
                 logger.error(f"Failed to save integration '{integration_id}'")
-        
-        # Also save to file for backward compatibility
-        config_file = Path.home() / '.deeptempo' / 'integrations_config.json'
+
+        # Also save to file for backward compatibility — sanitized only.
+        config_file = Path.home() / ".deeptempo" / "integrations_config.json"
         config_file.parent.mkdir(parents=True, exist_ok=True)
         config_data = {
             "enabled_integrations": config.enabled_integrations,
-            "integrations": config.integrations
+            "integrations": sanitized_integrations,
         }
-        with open(config_file, 'w') as f:
+        with open(config_file, "w") as f:
             json.dump(config_data, f, indent=2)
-        
+
         return {"success": True, "message": "Integrations configuration saved"}
     except Exception as e:
         logger.error(f"Error setting integrations config: {e}")
@@ -643,7 +690,7 @@ async def set_integrations_config(config: IntegrationsConfig):
 async def get_integrations_status():
     """
     Get status of all integrations.
-    
+
     Returns:
         Status information for all integrations
     """
@@ -651,14 +698,11 @@ async def get_integrations_status():
         # Import here to avoid circular dependencies
         sys.path.insert(0, str(Path(__file__).parent.parent.parent))
         from services.integration_bridge_service import get_integration_bridge
-        
+
         bridge = get_integration_bridge()
         statuses = bridge.get_all_integration_statuses()
-        
-        return {
-            "success": True,
-            "statuses": statuses
-        }
+
+        return {"success": True, "statuses": statuses}
     except Exception as e:
         logger.error(f"Error getting integration statuses: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -668,10 +712,10 @@ async def get_integrations_status():
 async def test_integration(integration_id: str):
     """
     Test an integration connection.
-    
+
     Args:
         integration_id: Integration identifier
-    
+
     Returns:
         Test result with success/failure and message
     """
@@ -679,47 +723,49 @@ async def test_integration(integration_id: str):
         # Import here to avoid circular dependencies
         sys.path.insert(0, str(Path(__file__).parent.parent.parent))
         from services.integration_bridge_service import get_integration_bridge
-        
+
         bridge = get_integration_bridge()
         status = bridge.get_integration_status(integration_id)
-        
-        if not status['configured']:
+
+        if not status["configured"]:
             raise HTTPException(status_code=400, detail="Integration not configured")
-        
-        if not status['server_available']:
+
+        if not status["server_available"]:
             return {
                 "success": False,
                 "message": f"Integration server not yet implemented. The '{integration_id}' integration is planned but the backend MCP server needs to be created.",
                 "status": status,
-                "implementation_status": "pending"
+                "implementation_status": "pending",
             }
-        
-        if not status['enabled']:
+
+        if not status["enabled"]:
             return {
                 "success": False,
                 "message": "Integration is configured but not enabled. Please enable it in the integrations list.",
-                "status": status
+                "status": status,
             }
-        
+
         # TODO: Implement actual connection test using MCP client
         # For now, we just verify the configuration is complete
         integration_config = bridge.get_integration_config(integration_id)
-        
+
         # Check if required fields are present (basic validation)
         if not integration_config:
-            raise HTTPException(status_code=400, detail="Integration configuration is empty")
-        
+            raise HTTPException(
+                status_code=400, detail="Integration configuration is empty"
+            )
+
         # Prepare environment variables to verify they're being set correctly
         env_vars = bridge._config_to_env_vars(integration_id, integration_config)
-        
+
         return {
             "success": True,
             "message": f"Integration '{integration_id}' is configured and ready. Configuration will be passed to the MCP server as environment variables.",
             "status": status,
             "env_var_count": len(env_vars),
-            "server_name": status.get('server_name', 'unknown')
+            "server_name": status.get("server_name", "unknown"),
         }
-    
+
     except HTTPException:
         raise
     except Exception as e:
@@ -731,45 +777,45 @@ async def test_integration(integration_id: str):
 async def get_general_config():
     """
     Get general application settings.
-    
+
     Returns:
         General configuration
     """
     try:
         # Try database first
         config_service = get_config_service()
-        config_value = config_service.get_system_config('general.settings')
-        
+        config_value = config_service.get_system_config("general.settings")
+
         if config_value:
             return config_value
-        
+
         # Fallback to file-based config
-        config_file = Path.home() / '.deeptempo' / 'general_config.json'
-        
+        config_file = Path.home() / ".deeptempo" / "general_config.json"
+
         if config_file.exists():
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 config = json.load(f)
                 return {
-                    "auto_start_sync": config.get('auto_start_sync', False),
-                    "show_notifications": config.get('show_notifications', True),
-                    "theme": config.get('theme', 'dark'),
-                    "enable_keyring": config.get('enable_keyring', False)
+                    "auto_start_sync": config.get("auto_start_sync", False),
+                    "show_notifications": config.get("show_notifications", True),
+                    "theme": config.get("theme", "dark"),
+                    "enable_keyring": config.get("enable_keyring", False),
                 }
-        
+
         # Default values
         return {
-            "auto_start_sync": False, 
-            "show_notifications": True, 
+            "auto_start_sync": False,
+            "show_notifications": True,
             "theme": "dark",
-            "enable_keyring": False
+            "enable_keyring": False,
         }
     except Exception as e:
         logger.error(f"Error getting general config: {e}")
         return {
-            "auto_start_sync": False, 
-            "show_notifications": True, 
+            "auto_start_sync": False,
+            "show_notifications": True,
             "theme": "dark",
-            "enable_keyring": False
+            "enable_keyring": False,
         }
 
 
@@ -777,10 +823,10 @@ async def get_general_config():
 async def set_general_config(config: GeneralConfig):
     """
     Set general application settings.
-    
+
     Args:
         config: General configuration
-    
+
     Returns:
         Success status
     """
@@ -789,39 +835,45 @@ async def set_general_config(config: GeneralConfig):
             "auto_start_sync": config.auto_start_sync,
             "show_notifications": config.show_notifications,
             "theme": config.theme,
-            "enable_keyring": config.enable_keyring
+            "enable_keyring": config.enable_keyring,
         }
-        
+
         # Save to database
-        config_service = get_config_service(user_id='web_ui')
+        config_service = get_config_service(user_id="web_ui")
         success = config_service.set_system_config(
-            key='general.settings',
+            key="general.settings",
             value=config_data,
-            description='General application settings',
-            config_type='general',
-            change_reason='Updated via Settings UI'
+            description="General application settings",
+            config_type="general",
+            change_reason="Updated via Settings UI",
         )
-        
+
         if not success:
-            raise HTTPException(status_code=500, detail="Failed to save configuration to database")
-        
+            raise HTTPException(
+                status_code=500, detail="Failed to save configuration to database"
+            )
+
         # Also save to file for backward compatibility (during transition)
-        config_file = Path.home() / '.deeptempo' / 'general_config.json'
+        config_file = Path.home() / ".deeptempo" / "general_config.json"
         config_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(config_file, 'w') as f:
+        with open(config_file, "w") as f:
             json.dump(config_data, f, indent=2)
-        
+
         # Update the global secrets manager if keyring setting changed
         try:
             from secrets_manager import get_secrets_manager
+
             # Force reinitialize with new setting
             import secrets_manager as sm_module
+
             sm_module._secrets_manager = None  # Reset global instance
             get_secrets_manager(enable_keyring=config.enable_keyring)
-            logger.info(f"Secrets manager updated: enable_keyring={config.enable_keyring}")
+            logger.info(
+                f"Secrets manager updated: enable_keyring={config.enable_keyring}"
+            )
         except Exception as e:
             logger.warning(f"Could not update secrets manager: {e}")
-        
+
         return {"success": True, "message": "General settings saved"}
     except HTTPException:
         raise
@@ -834,17 +886,17 @@ async def set_general_config(config: GeneralConfig):
 async def get_github_config():
     """
     Get GitHub integration configuration status.
-    
+
     Returns:
         Configuration status (without exposing the token)
     """
     try:
         token = get_secret("GITHUB_TOKEN")
         has_token = bool(token)
-        
+
         return {
             "configured": has_token,
-            "token_preview": f"{token[:12]}..." if has_token else None
+            "token_preview": f"{token[:12]}..." if has_token else None,
         }
     except Exception as e:
         logger.error(f"Error getting GitHub config: {e}")
@@ -855,10 +907,10 @@ async def get_github_config():
 async def set_github_config(config: GitHubConfig):
     """
     Set GitHub integration configuration.
-    
+
     Args:
         config: GitHub configuration
-    
+
     Returns:
         Success status
     """
@@ -877,14 +929,14 @@ async def set_github_config(config: GitHubConfig):
 async def get_postgresql_config():
     """
     Get PostgreSQL database backend configuration status.
-    
+
     Returns:
         Configuration status
     """
     try:
         conn_str = get_secret("POSTGRESQL_CONNECTION_STRING")
         has_config = bool(conn_str)
-        
+
         # Extract host from connection string for preview (if exists)
         preview = None
         if conn_str and "postgresql://" in conn_str:
@@ -897,11 +949,8 @@ async def get_postgresql_config():
             except Exception as e:
                 logger.debug(f"Error parsing connection string preview: {e}")
                 preview = "postgresql://***:***@***/***"
-        
-        return {
-            "configured": has_config,
-            "connection_preview": preview
-        }
+
+        return {"configured": has_config, "connection_preview": preview}
     except Exception as e:
         logger.error(f"Error getting PostgreSQL config: {e}")
         return {"configured": False, "error": str(e)}
@@ -911,19 +960,24 @@ async def get_postgresql_config():
 async def set_postgresql_config(config: PostgreSQLConfig):
     """
     Set PostgreSQL database backend configuration.
-    
+
     Args:
         config: PostgreSQL configuration
-    
+
     Returns:
         Success status
     """
     try:
         success = set_secret("POSTGRESQL_CONNECTION_STRING", config.connection_string)
         if success:
-            return {"success": True, "message": "PostgreSQL connection string saved securely"}
+            return {
+                "success": True,
+                "message": "PostgreSQL connection string saved securely",
+            }
         else:
-            raise HTTPException(status_code=500, detail="Failed to save PostgreSQL connection string")
+            raise HTTPException(
+                status_code=500, detail="Failed to save PostgreSQL connection string"
+            )
     except Exception as e:
         logger.error(f"Error setting PostgreSQL config: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -938,6 +992,7 @@ class AIOperationsSettingsConfig(BaseModel):
     (AI Config → AI Operations) so operators can flip values live
     without restarting the backend / daemon / llm-worker.
     """
+
     prompt_cache_enabled: bool = True
     history_window: int = 20
     tool_response_budget_default: int = 8000
@@ -984,6 +1039,7 @@ async def set_ai_operations_config(config: AIOperationsSettingsConfig):
         # (default 60s) — acceptable since these are rarely-flipped toggles.
         try:
             from services.runtime_config import clear_cache
+
             clear_cache()
         except Exception as exc:  # noqa: BLE001
             logger.debug(f"runtime_config cache clear skipped: {exc}")
@@ -997,6 +1053,7 @@ async def set_ai_operations_config(config: AIOperationsSettingsConfig):
 
 class OrchestratorSettingsConfig(BaseModel):
     """Orchestrator configuration for autonomous investigations."""
+
     enabled: bool = True
     dry_run: bool = False
     auto_assign_findings: bool = True
@@ -1025,7 +1082,7 @@ async def get_orchestrator_config():
     """Get orchestrator configuration."""
     try:
         config_service = get_config_service()
-        config_value = config_service.get_system_config('orchestrator.settings')
+        config_value = config_service.get_system_config("orchestrator.settings")
 
         if config_value:
             merged = {**ORCHESTRATOR_DEFAULTS, **config_value}
@@ -1046,17 +1103,19 @@ async def set_orchestrator_config(config: OrchestratorSettingsConfig):
     try:
         config_data = config.model_dump()
 
-        config_service = get_config_service(user_id='web_ui')
+        config_service = get_config_service(user_id="web_ui")
         success = config_service.set_system_config(
-            key='orchestrator.settings',
+            key="orchestrator.settings",
             value=config_data,
-            description='Autonomous orchestrator settings',
-            config_type='orchestrator',
-            change_reason='Updated via Settings UI'
+            description="Autonomous orchestrator settings",
+            config_type="orchestrator",
+            change_reason="Updated via Settings UI",
         )
 
         if not success:
-            raise HTTPException(status_code=500, detail="Failed to save orchestrator config to database")
+            raise HTTPException(
+                status_code=500, detail="Failed to save orchestrator config to database"
+            )
 
         # Poke the in-process orchestrator (if the API happens to share one)
         # so a running daemon reacts immediately. No-op in backend-only
@@ -1064,6 +1123,7 @@ async def set_orchestrator_config(config: OrchestratorSettingsConfig):
         # seconds.
         try:
             from backend.api.orchestrator import _get_orchestrator
+
             orch = _get_orchestrator()
             if orch is not None:
                 if config_data.get("enabled"):
@@ -1211,6 +1271,7 @@ def _scan_palace(palace_path: Path) -> Dict[str, Any]:
             continue
 
     from datetime import datetime, timezone
+
     last_iso = (
         datetime.fromtimestamp(latest_mtime, tz=timezone.utc)
         .isoformat()
@@ -1276,6 +1337,7 @@ async def get_mempalace_health():
     error: Optional[str] = None
     try:
         from services.mcp_client import get_mcp_client
+
         mcp_client = get_mcp_client()
         if mcp_client is not None:
             statuses = mcp_client.get_connection_status() or {}

--- a/backend/main.py
+++ b/backend/main.py
@@ -93,6 +93,7 @@ from api.kafka import router as kafka_router
 
 from core.rate_limit import rate_limit_dependency
 from monitoring import init_sentry, PROMETHEUS_AVAILABLE, get_metrics_response
+
 if PROMETHEUS_AVAILABLE:
     from monitoring import PrometheusMiddleware
 
@@ -100,6 +101,7 @@ if PROMETHEUS_AVAILABLE:
 # is registered before the first request handler is defined.
 try:
     from core.telemetry import init_telemetry
+
     init_telemetry("vigil-backend")
 except Exception as _tel_err:
     logging.basicConfig(level=logging.INFO)
@@ -116,7 +118,7 @@ init_sentry()
 app = FastAPI(
     title="Vigil SOC API",
     description="REST API for Vigil SOC Application",
-    version="1.0.0"
+    version="1.0.0",
 )
 
 # Wire the shared slowapi Limiter used by auth endpoints. The decorator-based
@@ -127,6 +129,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 # Instrument FastAPI with OTEL tracing (health + metrics endpoints excluded)
 try:
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentation
+
     FastAPIInstrumentation().instrument_app(
         app,
         excluded_urls="api/health,metrics",
@@ -195,16 +198,29 @@ app.include_router(analytics_router, prefix="/api", tags=["analytics"])
 app.include_router(findings_router, prefix="/api/findings", tags=["findings"])
 app.include_router(cases_router, prefix="/api/cases", tags=["cases"])
 app.include_router(mcp_router, prefix="/api/mcp", tags=["mcp"])
-app.include_router(claude_router, prefix="/api/claude", tags=["claude"], dependencies=[Depends(rate_limit_dependency)])
+app.include_router(
+    claude_router,
+    prefix="/api/claude",
+    tags=["claude"],
+    dependencies=[Depends(rate_limit_dependency)],
+)
 app.include_router(reasoning_router, prefix="/api/reasoning", tags=["reasoning"])
 app.include_router(config_router, prefix="/api/config", tags=["config"])
-app.include_router(llm_providers_router, prefix="/api/llm/providers", tags=["llm-providers"])
+app.include_router(
+    llm_providers_router, prefix="/api/llm/providers", tags=["llm-providers"]
+)
 app.include_router(ai_config_router, prefix="/api/ai", tags=["ai-config"])
 app.include_router(attack_router, prefix="/api/attack", tags=["attack"])
 app.include_router(custom_agents_router, prefix="/api", tags=["custom-agents"])
 app.include_router(agents_router, prefix="/api/agents", tags=["agents"])
-app.include_router(compatibility_router, prefix="/api/integrations", tags=["integrations"])
-app.include_router(custom_integrations_router, prefix="/api/custom-integrations", tags=["custom-integrations"])
+app.include_router(
+    compatibility_router, prefix="/api/integrations", tags=["integrations"]
+)
+app.include_router(
+    custom_integrations_router,
+    prefix="/api/custom-integrations",
+    tags=["custom-integrations"],
+)
 app.include_router(skills_router, prefix="/api/skills", tags=["skills"])
 app.include_router(ingestion_router, prefix="/api/ingest", tags=["ingestion"])
 app.include_router(vstrike_router, prefix="/api/integrations/vstrike", tags=["vstrike"])
@@ -213,20 +229,30 @@ app.include_router(ai_decisions_router, prefix="/api/ai", tags=["ai-decisions"])
 app.include_router(timeline_router, prefix="/api/timeline", tags=["timeline"])
 app.include_router(graph_router, prefix="/api/graph", tags=["graph"])
 app.include_router(logs_router, prefix="/api/logs", tags=["logs"])
-app.include_router(local_services_router, prefix="/api/services", tags=["local-services"])
-app.include_router(detection_rules_router, prefix="/api/detection-rules", tags=["detection-rules"])
+app.include_router(
+    local_services_router, prefix="/api/services", tags=["local-services"]
+)
+app.include_router(
+    detection_rules_router, prefix="/api/detection-rules", tags=["detection-rules"]
+)
 
 # Workflows engine
 app.include_router(workflows_router, prefix="/api", tags=["workflows"])
 app.include_router(approvals_router, prefix="/api", tags=["approvals"])
 
 # Autonomous orchestrator
-app.include_router(orchestrator_router, prefix="/api/orchestrator", tags=["orchestrator"])
+app.include_router(
+    orchestrator_router, prefix="/api/orchestrator", tags=["orchestrator"]
+)
 app.include_router(kafka_router)
 
 # Enhanced case management routers
-app.include_router(case_templates_router, prefix="/api/cases/templates", tags=["case-templates"])
-app.include_router(case_metrics_router, prefix="/api/cases/metrics", tags=["case-metrics"])
+app.include_router(
+    case_templates_router, prefix="/api/cases/templates", tags=["case-templates"]
+)
+app.include_router(
+    case_metrics_router, prefix="/api/cases/metrics", tags=["case-metrics"]
+)
 app.include_router(case_search_router, prefix="/api/cases/search", tags=["case-search"])
 app.include_router(webhooks_router, prefix="/api/webhooks", tags=["webhooks"])
 # Darktrace inbound webhook receiver — only mount when explicitly enabled.
@@ -250,7 +276,10 @@ if cloudy_ingestion_enabled():
         prefix="/api/webhooks/cloudflare",
         tags=["cloudflare"],
     )
-app.include_router(sla_policies_router, prefix="/api/sla-policies", tags=["sla-policies"])
+app.include_router(
+    sla_policies_router, prefix="/api/sla-policies", tags=["sla-policies"]
+)
+
 
 @app.on_event("startup")
 async def startup_event():
@@ -262,15 +291,46 @@ async def startup_event():
     # Initialize Sentry error tracking (was never called before — bug fix)
     try:
         from backend.monitoring import init_sentry
+
         init_sentry()
     except Exception as e:
         logger.warning("Sentry initialization failed (non-fatal): %s", e)
+
+    # Probe the secrets manager singleton at a known time, after all
+    # third-party imports have settled. The singleton picks its write
+    # backend on first init and never re-evaluates, so if `cryptography`
+    # was unavailable at the moment of an earlier import-time call the
+    # whole process would fall through to the dotenv backend silently.
+    # Logging here gives us an explicit signal whenever that happens.
+    try:
+        from backend.secrets_manager import get_secrets_manager
+
+        _mgr = get_secrets_manager()
+        _status = _mgr.get_backend_status()
+        if _status["write_backend"] != _status["expected_write_backend"]:
+            logger.error(
+                "SecretsManager init: write_backend=%s but expected=%s "
+                "(cryptography_available=%s, master_key_present=%s). "
+                "POST /api/config/secrets/reinit to retry without restart.",
+                _status["write_backend"],
+                _status["expected_write_backend"],
+                _status["cryptography_available"],
+                _status["encrypted"]["master_key_present"],
+            )
+        else:
+            logger.info(
+                "SecretsManager ready: write_backend=%s, " "cryptography_available=%s",
+                _status["write_backend"],
+                _status["cryptography_available"],
+            )
+    except Exception as e:  # pragma: no cover - probe is best-effort
+        logger.warning("SecretsManager startup probe failed: %s", e)
 
     # Load secrets into environment for MCP servers
     try:
         from backend.secrets_manager import get_secret
         import os
-        
+
         # Load PostgreSQL connection string for database backend
         postgres_conn = get_secret("POSTGRESQL_CONNECTION_STRING")
         if postgres_conn:
@@ -281,13 +341,13 @@ async def startup_event():
             default_conn = "postgresql://deeptempo:deeptempo_secure_password_change_me@localhost:5432/deeptempo_soc"
             os.environ["POSTGRESQL_CONNECTION_STRING"] = default_conn
             logger.debug("Using default PostgreSQL connection string")
-            
+
         # Load GitHub token for MCP github server
         github_token = get_secret("GITHUB_TOKEN")
         if github_token:
             os.environ["GITHUB_TOKEN"] = github_token
             logger.debug("Loaded GitHub token from secrets")
-            
+
     except Exception as e:
         logger.warning(f"Error loading secrets for MCP servers: {e}")
 
@@ -297,6 +357,7 @@ async def startup_event():
     # time. Best-effort — Bifrost may not be up yet in all environments.
     try:
         from services.bifrost_admin import sync_all_provider_keys
+
         sync_all_provider_keys()
     except Exception as e:
         logger.warning(f"Bifrost provider sync skipped: {e}")
@@ -313,9 +374,7 @@ async def startup_event():
 
         from services.bifrost_admin import sync_all_provider_models
 
-        refresh_interval_s = int(
-            os.getenv("MODEL_CATALOG_REFRESH_INTERVAL_S", "300")
-        )
+        refresh_interval_s = int(os.getenv("MODEL_CATALOG_REFRESH_INTERVAL_S", "300"))
 
         async def _model_catalog_refresher():
             while True:
@@ -323,7 +382,8 @@ async def startup_event():
                     await sync_all_provider_models()
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
-                        "Model catalog refresh iteration failed: %s", exc,
+                        "Model catalog refresh iteration failed: %s",
+                        exc,
                     )
                 if refresh_interval_s <= 0:
                     break
@@ -347,10 +407,11 @@ async def startup_event():
         # here is fatal — we do NOT silently fall back to JSON because that
         # leaves the DB in an inconsistent state (some endpoints use
         # get_db_session() directly, see backend/api/case_metrics.py).
-        data_backend_env = os.getenv('DATA_BACKEND', 'database').lower()
-        if not is_demo_mode() and data_backend_env == 'database':
+        data_backend_env = os.getenv("DATA_BACKEND", "database").lower()
+        if not is_demo_mode() and data_backend_env == "database":
             try:
                 from database.connection import init_database
+
                 init_database(echo=False, create_tables=True)
                 logger.info("✓ Database schema ensured (create_all)")
             except Exception as schema_err:
@@ -372,14 +433,14 @@ async def startup_event():
             logger.info(f"  Backend: {backend_info['backend']}")
         else:
             # Check configuration preference
-            data_backend = os.getenv('DATA_BACKEND', 'database').lower()
-            use_database = data_backend == 'database'
-            
+            data_backend = os.getenv("DATA_BACKEND", "database").lower()
+            use_database = data_backend == "database"
+
             if use_database:
                 logger.info("Attempting to connect to PostgreSQL database...")
                 try:
                     test_service = DatabaseDataService()
-                    
+
                     if test_service.is_using_database():
                         logger.info("✓ PostgreSQL database connected and ready")
                         backend_info = test_service.get_backend_info()
@@ -388,79 +449,94 @@ async def startup_event():
                         logger.warning("⚠ PostgreSQL not available")
                         logger.warning("  Using JSON file storage as fallback")
                         logger.warning("  To enable PostgreSQL:")
-                        logger.warning("    1. Start database: ./scripts/start_database.sh")
+                        logger.warning(
+                            "    1. Start database: ./scripts/start_database.sh"
+                        )
                         logger.warning("    2. Restart application: ./start_web.sh")
-                    
+
                 except Exception as e:
                     logger.warning(f"⚠ Could not connect to PostgreSQL: {e}")
                     logger.warning("  Using JSON file storage as fallback")
             else:
                 logger.info("Using JSON file storage (DATA_BACKEND=json)")
-            
+
     except ImportError as e:
         logger.warning(f"Database modules not available: {e}")
         logger.warning("Using JSON file storage")
     except Exception as e:
         logger.error(f"Error during storage initialization: {e}")
         logger.warning("Falling back to JSON file storage")
-    
+
     # Check integration compatibility
     logger.info("Checking integration compatibility...")
     try:
         from services.integration_compatibility_service import get_compatibility_service
-        
+
         compat_service = get_compatibility_service()
         system_info = compat_service.get_system_info()
-        logger.info(f"System: Python {system_info['python_version']} on {system_info['platform']}")
-        
+        logger.info(
+            f"System: Python {system_info['python_version']} on {system_info['platform']}"
+        )
+
         # Log compatibility issues
         statuses = compat_service.get_all_statuses()
-        incompatible = [k for k, v in statuses.items() if v.get('status') == 'incompatible']
-        not_installed = [k for k, v in statuses.items() if v.get('status') == 'not_installed']
-        
+        incompatible = [
+            k for k, v in statuses.items() if v.get("status") == "incompatible"
+        ]
+        not_installed = [
+            k for k, v in statuses.items() if v.get("status") == "not_installed"
+        ]
+
         if incompatible:
             logger.warning(f"Incompatible integrations: {', '.join(incompatible)}")
         if not_installed:
             logger.info(f"Not installed integrations: {', '.join(not_installed)}")
-        
-        installed_count = sum(1 for v in statuses.values() if v.get('installed'))
+
+        installed_count = sum(1 for v in statuses.values() if v.get("installed"))
         logger.info(f"Integration status: {installed_count}/{len(statuses)} installed")
     except Exception as e:
         logger.error(f"Error checking compatibility: {e}")
-    
+
     # Initialize LLM Gateway (connects to Redis for ARQ job queue)
     logger.info("Initializing LLM Gateway (ARQ / Redis)...")
     try:
         from services.llm_gateway import get_llm_gateway
+
         await get_llm_gateway()
         logger.info("✓ LLM Gateway connected to Redis")
     except Exception as e:
         logger.warning(f"⚠ LLM Gateway not available: {e}")
-        logger.warning("  LLM calls will fail until Redis is running and ARQ worker is started")
-    
+        logger.warning(
+            "  LLM calls will fail until Redis is running and ARQ worker is started"
+        )
+
     logger.info("Initializing MCP client with persistent connections...")
     try:
         from services.mcp_client import get_mcp_client
         from services.mcp_service import MCPService
         import asyncio
-        
+
         # Get MCP client and service
         mcp_client = get_mcp_client()
-        
+
         if mcp_client:
             # Get list of all servers
             mcp_service = mcp_client.mcp_service
             servers = mcp_service.list_servers()
-            
+
             # Connect to each server with persistent connections
             connected_count = 0
             for server_name in servers:
                 try:
                     # persistent=True establishes a long-lived connection
-                    success = await mcp_client.connect_to_server(server_name, persistent=True)
+                    success = await mcp_client.connect_to_server(
+                        server_name, persistent=True
+                    )
                     if success:
                         connected_count += 1
-                        logger.info(f"✓ Persistent connection established: {server_name}")
+                        logger.info(
+                            f"✓ Persistent connection established: {server_name}"
+                        )
                     else:
                         # Dormant-by-design when the user hasn't supplied
                         # credentials yet — log at info and name the vars
@@ -480,9 +556,11 @@ async def startup_event():
                             )
                 except Exception as e:
                     logger.error(f"Error connecting to {server_name}: {e}")
-            
-            logger.info(f"MCP initialization complete: {connected_count}/{len(servers)} persistent connections")
-            
+
+            logger.info(
+                f"MCP initialization complete: {connected_count}/{len(servers)} persistent connections"
+            )
+
             # Log available tools
             tools = await mcp_client.list_tools()
             total_tools = sum(len(t) for t in tools.values())
@@ -499,17 +577,19 @@ async def startup_event():
                     cache_data[server_name] = []
                     for tool in server_tools:
                         input_schema = tool.get("inputSchema", {})
-                        if hasattr(input_schema, 'model_dump'):
+                        if hasattr(input_schema, "model_dump"):
                             input_schema = input_schema.model_dump()
                         elif not isinstance(input_schema, dict):
                             input_schema = dict(input_schema) if input_schema else {}
-                        cache_data[server_name].append({
-                            "name": tool.get("name"),
-                            "description": tool.get("description", ""),
-                            "inputSchema": input_schema
-                        })
+                        cache_data[server_name].append(
+                            {
+                                "name": tool.get("name"),
+                                "description": tool.get("description", ""),
+                                "inputSchema": input_schema,
+                            }
+                        )
 
-                with open(cache_file, 'w') as f:
+                with open(cache_file, "w") as f:
                     json.dump(cache_data, f, indent=2)
 
                 logger.info(f"✓ Saved MCP tools cache to {cache_file}")
@@ -518,7 +598,9 @@ async def startup_event():
 
             # Log connection status
             status = mcp_client.get_connection_status()
-            logger.info(f"Persistent connections: {sum(1 for connected in status.values() if connected)}/{len(status)}")
+            logger.info(
+                f"Persistent connections: {sum(1 for connected in status.values() if connected)}/{len(status)}"
+            )
         else:
             logger.warning("MCP client not available - MCP SDK may not be installed")
     except Exception as e:
@@ -529,6 +611,7 @@ async def startup_event():
     # also trigger a refresh at request time, so this is a convenience preload.
     try:
         from backend.api.agents import agent_manager
+
         loaded = agent_manager.refresh_custom_agents()
         logger.info(f"Loaded {loaded} custom agent(s) from database")
     except Exception as e:
@@ -541,11 +624,12 @@ async def shutdown_event():
     logger.info("Shutting down LLM Gateway...")
     try:
         from services.llm_gateway import close_llm_gateway
+
         await close_llm_gateway()
         logger.info("LLM Gateway closed")
     except Exception as e:
         logger.error(f"Error closing LLM Gateway: {e}")
-    
+
     logger.info("Shutting down MCP connections...")
     try:
         from services.mcp_client import get_mcp_client
@@ -564,6 +648,7 @@ async def shutdown_event():
     # Flush and shut down OTEL providers
     try:
         from core.telemetry import shutdown_telemetry
+
         shutdown_telemetry()
     except Exception as e:
         logger.warning("Telemetry shutdown error (non-fatal): %s", e)
@@ -583,19 +668,19 @@ async def health_check():
     try:
         from services.database_data_service import DatabaseDataService
         from core.config import is_demo_mode
-        
+
         service = DatabaseDataService()
         backend_info = service.get_backend_info()
-        
+
         return {
             "status": "healthy",
             "version": "1.0.0",
             "demo_mode": is_demo_mode(),
             "storage": {
-                "backend": backend_info['backend'],
-                "database_available": backend_info.get('database_available', False),
-                "demo_mode": backend_info.get('demo_mode', False)
-            }
+                "backend": backend_info["backend"],
+                "database_available": backend_info.get("database_available", False),
+                "demo_mode": backend_info.get("demo_mode", False),
+            },
         }
     except Exception as e:
         logger.error(f"Health check error: {e}")
@@ -603,11 +688,9 @@ async def health_check():
             "status": "healthy",
             "version": "1.0.0",
             "demo_mode": False,
-            "storage": {
-                "backend": "unknown",
-                "error": str(e)
-            }
+            "storage": {"backend": "unknown", "error": str(e)},
         }
+
 
 # Serve React static files in production
 frontend_build_dir = Path(__file__).parent.parent / "frontend" / "build"
@@ -624,32 +707,30 @@ if frontend_build_dir.exists() and static_dir.exists():
 else:
     logger.info("Frontend build directory not found - static file serving disabled")
     logger.info(f"  Expected: {frontend_build_dir}")
-    logger.info("  Run 'npm run build' in the frontend directory to enable production mode")
+    logger.info(
+        "  Run 'npm run build' in the frontend directory to enable production mode"
+    )
 
 if frontend_build_dir.exists() and (frontend_build_dir / "index.html").exists():
-    
+
     @app.get("/{full_path:path}")
     async def serve_react_app(full_path: str):
         """Serve React app for all non-API routes."""
         # Don't interfere with API routes
         if full_path.startswith("api/"):
             return {"error": "Not found"}, 404
-        
+
         # Serve index.html for React routing
         index_file = frontend_build_dir / "index.html"
         if index_file.exists():
             return FileResponse(index_file)
         return {"error": "Frontend not built"}, 404
 
+
 if __name__ == "__main__":
     import uvicorn
-    
+
     logger.info("Starting Vigil SOC API server...")
     uvicorn.run(
-        "backend.main:app",
-        host="0.0.0.0",
-        port=6987,
-        reload=True,
-        log_level="info"
+        "backend.main:app", host="0.0.0.0", port=6987, reload=True, log_level="info"
     )
-

--- a/backend/secrets_manager.py
+++ b/backend/secrets_manager.py
@@ -26,25 +26,47 @@ logger = logging.getLogger(__name__)
 # Service name for keyring storage
 SERVICE_NAME = "deeptempo-ai-soc"
 
+# Eagerly probe `cryptography` availability at module import so the answer
+# is stable for the rest of the process's lifetime. The encrypted backend
+# was previously deciding this inside ``EncryptedFileBackend.__init__`` per
+# instance, which made the singleton's chosen write backend depend on
+# whether ``cryptography`` happened to be importable at the moment of
+# first ``get_secrets_manager()`` invocation. If a router-import side
+# effect kicked off the singleton before all third-party packages had
+# resolved, we silently fell through to the dotenv backend for the
+# entire process. Hoisting the import means the answer is the same for
+# every consumer regardless of init order.
+try:
+    from cryptography.fernet import Fernet as _Fernet  # noqa: F401
+
+    _CRYPTOGRAPHY_AVAILABLE = True
+except Exception as _crypto_import_error:  # pragma: no cover - import-time
+    logger.debug(
+        "cryptography unavailable at module import (%s); "
+        "EncryptedFileBackend will be disabled for this process",
+        _crypto_import_error,
+    )
+    _CRYPTOGRAPHY_AVAILABLE = False
+
 
 class SecretsBackend(ABC):
     """Abstract base class for secrets storage backends."""
-    
+
     @abstractmethod
     def get(self, key: str) -> Optional[str]:
         """Get a secret value."""
         pass
-    
+
     @abstractmethod
     def set(self, key: str, value: str) -> bool:
         """Set a secret value."""
         pass
-    
+
     @abstractmethod
     def delete(self, key: str) -> bool:
         """Delete a secret value."""
         pass
-    
+
     @abstractmethod
     def is_available(self) -> bool:
         """Check if this backend is available."""
@@ -53,14 +75,14 @@ class SecretsBackend(ABC):
 
 class EnvironmentBackend(SecretsBackend):
     """Store secrets in environment variables."""
-    
+
     def get(self, key: str) -> Optional[str]:
         """Get secret from environment variable."""
         value = os.environ.get(key)
         if value:
             logger.debug(f"Found secret '{key}' in environment variables")
         return value
-    
+
     def set(self, key: str, value: str) -> bool:
         """Set environment variable (only for current process)."""
         try:
@@ -70,7 +92,7 @@ class EnvironmentBackend(SecretsBackend):
         except Exception as e:
             logger.error(f"Error setting environment variable '{key}': {e}")
             return False
-    
+
     def delete(self, key: str) -> bool:
         """Delete environment variable."""
         try:
@@ -81,7 +103,7 @@ class EnvironmentBackend(SecretsBackend):
         except Exception as e:
             logger.error(f"Error deleting environment variable '{key}': {e}")
             return False
-    
+
     def is_available(self) -> bool:
         """Environment variables are always available."""
         return True
@@ -89,82 +111,84 @@ class EnvironmentBackend(SecretsBackend):
 
 class DotEnvBackend(SecretsBackend):
     """Store secrets in a .env file."""
-    
+
     def __init__(self, env_file: Optional[Path] = None):
         """Initialize with path to .env file."""
         self.env_file = env_file or Path.home() / ".deeptempo" / ".env"
         self._cache: Dict[str, str] = {}
         self._load_env_file()
-    
+
     def _load_env_file(self):
         """Load .env file into cache."""
         if self.env_file.exists():
             try:
-                with open(self.env_file, 'r') as f:
+                with open(self.env_file, "r") as f:
                     for line in f:
                         line = line.strip()
-                        if line and not line.startswith('#') and '=' in line:
-                            key, value = line.split('=', 1)
+                        if line and not line.startswith("#") and "=" in line:
+                            key, value = line.split("=", 1)
                             # Remove quotes if present
                             value = value.strip('"').strip("'")
                             self._cache[key.strip()] = value
                 logger.debug(f"Loaded {len(self._cache)} secrets from {self.env_file}")
             except Exception as e:
                 logger.error(f"Error loading .env file: {e}")
-    
+
     def get(self, key: str) -> Optional[str]:
         """Get secret from .env file."""
         value = self._cache.get(key)
         if value:
             logger.debug(f"Found secret '{key}' in .env file")
         return value
-    
+
     def set(self, key: str, value: str) -> bool:
         """Set secret in .env file."""
         try:
             # Update cache
             self._cache[key] = value
-            
+
             # Create directory if needed
             self.env_file.parent.mkdir(parents=True, exist_ok=True)
-            
+
             # Write all secrets to file
-            with open(self.env_file, 'w') as f:
+            with open(self.env_file, "w") as f:
                 f.write("# Vigil SOC Secrets\n")
-                f.write("# This file contains sensitive credentials - keep it secure!\n\n")
+                f.write(
+                    "# This file contains sensitive credentials - keep it secure!\n\n"
+                )
                 for k, v in self._cache.items():
                     # Escape quotes in value
                     escaped_value = v.replace('"', '\\"')
                     f.write(f'{k}="{escaped_value}"\n')
-            
+
             # Set restrictive permissions (owner read/write only)
             os.chmod(self.env_file, 0o600)
-            
+
             logger.info(f"Set secret '{key}' in .env file")
             return True
         except Exception as e:
             logger.error(f"Error setting secret in .env file: {e}")
             return False
-    
+
     def delete(self, key: str) -> bool:
         """Delete secret from .env file."""
         try:
             if key in self._cache:
                 del self._cache[key]
-                
+
                 # Rewrite file without this secret
-                with open(self.env_file, 'w') as f:
+                with open(self.env_file, "w") as f:
                     f.write("# Vigil SOC Secrets\n\n")
                     for k, v in self._cache.items():
                         escaped_value = v.replace('"', '\\"')
                         f.write(f'{k}="{escaped_value}"\n')
-                
+
                 logger.info(f"Deleted secret '{key}' from .env file")
             return True
         except Exception as e:
             logger.error(f"Error deleting secret from .env file: {e}")
             return False
-    
+
     def is_available(self) -> bool:
         """Check if .env file backend is available."""
         return True
@@ -172,11 +196,11 @@ class DotEnvBackend(SecretsBackend):
 
 class KeyringBackend(SecretsBackend):
     """Store secrets in system keyring (macOS Keychain, Windows Credential Manager, etc)."""
-    
+
     def __init__(self, lazy_init: bool = True):
         """
         Initialize keyring backend.
-        
+
         Args:
             lazy_init: If True, don't check availability until first use (prevents keychain prompts).
                       If False, check availability immediately.
@@ -184,14 +208,15 @@ class KeyringBackend(SecretsBackend):
         self._lazy_init = lazy_init
         self._available = None if lazy_init else self._check_available()
         self._keyring_module = None
-    
+
     def _check_available(self) -> bool:
         """Check if keyring is available."""
         if self._available is not None:
             return self._available
-            
+
         try:
             import keyring
+
             self._keyring_module = keyring
             # Don't actually test keyring access - that triggers macOS prompts
             # Just check if the module imported successfully
@@ -206,21 +231,22 @@ class KeyringBackend(SecretsBackend):
             logger.debug(f"Keyring not available: {e}")
             self._available = False
             return False
-    
+
     def get(self, key: str) -> Optional[str]:
         """Get secret from keyring."""
         # Lazy initialization - check availability on first use
         if self._available is None:
             self._check_available()
-        
+
         if not self._available:
             return None
-        
+
         try:
             if self._keyring_module is None:
                 import keyring
+
                 self._keyring_module = keyring
-            
+
             value = self._keyring_module.get_password(SERVICE_NAME, key)
             if value:
                 logger.debug(f"Found secret '{key}' in keyring")
@@ -228,50 +254,52 @@ class KeyringBackend(SecretsBackend):
         except Exception as e:
             logger.debug(f"Error getting secret from keyring: {e}")
             return None
-    
+
     def set(self, key: str, value: str) -> bool:
         """Set secret in keyring."""
         # Lazy initialization - check availability on first use
         if self._available is None:
             self._check_available()
-        
+
         if not self._available:
             logger.warning("Keyring not available, cannot store secret")
             return False
-        
+
         try:
             if self._keyring_module is None:
                 import keyring
+
                 self._keyring_module = keyring
-            
+
             self._keyring_module.set_password(SERVICE_NAME, key, value)
             logger.info(f"Set secret '{key}' in keyring")
             return True
         except Exception as e:
             logger.error(f"Error setting secret in keyring: {e}")
             return False
-    
+
     def delete(self, key: str) -> bool:
         """Delete secret from keyring."""
         # Lazy initialization - check availability on first use
         if self._available is None:
             self._check_available()
-        
+
         if not self._available:
             return True
-        
+
         try:
             if self._keyring_module is None:
                 import keyring
+
                 self._keyring_module = keyring
-            
+
             self._keyring_module.delete_password(SERVICE_NAME, key)
             logger.info(f"Deleted secret '{key}' from keyring")
             return True
         except Exception as e:
             logger.debug(f"Error deleting secret from keyring: {e}")
             return False
-    
+
     def is_available(self) -> bool:
         """Check if keyring is available."""
         # For lazy init, return False until explicitly checked
@@ -307,14 +335,10 @@ class EncryptedFileBackend(SecretsBackend):
         # to detect cross-process writes so the backend picks up secrets
         # saved by sibling processes without a restart.
         self._cache_mtime: float = 0.0
-        # `cryptography` is listed in requirements.txt; guard in case a
-        # slim deploy is missing it.
-        try:
-            from cryptography.fernet import Fernet  # noqa: F401
-            self._crypto_ok = True
-        except Exception as e:
-            logger.debug(f"EncryptedFileBackend disabled (cryptography missing): {e}")
-            self._crypto_ok = False
+        # `cryptography` availability is decided ONCE at module import
+        # (see `_CRYPTOGRAPHY_AVAILABLE` above) so it can't depend on
+        # singleton init order.
+        self._crypto_ok = _CRYPTOGRAPHY_AVAILABLE
 
     def _ensure_dir(self) -> None:
         self.data_dir.mkdir(parents=True, exist_ok=True)
@@ -341,6 +365,7 @@ class EncryptedFileBackend(SecretsBackend):
 
     def _get_fernet(self):
         from cryptography.fernet import Fernet
+
         if self._fernet is None:
             self._fernet = Fernet(self._load_or_create_master_key())
         return self._fernet
@@ -375,6 +400,7 @@ class EncryptedFileBackend(SecretsBackend):
             return self._cache
         try:
             from cryptography.fernet import InvalidToken  # noqa: F401
+
             blob = self.secrets_path.read_bytes()
             plaintext = self._get_fernet().decrypt(blob)
             self._cache = json.loads(plaintext.decode("utf-8"))
@@ -489,7 +515,9 @@ class SecretsManager:
         if self.enable_keyring:
             self.read_backends.append(self.keyring_backend)
         else:
-            logger.debug("Keyring backend disabled - will not check keyring for secrets")
+            logger.debug(
+                "Keyring backend disabled - will not check keyring for secrets"
+            )
 
         # Write backend (configurable based on deployment)
         self.write_backend_name = write_backend
@@ -502,15 +530,15 @@ class SecretsManager:
         self.write_backend = backend_map.get(write_backend, self.encrypted_backend)
 
         logger.info(f"Secrets manager initialized (write backend: {write_backend})")
-    
+
     def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
         """
         Get a secret, trying all backends in priority order.
-        
+
         Args:
             key: Secret key to retrieve
             default: Default value if not found
-            
+
         Returns:
             Secret value or default
         """
@@ -519,28 +547,28 @@ class SecretsManager:
                 value = backend.get(key)
                 if value:
                     return value
-        
+
         logger.debug(f"Secret '{key}' not found in any backend")
         return default
-    
+
     def set(self, key: str, value: str) -> bool:
         """
         Set a secret using the configured write backend.
-        
+
         Also updates os.environ so the in-process environment stays in sync
         (prevents stale values from the EnvironmentBackend shadowing new ones).
-        
+
         Args:
             key: Secret key
             value: Secret value
-            
+
         Returns:
             True if successful
         """
         if not self.write_backend.is_available():
             logger.error(f"Write backend '{self.write_backend_name}' not available")
             return False
-        
+
         result = self.write_backend.set(key, value)
         if result:
             if value:
@@ -548,14 +576,14 @@ class SecretsManager:
             elif key in os.environ:
                 del os.environ[key]
         return result
-    
+
     def delete(self, key: str) -> bool:
         """
         Delete a secret from all backends.
-        
+
         Args:
             key: Secret key to delete
-            
+
         Returns:
             True if successful
         """
@@ -570,54 +598,173 @@ class SecretsManager:
                 if not backend.delete(key):
                     success = False
         return success
-    
+
     def get_backend_status(self) -> Dict[str, Any]:
         """Get status of all backends."""
+        master_key_path = self.encrypted_backend.master_key_path
         return {
             "encrypted": {
                 "available": self.encrypted_backend.is_available(),
                 "path": str(self.encrypted_backend.secrets_path),
-                "description": "Project-local encrypted file (preferred)"
+                "secrets_file_exists": self.encrypted_backend.secrets_path.exists(),
+                "master_key_present": master_key_path.exists(),
+                "master_key_path": str(master_key_path),
+                "description": "Project-local encrypted file (preferred)",
             },
             "environment": {
                 "available": self.env_backend.is_available(),
-                "description": "Environment variables (best for containers/servers)"
+                "description": "Environment variables (best for containers/servers)",
             },
             "dotenv": {
                 "available": self.dotenv_backend.is_available(),
                 "path": str(self.dotenv_backend.env_file),
-                "description": "File-based secrets (legacy)"
+                "exists": self.dotenv_backend.env_file.exists(),
+                "description": "File-based secrets (legacy)",
             },
             "keyring": {
                 "available": self.keyring_backend.is_available(),
-                "description": "OS keyring (macOS/Windows/Linux credential managers)"
+                "description": "OS keyring (macOS/Windows/Linux credential managers)",
             },
-            "write_backend": self.write_backend_name
+            "cryptography_available": _CRYPTOGRAPHY_AVAILABLE,
+            "write_backend": self.write_backend_name,
+            "read_backends": [type(b).__name__ for b in self.read_backends],
+            "expected_write_backend": os.environ.get("SECRETS_BACKEND", "encrypted"),
         }
+
+    def migrate_dotenv_secrets_to_encrypted(
+        self,
+        keys: Optional[list[str]] = None,
+        remove_from_dotenv: bool = True,
+    ) -> Dict[str, Any]:
+        """Move secrets from the dotenv backend to the encrypted backend.
+
+        For each key currently stored in ``~/.deeptempo/.env`` (the dotenv
+        backend's file):
+
+        - If the encrypted store doesn't have the key, copy it across, then
+          delete from the dotenv file (when ``remove_from_dotenv`` is True).
+        - If the encrypted store already has the SAME value, just remove
+          the dotenv copy.
+        - If the encrypted store has a DIFFERENT value, the encrypted store
+          wins. The dotenv copy is left in place and the conflict is
+          reported so an operator can resolve it manually.
+
+        Args:
+            keys: Optional explicit allow-list. When None, every key in
+                the dotenv file is considered.
+            remove_from_dotenv: When False, copy to encrypted but don't
+                delete the dotenv source — useful for dry-run validation.
+
+        Returns:
+            Structured report::
+
+                {
+                    "migrated":  [keys copied + (optionally) removed from dotenv],
+                    "already_present": [keys whose value matched encrypted],
+                    "conflicts": [{"key": ..., "reason": "value_mismatch"}],
+                    "errors":    [{"key": ..., "error": "..."}],
+                    "encrypted_available": bool,
+                    "dotenv_path": str,
+                }
+        """
+        result: Dict[str, Any] = {
+            "migrated": [],
+            "already_present": [],
+            "conflicts": [],
+            "errors": [],
+            "encrypted_available": self.encrypted_backend.is_available(),
+            "dotenv_path": str(self.dotenv_backend.env_file),
+        }
+
+        if not self.encrypted_backend.is_available():
+            result["errors"].append(
+                {
+                    "key": "<all>",
+                    "error": (
+                        "Encrypted backend unavailable; refusing to migrate. "
+                        "Install `cryptography` and ensure ~/.vigil/master.key "
+                        "exists, then retry."
+                    ),
+                }
+            )
+            return result
+
+        # Reload the dotenv cache so the migration sees the latest file
+        # (the cache is populated only at __init__ time otherwise).
+        self.dotenv_backend._cache = {}
+        self.dotenv_backend._load_env_file()
+        dotenv_keys = list(self.dotenv_backend._cache.keys())
+        if keys is not None:
+            dotenv_keys = [k for k in dotenv_keys if k in set(keys)]
+
+        for key in dotenv_keys:
+            try:
+                dotenv_value = self.dotenv_backend.get(key)
+                if dotenv_value is None or dotenv_value == "":
+                    continue
+                encrypted_value = self.encrypted_backend.get(key)
+
+                if encrypted_value is not None and encrypted_value != "":
+                    if encrypted_value == dotenv_value:
+                        # Already migrated; just clean up the dotenv copy.
+                        if remove_from_dotenv:
+                            self.dotenv_backend.delete(key)
+                        result["already_present"].append(key)
+                    else:
+                        # Encrypted store wins. Leave both untouched.
+                        result["conflicts"].append(
+                            {"key": key, "reason": "value_mismatch"}
+                        )
+                    continue
+
+                if not self.encrypted_backend.set(key, dotenv_value):
+                    result["errors"].append(
+                        {"key": key, "error": "encrypted set() returned False"}
+                    )
+                    continue
+                if remove_from_dotenv:
+                    self.dotenv_backend.delete(key)
+                result["migrated"].append(key)
+            except Exception as e:  # pragma: no cover - defensive
+                result["errors"].append({"key": key, "error": str(e)})
+
+        return result
 
 
 # Global secrets manager instance
 _secrets_manager: Optional[SecretsManager] = None
 
 
-def get_secrets_manager(write_backend: Optional[str] = None, enable_keyring: Optional[bool] = None) -> SecretsManager:
+def get_secrets_manager(
+    write_backend: Optional[str] = None,
+    enable_keyring: Optional[bool] = None,
+    force_reload: bool = False,
+) -> SecretsManager:
     """
     Get or create the global secrets manager instance.
-    
+
     Args:
         write_backend: Backend to use for writing secrets
                       Can be set via SECRETS_BACKEND env var
         enable_keyring: Whether to enable keyring for reading secrets
                        Can be set via ENABLE_KEYRING env var or general config
                        Default: False (prevents macOS keychain prompts)
+        force_reload: When True, drop the cached singleton and rebuild it.
+                     Useful for recovering a process that picked the wrong
+                     write backend on first init (e.g. cryptography wasn't
+                     yet importable) without bouncing uvicorn. Exposed via
+                     POST /api/config/secrets/reinit.
     """
     global _secrets_manager
-    
+
+    if force_reload:
+        _secrets_manager = None
+
     if _secrets_manager is None:
         # Check environment variable for backend preference
         if write_backend is None:
             write_backend = os.environ.get("SECRETS_BACKEND", "encrypted")
-        
+
         # Check if keyring should be enabled (priority order: arg > env var > config file)
         if enable_keyring is None:
             # Check environment variable first
@@ -631,24 +778,28 @@ def get_secrets_manager(write_backend: Optional[str] = None, enable_keyring: Opt
                 try:
                     from pathlib import Path
                     import json
-                    config_file = Path.home() / '.deeptempo' / 'general_config.json'
+
+                    config_file = Path.home() / ".deeptempo" / "general_config.json"
                     if config_file.exists():
-                        with open(config_file, 'r') as f:
+                        with open(config_file, "r") as f:
                             config = json.load(f)
-                            enable_keyring = config.get('enable_keyring', False)
+                            enable_keyring = config.get("enable_keyring", False)
                     else:
                         enable_keyring = False
                 except Exception as e:
-                    logger.debug(f"Could not read general config for keyring setting: {e}")
+                    logger.debug(
+                        f"Could not read general config for keyring setting: {e}"
+                    )
                     enable_keyring = False
-        
+
         _secrets_manager = SecretsManager(
-            write_backend=write_backend,
-            enable_keyring=enable_keyring
+            write_backend=write_backend, enable_keyring=enable_keyring
         )
-        
-        logger.info(f"Secrets manager initialized: backend={write_backend}, keyring={enable_keyring}")
-    
+
+        logger.info(
+            f"Secrets manager initialized: backend={write_backend}, keyring={enable_keyring}"
+        )
+
     return _secrets_manager
 
 
@@ -665,4 +816,3 @@ def set_secret(key: str, value: str) -> bool:
 def delete_secret(key: str) -> bool:
     """Convenience function to delete a secret."""
     return get_secrets_manager().delete(key)
-

--- a/backend/tools/__init__.py
+++ b/backend/tools/__init__.py
@@ -1,0 +1,6 @@
+"""Operational utilities for Vigil's backend.
+
+Modules in this package are meant to be invoked as ``python -m
+backend.tools.<name>`` for one-shot operator tasks (migrations,
+diagnostics) that should not run as part of the normal request flow.
+"""

--- a/backend/tools/migrate_secrets.py
+++ b/backend/tools/migrate_secrets.py
@@ -1,0 +1,79 @@
+"""CLI: move secrets from ~/.deeptempo/.env into ~/.vigil/secrets.enc.
+
+Wraps ``SecretsManager.migrate_dotenv_secrets_to_encrypted`` so an operator
+can run the migration outside the running backend, e.g. before the first
+restart that picks up the eager-cryptography fix.
+
+Usage:
+
+    # Move every key, removing each from the dotenv file as it's migrated:
+    python -m backend.tools.migrate_secrets
+
+    # Dry-run (don't touch the dotenv source):
+    python -m backend.tools.migrate_secrets --dry-run
+
+    # Restrict to specific keys:
+    python -m backend.tools.migrate_secrets --keys VSTRIKE_USERNAME VSTRIKE_PASSWORD
+
+Encrypted store is authoritative on conflicts. If a key exists in both
+the dotenv file and ``secrets.enc`` with different values, the migrator
+leaves both untouched and reports the conflict so the operator can
+resolve it manually.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import List, Optional
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="migrate_secrets",
+        description=(
+            "Move secrets from the dotenv backend (~/.deeptempo/.env) into "
+            "the encrypted backend (~/.vigil/secrets.enc)."
+        ),
+    )
+    parser.add_argument(
+        "--keys",
+        nargs="*",
+        default=None,
+        help=(
+            "Optional allow-list of keys to migrate. If omitted, every key "
+            "found in the dotenv file is considered."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Copy to encrypted but don't delete from the dotenv source. "
+            "Useful for previewing what the migration would do."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    from backend.secrets_manager import get_secrets_manager
+
+    mgr = get_secrets_manager()
+    report = mgr.migrate_dotenv_secrets_to_encrypted(
+        keys=args.keys,
+        remove_from_dotenv=not args.dry_run,
+    )
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+    if not report["encrypted_available"]:
+        return 2
+    if report["errors"]:
+        return 1
+    if report["conflicts"]:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/env.example
+++ b/env.example
@@ -7,7 +7,7 @@
 # -----------------------------------------------------------------------------
 # DEV_MODE bypasses authentication for rapid local development
 # ⚠️  WARNING: NEVER enable this in staging or production!
-# 
+#
 # When enabled (this single setting controls BOTH backend AND frontend):
 #   - Backend: JWT auth is bypassed, returns mock admin user
 #   - Frontend: Login UI is bypassed, uses mock admin user
@@ -18,12 +18,12 @@
 # No need to configure the frontend separately.
 #
 # See DEV_MODE.md for full details
-DEV_MODE=true
+DEV_MODE = true
 
 # -----------------------------------------------------------------------------
 # Core AI Configuration
 # -----------------------------------------------------------------------------
-ANTHROPIC_API_KEY="sk-ant-api03-..."
+ANTHROPIC_API_KEY = "sk-ant-api03-..."
 
 # Extra model IDs to always include in the Settings dropdown, on top of
 # whatever upstream /v1/models returns. Intended for IDs the provider
@@ -43,13 +43,13 @@ ANTHROPIC_API_KEY="sk-ant-api03-..."
 # -----------------------------------------------------------------------------
 # Database
 # -----------------------------------------------------------------------------
-DATABASE_URL="postgresql://deeptempo:deeptempo_secure_password_change_me@localhost:5432/deeptempo_soc"
-POSTGRES_PASSWORD="deeptempo_secure_password_change_me"
+DATABASE_URL = "postgresql://deeptempo:deeptempo_secure_password_change_me@localhost:5432/deeptempo_soc"
+POSTGRES_PASSWORD = "deeptempo_secure_password_change_me"
 
 # -----------------------------------------------------------------------------
 # Redis (LLM job queue + session store)
 # -----------------------------------------------------------------------------
-REDIS_URL="redis://localhost:6379/0"
+REDIS_URL = "redis://localhost:6379/0"
 
 
 # -----------------------------------------------------------------------------
@@ -57,13 +57,25 @@ REDIS_URL="redis://localhost:6379/0"
 # -----------------------------------------------------------------------------
 # Set to 0.0.0.0 to allow external/remote access (e.g. deploying on a VM)
 # Default 127.0.0.1 restricts access to localhost only
-BIND_HOST="127.0.0.1"
+BIND_HOST = "127.0.0.1"
 
 # -----------------------------------------------------------------------------
 # Secrets Backend
 # -----------------------------------------------------------------------------
-SECRETS_BACKEND="dotenv"
-ENABLE_KEYRING="false"
+# Where Vigil writes credentials saved through the Settings UI / API.
+#   - "encrypted" (recommended): AES-encrypted blob at ~/.vigil/secrets.enc.
+#     The master key auto-generates on first use at ~/.vigil/master.key
+#     (chmod 600). Requires the `cryptography` package, which ships with
+#     requirements.txt. This is the right choice for almost everyone.
+#   - "dotenv": plaintext ~/.deeptempo/.env. Use only in environments where
+#     `cryptography` can't be installed.
+#   - "keyring": OS credential manager (macOS Keychain etc). Triggers
+#     interactive prompts on macOS, off by default.
+# Reads always traverse encrypted → env → dotenv → keyring regardless of
+# this setting, so existing dotenv secrets keep working until you run
+# `python -m backend.tools.migrate_secrets` to move them encrypted-side.
+SECRETS_BACKEND = "encrypted"
+ENABLE_KEYRING = "false"
 
 # -----------------------------------------------------------------------------
 # Authentication
@@ -71,26 +83,26 @@ ENABLE_KEYRING="false"
 # JWT signing secret. REQUIRED when DEV_MODE=false — startup will fail without
 # it. In DEV_MODE the service falls back to a predictable dev value and logs a
 # warning. Generate a strong value with: python -c "import secrets; print(secrets.token_urlsafe(64))"
-JWT_SECRET_KEY=""
+JWT_SECRET_KEY = ""
 
 # Account lockout — after N consecutive failed logins the account is locked
 # for DURATION minutes. Successful login resets the counter.
-AUTH_LOCKOUT_THRESHOLD="5"
-AUTH_LOCKOUT_DURATION_MINUTES="15"
+AUTH_LOCKOUT_THRESHOLD = "5"
+AUTH_LOCKOUT_DURATION_MINUTES = "15"
 
 # Password policy (length-forward, NIST 800-63B aligned).
-AUTH_MIN_PASSWORD_LENGTH="12"
+AUTH_MIN_PASSWORD_LENGTH = "12"
 # Reject reuse of the last N passwords. Stored as bcrypt hashes in the
 # users.password_history JSONB column; older entries are evicted.
-AUTH_PASSWORD_HISTORY_LIMIT="5"
+AUTH_PASSWORD_HISTORY_LIMIT = "5"
 
 # Password reset signed-token TTL (seconds). Reset tokens are single-use
 # and auto-expire after this window.
-PASSWORD_RESET_TTL_SECONDS="3600"
+PASSWORD_RESET_TTL_SECONDS = "3600"
 
 # Frontend URL used to build password-reset links sent via email. When
 # unset the reset email includes the raw token with a "(token)" prefix.
-VIGIL_FRONTEND_URL=""
+VIGIL_FRONTEND_URL = ""
 
 # -----------------------------------------------------------------------------
 # Email (password reset + future notifications)
@@ -98,13 +110,13 @@ VIGIL_FRONTEND_URL=""
 # Backend selector: "console" logs messages to the app log (dev default);
 # "smtp" sends via an SMTP relay configured below. No external provider
 # SDK is required — point SMTP_HOST at SES / SendGrid / Mailgun / etc.
-VIGIL_EMAIL_BACKEND="console"
-SMTP_HOST=""
-SMTP_PORT="587"
-SMTP_USER=""
-SMTP_PASSWORD=""
-SMTP_TLS="true"
-SMTP_FROM="noreply@vigil.local"
+VIGIL_EMAIL_BACKEND = "console"
+SMTP_HOST = ""
+SMTP_PORT = "587"
+SMTP_USER = ""
+SMTP_PASSWORD = ""
+SMTP_TLS = "true"
+SMTP_FROM = "noreply@vigil.local"
 
 # -----------------------------------------------------------------------------
 # HTTP Security (CORS + security headers)
@@ -112,22 +124,22 @@ SMTP_FROM="noreply@vigil.local"
 # CORS origins. Comma-separated list. Leave unset to use the built-in dev
 # defaults (localhost:6988, :3000, :5173). Production deployments MUST set
 # this to the real origin(s), e.g. "https://vigil.example.com".
-VIGIL_CORS_ORIGINS=""
+VIGIL_CORS_ORIGINS = ""
 
 # Security headers — each one can be toggled off if a reverse proxy in front
 # of the backend already sets it (to avoid duplicate values).
-VIGIL_HSTS_ENABLED="true"
-VIGIL_HSTS_MAX_AGE="31536000"
-VIGIL_FRAME_OPTIONS_ENABLED="true"
-VIGIL_CONTENT_TYPE_OPTIONS_ENABLED="true"
-VIGIL_REFERRER_POLICY_ENABLED="true"
+VIGIL_HSTS_ENABLED = "true"
+VIGIL_HSTS_MAX_AGE = "31536000"
+VIGIL_FRAME_OPTIONS_ENABLED = "true"
+VIGIL_CONTENT_TYPE_OPTIONS_ENABLED = "true"
+VIGIL_REFERRER_POLICY_ENABLED = "true"
 
 # Content-Security-Policy. VIGIL_CSP_POLICY overrides the default entirely.
 # The default policy allows 'unsafe-inline' for styles (required by MUI) but
 # not for scripts. If you serve the frontend from a different origin than the
 # API you may need to widen connect-src.
-VIGIL_CSP_ENABLED="true"
-VIGIL_CSP_POLICY=""
+VIGIL_CSP_ENABLED = "true"
+VIGIL_CSP_POLICY = ""
 
 # -----------------------------------------------------------------------------
 # CSRF Protection
@@ -135,13 +147,13 @@ VIGIL_CSP_POLICY=""
 # Double-submit cookie pattern, enabled by default alongside the cookie-based
 # auth migration. The frontend's axios interceptor reads csrf_token and
 # echoes it as the X-CSRF-Token header on mutating requests.
-VIGIL_CSRF_ENABLED="true"
+VIGIL_CSRF_ENABLED = "true"
 # Report-only logs violations without rejecting. Keep "true" for one rollout
 # window, then flip to "false" to enforce.
-VIGIL_CSRF_REPORT_ONLY="true"
+VIGIL_CSRF_REPORT_ONLY = "true"
 # Comma-separated path prefixes exempt from CSRF checks (webhooks that
 # authenticate themselves with HMAC, server-to-server ingestion endpoints).
-VIGIL_CSRF_EXEMPT_PATHS="/api/webhooks/,/api/ingest/"
+VIGIL_CSRF_EXEMPT_PATHS = "/api/webhooks/,/api/ingest/"
 
 # -----------------------------------------------------------------------------
 # Auth Cookies (HttpOnly access_token + refresh_token)
@@ -149,67 +161,67 @@ VIGIL_CSRF_EXEMPT_PATHS="/api/webhooks/,/api/ingest/"
 # Whether the csrf_token and auth cookies should be set with Secure.
 # Leave "true" for anything served over HTTPS; set "false" ONLY for local
 # HTTP dev.
-VIGIL_COOKIE_SECURE="true"
+VIGIL_COOKIE_SECURE = "true"
 # SameSite attribute on auth cookies. "strict" is strongest; use "lax" if
 # the deployment has SSO redirects that need cookies on cross-site nav.
 # "none" requires Secure=true and is only sensible for cross-origin setups.
-VIGIL_COOKIE_SAMESITE="strict"
+VIGIL_COOKIE_SAMESITE = "strict"
 
 # -----------------------------------------------------------------------------
 # MemPalace — Persistent AI Memory Layer
 # -----------------------------------------------------------------------------
 # Path to the ChromaDB palace data directory (used by MCP server and Python API)
-MEMPALACE_PALACE_PATH="~/.vigil/mempalace/palace"
+MEMPALACE_PALACE_PATH = "~/.vigil/mempalace/palace"
 # Set to true to enable cross-run memory in the autonomous daemon
-MEMPALACE_DAEMON_ENABLED="false"
+MEMPALACE_DAEMON_ENABLED = "false"
 
 # -----------------------------------------------------------------------------
 # Data Source Integrations
 # -----------------------------------------------------------------------------
 
 # Splunk SIEM
-SPLUNK_URL="https://splunk.example.com:8089"
-SPLUNK_USERNAME="admin"
-SPLUNK_PASSWORD="your_splunk_password"
+SPLUNK_URL = "https://splunk.example.com:8089"
+SPLUNK_USERNAME = "admin"
+SPLUNK_PASSWORD = "your_splunk_password"
 # Note: Splunk's REST API on port 8089 uses HTTPS by default
 # Set SPLUNK_URL to https://splunk.example.com:8089, not http://
 
 # CrowdStrike Falcon
-CROWDSTRIKE_CLIENT_ID=""
-CROWDSTRIKE_CLIENT_SECRET=""
-CROWDSTRIKE_BASE_URL="https://api.crowdstrike.com"
+CROWDSTRIKE_CLIENT_ID = ""
+CROWDSTRIKE_CLIENT_SECRET = ""
+CROWDSTRIKE_BASE_URL = "https://api.crowdstrike.com"
 
 # Elastic Security / Elasticsearch SIEM
-ELASTIC_HOST="https://elasticsearch.example.com:9200"
-ELASTIC_KIBANA_URL="https://kibana.example.com:5601"
-ELASTIC_API_KEY=""
+ELASTIC_HOST = "https://elasticsearch.example.com:9200"
+ELASTIC_KIBANA_URL = "https://kibana.example.com:5601"
+ELASTIC_API_KEY = ""
 # Alternative to API key — basic auth:
 # ELASTIC_USERNAME="elastic"
 # ELASTIC_PASSWORD="your_elastic_password"
-ELASTIC_VERIFY_SSL="true"
-ELASTIC_INDEX_PATTERN=".alerts-security.alerts-default"
+ELASTIC_VERIFY_SSL = "true"
+ELASTIC_INDEX_PATTERN = ".alerts-security.alerts-default"
 
 # Timesketch
-TIMESKETCH_URL="http://localhost:5000"
-TIMESKETCH_USERNAME="admin"
-TIMESKETCH_PASSWORD="your_timesketch_password"
+TIMESKETCH_URL = "http://localhost:5000"
+TIMESKETCH_USERNAME = "admin"
+TIMESKETCH_PASSWORD = "your_timesketch_password"
 
 # Cribl Stream
-CRIBL_URL="https://cribl.example.com:9000"
-CRIBL_USERNAME="admin"
-CRIBL_PASSWORD="your_cribl_password"
-CRIBL_WORKER_GROUP="default"
+CRIBL_URL = "https://cribl.example.com:9000"
+CRIBL_USERNAME = "admin"
+CRIBL_PASSWORD = "your_cribl_password"
+CRIBL_WORKER_GROUP = "default"
 
 # Darktrace (inbound webhook receiver — push-only in this integration)
 # Works with both SaaS tenants and on-prem master appliances.
 # DARKTRACE_URL is optional; when set it's used to build back-links from
 # findings into the Darktrace console (SaaS: https://<tenant>.cloud.darktrace.com,
 # on-prem: https://<master-ip-or-host>).
-DARKTRACE_ENABLED="false"
-DARKTRACE_URL=""
-DARKTRACE_WEBHOOK_SECRET=""
+DARKTRACE_ENABLED = "false"
+DARKTRACE_URL = ""
+DARKTRACE_WEBHOOK_SECRET = ""
 # Optional hard cap on webhook body size (KB). Default 1024.
-DARKTRACE_MAX_BODY_KB="1024"
+DARKTRACE_MAX_BODY_KB = "1024"
 
 # VStrike (CloudCurrent network topology fusion layer)
 # Outbound: Vigil queries VStrike for asset topology / blast radius.
@@ -221,100 +233,100 @@ DARKTRACE_MAX_BODY_KB="1024"
 # these are set, the frontend hard-replaces the EntityGraph with a
 # VStrike iframe in the Dashboard "Entity Graph" tab and the Investigation
 # workspace.
-VSTRIKE_BASE_URL="https://vstrike.net"
-VSTRIKE_API_KEY=""
-VSTRIKE_VERIFY_SSL="true"
-VSTRIKE_INBOUND_API_KEY=""
-VSTRIKE_USERNAME=""
-VSTRIKE_PASSWORD=""
+VSTRIKE_BASE_URL = "https://vstrike.net"
+VSTRIKE_API_KEY = ""
+VSTRIKE_VERIFY_SSL = "true"
+VSTRIKE_INBOUND_API_KEY = ""
+VSTRIKE_USERNAME = ""
+VSTRIKE_PASSWORD = ""
 
 # -----------------------------------------------------------------------------
 # Threat Intelligence
 # -----------------------------------------------------------------------------
 
 # VirusTotal
-VIRUSTOTAL_API_KEY=""
+VIRUSTOTAL_API_KEY = ""
 
 # Shodan
-SHODAN_API_KEY=""
+SHODAN_API_KEY = ""
 
 # AlienVault OTX
-ALIENVAULT_OTX_API_KEY=""
+ALIENVAULT_OTX_API_KEY = ""
 
 # Cloudforce One STIX/TAXII threat-intel feed (Cloudflare partnership).
 # Configure via Settings → Integrations → Cloudflare Cloudforce One; these
 # env vars are fallbacks only. Polling is disabled when the integration
 # itself is not enabled — these vars do nothing on their own.
-CLOUDFORCE_ONE_API_TOKEN=""
-CLOUDFORCE_ONE_TAXII_SERVER_URL=""
-CLOUDFORCE_ONE_COLLECTION_IDS=""
+CLOUDFORCE_ONE_API_TOKEN = ""
+CLOUDFORCE_ONE_TAXII_SERVER_URL = ""
+CLOUDFORCE_ONE_COLLECTION_IDS = ""
 # How often the daemon pulls TAXII collections. Minimum enforced at 60s.
-THREAT_FEED_POLL_INTERVAL="900"
+THREAT_FEED_POLL_INTERVAL = "900"
 
 # Cloudflare Cloudy webhook ingestion (gated; off by default).
 # Flip CLOUDY_INGESTION_ENABLED=true once the Cloudflare partnership confirms
 # the public webhook contract. The receiver also requires CLOUDY_WEBHOOK_SECRET
 # for HMAC verification — without it, the endpoint returns 503.
-CLOUDY_INGESTION_ENABLED="false"
-CLOUDY_WEBHOOK_SECRET=""
-CLOUDY_WEBHOOK_MAX_BODY_KB="1024"
+CLOUDY_INGESTION_ENABLED = "false"
+CLOUDY_WEBHOOK_SECRET = ""
+CLOUDY_WEBHOOK_MAX_BODY_KB = "1024"
 
 # -----------------------------------------------------------------------------
 # Sandbox / Malware Detonation (issue #86)
 # -----------------------------------------------------------------------------
 # Joe Sandbox (external MCP server — see mcp-config.json joe-sandbox entry)
-JOE_SANDBOX_ENABLED="false"
-JOE_SANDBOX_URL="https://jbxcloud.joesecurity.org/api"
-JOE_SANDBOX_API_KEY=""
+JOE_SANDBOX_ENABLED = "false"
+JOE_SANDBOX_URL = "https://jbxcloud.joesecurity.org/api"
+JOE_SANDBOX_API_KEY = ""
 
 # CAPE Sandbox (open-source Cuckoo fork — tools/cape_sandbox.py)
 # Assumes you bring your own CAPE deployment (docker-compose self-hosting is
 # out of scope; CAPE needs KVM + Windows guest VMs).
-CAPE_SANDBOX_ENABLED="false"
-CAPE_SANDBOX_URL="http://localhost:8000"
-CAPE_SANDBOX_API_KEY=""
+CAPE_SANDBOX_ENABLED = "false"
+CAPE_SANDBOX_URL = "http://localhost:8000"
+CAPE_SANDBOX_API_KEY = ""
 
 # Hybrid Analysis / Any.Run already use get_integration_config(); these flags
 # just toggle whether the daemon auto-submission pipeline consults them.
-HYBRID_ANALYSIS_ENABLED="false"
-ANYRUN_ENABLED="false"
+HYBRID_ANALYSIS_ENABLED = "false"
+ANYRUN_ENABLED = "false"
 
 # Auto-submission pipeline (off by default — opt-in)
 # When true, daemon/processor.py will call sandbox search APIs during the
 # enrichment step for each file hash on a finding. Binary upload is NOT
 # performed from Vigil — only hash-cache lookups + submission-by-hash where
 # the sandbox supports it.
-SANDBOX_AUTO_SUBMIT="false"
-SANDBOX_MAX_FILE_SIZE_MB="100"
-SANDBOX_ALLOWED_FILE_TYPES="exe,dll,doc,docx,xls,xlsx,pdf,js,vbs,ps1,bat,msi"
-SANDBOX_ANALYSIS_TIMEOUT="300"
-SANDBOX_POLL_INTERVAL="60"
+SANDBOX_AUTO_SUBMIT = "false"
+SANDBOX_MAX_FILE_SIZE_MB = "100"
+SANDBOX_ALLOWED_FILE_TYPES = "exe,dll,doc,docx,xls,xlsx,pdf,js,vbs,ps1,bat,msi"
+SANDBOX_ANALYSIS_TIMEOUT = "300"
+SANDBOX_POLL_INTERVAL = "60"
 
 # -----------------------------------------------------------------------------
 # Notification / Escalation
 # -----------------------------------------------------------------------------
 
 # Slack
-SLACK_BOT_TOKEN="xoxb-..."
-SLACK_DEFAULT_CHANNEL="#soc-alerts"
+SLACK_BOT_TOKEN = "xoxb-..."
+SLACK_DEFAULT_CHANNEL = "#soc-alerts"
 
 # PagerDuty
-PAGERDUTY_ROUTING_KEY=""
+PAGERDUTY_ROUTING_KEY = ""
 
 # Microsoft Teams
-TEAMS_WEBHOOK_URL=""
+TEAMS_WEBHOOK_URL = ""
 
 # -----------------------------------------------------------------------------
 # Cloud Integrations
 # -----------------------------------------------------------------------------
 
 # AWS
-AWS_ACCESS_KEY_ID="AKIA..."
-AWS_SECRET_ACCESS_KEY="..."
-AWS_REGION="us-east-1"
+AWS_ACCESS_KEY_ID = "AKIA..."
+AWS_SECRET_ACCESS_KEY = "..."
+AWS_REGION = "us-east-1"
 
 # GitHub (for skill installer)
-GITHUB_TOKEN="ghp_..."
+GITHUB_TOKEN = "ghp_..."
 
 # =============================================================================
 # SOC Daemon Configuration
@@ -324,131 +336,131 @@ GITHUB_TOKEN="ghp_..."
 # Polling Intervals (seconds)
 # -----------------------------------------------------------------------------
 # 5 minutes
-DAEMON_SPLUNK_POLL_INTERVAL="300"
+DAEMON_SPLUNK_POLL_INTERVAL = "300"
 # 1 minute
-DAEMON_CROWDSTRIKE_POLL_INTERVAL="60"
+DAEMON_CROWDSTRIKE_POLL_INTERVAL = "60"
 
 # -----------------------------------------------------------------------------
 # Webhook Ingestion
 # -----------------------------------------------------------------------------
-DAEMON_WEBHOOK_ENABLED="true"
-DAEMON_WEBHOOK_PORT="8081"
+DAEMON_WEBHOOK_ENABLED = "true"
+DAEMON_WEBHOOK_PORT = "8081"
 
 # -----------------------------------------------------------------------------
 # AI Processing
 # -----------------------------------------------------------------------------
 # Enable AI-powered triage
-DAEMON_AUTO_TRIAGE="true"
+DAEMON_AUTO_TRIAGE = "true"
 # Enable threat intel enrichment
-DAEMON_AUTO_ENRICH="true"
+DAEMON_AUTO_ENRICH = "true"
 # Findings to process per batch
-DAEMON_BATCH_SIZE="10"
+DAEMON_BATCH_SIZE = "10"
 
 # -----------------------------------------------------------------------------
 # Autonomous Response
 # -----------------------------------------------------------------------------
 # Enable autonomous response actions
-DAEMON_AUTO_RESPONSE="true"
+DAEMON_AUTO_RESPONSE = "true"
 # Auto-execute above this confidence
-DAEMON_CONFIDENCE_THRESHOLD="0.90"
+DAEMON_CONFIDENCE_THRESHOLD = "0.90"
 # Require approval for all actions
-DAEMON_FORCE_APPROVAL="false"
+DAEMON_FORCE_APPROVAL = "false"
 # Log actions without executing
-DAEMON_DRY_RUN="false"
+DAEMON_DRY_RUN = "false"
 
 # -----------------------------------------------------------------------------
 # Escalation
 # -----------------------------------------------------------------------------
-DAEMON_ESCALATION_ENABLED="true"
-DAEMON_ESCALATE_SEVERITIES="critical,high"
-DAEMON_SLACK_ENABLED="true"
-DAEMON_SLACK_CHANNEL="#soc-alerts"
-DAEMON_PAGERDUTY_ENABLED="false"
+DAEMON_ESCALATION_ENABLED = "true"
+DAEMON_ESCALATE_SEVERITIES = "critical,high"
+DAEMON_SLACK_ENABLED = "true"
+DAEMON_SLACK_CHANNEL = "#soc-alerts"
+DAEMON_PAGERDUTY_ENABLED = "false"
 
 # -----------------------------------------------------------------------------
 # Scheduled Tasks
 # -----------------------------------------------------------------------------
-DAEMON_THREAT_HUNT_ENABLED="true"
+DAEMON_THREAT_HUNT_ENABLED = "true"
 # Daily (24 hours)
-DAEMON_THREAT_HUNT_INTERVAL="86400"
+DAEMON_THREAT_HUNT_INTERVAL = "86400"
 # Keep data for 90 days
-DAEMON_CLEANUP_RETENTION_DAYS="90"
+DAEMON_CLEANUP_RETENTION_DAYS = "90"
 
 # -----------------------------------------------------------------------------
 # Metrics / Monitoring
 # -----------------------------------------------------------------------------
-DAEMON_METRICS_ENABLED="true"
-DAEMON_METRICS_PORT="9090"
+DAEMON_METRICS_ENABLED = "true"
+DAEMON_METRICS_PORT = "9090"
 
 # -----------------------------------------------------------------------------
 # Logging
 # -----------------------------------------------------------------------------
 # Allowed values: DEBUG, INFO, WARNING, ERROR
-DAEMON_LOG_LEVEL="INFO"
+DAEMON_LOG_LEVEL = "INFO"
 
 # -----------------------------------------------------------------------------
 # Detection Engineering (Security-Detections-MCP)
 # -----------------------------------------------------------------------------
 # Paths to detection rule repositories (auto-configured by setup_dev.sh)
 # To skip auto-setup: SKIP_DETECTION_REPOS=true ./setup_dev.sh
-SIGMA_PATHS="${HOME}/security-detections/sigma/rules"
-SPLUNK_PATHS="${HOME}/security-detections/security_content/detections"
-ELASTIC_PATHS="${HOME}/security-detections/detection-rules/rules"
-KQL_PATHS="${HOME}/security-detections/Hunting-Queries-Detection-Rules"
-STORY_PATHS="${HOME}/security-detections/security_content/stories"
+SIGMA_PATHS = "${HOME}/security-detections/sigma/rules"
+SPLUNK_PATHS = "${HOME}/security-detections/security_content/detections"
+ELASTIC_PATHS = "${HOME}/security-detections/detection-rules/rules"
+KQL_PATHS = "${HOME}/security-detections/Hunting-Queries-Detection-Rules"
+STORY_PATHS = "${HOME}/security-detections/security_content/stories"
 
 # =============================================================================
 # Autonomous Orchestrator
 # =============================================================================
 
 # Master toggle for autonomous operations
-ORCHESTRATOR_ENABLED="false"
+ORCHESTRATOR_ENABLED = "false"
 
 # How often (seconds) the orchestrator loops check for new work
-ORCHESTRATOR_LOOP_INTERVAL="60"
+ORCHESTRATOR_LOOP_INTERVAL = "60"
 
 # Max sub-agents running simultaneously (respects API rate limits)
-ORCHESTRATOR_MAX_CONCURRENT_AGENTS="3"
+ORCHESTRATOR_MAX_CONCURRENT_AGENTS = "3"
 
 # Per-agent limits
 # Max Claude calls per investigation
-ORCHESTRATOR_MAX_ITERATIONS="50"
+ORCHESTRATOR_MAX_ITERATIONS = "50"
 # Max USD spend per investigation
-ORCHESTRATOR_MAX_COST="5.0"
+ORCHESTRATOR_MAX_COST = "5.0"
 # Max seconds per investigation (1 hour)
-ORCHESTRATOR_MAX_RUNTIME="3600"
+ORCHESTRATOR_MAX_RUNTIME = "3600"
 
 # Global cost guardrails
 # Pause intake if hourly spend exceeds this
-ORCHESTRATOR_MAX_HOURLY_COST="20.0"
+ORCHESTRATOR_MAX_HOURLY_COST = "20.0"
 # Hard daily ceiling
-ORCHESTRATOR_MAX_DAILY_COST="100.0"
+ORCHESTRATOR_MAX_DAILY_COST = "100.0"
 
 # Stale agent detection (seconds of inactivity before killing)
-ORCHESTRATOR_STALE_THRESHOLD="300"
+ORCHESTRATOR_STALE_THRESHOLD = "300"
 
 # Working directory for investigation files
-ORCHESTRATOR_WORKDIR="data/investigations"
+ORCHESTRATOR_WORKDIR = "data/investigations"
 
 # Automatically investigate findings at these severities
-ORCHESTRATOR_AUTO_ASSIGN="true"
-ORCHESTRATOR_AUTO_SEVERITIES="critical,high"
+ORCHESTRATOR_AUTO_ASSIGN = "true"
+ORCHESTRATOR_AUTO_SEVERITIES = "critical,high"
 
 # Dry run mode: agents gather data but skip managed/destructive tool calls
-ORCHESTRATOR_DRY_RUN="false"
+ORCHESTRATOR_DRY_RUN = "false"
 
 # Deduplication window (minutes) for overlapping findings
-ORCHESTRATOR_DEDUP_WINDOW="30"
+ORCHESTRATOR_DEDUP_WINDOW = "30"
 
 # Delay (seconds) between agent loop iterations
-ORCHESTRATOR_AGENT_LOOP_DELAY="2"
+ORCHESTRATOR_AGENT_LOOP_DELAY = "2"
 
 # Max characters of context.md to include in agent prompts
-ORCHESTRATOR_CONTEXT_MAX_CHARS="10000"
+ORCHESTRATOR_CONTEXT_MAX_CHARS = "10000"
 
 # Models used for plan generation and review
-ORCHESTRATOR_PLAN_MODEL="claude-sonnet-4-5-20250929"
-ORCHESTRATOR_REVIEW_MODEL="claude-sonnet-4-5-20250929"
+ORCHESTRATOR_PLAN_MODEL = "claude-sonnet-4-5-20250929"
+ORCHESTRATOR_REVIEW_MODEL = "claude-sonnet-4-5-20250929"
 # =============================================================================
 # OPENTELEMETRY (OTEL) OBSERVABILITY
 # =============================================================================
@@ -456,28 +468,28 @@ ORCHESTRATOR_REVIEW_MODEL="claude-sonnet-4-5-20250929"
 # Enable/disable the full OTEL stack (traces, metrics, structured logging)
 # When true: PrometheusMetricReader serves /metrics on port 9090 and
 #            all processes emit structured JSON logs with trace_id/span_id.
-VIGIL_OTEL_ENABLED="false"
+VIGIL_OTEL_ENABLED = "false"
 
 # OTLP exporter endpoint (gRPC) — points to the OTEL Collector
 # Default: local docker-compose collector
-OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
 
 # Traces sampler — "parentbased_always_on" | "parentbased_traceidratio" | "always_off"
-OTEL_TRACES_SAMPLER="parentbased_always_on"
+OTEL_TRACES_SAMPLER = "parentbased_always_on"
 
 # When using traceidratio, set the sampling fraction (0.0–1.0)
 # OTEL_TRACES_SAMPLER_ARG="0.1"
 
 # Allow LLM prompt/completion content to be recorded in spans (default: false)
 # WARNING: may capture PII / sensitive IOC data — review before enabling
-VIGIL_OTEL_LOG_LLM_CONTENT="false"
+VIGIL_OTEL_LOG_LLM_CONTENT = "false"
 
 # Health server port (daemon only) — /health and /status endpoints
 # Port 9090 is reserved for the Prometheus /metrics endpoint (OTEL reader)
-DAEMON_HEALTH_PORT="9091"
+DAEMON_HEALTH_PORT = "9091"
 
 # Grafana admin password (used by docker-compose observability profile)
-GRAFANA_PASSWORD="admin"
+GRAFANA_PASSWORD = "admin"
 
 # =============================================================================
 # Kafka Ingestion (optional; start with: docker compose --profile kafka up)
@@ -485,22 +497,22 @@ GRAFANA_PASSWORD="admin"
 # Most of these can be overridden at runtime in the Settings > Kafka tab.
 # Secrets (SASL password, SSL cert path) are intentionally env-only — the
 # Settings UI will not read or write them.
-KAFKA_ENABLED="false"
-KAFKA_BOOTSTRAP_SERVERS="localhost:9092"
-KAFKA_CONSUMER_GROUP="vigil-soc"
+KAFKA_ENABLED = "false"
+KAFKA_BOOTSTRAP_SERVERS = "localhost:9092"
+KAFKA_CONSUMER_GROUP = "vigil-soc"
 # Comma-separated list of topics (leave empty to disable until configured)
-KAFKA_TOPICS=""
+KAFKA_TOPICS = ""
 # "latest" (default) | "earliest"
-KAFKA_AUTO_OFFSET_RESET="latest"
+KAFKA_AUTO_OFFSET_RESET = "latest"
 # PLAINTEXT | SSL | SASL_SSL | SASL_PLAINTEXT
-KAFKA_SECURITY_PROTOCOL="PLAINTEXT"
+KAFKA_SECURITY_PROTOCOL = "PLAINTEXT"
 # PLAIN | SCRAM-SHA-256 | SCRAM-SHA-512 (empty if not using SASL)
-KAFKA_SASL_MECHANISM=""
-KAFKA_SASL_USERNAME=""
-KAFKA_SASL_PASSWORD=""
-KAFKA_SSL_CA_LOCATION=""
-KAFKA_MAX_POLL_RECORDS="500"
-KAFKA_SESSION_TIMEOUT_MS="30000"
+KAFKA_SASL_MECHANISM = ""
+KAFKA_SASL_USERNAME = ""
+KAFKA_SASL_PASSWORD = ""
+KAFKA_SSL_CA_LOCATION = ""
+KAFKA_MAX_POLL_RECORDS = "500"
+KAFKA_SESSION_TIMEOUT_MS = "30000"
 
 # =============================================================================
 # Multi-Provider LLM (Issues #84, #88)
@@ -508,42 +520,42 @@ KAFKA_SESSION_TIMEOUT_MS="30000"
 # Bifrost is the single gateway for ALL LLM traffic (GH #84 PR-B). Anthropic
 # calls hit the /anthropic passthrough (preserves extended thinking + prompt
 # caching); OpenAI/Ollama/etc. hit the /v1 OpenAI-format surface.
-BIFROST_URL="http://bifrost:8080"
+BIFROST_URL = "http://bifrost:8080"
 # Kill-switch for Anthropic native prompt caching (GH #84 PR-C). Leave on —
 # cached prefixes cost ~10% of normal input tokens. Set to "false" only to
 # debug whether a problem is cache-related.
-ANTHROPIC_PROMPT_CACHE_ENABLED="true"
+ANTHROPIC_PROMPT_CACHE_ENABLED = "true"
 
 # Conversation-history sliding window (GH #84 PR-D). Caps per-session turns
 # passed to Claude before summarization fires. A "turn" is one user +
 # assistant pair, so 20 = up to 40 messages. Summarization itself costs
 # tokens; avoiding it on short sessions is a cost win. Set to 0 to disable
 # the window and always summarize when context overflows.
-CLAUDE_HISTORY_WINDOW="20"
+CLAUDE_HISTORY_WINDOW = "20"
 
 # Default per-tool-result truncation budget (GH #84 PR-D). Per-tool
 # overrides live in ClaudeService.TOOL_RESPONSE_BUDGETS (e.g. get_raw_logs
 # keeps 30k). Lower to squeeze token spend harder; raise if you see
 # analyses losing critical detail past the truncation marker.
-TOOL_RESPONSE_BUDGET_DEFAULT="8000"
+TOOL_RESPONSE_BUDGET_DEFAULT = "8000"
 
 # Default extended-thinking budget for the autonomous daemon runner
 # (GH #84 PR-D). Per-agent overrides in services/soc_agents.py take
 # precedence when the caller has agent context; the daemon runner falls
 # back to this process-wide default.
-CLAUDE_THINKING_BUDGET="10000"
+CLAUDE_THINKING_BUDGET = "10000"
 
 # Ollama (local or remote). base_url and per-provider config are also stored
 # per-row in llm_provider_configs; these are defaults for first-boot seeding.
-OLLAMA_ENABLED="false"
-OLLAMA_URL="http://localhost:11434"
-OLLAMA_DEFAULT_MODEL="llama3.1:70b"
+OLLAMA_ENABLED = "false"
+OLLAMA_URL = "http://localhost:11434"
+OLLAMA_DEFAULT_MODEL = "llama3.1:70b"
 
 # OpenAI (direct API or OpenAI-compatible endpoint)
-OPENAI_ENABLED="false"
-OPENAI_API_KEY=""
-OPENAI_BASE_URL="https://api.openai.com/v1"
-OPENAI_ORGANIZATION=""
+OPENAI_ENABLED = "false"
+OPENAI_API_KEY = ""
+OPENAI_BASE_URL = "https://api.openai.com/v1"
+OPENAI_ORGANIZATION = ""
 
 # Default provider for new LLM requests when no provider_id is supplied
-DEFAULT_LLM_PROVIDER="anthropic"
+DEFAULT_LLM_PROVIDER = "anthropic"

--- a/frontend/src/components/cases/CaseDetailDialog.tsx
+++ b/frontend/src/components/cases/CaseDetailDialog.tsx
@@ -53,7 +53,7 @@ import { casesApi, findingsApi, timelineApi, graphApi } from '../../services/api
 import ExportToTimesketchDialog from '../timesketch/ExportToTimesketchDialog'
 import JiraExportDialog from '../jira/JiraExportDialog'
 import EventTimeline from '../timeline/EventTimeline'
-import EntityGraph from '../graph/EntityGraph'
+import EntityVisualization from '../graph/EntityVisualization'
 import CaseComments from './CaseComments'
 import CaseEvidence from './CaseEvidence'
 import CaseIOCs from './CaseIOCs'
@@ -559,18 +559,19 @@ export default function CaseDetailDialog({
             <Grid item xs={12} md={6}>
               <Paper sx={{ p: 2, overflow: 'hidden' }}>
                 <Typography variant="h6" gutterBottom>Entity Graph</Typography>
-                {graphData.nodes.length > 0 ? (
-                  <Box sx={{ height: 400, width: '100%', overflow: 'hidden', position: 'relative' }}>
-                    <EntityGraph 
-                      nodes={graphData.nodes} 
-                      links={graphData.links} 
-                      height={400}
-                      showControls={false}
-                    />
-                  </Box>
-                ) : (
-                  <Typography color="text.secondary">No entities to display</Typography>
-                )}
+                <Box sx={{ height: 400, width: '100%', overflow: 'hidden', position: 'relative' }}>
+                  <EntityVisualization
+                    nodes={graphData.nodes}
+                    links={graphData.links}
+                    height={400}
+                    showControls={false}
+                    emptyState={
+                      <Typography color="text.secondary">
+                        No entities to display
+                      </Typography>
+                    }
+                  />
+                </Box>
               </Paper>
             </Grid>
             <Grid item xs={12}>

--- a/frontend/src/components/graph/EntityVisualization.tsx
+++ b/frontend/src/components/graph/EntityVisualization.tsx
@@ -19,7 +19,7 @@
  * to the legacy graph silently.
  */
 
-import { useEffect, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import { Box, CircularProgress } from '@mui/material'
 import { useQuery } from '@tanstack/react-query'
 import EntityGraph, { GraphLink, GraphNode } from './EntityGraph'
@@ -41,6 +41,12 @@ export interface EntityVisualizationProps {
   // VStrike-specific: when present, the iframe auto-loads this network
   // on mount (user can still override via the dropdown).
   vstrikeNetworkId?: string
+
+  // Rendered on the legacy (non-VStrike) path when `nodes.length === 0`.
+  // Lets call sites keep their existing empty-state copy without gating
+  // on node count themselves (which would skip the iframe path entirely
+  // when the case happens to have zero entities).
+  emptyState?: ReactNode
 }
 
 interface VStrikeReadiness {
@@ -73,6 +79,7 @@ export default function EntityVisualization(props: EntityVisualizationProps) {
   const {
     height = 500,
     vstrikeNetworkId,
+    emptyState,
     ...graphProps
   } = props
 
@@ -111,6 +118,10 @@ export default function EntityVisualization(props: EntityVisualizationProps) {
     return (
       <VStrikeIframe height={height} initialNetworkId={vstrikeNetworkId} />
     )
+  }
+
+  if (emptyState !== undefined && (!graphProps.nodes || graphProps.nodes.length === 0)) {
+    return <>{emptyState}</>
   }
 
   return <EntityGraph height={height} {...graphProps} />

--- a/frontend/src/components/timeline/EventVisualizationDialog.tsx
+++ b/frontend/src/components/timeline/EventVisualizationDialog.tsx
@@ -49,7 +49,7 @@ import {
 } from '@mui/icons-material'
 import { format } from 'date-fns'
 import { timelineApi } from '../../services/api'
-import EntityGraph from '../graph/EntityGraph'
+import EntityVisualization from '../graph/EntityVisualization'
 
 interface EventVisualizationDialogProps {
   open: boolean
@@ -342,18 +342,19 @@ export default function EventVisualizationDialog({
                     <Typography variant="h6" gutterBottom>
                       Entity Relationships
                     </Typography>
-                    {vizData.entity_graph && vizData.entity_graph.nodes?.length > 0 ? (
-                      <Box sx={{ height: 400, overflow: 'hidden', position: 'relative' }}>
-                        <EntityGraph 
-                          nodes={vizData.entity_graph.nodes || []} 
-                          links={vizData.entity_graph.links || []} 
-                          height={400}
-                          showControls={false}
-                        />
-                      </Box>
-                    ) : (
-                      <Typography color="textSecondary">No entity graph available</Typography>
-                    )}
+                    <Box sx={{ height: 400, overflow: 'hidden', position: 'relative' }}>
+                      <EntityVisualization
+                        nodes={vizData.entity_graph?.nodes || []}
+                        links={vizData.entity_graph?.links || []}
+                        height={400}
+                        showControls={false}
+                        emptyState={
+                          <Typography color="textSecondary">
+                            No entity graph available
+                          </Typography>
+                        }
+                      />
+                    </Box>
                   </Paper>
                 </Grid>
                 <Grid item xs={12} md={6}>

--- a/services/integration_secrets.py
+++ b/services/integration_secrets.py
@@ -1,0 +1,94 @@
+"""Per-integration registry of secret-typed configuration fields.
+
+Vigil's persistence story for integration credentials is split:
+
+- **Non-secret config** (URLs, regions, verify_ssl flags, paths) goes into the
+  ``IntegrationConfig`` database table via ``database.config_service`` and is
+  mirrored to ``~/.deeptempo/integrations_config.json`` for back-compat.
+- **Secret credentials** (API keys, passwords, bearer tokens) go into the
+  encrypted secrets store at ``~/.vigil/secrets.enc`` via
+  ``backend.secrets_manager.set_secret`` / ``get_secret``.
+
+This module exposes the mapping from frontend form-field name → environment
+variable name (which is also the secrets-store key) for each integration's
+secret-typed fields. The generic ``POST /config/integrations`` save handler
+uses it to:
+
+1. Route the value of each registered secret field through ``set_secret`` so
+   the credential lands in the encrypted store (and ``os.environ`` for the
+   in-process backend, see ``SecretsManager.set``).
+2. Strip the field from the dict that gets persisted to the DB / JSON, so we
+   never write plaintext credentials to those stores.
+3. On read, redact the same fields from the response so secrets don't leak
+   back to the frontend.
+
+When you add a new integration that has password-typed fields in
+``frontend/src/config/integrations.ts``, add a matching entry here.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping
+
+# integration_id → {form_field_name: secrets_manager_key}
+INTEGRATION_SECRET_FIELDS: Mapping[str, Mapping[str, str]] = {
+    "vstrike": {
+        "api_key": "VSTRIKE_API_KEY",
+        "inbound_api_key": "VSTRIKE_INBOUND_API_KEY",
+        "username": "VSTRIKE_USERNAME",
+        "password": "VSTRIKE_PASSWORD",
+    },
+}
+
+
+def secret_fields_for(integration_id: str) -> Mapping[str, str]:
+    """Return the secret-field map for an integration, empty if unregistered."""
+    return INTEGRATION_SECRET_FIELDS.get(integration_id, {})
+
+
+def split_secrets(
+    integration_id: str, config: Dict[str, object]
+) -> tuple[Dict[str, str], Dict[str, object]]:
+    """Partition a config dict into (secrets, non_secrets).
+
+    `secrets` maps secrets-store key → value (ready to feed `set_secret`).
+    Empty-string and `None` values are kept in `secrets` so the caller can
+    decide whether to apply or skip them (the convention is "empty means
+    don't overwrite an existing secret").
+
+    The returned non_secrets dict is a fresh copy with secret fields
+    removed — safe to persist to the DB / JSON.
+    """
+    mapping = secret_fields_for(integration_id)
+    if not mapping:
+        return {}, dict(config)
+
+    secrets: Dict[str, str] = {}
+    non_secrets: Dict[str, object] = {}
+    for field, value in config.items():
+        env_key = mapping.get(field)
+        if env_key is None:
+            non_secrets[field] = value
+            continue
+        # Coerce to string so callers don't have to. Non-string values for
+        # secret fields are pathological — log via the redact step if needed.
+        secrets[env_key] = "" if value is None else str(value)
+    return secrets, non_secrets
+
+
+def redact_secrets(integration_id: str, config: Dict[str, object]) -> Dict[str, object]:
+    """Return a copy of ``config`` with registered secret fields removed.
+
+    Used by the GET handler so the frontend never receives plaintext
+    credentials. The form will treat absent secret fields as "leave existing
+    value untouched" on the next save.
+    """
+    mapping = secret_fields_for(integration_id)
+    if not mapping:
+        return dict(config)
+    return {k: v for k, v in config.items() if k not in mapping}
+
+
+def secret_field_names(integration_id: str) -> Iterable[str]:
+    """Iterable over the form-field names that are secrets for an integration."""
+    return secret_fields_for(integration_id).keys()

--- a/services/integration_secrets.py
+++ b/services/integration_secrets.py
@@ -23,22 +23,191 @@ uses it to:
    back to the frontend.
 
 When you add a new integration that has password-typed fields in
-``frontend/src/config/integrations.ts``, add a matching entry here.
+``frontend/src/config/integrations.ts``, add a tuple entry to
+``_SECRET_FIELDS`` below. The default ``<INTEGRATION_ID>_<FIELD>``
+convention is built automatically; add an ``_ENV_VAR_OVERRIDES`` entry
+only when the consumer reads the secret under a non-canonical name
+(e.g. CrowdStrike's official MCP server reads ``FALCON_*``).
 """
 
 from __future__ import annotations
 
 from typing import Dict, Iterable, Mapping
 
-# integration_id → {form_field_name: secrets_manager_key}
-INTEGRATION_SECRET_FIELDS: Mapping[str, Mapping[str, str]] = {
-    "vstrike": {
-        "api_key": "VSTRIKE_API_KEY",
-        "inbound_api_key": "VSTRIKE_INBOUND_API_KEY",
-        "username": "VSTRIKE_USERNAME",
-        "password": "VSTRIKE_PASSWORD",
-    },
+# Default form-field → env-var-suffix translations. Mirrors
+# ``services.integration_bridge_service.IntegrationBridgeService.FIELD_TO_ENV_MAP``
+# so credentials saved via the Settings UI land under the same env-var
+# names that the bridge service uses when injecting env vars into MCP
+# server child processes.
+_DEFAULT_FIELD_SUFFIX: Mapping[str, str] = {
+    "api_key": "API_KEY",
+    "api_token": "API_TOKEN",
+    "api_secret": "API_SECRET",
+    "access_key": "ACCESS_KEY",
+    "secret_key": "SECRET_KEY",
+    "client_id": "CLIENT_ID",
+    "client_secret": "CLIENT_SECRET",
+    "username": "USERNAME",
+    "password": "PASSWORD",
+    "token": "TOKEN",
+    "bot_token": "BOT_TOKEN",
+    "auth_token": "AUTH_TOKEN",
+    "webhook_url": "WEBHOOK_URL",
+    "integration_key": "INTEGRATION_KEY",
+    "credentials_json": "CREDENTIALS_JSON",
+    "secret_access_key": "SECRET_ACCESS_KEY",
+    "smtp_password": "SMTP_PASSWORD",
+    "sec_token": "SEC_TOKEN",
+    "api_key_secret": "API_KEY_SECRET",
+    "inbound_api_key": "INBOUND_API_KEY",
 }
+
+
+def _default_env_var(integration_id: str, field_name: str) -> str:
+    """Build the canonical env-var name for a given integration + field.
+
+    Convention: ``<UPPER_SNAKE_INTEGRATION_ID>_<FIELD_SUFFIX>`` where the
+    suffix comes from ``_DEFAULT_FIELD_SUFFIX`` if known, otherwise the
+    upper-snake-cased field name. Matches ``IntegrationBridgeService``'s
+    convention for env-var injection into MCP server child processes.
+    """
+    prefix = integration_id.upper().replace("-", "_")
+    suffix = _DEFAULT_FIELD_SUFFIX.get(field_name, field_name.upper())
+    return f"{prefix}_{suffix}"
+
+
+# Form-field names per integration that are sensitive (mirrors `type:
+# 'password'` entries in ``frontend/src/config/integrations.ts``). The
+# values get routed through the secrets manager rather than persisted
+# plaintext to the DB / JSON file.
+_SECRET_FIELDS: Mapping[str, tuple[str, ...]] = {
+    "github": ("token",),
+    "virustotal": ("api_key",),
+    "alienvault-otx": ("api_key",),
+    "shodan": ("api_key",),
+    "misp": ("api_key",),
+    "gcp-threat-intel": ("api_key",),
+    "url-analysis": ("api_key",),
+    "ip-geolocation": ("api_key",),
+    "crowdstrike": ("client_secret",),
+    "sentinelone": ("api_token",),
+    "carbon-black": ("api_key",),
+    "microsoft-defender": ("client_secret",),
+    "cortex-xdr": ("api_key",),
+    "trend-micro-vision-one": ("api_token",),
+    "sophos-intercept-x": ("client_secret",),
+    "cybereason": ("password",),
+    "trellix": ("client_secret", "api_key"),
+    "tanium": ("password",),
+    "cynet": ("api_key",),
+    "eset": ("password",),
+    "bitdefender-gravityzone": ("api_key",),
+    "fortinet-fortiedr": ("api_token",),
+    "kaspersky": ("password",),
+    "cisco-secure-endpoint": ("api_key",),
+    "symantec-edr": ("client_secret",),
+    "splunk": ("password",),
+    "cribl-stream": ("password",),
+    "elastic-siem": ("api_key", "password"),
+    "azure-sentinel": ("client_secret",),
+    "qradar": ("sec_token",),
+    "arcsight": ("password",),
+    "logrhythm": ("api_token",),
+    "exabeam": ("password",),
+    "securonix": ("password",),
+    "sumo-logic": ("access_key",),
+    "graylog": ("api_token",),
+    "aws-security-hub": ("secret_access_key",),
+    "aws-guardduty": ("secret_access_key",),
+    "gcp-security": ("credentials_json",),
+    "azure-defender": ("client_secret",),
+    "prisma-cloud": ("secret_key",),
+    "orca-security": ("api_token",),
+    "wiz": ("client_secret",),
+    "lacework": ("api_secret",),
+    "aqua-security": ("password",),
+    "snyk": ("api_token",),
+    "okta": ("api_token",),
+    "azure-ad": ("client_secret",),
+    "ping-identity": ("client_secret",),
+    "auth0": ("client_secret",),
+    "onelogin": ("client_secret",),
+    "duo-security": ("secret_key",),
+    "jumpcloud": ("api_key",),
+    "sailpoint": ("client_secret",),
+    "cyberark": ("password",),
+    "beyond-trust": ("api_key",),
+    "palo-alto": ("api_key",),
+    "cisco-firepower": ("password",),
+    "fortinet": ("api_key",),
+    "checkpoint": ("password",),
+    "zscaler": ("api_key", "password"),
+    "sophos": ("api_token",),
+    "cloudflare": ("api_token",),
+    "cloudforce_one": ("api_token",),
+    "juniper-srx": ("password",),
+    "jira": ("api_token",),
+    "servicenow": ("password",),
+    "thehive": ("api_key",),
+    "cortex-xsoar": ("api_key",),
+    "swimlane": ("password",),
+    "ibm-resilient": ("api_key_secret",),
+    "opsgenie": ("api_key",),
+    "slack": ("bot_token",),
+    "pagerduty": ("api_token", "integration_key"),
+    "microsoft-teams": ("webhook_url",),
+    "email": ("smtp_password",),
+    "webhook": ("auth_token",),
+    "discord": ("webhook_url",),
+    "mattermost": ("webhook_url",),
+    "hybrid-analysis": ("api_key",),
+    "joe-sandbox": ("api_key",),
+    "anyrun": ("api_key",),
+    "timesketch": ("password", "api_token"),
+    "velociraptor": ("api_key",),
+    "grr": ("password",),
+    "autopsy": ("password",),
+    "osquery": ("api_token",),
+    "cuckoo": ("api_token",),
+    "vstrike": ("api_key", "inbound_api_key", "username", "password"),
+}
+
+
+# Per-integration overrides where the consumer reads the secret under a
+# name that doesn't match the default ``<ID>_<FIELD>`` convention.
+# Anything NOT listed here uses ``_default_env_var(integration_id, field)``.
+#
+# Each entry is keyed by integration_id; values are partial maps from
+# form-field name → env-var name. Missing fields fall back to the default.
+_ENV_VAR_OVERRIDES: Mapping[str, Mapping[str, str]] = {
+    # CrowdStrike's official MCP server (falcon-mcp) reads FALCON_*
+    # rather than CROWDSTRIKE_*. Match the upstream so secrets saved
+    # via the Settings UI flow straight into the MCP server.
+    "crowdstrike": {"client_secret": "FALCON_CLIENT_SECRET"},
+    # mcp-config.json's PagerDuty server reads ${PAGERDUTY_API_KEY},
+    # not PAGERDUTY_API_TOKEN.
+    "pagerduty": {"api_token": "PAGERDUTY_API_KEY"},
+}
+
+
+def _resolve_env_var(integration_id: str, field_name: str) -> str:
+    """Resolve the secrets-store key for one integration field."""
+    overrides = _ENV_VAR_OVERRIDES.get(integration_id, {})
+    return overrides.get(field_name) or _default_env_var(integration_id, field_name)
+
+
+def _build_registry() -> Dict[str, Dict[str, str]]:
+    """Materialize the per-integration secret registry from the field list."""
+    return {
+        integration_id: {
+            field: _resolve_env_var(integration_id, field) for field in fields
+        }
+        for integration_id, fields in _SECRET_FIELDS.items()
+    }
+
+
+# integration_id → {form_field_name: secrets_manager_key}
+INTEGRATION_SECRET_FIELDS: Mapping[str, Mapping[str, str]] = _build_registry()
 
 
 def secret_fields_for(integration_id: str) -> Mapping[str, str]:

--- a/services/vstrike_service.py
+++ b/services/vstrike_service.py
@@ -450,27 +450,44 @@ def get_vstrike_service() -> Optional[VStrikeService]:
       - username + password (`VSTRIKE_USERNAME` / `VSTRIKE_PASSWORD`) —
         enables the MCP UI-control plane (iframe auto-login + ui-network-load).
 
-    Either or both modes may be configured. Within each, env vars take
-    precedence over the integration config persisted by the Settings UI.
+    Either or both modes may be configured. Credential lookups go through
+    Vigil's secrets manager, which checks (in priority order) the encrypted
+    store at ``~/.vigil/secrets.enc``, process env vars, ``.env`` file, and
+    the keyring (if enabled). The non-secret ``url`` and ``verify_ssl``
+    values are read from ``IntegrationConfig`` (DB) or its JSON
+    back-compat mirror via ``core.config.get_integration_config``.
     """
-    base_url = os.environ.get("VSTRIKE_BASE_URL")
-    api_key = os.environ.get("VSTRIKE_API_KEY")
-    username = os.environ.get("VSTRIKE_USERNAME")
-    password = os.environ.get("VSTRIKE_PASSWORD")
-    verify_ssl_env = os.environ.get("VSTRIKE_VERIFY_SSL", "true").lower() != "false"
+    try:
+        from backend.secrets_manager import get_secret
+    except Exception as e:  # pragma: no cover - import-time fallback
+        logger.debug("Secrets manager unavailable, using os.environ: %s", e)
 
+        def get_secret(name: str) -> Optional[str]:  # type: ignore[misc]
+            return os.environ.get(name)
+
+    base_url = get_secret("VSTRIKE_BASE_URL")
+    api_key = get_secret("VSTRIKE_API_KEY")
+    username = get_secret("VSTRIKE_USERNAME")
+    password = get_secret("VSTRIKE_PASSWORD")
+    verify_ssl_value = get_secret("VSTRIKE_VERIFY_SSL")
+    verify_ssl_env: Optional[bool] = None
+    if verify_ssl_value is not None:
+        verify_ssl_env = verify_ssl_value.lower() != "false"
+
+    # Non-secret fields (and any legacy plaintext credentials) may still
+    # live in the integration config — read it once for back-compat.
     config: Optional[Dict[str, Any]] = None
-    needs_config_lookup = not base_url or not (api_key or (username and password))
-    if needs_config_lookup:
-        try:
-            from core.config import get_integration_config
+    try:
+        from core.config import get_integration_config
 
-            config = get_integration_config("vstrike")
-        except Exception as e:
-            logger.debug("VStrike integration config not loaded: %s", e)
-            config = None
+        config = get_integration_config("vstrike")
+    except Exception as e:
+        logger.debug("VStrike integration config not loaded: %s", e)
+        config = None
 
     base_url = base_url or _config_value("url", config)
+    # Credentials should normally come from the secrets store; fall back to
+    # the integration config only for legacy installs that haven't migrated.
     api_key = api_key or _config_value("api_key", config)
     username = username or _config_value("username", config)
     password = password or _config_value("password", config)
@@ -480,9 +497,12 @@ def get_vstrike_service() -> Optional[VStrikeService]:
     if not (api_key or (username and password)):
         return None
 
-    verify_ssl = verify_ssl_env
-    if config is not None and "verify_ssl" in config:
+    if verify_ssl_env is not None:
+        verify_ssl = verify_ssl_env
+    elif config is not None and "verify_ssl" in config:
         verify_ssl = bool(config.get("verify_ssl", True))
+    else:
+        verify_ssl = True
 
     return VStrikeService(
         base_url=base_url,

--- a/tests/integration/test_integration_secrets_api.py
+++ b/tests/integration/test_integration_secrets_api.py
@@ -1,0 +1,174 @@
+"""Integration tests for the integration-config endpoints' secret handling.
+
+The generic ``POST /config/integrations`` endpoint must route registered
+secret fields through ``set_secret`` (so they land in the encrypted
+secrets store) and strip them from the dict that gets persisted to the
+database / JSON file. The matching ``GET`` endpoint must redact those
+fields on read so plaintext credentials never leak to the frontend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (ROOT, ROOT / "backend"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+os.environ.setdefault("DEV_MODE", "true")
+
+
+def _post_payload():
+    """Realistic VStrike save payload from the Settings UI."""
+    from backend.api.config import IntegrationsConfig
+
+    return IntegrationsConfig(
+        enabled_integrations=["vstrike"],
+        integrations={
+            "vstrike": {
+                "url": "https://vstrike.net",
+                "verify_ssl": False,
+                "api_key": "outbound-bearer",
+                "inbound_api_key": "inbound-bearer",
+                "username": "deeptempo_manager",
+                "password": "shh-secret",
+            }
+        },
+    )
+
+
+def _invoke_post(payload, *, set_secret=None, config_service=None, tmp_home=None):
+    """Run the async handler with patched secrets writer + config service."""
+    from backend.api import config as config_module
+
+    set_secret = set_secret or MagicMock(return_value=True)
+    config_service = config_service or MagicMock()
+    config_service.set_integration_config.return_value = True
+
+    patches = [
+        patch.object(config_module, "set_secret", set_secret),
+        patch.object(config_module, "get_config_service", return_value=config_service),
+    ]
+    if tmp_home is not None:
+        patches.append(patch.object(Path, "home", return_value=tmp_home))
+
+    for p in patches:
+        p.start()
+    try:
+        result = asyncio.run(config_module.set_integrations_config(payload))
+    finally:
+        for p in reversed(patches):
+            p.stop()
+    return result, set_secret, config_service
+
+
+def test_post_routes_secrets_to_set_secret(tmp_path):
+    payload = _post_payload()
+    result, set_secret, config_service = _invoke_post(payload, tmp_home=tmp_path)
+
+    assert result["success"] is True
+
+    # Each registered secret field should go through set_secret with the
+    # secrets-store key from services.integration_secrets.
+    written = {call.args[0]: call.args[1] for call in set_secret.call_args_list}
+    assert written["VSTRIKE_API_KEY"] == "outbound-bearer"
+    assert written["VSTRIKE_INBOUND_API_KEY"] == "inbound-bearer"
+    assert written["VSTRIKE_USERNAME"] == "deeptempo_manager"
+    assert written["VSTRIKE_PASSWORD"] == "shh-secret"
+
+    # The DB write should contain ONLY non-secret fields.
+    saved_config = config_service.set_integration_config.call_args.kwargs["config"]
+    assert saved_config == {"url": "https://vstrike.net", "verify_ssl": False}
+    assert "api_key" not in saved_config
+    assert "password" not in saved_config
+
+
+def test_post_strips_secrets_from_json_mirror(tmp_path):
+    payload = _post_payload()
+    _invoke_post(payload, tmp_home=tmp_path)
+
+    json_path = tmp_path / ".deeptempo" / "integrations_config.json"
+    assert json_path.exists()
+    import json
+
+    on_disk = json.loads(json_path.read_text())
+    assert on_disk["enabled_integrations"] == ["vstrike"]
+    persisted = on_disk["integrations"]["vstrike"]
+    assert persisted == {"url": "https://vstrike.net", "verify_ssl": False}
+    # No secrets in plaintext
+    for forbidden in ("api_key", "inbound_api_key", "username", "password"):
+        assert forbidden not in persisted
+
+
+def test_post_skips_empty_secret_means_keep_existing(tmp_path):
+    """Empty-string secret fields must NOT call set_secret (overwrite-skip)."""
+    from backend.api.config import IntegrationsConfig
+
+    payload = IntegrationsConfig(
+        enabled_integrations=["vstrike"],
+        integrations={
+            "vstrike": {
+                "url": "https://vstrike.net",
+                "verify_ssl": True,
+                "api_key": "",
+                "username": "alice",
+                "password": "",
+            }
+        },
+    )
+    _result, set_secret, _ = _invoke_post(payload, tmp_home=tmp_path)
+
+    written = {call.args[0]: call.args[1] for call in set_secret.call_args_list}
+    # Only the non-empty username should have been written.
+    assert written == {"VSTRIKE_USERNAME": "alice"}
+
+
+def test_post_unregistered_integration_pass_through(tmp_path):
+    """Integrations without a secret-field registry retain old behavior."""
+    from backend.api.config import IntegrationsConfig
+
+    payload = IntegrationsConfig(
+        enabled_integrations=["brand-new-thing"],
+        integrations={"brand-new-thing": {"foo": "bar", "verify_ssl": True}},
+    )
+    _result, set_secret, config_service = _invoke_post(payload, tmp_home=tmp_path)
+
+    # No secrets routed to the secrets store...
+    assert set_secret.call_args_list == []
+    # ...and the full config still reaches the DB write.
+    saved = config_service.set_integration_config.call_args.kwargs["config"]
+    assert saved == {"foo": "bar", "verify_ssl": True}
+
+
+def test_get_redacts_registered_secret_fields(tmp_path):
+    """GET handler must strip registered secret fields on read."""
+    from backend.api import config as config_module
+
+    fake_service = MagicMock()
+    fake_service.list_integrations.return_value = [
+        {
+            "integration_id": "vstrike",
+            "enabled": True,
+            "config": {
+                # Pretend a legacy plaintext row still exists in DB.
+                "url": "https://vstrike.net",
+                "verify_ssl": True,
+                "api_key": "leaked-from-db",
+                "username": "alice",
+                "password": "wonderland",
+            },
+        }
+    ]
+
+    with patch.object(config_module, "get_config_service", return_value=fake_service):
+        result = asyncio.run(config_module.get_integrations_config())
+
+    cfg = result["integrations"]["vstrike"]
+    assert cfg == {"url": "https://vstrike.net", "verify_ssl": True}
+    for forbidden in ("api_key", "username", "password"):
+        assert forbidden not in cfg

--- a/tests/integration/test_secrets_routes.py
+++ b/tests/integration/test_secrets_routes.py
@@ -1,0 +1,135 @@
+"""Integration tests for /api/config/secrets/* admin routes."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (ROOT, ROOT / "backend"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+os.environ.setdefault("DEV_MODE", "true")
+
+
+def _fake_status(**overrides):
+    base = {
+        "encrypted": {
+            "available": True,
+            "path": "/tmp/secrets.enc",
+            "secrets_file_exists": True,
+            "master_key_present": True,
+            "master_key_path": "/tmp/master.key",
+            "description": "encrypted",
+        },
+        "environment": {"available": True, "description": "env"},
+        "dotenv": {
+            "available": True,
+            "path": "/tmp/.env",
+            "exists": True,
+            "description": "dotenv",
+        },
+        "keyring": {"available": False, "description": "keyring"},
+        "cryptography_available": True,
+        "write_backend": "encrypted",
+        "expected_write_backend": "encrypted",
+        "read_backends": ["EncryptedFileBackend", "EnvironmentBackend"],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_status_route_returns_backend_state():
+    from backend.api import config as config_module
+
+    mgr = MagicMock()
+    mgr.get_backend_status.return_value = _fake_status()
+    with patch("backend.secrets_manager.get_secrets_manager", return_value=mgr):
+        result = asyncio.run(config_module.secrets_status())
+    assert result["write_backend"] == "encrypted"
+    assert result["cryptography_available"] is True
+
+
+def test_reinit_route_force_reloads_singleton():
+    from backend.api import config as config_module
+
+    mgr = MagicMock()
+    mgr.get_backend_status.return_value = _fake_status(write_backend="encrypted")
+    with patch(
+        "backend.secrets_manager.get_secrets_manager", return_value=mgr
+    ) as mock_get:
+        result = asyncio.run(config_module.secrets_reinit())
+    # No body → no override; force_reload must still be True.
+    mock_get.assert_called_with(write_backend=None, force_reload=True)
+    assert result["reloaded"] is True
+    assert result["status"]["write_backend"] == "encrypted"
+
+
+def test_reinit_route_accepts_write_backend_override():
+    """Pass {'write_backend': 'encrypted'} to force a backend even when
+    os.environ['SECRETS_BACKEND'] is stale (e.g. user just edited .env)."""
+    from backend.api import config as config_module
+    from backend.api.config import _SecretsReinitRequest
+
+    mgr = MagicMock()
+    mgr.get_backend_status.return_value = _fake_status(write_backend="encrypted")
+    with patch(
+        "backend.secrets_manager.get_secrets_manager", return_value=mgr
+    ) as mock_get:
+        asyncio.run(
+            config_module.secrets_reinit(
+                _SecretsReinitRequest(write_backend="encrypted")
+            )
+        )
+    mock_get.assert_called_with(write_backend="encrypted", force_reload=True)
+
+
+def test_migrate_route_routes_to_secrets_manager_helper():
+    from backend.api import config as config_module
+    from backend.api.config import _SecretsMigrateRequest
+
+    mgr = MagicMock()
+    mgr.migrate_dotenv_secrets_to_encrypted.return_value = {
+        "migrated": ["FOO"],
+        "already_present": [],
+        "conflicts": [],
+        "errors": [],
+        "encrypted_available": True,
+        "dotenv_path": "/tmp/.env",
+    }
+    with patch("backend.secrets_manager.get_secrets_manager", return_value=mgr):
+        result = asyncio.run(
+            config_module.secrets_migrate_to_encrypted(
+                _SecretsMigrateRequest(keys=["FOO"], remove_from_dotenv=False)
+            )
+        )
+
+    mgr.migrate_dotenv_secrets_to_encrypted.assert_called_once_with(
+        keys=["FOO"], remove_from_dotenv=False
+    )
+    assert result["migrated"] == ["FOO"]
+
+
+def test_migrate_route_defaults_when_body_omitted():
+    """Body is optional; defaults are keys=None, remove_from_dotenv=True."""
+    from backend.api import config as config_module
+
+    mgr = MagicMock()
+    mgr.migrate_dotenv_secrets_to_encrypted.return_value = {
+        "migrated": [],
+        "already_present": [],
+        "conflicts": [],
+        "errors": [],
+        "encrypted_available": True,
+        "dotenv_path": "/tmp/.env",
+    }
+    with patch("backend.secrets_manager.get_secrets_manager", return_value=mgr):
+        asyncio.run(config_module.secrets_migrate_to_encrypted(None))
+
+    mgr.migrate_dotenv_secrets_to_encrypted.assert_called_once_with(
+        keys=None, remove_from_dotenv=True
+    )

--- a/tests/unit/test_integration_secrets.py
+++ b/tests/unit/test_integration_secrets.py
@@ -112,3 +112,193 @@ def test_registry_is_a_mapping_not_a_dict_alias():
     assert len(secret_fields_for("vstrike")) == original_size
     # And the registry export is keyed by integration_id
     assert "vstrike" in INTEGRATION_SECRET_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Coverage of every password-typed integration in integrations.ts
+# ---------------------------------------------------------------------------
+
+
+def test_every_audited_integration_is_registered():
+    """Sweep test: every integration with password-typed fields in the
+    frontend metadata must have a corresponding registry entry, otherwise
+    its credentials would still flow through the plaintext path on save.
+
+    The list below was derived by parsing
+    ``frontend/src/config/integrations.ts`` for ``type: 'password'`` fields
+    grouped by their parent integration ``id``. If a new integration with
+    password-typed fields is added to the frontend, add it here AND to
+    ``_SECRET_FIELDS`` in services.integration_secrets.
+    """
+    expected = {
+        "github",
+        "virustotal",
+        "alienvault-otx",
+        "shodan",
+        "misp",
+        "gcp-threat-intel",
+        "url-analysis",
+        "ip-geolocation",
+        "crowdstrike",
+        "sentinelone",
+        "carbon-black",
+        "microsoft-defender",
+        "cortex-xdr",
+        "trend-micro-vision-one",
+        "sophos-intercept-x",
+        "cybereason",
+        "trellix",
+        "tanium",
+        "cynet",
+        "eset",
+        "bitdefender-gravityzone",
+        "fortinet-fortiedr",
+        "kaspersky",
+        "cisco-secure-endpoint",
+        "symantec-edr",
+        "splunk",
+        "cribl-stream",
+        "elastic-siem",
+        "azure-sentinel",
+        "qradar",
+        "arcsight",
+        "logrhythm",
+        "exabeam",
+        "securonix",
+        "sumo-logic",
+        "graylog",
+        "aws-security-hub",
+        "aws-guardduty",
+        "gcp-security",
+        "azure-defender",
+        "prisma-cloud",
+        "orca-security",
+        "wiz",
+        "lacework",
+        "aqua-security",
+        "snyk",
+        "okta",
+        "azure-ad",
+        "ping-identity",
+        "auth0",
+        "onelogin",
+        "duo-security",
+        "jumpcloud",
+        "sailpoint",
+        "cyberark",
+        "beyond-trust",
+        "palo-alto",
+        "cisco-firepower",
+        "fortinet",
+        "checkpoint",
+        "zscaler",
+        "sophos",
+        "cloudflare",
+        "cloudforce_one",
+        "juniper-srx",
+        "jira",
+        "servicenow",
+        "thehive",
+        "cortex-xsoar",
+        "swimlane",
+        "ibm-resilient",
+        "opsgenie",
+        "slack",
+        "pagerduty",
+        "microsoft-teams",
+        "email",
+        "webhook",
+        "discord",
+        "mattermost",
+        "hybrid-analysis",
+        "joe-sandbox",
+        "anyrun",
+        "timesketch",
+        "velociraptor",
+        "grr",
+        "autopsy",
+        "osquery",
+        "cuckoo",
+        "vstrike",
+    }
+    missing = expected - set(INTEGRATION_SECRET_FIELDS.keys())
+    assert not missing, f"Integrations missing from registry: {sorted(missing)}"
+
+
+def test_default_naming_convention_for_well_known_integrations():
+    """Sample of integrations that should follow ``<ID>_<FIELD>`` exactly."""
+    cases = [
+        ("virustotal", "api_key", "VIRUSTOTAL_API_KEY"),
+        ("shodan", "api_key", "SHODAN_API_KEY"),
+        ("github", "token", "GITHUB_TOKEN"),
+        ("splunk", "password", "SPLUNK_PASSWORD"),
+        ("sentinelone", "api_token", "SENTINELONE_API_TOKEN"),
+        ("aws-security-hub", "secret_access_key", "AWS_SECURITY_HUB_SECRET_ACCESS_KEY"),
+        ("microsoft-defender", "client_secret", "MICROSOFT_DEFENDER_CLIENT_SECRET"),
+        ("cribl-stream", "password", "CRIBL_STREAM_PASSWORD"),
+        ("cloudforce_one", "api_token", "CLOUDFORCE_ONE_API_TOKEN"),
+    ]
+    for integration_id, field, expected_env in cases:
+        actual = INTEGRATION_SECRET_FIELDS[integration_id][field]
+        assert (
+            actual == expected_env
+        ), f"{integration_id}.{field} expected {expected_env}, got {actual}"
+
+
+def test_overrides_take_precedence_over_default_naming():
+    """CrowdStrike's MCP server reads FALCON_*, not CROWDSTRIKE_*."""
+    assert (
+        INTEGRATION_SECRET_FIELDS["crowdstrike"]["client_secret"]
+        == "FALCON_CLIENT_SECRET"
+    )
+    # PagerDuty mcp-config.json source placeholder is PAGERDUTY_API_KEY.
+    assert INTEGRATION_SECRET_FIELDS["pagerduty"]["api_token"] == "PAGERDUTY_API_KEY"
+    # The other PagerDuty secret falls back to the default convention.
+    assert (
+        INTEGRATION_SECRET_FIELDS["pagerduty"]["integration_key"]
+        == "PAGERDUTY_INTEGRATION_KEY"
+    )
+
+
+def test_multi_secret_integrations_register_each_field():
+    """Integrations with multiple password fields must register every one."""
+    assert set(INTEGRATION_SECRET_FIELDS["trellix"].keys()) == {
+        "client_secret",
+        "api_key",
+    }
+    assert set(INTEGRATION_SECRET_FIELDS["zscaler"].keys()) == {
+        "api_key",
+        "password",
+    }
+    assert set(INTEGRATION_SECRET_FIELDS["timesketch"].keys()) == {
+        "password",
+        "api_token",
+    }
+    assert set(INTEGRATION_SECRET_FIELDS["pagerduty"].keys()) == {
+        "api_token",
+        "integration_key",
+    }
+    assert set(INTEGRATION_SECRET_FIELDS["vstrike"].keys()) == {
+        "api_key",
+        "inbound_api_key",
+        "username",
+        "password",
+    }
+
+
+def test_no_env_var_collisions_across_integrations():
+    """No two registered (integration, field) pairs may share an env-var
+    name unless that's an explicit override (e.g. shared keys across
+    integrations would collide silently in the secrets store)."""
+    seen: dict[str, tuple[str, str]] = {}
+    collisions: list[str] = []
+    for integration_id, fields in INTEGRATION_SECRET_FIELDS.items():
+        for field, env_var in fields.items():
+            if env_var in seen:
+                prior = seen[env_var]
+                collisions.append(
+                    f"{env_var}: {prior[0]}.{prior[1]} vs {integration_id}.{field}"
+                )
+            else:
+                seen[env_var] = (integration_id, field)
+    assert not collisions, "Env-var name collisions: " + ", ".join(collisions)

--- a/tests/unit/test_integration_secrets.py
+++ b/tests/unit/test_integration_secrets.py
@@ -1,0 +1,114 @@
+"""Unit tests for the per-integration secret-field registry."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from services.integration_secrets import (  # noqa: E402
+    INTEGRATION_SECRET_FIELDS,
+    redact_secrets,
+    secret_field_names,
+    secret_fields_for,
+    split_secrets,
+)
+
+
+def test_vstrike_secret_fields_registered():
+    """The four VStrike secret fields must round-trip to env-var keys."""
+    fields = secret_fields_for("vstrike")
+    assert fields["api_key"] == "VSTRIKE_API_KEY"
+    assert fields["inbound_api_key"] == "VSTRIKE_INBOUND_API_KEY"
+    assert fields["username"] == "VSTRIKE_USERNAME"
+    assert fields["password"] == "VSTRIKE_PASSWORD"
+
+
+def test_secret_fields_for_unregistered_returns_empty():
+    assert secret_fields_for("not-a-real-integration") == {}
+
+
+def test_split_secrets_partitions_correctly():
+    raw = {
+        "url": "https://vstrike.net",
+        "verify_ssl": True,
+        "username": "alice",
+        "password": "wonderland",
+        "api_key": "bearer-token",
+    }
+    secrets, non_secrets = split_secrets("vstrike", raw)
+    # Secrets keyed by env-var name, ready for set_secret().
+    assert secrets == {
+        "VSTRIKE_USERNAME": "alice",
+        "VSTRIKE_PASSWORD": "wonderland",
+        "VSTRIKE_API_KEY": "bearer-token",
+    }
+    # Non-secrets retain original field names; no plaintext credentials.
+    assert non_secrets == {
+        "url": "https://vstrike.net",
+        "verify_ssl": True,
+    }
+
+
+def test_split_secrets_keeps_empty_secret_values():
+    """Empty strings must reach the caller so it can choose 'don't overwrite'."""
+    raw = {
+        "url": "https://vstrike.net",
+        "username": "",
+        "password": "",
+    }
+    secrets, _non_secrets = split_secrets("vstrike", raw)
+    assert secrets["VSTRIKE_USERNAME"] == ""
+    assert secrets["VSTRIKE_PASSWORD"] == ""
+
+
+def test_split_secrets_unregistered_integration_passthrough():
+    """Unregistered integrations get an empty secrets dict + a copy of input."""
+    raw = {"foo": "bar", "baz": 42}
+    secrets, non_secrets = split_secrets("brand-new", raw)
+    assert secrets == {}
+    assert non_secrets == raw
+    assert non_secrets is not raw  # copy, not alias
+
+
+def test_redact_secrets_removes_registered_fields():
+    raw = {
+        "url": "https://vstrike.net",
+        "api_key": "leaked-bearer",
+        "username": "alice",
+        "password": "wonderland",
+        "verify_ssl": True,
+    }
+    redacted = redact_secrets("vstrike", raw)
+    assert "api_key" not in redacted
+    assert "username" not in redacted
+    assert "password" not in redacted
+    assert redacted["url"] == "https://vstrike.net"
+    assert redacted["verify_ssl"] is True
+
+
+def test_redact_secrets_unregistered_integration_passthrough():
+    raw = {"foo": "bar"}
+    redacted = redact_secrets("brand-new", raw)
+    assert redacted == raw
+
+
+def test_secret_field_names_returns_form_field_names():
+    names = list(secret_field_names("vstrike"))
+    assert set(names) == {"api_key", "inbound_api_key", "username", "password"}
+
+
+def test_registry_is_a_mapping_not_a_dict_alias():
+    """Sanity: callers shouldn't be able to mutate the registry by accident."""
+    # `secret_fields_for` returns the registry's inner mapping by reference.
+    # We don't enforce immutability here, but flag it if a caller mutates.
+    fields = secret_fields_for("vstrike")
+    original_size = len(fields)
+    # Constructing a new dict from it is fine; the registry stays intact.
+    {**fields, "extra": "ENV"}
+    assert len(secret_fields_for("vstrike")) == original_size
+    # And the registry export is keyed by integration_id
+    assert "vstrike" in INTEGRATION_SECRET_FIELDS

--- a/tests/unit/test_secrets_manager_singleton.py
+++ b/tests/unit/test_secrets_manager_singleton.py
@@ -1,0 +1,235 @@
+"""Unit tests for the secrets-manager singleton + migration helpers.
+
+Specifically covers the regressions that motivated PR #158:
+
+- ``cryptography`` availability is decided ONCE at module import, not per
+  ``EncryptedFileBackend`` instance and not at each ``is_available()``
+  call. So the chosen write backend is stable across the process
+  lifetime regardless of singleton init order.
+- ``get_secrets_manager(force_reload=True)`` rebuilds the singleton, so
+  a process that picked the wrong write backend on first init can
+  recover without bouncing.
+- ``SecretsManager.migrate_dotenv_secrets_to_encrypted`` moves keys
+  out of the dotenv backend into the encrypted backend, refusing to
+  clobber on conflict and only deleting the dotenv copy on success.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend import secrets_manager  # noqa: E402
+from backend.secrets_manager import (  # noqa: E402
+    DotEnvBackend,
+    EncryptedFileBackend,
+    SecretsManager,
+    get_secrets_manager,
+)
+
+# ---------------------------------------------------------------------------
+# Eager cryptography availability
+# ---------------------------------------------------------------------------
+
+
+def test_cryptography_availability_is_module_level():
+    """Module-level constant is set exactly once, regardless of init order."""
+    # The constant must exist (regardless of value) and be a plain bool.
+    assert isinstance(secrets_manager._CRYPTOGRAPHY_AVAILABLE, bool)
+
+
+def test_encrypted_backend_uses_module_level_availability():
+    """Per-instance is_available reads the module constant — no per-call import."""
+    backend = EncryptedFileBackend()
+    assert backend.is_available() is secrets_manager._CRYPTOGRAPHY_AVAILABLE
+    # And it returns the same answer when called twice in a row even after
+    # the module-level constant is forced False (instances cache via
+    # _crypto_ok on init, so flipping post-init shouldn't lie about the
+    # backend they were constructed with).
+    backend2 = EncryptedFileBackend()
+    assert backend2.is_available() == backend.is_available()
+
+
+def test_encrypted_backend_init_does_not_reimport_cryptography(monkeypatch):
+    """`__init__` should rely on the module-level constant, not retry the import."""
+    # Construct a backend; if the constructor were doing its own
+    # `try: import cryptography` per instance, this would be the surface
+    # where we'd notice. Smoke test: the constructor must not raise even
+    # if the cryptography module isn't around at runtime.
+    monkeypatch.setattr(secrets_manager, "_CRYPTOGRAPHY_AVAILABLE", False)
+    backend = EncryptedFileBackend()
+    assert backend._crypto_ok is False
+    assert backend.is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# force_reload on the singleton
+# ---------------------------------------------------------------------------
+
+
+def test_get_secrets_manager_returns_singleton_by_default():
+    a = get_secrets_manager()
+    b = get_secrets_manager()
+    assert a is b
+
+
+def test_force_reload_returns_a_fresh_singleton():
+    a = get_secrets_manager()
+    b = get_secrets_manager(force_reload=True)
+    assert b is not a
+
+
+def test_force_reload_picks_up_changed_env_var(monkeypatch):
+    """SECRETS_BACKEND env var should win over the cached singleton."""
+    a = get_secrets_manager()
+    monkeypatch.setenv("SECRETS_BACKEND", "dotenv")
+    b = get_secrets_manager(force_reload=True)
+    assert b.write_backend_name == "dotenv"
+    assert b is not a
+
+
+# ---------------------------------------------------------------------------
+# Backend status reporting
+# ---------------------------------------------------------------------------
+
+
+def test_backend_status_reports_canonical_keys():
+    mgr = get_secrets_manager(force_reload=True)
+    status = mgr.get_backend_status()
+    for key in (
+        "encrypted",
+        "environment",
+        "dotenv",
+        "keyring",
+        "write_backend",
+        "expected_write_backend",
+        "cryptography_available",
+        "read_backends",
+    ):
+        assert key in status, f"missing key: {key}"
+    assert "secrets_file_exists" in status["encrypted"]
+    assert "master_key_present" in status["encrypted"]
+
+
+# ---------------------------------------------------------------------------
+# Migration: dotenv → encrypted
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_manager(tmp_path, monkeypatch):
+    """Build a SecretsManager with backends pointed at a tmp directory.
+
+    Avoids touching the developer's real ~/.vigil/ and ~/.deeptempo/.env
+    during tests.
+    """
+    monkeypatch.setattr(secrets_manager, "_CRYPTOGRAPHY_AVAILABLE", True)
+    encrypted = EncryptedFileBackend(data_dir=tmp_path / "vigil")
+    # Make sure _crypto_ok reflects the patched module-level value.
+    encrypted._crypto_ok = True
+    dotenv = DotEnvBackend(env_file=tmp_path / "deeptempo" / ".env")
+
+    mgr = SecretsManager(write_backend="encrypted")
+    mgr.encrypted_backend = encrypted
+    mgr.dotenv_backend = dotenv
+    # Re-build read_backends so the encrypted/dotenv tmp instances are used.
+    mgr.read_backends = [encrypted, mgr.env_backend, dotenv]
+    mgr.write_backend = encrypted
+    return mgr, dotenv, encrypted
+
+
+def _seed_dotenv(dotenv: DotEnvBackend, **kv):
+    for k, v in kv.items():
+        dotenv.set(k, v)
+
+
+def test_migrate_copies_keys_and_removes_from_dotenv(isolated_manager):
+    mgr, dotenv, encrypted = isolated_manager
+    _seed_dotenv(dotenv, FOO="alpha", BAR="beta")
+
+    report = mgr.migrate_dotenv_secrets_to_encrypted()
+
+    assert set(report["migrated"]) == {"FOO", "BAR"}
+    assert report["already_present"] == []
+    assert report["conflicts"] == []
+    assert report["errors"] == []
+
+    # Encrypted store now has both values.
+    assert encrypted.get("FOO") == "alpha"
+    assert encrypted.get("BAR") == "beta"
+    # And the dotenv source is empty.
+    assert dotenv.get("FOO") is None
+    assert dotenv.get("BAR") is None
+
+
+def test_migrate_dry_run_leaves_dotenv_intact(isolated_manager):
+    mgr, dotenv, encrypted = isolated_manager
+    _seed_dotenv(dotenv, FOO="alpha")
+
+    report = mgr.migrate_dotenv_secrets_to_encrypted(remove_from_dotenv=False)
+
+    assert report["migrated"] == ["FOO"]
+    assert encrypted.get("FOO") == "alpha"
+    # Dry-run keeps the source file untouched.
+    assert dotenv.get("FOO") == "alpha"
+
+
+def test_migrate_skips_keys_already_in_encrypted_with_same_value(isolated_manager):
+    mgr, dotenv, encrypted = isolated_manager
+    _seed_dotenv(dotenv, FOO="alpha")
+    encrypted.set("FOO", "alpha")
+
+    report = mgr.migrate_dotenv_secrets_to_encrypted()
+
+    assert report["migrated"] == []
+    assert report["already_present"] == ["FOO"]
+    # Dotenv source cleaned up since the values matched.
+    assert dotenv.get("FOO") is None
+
+
+def test_migrate_reports_value_conflicts_without_overwriting(isolated_manager):
+    mgr, dotenv, encrypted = isolated_manager
+    _seed_dotenv(dotenv, FOO="dotenv-value")
+    encrypted.set("FOO", "encrypted-value")
+
+    report = mgr.migrate_dotenv_secrets_to_encrypted()
+
+    assert report["migrated"] == []
+    assert report["already_present"] == []
+    assert report["conflicts"] == [{"key": "FOO", "reason": "value_mismatch"}]
+    # Encrypted store wins; both stores keep their values.
+    assert encrypted.get("FOO") == "encrypted-value"
+    assert dotenv.get("FOO") == "dotenv-value"
+
+
+def test_migrate_explicit_keys_filters_subset(isolated_manager):
+    mgr, dotenv, encrypted = isolated_manager
+    _seed_dotenv(dotenv, FOO="alpha", BAR="beta", BAZ="gamma")
+
+    report = mgr.migrate_dotenv_secrets_to_encrypted(keys=["FOO", "BAZ"])
+
+    assert set(report["migrated"]) == {"FOO", "BAZ"}
+    # BAR was excluded — left alone in dotenv, not in encrypted.
+    assert dotenv.get("BAR") == "beta"
+    assert encrypted.get("BAR") is None
+
+
+def test_migrate_refuses_when_encrypted_unavailable(isolated_manager, monkeypatch):
+    mgr, dotenv, _encrypted = isolated_manager
+    _seed_dotenv(dotenv, FOO="alpha")
+    # Simulate cryptography missing.
+    mgr.encrypted_backend._crypto_ok = False
+
+    report = mgr.migrate_dotenv_secrets_to_encrypted()
+
+    assert report["encrypted_available"] is False
+    assert report["errors"]
+    assert report["errors"][0]["key"] == "<all>"
+    # Source file untouched.
+    assert dotenv.get("FOO") == "alpha"

--- a/tests/unit/test_vstrike_service.py
+++ b/tests/unit/test_vstrike_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -25,6 +26,26 @@ def _clear_jwt_cache():
     _jwt_cache.clear()
     yield
     _jwt_cache.clear()
+
+
+@pytest.fixture
+def isolate_secrets(monkeypatch):
+    """Force the factory's `get_secret` lookups to consult only os.environ.
+
+    The real secrets manager reads from encrypted store + env + dotenv +
+    keyring. On a developer machine that store may already contain
+    VSTRIKE_* values (e.g. saved via a live Settings UI test), which would
+    leak into tests that expect those keys to be unset. This fixture
+    patches the factory's get_secret import to a thin wrapper that only
+    looks at os.environ — which the test then controls via monkeypatch.
+    """
+    import backend.secrets_manager as sm
+
+    def _env_only(key, default=None):
+        return os.environ.get(key, default)
+
+    monkeypatch.setattr(sm, "get_secret", _env_only)
+    return monkeypatch
 
 
 def _service(**kwargs) -> VStrikeService:
@@ -199,22 +220,24 @@ def test_get_vstrike_service_with_only_ui_credentials(monkeypatch):
     assert svc.has_ui_credentials is True
 
 
-def test_get_vstrike_service_returns_none_with_only_username(monkeypatch):
-    monkeypatch.setenv("VSTRIKE_BASE_URL", "https://vstrike.example.com")
-    monkeypatch.delenv("VSTRIKE_API_KEY", raising=False)
-    monkeypatch.setenv("VSTRIKE_USERNAME", "deeptempo_manager")
-    monkeypatch.delenv("VSTRIKE_PASSWORD", raising=False)
+def test_get_vstrike_service_returns_none_with_only_username(isolate_secrets):
+    isolate_secrets.setenv("VSTRIKE_BASE_URL", "https://vstrike.example.com")
+    isolate_secrets.delenv("VSTRIKE_API_KEY", raising=False)
+    isolate_secrets.setenv("VSTRIKE_USERNAME", "deeptempo_manager")
+    isolate_secrets.delenv("VSTRIKE_PASSWORD", raising=False)
     with patch("core.config.get_integration_config", return_value={}):
         svc = get_vstrike_service()
     # Username alone is not enough.
     assert svc is None
 
 
-def test_get_vstrike_service_ui_credentials_from_integration_config(monkeypatch):
-    monkeypatch.delenv("VSTRIKE_BASE_URL", raising=False)
-    monkeypatch.delenv("VSTRIKE_API_KEY", raising=False)
-    monkeypatch.delenv("VSTRIKE_USERNAME", raising=False)
-    monkeypatch.delenv("VSTRIKE_PASSWORD", raising=False)
+def test_get_vstrike_service_ui_credentials_from_integration_config(
+    isolate_secrets,
+):
+    isolate_secrets.delenv("VSTRIKE_BASE_URL", raising=False)
+    isolate_secrets.delenv("VSTRIKE_API_KEY", raising=False)
+    isolate_secrets.delenv("VSTRIKE_USERNAME", raising=False)
+    isolate_secrets.delenv("VSTRIKE_PASSWORD", raising=False)
     with patch(
         "core.config.get_integration_config",
         return_value={


### PR DESCRIPTION
## Summary

Closes the loop on PRs #156 + #157 (secrets routing + per-integration registry). Those routed credentials *through* the secrets manager but didn't change *where* the secrets manager wrote them — and on this user's setup that turned out to be `~/.deeptempo/.env` plaintext, not `~/.vigil/secrets.enc`.

Live testing during PR #156 narrowed the cause to a singleton-init quirk; this PR's live testing pinned the actual culprit: [env.example:65](env.example:65) shipped with `SECRETS_BACKEND="dotenv"`, so every new install (and every stale-env long-running process) overrode the in-code "encrypted" default. New installs were being actively steered into the plaintext path.

The fix is the five-piece plan from [`secrets-manager-encrypted-singleton-fix.md`](file:///Users/zfamilycomputer/.claude/plans/secrets-manager-encrypted-singleton-fix.md):

1. **Eager `cryptography` import** in [backend/secrets_manager.py](backend/secrets_manager.py) — `_CRYPTOGRAPHY_AVAILABLE` is decided once at module import. `EncryptedFileBackend.is_available()` reads it instead of doing per-instance try/except. Stable answer regardless of singleton init order.
2. **`get_secrets_manager(force_reload=True)`** drops the cached singleton and rebuilds. Backed by `POST /api/config/secrets/reinit` so a long-running process that initialized with the wrong backend can recover without bouncing.
3. **`GET /api/config/secrets/status`** renders the new `get_backend_status()` — write_backend, cryptography_available, master_key_present, expected_write_backend, dotenv path, etc. Answers "why are my creds in `~/.deeptempo/.env`?" without a debugger.
4. **`POST /api/config/secrets/migrate-to-encrypted`** + a CLI wrapper at `python -m backend.tools.migrate_secrets`. Moves keys from `~/.deeptempo/.env` to `~/.vigil/secrets.enc`, deleting the dotenv copy on success. Encrypted store is authoritative on conflict — never overwrites. Returns structured `{migrated, already_present, conflicts, errors}`.
5. **Lifespan startup probe** in [backend/main.py](backend/main.py) — initializes the singleton at a known time and logs LOUDLY if `write_backend != expected_write_backend`. Replaces the silent fallback that hid this bug.

Plus the actual fix that broke things on this install: [env.example:65](env.example:65) flipped from `"dotenv"` to `"encrypted"` with explanatory comments for each option.

A `write_backend` override on the reinit route is the bonus piece the plan didn't mention but live testing demanded — when you edit `.env` to flip backends, the running process's `os.environ` is still stale. `POST /secrets/reinit -d '{"write_backend":"encrypted"}'` lets you recover without restart.

## Test plan

- [x] `pytest tests/unit/test_secrets_manager_singleton.py tests/integration/test_secrets_routes.py tests/unit/test_integration_secrets.py tests/integration/test_integration_secrets_api.py tests/unit/test_vstrike_service.py tests/integration/test_vstrike_ui_routes.py tests/integration/test_vstrike_ingest.py` — **86 passed**.
- [x] Migration helper tested with tmp-path isolated fixture: copy + remove, dry-run, already-present cleanup, value-mismatch conflicts, encrypted-unavailable refusal.
- [x] Reinit endpoint tested without body (uses env) and with `{write_backend: "encrypted"}` override.
- [x] **Live verification on the running uvicorn (started 2h+ ago, originally on dotenv backend):**
  - `POST /api/config/secrets/reinit -d '{"write_backend":"encrypted"}'` → status switches to `write_backend: encrypted`.
  - `POST /api/config/secrets/migrate-to-encrypted -d '{}'` → migrated `VSTRIKE_USERNAME` + `VSTRIKE_PASSWORD`, kept `CLAUDE_API_KEY` (already-present, dotenv copy removed). 0 conflicts, 0 errors.
  - `~/.deeptempo/.env`: `VSTRIKE_*` lines gone (verified with grep). `CLAUDE_API_KEY` gone.
  - `~/.vigil/secrets.enc`: 740 bytes Fernet-encrypted JSON.
  - `POST /api/integrations/vstrike/ui/iframe-token` → **HTTP 200** with real token. Proves `get_secret()` reads from the encrypted store end-to-end.
- [x] `black` clean on all changed files.
- [ ] Manual: bounce uvicorn, watch for the new startup-probe log line: `SecretsManager ready: write_backend=encrypted, cryptography_available=True`. If the line says anything else, the override mechanism is one curl away.

## Notes for review

- After merge, anyone running with the old `.env` will still have `SECRETS_BACKEND=dotenv` exported by their `start_web.sh`. The fix is one line: edit `.env` to `SECRETS_BACKEND="encrypted"`, then either bounce uvicorn or `POST /api/config/secrets/reinit -d '{"write_backend":"encrypted"}'` followed by `POST /api/config/secrets/migrate-to-encrypted -d '{}'` to move existing secrets out of the dotenv backend.
- The reinit + migrate routes are intentionally not authenticated beyond Vigil's existing CSRF / dev-mode handling — same as the rest of `backend/api/config.py`. Worth flagging in case you want to gate them behind admin role; happy to follow up.
- The eager-cryptography hoist is the actual root-cause fix the plan was after even before the env.example finding. Keeping it because (a) it's strictly better than the per-instance try/except, and (b) it makes the singleton's chosen backend genuinely deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)