### PR TITLE
VStrike: auto-pull JWT, retire api_key field, show card description

### DIFF
--- a/frontend/src/config/integrations.ts
+++ b/frontend/src/config/integrations.ts
@@ -3063,7 +3063,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     name: 'CloudCurrent VStrike',
     category: 'Network Security',
     description:
-      'Network topology fusion layer. Correlates DeepTempo findings with asset, segment, mission system, and attack-path context, and pushes enriched findings back into Vigil.',
+      "Embed VStrike's network topology UI inside Vigil case investigations. Vigil drives which network and what kill-chain to play; VStrike streams the visualization back via WebSocket. Provides segment, criticality, mission-system, blast-radius, and attack-path enrichment to every Vigil agent.",
     functionality_type: 'Data Enrichment',
     fields: [
       {
@@ -3075,40 +3075,22 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
         helpText: 'Base URL of your VStrike deployment.',
       },
       {
-        name: 'api_key',
-        label: 'Outbound API Key',
-        type: 'password',
-        required: true,
-        placeholder: 'Bearer token for Vigil → VStrike calls',
-        helpText:
-          'Used for outbound topology lookups. Stored as VSTRIKE_API_KEY.',
-      },
-      {
-        name: 'inbound_api_key',
-        label: 'Inbound API Key',
-        type: 'password',
-        required: false,
-        placeholder: 'Bearer token VStrike presents to Vigil',
-        helpText:
-          'Required for /api/integrations/vstrike/findings unless DEV_MODE=true. Stored as VSTRIKE_INBOUND_API_KEY.',
-      },
-      {
         name: 'username',
-        label: 'MCP Username',
+        label: 'Username',
         type: 'text',
-        required: false,
+        required: true,
         placeholder: 'deeptempo_manager',
         helpText:
-          'VStrike MCP login username. Required to enable the embedded VStrike visualization (iframe replaces the default entity graph). Stored as VSTRIKE_USERNAME.',
+          'VStrike account username. Vigil exchanges username + password for a JWT via /mcp-login and refreshes it automatically — no API key paste needed.',
       },
       {
         name: 'password',
-        label: 'MCP Password',
+        label: 'Password',
         type: 'password',
-        required: false,
-        placeholder: 'Password for the MCP login user',
+        required: true,
+        placeholder: 'Password for the VStrike account',
         helpText:
-          'Password for the VStrike MCP login user. Stored as VSTRIKE_PASSWORD.',
+          'VStrike account password. Stored encrypted at ~/.vigil/secrets.enc — never written to disk in plaintext.',
       },
       {
         name: 'verify_ssl',

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -740,8 +740,11 @@ export default function Settings() {
               <Switch checked={isEnabled} onChange={(e) => handleToggleServer(serverName, e.target.checked)} size="small" />
             </Box>
 
-            {/* Row 2: Description */}
-            {SERVER_DESCRIPTIONS[serverName] && (
+            {/* Row 2: Description — curated SERVER_DESCRIPTIONS wins; otherwise
+                 fall back to the rich description carried on the integration
+                 metadata so cards like VStrike (no SERVER_DESCRIPTIONS entry)
+                 still render their integration blurb. */}
+            {(SERVER_DESCRIPTIONS[serverName] || integration?.description) && (
               <Typography
                 variant="caption"
                 color="text.secondary"
@@ -755,7 +758,7 @@ export default function Settings() {
                   mb: 0.75,
                 }}
               >
-                {SERVER_DESCRIPTIONS[serverName]}
+                {SERVER_DESCRIPTIONS[serverName] || integration?.description}
               </Typography>
             )}
 

--- a/services/integration_secrets.py
+++ b/services/integration_secrets.py
@@ -169,7 +169,7 @@ _SECRET_FIELDS: Mapping[str, tuple[str, ...]] = {
     "autopsy": ("password",),
     "osquery": ("api_token",),
     "cuckoo": ("api_token",),
-    "vstrike": ("api_key", "inbound_api_key", "username", "password"),
+    "vstrike": ("username", "password"),
 }
 
 

--- a/services/vstrike_service.py
+++ b/services/vstrike_service.py
@@ -152,55 +152,87 @@ def _extract_list(data: Any, keys: Tuple[str, ...]) -> Optional[List[Any]]:
 
 
 class VStrikeService:
-    """Thin REST + MCP client for the VStrike API."""
+    """Thin REST + MCP client for the VStrike API.
+
+    Auth is JWT-only: ``__init__`` takes username + password, exchanges them
+    for a JWT via ``/mcp-login`` on first use, and caches the token at the
+    module level. Every outbound call (REST or MCP tool) attaches the JWT
+    as ``Authorization: Bearer <jwt>``. On a 401 the cached JWT is dropped,
+    a fresh login runs, and the request retries once.
+
+    There is no static API-key path. Earlier revisions accepted a separate
+    ``api_key`` for the ``/api/v1/topology/*`` REST endpoints; that knob
+    has been retired so users only ever paste username + password into
+    Settings.
+    """
 
     def __init__(
         self,
         base_url: str,
-        api_key: Optional[str] = None,
         verify_ssl: bool = True,
         timeout: int = DEFAULT_TIMEOUT,
+        *,
         username: Optional[str] = None,
         password: Optional[str] = None,
     ):
         self.base_url = base_url.rstrip("/")
-        self.api_key = api_key
         self.verify_ssl = verify_ssl
         self.timeout = timeout
         self.username = username
         self.password = password
-
-        self.session = requests.Session()
-        self.session.verify = verify_ssl
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        }
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-        self.session.headers.update(headers)
 
     # ------------------------------------------------------------------ #
     # Credential predicates (used by API layer to branch cleanly)
     # ------------------------------------------------------------------ #
 
     @property
-    def has_api_credentials(self) -> bool:
-        """True when we can authenticate to the legacy topology REST API."""
-        return bool(self.api_key)
-
-    @property
     def has_ui_credentials(self) -> bool:
         """True when we can perform mcp-login + MCP tool calls for UI control."""
         return bool(self.username and self.password)
 
+    # Back-compat shim: a few callers still test ``has_api_credentials`` as
+    # a synonym for "can this service make outbound calls to VStrike?". With
+    # JWT-only auth, that's equivalent to having UI creds.
+    @property
+    def has_api_credentials(self) -> bool:
+        return self.has_ui_credentials
+
     # ------------------------------------------------------------------ #
-    # Legacy REST topology methods (Bearer api_key)
+    # REST topology helpers (JWT auth, with one-shot 401 retry)
     # ------------------------------------------------------------------ #
 
+    def _bearer_headers(self, jwt: str) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {jwt}",
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        }
+
     def _get(self, path: str, **kwargs) -> requests.Response:
+        """GET ``{base_url}{path}`` with JWT auth, retrying once on 401.
+
+        Used by every legacy ``/api/v1/*`` topology helper. The JWT is the
+        same one we use for MCP tool calls — VStrike accepts it anywhere.
+        """
         url = f"{self.base_url}{path}"
-        return self.session.get(url, timeout=self.timeout, **kwargs)
+        params = kwargs.pop("params", None)
+
+        def _do(jwt: str) -> requests.Response:
+            return requests.get(
+                url,
+                params=params,
+                timeout=self.timeout,
+                verify=self.verify_ssl,
+                headers=self._bearer_headers(jwt),
+                **kwargs,
+            )
+
+        jwt = self._ensure_jwt()
+        resp = _do(jwt)
+        if resp.status_code == 401:
+            self._invalidate_jwt()
+            resp = _do(self._ensure_jwt())
+        return resp
 
     def test_connection(self) -> Tuple[bool, str]:
         """Ping the VStrike health endpoint.
@@ -441,21 +473,19 @@ def _config_value(key: str, config: Optional[Dict[str, Any]]) -> Optional[str]:
 
 
 def get_vstrike_service() -> Optional[VStrikeService]:
-    """Construct a VStrikeService from env or integration config, or None.
+    """Construct a VStrikeService from env / encrypted store, or None.
 
-    Configured when both `base_url` is set AND at least one credential set
-    is present:
+    Configured when ``VSTRIKE_BASE_URL`` is set AND ``VSTRIKE_USERNAME`` +
+    ``VSTRIKE_PASSWORD`` are both present. Credentials are looked up via
+    Vigil's secrets manager (encrypted store → env → dotenv → keyring,
+    in priority order). The non-secret ``url`` and ``verify_ssl`` values
+    can come from the same chain, or from ``IntegrationConfig`` (DB) and
+    its JSON back-compat mirror via ``core.config.get_integration_config``.
 
-      - api_key (`VSTRIKE_API_KEY`) — enables legacy topology REST calls.
-      - username + password (`VSTRIKE_USERNAME` / `VSTRIKE_PASSWORD`) —
-        enables the MCP UI-control plane (iframe auto-login + ui-network-load).
-
-    Either or both modes may be configured. Credential lookups go through
-    Vigil's secrets manager, which checks (in priority order) the encrypted
-    store at ``~/.vigil/secrets.enc``, process env vars, ``.env`` file, and
-    the keyring (if enabled). The non-secret ``url`` and ``verify_ssl``
-    values are read from ``IntegrationConfig`` (DB) or its JSON
-    back-compat mirror via ``core.config.get_integration_config``.
+    The legacy ``VSTRIKE_API_KEY`` / ``api_key`` field is deprecated —
+    Vigil now exchanges username + password for a JWT internally on first
+    call and refreshes it on 401. Old api_key values left over in the
+    secrets store are tolerated but ignored.
     """
     try:
         from backend.secrets_manager import get_secret
@@ -466,7 +496,6 @@ def get_vstrike_service() -> Optional[VStrikeService]:
             return os.environ.get(name)
 
     base_url = get_secret("VSTRIKE_BASE_URL")
-    api_key = get_secret("VSTRIKE_API_KEY")
     username = get_secret("VSTRIKE_USERNAME")
     password = get_secret("VSTRIKE_PASSWORD")
     verify_ssl_value = get_secret("VSTRIKE_VERIFY_SSL")
@@ -474,8 +503,8 @@ def get_vstrike_service() -> Optional[VStrikeService]:
     if verify_ssl_value is not None:
         verify_ssl_env = verify_ssl_value.lower() != "false"
 
-    # Non-secret fields (and any legacy plaintext credentials) may still
-    # live in the integration config — read it once for back-compat.
+    # Non-secret fields (and any legacy plaintext username/password) may
+    # still live in the integration config — read it once for back-compat.
     config: Optional[Dict[str, Any]] = None
     try:
         from core.config import get_integration_config
@@ -486,15 +515,12 @@ def get_vstrike_service() -> Optional[VStrikeService]:
         config = None
 
     base_url = base_url or _config_value("url", config)
-    # Credentials should normally come from the secrets store; fall back to
-    # the integration config only for legacy installs that haven't migrated.
-    api_key = api_key or _config_value("api_key", config)
     username = username or _config_value("username", config)
     password = password or _config_value("password", config)
 
     if not base_url:
         return None
-    if not (api_key or (username and password)):
+    if not (username and password):
         return None
 
     if verify_ssl_env is not None:
@@ -506,7 +532,6 @@ def get_vstrike_service() -> Optional[VStrikeService]:
 
     return VStrikeService(
         base_url=base_url,
-        api_key=api_key,
         verify_ssl=verify_ssl,
         username=username,
         password=password,

--- a/tests/integration/test_integration_secrets_api.py
+++ b/tests/integration/test_integration_secrets_api.py
@@ -24,7 +24,7 @@ os.environ.setdefault("DEV_MODE", "true")
 
 
 def _post_payload():
-    """Realistic VStrike save payload from the Settings UI."""
+    """Realistic VStrike save payload from the Settings UI (JWT-only auth)."""
     from backend.api.config import IntegrationsConfig
 
     return IntegrationsConfig(
@@ -33,8 +33,6 @@ def _post_payload():
             "vstrike": {
                 "url": "https://vstrike.net",
                 "verify_ssl": False,
-                "api_key": "outbound-bearer",
-                "inbound_api_key": "inbound-bearer",
                 "username": "deeptempo_manager",
                 "password": "shh-secret",
             }
@@ -76,15 +74,13 @@ def test_post_routes_secrets_to_set_secret(tmp_path):
     # Each registered secret field should go through set_secret with the
     # secrets-store key from services.integration_secrets.
     written = {call.args[0]: call.args[1] for call in set_secret.call_args_list}
-    assert written["VSTRIKE_API_KEY"] == "outbound-bearer"
-    assert written["VSTRIKE_INBOUND_API_KEY"] == "inbound-bearer"
     assert written["VSTRIKE_USERNAME"] == "deeptempo_manager"
     assert written["VSTRIKE_PASSWORD"] == "shh-secret"
 
     # The DB write should contain ONLY non-secret fields.
     saved_config = config_service.set_integration_config.call_args.kwargs["config"]
     assert saved_config == {"url": "https://vstrike.net", "verify_ssl": False}
-    assert "api_key" not in saved_config
+    assert "username" not in saved_config
     assert "password" not in saved_config
 
 
@@ -101,7 +97,7 @@ def test_post_strips_secrets_from_json_mirror(tmp_path):
     persisted = on_disk["integrations"]["vstrike"]
     assert persisted == {"url": "https://vstrike.net", "verify_ssl": False}
     # No secrets in plaintext
-    for forbidden in ("api_key", "inbound_api_key", "username", "password"):
+    for forbidden in ("username", "password"):
         assert forbidden not in persisted
 
 
@@ -115,7 +111,6 @@ def test_post_skips_empty_secret_means_keep_existing(tmp_path):
             "vstrike": {
                 "url": "https://vstrike.net",
                 "verify_ssl": True,
-                "api_key": "",
                 "username": "alice",
                 "password": "",
             }
@@ -158,7 +153,6 @@ def test_get_redacts_registered_secret_fields(tmp_path):
                 # Pretend a legacy plaintext row still exists in DB.
                 "url": "https://vstrike.net",
                 "verify_ssl": True,
-                "api_key": "leaked-from-db",
                 "username": "alice",
                 "password": "wonderland",
             },
@@ -170,5 +164,5 @@ def test_get_redacts_registered_secret_fields(tmp_path):
 
     cfg = result["integrations"]["vstrike"]
     assert cfg == {"url": "https://vstrike.net", "verify_ssl": True}
-    for forbidden in ("api_key", "username", "password"):
+    for forbidden in ("username", "password"):
         assert forbidden not in cfg

--- a/tests/unit/test_integration_secrets.py
+++ b/tests/unit/test_integration_secrets.py
@@ -19,12 +19,16 @@ from services.integration_secrets import (  # noqa: E402
 
 
 def test_vstrike_secret_fields_registered():
-    """The four VStrike secret fields must round-trip to env-var keys."""
+    """VStrike's secret fields round-trip to env-var keys.
+
+    JWT-only auth: only username + password are user-supplied secrets. The
+    legacy api_key / inbound_api_key entries were retired in favor of
+    Vigil minting/refreshing the token internally."""
     fields = secret_fields_for("vstrike")
-    assert fields["api_key"] == "VSTRIKE_API_KEY"
-    assert fields["inbound_api_key"] == "VSTRIKE_INBOUND_API_KEY"
-    assert fields["username"] == "VSTRIKE_USERNAME"
-    assert fields["password"] == "VSTRIKE_PASSWORD"
+    assert fields == {
+        "username": "VSTRIKE_USERNAME",
+        "password": "VSTRIKE_PASSWORD",
+    }
 
 
 def test_secret_fields_for_unregistered_returns_empty():
@@ -37,14 +41,12 @@ def test_split_secrets_partitions_correctly():
         "verify_ssl": True,
         "username": "alice",
         "password": "wonderland",
-        "api_key": "bearer-token",
     }
     secrets, non_secrets = split_secrets("vstrike", raw)
     # Secrets keyed by env-var name, ready for set_secret().
     assert secrets == {
         "VSTRIKE_USERNAME": "alice",
         "VSTRIKE_PASSWORD": "wonderland",
-        "VSTRIKE_API_KEY": "bearer-token",
     }
     # Non-secrets retain original field names; no plaintext credentials.
     assert non_secrets == {
@@ -77,13 +79,11 @@ def test_split_secrets_unregistered_integration_passthrough():
 def test_redact_secrets_removes_registered_fields():
     raw = {
         "url": "https://vstrike.net",
-        "api_key": "leaked-bearer",
         "username": "alice",
         "password": "wonderland",
         "verify_ssl": True,
     }
     redacted = redact_secrets("vstrike", raw)
-    assert "api_key" not in redacted
     assert "username" not in redacted
     assert "password" not in redacted
     assert redacted["url"] == "https://vstrike.net"
@@ -98,7 +98,7 @@ def test_redact_secrets_unregistered_integration_passthrough():
 
 def test_secret_field_names_returns_form_field_names():
     names = list(secret_field_names("vstrike"))
-    assert set(names) == {"api_key", "inbound_api_key", "username", "password"}
+    assert set(names) == {"username", "password"}
 
 
 def test_registry_is_a_mapping_not_a_dict_alias():
@@ -279,8 +279,6 @@ def test_multi_secret_integrations_register_each_field():
         "integration_key",
     }
     assert set(INTEGRATION_SECRET_FIELDS["vstrike"].keys()) == {
-        "api_key",
-        "inbound_api_key",
         "username",
         "password",
     }

--- a/tests/unit/test_vstrike_service.py
+++ b/tests/unit/test_vstrike_service.py
@@ -49,24 +49,23 @@ def isolate_secrets(monkeypatch):
 
 
 def _service(**kwargs) -> VStrikeService:
+    """Build a fully-credentialed service. JWT-only auth — no api_key."""
     return VStrikeService(
         base_url=kwargs.get("base_url", "https://vstrike.example.com"),
-        api_key=kwargs.get("api_key", "test-key"),
         verify_ssl=kwargs.get("verify_ssl", False),
-        username=kwargs.get("username"),
-        password=kwargs.get("password"),
-    )
-
-
-def _ui_service(**kwargs) -> VStrikeService:
-    """Build a service configured for the UI/MCP path (no api_key)."""
-    return VStrikeService(
-        base_url=kwargs.get("base_url", "https://vstrike.example.com"),
-        api_key=kwargs.get("api_key"),
-        verify_ssl=False,
         username=kwargs.get("username", "deeptempo_manager"),
         password=kwargs.get("password", "secret"),
     )
+
+
+# Back-compat alias for tests that historically distinguished the two.
+def _ui_service(**kwargs) -> VStrikeService:
+    return _service(**kwargs)
+
+
+def _seed_jwt(svc: VStrikeService, value: str = "jwt-cached") -> None:
+    """Pre-seed the module-level JWT cache so REST tests skip /mcp-login."""
+    _jwt_cache[(svc.base_url, svc.username)] = (value, 9_999_999_999.0)
 
 
 def _mock_response(status_code=200, json_body=None, text=""):
@@ -74,17 +73,17 @@ def _mock_response(status_code=200, json_body=None, text=""):
     resp.status_code = status_code
     resp.json.return_value = json_body or {}
     resp.text = text
+    resp.headers = {"Content-Type": "application/json"}
     return resp
-
-
-def test_sets_bearer_auth_header():
-    svc = _service(api_key="abc123")
-    assert svc.session.headers["Authorization"] == "Bearer abc123"
 
 
 def test_test_connection_success():
     svc = _service()
-    with patch.object(svc.session, "get", return_value=_mock_response(200)):
+    _seed_jwt(svc)
+    with patch(
+        "services.vstrike_service.requests.get",
+        return_value=_mock_response(200),
+    ):
         ok, msg = svc.test_connection()
     assert ok is True
     assert "success" in msg.lower()
@@ -92,8 +91,10 @@ def test_test_connection_success():
 
 def test_test_connection_http_error():
     svc = _service()
-    with patch.object(
-        svc.session, "get", return_value=_mock_response(503, text="down")
+    _seed_jwt(svc)
+    with patch(
+        "services.vstrike_service.requests.get",
+        return_value=_mock_response(503, text="down"),
     ):
         ok, msg = svc.test_connection()
     assert ok is False
@@ -104,9 +105,9 @@ def test_test_connection_network_error():
     import requests
 
     svc = _service()
-    with patch.object(
-        svc.session,
-        "get",
+    _seed_jwt(svc)
+    with patch(
+        "services.vstrike_service.requests.get",
         side_effect=requests.exceptions.ConnectionError("boom"),
     ):
         ok, msg = svc.test_connection()
@@ -116,25 +117,76 @@ def test_test_connection_network_error():
 
 def test_get_asset_topology_returns_body_on_200():
     svc = _service()
+    _seed_jwt(svc)
     body = {"asset_id": "srv-01", "segment": "vlan-10"}
-    with patch.object(
-        svc.session, "get", return_value=_mock_response(200, json_body=body)
+    with patch(
+        "services.vstrike_service.requests.get",
+        return_value=_mock_response(200, json_body=body),
     ):
         result = svc.get_asset_topology("srv-01")
     assert result == body
 
 
+def test_get_asset_topology_attaches_jwt_bearer():
+    """Every legacy REST call must inject Authorization: Bearer <jwt>."""
+    svc = _service()
+    _seed_jwt(svc, "jwt-from-cache")
+    body = {"asset_id": "srv-01"}
+    with patch(
+        "services.vstrike_service.requests.get",
+        return_value=_mock_response(200, json_body=body),
+    ) as mock_get:
+        svc.get_asset_topology("srv-01")
+    headers = mock_get.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer jwt-from-cache"
+
+
 def test_get_asset_topology_returns_none_on_error():
     svc = _service()
-    with patch.object(svc.session, "get", return_value=_mock_response(404)):
+    _seed_jwt(svc)
+    with patch(
+        "services.vstrike_service.requests.get",
+        return_value=_mock_response(404),
+    ):
         assert svc.get_asset_topology("srv-missing") is None
+
+
+def test_legacy_rest_retries_on_401_after_invalidating_jwt():
+    """A 401 on the legacy REST path must drop the cached JWT, re-login,
+    and retry the request once — same pattern as `_call_mcp_tool`."""
+    svc = _service()
+    _seed_jwt(svc, "jwt-stale")
+
+    refreshed_login = _mock_response(200, json_body={"jsonwebtoken": "jwt-fresh"})
+    unauthorized = _mock_response(401, text="expired")
+    body = {"asset_id": "srv-01", "segment": "core"}
+    success = _mock_response(200, json_body=body)
+
+    with patch(
+        "services.vstrike_service.requests.get",
+        side_effect=[unauthorized, success],
+    ) as mock_get, patch(
+        "services.vstrike_service.requests.post",
+        return_value=refreshed_login,
+    ) as mock_post:
+        result = svc.get_asset_topology("srv-01")
+
+    assert result == body
+    # Two GETs: first 401 (jwt-stale), second 200 (jwt-fresh).
+    assert mock_get.call_count == 2
+    # One POST to /mcp-login between them.
+    assert mock_post.call_count == 1
+    # Cache now holds the refreshed JWT.
+    assert _jwt_cache[(svc.base_url, svc.username)][0] == "jwt-fresh"
 
 
 def test_list_adjacent_returns_list():
     svc = _service()
+    _seed_jwt(svc)
     body = {"adjacent": [{"asset_id": "dc-01", "hop_distance": 1}]}
-    with patch.object(
-        svc.session, "get", return_value=_mock_response(200, json_body=body)
+    with patch(
+        "services.vstrike_service.requests.get",
+        return_value=_mock_response(200, json_body=body),
     ):
         adjacent = svc.list_adjacent("srv-01")
     assert adjacent == [{"asset_id": "dc-01", "hop_distance": 1}]
@@ -142,82 +194,99 @@ def test_list_adjacent_returns_list():
 
 def test_find_findings_by_segment_uses_query_params():
     svc = _service()
+    _seed_jwt(svc)
     body = {"findings": [{"finding_id": "f1"}]}
-    with patch.object(
-        svc.session, "get", return_value=_mock_response(200, json_body=body)
+    with patch(
+        "services.vstrike_service.requests.get",
+        return_value=_mock_response(200, json_body=body),
     ) as mock_get:
         result = svc.find_findings_by_segment("dmz", limit=50)
 
     assert result == [{"finding_id": "f1"}]
-    call_kwargs = mock_get.call_args.kwargs
-    assert call_kwargs["params"] == {"segment": "dmz", "limit": 50}
+    assert mock_get.call_args.kwargs["params"] == {"segment": "dmz", "limit": 50}
 
 
-def test_get_vstrike_service_returns_none_when_unconfigured(monkeypatch):
-    monkeypatch.delenv("VSTRIKE_BASE_URL", raising=False)
-    monkeypatch.delenv("VSTRIKE_API_KEY", raising=False)
-    with patch(
-        "core.config.get_integration_config",
-        return_value={},
-    ):
+def test_get_vstrike_service_returns_none_when_unconfigured(isolate_secrets):
+    isolate_secrets.delenv("VSTRIKE_BASE_URL", raising=False)
+    isolate_secrets.delenv("VSTRIKE_USERNAME", raising=False)
+    isolate_secrets.delenv("VSTRIKE_PASSWORD", raising=False)
+    with patch("core.config.get_integration_config", return_value={}):
         assert get_vstrike_service() is None
 
 
-def test_get_vstrike_service_from_env(monkeypatch):
-    monkeypatch.setenv("VSTRIKE_BASE_URL", "https://vstrike.example.com")
-    monkeypatch.setenv("VSTRIKE_API_KEY", "env-key")
+def test_get_vstrike_service_from_env(isolate_secrets):
+    isolate_secrets.setenv("VSTRIKE_BASE_URL", "https://vstrike.example.com")
+    isolate_secrets.setenv("VSTRIKE_USERNAME", "alice")
+    isolate_secrets.setenv("VSTRIKE_PASSWORD", "wonderland")
     svc = get_vstrike_service()
     assert svc is not None
     assert svc.base_url == "https://vstrike.example.com"
-    assert svc.api_key == "env-key"
+    assert svc.username == "alice"
+    assert svc.password == "wonderland"
 
 
-def test_get_vstrike_service_falls_back_to_integration_config(monkeypatch):
-    monkeypatch.delenv("VSTRIKE_BASE_URL", raising=False)
-    monkeypatch.delenv("VSTRIKE_API_KEY", raising=False)
-    monkeypatch.delenv("VSTRIKE_USERNAME", raising=False)
-    monkeypatch.delenv("VSTRIKE_PASSWORD", raising=False)
+def test_get_vstrike_service_falls_back_to_integration_config(isolate_secrets):
+    isolate_secrets.delenv("VSTRIKE_BASE_URL", raising=False)
+    isolate_secrets.delenv("VSTRIKE_USERNAME", raising=False)
+    isolate_secrets.delenv("VSTRIKE_PASSWORD", raising=False)
     with patch(
         "core.config.get_integration_config",
         return_value={
             "url": "https://cfg.example.com",
-            "api_key": "cfg-key",
+            "username": "alice",
+            "password": "wonderland",
             "verify_ssl": False,
         },
     ):
         svc = get_vstrike_service()
     assert svc is not None
     assert svc.base_url == "https://cfg.example.com"
-    assert svc.api_key == "cfg-key"
+    assert svc.username == "alice"
+    assert svc.password == "wonderland"
     assert svc.verify_ssl is False
 
 
+def test_get_vstrike_service_ignores_legacy_api_key(isolate_secrets):
+    """Older installs may still have VSTRIKE_API_KEY in the secrets store —
+    the factory tolerates it but does not use it."""
+    isolate_secrets.setenv("VSTRIKE_BASE_URL", "https://vstrike.example.com")
+    isolate_secrets.setenv("VSTRIKE_API_KEY", "leftover-from-old-install")
+    isolate_secrets.delenv("VSTRIKE_USERNAME", raising=False)
+    isolate_secrets.delenv("VSTRIKE_PASSWORD", raising=False)
+    with patch("core.config.get_integration_config", return_value={}):
+        svc = get_vstrike_service()
+    # Without username+password, an api_key alone is no longer enough.
+    assert svc is None
+
+
 # ---------------------------------------------------------------------------
-# Credential predicates + factory resolution for UI path
+# Credential predicates
 # ---------------------------------------------------------------------------
 
 
 def test_has_ui_credentials_only_true_with_both():
-    assert _service(username="u").has_ui_credentials is False
-    assert _service(password="p").has_ui_credentials is False
+    assert _service(username="u", password=None).has_ui_credentials is False
+    assert _service(username=None, password="p").has_ui_credentials is False
     assert _service(username="u", password="p").has_ui_credentials is True
 
 
-def test_has_api_credentials_tracks_api_key():
-    assert _service(api_key="k").has_api_credentials is True
-    assert _service(api_key=None).has_api_credentials is False
+def test_has_api_credentials_is_alias_for_has_ui_credentials():
+    """JWT-only auth: 'configured' means username+password, regardless of which
+    predicate name a caller queries."""
+    svc = _service()
+    assert svc.has_api_credentials is svc.has_ui_credentials is True
+    assert _service(username=None, password=None).has_api_credentials is False
 
 
-def test_get_vstrike_service_with_only_ui_credentials(monkeypatch):
-    monkeypatch.setenv("VSTRIKE_BASE_URL", "https://vstrike.example.com")
-    monkeypatch.delenv("VSTRIKE_API_KEY", raising=False)
-    monkeypatch.setenv("VSTRIKE_USERNAME", "deeptempo_manager")
-    monkeypatch.setenv("VSTRIKE_PASSWORD", "secret")
+def test_get_vstrike_service_with_only_ui_credentials(isolate_secrets):
+    isolate_secrets.setenv("VSTRIKE_BASE_URL", "https://vstrike.example.com")
+    isolate_secrets.setenv("VSTRIKE_USERNAME", "deeptempo_manager")
+    isolate_secrets.setenv("VSTRIKE_PASSWORD", "secret")
     with patch("core.config.get_integration_config", return_value={}):
         svc = get_vstrike_service()
     assert svc is not None
-    assert svc.has_api_credentials is False
     assert svc.has_ui_credentials is True
+    assert svc.has_api_credentials is True
 
 
 def test_get_vstrike_service_returns_none_with_only_username(isolate_secrets):
@@ -302,7 +371,8 @@ def test_mcp_login_raises_when_response_missing_token():
 
 
 def test_mcp_login_requires_credentials():
-    svc = _service(api_key="only-key")  # no username/password
+    """Without username + password, _ensure_jwt must refuse, not blank-login."""
+    svc = _service(username=None, password=None)
     with pytest.raises(RuntimeError, match="not configured"):
         svc._ensure_jwt()
 


### PR DESCRIPTION
## Summary

Three coordinated changes from the [second-wave plan](file:///Users/zfamilycomputer/.claude/plans/i-have-been-working-sorted-toucan.md). All scoped to VStrike auth + Settings UI; the larger persistent-iframe and agent-enrichment pieces ship in follow-up PRs.

### 1. Auto-pull JWT (no more `api_key` field)

The Settings form now asks only for **VStrike URL + username + password**. The `api_key` and `inbound_api_key` fields are gone from [integrations.ts](frontend/src/config/integrations.ts) and from the secret registry at [integration_secrets.py](services/integration_secrets.py).

[VStrikeService](services/vstrike_service.py) is now JWT-only:
- Constructor takes `username` + `password`. There's no `api_key` parameter.
- The legacy `/api/v1/topology/*` REST helpers (`_get`) inject `Authorization: Bearer <jwt>` from `_ensure_jwt()` and one-shot retry on 401 — same pattern `_call_mcp_tool` already used.
- The factory `get_vstrike_service()` resolves `username`+`password` from the secrets manager (encrypted store → env → dotenv → keyring) and the integration config; service is "configured" iff both creds are present. Leftover `VSTRIKE_API_KEY` values in the encrypted store are tolerated but ignored.
- `has_api_credentials` stays as a back-compat alias for `has_ui_credentials` so existing callers don't break.

The session no longer carries a static `Authorization: Bearer <api_key>` header — every outbound call computes its bearer fresh from the JWT cache.

### 2. Settings card now shows the integration description

The MCP-server card renderer at [Settings.tsx:744](frontend/src/pages/Settings.tsx:744) used to gate the description on `SERVER_DESCRIPTIONS[serverName]` only. That dict has no `vstrike` entry, so VStrike's card always rendered with no blurb. Falls back to `integration?.description` when the curated dict is silent. The VStrike `description` string in [integrations.ts](frontend/src/config/integrations.ts) is updated to name what the integration actually does:

> "Embed VStrike's network topology UI inside Vigil case investigations. Vigil drives which network and what kill-chain to play; VStrike streams the visualization back via WebSocket. Provides segment, criticality, mission-system, blast-radius, and attack-path enrichment to every Vigil agent."

### 3. Tests aligned with JWT-only model

Every legacy-REST test now pre-seeds the module JWT cache and patches `requests.get` (instead of `svc.session.get` — which is gone, since the static-bearer session is gone). A new regression test exercises the 401 → invalidate-JWT → relogin → retry loop on the topology helper. New guard test: a leftover `VSTRIKE_API_KEY` without username+password no longer counts as "configured". Updated assertions in `test_integration_secrets.py` + `test_integration_secrets_api.py` for the new two-field secret set.

## Test plan

- [x] `pytest tests/unit/test_vstrike_service.py tests/unit/test_integration_secrets.py tests/integration/test_integration_secrets_api.py tests/integration/test_vstrike_ui_routes.py tests/integration/test_vstrike_ingest.py tests/unit/test_secrets_manager_singleton.py tests/integration/test_secrets_routes.py` — **88 passed**.
- [x] `black --check` clean.
- [x] `flake8 --select=E9,F` clean (selecting only real errors; the file already has pre-existing E501/W503 from prior PRs).
- [x] `tsc --noEmit` clean on the changed frontend files.
- [x] `eslint` clean on the changed frontend files (the 2 errors at `Settings.tsx:934/936` are pre-existing `_n` unused-args from the category filter list — not introduced by this PR).
- [ ] Manual: open Settings → Integrations / MCP. The CloudCurrent VStrike card now shows the description text. Click Configure — the form has only URL / Username / Password / Verify SSL fields. Save with username+password only. Hit `POST /api/integrations/vstrike/ui/iframe-token` → 200. Hit `GET /api/integrations/vstrike/topology/asset/<id>` → 200 (proves the legacy REST helper now uses JWT auth automatically).
- [ ] Manual: leave the running uvicorn for >50 min so the JWT cache expires, then call any topology endpoint — it should refresh transparently with no user-visible difference.

## Notes

- Inbound webhook auth (`VSTRIKE_INBOUND_API_KEY`) is unchanged in this PR. The plan calls for auto-generating it on first save with a copy-button surface, but that's coupled to a Settings UI change that doesn't fit alongside the auth refactor — splitting it out.
- This PR does NOT touch the iframe component, the Investigation page, or the AI prompt context. Those land in the next two follow-up PRs (persistent-iframe host + agent enrichment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)