### PR TITLE
VStrike killchain spec: reframe as problem ask, not fixed design

### DIFF
--- a/docs/integrations/vstrike-killchain-mcp-spec.md
+++ b/docs/integrations/vstrike-killchain-mcp-spec.md
@@ -1,44 +1,89 @@
-# VStrike MCP — `ui-killchain-replay` tool spec
+# VStrike kill-chain replay — integration ask
 
-This is the request to the CloudCurrent / VStrike engineering team for a new
-MCP tool that lets Vigil drive kill-chain replays through the VStrike UI.
+This document is the request to the CloudCurrent / VStrike engineering
+team. Vigil's side is shipped; we want to drive a kill-chain animation
+through the embedded VStrike iframe and need to know the shortest path
+on your side. **The framing here is "here's our problem and what we
+already have" — not a fixed design.** If your UI already does most of
+this, the tool we end up calling can be much smaller than the strawman
+below.
 
-The Vigil side of the wire is already shipped. Once VStrike's MCP server
-exposes `ui-killchain-replay`, Vigil's "Play" button (visible in the iframe
-toolbar inside every Vigil case dialog) starts working with no further code
-changes on Vigil's side. Until then, the button surfaces a friendly
-"VStrike server doesn't yet implement kill-chain replay" notice.
+## The problem
 
-## Why we need this
-
-When a Vigil analyst opens a case enriched by VStrike, every finding's
+When a Vigil analyst opens a case, every finding's
 `entity_context.vstrike` carries an `attack_path` (an ordered list of
-asset IDs from initial access to the target) plus `adjacent_assets` (the
-MITRE technique on each edge). Today, the user can see the topology in
-the embedded VStrike iframe, but they can't replay the kill-chain across
-those nodes without manually clicking through.
+asset IDs from initial access to the target) and `adjacent_assets`
+(MITRE technique on each edge). Vigil consolidates a case's findings
+into a single deduplicated step list and wants to ask the embedded
+VStrike iframe to **animate that list** — highlight each node in
+order, draw the edge transitions, surface the technique label per
+edge.
 
-Vigil walks the case's findings, dedupes by asset, and ships VStrike a
-clean step list. VStrike then animates that sequence — highlighting each
-node, drawing edges as transitions, surfacing the MITRE technique labels.
-One MCP tool, one WebSocket push to the active session, no iframe reload.
+A "Play" button is already in Vigil's iframe toolbar. Until VStrike
+exposes a way to drive replay, the button surfaces a friendly "VStrike
+server doesn't yet implement kill-chain replay" notice and is otherwise
+a no-op.
 
-This pattern is identical to the existing `ui-network-load` tool — same
-auth (JWT), same JSON-RPC transport, same SSE response framing, same
-session-state assumption (the iframe is already open and authenticated).
+## What Vigil already has
 
