### PR TITLE
Add database proxy support (PgBouncer / HTTP-SOCKS / SSH tunnel)

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -84,6 +84,26 @@ class DemoModeConfig(BaseModel):
     enabled: bool = False
 
 
+class PlatformDatabaseProxyConfig(BaseModel):
+    """Proxy configuration in front of the platform metadata Postgres.
+
+    Persisted in the encrypted secrets store (DB-independent — read at
+    boot before the engine exists). All fields optional; ``proxy_type``
+    of ``"none"`` (the default) disables the feature.
+
+    Empty-string secrets on POST mean "leave existing value untouched".
+    """
+
+    proxy_type: str = "none"  # none | pgbouncer | ssh_tunnel
+    proxy_host: str = ""
+    proxy_port: int = 0
+    proxy_username: str = ""
+    proxy_password: str = ""
+    ssh_private_key_path: str = ""
+    ssh_key_passphrase: str = ""
+    verify_proxy_tls: bool = True
+
+
 @router.get("/demo-mode")
 async def get_demo_mode():
     """
@@ -394,6 +414,128 @@ async def set_s3_config(config: S3Config):
         raise
     except Exception as e:
         logger.error(f"Error setting S3 config: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# Maps the form field names exposed in the UI to the secrets-store keys
+# read by ``database.connection._load_platform_db_proxy`` at boot. These
+# live in the encrypted secrets store rather than ``SystemConfig`` so
+# they're readable before the metadata DB connection exists.
+_PLATFORM_DB_PROXY_KEYS = {
+    "proxy_type": "PLATFORM_DB_PROXY_TYPE",
+    "proxy_host": "PLATFORM_DB_PROXY_HOST",
+    "proxy_port": "PLATFORM_DB_PROXY_PORT",
+    "proxy_username": "PLATFORM_DB_PROXY_USERNAME",
+    "proxy_password": "PLATFORM_DB_PROXY_PASSWORD",
+    "ssh_private_key_path": "PLATFORM_DB_SSH_PRIVATE_KEY_PATH",
+    "ssh_key_passphrase": "PLATFORM_DB_SSH_KEY_PASSPHRASE",
+    "verify_proxy_tls": "PLATFORM_DB_VERIFY_PROXY_TLS",
+}
+_PLATFORM_DB_SECRET_FIELDS = {"proxy_password", "ssh_key_passphrase"}
+
+
+@router.get("/platform-database")
+async def get_platform_database_config():
+    """Return the current proxy config in front of the platform DB.
+
+    Secret fields (proxy password, SSH key passphrase) are redacted.
+    A boolean ``has_*`` flag indicates whether a value is currently
+    stored, so the UI can show "set"/"not set" without exposing the
+    plaintext.
+    """
+    try:
+        result: Dict[str, Any] = {}
+        for field, key in _PLATFORM_DB_PROXY_KEYS.items():
+            value = get_secret(key)
+            if field in _PLATFORM_DB_SECRET_FIELDS:
+                result[f"has_{field}"] = bool(value)
+                continue
+            if field == "proxy_port":
+                try:
+                    result[field] = int(value) if value else 0
+                except (TypeError, ValueError):
+                    result[field] = 0
+                continue
+            if field == "verify_proxy_tls":
+                if value is None or value == "":
+                    result[field] = True
+                else:
+                    result[field] = str(value).lower() not in (
+                        "false",
+                        "0",
+                        "no",
+                        "off",
+                    )
+                continue
+            result[field] = value or ""
+        result.setdefault("proxy_type", "none")
+        return result
+    except Exception as e:
+        logger.error(f"Error getting platform DB proxy config: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/platform-database")
+async def set_platform_database_config(config: PlatformDatabaseProxyConfig):
+    """Persist the platform-DB proxy config to the encrypted secrets
+    store. Takes effect on the next backend restart — the live engine
+    can't be hot-swapped safely.
+
+    Empty-string secrets mean "leave existing value untouched".
+    """
+    try:
+        proxy_type = (config.proxy_type or "none").strip().lower()
+        if proxy_type not in ("none", "pgbouncer", "ssh_tunnel"):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "proxy_type must be one of: none, pgbouncer, ssh_tunnel "
+                    "(http/socks5 are not supported for the platform DB)"
+                ),
+            )
+
+        # Non-secret fields — always overwrite so disabling a setting
+        # actually clears the stored value.
+        set_secret(_PLATFORM_DB_PROXY_KEYS["proxy_type"], proxy_type)
+        set_secret(_PLATFORM_DB_PROXY_KEYS["proxy_host"], config.proxy_host or "")
+        set_secret(
+            _PLATFORM_DB_PROXY_KEYS["proxy_port"],
+            str(config.proxy_port) if config.proxy_port else "",
+        )
+        set_secret(
+            _PLATFORM_DB_PROXY_KEYS["proxy_username"], config.proxy_username or ""
+        )
+        set_secret(
+            _PLATFORM_DB_PROXY_KEYS["ssh_private_key_path"],
+            config.ssh_private_key_path or "",
+        )
+        set_secret(
+            _PLATFORM_DB_PROXY_KEYS["verify_proxy_tls"],
+            "true" if config.verify_proxy_tls else "false",
+        )
+
+        # Secret fields — only overwrite when caller supplied a non-empty
+        # value, matching the integrations-config convention.
+        if config.proxy_password:
+            set_secret(_PLATFORM_DB_PROXY_KEYS["proxy_password"], config.proxy_password)
+        if config.ssh_key_passphrase:
+            set_secret(
+                _PLATFORM_DB_PROXY_KEYS["ssh_key_passphrase"],
+                config.ssh_key_passphrase,
+            )
+
+        return {
+            "success": True,
+            "message": (
+                "Platform DB proxy configuration saved. "
+                "Restart the backend for changes to take effect."
+            ),
+            "restart_required": True,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error setting platform DB proxy config: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/database/connection.py
+++ b/database/connection.py
@@ -6,102 +6,223 @@ Handles database connections, session management, and connection pooling.
 
 import os
 import logging
-from typing import Optional, Generator
+from typing import Optional, Generator, TYPE_CHECKING
 from contextlib import contextmanager
 from sqlalchemy import create_engine, event, pool, text
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.engine import Engine
 
+if TYPE_CHECKING:
+    from services.db_proxy import ProxyConfig
+
 from database.models import Base
 
 # Import all models to register them with Base.metadata before create_all()
 from database.models import (
-    Finding, Case, SketchMapping, AttackLayer, AIDecisionLog,
-    SystemConfig, UserPreference, IntegrationConfig, ConfigAuditLog,
-    SLAPolicy, CaseSLA, CaseComment, CaseWatcher, CaseEvidence, CaseIOC,
-    CaseTask, CaseTemplate, CaseRelationship, CaseMetrics, CaseAttachment,
-    CaseClosureInfo, CaseEscalation, CaseAuditLog,
-    User, Role, Investigation, InvestigationLog, LLMInteractionLog,
-    SharedIOC, CaseNotification, CustomAgent, CustomWorkflow, Skill,
+    Finding,
+    Case,
+    SketchMapping,
+    AttackLayer,
+    AIDecisionLog,
+    SystemConfig,
+    UserPreference,
+    IntegrationConfig,
+    ConfigAuditLog,
+    SLAPolicy,
+    CaseSLA,
+    CaseComment,
+    CaseWatcher,
+    CaseEvidence,
+    CaseIOC,
+    CaseTask,
+    CaseTemplate,
+    CaseRelationship,
+    CaseMetrics,
+    CaseAttachment,
+    CaseClosureInfo,
+    CaseEscalation,
+    CaseAuditLog,
+    User,
+    Role,
+    Investigation,
+    InvestigationLog,
+    LLMInteractionLog,
+    SharedIOC,
+    CaseNotification,
+    CustomAgent,
+    CustomWorkflow,
+    Skill,
     LLMProviderConfig,
 )
 
 logger = logging.getLogger(__name__)
 
 
+# Secrets-store keys for the platform DB proxy. Read at boot before
+# the DB engine exists, so they must live in the encrypted secrets
+# store (DB-independent), not SystemConfig.
+_PLATFORM_DB_PROXY_KEYS = {
+    "proxy_type": "PLATFORM_DB_PROXY_TYPE",
+    "proxy_host": "PLATFORM_DB_PROXY_HOST",
+    "proxy_port": "PLATFORM_DB_PROXY_PORT",
+    "proxy_username": "PLATFORM_DB_PROXY_USERNAME",
+    "proxy_password": "PLATFORM_DB_PROXY_PASSWORD",
+    "ssh_private_key_path": "PLATFORM_DB_SSH_PRIVATE_KEY_PATH",
+    "ssh_key_passphrase": "PLATFORM_DB_SSH_KEY_PASSPHRASE",
+    "verify_proxy_tls": "PLATFORM_DB_VERIFY_PROXY_TLS",
+}
+
+
+def _load_platform_db_proxy() -> "ProxyConfig":
+    """Read platform-DB proxy settings from the encrypted secrets store.
+
+    Imports are local because services.db_proxy imports
+    ``backend.secrets_manager`` which itself isn't part of database/'s
+    boot dependency. Returns a disabled ProxyConfig when nothing is
+    configured.
+    """
+    try:
+        from services.db_proxy import ProxyConfig
+        from backend.secrets_manager import get_secret
+    except ImportError:
+        # If the secrets manager isn't importable yet (e.g. during a
+        # pre-install sanity check), skip proxy support gracefully.
+        from services.db_proxy import ProxyConfig
+
+        return ProxyConfig()
+
+    raw: dict[str, object] = {}
+    for field, secret_key in _PLATFORM_DB_PROXY_KEYS.items():
+        value = get_secret(secret_key)
+        if value is not None and value != "":
+            raw[field] = value
+    if not raw or (raw.get("proxy_type") or "none").lower() in ("", "none"):
+        return ProxyConfig()
+    raw.setdefault("verify_proxy_tls", True)
+    if isinstance(raw.get("verify_proxy_tls"), str):
+        raw["verify_proxy_tls"] = raw["verify_proxy_tls"].lower() not in (
+            "false",
+            "0",
+            "no",
+            "off",
+        )
+    # Password / passphrase already came out of the secrets store, so
+    # we don't pass *_secret_key to from_dict — values are inline.
+    return ProxyConfig.from_dict(raw)
+
+
 class DatabaseConfig:
     """Database configuration management."""
-    
+
     def __init__(self):
         """Initialize database configuration from environment variables."""
-        self.host = os.getenv('POSTGRES_HOST', 'localhost')
-        self.port = int(os.getenv('POSTGRES_PORT', '5432'))
-        self.database = os.getenv('POSTGRES_DB', 'deeptempo_soc')
-        self.user = os.getenv('POSTGRES_USER', 'deeptempo')
-        self.password = os.getenv('POSTGRES_PASSWORD', 'deeptempo_secure_password_change_me')
-        
+        self.host = os.getenv("POSTGRES_HOST", "localhost")
+        self.port = int(os.getenv("POSTGRES_PORT", "5432"))
+        self.database = os.getenv("POSTGRES_DB", "deeptempo_soc")
+        self.user = os.getenv("POSTGRES_USER", "deeptempo")
+        self.password = os.getenv(
+            "POSTGRES_PASSWORD", "deeptempo_secure_password_change_me"
+        )
+
         # Connection pool settings
-        self.pool_size = int(os.getenv('DB_POOL_SIZE', '5'))
-        self.max_overflow = int(os.getenv('DB_MAX_OVERFLOW', '10'))
-        self.pool_timeout = int(os.getenv('DB_POOL_TIMEOUT', '30'))
-        self.pool_recycle = int(os.getenv('DB_POOL_RECYCLE', '3600'))
-        
+        self.pool_size = int(os.getenv("DB_POOL_SIZE", "5"))
+        self.max_overflow = int(os.getenv("DB_MAX_OVERFLOW", "10"))
+        self.pool_timeout = int(os.getenv("DB_POOL_TIMEOUT", "30"))
+        self.pool_recycle = int(os.getenv("DB_POOL_RECYCLE", "3600"))
+
         # SSL settings
-        self.ssl_mode = os.getenv('POSTGRES_SSL_MODE', 'prefer')
-    
-    def get_database_url(self, async_driver: bool = False) -> str:
+        self.ssl_mode = os.getenv("POSTGRES_SSL_MODE", "prefer")
+
+        # Optional proxy in front of the DB (PgBouncer or SSH tunnel).
+        # Loaded lazily so unrelated tests that import DatabaseConfig
+        # don't need a live secrets manager.
+        self.proxy = _load_platform_db_proxy()
+
+    def get_database_url(
+        self,
+        async_driver: bool = False,
+        *,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+    ) -> str:
         """
         Get the database connection URL.
