### PR TITLE
Remove spaces around equals signs

### DIFF
--- a/env.example
+++ b/env.example
@@ -18,12 +18,12 @@
 # No need to configure the frontend separately.
 #
 # See DEV_MODE.md for full details
-DEV_MODE = true
+DEV_MODE=true
 
 # -----------------------------------------------------------------------------
 # Core AI Configuration
 # -----------------------------------------------------------------------------
-ANTHROPIC_API_KEY = "sk-ant-api03-..."
+ANTHROPIC_API_KEY="sk-ant-api03-..."
 
 # Extra model IDs to always include in the Settings dropdown, on top of
 # whatever upstream /v1/models returns. Intended for IDs the provider
@@ -43,13 +43,13 @@ ANTHROPIC_API_KEY = "sk-ant-api03-..."
 # -----------------------------------------------------------------------------
 # Database
 # -----------------------------------------------------------------------------
-DATABASE_URL = "postgresql://deeptempo:deeptempo_secure_password_change_me@localhost:5432/deeptempo_soc"
-POSTGRES_PASSWORD = "deeptempo_secure_password_change_me"
+DATABASE_URL="postgresql://deeptempo:deeptempo_secure_password_change_me@localhost:5432/deeptempo_soc"
+POSTGRES_PASSWORD="deeptempo_secure_password_change_me"
 
 # -----------------------------------------------------------------------------
 # Redis (LLM job queue + session store)
 # -----------------------------------------------------------------------------
-REDIS_URL = "redis://localhost:6379/0"
+REDIS_URL="redis://localhost:6379/0"
 
 
 # -----------------------------------------------------------------------------
@@ -57,7 +57,7 @@ REDIS_URL = "redis://localhost:6379/0"
 # -----------------------------------------------------------------------------
 # Set to 0.0.0.0 to allow external/remote access (e.g. deploying on a VM)
 # Default 127.0.0.1 restricts access to localhost only
-BIND_HOST = "127.0.0.1"
+BIND_HOST="127.0.0.1"
 
 # -----------------------------------------------------------------------------
 # Secrets Backend
@@ -74,8 +74,8 @@ BIND_HOST = "127.0.0.1"
 # Reads always traverse encrypted → env → dotenv → keyring regardless of
 # this setting, so existing dotenv secrets keep working until you run
 # `python -m backend.tools.migrate_secrets` to move them encrypted-side.
-SECRETS_BACKEND = "encrypted"
-ENABLE_KEYRING = "false"
+SECRETS_BACKEND="encrypted"
+ENABLE_KEYRING="false"
 
 # -----------------------------------------------------------------------------
 # Authentication
@@ -83,26 +83,26 @@ ENABLE_KEYRING = "false"
 # JWT signing secret. REQUIRED when DEV_MODE=false — startup will fail without
 # it. In DEV_MODE the service falls back to a predictable dev value and logs a
 # warning. Generate a strong value with: python -c "import secrets; print(secrets.token_urlsafe(64))"
-JWT_SECRET_KEY = ""
+JWT_SECRET_KEY=""
 
 # Account lockout — after N consecutive failed logins the account is locked
 # for DURATION minutes. Successful login resets the counter.
-AUTH_LOCKOUT_THRESHOLD = "5"
-AUTH_LOCKOUT_DURATION_MINUTES = "15"
+AUTH_LOCKOUT_THRESHOLD="5"
+AUTH_LOCKOUT_DURATION_MINUTES="15"
 
 # Password policy (length-forward, NIST 800-63B aligned).
-AUTH_MIN_PASSWORD_LENGTH = "12"
+AUTH_MIN_PASSWORD_LENGTH="12"
 # Reject reuse of the last N passwords. Stored as bcrypt hashes in the
 # users.password_history JSONB column; older entries are evicted.
-AUTH_PASSWORD_HISTORY_LIMIT = "5"
+AUTH_PASSWORD_HISTORY_LIMIT="5"
 
 # Password reset signed-token TTL (seconds). Reset tokens are single-use
 # and auto-expire after this window.
-PASSWORD_RESET_TTL_SECONDS = "3600"
+PASSWORD_RESET_TTL_SECONDS="3600"
 
 # Frontend URL used to build password-reset links sent via email. When
 # unset the reset email includes the raw token with a "(token)" prefix.
-VIGIL_FRONTEND_URL = ""
+VIGIL_FRONTEND_URL=""
 
 # -----------------------------------------------------------------------------
 # Email (password reset + future notifications)
