### PR TITLE
Stop silent heartbeat drops killing auto investigations

### DIFF
--- a/daemon/agent_runner.py
+++ b/daemon/agent_runner.py
@@ -218,6 +218,7 @@ class AgentRunner:
         self._claude_service = None
         self._data_service = None
         self._llm_gateway = None
+        self._db_smoke_checked = False
 
         self.stats = {
             "agents_started": 0,
@@ -248,6 +249,26 @@ class AgentRunner:
                 self._data_service = DatabaseDataService()
             except Exception as e:
                 logger.error(f"AgentRunner: Failed to init data service: {e}")
+
+        # Verify DB writes are reachable from this process at startup. Without
+        # this, a broken DB connection only surfaces later as silent heartbeat
+        # failures — which the supervisor then mistakes for a stale agent and
+        # kills as 'failed' (issue #147 follow-up).
+        if not self._db_smoke_checked:
+            try:
+                from database.connection import get_db_manager
+                from sqlalchemy import text
+
+                with get_db_manager().session_scope() as session:
+                    session.execute(text("SELECT 1"))
+                self._db_smoke_checked = True
+                logger.info("AgentRunner: DB write path verified")
+            except Exception as e:
+                logger.error(
+                    f"AgentRunner: DB write path unreachable; heartbeats will "
+                    f"fail and investigations may be stale-killed: {e}",
+                    exc_info=True,
+                )
 
     async def _ensure_gateway(self):
         """Lazily initialise the LLM gateway."""
@@ -1112,20 +1133,34 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
         })
 
     def _update_db_record(self, inv_id: str, updates: Dict[str, Any]):
-        """Update the Investigation record in the database."""
-        if not self._data_service:
-            return
+        """Update the Investigation record in the database.
+
+        Uses ``session_scope()`` (auto-commit + auto-close) so that heartbeats
+        and status writes can't silently leak connections or get swallowed
+        when the agent is making real progress. See issue #147 — the previous
+        raw ``get_session()`` + ``logger.debug`` pattern hid heartbeat failures
+        and let the supervisor mark healthy investigations as ``Stale: no
+        activity``.
+        """
         try:
-            from database.connection import get_session
+            from database.connection import get_db_manager
             from database.models import Investigation
-            session = get_session()
-            inv = session.query(Investigation).filter_by(investigation_id=inv_id).first()
-            if inv:
+
+            with get_db_manager().session_scope() as session:
+                inv = (
+                    session.query(Investigation)
+                    .filter_by(investigation_id=inv_id)
+                    .first()
+                )
+                if inv is None:
+                    logger.warning(f"DB update for {inv_id}: row not found")
+                    return
                 for key, val in updates.items():
                     if hasattr(inv, key):
                         if key.endswith("_at") and isinstance(val, str):
                             val = datetime.fromisoformat(val)
                         setattr(inv, key, val)
-                session.commit()
         except Exception as e:
-            logger.debug(f"DB update for {inv_id} failed: {e}")
+            logger.error(
+                f"DB update for {inv_id} failed: {e}", exc_info=True
+            )

--- a/services/llm_worker.py
+++ b/services/llm_worker.py
@@ -359,7 +359,11 @@ def _adapt_router_result_to_raw(router_result: Dict[str, Any]) -> Dict[str, Any]
     """Shape an LLMRouter result to match _serialize_raw_response output.
 
     AgentRunner expects a dict with ``content`` (list of blocks),
-    ``stop_reason``, ``input_tokens``, ``output_tokens``.
+    ``stop_reason``, ``input_tokens``, ``output_tokens``. ``stop_reason`` must
+    reflect whether the response actually contained tool_use blocks — the
+    agent's tool-use loop only continues when ``stop_reason == "tool_use"``,
+    so hardcoding ``"end_turn"`` would silently drop every tool call from
+    router-dispatched providers.
     """
     blocks: List[Dict[str, Any]] = []
     text = router_result.get("content") or ""