-        
+
         Args:
             async_driver: If True, use async driver (asyncpg), otherwise use psycopg2
-        
+            host: Override host (used after a proxy rewrites the endpoint).
+            port: Override port (used after a proxy rewrites the endpoint).
+
         Returns:
             Database connection URL
         """
-        driver = 'postgresql+asyncpg' if async_driver else 'postgresql+psycopg2'
-        
-        url = f"{driver}://{self.user}:{self.password}@{self.host}:{self.port}/{self.database}"
-        
-        if self.ssl_mode != 'prefer':
+        driver = "postgresql+asyncpg" if async_driver else "postgresql+psycopg2"
+        effective_host = host or self.host
+        effective_port = port or self.port
+        url = (
+            f"{driver}://{self.user}:{self.password}"
+            f"@{effective_host}:{effective_port}/{self.database}"
+        )
+
+        if self.ssl_mode != "prefer":
             url += f"?sslmode={self.ssl_mode}"
-        
+
         return url
 
 
 class DatabaseManager:
     """Manages database connections and sessions."""
-    
-    _instance: Optional['DatabaseManager'] = None
+
+    _instance: Optional["DatabaseManager"] = None
     _engine: Optional[Engine] = None
     _session_factory: Optional[sessionmaker] = None
-    
+
     def __new__(cls):
         """Singleton pattern to ensure only one database manager exists."""
         if cls._instance is None:
             cls._instance = super(DatabaseManager, cls).__new__(cls)
         return cls._instance
-    
+
     def __init__(self):
         """Initialize the database manager."""
-        if not hasattr(self, '_initialized'):
+        if not hasattr(self, "_initialized"):
             self.config = DatabaseConfig()
+            # Holds an SSH tunnel (or other proxy artifact) for the
+            # process lifetime when the platform DB is fronted by a
+            # tunneling proxy. Closed in :meth:`close`.
+            self._proxy_handle = None
             self._initialized = True
-    
+
     def initialize(self, echo: bool = False):
         """
         Initialize the database engine and session factory.
-        
+
         Args:
             echo: If True, log all SQL statements
         """
         if self._engine is not None:
             logger.warning("Database already initialized")
             return
-        
+
         try:
-            database_url = self.config.get_database_url()
-            
+            host = self.config.host
+            port = self.config.port
+            if self.config.proxy.enabled:
+                from services.db_proxy import apply as apply_proxy
+
+                applied = apply_proxy(host, port, self.config.proxy)
+                self._proxy_handle = applied
+                host = applied.host
+                port = applied.port
+                logger.info(
+                    "Platform DB proxy active: type=%s effective endpoint %s:%s",
+                    self.config.proxy.proxy_type,
+                    host,
+                    port,
+                )
+
+            database_url = self.config.get_database_url(host=host, port=port)
+
             self._engine = create_engine(
                 database_url,
                 echo=echo,
@@ -111,79 +232,81 @@ class DatabaseManager:
                 pool_recycle=self.config.pool_recycle,
                 pool_pre_ping=True,  # Verify connections before using them
             )
-            
+
             # Set up event listeners
             @event.listens_for(self._engine, "connect")
             def receive_connect(dbapi_conn, connection_record):
                 """Called when a new connection is created."""
                 logger.debug("New database connection established")
-            
+
             @event.listens_for(self._engine, "close")
             def receive_close(dbapi_conn, connection_record):
                 """Called when a connection is closed."""
                 logger.debug("Database connection closed")
-            
+
             # Create session factory
             self._session_factory = sessionmaker(
                 bind=self._engine,
                 expire_on_commit=False,
                 autoflush=True,
-                autocommit=False
+                autocommit=False,
             )
-            
-            logger.info(f"Database initialized: {self.config.host}:{self.config.port}/{self.config.database}")
-        
+
+            logger.info(
+                f"Database initialized: {self.config.host}:{self.config.port}/{self.config.database}"
+            )
+
         except Exception as e:
             logger.error(f"Failed to initialize database: {e}")
             raise
-    
+
     def create_tables(self):
         """Create all database tables."""
         if self._engine is None:
             raise RuntimeError("Database not initialized. Call initialize() first.")
-        
+
         try:
             Base.metadata.create_all(self._engine)
             logger.info("Database tables created successfully")
         except Exception as e:
             logger.error(f"Failed to create database tables: {e}")
             raise
-    
+
     def drop_tables(self):
         """Drop all database tables. USE WITH CAUTION!"""
         if self._engine is None:
             raise RuntimeError("Database not initialized. Call initialize() first.")
-        
+
         try:
             Base.metadata.drop_all(self._engine)
             logger.warning("All database tables dropped")
         except Exception as e:
             logger.error(f"Failed to drop database tables: {e}")
             raise
-    
+
     def get_session(self) -> Session:
         """
         Get a new database session.
-        
+
         Returns:
             SQLAlchemy session
         """
         if self._session_factory is None:
             raise RuntimeError("Database not initialized. Call initialize() first.")
-        
+
         return self._session_factory()
-    
+
     @contextmanager
     def session_scope(self) -> Generator[Session, None, None]:
         """
         Provide a transactional scope around a series of operations.
-        
+
         Usage:
             with db_manager.session_scope() as session:
                 # Use session here
                 session.add(obj)
                 # Automatically commits on success, rolls back on exception
-        
+
         Yields:
             SQLAlchemy session
         """
@@ -197,7 +320,7 @@ class DatabaseManager:
             raise
         finally:
             session.close()
-    
+
     def close(self):
         """Close the database connection pool."""
         if self._engine is not None:
@@ -205,11 +328,17 @@ class DatabaseManager:
             self._engine = None
             self._session_factory = None
             logger.info("Database connection pool closed")
-    
+        if self._proxy_handle is not None:
+            try:
+                self._proxy_handle.close()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Failed to close DB proxy handle cleanly: %s", exc)
+            self._proxy_handle = None
+
     def health_check(self) -> bool:
         """
         Check if the database is accessible.
-        
+
         Returns:
             True if database is accessible, False otherwise
         """
@@ -220,7 +349,7 @@ class DatabaseManager:
         except Exception as e:
             logger.error(f"Database health check failed: {e}")
             return False
-    
+
     @property
     def engine(self) -> Optional[Engine]:
         """Get the database engine."""
@@ -234,7 +363,7 @@ _db_manager: Optional[DatabaseManager] = None
 def get_db_manager() -> DatabaseManager:
     """
     Get the global database manager instance.
-    
+
     Returns:
         DatabaseManager instance
     """
@@ -247,9 +376,9 @@ def get_db_manager() -> DatabaseManager:
 def get_db_session() -> Session:
     """
     Get a new database session.
-    
+
     This is a convenience function for dependency injection in FastAPI.
-    
+
     Returns:
         SQLAlchemy session
     """
@@ -260,9 +389,9 @@ def get_db_session() -> Session:
 def get_session() -> Session:
     """
     Get a database session (convenience function for imports).
-    
+
     This is a convenience wrapper around get_db_session() for backward compatibility.
-    
+
     Returns:
         SQLAlchemy session
     """
@@ -272,14 +401,13 @@ def get_session() -> Session:
 def init_database(echo: bool = False, create_tables: bool = True):
     """
     Initialize the database.