@@ -110,13 +110,13 @@ VIGIL_FRONTEND_URL = ""
 # Backend selector: "console" logs messages to the app log (dev default);
 # "smtp" sends via an SMTP relay configured below. No external provider
 # SDK is required — point SMTP_HOST at SES / SendGrid / Mailgun / etc.
-VIGIL_EMAIL_BACKEND = "console"
-SMTP_HOST = ""
-SMTP_PORT = "587"
-SMTP_USER = ""
-SMTP_PASSWORD = ""
-SMTP_TLS = "true"
-SMTP_FROM = "noreply@vigil.local"
+VIGIL_EMAIL_BACKEND="console"
+SMTP_HOST=""
+SMTP_PORT="587"
+SMTP_USER=""
+SMTP_PASSWORD=""
+SMTP_TLS="true"
+SMTP_FROM="noreply@vigil.local"
 
 # -----------------------------------------------------------------------------
 # HTTP Security (CORS + security headers)
@@ -124,22 +124,22 @@ SMTP_FROM = "noreply@vigil.local"
 # CORS origins. Comma-separated list. Leave unset to use the built-in dev
 # defaults (localhost:6988, :3000, :5173). Production deployments MUST set
 # this to the real origin(s), e.g. "https://vigil.example.com".
-VIGIL_CORS_ORIGINS = ""
+VIGIL_CORS_ORIGINS=""
 
 # Security headers — each one can be toggled off if a reverse proxy in front
 # of the backend already sets it (to avoid duplicate values).
-VIGIL_HSTS_ENABLED = "true"
-VIGIL_HSTS_MAX_AGE = "31536000"
-VIGIL_FRAME_OPTIONS_ENABLED = "true"
-VIGIL_CONTENT_TYPE_OPTIONS_ENABLED = "true"
-VIGIL_REFERRER_POLICY_ENABLED = "true"
+VIGIL_HSTS_ENABLED="true"
+VIGIL_HSTS_MAX_AGE="31536000"
+VIGIL_FRAME_OPTIONS_ENABLED="true"
+VIGIL_CONTENT_TYPE_OPTIONS_ENABLED="true"
+VIGIL_REFERRER_POLICY_ENABLED="true"
 
 # Content-Security-Policy. VIGIL_CSP_POLICY overrides the default entirely.
 # The default policy allows 'unsafe-inline' for styles (required by MUI) but
 # not for scripts. If you serve the frontend from a different origin than the
 # API you may need to widen connect-src.
-VIGIL_CSP_ENABLED = "true"
-VIGIL_CSP_POLICY = ""
+VIGIL_CSP_ENABLED="true"
+VIGIL_CSP_POLICY=""
 
 # -----------------------------------------------------------------------------
 # CSRF Protection
@@ -147,13 +147,13 @@ VIGIL_CSP_POLICY = ""
 # Double-submit cookie pattern, enabled by default alongside the cookie-based
 # auth migration. The frontend's axios interceptor reads csrf_token and
 # echoes it as the X-CSRF-Token header on mutating requests.
-VIGIL_CSRF_ENABLED = "true"
+VIGIL_CSRF_ENABLED="true"
 # Report-only logs violations without rejecting. Keep "true" for one rollout
 # window, then flip to "false" to enforce.
-VIGIL_CSRF_REPORT_ONLY = "true"
+VIGIL_CSRF_REPORT_ONLY="true"
 # Comma-separated path prefixes exempt from CSRF checks (webhooks that
 # authenticate themselves with HMAC, server-to-server ingestion endpoints).
-VIGIL_CSRF_EXEMPT_PATHS = "/api/webhooks/,/api/ingest/"
+VIGIL_CSRF_EXEMPT_PATHS="/api/webhooks/,/api/ingest/"
 
 # -----------------------------------------------------------------------------
 # Auth Cookies (HttpOnly access_token + refresh_token)
@@ -161,67 +161,67 @@ VIGIL_CSRF_EXEMPT_PATHS = "/api/webhooks/,/api/ingest/"
 # Whether the csrf_token and auth cookies should be set with Secure.
 # Leave "true" for anything served over HTTPS; set "false" ONLY for local
 # HTTP dev.
-VIGIL_COOKIE_SECURE = "true"
+VIGIL_COOKIE_SECURE="true"
 # SameSite attribute on auth cookies. "strict" is strongest; use "lax" if
 # the deployment has SSO redirects that need cookies on cross-site nav.
 # "none" requires Secure=true and is only sensible for cross-origin setups.
-VIGIL_COOKIE_SAMESITE = "strict"
+VIGIL_COOKIE_SAMESITE="strict"
 
 # -----------------------------------------------------------------------------
 # MemPalace — Persistent AI Memory Layer
 # -----------------------------------------------------------------------------
 # Path to the ChromaDB palace data directory (used by MCP server and Python API)