@@ -368,7 +372,8 @@ def _adapt_router_result_to_raw(router_result: Dict[str, Any]) -> Dict[str, Any]
     thinking = router_result.get("thinking")
     if thinking:
         blocks.append({"type": "thinking", "thinking": thinking})
-    for tc in router_result.get("tool_calls") or []:
+    tool_calls = router_result.get("tool_calls") or []
+    for tc in tool_calls:
         blocks.append({
             "type": "tool_use",
             "id": tc.get("id"),
@@ -377,7 +382,7 @@ def _adapt_router_result_to_raw(router_result: Dict[str, Any]) -> Dict[str, Any]
         })
     return {
         "content": blocks,
-        "stop_reason": "end_turn",
+        "stop_reason": "tool_use" if tool_calls else "end_turn",
         "input_tokens": router_result.get("input_tokens", 0),
         "output_tokens": router_result.get("output_tokens", 0),
         "provider": router_result.get("provider"),

--- a/tests/test_llm_worker.py
+++ b/tests/test_llm_worker.py
@@ -1,0 +1,97 @@
+"""Unit tests for services.llm_worker.
+
+Covers ``_adapt_router_result_to_raw`` — its ``stop_reason`` must reflect
+whether the router returned tool_calls, otherwise AgentRunner's tool-use
+loop drops every tool invocation from router-dispatched providers.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from services.llm_worker import _adapt_router_result_to_raw
+
+pytestmark = pytest.mark.unit
+
+
+def test_adapt_router_result_emits_tool_use_stop_reason_when_tool_calls_present():
+    router_result = {
+        "content": "I'll list findings now.",
+        "tool_calls": [
+            {"id": "tool_1", "name": "list_findings", "input": {"limit": 5}}
+        ],
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "provider": "anthropic",
+        "path": "anthropic-direct",
+    }
+
+    adapted = _adapt_router_result_to_raw(router_result)
+
+    assert adapted["stop_reason"] == "tool_use"
+    tool_blocks = [b for b in adapted["content"] if b["type"] == "tool_use"]
+    assert len(tool_blocks) == 1
+    assert tool_blocks[0]["name"] == "list_findings"
+    assert tool_blocks[0]["input"] == {"limit": 5}
+
+
+def test_adapt_router_result_emits_end_turn_when_no_tool_calls():
+    router_result = {
+        "content": "Investigation complete.",
+        "tool_calls": None,
+        "input_tokens": 50,
+        "output_tokens": 10,
+    }
+
+    adapted = _adapt_router_result_to_raw(router_result)
+
+    assert adapted["stop_reason"] == "end_turn"
+    assert all(b["type"] != "tool_use" for b in adapted["content"])
+
+
+def test_adapt_router_result_emits_end_turn_when_tool_calls_empty_list():
+    router_result = {
+        "content": "Nothing to do.",
+        "tool_calls": [],
+        "input_tokens": 5,
+        "output_tokens": 5,
+    }
+
+    adapted = _adapt_router_result_to_raw(router_result)
+
+    assert adapted["stop_reason"] == "end_turn"
+
+
+def test_adapt_router_result_preserves_thinking_block():
+    router_result = {
+        "content": "Result text.",
+        "thinking": "Reasoning content here.",
+        "tool_calls": [],
+        "input_tokens": 1,
+        "output_tokens": 1,
+    }
+
+    adapted = _adapt_router_result_to_raw(router_result)
+
+    thinking_blocks = [b for b in adapted["content"] if b["type"] == "thinking"]
+    assert len(thinking_blocks) == 1
+    assert thinking_blocks[0]["thinking"] == "Reasoning content here."
+
+
+def test_adapt_router_result_normalizes_missing_tool_input():
+    router_result = {
+        "content": "",
+        "tool_calls": [{"id": "t1", "name": "do_thing", "input": None}],
+    }
+
+    adapted = _adapt_router_result_to_raw(router_result)
+
+    tool_blocks = [b for b in adapted["content"] if b["type"] == "tool_use"]
+    assert tool_blocks[0]["input"] == {}
+    assert adapted["stop_reason"] == "tool_use"

--- a/tests/unit/test_agent_runner_db_update.py
+++ b/tests/unit/test_agent_runner_db_update.py
@@ -1,0 +1,140 @@
+"""Unit tests for AgentRunner._update_db_record.
+
+Regression coverage for the silent-heartbeat bug that caused
+auto-investigations to be stale-killed by the supervisor (issue #147
+follow-up). The fix: route every DB write through ``session_scope()``
+and surface failures at ``logger.error`` with a stack trace, instead of
+swallowing them at ``logger.debug``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from daemon.agent_runner import AgentRunner
+from daemon.config import OrchestratorConfig
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeSession:
+    """Minimal fake SQLAlchemy session that records setattr calls."""
+
+    def __init__(self, row):
+        self._row = row
+
+    def query(self, _model):
+        return self
+
+    def filter_by(self, **_kwargs):
+        return self
+
+    def first(self):
+        return self._row
+
+
+def _make_runner() -> AgentRunner:
+    config = OrchestratorConfig()
+    workdir = MagicMock()
+    return AgentRunner(config, workdir)
+
+
+def _patch_session_scope(row):
+    """Build a context manager that yields _FakeSession(row)."""
+
+    @contextmanager
+    def fake_scope():
+        yield _FakeSession(row)
+
+    db_manager = MagicMock()
+    db_manager.session_scope = fake_scope
+    return db_manager
+
+
+def test_update_db_record_writes_fields_via_session_scope():
+    runner = _make_runner()
+    row = MagicMock()
+    row.iteration_count = 0
+    row.cost_usd = 0.0
+
+    db_manager = _patch_session_scope(row)
+    with patch("database.connection.get_db_manager", return_value=db_manager):
+        with patch("database.models.Investigation"):
+            runner._update_db_record(
+                "inv-test-1",
+                {"iteration_count": 5, "cost_usd": 0.12},
+            )
+
+    assert row.iteration_count == 5
+    assert row.cost_usd == 0.12
+
+
+def test_update_db_record_parses_iso_string_for_at_fields():
+    runner = _make_runner()
+    row = MagicMock()
+    row.last_activity_at = None
+
+    db_manager = _patch_session_scope(row)
+    iso = "2026-04-28T12:34:56"
+    with patch("database.connection.get_db_manager", return_value=db_manager):
+        with patch("database.models.Investigation"):
+            runner._update_db_record(
+                "inv-test-2",
+                {"last_activity_at": iso},
+            )
+
+    assert isinstance(row.last_activity_at, datetime)
+    assert row.last_activity_at == datetime.fromisoformat(iso)
+
+
+def test_update_db_record_logs_error_with_traceback_on_failure(caplog):
+    """A broken DB connection must log at ERROR with exc_info, not DEBUG.
+
+    The previous behaviour swallowed exceptions to ``logger.debug``, which
+    hid silent heartbeat failures and let the supervisor mark healthy
+    investigations as ``Stale: no activity``.
+    """
+    runner = _make_runner()
+
+    db_manager = MagicMock()
+
+    @contextmanager
+    def broken_scope():
+        raise RuntimeError("connection pool exhausted")
+        yield  # unreachable, satisfies generator contract
+
+    db_manager.session_scope = broken_scope
+
+    with patch("database.connection.get_db_manager", return_value=db_manager):
+        with caplog.at_level(logging.ERROR, logger="daemon.agent_runner"):
+            runner._update_db_record("inv-test-3", {"cost_usd": 1.0})
+
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert any("DB update for inv-test-3 failed" in r.message for r in error_records)
+    # exc_info=True records exception info on the LogRecord
+    assert any(r.exc_info is not None for r in error_records)
+
+
+def test_update_db_record_warns_when_row_missing():
+    runner = _make_runner()
+    db_manager = _patch_session_scope(row=None)  # query returns no row
+
+    with patch("database.connection.get_db_manager", return_value=db_manager):
+        with patch("database.models.Investigation"):
+            with patch.object(
+                __import__("daemon.agent_runner", fromlist=["logger"]).logger,
+                "warning",
+            ) as warn:
+                runner._update_db_record("inv-missing", {"cost_usd": 0.0})
+                warn.assert_called_once()
+                assert "row not found" in warn.call_args[0][0]


### PR DESCRIPTION
## Summary

- Auto investigations were landing in `failed` because the agent's per-turn DB heartbeats — added in d4ef7f1 to fix #147 — were silently dropping inside `_update_db_record`. The supervisor saw `last_activity_at` go stale after 300s and killed healthy agents with `master_review_notes="Stale: no activity"`. The previous fix added more heartbeat call sites but didn't address the silent drop, so the symptom recurred.
- Rewrites `_update_db_record` to use `session_scope()` (auto-commit + auto-close — no more leaked pool connections), drops the brittle `_data_service` short-circuit, and promotes swallowed errors from `logger.debug` to `logger.error(..., exc_info=True)` so future regressions are visible.
- Adds a one-time DB-write smoke check at agent runner startup that logs INFO on success or ERROR on failure, so a broken DB write path surfaces at boot instead of as silent stale-kills hours later.
- Bonus: fixes a latent bug in `_adapt_router_result_to_raw` that hardcoded `stop_reason="end_turn"`, which would have silently broken the agent's tool-use loop for any non-default `provider_id`. Not biting today (the daemon doesn't pass `provider_id`) but the next custom provider would have hit it.

