### PR TITLE
ATT&CK tab: list techniques by occurrence with time-range filter

### DIFF
--- a/backend/api/analytics.py
+++ b/backend/api/analytics.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 from database.models import Finding, Case, CaseClosureInfo, LLMInteractionLog
 from database.connection import get_db_session
 from backend.services.ai_insights_service import AIInsightsService
+from services.mitre_lookup import resolve_technique
 
 logger = logging.getLogger(__name__)
 
@@ -617,75 +618,52 @@ async def get_mitre_technique_distribution(
         Finding.created_at.between(start_time, end_time)
     ).all()
     
-    technique_counts = {}
-    technique_tactics = {}
-    
+    technique_counts: dict[str, int] = {}
+    technique_meta: dict[str, tuple[str, str]] = {}
+
+    def _record(tech):
+        tid, name, tactic = resolve_technique(tech)
+        if not tid:
+            return
+        technique_counts[tid] = technique_counts.get(tid, 0) + 1
+        if tid not in technique_meta:
+            technique_meta[tid] = (name, tactic)
+
     for finding in findings:
         if not finding.mitre_predictions:
             continue
-        
+
         predictions = finding.mitre_predictions
-        
-        # Handle different mitre_predictions structures
+
         if isinstance(predictions, dict):
-            if all(isinstance(v, (int, float)) for v in predictions.values()) and predictions:
+            if predictions and all(
+                isinstance(v, (int, float)) for v in predictions.values()
+            ):
                 # Standard format: {tactic_or_technique_id: confidence}
-                for tech_id, confidence in predictions.items():
-                    if tech_id not in technique_counts:
-                        technique_counts[tech_id] = 0
-                        technique_tactics[tech_id] = {
-                            'name': tech_id,
-                            'tactic': tech_id
-                        }
-                    technique_counts[tech_id] += 1
+                for tech_id in predictions.keys():
+                    _record(tech_id)
             else:
-                techniques = []
                 if 'techniques' in predictions:
-                    techniques = predictions['techniques']
+                    nested = predictions['techniques']
                 elif 'predicted_techniques' in predictions:
-                    techniques = predictions['predicted_techniques']
+                    nested = predictions['predicted_techniques']
                 else:
-                    techniques = [predictions]
-                
-                for tech in techniques:
+                    nested = [predictions]
+
+                for tech in nested:
                     if isinstance(tech, dict):
-                        tech_id = tech.get('technique_id') or tech.get('id')
-                        tech_name = tech.get('technique_name') or tech.get('name') or tech_id
-                        tactics_val = tech.get('tactics')
-                        tactic = tech.get('tactic') or (tactics_val[0] if isinstance(tactics_val, list) and tactics_val else 'Unknown')
-                        
-                        if tech_id:
-                            if tech_id not in technique_counts:
-                                technique_counts[tech_id] = 0
-                                technique_tactics[tech_id] = {
-                                    'name': tech_name,
-                                    'tactic': tactic
-                                }
-                            technique_counts[tech_id] += 1
+                        _record(tech)
         elif isinstance(predictions, list):
             for tech in predictions:
                 if isinstance(tech, dict):
-                    tech_id = tech.get('technique_id') or tech.get('id')
-                    tech_name = tech.get('technique_name') or tech.get('name') or tech_id
-                    tactics_val = tech.get('tactics')
-                    tactic = tech.get('tactic') or (tactics_val[0] if isinstance(tactics_val, list) and tactics_val else 'Unknown')
-                    
-                    if tech_id:
-                        if tech_id not in technique_counts:
-                            technique_counts[tech_id] = 0
-                            technique_tactics[tech_id] = {
-                                'name': tech_name,
-                                'tactic': tactic
-                            }
-                        technique_counts[tech_id] += 1
-    
-    # Convert to list and sort
+                    _record(tech)
+
     techniques_list = [
         {
             'techniqueId': tech_id,
-            'techniqueName': technique_tactics[tech_id]['name'],
-            'tactic': technique_tactics[tech_id]['tactic'],
-            'count': count
+            'techniqueName': technique_meta[tech_id][0],
+            'tactic': technique_meta[tech_id][1],
+            'count': count,
         }
         for tech_id, count in technique_counts.items()
     ]

--- a/backend/api/attack.py
+++ b/backend/api/attack.py
@@ -1,40 +1,64 @@
 """ATT&CK framework API endpoints."""
 