-MEMPALACE_PALACE_PATH = "~/.vigil/mempalace/palace"
+MEMPALACE_PALACE_PATH="~/.vigil/mempalace/palace"
 # Set to true to enable cross-run memory in the autonomous daemon
-MEMPALACE_DAEMON_ENABLED = "false"
+MEMPALACE_DAEMON_ENABLED="false"
 
 # -----------------------------------------------------------------------------
 # Data Source Integrations
 # -----------------------------------------------------------------------------
 
 # Splunk SIEM
-SPLUNK_URL = "https://splunk.example.com:8089"
-SPLUNK_USERNAME = "admin"
-SPLUNK_PASSWORD = "your_splunk_password"
+SPLUNK_URL="https://splunk.example.com:8089"
+SPLUNK_USERNAME="admin"
+SPLUNK_PASSWORD="your_splunk_password"
 # Note: Splunk's REST API on port 8089 uses HTTPS by default
 # Set SPLUNK_URL to https://splunk.example.com:8089, not http://
 
 # CrowdStrike Falcon
-CROWDSTRIKE_CLIENT_ID = ""
-CROWDSTRIKE_CLIENT_SECRET = ""
-CROWDSTRIKE_BASE_URL = "https://api.crowdstrike.com"
+CROWDSTRIKE_CLIENT_ID=""
+CROWDSTRIKE_CLIENT_SECRET=""
+CROWDSTRIKE_BASE_URL="https://api.crowdstrike.com"
 
 # Elastic Security / Elasticsearch SIEM
-ELASTIC_HOST = "https://elasticsearch.example.com:9200"
-ELASTIC_KIBANA_URL = "https://kibana.example.com:5601"
-ELASTIC_API_KEY = ""
+ELASTIC_HOST="https://elasticsearch.example.com:9200"
+ELASTIC_KIBANA_URL="https://kibana.example.com:5601"
+ELASTIC_API_KEY=""
 # Alternative to API key — basic auth:
 # ELASTIC_USERNAME="elastic"
 # ELASTIC_PASSWORD="your_elastic_password"
-ELASTIC_VERIFY_SSL = "true"
-ELASTIC_INDEX_PATTERN = ".alerts-security.alerts-default"
+ELASTIC_VERIFY_SSL="true"
+ELASTIC_INDEX_PATTERN=".alerts-security.alerts-default"
 
 # Timesketch
-TIMESKETCH_URL = "http://localhost:5000"
-TIMESKETCH_USERNAME = "admin"
-TIMESKETCH_PASSWORD = "your_timesketch_password"
+TIMESKETCH_URL="http://localhost:5000"
+TIMESKETCH_USERNAME="admin"
+TIMESKETCH_PASSWORD="your_timesketch_password"
 
 # Cribl Stream
-CRIBL_URL = "https://cribl.example.com:9000"
-CRIBL_USERNAME = "admin"
-CRIBL_PASSWORD = "your_cribl_password"
-CRIBL_WORKER_GROUP = "default"
+CRIBL_URL="https://cribl.example.com:9000"
+CRIBL_USERNAME="admin"
+CRIBL_PASSWORD="your_cribl_password"
+CRIBL_WORKER_GROUP="default"
 
 # Darktrace (inbound webhook receiver — push-only in this integration)
 # Works with both SaaS tenants and on-prem master appliances.
 # DARKTRACE_URL is optional; when set it's used to build back-links from
 # findings into the Darktrace console (SaaS: https://<tenant>.cloud.darktrace.com,
 # on-prem: https://<master-ip-or-host>).
-DARKTRACE_ENABLED = "false"
-DARKTRACE_URL = ""
-DARKTRACE_WEBHOOK_SECRET = ""
+DARKTRACE_ENABLED="false"
+DARKTRACE_URL=""
+DARKTRACE_WEBHOOK_SECRET=""
 # Optional hard cap on webhook body size (KB). Default 1024.
-DARKTRACE_MAX_BODY_KB = "1024"
+DARKTRACE_MAX_BODY_KB="1024"
 
 # VStrike (CloudCurrent network topology fusion layer)
 # Outbound: Vigil queries VStrike for asset topology / blast radius.
@@ -233,100 +233,100 @@ DARKTRACE_MAX_BODY_KB = "1024"
 # these are set, the frontend hard-replaces the EntityGraph with a
 # VStrike iframe in the Dashboard "Entity Graph" tab and the Investigation
 # workspace.
