### PR TITLE
fix: resolve auto-ops investigation failures (Bifrost config, worker errors, logging)

### DIFF
--- a/daemon/agent_runner.py
+++ b/daemon/agent_runner.py
@@ -417,7 +417,11 @@ class AgentRunner:
                 try:
                     result = await self._call_claude(inv_id, prompt)
                 except Exception as e:
-                    logger.error(f"{inv_id}: Claude call failed: {e}")
+                    logger.error(
+                        "%s: iteration %d failed: %s",
+                        inv_id, iteration, e,
+                        exc_info=True,
+                    )
                     self.workdir.append_log(inv_id, {"event": "error", "error": str(e)})
                     if _iter_span is not None:
                         try:
@@ -681,13 +685,27 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                     timeout=180,
                 )
             except Exception as e:
-                logger.error(f"{inv_id}: LLM queue error: {e}")
                 try:
                     if _llm_span is not None:
                         _llm_span.end()
                 except Exception:
                     pass
-                raise
+                raise RuntimeError(
+                    f"LLM turn {turn} failed [model={self.config.plan_model}]: {e}"
+                ) from e
+
+            # Worker returns an error dict instead of raising when the API call
+            # fails, so the result is always deserializable. Surface the error.
+            if response.get("stop_reason") == "error" or response.get("error"):
+                worker_error = response.get("error", "unknown worker error")
+                try:
+                    if _llm_span is not None:
+                        _llm_span.end()
+                except Exception:
+                    pass
+                raise RuntimeError(
+                    f"LLM turn {turn} failed [model={self.config.plan_model}]: {worker_error}"
+                )
 
             try:
                 if _llm_span is not None:

--- a/daemon/llm_worker_manager.py
+++ b/daemon/llm_worker_manager.py
@@ -95,15 +95,21 @@ class LLMWorkerManager:
     def _start_worker(self):
         """Spawn the ARQ worker as a child process."""
         env = {**os.environ, "PYTHONPATH": PROJECT_ROOT}
+        log_path = Path(PROJECT_ROOT) / "logs" / "llm_worker.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
         try:
+            log_file = open(log_path, "a")
             self._process = subprocess.Popen(
                 [sys.executable, "-m", "services.run_llm_worker"],
                 cwd=PROJECT_ROOT,
                 env=env,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=log_file,
+                stderr=log_file,
             )
-            logger.info("LLM Worker started (PID: %d)", self._process.pid)
+            logger.info(
+                "LLM Worker started (PID: %d) — logs: %s",
+                self._process.pid, log_path,
+            )
         except Exception as exc:
             logger.error("Failed to start LLM Worker: %s", exc)
             self._process = None