-    
+
     Args:
         echo: If True, log all SQL statements
         create_tables: If True, create all tables
     """
     db_manager = get_db_manager()
     db_manager.initialize(echo=echo)
-    
+
     if create_tables:
         db_manager.create_tables()
-

--- a/frontend/src/components/settings/IntegrationWizard.tsx
+++ b/frontend/src/components/settings/IntegrationWizard.tsx
@@ -19,8 +19,14 @@ import {
   FormControl,
   InputLabel,
   Chip,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
 } from '@mui/material'
-import { Check as CheckIcon } from '@mui/icons-material'
+import {
+  Check as CheckIcon,
+  ExpandMore as ExpandMoreIcon,
+} from '@mui/icons-material'
 
 export interface IntegrationField {
   name: string
@@ -31,7 +37,94 @@ export interface IntegrationField {
   placeholder?: string
   helpText?: string
   options?: Array<{ value: string; label: string }>
+  // Optional grouping. Fields without a section render in the main
+  // body; fields sharing a non-default section render inside a
+  // collapsible accordion with that section's label.
+  section?: string
 }
+
+// Human label and default-collapsed state for known sections. Anything
+// not listed renders with the section name as its title.
+export const SECTION_LABELS: Record<string, string> = {
+  proxy: 'Network / Proxy (optional)',
+}
+
+// Shared "Network / Proxy" field block. Appended to any integration
+// whose metadata has ``proxy_supported: true``. Backend-side handling
+// lives in services/db_proxy.py + services/integration_bridge_service.py.
+export const PROXY_FIELDS: IntegrationField[] = [
+  {
+    name: 'proxy_type',
+    label: 'Proxy Type',
+    type: 'select',
+    section: 'proxy',
+    default: 'none',
+    options: [
+      { value: 'none', label: 'None (direct connection)' },
+      { value: 'pgbouncer', label: 'PgBouncer (Postgres-only)' },
+      { value: 'http', label: 'HTTP proxy' },
+      { value: 'socks5', label: 'SOCKS5 proxy' },
+      { value: 'ssh_tunnel', label: 'SSH tunnel' },
+    ],
+    helpText:
+      'Route this integration through an intermediate hop. Leave as "None" for a direct connection.',
+  },
+  {
+    name: 'proxy_host',
+    label: 'Proxy Host',
+    type: 'text',
+    section: 'proxy',
+    placeholder: 'e.g. bastion.internal',
+    helpText: 'Hostname or IP of the proxy / pooler / bastion.',
+  },
+  {
+    name: 'proxy_port',
+    label: 'Proxy Port',
+    type: 'number',
+    section: 'proxy',
+    placeholder: 'e.g. 6432, 1080, 22',
+  },
+  {
+    name: 'proxy_username',
+    label: 'Proxy Username',
+    type: 'text',
+    section: 'proxy',
+    helpText:
+      'Auth user for the proxy or SSH bastion. Leave blank if none.',
+  },
+  {
+    name: 'proxy_password',
+    label: 'Proxy Password',
+    type: 'password',
+    section: 'proxy',
+    helpText:
+      'Stored in the encrypted secrets store. Leave blank to keep the existing value.',
+  },
+  {
+    name: 'ssh_private_key_path',
+    label: 'SSH Private Key Path',
+    type: 'text',
+    section: 'proxy',
+    placeholder: 'e.g. /home/vigil/.ssh/id_ed25519',
+    helpText: 'Used only when Proxy Type is "SSH tunnel".',
+  },
+  {
+    name: 'ssh_key_passphrase',
+    label: 'SSH Key Passphrase',
+    type: 'password',
+    section: 'proxy',
+    helpText:
+      'Stored in the encrypted secrets store. Used only with an encrypted private key.',
+  },
+  {
+    name: 'verify_proxy_tls',
+    label: 'Verify Proxy TLS',
+    type: 'boolean',
+    section: 'proxy',
+    default: true,
+    helpText: 'Disable only when explicitly testing against a self-signed proxy.',
+  },
+]
 
 export interface IntegrationMetadata {
   id: string
@@ -43,6 +136,9 @@ export interface IntegrationMetadata {
   icon?: string
   fields: IntegrationField[]
   docs_url?: string
+  // When true, the wizard appends the shared PROXY_FIELDS block to
+  // ``fields`` and renders it under the "Network / Proxy" section.
+  proxy_supported?: boolean
 }
 
 interface IntegrationWizardProps {
@@ -66,6 +162,13 @@ export default function IntegrationWizard({
   const [error, setError] = useState<string | null>(null)
 
   const steps = ['Configuration', 'Review']
+
+  // Append the shared proxy block when this integration opts in.
+  // Done here (rather than in integrations.ts) so the field list and
+  // its rendering live in the same module.
+  const effectiveFields: IntegrationField[] = integration.proxy_supported
+    ? [...integration.fields, ...PROXY_FIELDS]
+    : integration.fields
 
   const handleNext = () => {
     setActiveStep((prevActiveStep) => prevActiveStep + 1)
@@ -105,7 +208,7 @@ export default function IntegrationWizard({
   const isStepComplete = (step: number) => {
     if (step === 0) {
       // Check if all required fields are filled
-      return integration.fields
+      return effectiveFields
         .filter((f) => f.required)
         .every((f) => config[f.name] && config[f.name] !== '')
     }
@@ -203,7 +306,29 @@ export default function IntegrationWizard({
                 </a>
               </Alert>
             )}
-            {integration.fields.map((field) => renderField(field))}
+            {effectiveFields
+              .filter((field) => !field.section)
+              .map((field) => renderField(field))}
+            {Object.entries(
+              effectiveFields
+                .filter((field) => field.section)
+                .reduce<Record<string, IntegrationField[]>>((groups, field) => {
+                  const key = field.section as string
+                  ;(groups[key] = groups[key] || []).push(field)
+                  return groups
+                }, {})
+            ).map(([sectionName, fields]) => (
+              <Accordion key={sectionName} defaultExpanded={false} sx={{ mt: 2 }}>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography>
+                    {SECTION_LABELS[sectionName] || sectionName}
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  {fields.map((field) => renderField(field))}
+                </AccordionDetails>
+              </Accordion>
+            ))}
           </Box>
         )
 
@@ -214,7 +339,7 @@ export default function IntegrationWizard({
               Review your configuration before saving:
             </Typography>
             <Box sx={{ mt: 2 }}>
-              {integration.fields.map((field) => {
+              {effectiveFields.map((field) => {
                 const value = config[field.name]
                 const displayValue =
                   field.type === 'password' ? '••••••••' : value?.toString() || '(not set)'

--- a/frontend/src/components/settings/PlatformDatabaseTab.tsx
+++ b/frontend/src/components/settings/PlatformDatabaseTab.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { Save as SaveIcon } from '@mui/icons-material'
+
+import { configApi } from '../../services/api'
+
+type ProxyType = 'none' | 'pgbouncer' | 'ssh_tunnel'
+
+interface FormState {
+  proxy_type: ProxyType
+  proxy_host: string
+  proxy_port: number
+  proxy_username: string
+  proxy_password: string
+  ssh_private_key_path: string
+  ssh_key_passphrase: string
+  verify_proxy_tls: boolean
+}
+
+const EMPTY_FORM: FormState = {
+  proxy_type: 'none',
+  proxy_host: '',
+  proxy_port: 0,
+  proxy_username: '',
+  proxy_password: '',
+  ssh_private_key_path: '',
+  ssh_key_passphrase: '',
+  verify_proxy_tls: true,
+}
+
+interface Props {
+  setMessage: (m: { type: 'success' | 'error'; text: string } | null) => void
+}
+
+// The platform's own metadata Postgres can be fronted by PgBouncer or
+// reached via an SSH tunnel. HTTP/SOCKS aren't offered: the Postgres
+// wire protocol isn't proxy-aware in psycopg2/asyncpg, so a SOCKS
+// "proxy" on the platform DB would silently fail.
+export default function PlatformDatabaseTab({ setMessage }: Props) {
+  const [form, setForm] = useState<FormState>(EMPTY_FORM)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [hasPassword, setHasPassword] = useState(false)
+  const [hasPassphrase, setHasPassphrase] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const { data } = await configApi.getPlatformDatabase()
+        if (cancelled) return
+        const proxyType = (
+          ['none', 'pgbouncer', 'ssh_tunnel'].includes(data.proxy_type)
+            ? data.proxy_type
+            : 'none'
+        ) as ProxyType
+        setForm({
+          proxy_type: proxyType,
+          proxy_host: data.proxy_host || '',
+          proxy_port: Number(data.proxy_port) || 0,
+          proxy_username: data.proxy_username || '',
+          proxy_password: '',
+          ssh_private_key_path: data.ssh_private_key_path || '',
+          ssh_key_passphrase: '',
+          verify_proxy_tls: data.verify_proxy_tls ?? true,
+        })
+        setHasPassword(Boolean(data.has_proxy_password))
+        setHasPassphrase(Boolean(data.has_ssh_key_passphrase))
+      } catch (err: any) {
+        setMessage({
+          type: 'error',
+          text: `Failed to load platform DB proxy config: ${err?.message || err}`,
+        })
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [setMessage])
+
+  const handleSave = async () => {
+    setSaving(true)
+    try {
+      await configApi.setPlatformDatabase({
+        proxy_type: form.proxy_type,
+        proxy_host: form.proxy_host,
+        proxy_port: form.proxy_port || 0,
+        proxy_username: form.proxy_username,
+        proxy_password: form.proxy_password,
+        ssh_private_key_path: form.ssh_private_key_path,
+        ssh_key_passphrase: form.ssh_key_passphrase,
+        verify_proxy_tls: form.verify_proxy_tls,
+      })
+      // Clear secret inputs so a future save doesn't accidentally
+      // overwrite stored values with stale UI state.
+      setForm((prev) => ({ ...prev, proxy_password: '', ssh_key_passphrase: '' }))
+      if (form.proxy_password) setHasPassword(true)
+      if (form.ssh_key_passphrase) setHasPassphrase(true)
+      setMessage({
+        type: 'success',
+        text: 'Platform DB proxy saved. Restart the backend for changes to take effect.',
+      })
+    } catch (err: any) {
+      setMessage({
+        type: 'error',
+        text: `Failed to save platform DB proxy: ${err?.message || err}`,
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  const sshFieldsRelevant = form.proxy_type === 'ssh_tunnel'
+
+  return (
+    <Box sx={{ maxWidth: 760 }}>
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        Platform Database Proxy
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Optional intermediate hop in front of Vigil's own metadata
+        Postgres (PgBouncer pooler or SSH tunnel to a private bastion).
+        Credentials are kept in the encrypted secrets store, never the
+        DB itself. HTTP/SOCKS proxies are not offered for the platform
+        DB because the Postgres wire protocol is not proxy-aware.
+      </Typography>
+
+      <Alert severity="warning" sx={{ mb: 3 }}>
+        Changes here take effect after the backend is restarted. The
+        live engine cannot be hot-swapped safely.
+      </Alert>
+
+      <Paper sx={{ p: 3 }} variant="outlined">
+        <FormControl fullWidth margin="normal">
+          <InputLabel>Proxy Type</InputLabel>
+          <Select
+            value={form.proxy_type}
+            label="Proxy Type"
+            onChange={(e) =>
+              setForm({ ...form, proxy_type: e.target.value as ProxyType })
+            }
+          >
+            <MenuItem value="none">None (direct connection)</MenuItem>
+            <MenuItem value="pgbouncer">PgBouncer</MenuItem>
+            <MenuItem value="ssh_tunnel">SSH tunnel</MenuItem>
+          </Select>
+        </FormControl>
+
+        {form.proxy_type !== 'none' && (
+          <>
+            <TextField
+              fullWidth
+              margin="normal"
+              label="Proxy Host"
+              value={form.proxy_host}
+              onChange={(e) => setForm({ ...form, proxy_host: e.target.value })}
+              placeholder={sshFieldsRelevant ? 'bastion.internal' : 'pgbouncer.internal'}
+              required
+            />
+            <TextField
+              fullWidth
+              margin="normal"
+              type="number"
+              label="Proxy Port"
+              value={form.proxy_port || ''}
+              onChange={(e) =>
+                setForm({ ...form, proxy_port: parseInt(e.target.value) || 0 })
+              }
+              placeholder={sshFieldsRelevant ? '22' : '6432'}
+              required
+            />
+            <TextField
+              fullWidth
+              margin="normal"
+              label={sshFieldsRelevant ? 'SSH Username' : 'Proxy Username'}
+              value={form.proxy_username}
+              onChange={(e) =>
+                setForm({ ...form, proxy_username: e.target.value })
+              }
+            />
+            <TextField
+              fullWidth
+              margin="normal"
+              type="password"
+              label="Proxy Password"
+              value={form.proxy_password}
+              onChange={(e) =>
+                setForm({ ...form, proxy_password: e.target.value })
+              }
+              helperText={
+                hasPassword
+                  ? 'A password is currently stored. Leave blank to keep it; type a new value to overwrite.'
+                  : 'Stored in the encrypted secrets store.'
+              }
+            />
+
+            {sshFieldsRelevant && (
+              <>
+                <TextField
+                  fullWidth
+                  margin="normal"
+                  label="SSH Private Key Path"
+                  value={form.ssh_private_key_path}
+                  onChange={(e) =>
+                    setForm({
+                      ...form,
+                      ssh_private_key_path: e.target.value,
+                    })
+                  }
+                  placeholder="/home/vigil/.ssh/id_ed25519"
+                  helperText="Absolute path on the backend host."
+                />
+                <TextField
+                  fullWidth
+                  margin="normal"
+                  type="password"
+                  label="SSH Key Passphrase"
+                  value={form.ssh_key_passphrase}
+                  onChange={(e) =>
+                    setForm({ ...form, ssh_key_passphrase: e.target.value })
+                  }
+                  helperText={
+                    hasPassphrase
+                      ? 'A passphrase is currently stored. Leave blank to keep it.'
+                      : 'Required only with an encrypted private key.'
+                  }
+                />
+              </>
+            )}
+
+            <FormControlLabel
+              sx={{ mt: 2 }}
+              control={
+                <Switch
+                  checked={form.verify_proxy_tls}
+                  onChange={(e) =>
+                    setForm({ ...form, verify_proxy_tls: e.target.checked })
+                  }
+                />
+              }
+              label="Verify proxy TLS"
+            />
+          </>
+        )}
+
+        <Box sx={{ mt: 3 }}>
+          <Button
+            variant="contained"
+            startIcon={<SaveIcon />}
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? 'Saving...' : 'Save Configuration'}
+          </Button>
+        </Box>
+      </Paper>
+    </Box>
+  )
+}

--- a/frontend/src/config/integrations.ts
+++ b/frontend/src/config/integrations.ts
@@ -82,6 +82,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     category: 'Threat Intelligence',
     description: 'Connect to MISP (Malware Information Sharing Platform) for threat sharing.',
     functionality_type: 'Data Enrichment',
+    proxy_supported: true,
     fields: [
       {
         name: 'url',
@@ -721,6 +722,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     description: 'Connect to Splunk Enterprise or Splunk Cloud for log aggregation, search, and analysis with natural language query generation.',
     functionality_type: 'Log Analysis & SIEM',
     has_ui: true,
+    proxy_supported: true,
     fields: [
       {
         name: 'server_url',
@@ -769,6 +771,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     description: 'Observability pipeline for collecting, processing, enriching, and routing security data. Normalize logs, reduce volume, and optimize data flow before AI analysis.',
     functionality_type: 'Data Pipeline & Enrichment',
     has_ui: false,
+    proxy_supported: true,
     fields: [
       {
         name: 'server_url',
@@ -816,6 +819,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     category: 'SIEM',
     description: 'Elastic Security SIEM with advanced analytics, threat hunting, and incident response capabilities.',
     functionality_type: 'Log Analysis & SIEM',
+    proxy_supported: true,
     fields: [
       {
         name: 'elasticsearch_url',
@@ -944,6 +948,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     category: 'SIEM',
     description: 'IBM QRadar SIEM for enterprise security intelligence and threat detection.',
     functionality_type: 'Log Analysis & SIEM',
+    proxy_supported: true,
     fields: [
       {
         name: 'console_url',
@@ -974,6 +979,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     category: 'SIEM',
     description: 'OpenText ArcSight ESM for enterprise security event management and correlation.',
     functionality_type: 'Log Analysis & SIEM',
+    proxy_supported: true,
     fields: [
       {
         name: 'manager_url',
@@ -1009,6 +1015,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     category: 'SIEM',
     description: 'LogRhythm SIEM platform with advanced analytics and automated response capabilities.',
     functionality_type: 'Log Analysis & SIEM',
+    proxy_supported: true,
     fields: [
       {
         name: 'api_url',
@@ -1039,6 +1046,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     category: 'SIEM',
     description: 'Exabeam Security Operations Platform with behavioral analytics and UEBA capabilities.',
     functionality_type: 'Log Analysis & SIEM',
+    proxy_supported: true,
     fields: [
       {
         name: 'api_url',
@@ -1074,6 +1082,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     category: 'SIEM',
     description: 'Securonix Next-Gen SIEM with advanced threat detection using machine learning and UEBA.',
     functionality_type: 'Log Analysis & SIEM',
+    proxy_supported: true,
     fields: [
       {
         name: 'api_url',
@@ -1110,6 +1119,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     category: 'SIEM',
     description: 'Cloud-native SIEM and log analytics platform with real-time insights and security analytics.',
     functionality_type: 'Log Analysis & SIEM',
+    proxy_supported: true,
     fields: [
       {
         name: 'access_id',
@@ -1146,6 +1156,7 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     category: 'SIEM',
     description: 'Open-source log management and SIEM solution for centralized log collection and analysis.',
     functionality_type: 'Log Analysis & SIEM',
+    proxy_supported: true,
     fields: [
       {
         name: 'server_url',

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -69,6 +69,7 @@ import KafkaTab from '../components/settings/KafkaTab'
 import LLMProvidersTab from '../components/settings/LLMProvidersTab'
 import ModelAssignmentTab from '../components/settings/ModelAssignmentTab'
 import AIOperationsTab from '../components/settings/AIOperationsTab'
+import PlatformDatabaseTab from '../components/settings/PlatformDatabaseTab'
 import CostAnalytics from './CostAnalytics'
 
 interface TabPanelProps {
@@ -99,6 +100,7 @@ const TAB_DEFS: { key: string; label: string; devOnly: boolean }[] = [
   { key: 'integrations', label: 'Integrations / MCP', devOnly: false },
   { key: 'users', label: 'Users', devOnly: false },
   { key: 'autoinvestigate', label: 'Auto Investigate', devOnly: false },
+  { key: 'system', label: 'System', devOnly: false },
   { key: 'general', label: 'General', devOnly: false },
   { key: 'dev', label: 'Developer', devOnly: true },
 ]
@@ -1586,6 +1588,13 @@ export default function Settings() {
             <Box sx={{ maxWidth: 800 }}>
               <AutoInvestigateTab onMessage={setMessage} showConfirm={showConfirm} />
             </Box>
+          </TabPanel>
+        )
+
+      case 'system':
+        return (
+          <TabPanel value={currentTab} index={idx} key={tabKey}>
+            <PlatformDatabaseTab setMessage={setMessage} />
           </TabPanel>
         )
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -741,6 +741,21 @@ export const configApi = {
   getPostgreSQL: () => api.get('/config/postgresql'),
   setPostgreSQL: (connection_string: string) => api.post('/config/postgresql', { connection_string }),
 
+  // Platform metadata DB proxy (PgBouncer / SSH tunnel) — settings live
+  // in the encrypted secrets store so they're readable before the engine
+  // boots. Restart-required.
+  getPlatformDatabase: () => api.get<PlatformDatabaseProxyConfig>('/config/platform-database'),
+  setPlatformDatabase: (data: {
+    proxy_type: string
+    proxy_host?: string
+    proxy_port?: number
+    proxy_username?: string
+    proxy_password?: string
+    ssh_private_key_path?: string
+    ssh_key_passphrase?: string
+    verify_proxy_tls?: boolean
+  }) => api.post('/config/platform-database', data),
+
   // GH #84 PR-F — runtime AI cost/perf toggles
   getAIOperations: () => api.get('/config/ai-operations'),
   setAIOperations: (data: {
@@ -781,6 +796,18 @@ export const configApi = {
   }) => api.post('/config/orchestrator', data),
 
   getMempalaceHealth: () => api.get<MempalaceHealth>('/config/mempalace/health'),
+}
+
+export interface PlatformDatabaseProxyConfig {
+  proxy_type: string
+  proxy_host: string
+  proxy_port: number
+  proxy_username: string
+  ssh_private_key_path: string
+  verify_proxy_tls: boolean
+  // Booleans only — secret values are never returned by the API.
+  has_proxy_password: boolean
+  has_ssh_key_passphrase: boolean
 }
 
 // GH #136 — Mempalace is hidden from the MCP servers list because it's an

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,14 @@ sqlalchemy>=2.0.0
 psycopg2-binary>=2.9.9
 alembic>=1.13.0
 
+# Optional proxy hops in front of the metadata DB and DB-shaped
+# integrations (Settings → System → Database, plus per-integration
+# proxy block). sshtunnel only loaded when the operator picks an SSH
+# tunnel; pysocks gives requests/urllib SOCKS5 support for
+# integrations whose clients pick up HTTPS_PROXY / ALL_PROXY.
+sshtunnel>=0.4.0
+pysocks>=1.7.1
+
 # MCP SDK (for MCP tools)
 # Install with: pip install mcp
 

--- a/services/db_proxy.py
+++ b/services/db_proxy.py
@@ -1,0 +1,308 @@
+"""Database / integration proxy runtime helper.
+
+Wraps three optional hop types operators may want between Vigil and either
+its own metadata Postgres or a DB-shaped integration target:
+
+* ``pgbouncer`` — connection pooler in front of Postgres. Just an endpoint
+  rewrite; the wire protocol is unchanged.
+* ``http`` / ``socks5`` — a generic egress proxy. Honored by HTTP-based
+  integration clients (we propagate ``HTTPS_PROXY`` / ``ALL_PROXY`` to
+  child processes that read them). Not applicable to Postgres directly.
+* ``ssh_tunnel`` — open a local SSH forward via ``sshtunnel`` and rewrite
+  the effective ``(host, port)`` to point at ``127.0.0.1:<local_port>``.
+
+The runtime resolves a :class:`ProxyConfig` against the encrypted secrets
+manager so the caller never has to assemble credentials from env. The
+non-secret half of the config (type, host, port, ssh user) lives in either
+``SystemConfig`` (platform DB) or the integration's stored config dict;
+the secret half (proxy_password, ssh_key_passphrase) is fetched from the
+secrets manager just-in-time.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from backend.secrets_manager import get_secret
+
+logger = logging.getLogger(__name__)
+
+
+# Set of proxy_type values understood by this module. Anything else is
+# treated as "no proxy" (a no-op) so a stray value can't break boot.
+PROXY_TYPES_ALL = ("pgbouncer", "http", "socks5", "ssh_tunnel")
+PROXY_TYPES_NONE = ("", "none", None)
+
+# Subset offered for the platform metadata DB. http/socks5 are excluded
+# because the Postgres wire protocol isn't proxy-aware in
+# psycopg2/asyncpg — using a SOCKS proxy on the platform DB would be a
+# silent footgun.
+PROXY_TYPES_PLATFORM_DB = ("none", "pgbouncer", "ssh_tunnel")
+
+# Form-field names that are sensitive. Used by integration_secrets to
+# route the values through the encrypted store rather than the DB row.
+PROXY_SECRET_FIELDS: Tuple[str, ...] = ("proxy_password", "ssh_key_passphrase")
+
+
+@dataclass
+class ProxyConfig:
+    """Resolved proxy configuration for one connection target.
+
+    All credential lookups happen at construction time via
+    :meth:`from_dict`, which pulls secrets out of the encrypted secrets
+    manager. Callers receive a fully-populated value object and don't
+    need to know where any individual field came from.
+    """
+
+    proxy_type: str = "none"
+    proxy_host: str = ""
+    proxy_port: int = 0
+    proxy_username: str = ""
+    proxy_password: str = ""
+    ssh_private_key_path: str = ""
+    ssh_key_passphrase: str = ""
+    verify_proxy_tls: bool = True
+
+    @classmethod
+    def from_dict(
+        cls,
+        config: Mapping[str, Any],
+        *,
+        password_secret_key: Optional[str] = None,
+        passphrase_secret_key: Optional[str] = None,
+    ) -> "ProxyConfig":
+        """Build a config from a non-secret dict, hydrating secrets.
+
+        ``password_secret_key`` / ``passphrase_secret_key`` are the keys
+        under which the encrypted secrets manager holds the proxy
+        password and SSH key passphrase respectively. When omitted, the
+        method falls back to the value present in ``config`` (used by
+        unit tests and by the platform-DB path where the secrets
+        manager already round-trips both).
+        """
+
+        proxy_type = (config.get("proxy_type") or "none").strip().lower()
+        if proxy_type in PROXY_TYPES_NONE:
+            return cls()
+
+        password = config.get("proxy_password") or ""
+        if password_secret_key:
+            password = get_secret(password_secret_key) or password
+
+        passphrase = config.get("ssh_key_passphrase") or ""
+        if passphrase_secret_key:
+            passphrase = get_secret(passphrase_secret_key) or passphrase
+
+        try:
+            port = int(config.get("proxy_port") or 0)
+        except (TypeError, ValueError):
+            port = 0
+
+        return cls(
+            proxy_type=proxy_type,
+            proxy_host=str(config.get("proxy_host") or ""),
+            proxy_port=port,
+            proxy_username=str(config.get("proxy_username") or ""),
+            proxy_password=str(password),
+            ssh_private_key_path=str(config.get("ssh_private_key_path") or ""),
+            ssh_key_passphrase=str(passphrase),
+            verify_proxy_tls=bool(config.get("verify_proxy_tls", True)),
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return (
+            self.proxy_type not in PROXY_TYPES_NONE
+            and self.proxy_type in PROXY_TYPES_ALL
+        )
+
+
+@dataclass
+class AppliedProxy:
+    """Result of applying a proxy to a target ``(host, port)``.
+
+    * ``host`` / ``port`` — the *effective* endpoint a client should
+      connect to. For ``pgbouncer`` and ``ssh_tunnel`` modes these are
+      rewritten; for HTTP/SOCKS they are unchanged.
+    * ``http_proxy_url`` — populated for ``http`` / ``socks5`` so HTTP
+      clients (or child processes via env vars) can route through the
+      egress proxy.
+    * ``ssl_disabled`` — set when the operator chose ``verify_proxy_tls
+      = False`` and the underlying client supports a flag for it.
+    * ``tunnel_handle`` — opaque object that owns the SSH tunnel
+      lifetime. The caller must keep this alive (and call
+      ``handle.close()`` on shutdown) for as long as the rewritten
+      endpoint is in use.
+    """
+
+    host: str
+    port: int
+    http_proxy_url: Optional[str] = None
+    ssl_disabled: bool = False
+    tunnel_handle: Optional[Any] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def close(self) -> None:
+        """Tear down any underlying tunnel. Idempotent."""
+
+        handle = self.tunnel_handle
+        self.tunnel_handle = None
+        if handle is None:
+            return
+        try:
+            stop = getattr(handle, "stop", None)
+            if callable(stop):
+                stop()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to stop proxy tunnel cleanly: %s", exc)
+
+
+def apply(
+    target_host: str,
+    target_port: int,
+    proxy: ProxyConfig,
+) -> AppliedProxy:
+    """Apply ``proxy`` to ``(target_host, target_port)`` and return the
+    effective endpoint plus any side-effects (open tunnels, env vars).
+
+    Safe to call with a disabled :class:`ProxyConfig`; in that case it
+    returns an :class:`AppliedProxy` that's a pass-through of the
+    original target.
+    """
+
+    if not proxy.enabled:
+        return AppliedProxy(host=target_host, port=target_port)
+
+    proxy_type = proxy.proxy_type
+    if proxy_type == "pgbouncer":
+        if not proxy.proxy_host or not proxy.proxy_port:
+            raise ValueError("pgbouncer proxy requires proxy_host and proxy_port")
+        return AppliedProxy(
+            host=proxy.proxy_host,
+            port=proxy.proxy_port,
+            ssl_disabled=not proxy.verify_proxy_tls,
+        )
+
+    if proxy_type in ("http", "socks5"):
+        if not proxy.proxy_host or not proxy.proxy_port:
+            raise ValueError(f"{proxy_type} proxy requires proxy_host and proxy_port")
+        url = _http_proxy_url(proxy)
+        return AppliedProxy(
+            host=target_host,
+            port=target_port,
+            http_proxy_url=url,
+            ssl_disabled=not proxy.verify_proxy_tls,
+        )
+
+    if proxy_type == "ssh_tunnel":
+        if not proxy.proxy_host or not proxy.proxy_port:
+            raise ValueError("ssh_tunnel requires proxy_host and proxy_port")
+        handle, local_host, local_port = _open_ssh_tunnel(
+            proxy, target_host, target_port
+        )
+        return AppliedProxy(
+            host=local_host,
+            port=local_port,
+            tunnel_handle=handle,
+        )
+
+    # Defensive: unknown type — pretend it's disabled.
+    logger.warning("Unknown proxy_type=%r; ignoring", proxy_type)
+    return AppliedProxy(host=target_host, port=target_port)
+
+
+def _http_proxy_url(proxy: ProxyConfig) -> str:
+    """Build an ``http://``/``socks5://`` proxy URL for client libraries."""
+
+    scheme = "http" if proxy.proxy_type == "http" else "socks5"
+    if proxy.proxy_username:
+        from urllib.parse import quote
+
+        creds = quote(proxy.proxy_username, safe="")
+        if proxy.proxy_password:
+            creds = f"{creds}:{quote(proxy.proxy_password, safe='')}"
+        return f"{scheme}://{creds}@{proxy.proxy_host}:{proxy.proxy_port}"
+    return f"{scheme}://{proxy.proxy_host}:{proxy.proxy_port}"
+
+
+def _open_ssh_tunnel(
+    proxy: ProxyConfig, target_host: str, target_port: int
+) -> Tuple[Any, str, int]:
+    """Open an SSH tunnel and return (handle, local_host, local_port).
+
+    Imported lazily so the dep is only required when the feature is used.
+    """
+
+    try:
+        from sshtunnel import SSHTunnelForwarder  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "ssh_tunnel proxy requires the 'sshtunnel' package. "
+            "Install it with: pip install sshtunnel"
+        ) from exc
+
+    kwargs: Dict[str, Any] = {
+        "ssh_address_or_host": (proxy.proxy_host, proxy.proxy_port),
+        "remote_bind_address": (target_host, target_port),
+        "local_bind_address": ("127.0.0.1", 0),  # let OS pick a free port
+    }
+    if proxy.proxy_username:
+        kwargs["ssh_username"] = proxy.proxy_username
+    if proxy.ssh_private_key_path:
+        kwargs["ssh_pkey"] = proxy.ssh_private_key_path
+        if proxy.ssh_key_passphrase:
+            kwargs["ssh_private_key_password"] = proxy.ssh_key_passphrase
+    elif proxy.proxy_password:
+        kwargs["ssh_password"] = proxy.proxy_password
+
+    forwarder = SSHTunnelForwarder(**kwargs)
+    forwarder.start()
+    local_host, local_port = forwarder.local_bind_address
+    logger.info(
+        "Opened SSH tunnel %s:%s -> %s:%s via %s:%s",
+        local_host,
+        local_port,
+        target_host,
+        target_port,
+        proxy.proxy_host,
+        proxy.proxy_port,
+    )
+    return forwarder, local_host, local_port
+
+
+def child_env_for_proxy(proxy: ProxyConfig) -> Dict[str, str]:
+    """Return env-var overrides that should be merged into a child
+    process so its HTTP client respects the proxy.
+
+    Targets the conventional ``HTTPS_PROXY`` / ``HTTP_PROXY`` /
+    ``ALL_PROXY`` variables, which ``requests``, ``httpx``, and ``urllib``
+    all honor by default. Empty dict when proxy is disabled or non-HTTP.
+    """
+
+    if not proxy.enabled or proxy.proxy_type not in ("http", "socks5"):
+        return {}
+    url = _http_proxy_url(proxy)
+    env = {
+        "HTTPS_PROXY": url,
+        "HTTP_PROXY": url,
+        "ALL_PROXY": url,
+        # lowercase aliases for tools that only check those
+        "https_proxy": url,
+        "http_proxy": url,
+        "all_proxy": url,
+    }
+    return env
+
+
+__all__ = [
+    "AppliedProxy",
+    "PROXY_SECRET_FIELDS",
+    "PROXY_TYPES_ALL",
+    "PROXY_TYPES_NONE",
+    "PROXY_TYPES_PLATFORM_DB",
+    "ProxyConfig",
+    "apply",
+    "child_env_for_proxy",
+]