-VSTRIKE_BASE_URL = "https://vstrike.net"
-VSTRIKE_API_KEY = ""
-VSTRIKE_VERIFY_SSL = "true"
-VSTRIKE_INBOUND_API_KEY = ""
-VSTRIKE_USERNAME = ""
-VSTRIKE_PASSWORD = ""
+VSTRIKE_BASE_URL="https://vstrike.net"
+VSTRIKE_API_KEY=""
+VSTRIKE_VERIFY_SSL="true"
+VSTRIKE_INBOUND_API_KEY=""
+VSTRIKE_USERNAME=""
+VSTRIKE_PASSWORD=""
 
 # -----------------------------------------------------------------------------
 # Threat Intelligence
 # -----------------------------------------------------------------------------
 
 # VirusTotal
-VIRUSTOTAL_API_KEY = ""
+VIRUSTOTAL_API_KEY=""
 
 # Shodan
-SHODAN_API_KEY = ""
+SHODAN_API_KEY=""
 
 # AlienVault OTX
-ALIENVAULT_OTX_API_KEY = ""
+ALIENVAULT_OTX_API_KEY=""
 
 # Cloudforce One STIX/TAXII threat-intel feed (Cloudflare partnership).
 # Configure via Settings → Integrations → Cloudflare Cloudforce One; these
 # env vars are fallbacks only. Polling is disabled when the integration
 # itself is not enabled — these vars do nothing on their own.
-CLOUDFORCE_ONE_API_TOKEN = ""
-CLOUDFORCE_ONE_TAXII_SERVER_URL = ""
-CLOUDFORCE_ONE_COLLECTION_IDS = ""
+CLOUDFORCE_ONE_API_TOKEN=""
+CLOUDFORCE_ONE_TAXII_SERVER_URL=""
+CLOUDFORCE_ONE_COLLECTION_IDS=""
 # How often the daemon pulls TAXII collections. Minimum enforced at 60s.
-THREAT_FEED_POLL_INTERVAL = "900"
+THREAT_FEED_POLL_INTERVAL="900"
 
 # Cloudflare Cloudy webhook ingestion (gated; off by default).
 # Flip CLOUDY_INGESTION_ENABLED=true once the Cloudflare partnership confirms
 # the public webhook contract. The receiver also requires CLOUDY_WEBHOOK_SECRET
 # for HMAC verification — without it, the endpoint returns 503.
-CLOUDY_INGESTION_ENABLED = "false"
-CLOUDY_WEBHOOK_SECRET = ""
-CLOUDY_WEBHOOK_MAX_BODY_KB = "1024"
+CLOUDY_INGESTION_ENABLED="false"
+CLOUDY_WEBHOOK_SECRET=""
+CLOUDY_WEBHOOK_MAX_BODY_KB="1024"
 
 # -----------------------------------------------------------------------------
 # Sandbox / Malware Detonation (issue #86)
 # -----------------------------------------------------------------------------
 # Joe Sandbox (external MCP server — see mcp-config.json joe-sandbox entry)
-JOE_SANDBOX_ENABLED = "false"
-JOE_SANDBOX_URL = "https://jbxcloud.joesecurity.org/api"
-JOE_SANDBOX_API_KEY = ""
+JOE_SANDBOX_ENABLED="false"
+JOE_SANDBOX_URL="https://jbxcloud.joesecurity.org/api"
+JOE_SANDBOX_API_KEY=""
 
 # CAPE Sandbox (open-source Cuckoo fork — tools/cape_sandbox.py)
 # Assumes you bring your own CAPE deployment (docker-compose self-hosting is
 # out of scope; CAPE needs KVM + Windows guest VMs).
-CAPE_SANDBOX_ENABLED = "false"
-CAPE_SANDBOX_URL = "http://localhost:8000"
-CAPE_SANDBOX_API_KEY = ""
+CAPE_SANDBOX_ENABLED="false"
+CAPE_SANDBOX_URL="http://localhost:8000"
+CAPE_SANDBOX_API_KEY=""
 
 # Hybrid Analysis / Any.Run already use get_integration_config(); these flags
 # just toggle whether the daemon auto-submission pipeline consults them.
-HYBRID_ANALYSIS_ENABLED = "false"
-ANYRUN_ENABLED = "false"
+HYBRID_ANALYSIS_ENABLED="false"
+ANYRUN_ENABLED="false"
 
 # Auto-submission pipeline (off by default — opt-in)
 # When true, daemon/processor.py will call sandbox search APIs during the
 # enrichment step for each file hash on a finding. Binary upload is NOT
 # performed from Vigil — only hash-cache lookups + submission-by-hash where
 # the sandbox supports it.