--- a/docker/bifrost/config.json
+++ b/docker/bifrost/config.json
@@ -2,6 +2,9 @@
   "$schema": "https://www.getbifrost.ai/schema",
   "providers": {
     "anthropic": {
+      "network_config": {
+        "default_request_timeout_in_seconds": 1800
+      },
       "keys": [
         {
           "name": "default-anthropic-key",

--- a/services/llm_gateway.py
+++ b/services/llm_gateway.py
@@ -268,10 +268,16 @@ class LLMGateway:
             return await job.result(timeout=timeout)
         except DeserializationError as exc:
             logger.error(
-                "arq job result deserialization failed for investigation_turn job: %s",
-                exc,
+                "arq deserialization error for investigation_turn [inv=%s job=%s]: %s — "
+                "likely the worker raised an unserializable exception (e.g. APIStatusError). "
+                "Check llm-worker logs for the real error.",
+                inv_id, getattr(job, "job_id", "?"), exc,
+                exc_info=True,
             )
-            raise RuntimeError(f"LLM job result deserialization failed: {exc}") from exc
+            raise RuntimeError(
+                f"LLM worker returned an undeserializable result for {inv_id} "
+                f"(check llm-worker logs): {exc}"
+            ) from exc
 
     async def submit_chat(
         self,

--- a/services/llm_worker.py
+++ b/services/llm_worker.py
@@ -66,7 +66,7 @@ async def llm_call(
     agent_id: Optional[str] = None,
     investigation_id: Optional[str] = None,
     provider_id: Optional[str] = None,
-) -> Any:
+) -> Dict[str, Any]:
     """Execute a single LLM call through the shared ClaudeService.
 
     This is the primary worker function.  It:
@@ -100,71 +100,82 @@ async def llm_call(
     except Exception:
         worker_span = None
 
-    # Load session history if applicable
-    if session_id:
-        history = await session_store.load(session_id)
-        if history:
-            messages = history + messages
+    try:
+        # Load session history if applicable
+        if session_id:
+            history = await session_store.load(session_id)
+            if history:
+                messages = history + messages
 
-    # Multi-provider routing (GH #88): if a non-default provider_id is set
-    # and the router wants the Bifrost path, dispatch there instead of
-    # hitting ClaudeService directly. provider_id=None preserves the
-    # pre-#88 Anthropic-SDK path exactly.
-    router_result = await _maybe_dispatch_via_router(
-        ctx,
-        provider_id=provider_id,
-        messages=messages,
-        system_prompt=system_prompt,
-        model=model,
-        max_tokens=max_tokens,
-        temperature=temperature,
-        tools=tools,
-        enable_thinking=enable_thinking,
-        thinking_budget=thinking_budget,
-    )
-    if router_result is not None:
-        result = router_result
-    else:
-        await rate_limiter.acquire()
-        try:
-            response = await asyncio.to_thread(
-                _sync_claude_call,
-                claude_service,
-                messages=messages,
-                model=model,
-                max_tokens=max_tokens,
-                system_prompt=system_prompt,
-                enable_thinking=enable_thinking,
-                thinking_budget=thinking_budget,
-                tools=tools,
-                temperature=temperature,
-                session_id=session_id,
-                agent_id=agent_id,
-                investigation_id=investigation_id,
-            )
-        finally:
-            rate_limiter.release()
-        result = _extract_result(response)
-
-    if worker_span is not None:
-        try:
-            worker_span.end()
-        except Exception:
-            pass
-
-    # Persist session
-    if session_id:
-        # Bifrost results are always dicts; the legacy ClaudeService path
-        # can be a bare string, so guard against it.
-        assistant_content = (
-            result.get("content", "") if isinstance(result, dict) else result
+        # Multi-provider routing (GH #88): if a non-default provider_id is set
+        # and the router wants the Bifrost path, dispatch there instead of
+        # hitting ClaudeService directly. provider_id=None preserves the
+        # pre-#88 Anthropic-SDK path exactly.
+        router_result = await _maybe_dispatch_via_router(
+            ctx,
+            provider_id=provider_id,
+            messages=messages,
+            system_prompt=system_prompt,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tools=tools,
+            enable_thinking=enable_thinking,
+            thinking_budget=thinking_budget,
         )
-        updated = messages + [
-            {"role": "assistant", "content": assistant_content}
-        ]
-        await session_store.save(session_id, updated)
+        if router_result is not None:
+            result = router_result
+        else:
+            await rate_limiter.acquire()
+            try:
+                response = await asyncio.to_thread(
+                    _sync_claude_call,
+                    claude_service,
+                    messages=messages,
+                    model=model,
+                    max_tokens=max_tokens,
+                    system_prompt=system_prompt,
+                    enable_thinking=enable_thinking,
+                    thinking_budget=thinking_budget,
+                    tools=tools,
+                    temperature=temperature,
+                    session_id=session_id,
+                    agent_id=agent_id,
+                    investigation_id=investigation_id,
+                )
+            finally:
+                rate_limiter.release()
+            result = _extract_result(response)
 
-    return result
+        if worker_span is not None:
+            try:
+                worker_span.end()
+            except Exception:
+                pass
+
+        # Persist session
+        if session_id:
+            # Bifrost results are always dicts; the legacy ClaudeService path
+            # can be a bare string, so guard against it.
+            assistant_content = (
+                result.get("content", "") if isinstance(result, dict) else result
+            )
+            updated = messages + [
+                {"role": "assistant", "content": assistant_content}
+            ]
+            await session_store.save(session_id, updated)
+
+        return result
+
+    except Exception as exc:
+        if worker_span is not None:
+            try:
+                worker_span.end()
+            except Exception:
+                pass
+        error_msg = f"{type(exc).__name__}: {exc}"
+        logger.error("llm_call failed (returning error dict): %s", error_msg)
+        return {"content": "", "type": "error", "error": error_msg}
 
 
 async def llm_call_raw(
@@ -207,54 +218,71 @@ async def llm_call_raw(
     except Exception:
         worker_span = None
 
-    router_result = await _maybe_dispatch_via_router(
-        ctx,
-        provider_id=provider_id,
-        messages=messages,
-        system_prompt=None,
-        model=model,
-        max_tokens=max_tokens,
-        temperature=temperature,
-        tools=tools,
-        enable_thinking=enable_thinking,
-        thinking_budget=thinking_budget,
-    )
-    if router_result is not None:
-        result = _adapt_router_result_to_raw(router_result)
-    else:
-        await rate_limiter.acquire()
-        try:
-            response = await asyncio.to_thread(
-                _sync_claude_raw,
-                claude_service,
-                messages=messages,
-                model=model,
-                max_tokens=max_tokens,
-                enable_thinking=enable_thinking,
-                thinking_budget=thinking_budget,
-                tools=tools,
-                temperature=temperature,
-                investigation_id=investigation_id,
-                agent_id=agent_id,
-            )
-        finally:
-            rate_limiter.release()
-        result = _serialize_raw_response(response)
+    try:
+        router_result = await _maybe_dispatch_via_router(
+            ctx,
+            provider_id=provider_id,
+            messages=messages,
+            system_prompt=None,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tools=tools,
+            enable_thinking=enable_thinking,
+            thinking_budget=thinking_budget,
+        )
+        if router_result is not None:
+            result = _adapt_router_result_to_raw(router_result)
+        else:
+            await rate_limiter.acquire()
+            try:
+                response = await asyncio.to_thread(
+                    _sync_claude_raw,
+                    claude_service,
+                    messages=messages,
+                    model=model,
+                    max_tokens=max_tokens,
+                    enable_thinking=enable_thinking,
+                    thinking_budget=thinking_budget,
+                    tools=tools,
+                    temperature=temperature,
+                    investigation_id=investigation_id,
+                    agent_id=agent_id,
+                )
+            finally:
+                rate_limiter.release()
+            result = _serialize_raw_response(response)
 
-    if worker_span is not None:
-        try:
-            in_tok = result.get("input_tokens", 0)
-            out_tok = result.get("output_tokens", 0)
-            worker_span.set_attribute("gen_ai.usage.input_tokens", in_tok)
-            worker_span.set_attribute("gen_ai.usage.output_tokens", out_tok)
-            worker_span.set_attribute(
-                "gen_ai.finish_reason", result.get("stop_reason", "")
-            )
-            worker_span.end()
-        except Exception:
-            pass
+        if worker_span is not None:
+            try:
+                in_tok = result.get("input_tokens", 0)
+                out_tok = result.get("output_tokens", 0)
+                worker_span.set_attribute("gen_ai.usage.input_tokens", in_tok)
+                worker_span.set_attribute("gen_ai.usage.output_tokens", out_tok)
+                worker_span.set_attribute(
+                    "gen_ai.finish_reason", result.get("stop_reason", "")
+                )
+                worker_span.end()
+            except Exception:
+                pass
 
-    return result
+        return result
+
+    except Exception as exc:
+        if worker_span is not None:
+            try:
+                worker_span.end()
+            except Exception:
+                pass
+        error_msg = f"{type(exc).__name__}: {exc}"
+        logger.error("llm_call_raw failed (returning error dict): %s", error_msg)
+        return {
+            "content": [],
+            "stop_reason": "error",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "error": error_msg,
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Bifrost not running / wrong URL**: `start_daemon.sh` never starts Bifrost, and `BIFROST_URL` defaulted to the Docker-internal hostname `bifrost:8080` which local processes can't resolve. Added `BIFROST_URL=http://localhost:8080` to `.env` and documented the correct startup command.
- **Real errors hidden by arq deserialization**: When the worker raised `APIConnectionError` or `APIStatusError`, arq couldn't pickle/unpickle them, producing a cryptic `DeserializationError` that completely swallowed the actual failure. Both `llm_call` and `llm_call_raw` now wrap all exceptions and return a serializable error dict instead of raising.
- **Worker output discarded**: `llm_worker_manager` used `stdout=DEVNULL, stderr=DEVNULL`. Worker logs now go to `logs/llm_worker.log`.
- **Bifrost API key blank**: Running `docker compose` from the `docker/` subdirectory meant Docker Compose never found the project-root `.env`. Must use `--env-file .env` from the project root.
- **Bifrost 30-second timeout**: Extended-thinking calls exceed Bifrost's default timeout. Set `default_request_timeout_in_seconds: 1800` in `docker/bifrost/config.json`.
- **Improved agent_runner logging**: Errors now log once with iteration, model, turn number, and full traceback — previously the same error was logged twice with no context.

## Test plan

- [ ] Start Bifrost: `docker compose -f docker/docker-compose.yml --env-file .env up -d --no-deps bifrost`
- [ ] Run `./start_daemon.sh`
- [ ] Go to Auto Ops → Scan Findings
- [ ] Verify investigations progress past turn 0 and complete without deserialization errors
- [ ] Verify `logs/llm_worker.log` is created and contains worker output