--- a/services/integration_bridge_service.py
+++ b/services/integration_bridge_service.py
@@ -8,119 +8,134 @@ from typing import Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
+# Form-field names contributed by the shared proxy block (see
+# ``frontend/src/config/integrations.ts``). These are meta-config — the
+# bridge translates them into HTTPS_PROXY / ALL_PROXY env vars (which
+# requests/httpx/urllib all honor) rather than emitting raw
+# ``<ID>_PROXY_*`` vars that downstream MCP servers wouldn't know to
+# read. PgBouncer / SSH-tunnel rewriting of the integration's host:port
+# also happens here.
+_PROXY_FORM_FIELDS = frozenset(
+    {
+        "proxy_type",
+        "proxy_host",
+        "proxy_port",
+        "proxy_username",
+        "proxy_password",
+        "ssh_private_key_path",
+        "ssh_key_passphrase",
+        "verify_proxy_tls",
+    }
+)
+
+
 class IntegrationBridgeService:
     """Bridges integration configs to MCP server configurations."""
-    
+
     # Map integration IDs (frontend) to MCP server names (backend)
     INTEGRATION_TO_SERVER_MAP = {
         # Threat Intelligence
-        'virustotal': 'virustotal-server',
-        'alienvault-otx': 'alienvault-otx-server',
-        'shodan': 'shodan-server',
-        'misp': 'misp-server',
-        'url-analysis': 'url-analysis-server',
-        'ip-geolocation': 'ip-geolocation-server',
-        
+        "virustotal": "virustotal-server",
+        "alienvault-otx": "alienvault-otx-server",
+        "shodan": "shodan-server",
+        "misp": "misp-server",
+        "url-analysis": "url-analysis-server",
+        "ip-geolocation": "ip-geolocation-server",
         # EDR/XDR
-        'crowdstrike': 'crowdstrike-server',
-        'sentinelone': 'sentinelone-server',
-        'carbon-black': 'carbon-black-server',
-        'microsoft-defender': 'microsoft-defender-server',
-        
+        "crowdstrike": "crowdstrike-server",
+        "sentinelone": "sentinelone-server",
+        "carbon-black": "carbon-black-server",
+        "microsoft-defender": "microsoft-defender-server",
         # SIEM
-        'splunk': 'splunk-server',
-        'azure-sentinel': 'azure-sentinel-server',
-        
+        "splunk": "splunk-server",
+        "azure-sentinel": "azure-sentinel-server",
         # Cloud Security
-        'aws-security-hub': 'aws-security-hub-server',
-        'gcp-security': 'gcp-security-server',
-        
+        "aws-security-hub": "aws-security-hub-server",
+        "gcp-security": "gcp-security-server",
         # Identity & Access
-        'okta': 'okta-server',
-        'azure-ad': 'azure-ad-server',
-        
+        "okta": "okta-server",
+        "azure-ad": "azure-ad-server",
         # Network Security
-        'palo-alto': 'palo-alto-server',
-        
+        "palo-alto": "palo-alto-server",
         # Incident Management
-        'jira': 'jira-server',
-        
+        "jira": "jira-server",
         # Communications
-        'slack': 'slack-server',
-        'pagerduty': 'pagerduty-server',
-        'microsoft-teams': 'microsoft-teams-server',
-        
+        "slack": "slack-server",
+        "pagerduty": "pagerduty-server",
+        "microsoft-teams": "microsoft-teams-server",
         # Sandbox Analysis
-        'hybrid-analysis': 'hybrid-analysis-server',
-        'joe-sandbox': 'joe-sandbox-server',
-        'anyrun': 'anyrun-server',
-        'cape-sandbox': 'cape-sandbox-server',
-        'cape_sandbox': 'cape-sandbox-server',
+        "hybrid-analysis": "hybrid-analysis-server",
+        "joe-sandbox": "joe-sandbox-server",
+        "anyrun": "anyrun-server",
+        "cape-sandbox": "cape-sandbox-server",
+        "cape_sandbox": "cape-sandbox-server",
     }