-SANDBOX_AUTO_SUBMIT = "false"
-SANDBOX_MAX_FILE_SIZE_MB = "100"
-SANDBOX_ALLOWED_FILE_TYPES = "exe,dll,doc,docx,xls,xlsx,pdf,js,vbs,ps1,bat,msi"
-SANDBOX_ANALYSIS_TIMEOUT = "300"
-SANDBOX_POLL_INTERVAL = "60"
+SANDBOX_AUTO_SUBMIT="false"
+SANDBOX_MAX_FILE_SIZE_MB="100"
+SANDBOX_ALLOWED_FILE_TYPES="exe,dll,doc,docx,xls,xlsx,pdf,js,vbs,ps1,bat,msi"
+SANDBOX_ANALYSIS_TIMEOUT="300"
+SANDBOX_POLL_INTERVAL="60"
 
 # -----------------------------------------------------------------------------
 # Notification / Escalation
 # -----------------------------------------------------------------------------
 
 # Slack
-SLACK_BOT_TOKEN = "xoxb-..."
-SLACK_DEFAULT_CHANNEL = "#soc-alerts"
+SLACK_BOT_TOKEN="xoxb-..."
+SLACK_DEFAULT_CHANNEL="#soc-alerts"
 
 # PagerDuty
-PAGERDUTY_ROUTING_KEY = ""
+PAGERDUTY_ROUTING_KEY=""
 
 # Microsoft Teams
-TEAMS_WEBHOOK_URL = ""
+TEAMS_WEBHOOK_URL=""
 
 # -----------------------------------------------------------------------------
 # Cloud Integrations
 # -----------------------------------------------------------------------------
 
 # AWS
-AWS_ACCESS_KEY_ID = "AKIA..."
-AWS_SECRET_ACCESS_KEY = "..."
-AWS_REGION = "us-east-1"
+AWS_ACCESS_KEY_ID="AKIA..."
+AWS_SECRET_ACCESS_KEY="..."
+AWS_REGION="us-east-1"
 
 # GitHub (for skill installer)
-GITHUB_TOKEN = "ghp_..."
+GITHUB_TOKEN="ghp_..."
 
 # =============================================================================
 # SOC Daemon Configuration
@@ -336,131 +336,131 @@ GITHUB_TOKEN = "ghp_..."
 # Polling Intervals (seconds)
 # -----------------------------------------------------------------------------
 # 5 minutes
-DAEMON_SPLUNK_POLL_INTERVAL = "300"
+DAEMON_SPLUNK_POLL_INTERVAL="300"
 # 1 minute
-DAEMON_CROWDSTRIKE_POLL_INTERVAL = "60"
+DAEMON_CROWDSTRIKE_POLL_INTERVAL="60"
 
 # -----------------------------------------------------------------------------
 # Webhook Ingestion
 # -----------------------------------------------------------------------------
-DAEMON_WEBHOOK_ENABLED = "true"
-DAEMON_WEBHOOK_PORT = "8081"
+DAEMON_WEBHOOK_ENABLED="true"
+DAEMON_WEBHOOK_PORT="8081"
 
 # -----------------------------------------------------------------------------
 # AI Processing
 # -----------------------------------------------------------------------------
 # Enable AI-powered triage
-DAEMON_AUTO_TRIAGE = "true"
+DAEMON_AUTO_TRIAGE="true"
 # Enable threat intel enrichment
-DAEMON_AUTO_ENRICH = "true"
+DAEMON_AUTO_ENRICH="true"
 # Findings to process per batch
-DAEMON_BATCH_SIZE = "10"
+DAEMON_BATCH_SIZE="10"
 
 # -----------------------------------------------------------------------------
 # Autonomous Response
 # -----------------------------------------------------------------------------
 # Enable autonomous response actions
-DAEMON_AUTO_RESPONSE = "true"
+DAEMON_AUTO_RESPONSE="true"
 # Auto-execute above this confidence
-DAEMON_CONFIDENCE_THRESHOLD = "0.90"
+DAEMON_CONFIDENCE_THRESHOLD="0.90"
 # Require approval for all actions
-DAEMON_FORCE_APPROVAL = "false"
+DAEMON_FORCE_APPROVAL="false"
 # Log actions without executing
-DAEMON_DRY_RUN = "false"
+DAEMON_DRY_RUN="false"
 
 # -----------------------------------------------------------------------------
 # Escalation
 # -----------------------------------------------------------------------------
