### PR TITLE
Fix attack.py circular import on boot

### DIFF
--- a/backend/api/analytics.py
+++ b/backend/api/analytics.py
@@ -20,31 +20,12 @@ from sqlalchemy.orm import Session
 from database.models import Finding, Case, CaseClosureInfo, LLMInteractionLog
 from database.connection import get_db_session
 from backend.services.ai_insights_service import AIInsightsService
-from services.mitre_lookup import resolve_technique
+from services.mitre_lookup import get_time_range, resolve_technique  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 ai_insights_service = AIInsightsService()
-
-
-def get_time_range(time_range: str) -> tuple[datetime, datetime]:
-    """Get start and end datetime for the given time range."""
-    end_time = datetime.utcnow()
-    
-    if time_range == '24h':
-        start_time = end_time - timedelta(hours=24)
-    elif time_range == '7d':
-        start_time = end_time - timedelta(days=7)
-    elif time_range == '30d':
-        start_time = end_time - timedelta(days=30)
-    elif time_range == 'all':
-        # For "all time", use a very early date (e.g., year 2000)
-        start_time = datetime(2000, 1, 1)
-    else:
-        start_time = end_time - timedelta(days=7)  # Default to 7 days
-    
-    return start_time, end_time
 
 
 @router.get("/analytics")

--- a/backend/api/attack.py
+++ b/backend/api/attack.py
@@ -6,8 +6,7 @@ from fastapi import APIRouter, Query
 import logging
 
 from services.database_data_service import DatabaseDataService
-from services.mitre_lookup import iter_techniques, resolve_technique
-from backend.api.analytics import get_time_range
+from services.mitre_lookup import get_time_range, iter_techniques, resolve_technique
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/services/mitre_lookup.py
+++ b/services/mitre_lookup.py
@@ -11,7 +11,31 @@ Findings in this codebase carry MITRE data in two shapes:
   iter_techniques below for the dispatching).
 """
 
+from datetime import datetime, timedelta
 from typing import Iterable, Optional
+
+
+def get_time_range(time_range: str) -> tuple[datetime, datetime]:
+    """Get start and end datetime for the given time range.
+
+    Lives here (not in backend.api.analytics) so that `services/` and
+    `backend/api/` modules can both depend on it without forming a cycle
+    through `backend/api/__init__.py`.
+    """
+    end_time = datetime.utcnow()
+
+    if time_range == "24h":
+        start_time = end_time - timedelta(hours=24)
+    elif time_range == "7d":
+        start_time = end_time - timedelta(days=7)
+    elif time_range == "30d":
+        start_time = end_time - timedelta(days=30)
+    elif time_range == "all":
+        start_time = datetime(2000, 1, 1)
+    else:
+        start_time = end_time - timedelta(days=7)  # Default to 7 days
+
+    return start_time, end_time
 
 # {technique_id: (name, tactic)} — extend as ATT&CK coverage grows.
 TECHNIQUE_NAME_FALLBACKS: dict[str, tuple[str, str]] = {


### PR DESCRIPTION
## Summary
Hotfix for [#178](https://github.com/Vigil-SOC/vigil/pull/178). The merged change had `backend/api/attack.py` importing `get_time_range` from `backend.api.analytics`. Since `backend/api/__init__.py` eagerly imports both modules at package load, the cross-import re-entered the package init mid-load and tripped:

```
ImportError: cannot import name 'router' from partially initialized module 'api.attack'
(most likely due to a circular import)
```

This blocked the backend from booting on `main`.

## Fix
- Move `get_time_range` into `services/mitre_lookup.py` next to the other shared MITRE helpers — `services/` modules don't sit inside the `backend.api` package, so importing from there can't re-enter `backend/api/__init__.py`.
- `backend/api/analytics.py` keeps its public `get_time_range` name via a re-export, so any code outside this PR that imported `from backend.api.analytics import get_time_range` continues to work unchanged.
- `backend/api/attack.py` now imports the helper directly from `services.mitre_lookup`.

## Verified
- Backend boots cleanly: `Started server process [27947]` in `logs/backend.log`, no traceback.
- `GET /attack/techniques/rollup?time_range=24h` returns 200 with the expected payload shape.

## Test plan
- [ ] `tail -f logs/backend.log` — no `ImportError` on startup.
- [ ] `curl 'http://localhost:6987/attack/techniques/rollup?time_range=24h'` — 200.
- [ ] Dashboard ATT&CK tab loads and the time-range toggle still re-fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)