+from datetime import datetime
 from typing import Optional
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Query
 import logging
 
 from services.database_data_service import DatabaseDataService
+from services.mitre_lookup import iter_techniques, resolve_technique
+from backend.api.analytics import get_time_range
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 data_service = DatabaseDataService()
 
 
+def _parse_finding_timestamp(finding: dict) -> Optional[datetime]:
+    """Parse a finding's timestamp (ISO string or datetime) into a naive UTC datetime.
+
+    Findings come from `Finding.to_dict()` (ISO string) or the JSON fallback
+    (raw dict values) — handle both.
+    """
+    raw = finding.get("timestamp") or finding.get("created_at")
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        return raw.replace(tzinfo=None) if raw.tzinfo else raw
+    if isinstance(raw, str):
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            return parsed.replace(tzinfo=None) if parsed.tzinfo else parsed
+        except ValueError:
+            return None
+    return None
+
+
 @router.get("/layer")
 async def get_attack_layer():
     """
     Get ATT&CK Navigator layer data.
-    
+
     Builds an ATT&CK Navigator layer from findings technique predictions.
-    
+
     Returns:
         ATT&CK layer JSON
     """
     try:
         findings = data_service.get_findings()
-        
+
         # Build technique scores from findings
         technique_scores = {}
         for finding in findings:
-            predicted_techniques = finding.get('predicted_techniques', [])
-            for tech in predicted_techniques:
-                tid = tech.get('technique_id')
-                confidence = tech.get('confidence', 0)
+            for tech in iter_techniques(finding):
+                tid = tech.get("technique_id") or tech.get("id")
+                confidence = tech.get("confidence", 0) or 0
                 if tid:
                     # Track max confidence per technique
-                    technique_scores[tid] = max(technique_scores.get(tid, 0), confidence)
-        
+                    technique_scores[tid] = max(
+                        technique_scores.get(tid, 0), confidence
+                    )
+
         techniques = [
             {
                 "techniqueID": tid,
@@ -45,7 +69,7 @@ async def get_attack_layer():
             }
             for tid, score in technique_scores.items()
         ]
-        
+
         layer = {
             "name": "DeepTempo Findings",
             "version": "4.5",
@@ -53,7 +77,7 @@ async def get_attack_layer():
             "description": "ATT&CK techniques detected in findings",
             "techniques": techniques,
         }
-        
+
         return layer
     except Exception as e:
         logger.error(f"Error building ATT&CK layer: {e}")
@@ -62,70 +86,88 @@ async def get_attack_layer():
             "version": "4.5",
             "domain": "enterprise-attack",
             "description": "ATT&CK techniques detected in findings",
-            "techniques": []
+            "techniques": [],
         }
 
 
 @router.get("/techniques/rollup")
-async def get_technique_rollup(min_confidence: float = 0.0):
+async def get_technique_rollup(
+    min_confidence: float = 0.0,
+    time_range: str = Query("all", regex="^(24h|7d|30d|all)$"),
+):
     """
     Get rollup of ATT&CK techniques across all findings.
-    
+
     Args:
         min_confidence: Minimum confidence threshold
-    
+        time_range: Optional time window — '24h', '7d', '30d', or 'all' (default).
+
     Returns:
-        Technique statistics
+        Technique statistics sorted by occurrence count, including
+        human-readable technique name and tactic per row.
     """
     findings = data_service.get_findings()
-    
-    technique_counts = {}
-    technique_severities = {}
-    
+
+    if time_range != "all":
+        start_time, end_time = get_time_range(time_range)
+        scoped: list[dict] = []
+        for finding in findings:
+            ts = _parse_finding_timestamp(finding)
+            if ts is None or start_time <= ts <= end_time:
+                scoped.append(finding)
+        findings = scoped
+
+    technique_counts: dict[str, int] = {}
+    technique_severities: dict[str, dict[str, int]] = {}
+    technique_meta: dict[str, tuple[str, str]] = {}
+
     for finding in findings:
-        predicted_techniques = finding.get('predicted_techniques', [])
-        severity = finding.get('severity', 'unknown')
-        
-        for tech in predicted_techniques:
-            technique_id = tech.get('technique_id')
-            confidence = tech.get('confidence', 0)
-            
+        severity = finding.get("severity", "unknown")
+
+        for tech in iter_techniques(finding):
+            confidence = tech.get("confidence", 0) or 0
+
             if confidence < min_confidence:
                 continue