-DAEMON_ESCALATION_ENABLED = "true"
-DAEMON_ESCALATE_SEVERITIES = "critical,high"
-DAEMON_SLACK_ENABLED = "true"
-DAEMON_SLACK_CHANNEL = "#soc-alerts"
-DAEMON_PAGERDUTY_ENABLED = "false"
+DAEMON_ESCALATION_ENABLED="true"
+DAEMON_ESCALATE_SEVERITIES="critical,high"
+DAEMON_SLACK_ENABLED="true"
+DAEMON_SLACK_CHANNEL="#soc-alerts"
+DAEMON_PAGERDUTY_ENABLED="false"
 
 # -----------------------------------------------------------------------------
 # Scheduled Tasks
 # -----------------------------------------------------------------------------
-DAEMON_THREAT_HUNT_ENABLED = "true"
+DAEMON_THREAT_HUNT_ENABLED="true"
 # Daily (24 hours)
-DAEMON_THREAT_HUNT_INTERVAL = "86400"
+DAEMON_THREAT_HUNT_INTERVAL="86400"
 # Keep data for 90 days
-DAEMON_CLEANUP_RETENTION_DAYS = "90"
+DAEMON_CLEANUP_RETENTION_DAYS="90"
 
 # -----------------------------------------------------------------------------
 # Metrics / Monitoring
 # -----------------------------------------------------------------------------
-DAEMON_METRICS_ENABLED = "true"
-DAEMON_METRICS_PORT = "9090"
+DAEMON_METRICS_ENABLED="true"
+DAEMON_METRICS_PORT="9090"
 
 # -----------------------------------------------------------------------------
 # Logging
 # -----------------------------------------------------------------------------
 # Allowed values: DEBUG, INFO, WARNING, ERROR
-DAEMON_LOG_LEVEL = "INFO"
+DAEMON_LOG_LEVEL="INFO"
 
 # -----------------------------------------------------------------------------
 # Detection Engineering (Security-Detections-MCP)
 # -----------------------------------------------------------------------------
 # Paths to detection rule repositories (auto-configured by setup_dev.sh)
 # To skip auto-setup: SKIP_DETECTION_REPOS=true ./setup_dev.sh
-SIGMA_PATHS = "${HOME}/security-detections/sigma/rules"
-SPLUNK_PATHS = "${HOME}/security-detections/security_content/detections"
-ELASTIC_PATHS = "${HOME}/security-detections/detection-rules/rules"
-KQL_PATHS = "${HOME}/security-detections/Hunting-Queries-Detection-Rules"
-STORY_PATHS = "${HOME}/security-detections/security_content/stories"
+SIGMA_PATHS="${HOME}/security-detections/sigma/rules"
+SPLUNK_PATHS="${HOME}/security-detections/security_content/detections"
+ELASTIC_PATHS="${HOME}/security-detections/detection-rules/rules"
+KQL_PATHS="${HOME}/security-detections/Hunting-Queries-Detection-Rules"
+STORY_PATHS="${HOME}/security-detections/security_content/stories"
 
 # =============================================================================
 # Autonomous Orchestrator
 # =============================================================================
 
 # Master toggle for autonomous operations
-ORCHESTRATOR_ENABLED = "false"
+ORCHESTRATOR_ENABLED="false"
 
 # How often (seconds) the orchestrator loops check for new work
-ORCHESTRATOR_LOOP_INTERVAL = "60"
+ORCHESTRATOR_LOOP_INTERVAL="60"
 
 # Max sub-agents running simultaneously (respects API rate limits)
-ORCHESTRATOR_MAX_CONCURRENT_AGENTS = "3"
+ORCHESTRATOR_MAX_CONCURRENT_AGENTS="3"
 
 # Per-agent limits
 # Max Claude calls per investigation
-ORCHESTRATOR_MAX_ITERATIONS = "50"
+ORCHESTRATOR_MAX_ITERATIONS="50"
 # Max USD spend per investigation
-ORCHESTRATOR_MAX_COST = "5.0"
+ORCHESTRATOR_MAX_COST="5.0"
 # Max seconds per investigation (1 hour)
-ORCHESTRATOR_MAX_RUNTIME = "3600"
+ORCHESTRATOR_MAX_RUNTIME="3600"
 
 # Global cost guardrails
 # Pause intake if hourly spend exceeds this
-ORCHESTRATOR_MAX_HOURLY_COST = "20.0"
+ORCHESTRATOR_MAX_HOURLY_COST="20.0"
 # Hard daily ceiling
-ORCHESTRATOR_MAX_DAILY_COST = "100.0"
+ORCHESTRATOR_MAX_DAILY_COST="100.0"
 
 # Stale agent detection (seconds of inactivity before killing)
-ORCHESTRATOR_STALE_THRESHOLD = "300"
+ORCHESTRATOR_STALE_THRESHOLD="300"
 
 # Working directory for investigation files
