### PR TITLE
attack.py (added in the recent ATT&CK tab PR) imports get_time_range …

### DIFF
--- a/backend/api/attack.py
+++ b/backend/api/attack.py
@@ -1,13 +1,25 @@
 """ATT&CK framework API endpoints."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 from fastapi import APIRouter, Query
 import logging
 
 from services.database_data_service import DatabaseDataService
 from services.mitre_lookup import iter_techniques, resolve_technique
-from backend.api.analytics import get_time_range
+
+
+def get_time_range(time_range: str) -> tuple[datetime, datetime]:
+    end_time = datetime.utcnow()
+    if time_range == '24h':
+        start_time = end_time - timedelta(hours=24)
+    elif time_range == '30d':
+        start_time = end_time - timedelta(days=30)
+    elif time_range == 'all':
+        start_time = datetime(2000, 1, 1)
+    else:
+        start_time = end_time - timedelta(days=7)
+    return start_time, end_time
 
 router = APIRouter()
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
…from backend.api.analytics, but since api/__init__.py imports both modules during startup, it creates a cycle — attack tries to import from analytics before analytics is fully initialized.