-## Tool definition
+The iframe embed and live tool calls (`ui-login-token`, `network-list`,
+`ui-network-load`) are working end-to-end. For replay specifically,
+Vigil produces a step list per case that looks like this:
+
+```json
+[
+  { "node_id": "asset-001", "timestamp": "2026-04-28T11:00:00Z", "label": "Initial Access" },
+  { "node_id": "asset-042", "timestamp": "2026-04-28T11:05:00Z", "technique": "T1021.002", "label": "Lateral movement → file-server" },
+  { "node_id": "asset-077", "timestamp": "2026-04-28T11:12:00Z", "technique": "T1003.001", "label": "Target: domain-controller" }
+]
+```
+
+The step list is sorted by timestamp, deduplicated by `node_id`,
+length 1..N, and the same JWT-authenticated session is already open in
+the iframe.
+
+## Questions for you (in priority order)
+
+1. **What replay capabilities does VStrike already have?**
+   - Does the iframe app today support a "play this sequence" mode
+     (timeline scrubber, animated path-walk, anything close)?
+   - If yes: what's the shortest way for Vigil to trigger it? A new
+     thin MCP tool that pushes our step list onto an existing
+     animation engine? A URL/postMessage parameter? An existing tool
+     we're not seeing in `tools/list`?
+   - If no: see the strawman below for what we'd ask you to build.
+
+2. **Edge animations between sequential nodes.** The kill-chain
+   visualization the analyst wants is the *edges* drawing as
+   transitions, not just the nodes blinking. Does the UI render edges
+   as motion between sequential highlights today?
+
+3. **`node_id` format.** Vigil emits the asset identifiers carried on
+   case findings. We assume those match what `node-list` returns per
+   network (`id` / `network_id` / `uuid`, in priority order). Please
+   confirm or tell us what shape you actually want.
+
+4. **Bidirectional "playback finished" signal.** Can the iframe emit a
+   message back over its existing WebSocket when an animation ends, so
+   Vigil's EventTimeline scrubber can sync? Nice-to-have. If absent,
+   Vigil falls back to a `sum(dwell_ms)` estimate.
+
+## Strawman tool — only if you're starting from zero
+
+If there's no existing replay path on your side, here's a candidate
+tool definition we can call. Names, fields, defaults are all
+negotiable — happy to adopt whatever fits your existing patterns.
 
 ```jsonc
 {
   "name": "ui-killchain-replay",
-  "description": "Animate a kill-chain through the active VStrike UI session. The iframe receives a WebSocket message and walks the supplied step sequence — highlighting each node, drawing edges as transitions, and surfacing MITRE technique labels.",
+  "description": "Animate a kill-chain through the active VStrike UI session.",
   "inputSchema": {
     "type": "object",
     "properties": {
       "networkId": {
         "type": "string",
-        "description": "The network identifier to load before stepping. The tool MUST internally do a `ui-network-load` if the active session is on a different network."
+        "description": "Network identifier. The tool should internally do a `ui-network-load` if the active session is on a different network."
       },
       "steps": {
         "type": "array",
@@ -46,66 +91,32 @@ session-state assumption (the iframe is already open and authenticated).
         "items": {
           "type": "object",
           "properties": {
-            "node_id":   { "type": "string",  "description": "Asset ID to highlight at this step. Must exist in networkId." },
-            "timestamp": { "type": "string",  "description": "ISO-8601 timestamp of the originating event. Surfaced as a label." },
+            "node_id":   { "type": "string" },
+            "timestamp": { "type": "string",  "description": "ISO-8601." },
             "technique": { "type": "string",  "description": "Optional MITRE ATT&CK ID for the EDGE leading into this node (e.g. T1021.002)." },
-            "label":     { "type": "string",  "description": "Optional human-readable annotation to display alongside the node during dwell." },
-            "dwell_ms":  { "type": "integer", "description": "Optional per-step dwell override; default 2000 ms." }
+            "label":     { "type": "string",  "description": "Optional human-readable annotation." },
+            "dwell_ms":  { "type": "integer", "description": "Per-step dwell override; default 2000." }
           },
           "required": ["node_id", "timestamp"]
         }
       },
-      "loop":      { "type": "boolean", "description": "If true, restart from step 0 after the last step (default false)." },
-      "auto_play": { "type": "boolean", "description": "If false, the iframe shows the steps loaded but waits for the user's Play button (default true)." }
+      "loop":      { "type": "boolean", "description": "Restart from step 0 after the last step (default false)." },
+      "auto_play": { "type": "boolean", "description": "If false, load the steps but wait for the user (default true)." }
     },
     "required": ["networkId", "steps"]
-  },
-  "execution": { "taskSupport": "forbidden" }
+  }
 }
 ```
 
-### Patterns this borrows from `ui-network-load`
+This borrows the contract of your existing `ui-network-load`:
+WebSocket push to the active session, stateless server-side, JSON-RPC
+`result.content[].text` confirmation with `isError` for failures.
 
-- **WebSocket push to the active session.** No iframe reload. Single tool
-  call per replay. The MCP tool itself is stateless — VStrike's UI side
-  consumes the message and animates.
-- **Stateless server-side.** No per-replay session record. The MCP tool
-  just routes the steps to whichever VStrike UI session matches the
-  caller's JWT.
-- **Returns a `content` text confirmation.** Same shape as the existing
-  `ui-network-load` response — JSON-RPC `result.content[].text`, with
-  `isError` as the failure signal so Vigil's existing extractor works
-  unchanged.
+## What a call would look like under the strawman
 