-ORCHESTRATOR_WORKDIR = "data/investigations"
+ORCHESTRATOR_WORKDIR="data/investigations"
 
 # Automatically investigate findings at these severities
-ORCHESTRATOR_AUTO_ASSIGN = "true"
-ORCHESTRATOR_AUTO_SEVERITIES = "critical,high"
+ORCHESTRATOR_AUTO_ASSIGN="true"
+ORCHESTRATOR_AUTO_SEVERITIES="critical,high"
 
 # Dry run mode: agents gather data but skip managed/destructive tool calls
-ORCHESTRATOR_DRY_RUN = "false"
+ORCHESTRATOR_DRY_RUN="false"
 
 # Deduplication window (minutes) for overlapping findings
-ORCHESTRATOR_DEDUP_WINDOW = "30"
+ORCHESTRATOR_DEDUP_WINDOW="30"
 
 # Delay (seconds) between agent loop iterations
-ORCHESTRATOR_AGENT_LOOP_DELAY = "2"
+ORCHESTRATOR_AGENT_LOOP_DELAY="2"
 
 # Max characters of context.md to include in agent prompts
-ORCHESTRATOR_CONTEXT_MAX_CHARS = "10000"
+ORCHESTRATOR_CONTEXT_MAX_CHARS="10000"
 
 # Models used for plan generation and review
-ORCHESTRATOR_PLAN_MODEL = "claude-sonnet-4-5-20250929"
-ORCHESTRATOR_REVIEW_MODEL = "claude-sonnet-4-5-20250929"
+ORCHESTRATOR_PLAN_MODEL="claude-sonnet-4-5-20250929"
+ORCHESTRATOR_REVIEW_MODEL="claude-sonnet-4-5-20250929"
 # =============================================================================
 # OPENTELEMETRY (OTEL) OBSERVABILITY
 # =============================================================================
@@ -468,28 +468,28 @@ ORCHESTRATOR_REVIEW_MODEL = "claude-sonnet-4-5-20250929"
 # Enable/disable the full OTEL stack (traces, metrics, structured logging)
 # When true: PrometheusMetricReader serves /metrics on port 9090 and
 #            all processes emit structured JSON logs with trace_id/span_id.
-VIGIL_OTEL_ENABLED = "false"
+VIGIL_OTEL_ENABLED="false"
 
 # OTLP exporter endpoint (gRPC) — points to the OTEL Collector
 # Default: local docker-compose collector
-OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
+OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
 
 # Traces sampler — "parentbased_always_on" | "parentbased_traceidratio" | "always_off"
-OTEL_TRACES_SAMPLER = "parentbased_always_on"
+OTEL_TRACES_SAMPLER="parentbased_always_on"
 
 # When using traceidratio, set the sampling fraction (0.0–1.0)
 # OTEL_TRACES_SAMPLER_ARG="0.1"
 
 # Allow LLM prompt/completion content to be recorded in spans (default: false)
 # WARNING: may capture PII / sensitive IOC data — review before enabling
-VIGIL_OTEL_LOG_LLM_CONTENT = "false"
+VIGIL_OTEL_LOG_LLM_CONTENT="false"
 
 # Health server port (daemon only) — /health and /status endpoints
 # Port 9090 is reserved for the Prometheus /metrics endpoint (OTEL reader)
-DAEMON_HEALTH_PORT = "9091"
+DAEMON_HEALTH_PORT="9091"
 
 # Grafana admin password (used by docker-compose observability profile)
-GRAFANA_PASSWORD = "admin"
+GRAFANA_PASSWORD="admin"
 
 # =============================================================================
 # Kafka Ingestion (optional; start with: docker compose --profile kafka up)
@@ -497,22 +497,22 @@ GRAFANA_PASSWORD = "admin"
 # Most of these can be overridden at runtime in the Settings > Kafka tab.
 # Secrets (SASL password, SSL cert path) are intentionally env-only — the
 # Settings UI will not read or write them.
-KAFKA_ENABLED = "false"
-KAFKA_BOOTSTRAP_SERVERS = "localhost:9092"
-KAFKA_CONSUMER_GROUP = "vigil-soc"
+KAFKA_ENABLED="false"
+KAFKA_BOOTSTRAP_SERVERS="localhost:9092"
+KAFKA_CONSUMER_GROUP="vigil-soc"
 # Comma-separated list of topics (leave empty to disable until configured)
-KAFKA_TOPICS = ""
+KAFKA_TOPICS=""
 # "latest" (default) | "earliest"