-            
-            if not technique_id:
+
+            tid, name, tactic = resolve_technique(tech)
+            if not tid:
                 continue
-            
-            # Count occurrences
-            technique_counts[technique_id] = technique_counts.get(technique_id, 0) + 1
-            
-            # Track severities
-            if technique_id not in technique_severities:
-                technique_severities[technique_id] = {
-                    'critical': 0,
-                    'high': 0,
-                    'medium': 0,
-                    'low': 0
+
+            technique_counts[tid] = technique_counts.get(tid, 0) + 1
+            if tid not in technique_meta:
+                technique_meta[tid] = (name, tactic)
+
+            if tid not in technique_severities:
+                technique_severities[tid] = {
+                    "critical": 0,
+                    "high": 0,
+                    "medium": 0,
+                    "low": 0,
                 }
-            
-            technique_severities[technique_id][severity] = \
-                technique_severities[technique_id].get(severity, 0) + 1
-    
-    # Build result
+
+            technique_severities[tid][severity] = (
+                technique_severities[tid].get(severity, 0) + 1
+            )
+
     techniques = []
-    for technique_id, count in technique_counts.items():
-        techniques.append({
-            "technique_id": technique_id,
-            "count": count,
-            "severities": technique_severities[technique_id]
-        })
-    
-    # Sort by count
-    techniques.sort(key=lambda x: x['count'], reverse=True)
-    
+    for tid, count in technique_counts.items():
+        name, tactic = technique_meta[tid]
+        techniques.append(
+            {
+                "technique_id": tid,
+                "technique_name": name,
+                "tactic": tactic,
+                "count": count,
+                "severities": technique_severities[tid],
+            }
+        )
+
+    techniques.sort(key=lambda x: x["count"], reverse=True)
+
     return {
         "total_techniques": len(techniques),
-        "techniques": techniques
+        "techniques": techniques,
     }
 
 
@@ -133,29 +175,27 @@ async def get_technique_rollup(min_confidence: float = 0.0):
 async def get_findings_by_technique(technique_id: str):
     """
     Get all findings associated with a specific technique.
-    
+
     Args:
         technique_id: MITRE ATT&CK technique ID
-    
+
     Returns:
         List of findings
     """
     findings = data_service.get_findings()
-    
+
     matching_findings = []
-    
+
     for finding in findings:
-        predicted_techniques = finding.get('predicted_techniques', [])
-        
-        for tech in predicted_techniques:
-            if tech.get('technique_id') == technique_id:
+        for tech in iter_techniques(finding):
+            if (tech.get("technique_id") or tech.get("id")) == technique_id:
                 matching_findings.append(finding)
                 break
-    
+
     return {
         "technique_id": technique_id,
         "findings": matching_findings,
-        "total": len(matching_findings)
+        "total": len(matching_findings),
     }
 
 
@@ -163,45 +203,26 @@ async def get_findings_by_technique(technique_id: str):
 async def get_tactics_summary():
     """
     Get summary of tactics across all findings.
-    
+
     Returns:
         Tactics summary
     """
     findings = data_service.get_findings()
-    
-    # Map techniques to tactics (simplified - in production, use ATT&CK data)
-    technique_to_tactic = {
-        'T1071': 'Command and Control',
-        'T1573': 'Command and Control',
-        'T1059': 'Execution',
-        'T1055': 'Defense Evasion',
-        'T1036': 'Defense Evasion',
-        # Add more mappings as needed
-    }
-    
-    tactic_counts = {}
-    
+
+    tactic_counts: dict[str, int] = {}
+
     for finding in findings:
-        predicted_techniques = finding.get('predicted_techniques', [])
-        
-        for tech in predicted_techniques:
-            technique_id = tech.get('technique_id', '')
-            
-            # Extract base technique (without sub-technique)
-            base_technique = technique_id.split('.')[0]
-            
-            # Get tactic
-            tactic = technique_to_tactic.get(base_technique, 'Unknown')
+        for tech in iter_techniques(finding):
+            _tid, _name, tactic = resolve_technique(tech)
             tactic_counts[tactic] = tactic_counts.get(tactic, 0) + 1
-    
+
     return {
         "tactics": [
             {"tactic": tactic, "count": count}
             for tactic, count in sorted(
                 tactic_counts.items(),
                 key=lambda x: x[1],
-                reverse=True
+                reverse=True,
             )
         ]
     }
-

--- a/frontend/src/components/attack/AttackChart.tsx
+++ b/frontend/src/components/attack/AttackChart.tsx
@@ -19,6 +19,9 @@ import {
   Collapse,
   IconButton,
   Alert,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material'
 import { 
   BarChart, 
@@ -43,6 +46,8 @@ import { severityColors as themeSeverityColors } from '../../theme'
 
 interface TechniqueData {
   technique_id: string
+  technique_name: string
+  tactic: string
   count: number
   severities: {
     critical: number
@@ -51,6 +56,8 @@ interface TechniqueData {
     low: number
   }
 }
+
+type TimeRange = '24h' | '7d' | '30d' | 'all'
 
 interface TacticData {
   tactic: string
@@ -62,6 +69,7 @@ export default function AttackChart() {
   const [techniquesData, setTechniquesData] = useState<TechniqueData[]>([])
   const [loading, setLoading] = useState(true)
   const [minConfidence, setMinConfidence] = useState(0.0)
+  const [timeRange, setTimeRange] = useState<TimeRange>('all')
   const [expandedTechnique, setExpandedTechnique] = useState<string | null>(null)
   const [techniqueFindings, setTechniqueFindings] = useState<any[]>([])
   const [loadingFindings, setLoadingFindings] = useState(false)
@@ -69,7 +77,8 @@ export default function AttackChart() {
 
   useEffect(() => {
     loadData()
-  }, [minConfidence])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [minConfidence, timeRange])
 
   const loadData = async () => {
     setLoading(true)
@@ -77,7 +86,7 @@ export default function AttackChart() {
     try {
       const [tacticsResponse, techniquesResponse] = await Promise.all([
         attackApi.getTacticsSummary(),
-        attackApi.getTechniqueRollup(minConfidence),
+        attackApi.getTechniqueRollup(minConfidence, timeRange),
       ])
       
       setTacticsData(tacticsResponse.data.tactics || [])
@@ -242,32 +251,53 @@ export default function AttackChart() {
         </Grid>
       </Grid>
 
-      {/* Confidence Filter */}
+      {/* Filters */}
       <Paper sx={{ p: 2, mb: 3 }}>
-        <Box display="flex" alignItems="center" gap={2}>
-          <Typography variant="body2" sx={{ minWidth: 150 }}>
-            Min Confidence: {minConfidence.toFixed(2)}
-          </Typography>
-          <Slider
-            value={minConfidence}
-            onChange={(_, value) => setMinConfidence(value as number)}
-            min={0}
-            max={1}
-            step={0.1}
-            marks
-            aria-label="Minimum confidence threshold"
-            sx={{ flex: 1 }}
-          />
-          <Button 
-            startIcon={loading ? <CircularProgress size={16} /> : <RefreshIcon />} 
-            onClick={loadData}
-            size="small"
-            variant="outlined"
-            disabled={loading}
-          >
-            Refresh
-          </Button>
-        </Box>
+        <Stack direction="column" spacing={2}>
+          <Box display="flex" alignItems="center" gap={2} flexWrap="wrap">
+            <Typography variant="body2" sx={{ minWidth: 100 }}>
+              Time Range:
+            </Typography>
+            <ToggleButtonGroup
+              value={timeRange}
+              exclusive
+              size="small"
+              onChange={(_, value) => {
+                if (value !== null) setTimeRange(value as TimeRange)
+              }}
+              aria-label="Time range"
+            >
+              <ToggleButton value="24h">24 Hours</ToggleButton>
+              <ToggleButton value="7d">7 Days</ToggleButton>
+              <ToggleButton value="30d">30 Days</ToggleButton>
+              <ToggleButton value="all">All Time</ToggleButton>
+            </ToggleButtonGroup>
+          </Box>
+          <Box display="flex" alignItems="center" gap={2}>
+            <Typography variant="body2" sx={{ minWidth: 150 }}>
+              Min Confidence: {minConfidence.toFixed(2)}
+            </Typography>
+            <Slider
+              value={minConfidence}
+              onChange={(_, value) => setMinConfidence(value as number)}
+              min={0}
+              max={1}
+              step={0.1}
+              marks
+              aria-label="Minimum confidence threshold"
+              sx={{ flex: 1 }}
+            />
+            <Button
+              startIcon={loading ? <CircularProgress size={16} /> : <RefreshIcon />}
+              onClick={loadData}
+              size="small"
+              variant="outlined"
+              disabled={loading}
+            >
+              Refresh
+            </Button>
+          </Box>
+        </Stack>
       </Paper>
 
       {/* Charts Row */}
@@ -324,22 +354,24 @@ export default function AttackChart() {
         )}
       </Grid>
 
-      {/* Top Techniques Table */}
+      {/* MITRE Techniques Table */}
       {techniquesData.length > 0 && (
         <Paper sx={{ width: '100%' }}>
           <Box sx={{ p: 2 }}>
             <Typography variant="h6" gutterBottom>
-              Top MITRE ATT&CK Techniques
+              MITRE ATT&CK Techniques by Occurrence
             </Typography>
             <Typography variant="body2" color="textSecondary" gutterBottom>
-              Click on a technique to see associated findings
+              {techniquesData.length} distinct technique{techniquesData.length === 1 ? '' : 's'} observed. Click a row to see associated findings.
             </Typography>
           </Box>
-          <TableContainer>
-            <Table>
+          <TableContainer sx={{ maxHeight: 600 }}>
+            <Table stickyHeader>
               <TableHead>
                 <TableRow>
                   <TableCell>Technique ID</TableCell>
+                  <TableCell>Technique Name</TableCell>
+                  <TableCell>Tactic</TableCell>
                   <TableCell align="right">Total Detections</TableCell>
                   <TableCell align="center">Critical</TableCell>
                   <TableCell align="center">High</TableCell>
@@ -349,7 +381,7 @@ export default function AttackChart() {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {techniquesData.slice(0, 20).map((technique) => (
+                {techniquesData.map((technique) => (
                   <React.Fragment key={technique.technique_id}>
                     <TableRow
                       hover
@@ -360,6 +392,18 @@ export default function AttackChart() {
                         <Typography variant="body2" fontWeight="medium">
                           {technique.technique_id}
                         </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2" noWrap sx={{ maxWidth: 240 }}>
+                          {technique.technique_name}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Chip
+                          label={technique.tactic}
+                          size="small"
+                          variant="outlined"
+                        />
                       </TableCell>
                       <TableCell align="right">
                         <Chip label={technique.count} size="small" />
@@ -415,7 +459,7 @@ export default function AttackChart() {
                     </TableRow>
                     {/* Expanded Findings Row */}
                     <TableRow>
-                      <TableCell colSpan={7} sx={{ p: 0 }}>
+                      <TableCell colSpan={9} sx={{ p: 0 }}>
                         <Collapse 
                           in={expandedTechnique === technique.technique_id} 
                           timeout="auto" 
@@ -485,13 +529,6 @@ export default function AttackChart() {
               </TableBody>
             </Table>
           </TableContainer>
-          {techniquesData.length > 20 && (
-            <Box sx={{ p: 2, textAlign: 'center' }}>
-              <Typography variant="caption" color="textSecondary">
-                Showing top 20 of {techniquesData.length} techniques
-              </Typography>
-            </Box>
-          )}
         </Paper>
       )}
     </Box>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1010,8 +1010,8 @@ export const timesketchApi = {
 export const attackApi = {
   getLayer: () => api.get('/attack/layer'),
   
-  getTechniqueRollup: (min_confidence: number = 0.0) =>
-    api.get('/attack/techniques/rollup', { params: { min_confidence } }),
+  getTechniqueRollup: (min_confidence: number = 0.0, time_range: string = 'all') =>
+    api.get('/attack/techniques/rollup', { params: { min_confidence, time_range } }),
   
   getFindingsByTechnique: (technique_id: string) =>
     api.get(`/attack/techniques/${technique_id}/findings`),

--- a/services/attack_data_loader.py
+++ b/services/attack_data_loader.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Dict, List, Any
 from services.database_data_service import DatabaseDataService
 from services.ingestion_service import MITRE_TACTIC_MAP
+from services.mitre_lookup import TECHNIQUE_NAME_FALLBACKS
 
 VALID_TACTICS = set(MITRE_TACTIC_MAP.values())
 
@@ -137,22 +138,10 @@ def findings_to_attack_data(findings: List[Dict]) -> Dict:
     
     # Build MITRE techniques list
     mitre_techniques = []
-    technique_names = {
-        "T1071.001": ("Web Protocols", "Command and Control"),
-        "T1071.004": ("DNS", "Command and Control"),
-        "T1573.001": ("Encrypted Channel", "Command and Control"),
-        "T1021.001": ("RDP", "Lateral Movement"),
-        "T1021.002": ("SMB/Windows Admin Shares", "Lateral Movement"),
-        "T1048.003": ("Exfiltration Over DNS", "Exfiltration"),
-        "T1190": ("Exploit Public-Facing Application", "Initial Access"),
-        "T1078": ("Valid Accounts", "Initial Access"),
-        "T1059.001": ("PowerShell", "Execution"),
-        "T1018": ("Remote System Discovery", "Discovery"),
-    }
-    
+
     for technique, stats in technique_counts.items():
-        if technique in technique_names:
-            name, tactic = technique_names[technique]
+        if technique in TECHNIQUE_NAME_FALLBACKS:
+            name, tactic = TECHNIQUE_NAME_FALLBACKS[technique]
         elif technique in VALID_TACTICS:
             name, tactic = technique, technique
         else:

--- a/services/mitre_lookup.py
+++ b/services/mitre_lookup.py
@@ -1,0 +1,121 @@
+"""Shared MITRE ATT&CK technique → name/tactic resolution.
+
+Single source of truth used by:
+- backend/api/attack.py — /attack/techniques/rollup
+- backend/api/analytics.py — get_mitre_technique_distribution
+- services/attack_data_loader.py — visualization data
+
+Findings in this codebase carry MITRE data in two shapes:
+- Demo path: `predicted_techniques: list[{technique_id, confidence, technique_name}]`
+- Production path: `mitre_predictions: dict | list` (multiple formats — see
+  iter_techniques below for the dispatching).
+"""
+
+from typing import Iterable, Optional
+
+# {technique_id: (name, tactic)} — extend as ATT&CK coverage grows.
+TECHNIQUE_NAME_FALLBACKS: dict[str, tuple[str, str]] = {
+    "T1071.001": ("Web Protocols", "Command and Control"),
+    "T1071.004": ("DNS", "Command and Control"),
+    "T1573.001": ("Encrypted Channel", "Command and Control"),
+    "T1021.001": ("RDP", "Lateral Movement"),
+    "T1021.002": ("SMB/Windows Admin Shares", "Lateral Movement"),
+    "T1048.003": ("Exfiltration Over DNS", "Exfiltration"),
+    "T1190": ("Exploit Public-Facing Application", "Initial Access"),
+    "T1078": ("Valid Accounts", "Initial Access"),
+    "T1059.001": ("PowerShell", "Execution"),
+    "T1018": ("Remote System Discovery", "Discovery"),
+    # Base techniques referenced by the legacy tactics-summary mapping.
+    "T1071": ("Application Layer Protocol", "Command and Control"),
+    "T1573": ("Encrypted Channel", "Command and Control"),
+    "T1059": ("Command and Scripting Interpreter", "Execution"),
+    "T1055": ("Process Injection", "Defense Evasion"),
+    "T1036": ("Masquerading", "Defense Evasion"),
+}
+
+
+def resolve_technique(
+    tech: dict | str,
+    technique_id: Optional[str] = None,
+) -> tuple[str, str, str]:
+    """Resolve a technique reference to (technique_id, technique_name, tactic).
+
+    Resolution order:
+      1. Explicit `technique_name`/`name` and `tactic`/`tactics[0]` on the dict.
+      2. Full ID lookup in TECHNIQUE_NAME_FALLBACKS.
+      3. Base ID (strip `.NNN` sub-technique) lookup.
+      4. Fallback (technique_id, technique_id, "Unknown").
+    """
+    if isinstance(tech, dict):
+        tid = tech.get("technique_id") or tech.get("id") or technique_id or ""
+        explicit_name = tech.get("technique_name") or tech.get("name")
+        tactics_val = tech.get("tactics")
+        explicit_tactic = tech.get("tactic") or (
+            tactics_val[0] if isinstance(tactics_val, list) and tactics_val else None
+        )
+    else:
+        tid = tech or technique_id or ""
+        explicit_name = None
+        explicit_tactic = None
+
+    if not tid:
+        return ("", "", "Unknown")
+
+    fallback_name, fallback_tactic = TECHNIQUE_NAME_FALLBACKS.get(tid, (None, None))
+    if fallback_name is None:
+        base_id = tid.split(".")[0]
+        fallback_name, fallback_tactic = TECHNIQUE_NAME_FALLBACKS.get(
+            base_id, (None, None)
+        )
+
+    name = explicit_name or fallback_name or tid
+    tactic = explicit_tactic or fallback_tactic or "Unknown"
+    return (tid, name, tactic)
+
+
+def iter_techniques(finding: dict) -> Iterable[dict]:
+    """Yield per-technique dicts from a finding regardless of storage shape.
+
+    Each yielded dict has at least `technique_id` and may have `confidence`,
+    `technique_name`, `tactic`. Callers should pipe results through
+    `resolve_technique` to fill in name/tactic.
+
+    Handles:
+      - Demo shape: `predicted_techniques: list[{technique_id, confidence, ...}]`
+      - Production `mitre_predictions: dict[tech_id, confidence]`
+      - Production `mitre_predictions: {"techniques": [...]}` /
+        `{"predicted_techniques": [...]}`
+      - Production `mitre_predictions: list[dict]`
+    """
+    pt = finding.get("predicted_techniques")
+    if isinstance(pt, list) and pt:
+        for tech in pt:
+            if isinstance(tech, dict) and tech.get("technique_id"):
+                yield tech
+        return
+
+    predictions = finding.get("mitre_predictions")
+    if not predictions:
+        return
+
+    if isinstance(predictions, dict):
+        if predictions and all(
+            isinstance(v, (int, float)) for v in predictions.values()
+        ):
+            for tech_id, confidence in predictions.items():
+                yield {"technique_id": tech_id, "confidence": confidence}
+            return
+        nested = (
+            predictions.get("techniques")
+            or predictions.get("predicted_techniques")
+            or [predictions]
+        )
+        for tech in nested:
+            if isinstance(tech, dict) and (tech.get("technique_id") or tech.get("id")):
+                yield tech
+        return
+
+    if isinstance(predictions, list):
+        for tech in predictions:
+            if isinstance(tech, dict) and (tech.get("technique_id") or tech.get("id")):
+                yield tech


### PR DESCRIPTION
## Summary
- Surface every observed MITRE technique on the Dashboard's ATT&CK tab, ranked by count, scoped by 24h / 7d / 30d / all.
- Each row now shows the technique's human-readable **name** and **tactic** alongside the ID and severity breakdown. Removed the previous top-20 cap; the table is now a sticky-header scrollable list.
- New `services/mitre_lookup.py` becomes the single source of truth for technique-id → name/tactic resolution and for the `predicted_techniques` / `mitre_predictions` shape dispatching that was duplicated across `attack.py`, `analytics.py`, and `attack_data_loader.py`. Both adopters refactored to use it.
- As a side benefit, the rollup endpoint now also counts production findings (`mitre_predictions` field) instead of only the demo-only `predicted_techniques` shape.

## Out of scope (intentional)
- `/attack/tactics/summary` (which feeds the bar chart on the same tab) is **not** time-filtered in this PR. The chart will keep showing all-time tactic counts while the table reflects the selected window. Happy to extend in a follow-up if reviewers prefer.
- No new automated tests. There were no existing tests for `/attack/techniques/rollup` to extend, and adding test scaffolding was out of scope for this bundled change. The pure-function `services.mitre_lookup.resolve_technique` would be the natural starting point if we add coverage.

## API change
`GET /attack/techniques/rollup` accepts a new optional `time_range` query param: `24h | 7d | 30d | all` (default `all` — preserves current behavior for any caller that omits it). Each returned row gains `technique_name` and `tactic` fields; existing fields (`technique_id`, `count`, `severities`, top-level `total_techniques`) are unchanged.

## Test plan
- [ ] `curl 'http://localhost:6987/attack/techniques/rollup'` — default response shape unchanged for the `all` window.
- [ ] `curl 'http://localhost:6987/attack/techniques/rollup?time_range=24h'` and `?time_range=7d` — counts shrink monotonically as window narrows.
- [ ] `curl 'http://localhost:6987/attack/techniques/rollup?time_range=invalid'` — 422.
- [ ] Dashboard → ATT&CK tab loads with the new time-range toggle (defaults to All Time, matching pre-change UI).
- [ ] Switching to 24h / 7d / 30d re-fetches and updates the table.
- [ ] Confidence slider still composes with the new toggle.
- [ ] Clicking a technique row still expands and loads associated findings.
- [ ] Table renders > 20 rows without truncation when the dataset has them; sticky header works while scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)