-## Open questions
-
-These don't block shipping the tool, but they affect what the user sees:
-
-1. **Edge animations.** Does the VStrike UI already render edge animations
-   between sequential nodes? If not, the kill-chain replay would step one
-   node at a time without showing the link visualization the analyst
-   wants. Vigil's UX assumption is that VStrike draws the edge into each
-   highlighted node. If that doesn't exist today, can it ship alongside
-   the MCP tool?
-
-2. **Playback-finished event.** Can the iframe send a "playback finished"
-   message back over its existing WebSocket so Vigil can sync its
-   EventTimeline scrubber? Bidirectional channel — nice-to-have, not a
-   blocker. If you can emit this, Vigil will hook it up; if not, we'll
-   add a dwell-sum estimate on Vigil's side.
-
-3. **`node_id` format.** Vigil's findings carry asset identifiers that
-   we believe match VStrike's `node-list` output (the `id` / `network_id`
-   / `uuid` field, in that priority order). Please confirm. If `node_id`
-   needs to be the same shape `node-list` returns per network, Vigil
-   already produces that shape.
-
-## Curl example — what Vigil sends
-
-This is what a real call looks like once the tool ships. Vigil already
-emits exactly this payload via `POST /api/integrations/vstrike/ui/killchain-replay`,
-which translates to a `tools/call` JSON-RPC request against VStrike's
-`/mcp` endpoint:
+For shape only — Vigil already emits this exact payload via
+`POST /api/integrations/vstrike/ui/killchain-replay`, which proxies to
+your `/mcp` endpoint:
 
 ```bash
 curl -X POST 'https://vstrike.example/mcp' \
@@ -132,18 +143,14 @@ curl -X POST 'https://vstrike.example/mcp' \
   }'
 ```
 
-Expected success response (SSE-framed JSON-RPC, matching `ui-network-load`):
-
-```
-event: message
-data: {"jsonrpc":"2.0","id":1730000000000,"result":{"content":[{"type":"text","text":"Replay queued: 3 steps, network net-123"}],"isError":false}}
-```
+If your team renames the tool, restructures the schema, or replaces
+the whole approach with something simpler that already exists — tell
+us, and Vigil's adapter is a small edit.
 
 ## Contact
 
-Direct questions about the Vigil-side implementation to:
 - Vigil repo: <https://github.com/Vigil-SOC/vigil>
-- Tool client lives in [`services/vstrike_service.py`](../../services/vstrike_service.py) (see
-  `killchain_replay_in_ui`)
-- API surface: [`backend/api/vstrike.py`](../../backend/api/vstrike.py) (`POST /ui/killchain-replay`)
+- Vigil's outbound client (rename target if the tool name changes):
+  [`services/vstrike_service.py`](../../services/vstrike_service.py) → `killchain_replay_in_ui`
+- API surface: [`backend/api/vstrike.py`](../../backend/api/vstrike.py) → `POST /ui/killchain-replay`
 - Frontend Play button: [`frontend/src/components/graph/VStrikeIframeHost.tsx`](../../frontend/src/components/graph/VStrikeIframeHost.tsx)


### PR DESCRIPTION
## Summary

The original spec at [`docs/integrations/vstrike-killchain-mcp-spec.md`](docs/integrations/vstrike-killchain-mcp-spec.md) was written greenfield — naming a tool (`ui-killchain-replay`), prescribing a JSON schema, then asking "do you already have edge animations?" as an afterthought. Wrong framing: the VStrike iframe app may already have replay capability we'd just need a thin trigger for, and engineers respond better to "here's our problem" than "here's our design for your system".

This reframe keeps the same factual content but flips the structure:

- Leads with the problem statement and what Vigil already produces (the deduplicated step list, with an example).
- Promotes "what replay capabilities do you already have?" to **Q1** so the engineer can short-circuit the rest of the doc if they already have a hook.
- Demotes the JSON schema to a "strawman — only if you're starting from zero" section, explicitly labels names/fields/defaults as negotiable.
- Closes with "if your team renames the tool, restructures the schema, or replaces the whole approach with something simpler that already exists — tell us, and Vigil's adapter is a small edit."

Pure documentation change. No code, no tests, no schema, no behavior. The Vigil-side wiring (`POST /ui/killchain-replay`, `killchain_replay_in_ui`, the Play button, the 501 graceful-degradation path) is unchanged and will adapt to whatever the engineer chooses to ship.

## Test plan

- [x] Doc-only change; no tests to run.
- [ ] Reads well end-to-end; engineer can answer Q1 in two sentences and skip the strawman if their UI already has a replay path.