-KAFKA_AUTO_OFFSET_RESET = "latest"
+KAFKA_AUTO_OFFSET_RESET="latest"
 # PLAINTEXT | SSL | SASL_SSL | SASL_PLAINTEXT
-KAFKA_SECURITY_PROTOCOL = "PLAINTEXT"
+KAFKA_SECURITY_PROTOCOL="PLAINTEXT"
 # PLAIN | SCRAM-SHA-256 | SCRAM-SHA-512 (empty if not using SASL)
-KAFKA_SASL_MECHANISM = ""
-KAFKA_SASL_USERNAME = ""
-KAFKA_SASL_PASSWORD = ""
-KAFKA_SSL_CA_LOCATION = ""
-KAFKA_MAX_POLL_RECORDS = "500"
-KAFKA_SESSION_TIMEOUT_MS = "30000"
+KAFKA_SASL_MECHANISM=""
+KAFKA_SASL_USERNAME=""
+KAFKA_SASL_PASSWORD=""
+KAFKA_SSL_CA_LOCATION=""
+KAFKA_MAX_POLL_RECORDS="500"
+KAFKA_SESSION_TIMEOUT_MS="30000"
 
 # =============================================================================
 # Multi-Provider LLM (Issues #84, #88)
@@ -520,42 +520,42 @@ KAFKA_SESSION_TIMEOUT_MS = "30000"
 # Bifrost is the single gateway for ALL LLM traffic (GH #84 PR-B). Anthropic
 # calls hit the /anthropic passthrough (preserves extended thinking + prompt
 # caching); OpenAI/Ollama/etc. hit the /v1 OpenAI-format surface.
-BIFROST_URL = "http://bifrost:8080"
+BIFROST_URL="http://bifrost:8080"
 # Kill-switch for Anthropic native prompt caching (GH #84 PR-C). Leave on —
 # cached prefixes cost ~10% of normal input tokens. Set to "false" only to
 # debug whether a problem is cache-related.
-ANTHROPIC_PROMPT_CACHE_ENABLED = "true"
+ANTHROPIC_PROMPT_CACHE_ENABLED="true"
 
 # Conversation-history sliding window (GH #84 PR-D). Caps per-session turns
 # passed to Claude before summarization fires. A "turn" is one user +
 # assistant pair, so 20 = up to 40 messages. Summarization itself costs
 # tokens; avoiding it on short sessions is a cost win. Set to 0 to disable
 # the window and always summarize when context overflows.
-CLAUDE_HISTORY_WINDOW = "20"
+CLAUDE_HISTORY_WINDOW="20"
 
 # Default per-tool-result truncation budget (GH #84 PR-D). Per-tool
 # overrides live in ClaudeService.TOOL_RESPONSE_BUDGETS (e.g. get_raw_logs
 # keeps 30k). Lower to squeeze token spend harder; raise if you see
 # analyses losing critical detail past the truncation marker.
-TOOL_RESPONSE_BUDGET_DEFAULT = "8000"
+TOOL_RESPONSE_BUDGET_DEFAULT="8000"
 
 # Default extended-thinking budget for the autonomous daemon runner
 # (GH #84 PR-D). Per-agent overrides in services/soc_agents.py take
 # precedence when the caller has agent context; the daemon runner falls
 # back to this process-wide default.
-CLAUDE_THINKING_BUDGET = "10000"
+CLAUDE_THINKING_BUDGET="10000"
 
 # Ollama (local or remote). base_url and per-provider config are also stored
 # per-row in llm_provider_configs; these are defaults for first-boot seeding.
-OLLAMA_ENABLED = "false"
-OLLAMA_URL = "http://localhost:11434"
-OLLAMA_DEFAULT_MODEL = "llama3.1:70b"
+OLLAMA_ENABLED="false"
+OLLAMA_URL="http://localhost:11434"
+OLLAMA_DEFAULT_MODEL="llama3.1:70b"
 
 # OpenAI (direct API or OpenAI-compatible endpoint)
-OPENAI_ENABLED = "false"
-OPENAI_API_KEY = ""
-OPENAI_BASE_URL = "https://api.openai.com/v1"
-OPENAI_ORGANIZATION = ""
+OPENAI_ENABLED="false"
+OPENAI_API_KEY=""
+OPENAI_BASE_URL="https://api.openai.com/v1"
+OPENAI_ORGANIZATION=""
 
 # Default provider for new LLM requests when no provider_id is supplied
-DEFAULT_LLM_PROVIDER = "anthropic"
+DEFAULT_LLM_PROVIDER="anthropic"


### PR DESCRIPTION
The spaces around the equals signs in the example .env file were causing the source command to fail with "Command Not Found" for all the variable names, since it thought they were commands.