## Root cause

`daemon/agent_runner.py:_update_db_record` had three independent bugs that combined into the symptom:

1. **Silent init guard.** `_data_service = DatabaseDataService()` is lazy-initialized in a try/except. If init raises once (e.g. DB not ready at startup), `_data_service` stays `None` permanently and every subsequent heartbeat returns at the `if not self._data_service: return` guard.
2. **Connection leak.** `get_session()` returns a raw session — no `session.close()`, no context manager. Each heartbeat (one per LLM turn, one per tool call) leaked a pooled connection. Within tens of iterations the pool was exhausted and all subsequent commits raised.
3. **Errors logged at DEBUG.** The `except` swallowed every failure to `logger.debug`, suppressed at INFO/WARNING — there was no way to notice heartbeats were broken.

When heartbeats stop reaching the DB, the supervisor at `daemon/orchestrator.py:_supervision_loop` sees `idle_seconds > stale_threshold` (300s default), calls `agent_runner.stop_agent()`, and writes `status="failed", master_review_notes="Stale: no activity"` — even though the agent is actively working and writing to local `state.json`.

The same `_update_db_record` path is used by `_handle_signal_complete` and `_mark_failed`, so the fix also restores reliable status transitions for completed/failed investigations.

## Test plan

- [x] `pytest tests/test_llm_worker.py` — 5 new tests exercise both branches of the router adapter (`tool_use` vs `end_turn`), thinking-block preservation, and missing-input normalization
- [x] `pytest tests/unit/test_agent_runner_db_update.py` — 4 new tests assert writes go through `session_scope()`, ISO timestamp parsing, that failures log at ERROR with `exc_info`, and that a missing row warns
- [x] `pytest tests/test_llm_router.py tests/unit/test_daemon.py` — no regressions in adjacent suites
- [ ] Smoke: run a daemon-triggered investigation against a local PostgreSQL with `ORCHESTRATOR_STALE_THRESHOLD=120` so stale-kills fire fast; investigation should transition `queued → assigned → executing → review_submitted → completed` without hitting `failed`
- [ ] Connection-leak check: `SELECT count(*) FROM pg_stat_activity WHERE datname='vigil'` before/after a 10-min investigation — should stay flat post-fix
- [ ] Log smoke: `grep -E "AgentRunner|supervisor.kill" daemon.log` after running an investigation — no `supervisor.kill stale` should fire on a healthy run; if heartbeats fail for a real reason, the new ERROR log surfaces it with a stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)