-    
+
     # Map integration field names to environment variable names
     # These are common patterns - specific integrations may need custom mappings
     FIELD_TO_ENV_MAP = {
-        'api_key': 'API_KEY',
-        'api_token': 'API_TOKEN',
-        'api_secret': 'API_SECRET',
-        'access_key': 'ACCESS_KEY',
-        'secret_key': 'SECRET_KEY',
-        'client_id': 'CLIENT_ID',
-        'client_secret': 'CLIENT_SECRET',
-        'username': 'USERNAME',
-        'password': 'PASSWORD',
-        'server_url': 'SERVER_URL',
-        'api_url': 'API_URL',
-        'base_url': 'BASE_URL',
-        'url': 'URL',
-        'hostname': 'HOSTNAME',
-        'tenant_id': 'TENANT_ID',
-        'workspace_id': 'WORKSPACE_ID',
-        'region': 'REGION',
-        'domain': 'DOMAIN',
-        'org_key': 'ORG_KEY',
-        'organization_id': 'ORGANIZATION_ID',
-        'project_id': 'PROJECT_ID',
-        'verify_ssl': 'VERIFY_SSL',
-        'port': 'PORT',
-        'access_key_id': 'ACCESS_KEY_ID',
-        'secret_access_key': 'SECRET_ACCESS_KEY',
-        'credentials_json': 'CREDENTIALS_JSON',
-        'integration_key': 'INTEGRATION_KEY',
-        'webhook_url': 'WEBHOOK_URL',
-        'bot_token': 'BOT_TOKEN',
-        'default_channel': 'DEFAULT_CHANNEL',
+        "api_key": "API_KEY",
+        "api_token": "API_TOKEN",
+        "api_secret": "API_SECRET",
+        "access_key": "ACCESS_KEY",
+        "secret_key": "SECRET_KEY",
+        "client_id": "CLIENT_ID",
+        "client_secret": "CLIENT_SECRET",
+        "username": "USERNAME",
+        "password": "PASSWORD",
+        "server_url": "SERVER_URL",
+        "api_url": "API_URL",
+        "base_url": "BASE_URL",
+        "url": "URL",
+        "hostname": "HOSTNAME",
+        "tenant_id": "TENANT_ID",
+        "workspace_id": "WORKSPACE_ID",
+        "region": "REGION",
+        "domain": "DOMAIN",
+        "org_key": "ORG_KEY",
+        "organization_id": "ORGANIZATION_ID",
+        "project_id": "PROJECT_ID",
+        "verify_ssl": "VERIFY_SSL",
+        "port": "PORT",
+        "access_key_id": "ACCESS_KEY_ID",
+        "secret_access_key": "SECRET_ACCESS_KEY",
+        "credentials_json": "CREDENTIALS_JSON",
+        "integration_key": "INTEGRATION_KEY",
+        "webhook_url": "WEBHOOK_URL",
+        "bot_token": "BOT_TOKEN",
+        "default_channel": "DEFAULT_CHANNEL",
     }
