### PR TITLE
Cloud incident workflow (#168) + VStrike data-plane proxies

### DIFF
--- a/backend/api/vstrike.py
+++ b/backend/api/vstrike.py
@@ -429,3 +429,225 @@ async def ui_killchain_replay(request: VStrikeKillchainReplayRequest) -> dict:
         logger.error("VStrike ui-killchain-replay failed: %s", e)
         raise HTTPException(status_code=502, detail=str(e))
     return {"ok": True, "result": result}
+
+
+# ---------------------------------------------------------------------------
+# Data-plane proxies (node search, drift, storylines, legends)
+# ---------------------------------------------------------------------------
+
+
+class VStrikeNodeSearchRequest(BaseModel):
+    query: str
+    network_id: Optional[str] = None
+    limit: int = 50
+
+
+@router.post("/nodes/search")
+async def node_search(request: VStrikeNodeSearchRequest) -> dict:
+    """Omni-search across nodes in the VStrike network."""
+    service = _ui_service_or_503()
+    try:
+        results = service.node_search(
+            request.query, network_id=request.network_id, limit=request.limit
+        )
+    except Exception as e:
+        logger.error("VStrike node-search failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"query": request.query, "results": results or []}
+
+
+class VStrikeNodeDriftRequest(BaseModel):
+    node_id: str
+    network_id: Optional[str] = None
+
+
+@router.post("/nodes/drift")
+async def node_drift(request: VStrikeNodeDriftRequest) -> dict:
+    """Return end-node state changes for the supplied node."""
+    service = _ui_service_or_503()
+    try:
+        drift = service.node_drift_get(request.node_id, network_id=request.network_id)
+    except Exception as e:
+        logger.error("VStrike node-drift-get failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"node_id": request.node_id, "drift": drift or []}
+
+
+@router.get("/storylines")
+async def list_storylines(network_id: Optional[str] = None) -> dict:
+    """List storylines available for the network."""
+    service = _ui_service_or_503()
+    try:
+        storylines = service.storyline_list(network_id=network_id)
+    except Exception as e:
+        logger.error("VStrike storyline-list failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"network_id": network_id, "storylines": storylines or []}
+
+
+class VStrikeStorylineEventsRequest(BaseModel):
+    storyline_id: str
+    network_id: Optional[str] = None
+
+
+@router.post("/storylines/events")
+async def storyline_events(request: VStrikeStorylineEventsRequest) -> dict:
+    """List events in a storyline along with their properties."""
+    service = _ui_service_or_503()
+    try:
+        events = service.storyline_events_get(
+            request.storyline_id, network_id=request.network_id
+        )
+    except Exception as e:
+        logger.error("VStrike storyline-events-get failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"storyline_id": request.storyline_id, "events": events or []}
+
+
+@router.get("/legend-runs")
+async def list_legend_runs(network_id: Optional[str] = None) -> dict:
+    """List legend runs available for the network."""
+    service = _ui_service_or_503()
+    try:
+        runs = service.legend_run_list(network_id=network_id)
+    except Exception as e:
+        logger.error("VStrike legend-run-list failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"network_id": network_id, "legend_runs": runs or []}
+
+
+class VStrikeLegendRunResultsRequest(BaseModel):
+    legend_run_id: str
+    network_id: Optional[str] = None
+
+
+@router.post("/legend-runs/results")
+async def legend_run_results(request: VStrikeLegendRunResultsRequest) -> dict:
+    """Return results for the specified legend run."""
+    service = _ui_service_or_503()
+    try:
+        results = service.legend_run_results_get(
+            request.legend_run_id, network_id=request.network_id
+        )
+    except Exception as e:
+        logger.error("VStrike legend-run-results-get failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"legend_run_id": request.legend_run_id, "results": results}
+
+
+# ---------------------------------------------------------------------------
+# UI control plane (camera, storyline, VCR playback)
+# ---------------------------------------------------------------------------
+
+
+class VStrikeCameraNodeRequest(BaseModel):
+    node_ids: list[str]
+    network_id: Optional[str] = None
+
+
+@router.post("/ui/camera-node")
+async def ui_camera_node(request: VStrikeCameraNodeRequest) -> dict:
+    """Move the camera to focus on the provided nodes."""
+    service = _ui_service_or_503()
+    try:
+        result = service.ui_camera_node(request.node_ids, network_id=request.network_id)
+    except VStrikeToolNotImplemented as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    except Exception as e:
+        logger.error("VStrike ui-camera-node failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"ok": True, "result": result}
+
+
+class VStrikeCameraPositionRequest(BaseModel):
+    position: dict[str, float]
+    rotation: Optional[dict[str, float]] = None
+    network_id: Optional[str] = None
+
+
+@router.post("/ui/camera-position")
+async def ui_camera_position(request: VStrikeCameraPositionRequest) -> dict:
+    """Set the camera position and rotation explicitly."""
+    service = _ui_service_or_503()
+    try:
+        result = service.ui_camera_position(
+            request.position,
+            rotation=request.rotation,
+            network_id=request.network_id,
+        )
+    except VStrikeToolNotImplemented as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    except Exception as e:
+        logger.error("VStrike ui-camera-position failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"ok": True, "result": result}
+
+
+class VStrikeStorylineApplyRequest(BaseModel):
+    storyline_id: str
+    network_id: Optional[str] = None
+
+
+@router.post("/ui/storyline-apply")
+async def ui_storyline_apply(request: VStrikeStorylineApplyRequest) -> dict:
+    """Apply the specified storyline to the active network view."""
+    service = _ui_service_or_503()
+    try:
+        result = service.ui_storyline_apply(
+            request.storyline_id, network_id=request.network_id
+        )
+    except VStrikeToolNotImplemented as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    except Exception as e:
+        logger.error("VStrike ui-storyline-apply failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"ok": True, "result": result}
+
+
+class VStrikeStorylineModeRequest(BaseModel):
+    mode: str
+    network_id: Optional[str] = None
+
+
+@router.post("/ui/storyline-mode")
+async def ui_storyline_mode(request: VStrikeStorylineModeRequest) -> dict:
+    """Set the timeslice mode for the VCR controls and reset frame counters."""
+    service = _ui_service_or_503()
+    try:
+        result = service.ui_storyline_mode(
+            request.mode, network_id=request.network_id
+        )
+    except VStrikeToolNotImplemented as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    except Exception as e:
+        logger.error("VStrike ui-storyline-mode failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"ok": True, "result": result}
+
+
+@router.post("/ui/storyline-forward")
+async def ui_storyline_forward(network_id: Optional[str] = None) -> dict:
+    """Step forward in the storyline timeline."""
+    service = _ui_service_or_503()
+    try:
+        result = service.ui_storyline_forward(network_id=network_id)
+    except VStrikeToolNotImplemented as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    except Exception as e:
+        logger.error("VStrike ui-storyline-forward failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"ok": True, "result": result}
+
+
+@router.post("/ui/storyline-backward")
+async def ui_storyline_backward(network_id: Optional[str] = None) -> dict:
+    """Step backward in the storyline timeline."""
+    service = _ui_service_or_503()
+    try:
+        result = service.ui_storyline_backward(network_id=network_id)
+    except VStrikeToolNotImplemented as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    except Exception as e:
+        logger.error("VStrike ui-storyline-backward failed: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"ok": True, "result": result}

--- a/frontend/src/components/graph/VStrikeIframeHost.tsx
+++ b/frontend/src/components/graph/VStrikeIframeHost.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import {
   Alert,
   Box,
@@ -13,6 +13,7 @@ import {
   SelectChangeEvent,
   Snackbar,
   Stack,
+  TextField,
   Tooltip,
   Typography,
 } from '@mui/material'
@@ -20,6 +21,9 @@ import {
   Fullscreen as FullscreenIcon,
   FullscreenExit as FullscreenExitIcon,
   PlayArrow as PlayIcon,
+  SkipNext as SkipNextIcon,
+  SkipPrevious as SkipPreviousIcon,
+  Search as SearchIcon,
 } from '@mui/icons-material'
 import {
   useVStrikeIframe,
@@ -47,8 +51,9 @@ const TOP_BAR_OFFSET_PX = 64
  * bounding rect via a `ResizeObserver` + `scroll` listener; it never unmounts,
  * so the VStrike session inside the iframe survives every navigation.
  *
- * The toolbar (network selector + Play + Fullscreen) floats at the top of the
- * iframe rect and is only visible when an anchor is active.
+ * The toolbar floats at the top of the iframe rect and is only visible when an
+ * anchor is active. It includes network selection, storyline/legend controls,
+ * VCR playback, node search, and the legacy kill-chain play button.
  */
 export default function VStrikeIframeHost() {
   const ctx = useVStrikeIframe()
@@ -59,6 +64,11 @@ export default function VStrikeIframeHost() {
     severity: 'success' | 'error' | 'info'
     message: string
   } | null>(null)
+
+  // Node search local state
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<Array<Record<string, any>>>([])
+  const [showSearchResults, setShowSearchResults] = useState(false)
 
   const anchor = internals.activeAnchor
   const fullscreen = ctx.fullscreen
@@ -104,8 +114,52 @@ export default function VStrikeIframeHost() {
     }
   }, [anchor, fullscreen])
 
-  // Bridge the iframe's `onLoad` event into the context (so it can apply the
-  // pending network selection once the VStrike app is ready inside the frame).
+  // Keep latest selection values inside a ref so the postMessage handler
+  // can read them without re-registering the listener on every change.
+  const selectedNetworkRef = useRef(ctx.selectedNetwork)
+  const selectedStorylineRef = useRef(ctx.selectedStoryline)
+  const selectedLegendRunRef = useRef(ctx.selectedLegendRun)
+  selectedNetworkRef.current = ctx.selectedNetwork
+  selectedStorylineRef.current = ctx.selectedStoryline
+  selectedLegendRunRef.current = ctx.selectedLegendRun
+
+  // Listen for state-change messages from the VStrike iframe.
+  useEffect(() => {
+    if (!ctx.iframeUrl) return
+    let expectedOrigin: string
+    try {
+      expectedOrigin = new URL(ctx.iframeUrl).origin
+    } catch {
+      return
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== expectedOrigin) return
+      const data = event.data
+      if (data?.type !== 'vstrike:state') return
+
+      const networkId = typeof data.networkId === 'string' ? data.networkId : undefined
+      const storylineId =
+        data.storylineId === null ? '' : typeof data.storylineId === 'string' ? data.storylineId : undefined
+      const legendRunId =
+        data.legendRunId === null ? '' : typeof data.legendRunId === 'string' ? data.legendRunId : undefined
+
+      if (networkId !== undefined && networkId !== selectedNetworkRef.current) {
+        ctx.syncNetworkFromIframe(networkId)
+      }
+      if (storylineId !== undefined && storylineId !== selectedStorylineRef.current) {
+        ctx.syncStorylineFromIframe(storylineId)
+      }
+      if (legendRunId !== undefined && legendRunId !== selectedLegendRunRef.current) {
+        ctx.syncLegendRunFromIframe(legendRunId)
+      }
+    }
+
+    window.addEventListener('message', handleMessage)
+    return () => window.removeEventListener('message', handleMessage)
+  }, [ctx.iframeUrl, ctx.syncNetworkFromIframe, ctx.syncStorylineFromIframe, ctx.syncLegendRunFromIframe])
+
+  // Bridge the iframe's `onLoad` event into the context.
   const handleLoad = () => {
     internals.handleIframeLoad()
   }
@@ -142,6 +196,86 @@ export default function VStrikeIframeHost() {
     !ctx.hasAnchor ||
     ctx.activeFindings.length === 0
 
+  // -------------------------------------------------------------------------
+  // Storyline controls
+  // -------------------------------------------------------------------------
+
+  const handleStorylineChange = (event: SelectChangeEvent<string>) => {
+    ctx.setStoryline(event.target.value)
+  }
+
+  const handleApplyStoryline = async () => {
+    if (!ctx.selectedStoryline) {
+      setSnackbar({ severity: 'info', message: 'Select a storyline first.' })
+      return
+    }
+    const result = await ctx.applyStoryline(ctx.selectedStoryline)
+    if (result.ok) {
+      setSnackbar({ severity: 'success', message: 'Storyline applied.' })
+      return
+    }
+    setSnackbar({ severity: 'error', message: result.message })
+  }
+
+  // -------------------------------------------------------------------------
+  // Legend run controls
+  // -------------------------------------------------------------------------
+
+  const handleLegendRunChange = (event: SelectChangeEvent<string>) => {
+    ctx.setLegendRun(event.target.value)
+  }
+
+  // -------------------------------------------------------------------------
+  // VCR playback controls
+  // -------------------------------------------------------------------------
+
+  const handleStepBackward = async () => {
+    const result = await ctx.stepBackward()
+    if (!result.ok) {
+      setSnackbar({ severity: 'error', message: result.message })
+    }
+  }
+
+  const handleStepForward = async () => {
+    const result = await ctx.stepForward()
+    if (!result.ok) {
+      setSnackbar({ severity: 'error', message: result.message })
+    }
+  }
+
+  const vcrDisabled = ctx.state !== 'ready' || !ctx.hasAnchor
+
+  // -------------------------------------------------------------------------
+  // Node search
+  // -------------------------------------------------------------------------
+
+  const handleSearch = async () => {
+    if (!searchQuery.trim()) return
+    const results = await ctx.searchNodes(searchQuery.trim())
+    setSearchResults(results)
+    setShowSearchResults(true)
+    if (results.length === 0) {
+      setSnackbar({ severity: 'info', message: 'No nodes matched your search.' })
+    }
+  }
+
+  const handleSearchKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleSearch()
+    }
+  }
+
+  const handleFocusNode = async (nodeId: string) => {
+    const result = await ctx.cameraNode([nodeId])
+    if (result.ok) {
+      setShowSearchResults(false)
+      setSearchQuery('')
+      return
+    }
+    setSnackbar({ severity: 'error', message: result.message })
+  }
+
   // Error overlay positioned over the anchor.
   if (ctx.error && visible) {
     return (
@@ -153,8 +287,6 @@ export default function VStrikeIframeHost() {
           left: rect.left,
           width: rect.width,
           height: rect.height,
-          // Sit above MUI's modal layer (1300) so the iframe shows on top of
-          // the case dialog rather than behind it. Snackbars at 1400 still win.
           zIndex: 1301,
           display: 'flex',
           alignItems: 'center',
@@ -197,21 +329,14 @@ export default function VStrikeIframeHost() {
           left: rect.left,
           width: rect.width,
           height: rect.height,
-          // The iframe is always mounted, even when no anchor is active —
-          // visibility hidden + pointer-events none + offscreen rect parks it
-          // without unmounting (which would lose the VStrike session).
           visibility: visible ? 'visible' : 'hidden',
           pointerEvents: visible ? 'auto' : 'none',
           opacity: visible ? 1 : 0,
-          // 1301 puts the iframe above MUI's modal layer (1300) so it shows
-          // through case-dialog anchors instead of being hidden behind them.
           zIndex: 1301,
           transition: 'opacity 120ms ease',
           display: 'flex',
           flexDirection: 'column',
           bgcolor: 'background.paper',
-          // No border in fullscreen; subtle border otherwise to match the
-          // case-dialog look.
           border: fullscreen ? 0 : 1,
           borderColor: 'divider',
         }}
@@ -228,15 +353,19 @@ export default function VStrikeIframeHost() {
             borderColor: 'divider',
             bgcolor: 'background.paper',
             minHeight: 44,
+            gap: 1,
+            flexWrap: 'wrap',
           }}
         >
-          <Typography variant="subtitle2" sx={{ pl: 1 }}>
+          <Typography variant="subtitle2" sx={{ pl: 1, whiteSpace: 'nowrap' }}>
             VStrike Network View
           </Typography>
-          <Stack direction="row" spacing={1} alignItems="center">
+
+          <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+            {/* Network selector */}
             <FormControl
               size="small"
-              sx={{ minWidth: 220 }}
+              sx={{ minWidth: 180 }}
               disabled={ctx.state !== 'ready'}
             >
               <InputLabel id="vstrike-network-label">Network</InputLabel>
@@ -259,6 +388,117 @@ export default function VStrikeIframeHost() {
                 ))}
               </Select>
             </FormControl>
+
+            {/* Storyline selector */}
+            <FormControl
+              size="small"
+              sx={{ minWidth: 160 }}
+              disabled={ctx.state !== 'ready' || ctx.storylines.length === 0}
+            >
+              <InputLabel id="vstrike-storyline-label">Storyline</InputLabel>
+              <Select
+                labelId="vstrike-storyline-label"
+                label="Storyline"
+                value={ctx.selectedStoryline}
+                onChange={handleStorylineChange}
+                displayEmpty
+              >
+                <MenuItem value="">
+                  <em>
+                    {ctx.storylines.length ? 'Select…' : 'None'}
+                  </em>
+                </MenuItem>
+                {ctx.storylines.map((opt) => (
+                  <MenuItem key={opt.id} value={opt.id}>
+                    {opt.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <Button
+              size="small"
+              variant="outlined"
+              disabled={
+                ctx.state !== 'ready' || !ctx.selectedStoryline
+              }
+              onClick={handleApplyStoryline}
+            >
+              Apply
+            </Button>
+
+            {/* Legend run selector */}
+            <FormControl
+              size="small"
+              sx={{ minWidth: 140 }}
+              disabled={ctx.state !== 'ready' || ctx.legendRuns.length === 0}
+            >
+              <InputLabel id="vstrike-legend-label">Legend</InputLabel>
+              <Select
+                labelId="vstrike-legend-label"
+                label="Legend"
+                value={ctx.selectedLegendRun}
+                onChange={handleLegendRunChange}
+                displayEmpty
+              >
+                <MenuItem value="">
+                  <em>
+                    {ctx.legendRuns.length ? 'Select…' : 'None'}
+                  </em>
+                </MenuItem>
+                {ctx.legendRuns.map((opt) => (
+                  <MenuItem key={opt.id} value={opt.id}>
+                    {opt.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            {/* Node search */}
+            <TextField
+              size="small"
+              placeholder="Search nodes…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              disabled={ctx.state !== 'ready'}
+              sx={{ width: 140 }}
+              InputProps={{
+                endAdornment: (
+                  <IconButton size="small" onClick={handleSearch} disabled={ctx.state !== 'ready'}>
+                    <SearchIcon fontSize="small" />
+                  </IconButton>
+                ),
+              }}
+            />
+
+            {/* VCR controls */}
+            <Tooltip title="Step backward">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={handleStepBackward}
+                  disabled={vcrDisabled}
+                  aria-label="Step backward"
+                >
+                  <SkipPreviousIcon />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="Step forward">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={handleStepForward}
+                  disabled={vcrDisabled}
+                  aria-label="Step forward"
+                >
+                  <SkipNextIcon />
+                </IconButton>
+              </span>
+            </Tooltip>
+
+            {/* Legacy kill-chain play */}
             <Tooltip
               title={
                 playDisabled
@@ -277,6 +517,8 @@ export default function VStrikeIframeHost() {
                 </IconButton>
               </span>
             </Tooltip>
+
+            {/* Fullscreen */}
             <Tooltip title={fullscreen ? 'Exit full screen' : 'Full screen'}>
               <IconButton
                 size="small"
@@ -288,6 +530,52 @@ export default function VStrikeIframeHost() {
             </Tooltip>
           </Stack>
         </Box>
+
+        {/* Search results overlay */}
+        {showSearchResults && searchResults.length > 0 && (
+          <Paper
+            elevation={3}
+            sx={{
+              position: 'absolute',
+              top: 52,
+              right: 8,
+              width: 280,
+              maxHeight: 300,
+              overflow: 'auto',
+              zIndex: 10,
+              p: 1,
+            }}
+          >
+            <Stack spacing={0.5}>
+              <Typography variant="caption" color="text.secondary">
+                {searchResults.length} result{searchResults.length === 1 ? '' : 's'}
+              </Typography>
+              {searchResults.map((r) => {
+                const id = r.node_id || r.id || 'unknown'
+                const name = r.node_name || r.name || id
+                return (
+                  <Button
+                    key={id}
+                    size="small"
+                    variant="text"
+                    sx={{ justifyContent: 'flex-start' }}
+                    onClick={() => handleFocusNode(id)}
+                  >
+                    {name}
+                  </Button>
+                )
+              })}
+              <Button
+                size="small"
+                variant="text"
+                color="secondary"
+                onClick={() => setShowSearchResults(false)}
+              >
+                Close
+              </Button>
+            </Stack>
+          </Paper>
+        )}
 
         {/* Iframe + loading overlay */}
         <Box sx={{ flex: 1, position: 'relative', minHeight: 0 }}>
@@ -343,4 +631,3 @@ export default function VStrikeIframeHost() {
     </>
   )
 }
-

--- a/frontend/src/contexts/VStrikeIframeContext.tsx
+++ b/frontend/src/contexts/VStrikeIframeContext.tsx
@@ -62,6 +62,41 @@ export interface VStrikeIframeContextValue {
     steps: KillchainStep[],
     opts?: { networkId?: string; loop?: boolean; autoPlay?: boolean },
   ) => Promise<{ ok: true } | { ok: false; status: number; message: string }>
+  // -------------------------------------------------------------------------
+  // Storylines & legends
+  // -------------------------------------------------------------------------
+  storylines: Array<{ id: string; label: string; raw: Record<string, any> }>
+  selectedStoryline: string
+  setStoryline: (storylineId: string) => void
+  legendRuns: Array<{ id: string; label: string; raw: Record<string, any> }>
+  selectedLegendRun: string
+  setLegendRun: (legendRunId: string) => void
+  // -------------------------------------------------------------------------
+  // Iframe → toolbar sync (no API calls)
+  // -------------------------------------------------------------------------
+  syncNetworkFromIframe: (networkId: string) => void
+  syncStorylineFromIframe: (storylineId: string) => void
+  syncLegendRunFromIframe: (legendRunId: string) => void
+  // -------------------------------------------------------------------------
+  // Camera control
+  // -------------------------------------------------------------------------
+  cameraNode: (nodeIds: string[]) => Promise<{ ok: true } | { ok: false; message: string }>
+  cameraPosition: (
+    position: Record<string, number>,
+    rotation?: Record<string, number>,
+  ) => Promise<{ ok: true } | { ok: false; message: string }>
+  // -------------------------------------------------------------------------
+  // Storyline VCR playback
+  // -------------------------------------------------------------------------
+  applyStoryline: (storylineId: string) => Promise<{ ok: true } | { ok: false; message: string }>
+  setStorylineMode: (mode: string) => Promise<{ ok: true } | { ok: false; message: string }>
+  stepForward: () => Promise<{ ok: true } | { ok: false; message: string }>
+  stepBackward: () => Promise<{ ok: true } | { ok: false; message: string }>
+  // -------------------------------------------------------------------------
+  // Node search / drift
+  // -------------------------------------------------------------------------
+  searchNodes: (query: string) => Promise<Array<Record<string, any>>>
+  getNodeDrift: (nodeId: string) => Promise<Array<Record<string, any>>>
 }
 
 const VStrikeIframeContext = createContext<VStrikeIframeContextValue | null>(null)
@@ -85,6 +120,23 @@ function pickNetworkId(raw: Record<string, any>): string | null {
 
 function pickNetworkLabel(raw: Record<string, any>, fallbackId: string): string {
   for (const key of ['name', 'label', 'display_name', 'title']) {
+    const value = raw?.[key]
+    if (typeof value === 'string' && value) return value
+  }
+  return fallbackId
+}
+
+function pickId(raw: Record<string, any>): string | null {
+  for (const key of ['id', 'storyline_id', 'legend_run_id', 'uuid', 'runId']) {
+    const value = raw?.[key]
+    if (typeof value === 'string' && value) return value
+    if (typeof value === 'number') return String(value)
+  }
+  return null
+}
+
+function pickLabel(raw: Record<string, any>, fallbackId: string): string {
+  for (const key of ['name', 'label', 'display_name', 'title', 'description']) {
     const value = raw?.[key]
     if (typeof value === 'string' && value) return value
   }
@@ -140,9 +192,20 @@ export function VStrikeIframeProvider({ children }: ProviderProps) {
   >([])
   const [reloadKey, setReloadKey] = useState(0)
 
+  const [storylines, setStorylines] = useState<
+    Array<{ id: string; label: string; raw: Record<string, any> }>
+  >([])
+  const [selectedStoryline, setSelectedStoryline] = useState<string>('')
+  const [legendRuns, setLegendRuns] = useState<
+    Array<{ id: string; label: string; raw: Record<string, any> }>
+  >([])
+  const [selectedLegendRun, setSelectedLegendRun] = useState<string>('')
+
   const iframeReadyRef = useRef(false)
   const pendingNetworkRef = useRef<string | null>(null)
   const anchorOptsRef = useRef<Map<HTMLDivElement, AnchorOpts>>(new Map())
+  const currentNetworkRef = useRef<string>('')
+  const syncingFromIframeRef = useRef(false)
 
   // Fetch token + networks once per `reloadKey`. Mounted-once at provider
   // scope, so case-dialog opens never trigger a re-fetch.
@@ -196,7 +259,7 @@ export function VStrikeIframeProvider({ children }: ProviderProps) {
   }, [reloadKey])
 
   const applyNetwork = useCallback((networkId: string) => {
-    if (!networkId) return
+    if (!networkId || syncingFromIframeRef.current) return
     vstrikeApi.loadNetwork(networkId).catch((err) => {
       // eslint-disable-next-line no-console
       console.warn('VStrike loadNetwork failed:', err)
@@ -206,6 +269,7 @@ export function VStrikeIframeProvider({ children }: ProviderProps) {
   const setNetwork = useCallback(
     (networkId: string) => {
       setSelectedNetwork(networkId)
+      currentNetworkRef.current = networkId
       if (iframeReadyRef.current) {
         applyNetwork(networkId)
       } else {
@@ -214,6 +278,34 @@ export function VStrikeIframeProvider({ children }: ProviderProps) {
     },
     [applyNetwork],
   )
+
+  const syncNetworkFromIframe = useCallback((networkId: string) => {
+    syncingFromIframeRef.current = true
+    currentNetworkRef.current = networkId
+    setSelectedNetwork(networkId)
+    // Reset dependent selections when network changes from iframe.
+    setSelectedStoryline('')
+    setSelectedLegendRun('')
+    Promise.resolve().then(() => {
+      syncingFromIframeRef.current = false
+    })
+  }, [])
+
+  const syncStorylineFromIframe = useCallback((storylineId: string) => {
+    syncingFromIframeRef.current = true
+    setSelectedStoryline(storylineId)
+    Promise.resolve().then(() => {
+      syncingFromIframeRef.current = false
+    })
+  }, [])
+
+  const syncLegendRunFromIframe = useCallback((legendRunId: string) => {
+    syncingFromIframeRef.current = true
+    setSelectedLegendRun(legendRunId)
+    Promise.resolve().then(() => {
+      syncingFromIframeRef.current = false
+    })
+  }, [])
 
   const attach = useCallback(
     (anchor: HTMLDivElement, opts?: AnchorOpts) => {
@@ -300,6 +392,266 @@ export function VStrikeIframeProvider({ children }: ProviderProps) {
     [selectedNetwork],
   )
 
+  // -------------------------------------------------------------------------
+  // Data fetching (storylines, legend runs)
+  // -------------------------------------------------------------------------
+
+  const fetchStorylines = useCallback(
+    async (networkId: string) => {
+      if (!networkId) {
+        setStorylines([])
+        return
+      }
+      try {
+        const res = await vstrikeApi.listStorylines(networkId)
+        // Cancel if user switched networks while we were in-flight.
+        if (currentNetworkRef.current !== networkId) return
+        const items = res.data?.storylines || []
+        const opts: Array<{ id: string; label: string; raw: Record<string, any> }> =
+          []
+        for (const raw of items) {
+          const id = pickId(raw)
+          if (!id) continue
+          opts.push({ id, label: pickLabel(raw, id), raw })
+        }
+        setStorylines(opts)
+      } catch (err) {
+        if (currentNetworkRef.current !== networkId) return
+        // eslint-disable-next-line no-console
+        console.warn('VStrike listStorylines failed:', err)
+        setStorylines([])
+      }
+    },
+    [],
+  )
+
+  const fetchLegendRuns = useCallback(
+    async (networkId: string) => {
+      if (!networkId) {
+        setLegendRuns([])
+        return
+      }
+      try {
+        const res = await vstrikeApi.listLegendRuns(networkId)
+        // Cancel if user switched networks while we were in-flight.
+        if (currentNetworkRef.current !== networkId) return
+        const items = res.data?.legend_runs || []
+        const opts: Array<{ id: string; label: string; raw: Record<string, any> }> =
+          []
+        for (const raw of items) {
+          const id = pickId(raw)
+          if (!id) continue
+          opts.push({ id, label: pickLabel(raw, id), raw })
+        }
+        setLegendRuns(opts)
+      } catch (err) {
+        if (currentNetworkRef.current !== networkId) return
+        // eslint-disable-next-line no-console
+        console.warn('VStrike listLegendRuns failed:', err)
+        setLegendRuns([])
+      }
+    },
+    [],
+  )
+
+  // When network changes, fetch storylines and legend runs.
+  useEffect(() => {
+    let cancelled = false
+    if (selectedNetwork) {
+      fetchStorylines(selectedNetwork).then(() => {
+        if (cancelled) return
+      })
+      fetchLegendRuns(selectedNetwork).then(() => {
+        if (cancelled) return
+      })
+    } else {
+      setStorylines([])
+      setLegendRuns([])
+    }
+    return () => {
+      cancelled = true
+    }
+  }, [selectedNetwork, fetchStorylines, fetchLegendRuns])
+
+  const setStoryline = useCallback(
+    (storylineId: string) => {
+      setSelectedStoryline(storylineId)
+    },
+    [],
+  )
+
+  const setLegendRun = useCallback(
+    (legendRunId: string) => {
+      setSelectedLegendRun(legendRunId)
+    },
+    [],
+  )
+
+  // -------------------------------------------------------------------------
+  // Camera control
+  // -------------------------------------------------------------------------
+
+  const cameraNode = useCallback(
+    async (nodeIds: string[]) => {
+      const networkId = selectedNetwork
+      if (!networkId) {
+        return { ok: false as const, message: 'No VStrike network selected.' }
+      }
+      try {
+        await vstrikeApi.uiCameraNode(nodeIds, networkId)
+        return { ok: true as const }
+      } catch (err: any) {
+        const detail = err?.response?.data?.detail
+        const message =
+          typeof detail === 'string'
+            ? detail
+            : detail?.message || err?.message || 'Camera node focus failed.'
+        return { ok: false as const, message }
+      }
+    },
+    [selectedNetwork],
+  )
+
+  const cameraPosition = useCallback(
+    async (
+      position: Record<string, number>,
+      rotation?: Record<string, number>,
+    ) => {
+      const networkId = selectedNetwork
+      if (!networkId) {
+        return { ok: false as const, message: 'No VStrike network selected.' }
+      }
+      try {
+        await vstrikeApi.uiCameraPosition(position, rotation, networkId)
+        return { ok: true as const }
+      } catch (err: any) {
+        const detail = err?.response?.data?.detail
+        const message =
+          typeof detail === 'string'
+            ? detail
+            : detail?.message || err?.message || 'Camera position failed.'
+        return { ok: false as const, message }
+      }
+    },
+    [selectedNetwork],
+  )
+
+  // -------------------------------------------------------------------------
+  // Storyline VCR playback
+  // -------------------------------------------------------------------------
+
+  const applyStoryline = useCallback(
+    async (storylineId: string) => {
+      const networkId = selectedNetwork
+      if (!networkId) {
+        return { ok: false as const, message: 'No VStrike network selected.' }
+      }
+      try {
+        await vstrikeApi.uiStorylineApply(storylineId, networkId)
+        return { ok: true as const }
+      } catch (err: any) {
+        const detail = err?.response?.data?.detail
+        const message =
+          typeof detail === 'string'
+            ? detail
+            : detail?.message || err?.message || 'Apply storyline failed.'
+        return { ok: false as const, message }
+      }
+    },
+    [selectedNetwork],
+  )
+
+  const setStorylineMode = useCallback(
+    async (mode: string) => {
+      const networkId = selectedNetwork
+      if (!networkId) {
+        return { ok: false as const, message: 'No VStrike network selected.' }
+      }
+      try {
+        await vstrikeApi.uiStorylineMode(mode, networkId)
+        return { ok: true as const }
+      } catch (err: any) {
+        const detail = err?.response?.data?.detail
+        const message =
+          typeof detail === 'string'
+            ? detail
+            : detail?.message || err?.message || 'Set storyline mode failed.'
+        return { ok: false as const, message }
+      }
+    },
+    [selectedNetwork],
+  )
+
+  const stepForward = useCallback(async () => {
+    const networkId = selectedNetwork
+    if (!networkId) {
+      return { ok: false as const, message: 'No VStrike network selected.' }
+    }
+    try {
+      await vstrikeApi.uiStorylineForward(networkId)
+      return { ok: true as const }
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail
+      const message =
+        typeof detail === 'string'
+          ? detail
+          : detail?.message || err?.message || 'Step forward failed.'
+      return { ok: false as const, message }
+    }
+  }, [selectedNetwork])
+
+  const stepBackward = useCallback(async () => {
+    const networkId = selectedNetwork
+    if (!networkId) {
+      return { ok: false as const, message: 'No VStrike network selected.' }
+    }
+    try {
+      await vstrikeApi.uiStorylineBackward(networkId)
+      return { ok: true as const }
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail
+      const message =
+        typeof detail === 'string'
+          ? detail
+          : detail?.message || err?.message || 'Step backward failed.'
+      return { ok: false as const, message }
+    }
+  }, [selectedNetwork])
+
+  // -------------------------------------------------------------------------
+  // Node search / drift
+  // -------------------------------------------------------------------------
+
+  const searchNodes = useCallback(
+    async (query: string) => {
+      const networkId = selectedNetwork
+      try {
+        const res = await vstrikeApi.nodeSearch(query, networkId)
+        return res.data?.results || []
+      } catch (err: any) {
+        // eslint-disable-next-line no-console
+        console.warn('VStrike nodeSearch failed:', err)
+        return []
+      }
+    },
+    [selectedNetwork],
+  )
+
+  const getNodeDrift = useCallback(
+    async (nodeId: string) => {
+      const networkId = selectedNetwork
+      try {
+        const res = await vstrikeApi.nodeDrift(nodeId, networkId)
+        return res.data?.drift || []
+      } catch (err: any) {
+        // eslint-disable-next-line no-console
+        console.warn('VStrike nodeDrift failed:', err)
+        return []
+      }
+    },
+    [selectedNetwork],
+  )
+
   const value = useMemo<VStrikeIframeContextValue>(
     () => ({
       state,
@@ -317,6 +669,23 @@ export function VStrikeIframeProvider({ children }: ProviderProps) {
       detach,
       reload,
       triggerKillchain,
+      storylines,
+      selectedStoryline,
+      setStoryline,
+      legendRuns,
+      selectedLegendRun,
+      setLegendRun,
+      syncNetworkFromIframe,
+      syncStorylineFromIframe,
+      syncLegendRunFromIframe,
+      cameraNode,
+      cameraPosition,
+      applyStoryline,
+      setStorylineMode,
+      stepForward,
+      stepBackward,
+      searchNodes,
+      getNodeDrift,
     }),
     [
       state,
@@ -333,6 +702,23 @@ export function VStrikeIframeProvider({ children }: ProviderProps) {
       detach,
       reload,
       triggerKillchain,
+      storylines,
+      selectedStoryline,
+      setStoryline,
+      legendRuns,
+      selectedLegendRun,
+      setLegendRun,
+      syncNetworkFromIframe,
+      syncStorylineFromIframe,
+      syncLegendRunFromIframe,
+      cameraNode,
+      cameraPosition,
+      applyStoryline,
+      setStorylineMode,
+      stepForward,
+      stepBackward,
+      searchNodes,
+      getNodeDrift,
     ],
   )
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -505,6 +505,90 @@ export const vstrikeApi = {
         auto_play: opts?.autoPlay ?? true,
       },
     ),
+
+  // -------------------------------------------------------------------------
+  // Data-plane proxies (node search, drift, storylines, legends)
+  // -------------------------------------------------------------------------
+
+  nodeSearch: (query: string, network_id?: string, limit?: number) =>
+    api.post<{ query: string; results: Array<Record<string, any>> }>(
+      '/integrations/vstrike/nodes/search',
+      { query, network_id, limit },
+    ),
+
+  nodeDrift: (node_id: string, network_id?: string) =>
+    api.post<{ node_id: string; drift: Array<Record<string, any>> }>(
+      '/integrations/vstrike/nodes/drift',
+      { node_id, network_id },
+    ),
+
+  listStorylines: (network_id?: string) =>
+    api.get<{ network_id?: string; storylines: Array<Record<string, any>> }>(
+      '/integrations/vstrike/storylines',
+      { params: { network_id } },
+    ),
+
+  storylineEvents: (storyline_id: string, network_id?: string) =>
+    api.post<{ storyline_id: string; events: Array<Record<string, any>> }>(
+      '/integrations/vstrike/storylines/events',
+      { storyline_id, network_id },
+    ),
+
+  listLegendRuns: (network_id?: string) =>
+    api.get<{ network_id?: string; legend_runs: Array<Record<string, any>> }>(
+      '/integrations/vstrike/legend-runs',
+      { params: { network_id } },
+    ),
+
+  legendRunResults: (legend_run_id: string, network_id?: string) =>
+    api.post<{ legend_run_id: string; results: Record<string, any> }>(
+      '/integrations/vstrike/legend-runs/results',
+      { legend_run_id, network_id },
+    ),
+
+  // -------------------------------------------------------------------------
+  // UI control plane (camera, storyline, VCR playback)
+  // -------------------------------------------------------------------------
+
+  uiCameraNode: (node_ids: string[], network_id?: string) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/camera-node',
+      { node_ids, network_id },
+    ),
+
+  uiCameraPosition: (
+    position: Record<string, number>,
+    rotation?: Record<string, number>,
+    network_id?: string,
+  ) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/camera-position',
+      { position, rotation, network_id },
+    ),
+
+  uiStorylineApply: (storyline_id: string, network_id?: string) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/storyline-apply',
+      { storyline_id, network_id },
+    ),
+
+  uiStorylineMode: (mode: string, network_id?: string) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/storyline-mode',
+      { mode, network_id },
+    ),
+
+  uiStorylineForward: (network_id?: string) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/storyline-forward',
+      { network_id },
+    ),
+
+  uiStorylineBackward: (network_id?: string) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/storyline-backward',
+      { network_id },
+    ),
 }
 
 // Claude API

--- a/frontend/src/types/vstrike.ts
+++ b/frontend/src/types/vstrike.ts
@@ -43,3 +43,54 @@ export const VSTRIKE_GRAPH_HIGHLIGHT_EVENT = 'vstrike-graph-highlight'
 export interface VStrikeGraphHighlightDetail {
   nodeId: string
 }
+
+// ---------------------------------------------------------------------------
+// New VStrike data-plane types (storylines, legends, node search/drift)
+// ---------------------------------------------------------------------------
+
+export interface VStrikeNodeSearchResult {
+  node_id: string
+  node_name?: string
+  score?: number
+  [key: string]: any
+}
+
+export interface VStrikeNodeDriftEntry {
+  timestamp: string
+  source: string
+  state: string
+  [key: string]: any
+}
+
+export interface VStrikeStoryline {
+  storyline_id: string
+  name?: string
+  description?: string
+  [key: string]: any
+}
+
+export interface VStrikeStorylineEvent {
+  event_id: string
+  timestamp: string
+  properties: Record<string, any>
+  [key: string]: any
+}
+
+export interface VStrikeLegendRun {
+  legend_run_id: string
+  name?: string
+  status?: string
+  [key: string]: any
+}
+
+export interface VStrikeLegendRunResults {
+  legend_run_id: string
+  results: Record<string, any>
+  [key: string]: any
+}
+
+// ---------------------------------------------------------------------------
+// VCR / playback types
+// ---------------------------------------------------------------------------
+
+export type VStrikeStorylineMode = 'live' | 'replay' | 'pause'

--- a/services/vstrike_service.py
+++ b/services/vstrike_service.py
@@ -44,6 +44,9 @@ _JWT_DEFAULT_TTL_SECONDS = 50 * 60
 # Key: (base_url, username) → (jwt, expires_at_epoch_seconds)
 _jwt_cache: Dict[Tuple[str, str], Tuple[str, float]] = {}
 _jwt_lock = threading.Lock()
+# Per-credential lock so concurrent requests for the same account
+# don't race _mcp_login() and end up with different JWTs.
+_jwt_login_locks: Dict[Tuple[str, str], threading.Lock] = {}
 
 
 class VStrikeToolNotImplemented(RuntimeError):
@@ -361,14 +364,30 @@ class VStrikeService:
                 "(VSTRIKE_USERNAME / VSTRIKE_PASSWORD)"
             )
         key = (self.base_url, self.username)
+
+        # Fast-path: check cache under the shared lock.
         with _jwt_lock:
             cached = _jwt_cache.get(key)
             if cached and cached[1] > time.time():
                 return cached[0]
-        jwt = self._mcp_login()
+
+        # Slow-path: we need to log in.  Grab a per-credential lock so
+        # concurrent requests for the same account don't race _mcp_login()
+        # and end up with different JWTs (which would orphan an iframe
+        # session and cause VStrike to return "Unknown token match!").
         with _jwt_lock:
-            _jwt_cache[key] = (jwt, time.time() + _JWT_DEFAULT_TTL_SECONDS)
-        return jwt
+            login_lock = _jwt_login_locks.setdefault(key, threading.Lock())
+
+        with login_lock:
+            # Another thread may have logged in while we were waiting.
+            with _jwt_lock:
+                cached = _jwt_cache.get(key)
+                if cached and cached[1] > time.time():
+                    return cached[0]
+            jwt = self._mcp_login()
+            with _jwt_lock:
+                _jwt_cache[key] = (jwt, time.time() + _JWT_DEFAULT_TTL_SECONDS)
+            return jwt
 
     def _invalidate_jwt(self) -> None:
         if self.username:
@@ -521,6 +540,178 @@ class VStrikeService:
         """Build the auto-login iframe URL using a fresh ui-login-token."""
         token = self.get_ui_login_token()
         return f"{self.base_url}/login?token={token}"
+
+    # ------------------------------------------------------------------ #
+    # Data-plane MCP tools (node search, drift, storylines, legends)
+    # ------------------------------------------------------------------ #
+
+    def node_search(
+        self, query: str, *, network_id: Optional[str] = None, limit: int = 50
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Omni-search across nodes in the active VStrike network."""
+        args: Dict[str, Any] = {"query": query, "limit": limit}
+        if network_id:
+            args["networkId"] = network_id
+        try:
+            result = self._call_mcp_tool("node-search", args)
+            return _extract_list(result, ("nodes", "results", "items", "data"))
+        except RuntimeError as e:
+            logger.error("VStrike node-search failed: %s", e)
+            return None
+
+    def node_drift_get(
+        self, node_id: str, *, network_id: Optional[str] = None
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Return end-node state changes for the supplied node."""
+        args: Dict[str, Any] = {"nodeId": node_id}
+        if network_id:
+            args["networkId"] = network_id
+        try:
+            result = self._call_mcp_tool("node-drift-get", args)
+            return _extract_list(result, ("drift", "changes", "results", "items", "data"))
+        except RuntimeError as e:
+            logger.error("VStrike node-drift-get failed: %s", e)
+            return None
+
+    def storyline_list(
+        self, *, network_id: Optional[str] = None
+    ) -> Optional[List[Dict[str, Any]]]:
+        """List storylines available for the network."""
+        args: Dict[str, Any] = {}
+        if network_id:
+            args["networkId"] = network_id
+        try:
+            result = self._call_mcp_tool("storyline-list", args)
+            return _extract_list(result, ("storylines", "results", "items", "data"))
+        except RuntimeError as e:
+            logger.error("VStrike storyline-list failed: %s", e)
+            return None
+
+    def storyline_events_get(
+        self, storyline_id: str, *, network_id: Optional[str] = None
+    ) -> Optional[List[Dict[str, Any]]]:
+        """List events in a storyline along with their properties."""
+        args: Dict[str, Any] = {"storylineId": storyline_id}
+        if network_id:
+            args["networkId"] = network_id
+        try:
+            result = self._call_mcp_tool("storyline-events-get", args)
+            return _extract_list(result, ("events", "results", "items", "data"))
+        except RuntimeError as e:
+            logger.error("VStrike storyline-events-get failed: %s", e)
+            return None
+
+    def legend_run_list(
+        self, *, network_id: Optional[str] = None
+    ) -> Optional[List[Dict[str, Any]]]:
+        """List legend runs available for the network."""
+        args: Dict[str, Any] = {}
+        if network_id:
+            args["networkId"] = network_id
+        try:
+            result = self._call_mcp_tool("legend-run-list", args)
+            return _extract_list(result, ("legendRuns", "results", "items", "data"))
+        except RuntimeError as e:
+            logger.error("VStrike legend-run-list failed: %s", e)
+            return None
+
+    def legend_run_results_get(
+        self, legend_run_id: str, *, network_id: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Return results for the specified legend run."""
+        args: Dict[str, Any] = {"legendRunId": legend_run_id}
+        if network_id:
+            args["networkId"] = network_id
+        try:
+            result = self._call_mcp_tool("legend-run-results-get", args)
+            if isinstance(result, dict):
+                # Unwrap structuredContent if present (VStrike's typed payload).
+                structured = result.get("structuredContent")
+                if isinstance(structured, dict):
+                    return structured
+                # If the dict only contains a content envelope with JSON text,
+                # parse the first text chunk.
+                content = result.get("content")
+                if isinstance(content, list) and content:
+                    text = content[0].get("text") if isinstance(content[0], dict) else None
+                    if isinstance(text, str):
+                        try:
+                            parsed = json.loads(text)
+                        except (json.JSONDecodeError, TypeError):
+                            parsed = None
+                        if isinstance(parsed, dict):
+                            return parsed
+                return result
+            if isinstance(result, list) and result:
+                return {"results": result}
+            return None
+        except RuntimeError as e:
+            logger.error("VStrike legend-run-results-get failed: %s", e)
+            return None
+
+    # ------------------------------------------------------------------ #
+    # UI control-plane MCP tools (camera, storyline, VCR)
+    # ------------------------------------------------------------------ #
+
+    def ui_camera_node(
+        self, node_ids: List[str], *, network_id: Optional[str] = None
+    ) -> Any:
+        """Move the camera to focus on the nodes provided."""
+        args: Dict[str, Any] = {"nodeIds": node_ids}
+        if network_id:
+            args["networkId"] = network_id
+        return self._call_mcp_tool("ui-camera-node", args)
+
+    def ui_camera_position(
+        self,
+        position: Dict[str, float],
+        rotation: Optional[Dict[str, float]] = None,
+        *,
+        network_id: Optional[str] = None,
+    ) -> Any:
+        """Set the camera position and rotation explicitly."""
+        args: Dict[str, Any] = {"position": position}
+        if rotation:
+            args["rotation"] = rotation
+        if network_id:
+            args["networkId"] = network_id
+        return self._call_mcp_tool("ui-camera-position", args)
+
+    def ui_storyline_apply(
+        self, storyline_id: str, *, network_id: Optional[str] = None
+    ) -> Any:
+        """Apply the specified storyline to the active network view."""
+        args: Dict[str, Any] = {"storylineId": storyline_id}
+        if network_id:
+            args["networkId"] = network_id
+        return self._call_mcp_tool("ui-storyline-apply", args)
+
+    def ui_storyline_mode(
+        self, mode: str, *, network_id: Optional[str] = None
+    ) -> Any:
+        """Set the timeslice mode for the VCR controls and reset frame counters."""
+        args: Dict[str, Any] = {"mode": mode}
+        if network_id:
+            args["networkId"] = network_id
+        return self._call_mcp_tool("ui-storyline-mode", args)
+
+    def ui_storyline_forward(
+        self, *, network_id: Optional[str] = None
+    ) -> Any:
+        """Step forward in the storyline timeline."""
+        args: Dict[str, Any] = {}
+        if network_id:
+            args["networkId"] = network_id
+        return self._call_mcp_tool("ui-storyline-forward", args)
+
+    def ui_storyline_backward(
+        self, *, network_id: Optional[str] = None
+    ) -> Any:
+        """Step backward in the storyline timeline."""
+        args: Dict[str, Any] = {}
+        if network_id:
+            args["networkId"] = network_id
+        return self._call_mcp_tool("ui-storyline-backward", args)
 
 
 def _config_value(key: str, config: Optional[Dict[str, Any]]) -> Optional[str]:

--- a/tests/integration/test_vstrike_ui_routes.py
+++ b/tests/integration/test_vstrike_ui_routes.py
@@ -260,3 +260,256 @@ def test_killchain_replay_503_without_ui_credentials():
             asyncio.run(vstrike_module.ui_killchain_replay(_make_killchain_request()))
 
     assert exc_info.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Data-plane proxies (node search, drift, storylines, legends)
+# ---------------------------------------------------------------------------
+
+
+def _mock_data_service(**overrides):
+    svc = _mock_ui_service(**overrides)
+    svc.node_search.return_value = overrides.get(
+        "node_search", [{"node_id": "n1", "node_name": "Router-A"}]
+    )
+    svc.node_drift_get.return_value = overrides.get(
+        "node_drift", [{"timestamp": "t1", "source": "cve"}]
+    )
+    svc.storyline_list.return_value = overrides.get(
+        "storylines", [{"storyline_id": "s1", "name": "Exfil"}]
+    )
+    svc.storyline_events_get.return_value = overrides.get(
+        "storyline_events", [{"event_id": "e1", "timestamp": "t1"}]
+    )
+    svc.legend_run_list.return_value = overrides.get(
+        "legend_runs", [{"legend_run_id": "lr1", "name": "CVE-2026-001"}]
+    )
+    svc.legend_run_results_get.return_value = overrides.get(
+        "legend_results", {"legend_run_id": "lr1", "results": {"critical": 3}}
+    )
+    return svc
+
+
+def test_node_search_returns_results():
+    from backend.api import vstrike as vstrike_module
+    from backend.api.vstrike import VStrikeNodeSearchRequest
+
+    svc = _mock_data_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(
+            vstrike_module.node_search(VStrikeNodeSearchRequest(query="router", network_id="net-1", limit=10))
+        )
+
+    assert result["query"] == "router"
+    assert result["results"] == [{"node_id": "n1", "node_name": "Router-A"}]
+    svc.node_search.assert_called_once_with("router", network_id="net-1", limit=10)
+
+
+def test_node_search_503_without_ui_credentials():
+    from backend.api import vstrike as vstrike_module
+    from backend.api.vstrike import VStrikeNodeSearchRequest
+
+    svc = _mock_data_service(has_ui_credentials=False)
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(vstrike_module.node_search(VStrikeNodeSearchRequest(query="x")))
+
+    assert exc_info.value.status_code == 503
+
+
+def test_node_drift_returns_drift():
+    from backend.api import vstrike as vstrike_module
+    from backend.api.vstrike import VStrikeNodeDriftRequest
+
+    svc = _mock_data_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(
+            vstrike_module.node_drift(VStrikeNodeDriftRequest(node_id="node-1", network_id="net-1"))
+        )
+
+    assert result["node_id"] == "node-1"
+    assert result["drift"] == [{"timestamp": "t1", "source": "cve"}]
+    svc.node_drift_get.assert_called_once_with("node-1", network_id="net-1")
+
+
+def test_list_storylines_returns_storylines():
+    from backend.api import vstrike as vstrike_module
+
+    svc = _mock_data_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(vstrike_module.list_storylines("net-1"))
+
+    assert result["storylines"] == [{"storyline_id": "s1", "name": "Exfil"}]
+    svc.storyline_list.assert_called_once_with(network_id="net-1")
+
+
+def test_storyline_events_returns_events():
+    from backend.api import vstrike as vstrike_module
+    from backend.api.vstrike import VStrikeStorylineEventsRequest
+
+    svc = _mock_data_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(
+            vstrike_module.storyline_events(VStrikeStorylineEventsRequest(storyline_id="s1", network_id="net-1"))
+        )
+
+    assert result["storyline_id"] == "s1"
+    assert result["events"] == [{"event_id": "e1", "timestamp": "t1"}]
+    svc.storyline_events_get.assert_called_once_with("s1", network_id="net-1")
+
+
+def test_list_legend_runs_returns_runs():
+    from backend.api import vstrike as vstrike_module
+
+    svc = _mock_data_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(vstrike_module.list_legend_runs("net-1"))
+
+    assert result["legend_runs"] == [{"legend_run_id": "lr1", "name": "CVE-2026-001"}]
+    svc.legend_run_list.assert_called_once_with(network_id="net-1")
+
+
+def test_legend_run_results_returns_results():
+    from backend.api import vstrike as vstrike_module
+    from backend.api.vstrike import VStrikeLegendRunResultsRequest
+
+    svc = _mock_data_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(
+            vstrike_module.legend_run_results(VStrikeLegendRunResultsRequest(legend_run_id="lr1", network_id="net-1"))
+        )
+
+    assert result["legend_run_id"] == "lr1"
+    assert result["results"] == {"legend_run_id": "lr1", "results": {"critical": 3}}
+    svc.legend_run_results_get.assert_called_once_with("lr1", network_id="net-1")
+
+
+# ---------------------------------------------------------------------------
+# UI control plane (camera, storyline, VCR playback)
+# ---------------------------------------------------------------------------
+
+
+def _mock_ui_control_service(**overrides):
+    svc = _mock_ui_service(**overrides)
+    svc.ui_camera_node.return_value = overrides.get("camera_node", {"ok": True})
+    svc.ui_camera_position.return_value = overrides.get("camera_position", {"ok": True})
+    svc.ui_storyline_apply.return_value = overrides.get("storyline_apply", {"ok": True})
+    svc.ui_storyline_mode.return_value = overrides.get("storyline_mode", {"ok": True})
+    svc.ui_storyline_forward.return_value = overrides.get("storyline_forward", {"ok": True})
+    svc.ui_storyline_backward.return_value = overrides.get("storyline_backward", {"ok": True})
+    return svc
+
+
+def test_ui_camera_node_calls_service():
+    from backend.api import vstrike as vstrike_module
+    from backend.api.vstrike import VStrikeCameraNodeRequest
+
+    svc = _mock_ui_control_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(
+            vstrike_module.ui_camera_node(VStrikeCameraNodeRequest(node_ids=["n1", "n2"], network_id="net-1"))
+        )
+
+    assert result["ok"] is True
+    svc.ui_camera_node.assert_called_once_with(["n1", "n2"], network_id="net-1")
+
+
+def test_ui_camera_position_calls_service():
+    from backend.api import vstrike as vstrike_module
+    from backend.api.vstrike import VStrikeCameraPositionRequest
+
+    svc = _mock_ui_control_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(
+            vstrike_module.ui_camera_position(
+                VStrikeCameraPositionRequest(
+                    position={"x": 1.0, "y": 2.0, "z": 3.0},
+                    rotation={"pitch": 0.5},
+                    network_id="net-1",
+                )
+            )
+        )
+
+    assert result["ok"] is True
+    svc.ui_camera_position.assert_called_once_with(
+        {"x": 1.0, "y": 2.0, "z": 3.0},
+        rotation={"pitch": 0.5},
+        network_id="net-1",
+    )
+
+
+def test_ui_storyline_apply_calls_service():
+    from backend.api import vstrike as vstrike_module
+    from backend.api.vstrike import VStrikeStorylineApplyRequest
+
+    svc = _mock_ui_control_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(
+            vstrike_module.ui_storyline_apply(VStrikeStorylineApplyRequest(storyline_id="s1", network_id="net-1"))
+        )
+
+    assert result["ok"] is True
+    svc.ui_storyline_apply.assert_called_once_with("s1", network_id="net-1")
+
+
+def test_ui_storyline_mode_calls_service():
+    from backend.api import vstrike as vstrike_module
+    from backend.api.vstrike import VStrikeStorylineModeRequest
+
+    svc = _mock_ui_control_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(
+            vstrike_module.ui_storyline_mode(VStrikeStorylineModeRequest(mode="replay", network_id="net-1"))
+        )
+
+    assert result["ok"] is True
+    svc.ui_storyline_mode.assert_called_once_with("replay", network_id="net-1")
+
+
+def test_ui_storyline_forward_calls_service():
+    from backend.api import vstrike as vstrike_module
+
+    svc = _mock_ui_control_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(vstrike_module.ui_storyline_forward("net-1"))
+
+    assert result["ok"] is True
+    svc.ui_storyline_forward.assert_called_once_with(network_id="net-1")
+
+
+def test_ui_storyline_backward_calls_service():
+    from backend.api import vstrike as vstrike_module
+
+    svc = _mock_ui_control_service()
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        result = asyncio.run(vstrike_module.ui_storyline_backward("net-1"))
+
+    assert result["ok"] is True
+    svc.ui_storyline_backward.assert_called_once_with(network_id="net-1")
+
+
+def test_ui_camera_node_501_when_tool_not_implemented():
+    from backend.api import vstrike as vstrike_module
+    from backend.api.vstrike import VStrikeCameraNodeRequest
+    from services.vstrike_service import VStrikeToolNotImplemented
+
+    svc = _mock_ui_control_service()
+    svc.ui_camera_node.side_effect = VStrikeToolNotImplemented("ui-camera-node not implemented")
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(vstrike_module.ui_camera_node(VStrikeCameraNodeRequest(node_ids=["n1"])))
+
+    assert exc_info.value.status_code == 501
+
+
+def test_ui_storyline_forward_502_on_runtime_error():
+    from backend.api import vstrike as vstrike_module
+
+    svc = _mock_ui_control_service()
+    svc.ui_storyline_forward.side_effect = RuntimeError("websocket closed")
+    with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(vstrike_module.ui_storyline_forward("net-1"))
+
+    assert exc_info.value.status_code == 502
+    assert "websocket closed" in str(exc_info.value.detail)

--- a/tests/unit/test_vstrike_mcp_server.py
+++ b/tests/unit/test_vstrike_mcp_server.py
@@ -1,0 +1,180 @@
+"""Unit tests for tools/vstrike.py (MCP server)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import tools.vstrike as vstrike_module  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clear_service_cache():
+    """Ensure each test starts with a fresh service lookup."""
+    yield
+
+
+@pytest.fixture
+def mock_service():
+    svc = MagicMock()
+    svc.get_asset_topology.return_value = {"asset_id": "a1", "segment": "dmz"}
+    svc.list_adjacent.return_value = [{"asset_id": "a2", "hop_distance": 1}]
+    svc.get_blast_radius.return_value = {"count": 5, "sample": ["a3"]}
+    svc.find_findings_by_segment.return_value = [{"finding_id": "f1"}]
+    svc.node_search.return_value = [{"node_id": "n1", "node_name": "Router"}]
+    svc.node_drift_get.return_value = [{"timestamp": "t1", "source": "cve"}]
+    svc.storyline_list.return_value = [{"storyline_id": "s1", "name": "Exfil"}]
+    svc.storyline_events_get.return_value = [{"event_id": "e1", "timestamp": "t1"}]
+    svc.legend_run_list.return_value = [{"legend_run_id": "lr1", "name": "CVE"}]
+    svc.legend_run_results_get.return_value = {"critical": 3}
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Tool listing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_list_tools_includes_all_tools():
+    tools = await vstrike_module.handle_list_tools()
+    names = {t.name for t in tools}
+    expected = {
+        "vstrike_get_asset_topology",
+        "vstrike_list_adjacent_assets",
+        "vstrike_get_blast_radius",
+        "vstrike_get_segment_findings",
+        "vstrike_node_search",
+        "vstrike_node_drift_get",
+        "vstrike_storyline_list",
+        "vstrike_storyline_events_get",
+        "vstrike_legend_run_list",
+        "vstrike_legend_run_results_get",
+    }
+    assert expected.issubset(names)
+
+
+# ---------------------------------------------------------------------------
+# Existing tools (regression check)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_tool_get_asset_topology(mock_service):
+    with patch.object(vstrike_module, "_get_service", return_value=mock_service):
+        result = await vstrike_module.handle_call_tool(
+            "vstrike_get_asset_topology", {"asset_id": "a1"}
+        )
+    data = json.loads(result[0].text)
+    assert data["asset_id"] == "a1"
+    assert data["topology"]["segment"] == "dmz"
+
+
+# ---------------------------------------------------------------------------
+# New data-plane tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_tool_node_search(mock_service):
+    with patch.object(vstrike_module, "_get_service", return_value=mock_service):
+        result = await vstrike_module.handle_call_tool(
+            "vstrike_node_search", {"query": "router", "network_id": "net-1", "limit": 10}
+        )
+    data = json.loads(result[0].text)
+    assert data["query"] == "router"
+    assert data["results"] == [{"node_id": "n1", "node_name": "Router"}]
+    mock_service.node_search.assert_called_once_with("router", network_id="net-1", limit=10)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_node_search_requires_query(mock_service):
+    with patch.object(vstrike_module, "_get_service", return_value=mock_service):
+        result = await vstrike_module.handle_call_tool(
+            "vstrike_node_search", {"network_id": "net-1"}
+        )
+    data = json.loads(result[0].text)
+    assert "error" in data
+
+
+@pytest.mark.asyncio
+async def test_call_tool_node_drift_get(mock_service):
+    with patch.object(vstrike_module, "_get_service", return_value=mock_service):
+        result = await vstrike_module.handle_call_tool(
+            "vstrike_node_drift_get", {"node_id": "n1", "network_id": "net-1"}
+        )
+    data = json.loads(result[0].text)
+    assert data["node_id"] == "n1"
+    assert data["drift"] == [{"timestamp": "t1", "source": "cve"}]
+    mock_service.node_drift_get.assert_called_once_with("n1", network_id="net-1")
+
+
+@pytest.mark.asyncio
+async def test_call_tool_storyline_list(mock_service):
+    with patch.object(vstrike_module, "_get_service", return_value=mock_service):
+        result = await vstrike_module.handle_call_tool(
+            "vstrike_storyline_list", {"network_id": "net-1"}
+        )
+    data = json.loads(result[0].text)
+    assert data["storylines"] == [{"storyline_id": "s1", "name": "Exfil"}]
+    mock_service.storyline_list.assert_called_once_with(network_id="net-1")
+
+
+@pytest.mark.asyncio
+async def test_call_tool_storyline_events_get(mock_service):
+    with patch.object(vstrike_module, "_get_service", return_value=mock_service):
+        result = await vstrike_module.handle_call_tool(
+            "vstrike_storyline_events_get", {"storyline_id": "s1", "network_id": "net-1"}
+        )
+    data = json.loads(result[0].text)
+    assert data["storyline_id"] == "s1"
+    assert data["events"] == [{"event_id": "e1", "timestamp": "t1"}]
+    mock_service.storyline_events_get.assert_called_once_with("s1", network_id="net-1")
+
+
+@pytest.mark.asyncio
+async def test_call_tool_legend_run_list(mock_service):
+    with patch.object(vstrike_module, "_get_service", return_value=mock_service):
+        result = await vstrike_module.handle_call_tool(
+            "vstrike_legend_run_list", {"network_id": "net-1"}
+        )
+    data = json.loads(result[0].text)
+    assert data["legend_runs"] == [{"legend_run_id": "lr1", "name": "CVE"}]
+    mock_service.legend_run_list.assert_called_once_with(network_id="net-1")
+
+
+@pytest.mark.asyncio
+async def test_call_tool_legend_run_results_get(mock_service):
+    with patch.object(vstrike_module, "_get_service", return_value=mock_service):
+        result = await vstrike_module.handle_call_tool(
+            "vstrike_legend_run_results_get", {"legend_run_id": "lr1", "network_id": "net-1"}
+        )
+    data = json.loads(result[0].text)
+    assert data["legend_run_id"] == "lr1"
+    assert data["results"] == {"critical": 3}
+    mock_service.legend_run_results_get.assert_called_once_with("lr1", network_id="net-1")
+
+
+# ---------------------------------------------------------------------------
+# Service unconfigured
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_tool_returns_error_when_service_missing():
+    with patch.object(vstrike_module, "_get_service", return_value=None):
+        result = await vstrike_module.handle_call_tool(
+            "vstrike_node_search", {"query": "router"}
+        )
+    data = json.loads(result[0].text)
+    assert "error" in data
+    assert "not configured" in data["error"].lower()

--- a/tests/unit/test_vstrike_service.py
+++ b/tests/unit/test_vstrike_service.py
@@ -534,6 +534,247 @@ def test_iframe_url_embeds_token():
 
 
 # ---------------------------------------------------------------------------
+# New data-plane MCP tools (node search, drift, storylines, legends)
+# ---------------------------------------------------------------------------
+
+
+def test_node_search_passes_query_and_network_id():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    body = {
+        "result": {
+            "content": [
+                {"type": "text", "text": '{"nodes": [{"node_id": "n1", "name": "Router-A"}]}'}
+            ]
+        }
+    }
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body=body),
+    ) as mock_post:
+        result = svc.node_search("router", network_id="net-1", limit=10)
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["params"]["name"] == "node-search"
+    args = payload["params"]["arguments"]
+    assert args["query"] == "router"
+    assert args["networkId"] == "net-1"
+    assert args["limit"] == 10
+    assert result == [{"node_id": "n1", "name": "Router-A"}]
+
+
+def test_node_search_returns_none_on_error():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(500, text="boom"),
+    ):
+        assert svc.node_search("x") is None
+
+
+def test_node_drift_get_passes_node_id():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    body = {
+        "result": {
+            "content": [
+                {"type": "text", "text": '{"drift": [{"timestamp": "t1", "source": "cve"}]}'}
+            ]
+        }
+    }
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body=body),
+    ) as mock_post:
+        result = svc.node_drift_get("node-1", network_id="net-1")
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["params"]["name"] == "node-drift-get"
+    assert payload["params"]["arguments"]["nodeId"] == "node-1"
+    assert payload["params"]["arguments"]["networkId"] == "net-1"
+    assert result == [{"timestamp": "t1", "source": "cve"}]
+
+
+def test_storyline_list_returns_storylines():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    body = {
+        "result": {
+            "content": [
+                {"type": "text", "text": '{"storylines": [{"storyline_id": "s1", "name": "Exfil"}]}'}
+            ]
+        }
+    }
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body=body),
+    ):
+        result = svc.storyline_list(network_id="net-1")
+    assert result == [{"storyline_id": "s1", "name": "Exfil"}]
+
+
+def test_storyline_events_get_passes_storyline_id():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    body = {
+        "result": {
+            "content": [
+                {"type": "text", "text": '{"events": [{"event_id": "e1", "timestamp": "t1"}]}'}
+            ]
+        }
+    }
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body=body),
+    ) as mock_post:
+        result = svc.storyline_events_get("s1", network_id="net-1")
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["params"]["name"] == "storyline-events-get"
+    assert payload["params"]["arguments"]["storylineId"] == "s1"
+    assert result == [{"event_id": "e1", "timestamp": "t1"}]
+
+
+def test_legend_run_list_returns_runs():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    body = {
+        "result": {
+            "content": [
+                {"type": "text", "text": '{"legendRuns": [{"legend_run_id": "lr1", "name": "CVE-2026-001"}]}'}
+            ]
+        }
+    }
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body=body),
+    ):
+        result = svc.legend_run_list(network_id="net-1")
+    assert result == [{"legend_run_id": "lr1", "name": "CVE-2026-001"}]
+
+
+def test_legend_run_results_get_returns_dict():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    body = {
+        "result": {
+            "content": [
+                {"type": "text", "text": '{"legend_run_id": "lr1", "results": {"critical": 3}}'}
+            ]
+        }
+    }
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body=body),
+    ) as mock_post:
+        result = svc.legend_run_results_get("lr1", network_id="net-1")
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["params"]["name"] == "legend-run-results-get"
+    assert payload["params"]["arguments"]["legendRunId"] == "lr1"
+    assert result == {"legend_run_id": "lr1", "results": {"critical": 3}}
+
+
+# ---------------------------------------------------------------------------
+# New UI control-plane MCP tools (camera, storyline, VCR)
+# ---------------------------------------------------------------------------
+
+
+def test_ui_camera_node_passes_node_ids():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body={"result": {"ok": True}}),
+    ) as mock_post:
+        svc.ui_camera_node(["n1", "n2"], network_id="net-1")
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["params"]["name"] == "ui-camera-node"
+    args = payload["params"]["arguments"]
+    assert args["nodeIds"] == ["n1", "n2"]
+    assert args["networkId"] == "net-1"
+
+
+def test_ui_camera_position_passes_position_and_rotation():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body={"result": {"ok": True}}),
+    ) as mock_post:
+        svc.ui_camera_position(
+            {"x": 1.0, "y": 2.0, "z": 3.0},
+            {"pitch": 0.5, "yaw": 1.0},
+            network_id="net-1",
+        )
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["params"]["name"] == "ui-camera-position"
+    args = payload["params"]["arguments"]
+    assert args["position"] == {"x": 1.0, "y": 2.0, "z": 3.0}
+    assert args["rotation"] == {"pitch": 0.5, "yaw": 1.0}
+    assert args["networkId"] == "net-1"
+
+
+def test_ui_storyline_apply_passes_storyline_id():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body={"result": {"ok": True}}),
+    ) as mock_post:
+        svc.ui_storyline_apply("s1", network_id="net-1")
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["params"]["name"] == "ui-storyline-apply"
+    assert payload["params"]["arguments"]["storylineId"] == "s1"
+
+
+def test_ui_storyline_mode_passes_mode():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body={"result": {"ok": True}}),
+    ) as mock_post:
+        svc.ui_storyline_mode("replay", network_id="net-1")
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["params"]["name"] == "ui-storyline-mode"
+    assert payload["params"]["arguments"]["mode"] == "replay"
+
+
+def test_ui_storyline_forward_passes_network_id():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body={"result": {"ok": True}}),
+    ) as mock_post:
+        svc.ui_storyline_forward(network_id="net-1")
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["params"]["name"] == "ui-storyline-forward"
+    assert payload["params"]["arguments"]["networkId"] == "net-1"
+
+
+def test_ui_storyline_backward_passes_network_id():
+    svc = _ui_service()
+    _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
+    with patch(
+        "services.vstrike_service.requests.post",
+        return_value=_mock_response(200, json_body={"result": {"ok": True}}),
+    ) as mock_post:
+        svc.ui_storyline_backward(network_id="net-1")
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["params"]["name"] == "ui-storyline-backward"
+    assert payload["params"]["arguments"]["networkId"] == "net-1"
+
+
+# ---------------------------------------------------------------------------
 # Wire-format regressions discovered against the live VStrike server
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_workflow_discovery.py
+++ b/tests/unit/test_workflow_discovery.py
@@ -1,0 +1,55 @@
+"""Unit tests for file-based workflow discovery.
+
+Ensures that new workflows added to the workflows/ directory are correctly
+parsed and exposed by WorkflowsService.
+"""
+
+import pytest
+
+from services.workflows_service import WorkflowsService
+
+
+def test_cloud_incident_workflow_is_discovered():
+    """The cloud-incident workflow should load from disk with correct metadata."""
+    service = WorkflowsService()
+
+    wf = service.get_workflow("cloud-incident")
+    assert wf is not None, "cloud-incident workflow should be discovered"
+    assert wf.name == "cloud-incident"
+    assert wf.id == "cloud-incident"
+    assert "aws" in wf.description.lower() or "azure" in wf.description.lower()
+
+    expected_agents = {"investigator", "correlator", "mitre_analyst", "responder", "reporter"}
+    assert expected_agents.issubset(set(wf.agents)), f"Expected agents {expected_agents}, got {wf.agents}"
+
+    # Basic tools should be declared in frontmatter
+    assert "get_finding" in wf.tools_used
+    assert "create_approval_action" in wf.tools_used
+
+    # Body should contain cloud-specific guidance
+    body_lower = wf.body.lower()
+    assert "control-plane" in body_lower or "control plane" in body_lower
+    assert "cross-account" in body_lower or "cross account" in body_lower
+    assert "blast radius" in body_lower
+
+
+def test_cloud_incident_in_list_workflows():
+    """list_workflows should include the cloud-incident definition."""
+    service = WorkflowsService()
+    workflows = service.list_workflows()
+    ids = [w["id"] for w in workflows]
+    assert "cloud-incident" in ids
+
+    cloud_wf = next(w for w in workflows if w["id"] == "cloud-incident")
+    assert cloud_wf["name"] == "cloud-incident"
+    assert "investigator" in cloud_wf["agents"]
+
+
+def test_cloud_incident_workflow_dict():
+    """get_workflow_dict should return serializable metadata and body."""
+    service = WorkflowsService()
+    d = service.get_workflow_dict("cloud-incident", include_body=True)
+    assert d is not None
+    assert d["id"] == "cloud-incident"
+    assert "body" in d
+    assert "cloud" in d["body"].lower()

--- a/tools/vstrike.py
+++ b/tools/vstrike.py
@@ -8,6 +8,12 @@ Tools:
   - vstrike_list_adjacent_assets
   - vstrike_get_blast_radius
   - vstrike_get_segment_findings
+  - vstrike_node_search
+  - vstrike_node_drift_get
+  - vstrike_storyline_list
+  - vstrike_storyline_events_get
+  - vstrike_legend_run_list
+  - vstrike_legend_run_results_get
 """
 
 import asyncio
@@ -107,6 +113,91 @@ async def handle_list_tools():
                 "required": ["segment"],
             },
         ),
+        types.Tool(
+            name="vstrike_node_search",
+            description=(
+                "Omni-search across nodes in the active VStrike network. "
+                "Returns the nodes that caused the match."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "network_id": {"type": "string"},
+                    "limit": {"type": "integer", "default": 50},
+                },
+                "required": ["query"],
+            },
+        ),
+        types.Tool(
+            name="vstrike_node_drift_get",
+            description=(
+                "Returns the list of end-node state changes in order for the "
+                "supplied node and what source identified each change."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "node_id": {"type": "string"},
+                    "network_id": {"type": "string"},
+                },
+                "required": ["node_id"],
+            },
+        ),
+        types.Tool(
+            name="vstrike_storyline_list",
+            description=(
+                "List the storylines available for the network."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "network_id": {"type": "string"},
+                },
+                "required": [],
+            },
+        ),
+        types.Tool(
+            name="vstrike_storyline_events_get",
+            description=(
+                "List the events in the storylines along with their properties."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "storyline_id": {"type": "string"},
+                    "network_id": {"type": "string"},
+                },
+                "required": ["storyline_id"],
+            },
+        ),
+        types.Tool(
+            name="vstrike_legend_run_list",
+            description=(
+                "List the legend runs available for the network."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "network_id": {"type": "string"},
+                },
+                "required": [],
+            },
+        ),
+        types.Tool(
+            name="vstrike_legend_run_results_get",
+            description=(
+                "Returns the results for the legend provided."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "legend_run_id": {"type": "string"},
+                    "network_id": {"type": "string"},
+                },
+                "required": ["legend_run_id"],
+            },
+        ),
     ]
 
 
@@ -163,6 +254,61 @@ async def handle_call_tool(name: str, arguments: dict | None):
         return _result(
             {"segment": segment, "count": len(findings), "findings": findings}
         )
+
+    if name == "vstrike_node_search":
+        query = args.get("query")
+        if not query:
+            return _result({"error": "query required"})
+        network_id = args.get("network_id")
+        limit = int(args.get("limit", 50))
+        result = service.node_search(query, network_id=network_id, limit=limit)
+        if result is None:
+            return _result({"error": f"Node search failed for query {query}"})
+        return _result({"query": query, "network_id": network_id, "results": result})
+
+    if name == "vstrike_node_drift_get":
+        node_id = args.get("node_id")
+        if not node_id:
+            return _result({"error": "node_id required"})
+        network_id = args.get("network_id")
+        result = service.node_drift_get(node_id, network_id=network_id)
+        if result is None:
+            return _result({"error": f"Node drift failed for {node_id}"})
+        return _result({"node_id": node_id, "network_id": network_id, "drift": result})
+
+    if name == "vstrike_storyline_list":
+        network_id = args.get("network_id")
+        result = service.storyline_list(network_id=network_id)
+        if result is None:
+            return _result({"error": "Storyline list failed"})
+        return _result({"network_id": network_id, "storylines": result})
+
+    if name == "vstrike_storyline_events_get":
+        storyline_id = args.get("storyline_id")
+        if not storyline_id:
+            return _result({"error": "storyline_id required"})
+        network_id = args.get("network_id")
+        result = service.storyline_events_get(storyline_id, network_id=network_id)
+        if result is None:
+            return _result({"error": f"Storyline events failed for {storyline_id}"})
+        return _result({"storyline_id": storyline_id, "network_id": network_id, "events": result})
+
+    if name == "vstrike_legend_run_list":
+        network_id = args.get("network_id")
+        result = service.legend_run_list(network_id=network_id)
+        if result is None:
+            return _result({"error": "Legend run list failed"})
+        return _result({"network_id": network_id, "legend_runs": result})
+
+    if name == "vstrike_legend_run_results_get":
+        legend_run_id = args.get("legend_run_id")
+        if not legend_run_id:
+            return _result({"error": "legend_run_id required"})
+        network_id = args.get("network_id")
+        result = service.legend_run_results_get(legend_run_id, network_id=network_id)
+        if result is None:
+            return _result({"error": f"Legend run results failed for {legend_run_id}"})
+        return _result({"legend_run_id": legend_run_id, "network_id": network_id, "results": result})
 
     return _result({"error": f"Unknown tool: {name}"})
 

--- a/workflows/cloud-incident/WORKFLOW.md
+++ b/workflows/cloud-incident/WORKFLOW.md
@@ -1,0 +1,235 @@
+---
+name: cloud-incident
+description: "Investigate and respond to cloud security incidents across AWS, Azure, and GCP. Covers identity blast-radius, IAM/role analysis, control-plane vs data-plane attacks, cross-account/cross-tenant pivots, and provider-aware containment."
+agents:
+  - investigator
+  - correlator
+  - mitre_analyst
+  - responder
+  - reporter
+tools-used:
+  - get_finding
+  - list_findings
+  - nearest_neighbors
+  - search_detections
+  - get_technique_rollup
+  - create_attack_layer
+  - create_case
+  - create_approval_action
+  - update_case
+  - get_case
+use-case: "Cloud-native incident response — compromised credentials, IAM policy abuse, unauthorized data access, cross-account pivoting, or control-plane attacks in AWS, Azure, or GCP."
+trigger-examples:
+  - "Run cloud incident response on finding f-20260215-abc123"
+  - "Investigate this suspicious IAM activity in AWS"
+  - "Cloud incident: unauthorized S3 access from external IP"
+  - "Respond to Azure AD credential compromise alert"
+  - "Run cloud-incident workflow for this GCP SCC finding"
+---
+
+# Cloud Incident Investigation Workflow
+
+Multi-agent cloud incident response workflow. Sequences five specialized agents to gather cloud-specific evidence, correlate across accounts and tenants, map to cloud MITRE ATT&CK techniques, execute provider-aware containment, and produce a cloud-focused incident report.
+
+## When to Use
+
+- A cloud security alert has fired (GuardDuty, Security Hub, Azure Sentinel, GCP SCC, Chronicle)
+- IAM or identity-related anomaly is detected in AWS, Azure, or GCP
+- Unauthorized data access or exfiltration from cloud storage (S3, Blob, GCS)
+- Cross-account or cross-tenant suspicious activity is observed
+- Control-plane API abuse is detected (CloudTrail, Azure Activity Logs, GCP Audit Logs)
+- A finding involves cloud credentials, service accounts, or federation tokens
+
+## Agent Sequence
+
+### Phase 1: Cloud Evidence Gathering (Investigator Agent)
+
+**Purpose:** Root-cause analysis in cloud environments — collect audit logs, enumerate affected resources, and determine control-plane vs data-plane scope.
+
+**Tools:** `get_finding`, `list_findings`, `nearest_neighbors`, `search_detections`
+
+**Steps:**
+1. Fetch the target finding via `get_finding` and identify the cloud provider (AWS, Azure, GCP)
+2. Identify affected scope: account ID / subscription ID / project ID, region(s), organization/tenant
+3. Gather cloud audit logs:
+   - AWS: CloudTrail (management events + data events if available)
+   - Azure: Activity Logs + Azure Diagnostics
+   - GCP: Cloud Audit Logs (Admin Activity + Data Access)
+4. Determine attack plane:
+   - Control-plane: IAM changes, role assumption, policy modifications, resource creation/deletion
+   - Data-plane: direct object access (S3, Blob, GCS), database queries, compute metadata API abuse
+5. Enumerate affected resources: EC2 instances, S3 buckets, Lambda functions, Azure VMs, Storage Accounts, Entra users, GCP Compute Engine, Cloud Storage, service accounts
+6. Collect IAM/identity evidence: role assumption chains, access key usage, OAuth token grants, SAML/SSO sign-ins, conditional access failures
+7. Identify initial access vector: compromised credentials, leaked keys, instance metadata service abuse, supply chain, misconfigured bucket
+8. Use `nearest_neighbors` to find related findings via embedding similarity
+9. Document chain of evidence with cloud-native identifiers (ARNs, resource IDs, subscription IDs)
+
+**Output:** Cloud provider(s), affected accounts/subscriptions/projects, resource inventory, control-plane vs data-plane scope, IAM evidence chain, initial access vector, related findings
+
+### Phase 2: Cross-Cloud Correlation (Correlator Agent)
+
+**Purpose:** Link cloud events across providers, accounts, and tenants. Identify identity blast-radius and cross-account/cross-tenant pivot attempts.
+
+**Tools:** `list_findings`, `create_case`, `get_technique_rollup`, `nearest_neighbors`
+
+**Steps:**
+1. Gather all findings from Phase 1 and search for correlated alerts via `list_findings`
+2. Correlate by identity blast-radius:
+   - Compromised IAM user/role → assumed roles in other accounts (AWS STS)
+   - Compromised Azure AD user → guest access in other tenants, B2B collaborations
+   - Compromised GCP service account → cross-project IAM bindings
+3. Detect cross-account / cross-tenant pivot attempts:
+   - Look for STS `AssumeRole` / `AssumeRoleWithSAML` / `AssumeRoleWithWebIdentity` to external accounts
+   - Look for Azure AD invitations to external domains
+   - Look for GCP IAM policy changes granting external principals
+4. Correlate control-plane API calls with data-plane exfiltration:
+   - Match `PutBucketPolicy` / `SetContainerACL` events with subsequent large data transfers
+   - Match `CreateAccessKey` events with immediate API usage from new IPs
+5. Assess blast radius by IAM trust boundaries and resource hierarchy:
+   - AWS: OU/SCP boundaries, IAM trust policies, service-linked roles
+   - Azure: Management group hierarchy, RBAC assignments, PIM elevations
+   - GCP: Organization policy constraints, IAM hierarchy, custom roles
+6. Score correlation strength:
+   - Time proximity (within minutes/hours): +0.2
+   - Entity overlap (shared IAM roles, service accounts, source IPs): +0.3
+   - Cross-account/tenant technique chain: +0.4
+7. Group correlated alerts into a case via `create_case`
+
+**Output:** Correlated alert groups, identity blast-radius map, cross-account/tenant pivot indicators, attack chain narrative, correlation scores, new case groupings
+
+### Phase 3: Cloud ATT&CK Mapping (MITRE Analyst Agent)
+
+**Purpose:** Map cloud TTPs to MITRE ATT&CK, with emphasis on cloud-specific techniques and kill-chain progression in multi-tenant environments.
+
+**Tools:** `get_finding`, `get_technique_rollup`, `create_attack_layer`
+
+**Steps:**
+1. Extract all MITRE technique IDs from findings and related alerts
+2. Map techniques to cloud-specific ATT&CK tactics and techniques:
+   - **Initial Access:** T1078.004 Valid Accounts: Cloud Accounts, T1078.005 Valid Accounts: Cloud Accounts (Intermittent), T1566 Phishing (cloud console credentials)
+   - **Execution:** T1059.008 Command and Scripting Interpreter: Network Device CLI (AWS CLI, Azure CLI, gcloud), T1648 Serverless Execution (Lambda, Azure Functions, Cloud Functions)
+   - **Persistence:** T1098.001 Additional Cloud Credentials, T1098.002 Additional Email Delegate Permissions, T1136.003 Create Account: Cloud Account
+   - **Privilege Escalation:** T1078.004 Valid Accounts: Cloud Accounts (role assumption), T1484 Domain Policy Modification (Azure AD), T1548 Abuse Elevation Control Mechanism (GCP IAM conditions)
+   - **Defense Evasion:** T1535 Unused/Unsupported Cloud Regions, T1562.008 Impair Defenses: Disable Cloud Logs, T1659 Content Delivery Network (CDN) abuse
+   - **Credential Access:** T1528 Steal Application Access Token, T1552.001 Credentials In Files (instance user-data, Azure Key Vault), T1652 Cloud Instance Metadata API
+   - **Discovery:** T1526 Cloud Service Discovery, T1613 Container and Resource Discovery, T1069.003 Permission Groups Discovery: Cloud Groups
+   - **Lateral Movement:** T1078.004 Valid Accounts: Cloud Accounts (cross-account), T1550 Use Alternate Authentication Material (OAuth tokens, SAML assertions)
+   - **Collection:** T1530 Data from Cloud Storage Object, T1213.003 Data from Information Repositories: Code Repositories
+   - **Exfiltration:** T1567.002 Exfiltration to Cloud Storage, T1048.003 Exfiltration Over Alternative Protocol: Exfiltration Over Unencrypted/Obfuscated Non-C2 Protocol
+3. Assess kill chain progression in cloud context:
+   - How far has the attacker advanced within the cloud environment?
+   - Have they achieved persistent access to the control plane?
+   - Have they escalated to organization-level privileges?
+4. Identify gaps in cloud detection coverage:
+   - Missing CloudTrail data events, missing Azure Diagnostics, missing GCP Data Access logs
+   - Gaps in IAM change alerting, missing cross-account anomaly detection
+5. Evaluate adversary sophistication based on cloud TTPs:
+   - Script-kiddie: exposed keys, public S3 buckets
+   - APT: instance metadata service abuse, cross-account role chaining, log tampering
+6. Generate ATT&CK Navigator layer visualization highlighting cloud techniques
+7. Recommend detection rules for coverage gaps (Sigma, CloudWatch Alarms, Azure Monitor, GCP Security Health Analytics)
+
+**Output:** Technique IDs with confidence, kill chain stage assessment, cloud ATT&CK Navigator layer, detection coverage gaps, adversary sophistication profile
+
+### Phase 4: Cloud Containment & Response (Responder Agent)
+
+**Purpose:** Execute provider-aware containment actions with confidence scoring and approval gating.
+
+**Tools:** `create_approval_action`, `update_case`, `get_finding`
+
+**Steps:**
+1. Review investigation results and affected entities from Phases 1-3
+2. Assess blast radius — what accounts, tenants, resources, and identities are at risk
+3. Plan provider-aware containment actions with confidence scores:
+   - **0.95-1.0:** Critical threat (active data exfiltration, confirmed control-plane compromise) — auto-approve
+   - **0.85-0.94:** High confidence (confirmed unauthorized cross-account role assumption) — quick review
+   - **0.70-0.84:** Moderate (suspicious API pattern from new IP) — human approval required
+   - Below 0.70: Needs more investigation
+4. Identity containment:
+   - Revoke sessions (Azure AD / Entra, GCP OAuth tokens)
+   - Disable compromised IAM users/roles (AWS IAM, Azure AD, GCP IAM)
+   - Rotate exposed access keys and disable leaked credentials
+   - Revoke SAML/OAuth tokens if identity provider is compromised
+5. Network containment:
+   - Isolate instances: AWS Security Group quarantine, Azure NSG deny-all, GCP firewall deny
+   - Block malicious IPs at Cloudflare WAF (`cf_waf_block_ip`) or Gateway (`cf_gateway_block_domain`)
+6. Data containment:
+   - Restrict S3/Blob/GCS bucket policies (remove public access, tighten ACLs)
+   - Enable bucket versioning and object lock if ransomware is suspected
+7. Forensic preservation:
+   - Snapshot compromised EC2/Azure VM/GCE instances before isolation
+   - Preserve CloudTrail/Activity Log/Audit Log exports for legal hold
+8. Submit containment actions via `create_approval_action`
+9. Define eradication steps: remove rogue IAM policies, close metadata service vulnerabilities, patch misconfigurations
+10. Plan recovery and monitoring: re-enable services with hardened configs, enable additional logging
+
+**Output:** Provider-aware containment actions with confidence scores, approval requests, remediation checklist, forensic preservation plan, blast radius assessment
+
+### Phase 5: Cloud Incident Report (Reporter Agent)
+
+**Purpose:** Generate a cloud-focused incident report with executive, technical, and compliance sections tailored to multi-cloud incidents.
+
+**Tools:** `get_case`, `list_findings`, `create_attack_layer`
+
+**Steps:**
+1. Gather all data from prior phases (case, findings, actions taken, cloud audit logs)
+2. Generate final MITRE ATT&CK Navigator layer for the incident
+3. Structure the cloud incident report:
+   - **Executive Summary:** Business impact in plain language, including cloud spend impact, regulatory exposure (GDPR, HIPAA, PCI-DSS, SOC 2), and customer/data-subject impact
+   - **Cloud Environment Overview:** Affected providers, accounts/subscriptions/projects, regions, and resource inventory
+   - **Technical Details:** Evidence chain for the security team, including ARN/resource ID references, IAM change timeline, and control-plane vs data-plane analysis
+   - **Timeline:** Chronological reconstruction of cloud audit log events
+   - **Identity Blast-Radius:** Compromised identities, role assumption chains, cross-account/tenant pivots
+   - **MITRE ATT&CK Analysis:** Cloud-specific techniques, tactics, kill chain progression, and detection gaps
+   - **Correlation Results:** Attack chains, cross-account/tenant movements, campaign identification
+   - **Affected Assets:** Complete entity inventory organized by provider, account, and region
+   - **Containment Actions:** Provider-specific response measures taken (AWS, Azure, GCP, Cloudflare)
+   - **Recommendations:**
+     - IAM hardening: least-privilege roles, MFA enforcement, temporary credentials, service account key rotation
+     - Logging and detection: enable CloudTrail data events, Azure Diagnostics, GCP Data Access logs, cross-account anomaly alerts
+     - Architecture: VPC isolation, private endpoints, metadata service v2 (IMDSv2), workload identity federation
+   - **Lessons Learned:** What to improve in cloud security posture and incident response playbooks
+
+**Output:** Complete cloud incident report, cloud ATT&CK Navigator layer, event timeline, identity blast-radius map, recommendations
+
+## Example Invocation
+
+```
+User: "Run cloud incident response on finding f-20260215-a1b2c3d4"
+```
+
+## Expected Output
+
+```json
+{
+  "workflow": "cloud-incident",
+  "phases_completed": ["evidence-gathering", "correlation", "attack-mapping", "containment", "report"],
+  "cloud_providers": ["aws", "azure"],
+  "affected_scope": {
+    "aws": {
+      "account_id": "123456789012",
+      "regions": ["us-east-1", "eu-west-1"],
+      "resources": ["arn:aws:iam::123456789012:role/AdminRole", "arn:aws:s3:::data-bucket"]
+    },
+    "azure": {
+      "subscription_id": "sub-abc123",
+      "tenant_id": "tenant-xyz789",
+      "resources": ["Azure AD user: admin@corp.com", "Storage Account: corpdata"]
+    }
+  },
+  "attack_plane": "control-plane",
+  "identity_blast_radius": {
+    "compromised_identities": ["arn:aws:iam::123456789012:user/breach-user", "admin@corp.com"],
+    "cross_account_pivots": 2,
+    "cross_tenant_pivots": 0
+  },
+  "mitre_techniques": ["T1078.004", "T1526", "T1098.001", "T1567.002", "T1530"],
+  "kill_chain_stage": "lateral_movement",
+  "containment_actions": [
+    {"action": "disable_iam_user", "target": "breach-user", "provider": "aws", "confidence": 0.97, "status": "auto-approved"},
+    {"action": "revoke_sessions", "target": "admin@corp.com", "provider": "azure", "confidence": 0.95, "status": "auto-approved"},
+    {"action": "block_ip", "target": "185.220.101.1", "provider": "cloudflare", "confidence": 0.92, "status": "quick-review"}
+  ],
+  "report_sections": ["executive_summary", "environment_overview", "technical_details", "timeline", "identity_blast_radius", "mitre_analysis", "correlation", "affected_assets", "containment_actions", "recommendations", "lessons_learned"]
+}
+```


### PR DESCRIPTION
## Summary

This PR bundles two feature areas:

1. **Cloud incident investigation workflow** — closes #168
2. **VStrike data-plane proxies and JWT race-condition fix**

---

### Cloud Incident Workflow (#168)

Adds `workflows/cloud-incident/WORKFLOW.md`, a file-based workflow auto-discovered by `WorkflowsService`. It sequences five existing agents through cloud-specific phases:

- **Phase 1 — Cloud Evidence Gathering** (Investigator): control-plane vs data-plane scoping, IAM/role evidence, audit log collection (CloudTrail, Azure Activity Logs, GCP Audit Logs)
- **Phase 2 — Cross-Cloud Correlation** (Correlator): identity blast-radius, cross-account/cross-tenant pivot detection, IAM trust boundary analysis
- **Phase 3 — Cloud ATT&CK Mapping** (MITRE Analyst): cloud-specific techniques (T1078.004, T1526, T1535, T1613, T1652, T1567.002, T1098.001), kill-chain progression in multi-tenant environments
- **Phase 4 — Cloud Containment & Response** (Responder): provider-aware actions (revoke sessions, disable IAM roles, rotate keys, isolate instances, restrict bucket policies, snapshot for forensics, Cloudflare WAF/Gateway blocks)
- **Phase 5 — Cloud Incident Report** (Reporter): executive, technical, and compliance sections with IAM hardening recommendations

Also adds `tests/unit/test_workflow_discovery.py` to assert the workflow is parsed correctly.

### VStrike Data-Plane Proxies

- Backend: node search, drift, storylines, and legends API endpoints in `backend/api/vstrike.py`
- Frontend: iframe host and context updates for new VStrike views
- Service: per-credential JWT login lock to fix concurrent login race that orphaned iframe sessions
- Tests: expanded coverage for UI routes and MCP server integration

## Test plan
- [ ] `pytest tests/unit/test_workflow_discovery.py -v`
- [ ] `pytest tests/unit/test_vstrike_service.py -v`
- [ ] `pytest tests/integration/test_vstrike_ui_routes.py -v`
- [ ] `curl http://localhost:6987/api/workflows` lists `cloud-incident`

🤖 Generated with [Claude Code](https://claude.com/claude-code)