### PR TITLE
Honor base_url on Anthropic provider rows

### DIFF
--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -324,7 +324,10 @@ async def test_provider(provider_id: str, db: Session = Depends(get_db_session))
             # Must use AsyncAnthropic (not Anthropic) — this endpoint is
             # async and the sync client would block the FastAPI event loop
             # for up to the full timeout on an invalid key or slow network.
-            client = AsyncAnthropic(api_key=key, timeout=15.0)
+            anthropic_kwargs: Dict[str, Any] = {"api_key": key, "timeout": 15.0}
+            if row.base_url:
+                anthropic_kwargs["base_url"] = row.base_url
+            client = AsyncAnthropic(**anthropic_kwargs)
             await client.messages.create(
                 model=row.default_model,
                 max_tokens=1,
@@ -377,7 +380,9 @@ async def discover_models(req: DiscoverModelsRequest):
         if req.provider_type == "anthropic":
             if not req.api_key:
                 return {"models": ANTHROPIC_FALLBACK_MODELS}
-            meta = await discovery.fetch_anthropic_models(req.api_key)
+            meta = await discovery.fetch_anthropic_models(
+                req.api_key, base_url=req.base_url
+            )
         elif req.provider_type == "openai":
             if not req.api_key:
                 raise HTTPException(

--- a/services/bifrost_admin.py
+++ b/services/bifrost_admin.py
@@ -430,7 +430,7 @@ async def _fetch_meta_for_row(row_dict: Dict[str, Any], discovery) -> Optional[l
                 row_dict["provider_id"],
             )
             return None
-        return await discovery.fetch_anthropic_models(key)
+        return await discovery.fetch_anthropic_models(key, base_url=base_url)
 
     if provider_type == "openai":
         key = _resolve_key()

--- a/services/provider_model_discovery.py
+++ b/services/provider_model_discovery.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 _CACHE_TTL_S = 60.0
 _RETRIES = 3
 _RETRY_BACKOFF_S = 2.0
-_ANTHROPIC_API_URL = "https://api.anthropic.com/v1/models"
+_ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com/v1"
 _ANTHROPIC_VERSION = "2023-06-01"
 
 
@@ -148,17 +148,26 @@ def _anthropic_caps(api_caps: Dict[str, Any]) -> Dict[str, bool]:
     }
 
 
-async def fetch_anthropic_models(api_key: str) -> List[ModelMeta]:
-    """Fetch the live Anthropic model catalog.
+async def fetch_anthropic_models(
+    api_key: str,
+    base_url: Optional[str] = None,
+) -> List[ModelMeta]:
+    """Fetch the live Anthropic (or Anthropic-compatible) model catalog.
 
     Raises on unrecoverable error so the caller can fall back to the
-    hard-coded bootstrap list. A non-200 from Anthropic (e.g. invalid
+    hard-coded bootstrap list. A non-200 from upstream (e.g. invalid
     key) raises ``httpx.HTTPStatusError``.
+
+    ``base_url`` defaults to ``https://api.anthropic.com/v1``. Override
+    for on-prem / private Anthropic-compatible deployments. The full
+    models URL is derived as ``{base_url}/models``.
     """
     if not api_key:
         raise RuntimeError("fetch_anthropic_models: api_key required")
 
-    cache_key = _cache_key("anthropic", _ANTHROPIC_API_URL, api_key)
+    base = (base_url or _ANTHROPIC_DEFAULT_BASE_URL).rstrip("/")
+    models_url = f"{base}/models"
+    cache_key = _cache_key("anthropic", models_url, api_key)
     cached = _META_CACHE.get(cache_key)
     if cached is not None:
         return cached
@@ -176,9 +185,7 @@ async def fetch_anthropic_models(api_key: str) -> List[ModelMeta]:
                 params: Dict[str, Any] = {"limit": 1000}
                 if after_id:
                     params["after_id"] = after_id
-                resp = await client.get(
-                    _ANTHROPIC_API_URL, headers=headers, params=params
-                )
+                resp = await client.get(models_url, headers=headers, params=params)
                 resp.raise_for_status()
                 payload = resp.json()
                 for m in payload.get("data", []):


### PR DESCRIPTION
## Summary

- Brings the three Anthropic call sites that previously hardcoded `api.anthropic.com` to parity with the OpenAI/Ollama paths, which already accept a configurable `base_url`.
- `services/provider_model_discovery.fetch_anthropic_models` now takes an optional `base_url` (the existing public URL stays as the default).
- `services/bifrost_admin._fetch_meta_for_row` threads the row's `base_url` through to model discovery (the variable was already in scope).
- `backend/api/llm_providers`: `test_provider` passes `row.base_url` to `AsyncAnthropic` when set; `discover-models` passes `req.base_url`.

## Why

A customer asked about "sandboxed Claude" — the most likely match for a SOC customer is Anthropic's enterprise on-prem / air-gapped Claude deployment. Vigil's single-path Bifrost routing means that integration is mostly a Bifrost config change, **except** for these three Anthropic-specific bypasses (model discovery and key validation, which deliberately hit upstream rather than Bifrost). Without a configurable `base_url`, an Anthropic-compatible on-prem endpoint can't be added as a normal provider row.

Independently of any on-prem work, this is a parity bug — the Anthropic codepath was the odd one out.

## What's not in this PR

Bifrost-side configuration, env-var documentation, and any Vigil-on-prem deployment topology work. Those are all gated on discovery answers from the customer + Anthropic on endpoint shape, auth model, and feature parity. See the scoping doc that prompted this PR.

## Test plan

- [x] `pytest tests/test_provider_model_discovery.py tests/test_bifrost_admin.py tests/test_llm_providers_api.py` — 31/31 pass.
- [x] `black --check` clean on touched files.
- [x] Default behaviour preserved: existing provider rows with `base_url` unset still hit the public Anthropic API.
- [ ] (Future, gated on customer/Anthropic answers) End-to-end smoke against a real Anthropic-compatible on-prem endpoint, plus rerun of `scripts/bifrost_capability_probe.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)