-    
+
     def __init__(self):
         """Initialize the integration bridge service."""
-        self.config_path = Path.home() / '.deeptempo' / 'integrations_config.json'
-    
+        self.config_path = Path.home() / ".deeptempo" / "integrations_config.json"
+
     def load_integration_config(self) -> Dict:
         """
         Load integration configuration from disk.
-        
+
         Returns:
             Dictionary with 'enabled_integrations' and 'integrations' keys
         """
         if not self.config_path.exists():
             logger.info("No integration config file found, using empty config")
             return {"enabled_integrations": [], "integrations": {}}
-        
+
         try:
-            with open(self.config_path, 'r') as f:
+            with open(self.config_path, "r") as f:
                 config = json.load(f)
-            logger.info(f"Loaded integration config with {len(config.get('enabled_integrations', []))} enabled integrations")
+            logger.info(
+                f"Loaded integration config with {len(config.get('enabled_integrations', []))} enabled integrations"
+            )
             return config
         except Exception as e:
             logger.error(f"Error loading integration config: {e}")
             return {"enabled_integrations": [], "integrations": {}}
-    
+
     def get_enabled_servers(self) -> Dict[str, Dict]:
         """
         Get MCP server configurations for all enabled integrations.
-        
+
         Returns:
             Dict mapping server names to their configurations with env vars
             Example: {
@@ -131,162 +146,218 @@ class IntegrationBridgeService:
             }
         """
         config = self.load_integration_config()
-        enabled = config.get('enabled_integrations', [])
-        integrations = config.get('integrations', {})
-        
+        enabled = config.get("enabled_integrations", [])
+        integrations = config.get("integrations", {})
+
         servers = {}
-        
+
         for integration_id in enabled:
             # Check if this integration has a corresponding MCP server
             server_name = self.INTEGRATION_TO_SERVER_MAP.get(integration_id)
             if not server_name:
                 logger.debug(f"No MCP server mapped for integration: {integration_id}")
                 continue
-            
+
             # Get integration configuration
             integration_config = integrations.get(integration_id, {})
             if not integration_config:
-                logger.warning(f"No configuration found for enabled integration: {integration_id}")
+                logger.warning(
+                    f"No configuration found for enabled integration: {integration_id}"
+                )
                 continue
-            
+
             # Convert integration config to environment variables
             env_vars = self._config_to_env_vars(integration_id, integration_config)
-            
+
             servers[server_name] = {
-                'integration_id': integration_id,
-                'env_vars': env_vars,
-                'config': integration_config
+                "integration_id": integration_id,
+                "env_vars": env_vars,
+                "config": integration_config,
             }
-            
+
             logger.info(f"Prepared server config for {server_name} ({integration_id})")
-        
+
         return servers
-    
+
     def _config_to_env_vars(self, integration_id: str, config: Dict) -> Dict[str, str]:
         """
         Convert integration configuration to environment variables.
-        
+
         Args:
             integration_id: Integration identifier (e.g., 'virustotal')
             config: Integration configuration dictionary
-        
+
         Returns:
             Dictionary of environment variables with proper naming
         """
         env_vars = {}
-        
+
         # Add integration ID prefix for namespacing
         # Convert kebab-case to UPPER_SNAKE_CASE
-        prefix = integration_id.upper().replace('-', '_')
-        
+        prefix = integration_id.upper().replace("-", "_")
+
         for field_name, field_value in config.items():
-            # Skip empty values
-            if field_value is None or field_value == '':
+            # Proxy fields are translated separately below into
+            # HTTPS_PROXY / ALL_PROXY (and host/port rewrites), not
+            # exposed as <PREFIX>_PROXY_* — downstream MCP servers
+            # already speak the conventional env-var names.
+            if field_name in _PROXY_FORM_FIELDS:
                 continue
-            
+
+            # Skip empty values
+            if field_value is None or field_value == "":
+                continue
+
             # Convert boolean to string
             if isinstance(field_value, bool):
-                field_value = 'true' if field_value else 'false'
-            
+                field_value = "true" if field_value else "false"
+
             # Convert field name to env var name
             env_name = self.FIELD_TO_ENV_MAP.get(field_name, field_name.upper())
-            
+
             # Add prefix and set value
             full_env_name = f"{prefix}_{env_name}"
             env_vars[full_env_name] = str(field_value)
-        
+
+        # Append proxy-derived env vars (HTTPS_PROXY etc.) when this
+        # integration's config asks for HTTP/SOCKS routing.
+        env_vars.update(self._proxy_env_vars(integration_id, config))
+
         return env_vars
-    
+
+    def _proxy_env_vars(self, integration_id: str, config: Dict) -> Dict[str, str]:
+        """Translate proxy_* form fields into env vars for the MCP child.
+
+        For ``http`` / ``socks5``: emits ``HTTPS_PROXY`` / ``ALL_PROXY``
+        (recognised by every common Python HTTP client).
+
+        For ``pgbouncer`` and ``ssh_tunnel``: returns ``{}`` here. Those
+        modes need host:port rewriting on URL-shaped fields, which is
+        more invasive than env injection — handled (or warned about) by
+        callers that actually open connections. Documented in the
+        accompanying plan as a v1 limitation for integration-side
+        tunneling.
+        """
+        proxy_type = (config.get("proxy_type") or "none").strip().lower()
+        if proxy_type in ("", "none"):
+            return {}
+
+        try:
+            from services.db_proxy import ProxyConfig, child_env_for_proxy
+            from services.integration_secrets import secret_fields_for
+        except ImportError:  # pragma: no cover - defensive
+            return {}
+
+        secret_keys = secret_fields_for(integration_id)
+        proxy = ProxyConfig.from_dict(
+            config,
+            password_secret_key=secret_keys.get("proxy_password"),
+            passphrase_secret_key=secret_keys.get("ssh_key_passphrase"),
+        )
+        if proxy_type in ("http", "socks5"):
+            return child_env_for_proxy(proxy)
+
+        # pgbouncer / ssh_tunnel: log so operators know the bridge
+        # itself doesn't handle endpoint rewriting for MCP children.
+        logger.info(
+            "Integration %s configured proxy_type=%s; bridge does not "
+            "rewrite MCP server endpoints. Use http/socks5 for HTTP "
+            "integrations, or configure the proxy at the network layer.",
+            integration_id,
+            proxy_type,
+        )
+        return {}
+
     def is_integration_enabled(self, integration_id: str) -> bool:
         """
         Check if an integration is enabled.
-        
+
         Args:
             integration_id: Integration identifier
-            
+
         Returns:
             True if integration is enabled, False otherwise
         """
         config = self.load_integration_config()
-        return integration_id in config.get('enabled_integrations', [])
-    
+        return integration_id in config.get("enabled_integrations", [])
+
     def get_integration_config(self, integration_id: str) -> Optional[Dict]:
         """
         Get configuration for a specific integration.
-        
+
         Args:
             integration_id: Integration identifier
-            
+
         Returns:
             Integration configuration dictionary or None
         """
         config = self.load_integration_config()
-        return config.get('integrations', {}).get(integration_id)
-    
+        return config.get("integrations", {}).get(integration_id)
+
     def get_integration_status(self, integration_id: str) -> Dict:
         """
         Get status information for an integration.
-        
+
         Args:
             integration_id: Integration identifier
-            
+
         Returns:
             Dictionary with status information
         """
         config = self.load_integration_config()
-        
-        is_enabled = integration_id in config.get('enabled_integrations', [])
-        has_config = integration_id in config.get('integrations', {})
+
+        is_enabled = integration_id in config.get("enabled_integrations", [])
+        has_config = integration_id in config.get("integrations", {})
         has_server = integration_id in self.INTEGRATION_TO_SERVER_MAP
-        
+
         status = {
-            'enabled': is_enabled,
-            'configured': has_config,
-            'server_available': has_server,
-            'ready': is_enabled and has_config and has_server
+            "enabled": is_enabled,
+            "configured": has_config,
+            "server_available": has_server,
+            "ready": is_enabled and has_config and has_server,
         }
-        
+
         if has_server:
-            status['server_name'] = self.INTEGRATION_TO_SERVER_MAP[integration_id]
-        
+            status["server_name"] = self.INTEGRATION_TO_SERVER_MAP[integration_id]
+
         return status
-    
+
     def get_all_integration_statuses(self) -> Dict[str, Dict]:
         """
         Get status information for all integrations.
-        
+
         Returns:
             Dictionary mapping integration IDs to their status
         """
         config = self.load_integration_config()
         all_integrations = set(self.INTEGRATION_TO_SERVER_MAP.keys())
-        all_integrations.update(config.get('integrations', {}).keys())
-        
+        all_integrations.update(config.get("integrations", {}).keys())
+
         statuses = {}
         for integration_id in all_integrations:
             statuses[integration_id] = self.get_integration_status(integration_id)
-        
+
         return statuses
-    
+
     def get_server_module_path(self, integration_id: str) -> Optional[str]:
         """
         Get the Python module path for an integration's MCP server.
-        
+
         Args:
             integration_id: Integration identifier
-            
+
         Returns:
             Module path string or None
         """
         server_name = self.INTEGRATION_TO_SERVER_MAP.get(integration_id)
         if not server_name:
             return None
-        
+
         # Convert server name to module name
         # Example: 'virustotal-server' -> 'virustotal'
-        tool_name = server_name.replace('-server', '').replace('-', '_')
-        
-        return f'tools.{tool_name}'
+        tool_name = server_name.replace("-server", "").replace("-", "_")
+
+        return f"tools.{tool_name}"
 
 
 # Global instance
@@ -296,7 +367,7 @@ _bridge_service = None
 def get_integration_bridge() -> IntegrationBridgeService:
     """
     Get the global integration bridge service instance.
-    
+
     Returns:
         IntegrationBridgeService instance
     """
@@ -304,4 +375,3 @@ def get_integration_bridge() -> IntegrationBridgeService:
     if _bridge_service is None:
         _bridge_service = IntegrationBridgeService()
     return _bridge_service
-

--- a/services/integration_secrets.py
+++ b/services/integration_secrets.py
@@ -60,6 +60,11 @@ _DEFAULT_FIELD_SUFFIX: Mapping[str, str] = {
     "sec_token": "SEC_TOKEN",
     "api_key_secret": "API_KEY_SECRET",
     "inbound_api_key": "INBOUND_API_KEY",
+    # Proxy / SSH-tunnel credentials. Registered here so any integration
+    # that opts into the shared proxy field block (see PROXY_SUPPORTED
+    # below) gets its proxy secrets routed to the encrypted store too.
+    "proxy_password": "PROXY_PASSWORD",
+    "ssh_key_passphrase": "SSH_KEY_PASSPHRASE",
 }
 
 
@@ -190,19 +195,59 @@ _ENV_VAR_OVERRIDES: Mapping[str, Mapping[str, str]] = {
 }
 
 
+# Form-field names contributed by the shared proxy block (see
+# ``frontend/src/config/integrations.ts:PROXY_FIELDS``). Integrations
+# that opt in via ``PROXY_SUPPORTED`` get these added to their
+# secret-field registry so credentials are routed to the encrypted
+# store rather than persisted plaintext on the integration row.
+_PROXY_SECRET_FIELDS: tuple[str, ...] = ("proxy_password", "ssh_key_passphrase")
+
+
+# Integrations whose UI form includes the shared proxy field block.
+# Kept as a frozen set so the registry stays greppable: adding an
+# integration here means proxy_password / ssh_key_passphrase get the
+# same encrypted-store treatment as the integration's own credentials.
+PROXY_SUPPORTED: frozenset[str] = frozenset(
+    {
+        "splunk",
+        "elastic-siem",
+        "qradar",
+        "arcsight",
+        "logrhythm",
+        "exabeam",
+        "securonix",
+        "sumo-logic",
+        "graylog",
+        "cribl-stream",
+        "misp",
+    }
+)
+
+
 def _resolve_env_var(integration_id: str, field_name: str) -> str:
     """Resolve the secrets-store key for one integration field."""
     overrides = _ENV_VAR_OVERRIDES.get(integration_id, {})
     return overrides.get(field_name) or _default_env_var(integration_id, field_name)
 
 
+def _fields_for(integration_id: str) -> Iterable[str]:
+    """All secret-field names for an integration, including proxy fields
+    contributed by the shared block when the integration opts in."""
+    base = _SECRET_FIELDS.get(integration_id, ())
+    if integration_id in PROXY_SUPPORTED:
+        return (*base, *_PROXY_SECRET_FIELDS)
+    return base
+
+
 def _build_registry() -> Dict[str, Dict[str, str]]:
     """Materialize the per-integration secret registry from the field list."""
+    integration_ids = set(_SECRET_FIELDS) | PROXY_SUPPORTED
     return {
         integration_id: {
-            field: _resolve_env_var(integration_id, field) for field in fields
+            field: _resolve_env_var(integration_id, field)
+            for field in _fields_for(integration_id)
         }
-        for integration_id, fields in _SECRET_FIELDS.items()
+        for integration_id in integration_ids
     }
 
 

--- a/tests/test_db_proxy.py
+++ b/tests/test_db_proxy.py
@@ -1,0 +1,206 @@
+"""Unit tests for services.db_proxy.
+
+Each proxy mode is exercised with a dummy secrets-manager and (for the
+SSH tunnel mode) a stubbed ``sshtunnel.SSHTunnelForwarder`` so the test
+does not need a real ssh server.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from services import db_proxy
+from services.db_proxy import (
+    ProxyConfig,
+    apply,
+    child_env_for_proxy,
+)
+
+
+def test_proxy_config_disabled_by_default():
+    cfg = ProxyConfig()
+    assert cfg.enabled is False
+    applied = apply("db.internal", 5432, cfg)
+    assert applied.host == "db.internal"
+    assert applied.port == 5432
+    assert applied.http_proxy_url is None
+    assert applied.tunnel_handle is None
+
+
+def test_proxy_config_from_dict_none_returns_disabled():
+    cfg = ProxyConfig.from_dict({"proxy_type": "none"})
+    assert cfg.enabled is False
+    cfg2 = ProxyConfig.from_dict({"proxy_type": ""})
+    assert cfg2.enabled is False
+
+
+def test_pgbouncer_rewrites_endpoint():
+    cfg = ProxyConfig.from_dict(
+        {
+            "proxy_type": "pgbouncer",
+            "proxy_host": "pgbouncer.svc",
+            "proxy_port": 6432,
+            "verify_proxy_tls": False,
+        }
+    )
+    assert cfg.enabled is True
+    applied = apply("db.internal", 5432, cfg)
+    assert applied.host == "pgbouncer.svc"
+    assert applied.port == 6432
+    assert applied.ssl_disabled is True
+    assert applied.tunnel_handle is None
+
+
+def test_pgbouncer_requires_host_and_port():
+    cfg = ProxyConfig.from_dict({"proxy_type": "pgbouncer", "proxy_port": 6432})
+    with pytest.raises(ValueError):
+        apply("db.internal", 5432, cfg)
+
+
+def test_http_proxy_returns_proxy_url_and_passthrough_endpoint():
+    cfg = ProxyConfig.from_dict(
+        {
+            "proxy_type": "http",
+            "proxy_host": "egress.corp",
+            "proxy_port": 3128,
+            "proxy_username": "alice",
+            "proxy_password": "s3cret",
+        }
+    )
+    applied = apply("api.vendor.com", 443, cfg)
+    assert applied.host == "api.vendor.com"
+    assert applied.port == 443
+    assert applied.http_proxy_url == "http://alice:s3cret@egress.corp:3128"
+
+
+def test_socks5_proxy_uses_socks_scheme():
+    cfg = ProxyConfig.from_dict(
+        {"proxy_type": "socks5", "proxy_host": "socks.corp", "proxy_port": 1080}
+    )
+    applied = apply("api.vendor.com", 443, cfg)
+    assert applied.http_proxy_url == "socks5://socks.corp:1080"
+
+
+def test_proxy_password_resolved_from_secrets_manager():
+    """When ``password_secret_key`` is provided, the secret value is
+    fetched via ``backend.secrets_manager.get_secret`` rather than
+    pulled inline from the config dict."""
+    fake_secrets = {"SPLUNK_PROXY_PASSWORD": "from-store"}
+    with patch.object(db_proxy, "get_secret", side_effect=fake_secrets.get):
+        cfg = ProxyConfig.from_dict(
+            {
+                "proxy_type": "http",
+                "proxy_host": "egress.corp",
+                "proxy_port": 3128,
+                "proxy_username": "u",
+                "proxy_password": "",  # blank → use secret
+            },
+            password_secret_key="SPLUNK_PROXY_PASSWORD",
+        )
+        assert cfg.proxy_password == "from-store"
+
+
+def test_child_env_for_http_proxy_emits_standard_env_vars():
+    cfg = ProxyConfig.from_dict(
+        {"proxy_type": "http", "proxy_host": "egress.corp", "proxy_port": 3128}
+    )
+    env = child_env_for_proxy(cfg)
+    assert env["HTTPS_PROXY"] == "http://egress.corp:3128"
+    assert env["HTTP_PROXY"] == "http://egress.corp:3128"
+    assert env["ALL_PROXY"] == "http://egress.corp:3128"
+    assert env["https_proxy"] == "http://egress.corp:3128"
+
+
+def test_child_env_for_disabled_proxy_is_empty():
+    assert child_env_for_proxy(ProxyConfig()) == {}
+
+
+def test_child_env_for_pgbouncer_is_empty():
+    cfg = ProxyConfig.from_dict(
+        {"proxy_type": "pgbouncer", "proxy_host": "p", "proxy_port": 6432}
+    )
+    assert child_env_for_proxy(cfg) == {}
+
+
+def test_unknown_proxy_type_is_treated_as_passthrough():
+    cfg = ProxyConfig(proxy_type="garbage", proxy_host="x", proxy_port=1)
+    # ``enabled`` returns False for unknown types so the passthrough
+    # branch in apply() runs.
+    assert cfg.enabled is False
+    applied = apply("db.internal", 5432, cfg)
+    assert applied.host == "db.internal"
+    assert applied.port == 5432
+
+
+def test_ssh_tunnel_opens_forwarder_and_rewrites_endpoint():
+    """The SSH tunnel mode imports ``sshtunnel`` lazily. We inject a
+    fake module so the test doesn't need a real SSH server."""
+
+    started = {"ok": False, "stopped": False}
+
+    class FakeForwarder:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.local_bind_address = ("127.0.0.1", 54321)
+
+        def start(self):
+            started["ok"] = True
+
+        def stop(self):
+            started["stopped"] = True
+
+    fake_module = ModuleType("sshtunnel")
+    fake_module.SSHTunnelForwarder = FakeForwarder
+    sys.modules["sshtunnel"] = fake_module
+    try:
+        cfg = ProxyConfig.from_dict(
+            {
+                "proxy_type": "ssh_tunnel",
+                "proxy_host": "bastion.corp",
+                "proxy_port": 22,
+                "proxy_username": "vigil",
+                "ssh_private_key_path": "/keys/id_ed25519",
+            }
+        )
+        applied = apply("db.private.svc", 5432, cfg)
+        assert started["ok"] is True
+        assert applied.host == "127.0.0.1"
+        assert applied.port == 54321
+        assert isinstance(applied.tunnel_handle, FakeForwarder)
+        # close() is idempotent and stops the forwarder.
+        applied.close()
+        assert started["stopped"] is True
+        applied.close()  # second call is a no-op
+    finally:
+        sys.modules.pop("sshtunnel", None)
+
+
+def test_ssh_tunnel_missing_dep_raises_helpful_error():
+    """If sshtunnel isn't installed, the runtime raises a RuntimeError
+    pointing the operator at ``pip install sshtunnel``."""
+    sys.modules.pop("sshtunnel", None)
+    # Force ImportError by putting a sentinel that fails on attribute
+    # access — simulating "module installed but broken" is overkill,
+    # so we just rely on the absence of the module.
+    with patch.dict(sys.modules, {"sshtunnel": None}):
+        cfg = ProxyConfig.from_dict(
+            {
+                "proxy_type": "ssh_tunnel",
+                "proxy_host": "bastion.corp",
+                "proxy_port": 22,
+            }
+        )
+        with pytest.raises(RuntimeError, match="sshtunnel"):
+            apply("db.private.svc", 5432, cfg)
+
+
+def test_applied_proxy_close_is_safe_when_handle_lacks_stop():
+    """Defensive: if a future tunnel object doesn't have ``stop``, the
+    close() helper logs and returns instead of raising."""
+    applied = db_proxy.AppliedProxy(host="h", port=1, tunnel_handle=SimpleNamespace())
+    applied.close()  # should not raise
+    assert applied.tunnel_handle is None


### PR DESCRIPTION
## Summary

Lets operators route **both** the platform metadata Postgres and any DB-shaped integration (Splunk, Elastic SIEM, QRadar, MISP, …) through an intermediate hop — PgBouncer, HTTP/SOCKS5 proxy, or SSH tunnel — configured from the Settings UI. All credentials are stored in the encrypted secrets manager, not env vars or the DB row.

Two surfaces, one shared field schema and proxy runtime:

- **Settings → System** (new tab) — platform metadata DB. Offers `none / pgbouncer / ssh_tunnel`; HTTP/SOCKS is deliberately excluded because the Postgres wire protocol isn't proxy-aware in psycopg2/asyncpg.
- **Settings → Integrations → \<DB-shaped integration\>** — collapsible "Network / Proxy" accordion, all five hop types. Opt-in via `proxy_supported: true` on the integration metadata; flipped on splunk, elastic-siem, qradar, arcsight, logrhythm, exabeam, securonix, sumo-logic, graylog, cribl-stream, misp.

Implementation highlights:

- New `services/db_proxy.py` wraps all three modes behind one `apply()` helper. SSH tunnel uses a lazy `sshtunnel` import so the dep is only loaded when the feature is in use.
- `database/connection.py` reads platform-DB proxy settings from the encrypted secrets store at boot (sidesteps the chicken-and-egg of needing the DB to read its own config), opens the tunnel before `create_engine`, and tears it down on shutdown.
- New `/api/config/platform-database` GET/POST. Restart-required (live engine can't be hot-swapped); empty-string secrets mean "leave existing value untouched".
- `services/integration_secrets.py` got a `PROXY_SUPPORTED` set that auto-registers `proxy_password` / `ssh_key_passphrase` per integration so the existing `split_secrets()` machinery keeps them out of the DB row.
- `services/integration_bridge_service.py` translates per-integration HTTP/SOCKS fields into `HTTPS_PROXY` / `ALL_PROXY` env vars on the MCP child process (which `requests` / `httpx` / `urllib` all honor).
- Frontend `IntegrationWizard` gained a `section?` field property + `Accordion` grouping; new `PROXY_FIELDS` block is auto-injected when `proxy_supported: true`.

Out of scope (called out in the plan): conditional field visibility based on `proxy_type`, hot-reloading the platform engine on config change, host:port rewriting for pgbouncer/ssh_tunnel modes on integration MCP children, and a brand-new generic "External PostgreSQL" integration.

## Test plan
- [x] `pytest tests/test_db_proxy.py` — 14 unit tests covering all three modes; SSH tunnel uses a stubbed `sshtunnel` so no real ssh server needed
- [x] `black` clean on the new code
- [ ] Spin up `pgbouncer` in docker compose, configure via Settings → System → Database, restart backend, confirm `/health` is green
- [ ] Local sshd container with forwarded Postgres, configure SSH tunnel via UI, confirm `/health` and that backend shutdown cleanly closes the tunnel (no orphaned sshtunnel processes)
- [ ] Splunk via local mitmproxy: configure `proxy_type=http` in the Integrations tab, run a Splunk search, confirm the request hits mitmproxy and that `proxy_password` is stored in the secrets store rather than `integration_configs.config`
- [ ] Manual UI smoke: open Settings → Integrations → Splunk, expand the new "Network / Proxy" accordion, fill in proxy fields, save, reopen — secret fields come back blank (redacted), non-secret fields persist
- [ ] `cd frontend && npm run lint && npm run test:run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)