### PR TITLE
Federated monitoring + cost estimation + VStrike picker fix

### DIFF
--- a/backend/api/analytics.py
+++ b/backend/api/analytics.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
 from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
@@ -30,50 +31,56 @@ ai_insights_service = AIInsightsService()
 
 @router.get("/analytics")
 async def get_analytics(
-    time_range: str = Query('7d', regex='^(24h|7d|30d|all)$'),
-    db: Session = Depends(get_db_session)
+    time_range: str = Query("7d", regex="^(24h|7d|30d|all)$"),
+    db: Session = Depends(get_db_session),
 ) -> Dict[str, Any]:
     """
     Get comprehensive analytics data for the specified time range.
-    
+
     Args:
         time_range: Time range for analytics ('24h', '7d', '30d')
         db: Database session
-        
+
     Returns:
         Dictionary containing metrics, time series data, distributions, and AI insights
     """
     try:
         start_time, end_time = get_time_range(time_range)
-        
+
         # Get previous period for comparison
         period_duration = end_time - start_time
         prev_start = start_time - period_duration
-        
+
         # Calculate key metrics
-        metrics = await calculate_metrics(db, start_time, end_time, prev_start, start_time)
-        
+        metrics = await calculate_metrics(
+            db, start_time, end_time, prev_start, start_time
+        )
+
         # Get time series data
         time_series = await get_time_series_data(db, start_time, end_time, time_range)
-        
+
         # Get severity distribution
         severity_dist = await get_severity_distribution(db, start_time, end_time)
-        
+
         # Get top sources
         top_sources = await get_top_alert_sources(db, start_time, end_time)
-        
+
         # Get response time trend
-        response_time_data = await get_response_time_trend(db, start_time, end_time, time_range)
-        
+        response_time_data = await get_response_time_trend(
+            db, start_time, end_time, time_range
+        )
+
         # Get affected entities/devices
         affected_entities = await get_affected_entities(db, start_time, end_time)
-        
+
         # Get attack time heatmap
         attack_heatmap = await get_attack_time_heatmap(db, start_time, end_time)
-        
+
         # Get MITRE technique distribution
-        mitre_techniques = await get_mitre_technique_distribution(db, start_time, end_time)
-        
+        mitre_techniques = await get_mitre_technique_distribution(
+            db, start_time, end_time
+        )
+
         # NOTE: AI insights are intentionally NOT generated here — they are
         # served from an in-memory cache via GET /analytics/insights so this
         # endpoint returns fast and never blocks on the Claude API.
@@ -112,7 +119,7 @@ async def _collect_insights_inputs(
 
 @router.get("/analytics/insights")
 async def get_analytics_insights(
-    time_range: str = Query('7d', regex='^(24h|7d|30d|all)$'),
+    time_range: str = Query("7d", regex="^(24h|7d|30d|all)$"),
     db: Session = Depends(get_db_session),
 ) -> Dict[str, Any]:
     """Return cached AI insights for the given time_range.
@@ -148,7 +155,7 @@ async def get_analytics_insights(
 
 @router.post("/analytics/insights/refresh")
 async def refresh_analytics_insights(
-    time_range: str = Query('7d', regex='^(24h|7d|30d|all)$'),
+    time_range: str = Query("7d", regex="^(24h|7d|30d|all)$"),
     db: Session = Depends(get_db_session),
 ) -> Dict[str, Any]:
     """Force a background regeneration of insights for the given time_range.
@@ -183,113 +190,157 @@ async def calculate_metrics(
     start_time: datetime,
     end_time: datetime,
     prev_start: datetime,
-    prev_end: datetime
+    prev_end: datetime,
 ) -> Dict[str, Any]:
     """Calculate key SOC metrics and their period-over-period changes."""
-    
+
     # Current period metrics
-    total_findings = db.query(func.count(Finding.finding_id)).filter(
-        Finding.created_at.between(start_time, end_time)
-    ).scalar() or 0
-    
-    total_cases = db.query(func.count(Case.case_id)).filter(
-        Case.created_at.between(start_time, end_time)
-    ).scalar() or 0
-    
+    total_findings = (
+        db.query(func.count(Finding.finding_id))
+        .filter(Finding.created_at.between(start_time, end_time))
+        .scalar()
+        or 0
+    )
+
+    total_cases = (
+        db.query(func.count(Case.case_id))
+        .filter(Case.created_at.between(start_time, end_time))
+        .scalar()
+        or 0
+    )
+
     # Get average response time (time from case creation to first analyst interaction)
-    avg_response_time_result = db.query(
-        func.avg(
-            func.extract('epoch', Case.updated_at - Case.created_at) / 60
+    avg_response_time_result = (
+        db.query(
+            func.avg(func.extract("epoch", Case.updated_at - Case.created_at) / 60)
         )
-    ).filter(
-        and_(
-            Case.created_at.between(start_time, end_time),
-            Case.status != 'new'
+        .filter(
+            and_(Case.created_at.between(start_time, end_time), Case.status != "new")
         )
-    ).scalar()
-    
+        .scalar()
+    )
+
     avg_response_time = float(round(avg_response_time_result or 0, 1))
-    
+
     # Calculate false positive rate
-    total_closed = db.query(func.count(Case.case_id)).filter(
-        and_(
-            Case.created_at.between(start_time, end_time),
-            Case.status == 'closed'
+    total_closed = (
+        db.query(func.count(Case.case_id))
+        .filter(
+            and_(Case.created_at.between(start_time, end_time), Case.status == "closed")
         )
-    ).scalar() or 0
-    
-    false_positives = db.query(func.count(CaseClosureInfo.case_id)).join(
-        Case, Case.case_id == CaseClosureInfo.case_id
-    ).filter(
-        and_(
-            Case.created_at.between(start_time, end_time),
-            CaseClosureInfo.closure_category == 'false_positive'
+        .scalar()
+        or 0
+    )
+
+    false_positives = (
+        db.query(func.count(CaseClosureInfo.case_id))
+        .join(Case, Case.case_id == CaseClosureInfo.case_id)
+        .filter(
+            and_(
+                Case.created_at.between(start_time, end_time),
+                CaseClosureInfo.closure_category == "false_positive",
+            )
         )
-    ).scalar() or 0
-    
-    false_positive_rate = round((false_positives / total_closed * 100) if total_closed > 0 else 0, 1)
-    
+        .scalar()
+        or 0
+    )
+
+    false_positive_rate = round(
+        (false_positives / total_closed * 100) if total_closed > 0 else 0, 1
+    )
+
     # Previous period metrics for comparison
-    prev_total_findings = db.query(func.count(Finding.finding_id)).filter(
-        Finding.created_at.between(prev_start, prev_end)
-    ).scalar() or 0
-    
-    prev_total_cases = db.query(func.count(Case.case_id)).filter(
-        Case.created_at.between(prev_start, prev_end)
-    ).scalar() or 0
-    
-    prev_avg_response_time_result = db.query(
-        func.avg(
-            func.extract('epoch', Case.updated_at - Case.created_at) / 60
+    prev_total_findings = (
+        db.query(func.count(Finding.finding_id))
+        .filter(Finding.created_at.between(prev_start, prev_end))
+        .scalar()
+        or 0
+    )
+
+    prev_total_cases = (
+        db.query(func.count(Case.case_id))
+        .filter(Case.created_at.between(prev_start, prev_end))
+        .scalar()
+        or 0
+    )
+
+    prev_avg_response_time_result = (
+        db.query(
+            func.avg(func.extract("epoch", Case.updated_at - Case.created_at) / 60)
         )
-    ).filter(
-        and_(
-            Case.created_at.between(prev_start, prev_end),
-            Case.status != 'new'
+        .filter(
+            and_(Case.created_at.between(prev_start, prev_end), Case.status != "new")
         )
-    ).scalar()
-    
+        .scalar()
+    )
+
     prev_avg_response_time = round(prev_avg_response_time_result or 0, 1)
-    
-    prev_total_closed = db.query(func.count(Case.case_id)).filter(
-        and_(
-            Case.created_at.between(prev_start, prev_end),
-            Case.status == 'closed'
+
+    prev_total_closed = (
+        db.query(func.count(Case.case_id))
+        .filter(
+            and_(Case.created_at.between(prev_start, prev_end), Case.status == "closed")
         )
-    ).scalar() or 0
-    
-    prev_false_positives = db.query(func.count(CaseClosureInfo.case_id)).join(
-        Case, Case.case_id == CaseClosureInfo.case_id
-    ).filter(
-        and_(
-            Case.created_at.between(prev_start, prev_end),
-            CaseClosureInfo.closure_category == 'false_positive'
+        .scalar()
+        or 0
+    )
+
+    prev_false_positives = (
+        db.query(func.count(CaseClosureInfo.case_id))
+        .join(Case, Case.case_id == CaseClosureInfo.case_id)
+        .filter(
+            and_(
+                Case.created_at.between(prev_start, prev_end),
+                CaseClosureInfo.closure_category == "false_positive",
+            )
         )
-    ).scalar() or 0
-    
-    prev_false_positive_rate = round((prev_false_positives / prev_total_closed * 100) if prev_total_closed > 0 else 0, 1)
-    
+        .scalar()
+        or 0
+    )
+
+    prev_false_positive_rate = round(
+        (
+            (prev_false_positives / prev_total_closed * 100)
+            if prev_total_closed > 0
+            else 0
+        ),
+        1,
+    )
+
     # Calculate percentage changes
     findings_change = round(
-        ((total_findings - prev_total_findings) / prev_total_findings * 100) if prev_total_findings > 0 else 0,
-        1
+        (
+            ((total_findings - prev_total_findings) / prev_total_findings * 100)
+            if prev_total_findings > 0
+            else 0
+        ),
+        1,
     )
-    
+
     cases_change = round(
-        ((total_cases - prev_total_cases) / prev_total_cases * 100) if prev_total_cases > 0 else 0,
-        1
+        (
+            ((total_cases - prev_total_cases) / prev_total_cases * 100)
+            if prev_total_cases > 0
+            else 0
+        ),
+        1,
     )
-    
+
     response_time_change = round(
-        ((avg_response_time - prev_avg_response_time) / prev_avg_response_time * 100) if prev_avg_response_time > 0 else 0,
-        1
+        (
+            (
+                (avg_response_time - prev_avg_response_time)
+                / prev_avg_response_time
+                * 100
+            )
+            if prev_avg_response_time > 0
+            else 0
+        ),
+        1,
     )
-    
-    false_positive_change = round(
-        false_positive_rate - prev_false_positive_rate,
-        1
-    )
-    
+
+    false_positive_change = round(false_positive_rate - prev_false_positive_rate, 1)
+
     return {
         "totalFindings": total_findings,
         "totalCases": total_cases,
@@ -303,302 +354,323 @@ async def calculate_metrics(
 
 
 async def get_time_series_data(
-    db: Session,
-    start_time: datetime,
-    end_time: datetime,
-    time_range: str
+    db: Session, start_time: datetime, end_time: datetime, time_range: str
 ) -> List[Dict[str, Any]]:
     """Get time series data for findings, cases, and alerts."""
-    
+
     # Determine bucket size based on time range
-    if time_range == '24h':
+    if time_range == "24h":
         bucket_size = timedelta(hours=1)
         bucket_count = 24
-    elif time_range == '7d':
+    elif time_range == "7d":
         bucket_size = timedelta(hours=6)
         bucket_count = 28
     else:  # 30d
         bucket_size = timedelta(days=1)
         bucket_count = 30
-    
+
     time_series = []
     current_time = start_time
-    
+
     for _ in range(bucket_count):
         bucket_end = min(current_time + bucket_size, end_time)
-        
-        findings_count = db.query(func.count(Finding.finding_id)).filter(
-            Finding.created_at.between(current_time, bucket_end)
-        ).scalar() or 0
-        
-        cases_count = db.query(func.count(Case.case_id)).filter(
-            Case.created_at.between(current_time, bucket_end)
-        ).scalar() or 0
-        
+
+        findings_count = (
+            db.query(func.count(Finding.finding_id))
+            .filter(Finding.created_at.between(current_time, bucket_end))
+            .scalar()
+            or 0
+        )
+
+        cases_count = (
+            db.query(func.count(Case.case_id))
+            .filter(Case.created_at.between(current_time, bucket_end))
+            .scalar()
+            or 0
+        )
+
         # Alerts are high/critical severity findings
-        alerts_count = db.query(func.count(Finding.finding_id)).filter(
-            and_(
-                Finding.created_at.between(current_time, bucket_end),
-                Finding.severity.in_(['high', 'critical'])
+        alerts_count = (
+            db.query(func.count(Finding.finding_id))
+            .filter(
+                and_(
+                    Finding.created_at.between(current_time, bucket_end),
+                    Finding.severity.in_(["high", "critical"]),
+                )
             )
-        ).scalar() or 0
-        
-        time_series.append({
-            "timestamp": current_time.isoformat(),
-            "findings": findings_count,
-            "cases": cases_count,
-            "alerts": alerts_count,
-        })
-        
+            .scalar()
+            or 0
+        )
+
+        time_series.append(
+            {
+                "timestamp": current_time.isoformat(),
+                "findings": findings_count,
+                "cases": cases_count,
+                "alerts": alerts_count,
+            }
+        )
+
         current_time = bucket_end
-    
+
     return time_series
 
 
 async def get_severity_distribution(
-    db: Session,
-    start_time: datetime,
-    end_time: datetime
+    db: Session, start_time: datetime, end_time: datetime
 ) -> List[Dict[str, Any]]:
     """Get distribution of findings by severity."""
-    
+
     severity_colors = {
-        'critical': '#d32f2f',
-        'high': '#f57c00',
-        'medium': '#fbc02d',
-        'low': '#388e3c',
-        'informational': '#757575',
+        "critical": "#d32f2f",
+        "high": "#f57c00",
+        "medium": "#fbc02d",
+        "low": "#388e3c",
+        "informational": "#757575",
     }
-    
-    severity_counts = db.query(
-        Finding.severity,
-        func.count(Finding.finding_id).label('count')
-    ).filter(
-        Finding.created_at.between(start_time, end_time)
-    ).group_by(Finding.severity).all()
-    
+
+    severity_counts = (
+        db.query(Finding.severity, func.count(Finding.finding_id).label("count"))
+        .filter(Finding.created_at.between(start_time, end_time))
+        .group_by(Finding.severity)
+        .all()
+    )
+
     return [
         {
-            "name": severity.capitalize() if severity else 'Unknown',
+            "name": severity.capitalize() if severity else "Unknown",
             "value": count,
-            "color": severity_colors.get(severity, '#757575')
+            "color": severity_colors.get(severity, "#757575"),
         }
         for severity, count in severity_counts
     ]
 
 
 async def get_top_alert_sources(
-    db: Session,
-    start_time: datetime,
-    end_time: datetime,
-    limit: int = 10
+    db: Session, start_time: datetime, end_time: datetime, limit: int = 10
 ) -> List[Dict[str, Any]]:
     """Get top alert sources by finding count."""
-    
-    top_sources = db.query(
-        Finding.data_source,
-        func.count(Finding.finding_id).label('count')
-    ).filter(
-        Finding.created_at.between(start_time, end_time)
-    ).group_by(Finding.data_source).order_by(func.count(Finding.finding_id).desc()).limit(limit).all()
-    
+
+    top_sources = (
+        db.query(Finding.data_source, func.count(Finding.finding_id).label("count"))
+        .filter(Finding.created_at.between(start_time, end_time))
+        .group_by(Finding.data_source)
+        .order_by(func.count(Finding.finding_id).desc())
+        .limit(limit)
+        .all()
+    )
+
     return [
-        {
-            "name": source or 'Unknown',
-            "count": count
-        }
-        for source, count in top_sources
+        {"name": source or "Unknown", "count": count} for source, count in top_sources
     ]
 
 
 async def get_response_time_trend(
-    db: Session,
-    start_time: datetime,
-    end_time: datetime,
-    time_range: str
+    db: Session, start_time: datetime, end_time: datetime, time_range: str
 ) -> List[Dict[str, Any]]:
     """Get response time trend over the period."""
-    
+
     # Determine periods based on time range
-    if time_range == '24h':
+    if time_range == "24h":
         period_size = timedelta(hours=4)
         period_count = 6
-    elif time_range == '7d':
+    elif time_range == "7d":
         period_size = timedelta(days=1)
         period_count = 7
     else:  # 30d
         period_size = timedelta(days=5)
         period_count = 6
-    
+
     trend_data = []
     current_time = start_time
     target_time = 30  # 30 minute target response time
-    
+
     for i in range(period_count):
         period_end = min(current_time + period_size, end_time)
-        
-        avg_time_result = db.query(
-            func.avg(
-                func.extract('epoch', Case.updated_at - Case.created_at) / 60
+
+        avg_time_result = (
+            db.query(
+                func.avg(func.extract("epoch", Case.updated_at - Case.created_at) / 60)
             )
-        ).filter(
-            and_(
-                Case.created_at.between(current_time, period_end),
-                Case.status != 'new'
+            .filter(
+                and_(
+                    Case.created_at.between(current_time, period_end),
+                    Case.status != "new",
+                )
             )
-        ).scalar()
-        
+            .scalar()
+        )
+
         avg_time = round(avg_time_result or 0, 1)
-        
-        trend_data.append({
-            "period": f"P{i+1}",
-            "avgTime": avg_time,
-            "target": target_time,
-        })
-        
+
+        trend_data.append(
+            {
+                "period": f"P{i+1}",
+                "avgTime": avg_time,
+                "target": target_time,
+            }
+        )
+
         current_time = period_end
-    
+
     return trend_data
 
 
 async def get_affected_entities(
-    db: Session,
-    start_time: datetime,
-    end_time: datetime,
-    limit: int = 15
+    db: Session, start_time: datetime, end_time: datetime, limit: int = 15
 ) -> List[Dict[str, Any]]:
     """Get top affected entities/devices from findings."""
-    
-    findings = db.query(Finding).filter(
-        Finding.created_at.between(start_time, end_time)
-    ).all()
-    
+
+    findings = (
+        db.query(Finding).filter(Finding.created_at.between(start_time, end_time)).all()
+    )
+
     entity_counts = {}
     entity_severities = {}
-    
+
     for finding in findings:
         if not finding.entity_context:
             continue
-        
+
         # Extract entities from entity_context
         entities = []
         ctx = finding.entity_context
-        
+
         # Common entity types
         if isinstance(ctx, dict):
             # Network entities
-            for key in ['hostname', 'host', 'device', 'src_ip', 'dst_ip', 'dest_ip', 'ip_address', 'src_host', 'dst_host']:
+            for key in [
+                "hostname",
+                "host",
+                "device",
+                "src_ip",
+                "dst_ip",
+                "dest_ip",
+                "ip_address",
+                "src_host",
+                "dst_host",
+            ]:
                 if key in ctx and ctx[key]:
                     value = ctx[key]
-                    if value and value != 'null':  # Skip null values
+                    if value and value != "null":  # Skip null values
                         entities.append(str(value))
-            
+
             # User entities
-            for key in ['username', 'user', 'user_id', 'account']:
+            for key in ["username", "user", "user_id", "account"]:
                 if key in ctx and ctx[key]:
                     value = ctx[key]
-                    if value and value != 'null':
+                    if value and value != "null":
                         entities.append(str(value))
-        
+
         for entity in entities:
             if entity not in entity_counts:
                 entity_counts[entity] = 0
-                entity_severities[entity] = {'critical': 0, 'high': 0, 'medium': 0, 'low': 0}
-            
+                entity_severities[entity] = {
+                    "critical": 0,
+                    "high": 0,
+                    "medium": 0,
+                    "low": 0,
+                }
+
             entity_counts[entity] += 1
-            severity = finding.severity or 'low'
+            severity = finding.severity or "low"
             if severity in entity_severities[entity]:
                 entity_severities[entity][severity] += 1
-    
+
     # Convert to list and sort by count
     entities_list = [
         {
-            'entity': entity,
-            'count': count,
-            'critical': entity_severities[entity]['critical'],
-            'high': entity_severities[entity]['high'],
-            'medium': entity_severities[entity]['medium'],
-            'low': entity_severities[entity]['low'],
-            'riskScore': (
-                entity_severities[entity]['critical'] * 10 +
-                entity_severities[entity]['high'] * 5 +
-                entity_severities[entity]['medium'] * 2 +
-                entity_severities[entity]['low']
-            )
+            "entity": entity,
+            "count": count,
+            "critical": entity_severities[entity]["critical"],
+            "high": entity_severities[entity]["high"],
+            "medium": entity_severities[entity]["medium"],
+            "low": entity_severities[entity]["low"],
+            "riskScore": (
+                entity_severities[entity]["critical"] * 10
+                + entity_severities[entity]["high"] * 5
+                + entity_severities[entity]["medium"] * 2
+                + entity_severities[entity]["low"]
+            ),
         }
         for entity, count in entity_counts.items()
     ]
-    
+
     # Sort by risk score
-    entities_list.sort(key=lambda x: x['riskScore'], reverse=True)
-    
+    entities_list.sort(key=lambda x: x["riskScore"], reverse=True)
+
     return entities_list[:limit]
 
 
 async def get_attack_time_heatmap(
-    db: Session,
-    start_time: datetime,
-    end_time: datetime
+    db: Session, start_time: datetime, end_time: datetime
 ) -> List[Dict[str, Any]]:
     """Get attack time heatmap data (hour of day x day of week)."""
-    
-    findings = db.query(Finding).filter(
-        Finding.created_at.between(start_time, end_time)
-    ).all()
-    
+
+    findings = (
+        db.query(Finding).filter(Finding.created_at.between(start_time, end_time)).all()
+    )
+
     # Initialize heatmap grid (7 days x 24 hours)
     heatmap = {}
     for day in range(7):  # 0 = Monday, 6 = Sunday
         for hour in range(24):
             key = f"{day}:{hour}"
-            heatmap[key] = {'count': 0, 'critical': 0, 'high': 0}
-    
+            heatmap[key] = {"count": 0, "critical": 0, "high": 0}
+
     # Populate heatmap
     for finding in findings:
         timestamp = finding.timestamp
         day_of_week = timestamp.weekday()  # 0 = Monday
         hour = timestamp.hour
-        
+
         key = f"{day_of_week}:{hour}"
-        heatmap[key]['count'] += 1
-        
-        if finding.severity == 'critical':
-            heatmap[key]['critical'] += 1
-        elif finding.severity == 'high':
-            heatmap[key]['high'] += 1
-    
+        heatmap[key]["count"] += 1
+
+        if finding.severity == "critical":
+            heatmap[key]["critical"] += 1
+        elif finding.severity == "high":
+            heatmap[key]["high"] += 1
+
     # Convert to list format
     heatmap_data = []
-    day_names = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
-    
+    day_names = [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+    ]
+
     for day in range(7):
         for hour in range(24):
             key = f"{day}:{hour}"
-            heatmap_data.append({
-                'day': day_names[day],
-                'dayNum': day,
-                'hour': hour,
-                'count': heatmap[key]['count'],
-                'critical': heatmap[key]['critical'],
-                'high': heatmap[key]['high'],
-                'intensity': heatmap[key]['count']  # For heatmap color intensity
-            })
-    
+            heatmap_data.append(
+                {
+                    "day": day_names[day],
+                    "dayNum": day,
+                    "hour": hour,
+                    "count": heatmap[key]["count"],
+                    "critical": heatmap[key]["critical"],
+                    "high": heatmap[key]["high"],
+                    "intensity": heatmap[key]["count"],  # For heatmap color intensity
+                }
+            )
+
     return heatmap_data
 
 
 async def get_mitre_technique_distribution(
-    db: Session,
-    start_time: datetime,
-    end_time: datetime,
-    limit: int = 10
+    db: Session, start_time: datetime, end_time: datetime, limit: int = 10
 ) -> List[Dict[str, Any]]:
     """Get distribution of MITRE ATT&CK techniques from findings."""
-    
-    findings = db.query(Finding).filter(
-        Finding.created_at.between(start_time, end_time)
-    ).all()
-    
+
+    findings = (
+        db.query(Finding).filter(Finding.created_at.between(start_time, end_time)).all()
+    )
+
     technique_counts: dict[str, int] = {}
     technique_meta: dict[str, tuple[str, str]] = {}
 
@@ -624,10 +696,10 @@ async def get_mitre_technique_distribution(
                 for tech_id in predictions.keys():
                     _record(tech_id)
             else:
-                if 'techniques' in predictions:
-                    nested = predictions['techniques']
-                elif 'predicted_techniques' in predictions:
-                    nested = predictions['predicted_techniques']
+                if "techniques" in predictions:
+                    nested = predictions["techniques"]
+                elif "predicted_techniques" in predictions:
+                    nested = predictions["predicted_techniques"]
                 else:
                     nested = [predictions]
 
@@ -641,15 +713,15 @@ async def get_mitre_technique_distribution(
 
     techniques_list = [
         {
-            'techniqueId': tech_id,
-            'techniqueName': technique_meta[tech_id][0],
-            'tactic': technique_meta[tech_id][1],
-            'count': count,
+            "techniqueId": tech_id,
+            "techniqueName": technique_meta[tech_id][0],
+            "tactic": technique_meta[tech_id][1],
+            "count": count,
         }
         for tech_id, count in technique_counts.items()
     ]
-    
-    techniques_list.sort(key=lambda x: x['count'], reverse=True)
+
+    techniques_list.sort(key=lambda x: x["count"], reverse=True)
 
     return techniques_list[:limit]
 
@@ -658,9 +730,10 @@ async def get_mitre_technique_distribution(
 # LLM cost analytics (GH #84 — Phase 1 Measurement)
 # ---------------------------------------------------------------------------
 
+
 @router.get("/analytics/cost")
 async def get_cost_analytics(
-    time_range: str = Query('7d', regex='^(24h|7d|30d|all)$'),
+    time_range: str = Query("7d", regex="^(24h|7d|30d|all)$"),
     db: Session = Depends(get_db_session),
 ) -> Dict[str, Any]:
     """Return LLM cost + token breakdown for the given window.
@@ -708,14 +781,18 @@ def _cache_hit_rate(input_tokens: int, cache_read_tokens: int) -> float:
 
 
 def _cost_totals(db: Session, base_filter) -> Dict[str, Any]:
-    row = db.query(
-        func.coalesce(func.sum(LLMInteractionLog.input_tokens), 0),
-        func.coalesce(func.sum(LLMInteractionLog.output_tokens), 0),
-        func.coalesce(func.sum(LLMInteractionLog.cache_read_tokens), 0),
-        func.coalesce(func.sum(LLMInteractionLog.cache_creation_tokens), 0),
-        func.coalesce(func.sum(LLMInteractionLog.cost_usd), 0),
-        func.count(LLMInteractionLog.id),
-    ).filter(base_filter).one()
+    row = (
+        db.query(
+            func.coalesce(func.sum(LLMInteractionLog.input_tokens), 0),
+            func.coalesce(func.sum(LLMInteractionLog.output_tokens), 0),
+            func.coalesce(func.sum(LLMInteractionLog.cache_read_tokens), 0),
+            func.coalesce(func.sum(LLMInteractionLog.cache_creation_tokens), 0),
+            func.coalesce(func.sum(LLMInteractionLog.cost_usd), 0),
+            func.count(LLMInteractionLog.id),
+        )
+        .filter(base_filter)
+        .one()
+    )
 
     input_tokens, output_tokens, cache_read, cache_creation, cost_usd, calls = row
     return {
@@ -730,73 +807,125 @@ def _cost_totals(db: Session, base_filter) -> Dict[str, Any]:
 
 
 def _cost_group_by_agent(db: Session, base_filter) -> List[Dict[str, Any]]:
-    rows = db.query(
-        LLMInteractionLog.agent_id,
-        func.count(LLMInteractionLog.id).label('calls'),
-        func.coalesce(func.sum(LLMInteractionLog.input_tokens), 0).label('input_tokens'),
-        func.coalesce(func.sum(LLMInteractionLog.output_tokens), 0).label('output_tokens'),
-        func.coalesce(func.sum(LLMInteractionLog.cache_read_tokens), 0).label('cache_read'),
-        func.coalesce(func.sum(LLMInteractionLog.cache_creation_tokens), 0).label('cache_creation'),
-        func.coalesce(func.sum(LLMInteractionLog.cost_usd), 0).label('cost_usd'),
-    ).filter(base_filter).group_by(LLMInteractionLog.agent_id).order_by(
-        func.sum(LLMInteractionLog.cost_usd).desc().nullslast()
-    ).all()
+    rows = (
+        db.query(
+            LLMInteractionLog.agent_id,
+            func.count(LLMInteractionLog.id).label("calls"),
+            func.coalesce(func.sum(LLMInteractionLog.input_tokens), 0).label(
+                "input_tokens"
+            ),
+            func.coalesce(func.sum(LLMInteractionLog.output_tokens), 0).label(
+                "output_tokens"
+            ),
+            func.coalesce(func.sum(LLMInteractionLog.cache_read_tokens), 0).label(
+                "cache_read"
+            ),
+            func.coalesce(func.sum(LLMInteractionLog.cache_creation_tokens), 0).label(
+                "cache_creation"
+            ),
+            func.coalesce(func.sum(LLMInteractionLog.cost_usd), 0).label("cost_usd"),
+        )
+        .filter(base_filter)
+        .group_by(LLMInteractionLog.agent_id)
+        .order_by(func.sum(LLMInteractionLog.cost_usd).desc().nullslast())
+        .all()
+    )
 
     return [
         {
-            "agent_id": agent_id or 'unknown',
+            "agent_id": agent_id or "unknown",
             "calls": int(calls or 0),
             "input_tokens": int(input_tokens or 0),
             "output_tokens": int(output_tokens or 0),
             "cache_read_tokens": int(cache_read or 0),
             "cache_creation_tokens": int(cache_creation or 0),
             "cost_usd": float(cost_usd or 0),
-            "cache_hit_rate": _cache_hit_rate(int(input_tokens or 0), int(cache_read or 0)),
+            "cache_hit_rate": _cache_hit_rate(
+                int(input_tokens or 0), int(cache_read or 0)
+            ),
         }
         for agent_id, calls, input_tokens, output_tokens, cache_read, cache_creation, cost_usd in rows
     ]
 
 
 def _cost_group_by_model(db: Session, base_filter) -> List[Dict[str, Any]]:
-    rows = db.query(
-        LLMInteractionLog.model,
-        func.count(LLMInteractionLog.id).label('calls'),
-        func.coalesce(func.sum(LLMInteractionLog.input_tokens), 0).label('input_tokens'),
-        func.coalesce(func.sum(LLMInteractionLog.output_tokens), 0).label('output_tokens'),
-        func.coalesce(func.sum(LLMInteractionLog.cache_read_tokens), 0).label('cache_read'),
-        func.coalesce(func.sum(LLMInteractionLog.cache_creation_tokens), 0).label('cache_creation'),
-        func.coalesce(func.sum(LLMInteractionLog.cost_usd), 0).label('cost_usd'),
-    ).filter(base_filter).group_by(LLMInteractionLog.model).order_by(
-        func.sum(LLMInteractionLog.cost_usd).desc().nullslast()
-    ).all()
+    rows = (
+        db.query(
+            LLMInteractionLog.model,
+            func.count(LLMInteractionLog.id).label("calls"),
+            func.coalesce(func.sum(LLMInteractionLog.input_tokens), 0).label(
+                "input_tokens"
+            ),
+            func.coalesce(func.sum(LLMInteractionLog.output_tokens), 0).label(
+                "output_tokens"
+            ),
+            func.coalesce(func.sum(LLMInteractionLog.cache_read_tokens), 0).label(
+                "cache_read"
+            ),
+            func.coalesce(func.sum(LLMInteractionLog.cache_creation_tokens), 0).label(
+                "cache_creation"
+            ),
+            func.coalesce(func.sum(LLMInteractionLog.cost_usd), 0).label("cost_usd"),
+        )
+        .filter(base_filter)
+        .group_by(LLMInteractionLog.model)
+        .order_by(func.sum(LLMInteractionLog.cost_usd).desc().nullslast())
+        .all()
+    )
 
+    # #184 Phase 3: surface pricing_source per row so the dashboard can
+    # badge "heuristic" / "unknown" models — those rows record cost from
+    # tier-regex pricing (or $0 for unknown) and need to be visually
+    # distinguishable from "exact" rows. Provider is inferred from the
+    # model id since LLMInteractionLog doesn't carry provider_type.
+    from services.model_registry import (
+        get_registry,
+        infer_provider_type,
+    )
+
+    registry = get_registry()
     return [
         {
-            "model": model or 'unknown',
+            "model": model or "unknown",
+            "provider_type": infer_provider_type(model or ""),
+            "pricing_source": registry.get_pricing_source(
+                model or "", infer_provider_type(model or "")
+            ),
             "calls": int(calls or 0),
             "input_tokens": int(input_tokens or 0),
             "output_tokens": int(output_tokens or 0),
             "cache_read_tokens": int(cache_read or 0),
             "cache_creation_tokens": int(cache_creation or 0),
             "cost_usd": float(cost_usd or 0),
-            "cache_hit_rate": _cache_hit_rate(int(input_tokens or 0), int(cache_read or 0)),
+            "cache_hit_rate": _cache_hit_rate(
+                int(input_tokens or 0), int(cache_read or 0)
+            ),
         }
         for model, calls, input_tokens, output_tokens, cache_read, cache_creation, cost_usd in rows
     ]
 
 
-def _cost_top_investigations(db: Session, base_filter, limit: int = 10) -> List[Dict[str, Any]]:
-    rows = db.query(
-        LLMInteractionLog.investigation_id,
-        func.count(LLMInteractionLog.id).label('calls'),
-        func.coalesce(func.sum(LLMInteractionLog.input_tokens), 0).label('input_tokens'),
-        func.coalesce(func.sum(LLMInteractionLog.output_tokens), 0).label('output_tokens'),
-        func.coalesce(func.sum(LLMInteractionLog.cost_usd), 0).label('cost_usd'),
-    ).filter(
-        and_(base_filter, LLMInteractionLog.investigation_id.isnot(None))
-    ).group_by(LLMInteractionLog.investigation_id).order_by(
-        func.sum(LLMInteractionLog.cost_usd).desc().nullslast()
-    ).limit(limit).all()
+def _cost_top_investigations(
+    db: Session, base_filter, limit: int = 10
+) -> List[Dict[str, Any]]:
+    rows = (
+        db.query(
+            LLMInteractionLog.investigation_id,
+            func.count(LLMInteractionLog.id).label("calls"),
+            func.coalesce(func.sum(LLMInteractionLog.input_tokens), 0).label(
+                "input_tokens"
+            ),
+            func.coalesce(func.sum(LLMInteractionLog.output_tokens), 0).label(
+                "output_tokens"
+            ),
+            func.coalesce(func.sum(LLMInteractionLog.cost_usd), 0).label("cost_usd"),
+        )
+        .filter(and_(base_filter, LLMInteractionLog.investigation_id.isnot(None)))
+        .group_by(LLMInteractionLog.investigation_id)
+        .order_by(func.sum(LLMInteractionLog.cost_usd).desc().nullslast())
+        .limit(limit)
+        .all()
+    )
 
     return [
         {
@@ -808,3 +937,50 @@ def _cost_top_investigations(db: Session, base_filter, limit: int = 10) -> List[
         }
         for inv_id, calls, input_tokens, output_tokens, cost_usd in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# Pre-call cost estimation (#184 Phase 2)
+# ---------------------------------------------------------------------------
+
+
+class EstimateCostRequest(BaseModel):
+    """Body for POST /analytics/estimate-cost.
+
+    Mirrors the shape of an LLM call so the same payload a caller is
+    about to send can be passed straight in for an estimate. ``messages``
+    matches Anthropic / OpenAI message format — list of role+content
+    dicts; multimodal blocks are tolerated but token-counted as text-only
+    in the heuristic path.
+    """
+
+    provider_type: str = Field(..., description="anthropic | openai | ollama")
+    model_id: str
+    messages: List[Dict[str, Any]] = Field(default_factory=list)
+    system_prompt: Optional[str] = None
+    tools: Optional[List[Dict[str, Any]]] = None
+    max_tokens: int = Field(default=4096, ge=1, le=200_000)
+
+
+@router.post("/analytics/estimate-cost")
+async def estimate_cost_endpoint(payload: EstimateCostRequest) -> Dict[str, Any]:
+    """Return a USD low/high band for a hypothetical LLM call.
+
+    The chat composer and daemon planner call this before submitting a
+    real request so they can show the user a cost preview or gate the
+    call against a budget. ``low_usd`` assumes zero output tokens (e.g.
+    an immediate tool_use stop); ``high_usd`` assumes the call writes
+    out ``max_tokens`` of output. Real-world cost lands in between, and
+    is typically much closer to ``low_usd`` for cache-friendly workloads.
+    """
+    from services.cost_estimator import estimate_cost
+
+    estimate = await estimate_cost(
+        provider_type=payload.provider_type,
+        model_id=payload.model_id,
+        messages=payload.messages,
+        system_prompt=payload.system_prompt,
+        tools=payload.tools,
+        max_tokens=payload.max_tokens,
+    )
+    return estimate.to_dict()

--- a/backend/api/federation.py
+++ b/backend/api/federation.py
@@ -1,0 +1,210 @@
+"""Federation API — control + observe federated monitoring sources.
+
+Wraps :mod:`daemon.federation.store` and :func:`daemon.federation.runner.request_poll_now`
+so the Settings → Federation UI can read state and toggle sources without
+restarting the daemon. The daemon's ``FederationRunner`` re-reads DB rows on
+every tick, so PATCHes here propagate within a few seconds.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from daemon.federation import registry as fed_registry
+from daemon.federation import store as fed_store
+from daemon.federation.runner import request_poll_now
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+_VALID_SEVERITIES = {"low", "medium", "high", "critical"}
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class FederationGlobalSettings(BaseModel):
+    enabled: bool = False
+
+
+class FederationSourcePatch(BaseModel):
+    """Partial update for a federation source row.
+
+    Every field is optional — clients only send what they want to change.
+    Validation that doesn't fit Pydantic (e.g. min_severity enum) is done in
+    the handler so the error message can reference the field by name.
+    """
+
+    enabled: Optional[bool] = None
+    interval_seconds: Optional[int] = Field(default=None, ge=10, le=86400)
+    max_items: Optional[int] = Field(default=None, ge=1, le=10000)
+    min_severity: Optional[str] = None  # validated against _VALID_SEVERITIES
+
+
+class FederationSourceView(BaseModel):
+    source_id: str
+    enabled: bool
+    interval_seconds: int
+    max_items: int
+    min_severity: Optional[str]
+    last_poll_at: Optional[str]
+    last_success_at: Optional[str]
+    last_error: Optional[str]
+    consecutive_errors: int
+    is_configured: bool
+    default_interval_seconds: int
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _enrich_with_adapter(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge live adapter state (is_configured, default_interval) into a row dict."""
+    adapter = fed_registry.get_adapter(row["source_id"])
+    if adapter is None:
+        row["is_configured"] = False
+        row["default_interval_seconds"] = row.get("interval_seconds", 300)
+    else:
+        try:
+            row["is_configured"] = bool(adapter.is_configured())
+        except Exception:
+            row["is_configured"] = False
+        row["default_interval_seconds"] = adapter.default_interval()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Routes — global settings
+# ---------------------------------------------------------------------------
+
+
+@router.get("/settings")
+async def get_settings() -> Dict[str, Any]:
+    return fed_store.get_global_settings()
+
+
+@router.put("/settings")
+async def put_settings(payload: FederationGlobalSettings) -> Dict[str, Any]:
+    fed_store.set_global_settings({"enabled": payload.enabled}, updated_by="api")
+    return fed_store.get_global_settings()
+
+
+# ---------------------------------------------------------------------------
+# Routes — per-source
+# ---------------------------------------------------------------------------
+
+
+@router.get("/sources")
+async def list_sources() -> Dict[str, Any]:
+    """List federation sources.
+
+    Includes adapters that don't yet have a row (so the UI can show "configure
+    me" entries without the daemon being up). Adapters whose integration is
+    not configured are still listed but flagged ``is_configured=false``.
+    """
+    rows_by_id = {row["source_id"]: row for row in fed_store.list_sources()}
+
+    out: List[Dict[str, Any]] = []
+    for adapter in fed_registry.list_adapters():
+        row = rows_by_id.get(adapter.name)
+        if row is None:
+            # Adapter known to the registry but not yet seeded (e.g., daemon
+            # hasn't booted since this integration was configured). Surface a
+            # synthetic row so the UI can still toggle it after seeding.
+            row = {
+                "source_id": adapter.name,
+                "enabled": False,
+                "interval_seconds": adapter.default_interval(),
+                "max_items": 100,
+                "min_severity": None,
+                "cursor": {},
+                "last_poll_at": None,
+                "last_success_at": None,
+                "last_error": None,
+                "consecutive_errors": 0,
+            }
+        out.append(_enrich_with_adapter(dict(row)))
+
+    return {"sources": out, "global": fed_store.get_global_settings()}
+
+
+@router.patch("/sources/{source_id}")
+async def patch_source(source_id: str, payload: FederationSourcePatch) -> Dict[str, Any]:
+    if fed_registry.get_adapter(source_id) is None:
+        raise HTTPException(status_code=404, detail=f"Unknown source: {source_id}")
+
+    fields: Dict[str, Any] = {}
+    if payload.enabled is not None:
+        fields["enabled"] = payload.enabled
+    if payload.interval_seconds is not None:
+        fields["interval_seconds"] = payload.interval_seconds
+    if payload.max_items is not None:
+        fields["max_items"] = payload.max_items
+    if payload.min_severity is not None:
+        sev = payload.min_severity.lower() if payload.min_severity else None
+        if sev and sev not in _VALID_SEVERITIES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"min_severity must be one of {sorted(_VALID_SEVERITIES)} or empty",
+            )
+        fields["min_severity"] = sev or None
+
+    if not fields:
+        raise HTTPException(status_code=400, detail="No fields provided")
+
+    # Auto-create the row on first PATCH so the UI doesn't need a separate
+    # "register" endpoint — same shape we'd seed on daemon boot.
+    if fed_store.get_source(source_id) is None:
+        adapter = fed_registry.get_adapter(source_id)
+        seed_defaults = {
+            "enabled": False,
+            "interval_seconds": adapter.default_interval() if adapter else 300,
+            "max_items": 100,
+            "min_severity": None,
+            "cursor": {},
+            "consecutive_errors": 0,
+        }
+        seed_defaults.update(fields)
+        row = fed_store.upsert_source(source_id, seed_defaults)
+    else:
+        row = fed_store.update_source(source_id, fields)
+
+    if row is None:
+        raise HTTPException(status_code=500, detail="Failed to persist source")
+    return _enrich_with_adapter(row)
+
+
+@router.post("/sources/{source_id}/poll-now")
+async def poll_now(source_id: str) -> Dict[str, Any]:
+    if fed_registry.get_adapter(source_id) is None:
+        raise HTTPException(status_code=404, detail=f"Unknown source: {source_id}")
+    ok = request_poll_now(source_id)
+    return {"ok": ok, "source_id": source_id}
+
+
+@router.get("/health")
+async def health() -> Dict[str, Any]:
+    """Compact summary for dashboards: per-source last_success + error count."""
+    rows = fed_store.list_sources()
+    return {
+        "global": fed_store.get_global_settings(),
+        "sources": [
+            {
+                "source_id": r["source_id"],
+                "enabled": r["enabled"],
+                "last_success_at": r.get("last_success_at"),
+                "consecutive_errors": r.get("consecutive_errors", 0),
+                "last_error": r.get("last_error"),
+            }
+            for r in rows
+        ],
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -88,6 +88,9 @@ from api.detection_rules import router as detection_rules_router
 # Orchestrator router
 from api.orchestrator import router as orchestrator_router
 
+# Federation router (federated monitoring of external SIEM/EDR sources)
+from api.federation import router as federation_router
+
 # Kafka ingestion router
 from api.kafka import router as kafka_router
 
@@ -243,6 +246,10 @@ app.include_router(approvals_router, prefix="/api", tags=["approvals"])
 # Autonomous orchestrator
 app.include_router(
     orchestrator_router, prefix="/api/orchestrator", tags=["orchestrator"]
+)
+# Federated monitoring (per-source SIEM/EDR pull driven by federation_sources)
+app.include_router(
+    federation_router, prefix="/api/federation", tags=["federation"]
 )
 app.include_router(kafka_router)
 

--- a/daemon/agent_runner.py
+++ b/daemon/agent_runner.py
@@ -26,7 +26,9 @@ def _default_thinking_budget() -> int:
     context (e.g. ClaudeService.chat).
     """
     from services.runtime_config import get_ai_operations_setting
+
     return get_ai_operations_setting("thinking_budget", 10000)
+
 
 from daemon.config import OrchestratorConfig
 from daemon.plan_generator import WORKFLOW_STEP_MAP, DEFAULT_STEPS
@@ -37,71 +39,124 @@ logger = logging.getLogger(__name__)
 try:
     from core.telemetry import get_tracer, extract_traceparent
     from opentelemetry.trace import SpanKind
+
     _tracer = get_tracer("vigil.daemon.agent_runner")
 except Exception:
     _tracer = None  # type: ignore[assignment]
+
 
 def compute_call_cost(
     model_id: Optional[str],
     provider_type: Optional[str],
     input_tokens: int,
     output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
 ) -> float:
     """Compute USD cost of a single LLM call.
 
-    Looks up per-token rates from ``services.model_registry.get_cost_rates()``.
+    Looks up per-token rates from ``services.model_registry.get_cost_rates()``
+    and per-provider cache multipliers from ``get_cache_rates()``. Cache
+    tokens are billed at provider-specific rates (#184 Phase 3): Anthropic
+    ephemeral cache reads at 0.1× input, writes at 1.25× input; OpenAI
+    cached input at 0.5×. Counting them at full input rate (the pre-#184
+    behavior) over-bills cache reads by 10× and under-bills cache writes
+    by 25%, so this matters for any workload that uses prompt caching —
+    which after #84 PR-C is most of Vigil's traffic.
 
-    GH #84 PR-E removed the previous Sonnet-pricing fallback: with per-component
-    model selection (#89) active, silently billing a GPT-4o or Ollama call at
-    Sonnet rates would misattribute cost. On an unresolved model/provider we
-    return 0.0 and log at WARNING so the call surfaces as a visible zero on
-    the ``/analytics/cost`` dashboard rather than hiding inside a misattributed
-    bucket.
+    GH #84 PR-E removed the previous Sonnet-pricing fallback: with
+    per-component model selection (#89) active, silently billing a GPT-4o
+    or Ollama call at Sonnet rates would misattribute cost. On an
+    unresolved model/provider we return 0.0 and log at WARNING so the
+    call surfaces as a visible zero on the ``/analytics/cost`` dashboard
+    rather than hiding inside a misattributed bucket.
     """
     if not model_id or not provider_type:
         logger.warning(
             "compute_call_cost: missing model_id/provider_type (got %r / %r); "
             "recording cost as $0.00 (GH #84 PR-E)",
-            model_id, provider_type,
+            model_id,
+            provider_type,
         )
         return 0.0
     try:
         from services.model_registry import get_registry
-        in_rate, out_rate = get_registry().get_cost_rates(model_id, provider_type)
+
+        registry = get_registry()
+        in_rate, out_rate = registry.get_cost_rates(model_id, provider_type)
+        cache_read_rate, cache_creation_rate = registry.get_cache_rates(
+            model_id, provider_type
+        )
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "compute_call_cost: model_registry lookup failed for %s/%s (%s); "
             "recording cost as $0.00",
-            provider_type, model_id, exc,
+            provider_type,
+            model_id,
+            exc,
         )
         return 0.0
-    return input_tokens * in_rate + output_tokens * out_rate
+    return (
+        input_tokens * in_rate
+        + output_tokens * out_rate
+        + cache_read_tokens * cache_read_rate
+        + cache_creation_tokens * cache_creation_rate
+    )
+
 
 TOOL_TIERS = {
     "safe": [
-        "list_findings", "get_finding", "search_findings", "nearest_neighbors",
-        "get_findings_stats", "semantic_search_findings", "technique_rollup",
-        "list_cases", "get_case", "get_case_comments", "get_case_iocs",
-        "get_case_tasks", "search_detections", "get_coverage_stats",
-        "get_detection_count", "analyze_coverage", "identify_gaps",
-        "create_attack_layer", "get_attack_layer",
+        "list_findings",
+        "get_finding",
+        "search_findings",
+        "nearest_neighbors",
+        "get_findings_stats",
+        "semantic_search_findings",
+        "technique_rollup",
+        "list_cases",
+        "get_case",
+        "get_case_comments",
+        "get_case_iocs",
+        "get_case_tasks",
+        "search_detections",
+        "get_coverage_stats",
+        "get_detection_count",
+        "analyze_coverage",
+        "identify_gaps",
+        "create_attack_layer",
+        "get_attack_layer",
     ],
     "managed": [
-        "create_case", "update_case", "add_finding_to_case",
-        "bulk_add_findings_to_case", "remove_finding_from_case",
-        "add_case_activity", "add_case_timeline_entry",
-        "add_case_mitre_techniques", "add_resolution_step",
-        "add_case_comment", "add_case_evidence", "add_case_ioc",
-        "bulk_add_iocs", "add_case_task", "update_case_task",
-        "link_related_cases", "escalate_case",
+        "create_case",
+        "update_case",
+        "add_finding_to_case",
+        "bulk_add_findings_to_case",
+        "remove_finding_from_case",
+        "add_case_activity",
+        "add_case_timeline_entry",
+        "add_case_mitre_techniques",
+        "add_resolution_step",
+        "add_case_comment",
+        "add_case_evidence",
+        "add_case_ioc",
+        "bulk_add_iocs",
+        "add_case_task",
+        "update_case_task",
+        "link_related_cases",
+        "escalate_case",
         "create_approval_action",
     ],
     "requires_approval": [
-        "isolate_host", "block_ip", "disable_user",
-        "quarantine_file", "close_case",
+        "isolate_host",
+        "block_ip",
+        "disable_user",
+        "quarantine_file",
+        "close_case",
     ],
     "forbidden": [
-        "delete_case", "delete_finding", "approve_action",
+        "delete_case",
+        "delete_finding",
+        "approve_action",
         "reject_action",
     ],
 }
@@ -130,10 +185,13 @@ WORKDIR_TOOLS = [
         "input_schema": {
             "type": "object",
             "properties": {
-                "filename": {"type": "string", "description": "Relative path to file (e.g. 'iocs.json', 'evidence/query_results/scan1.json')"}
+                "filename": {
+                    "type": "string",
+                    "description": "Relative path to file (e.g. 'iocs.json', 'evidence/query_results/scan1.json')",
+                }
             },
-            "required": ["filename"]
-        }
+            "required": ["filename"],
+        },
     },
     {
         "name": "write_investigation_file",
@@ -142,10 +200,10 @@ WORKDIR_TOOLS = [
             "type": "object",
             "properties": {
                 "filename": {"type": "string", "description": "Relative path to file"},
-                "content": {"type": "string", "description": "File content to write"}
+                "content": {"type": "string", "description": "File content to write"},
             },
-            "required": ["filename", "content"]
-        }
+            "required": ["filename", "content"],
+        },
     },
     {
         "name": "append_investigation_file",
@@ -154,18 +212,15 @@ WORKDIR_TOOLS = [
             "type": "object",
             "properties": {
                 "filename": {"type": "string", "description": "Relative path to file"},
-                "content": {"type": "string", "description": "Content to append"}
+                "content": {"type": "string", "description": "Content to append"},
             },
-            "required": ["filename", "content"]
-        }
+            "required": ["filename", "content"],
+        },
     },
     {
         "name": "list_investigation_files",
         "description": "List all files in the current investigation working directory.",
-        "input_schema": {
-            "type": "object",
-            "properties": {}
-        }
+        "input_schema": {"type": "object", "properties": {}},
     },
     {
         "name": "update_plan_step",
@@ -173,12 +228,22 @@ WORKDIR_TOOLS = [
         "input_schema": {
             "type": "object",
             "properties": {
-                "step_number": {"type": "integer", "description": "Step number to update"},
-                "status": {"type": "string", "enum": ["in_progress", "completed", "blocked"], "description": "New status"},
-                "result_notes": {"type": "string", "description": "Optional notes about what was found/done"}
+                "step_number": {
+                    "type": "integer",
+                    "description": "Step number to update",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["in_progress", "completed", "blocked"],
+                    "description": "New status",
+                },
+                "result_notes": {
+                    "type": "string",
+                    "description": "Optional notes about what was found/done",
+                },
             },
-            "required": ["step_number", "status"]
-        }
+            "required": ["step_number", "status"],
+        },
     },
     {
         "name": "signal_complete",
@@ -186,7 +251,10 @@ WORKDIR_TOOLS = [
         "input_schema": {
             "type": "object",
             "properties": {
-                "summary": {"type": "string", "description": "Brief summary of investigation findings"},
+                "summary": {
+                    "type": "string",
+                    "description": "Brief summary of investigation findings",
+                },
                 "proposed_actions": {
                     "type": "array",
                     "items": {
@@ -195,14 +263,14 @@ WORKDIR_TOOLS = [
                             "action": {"type": "string"},
                             "target": {"type": "string"},
                             "reason": {"type": "string"},
-                            "requires_approval": {"type": "boolean"}
-                        }
+                            "requires_approval": {"type": "boolean"},
+                        },
                     },
-                    "description": "List of proposed response actions"
-                }
+                    "description": "List of proposed response actions",
+                },
             },
-            "required": ["summary"]
-        }
+            "required": ["summary"],
+        },
     },
 ]
 
@@ -232,6 +300,7 @@ class AgentRunner:
         if self._claude_service is None:
             try:
                 from services.claude_service import ClaudeService
+
                 self._claude_service = ClaudeService(
                     use_backend_tools=True,
                     use_mcp_tools=True,
@@ -246,6 +315,7 @@ class AgentRunner:
         if self._data_service is None:
             try:
                 from services.database_data_service import DatabaseDataService
+
                 self._data_service = DatabaseDataService()
             except Exception as e:
                 logger.error(f"AgentRunner: Failed to init data service: {e}")
@@ -275,6 +345,7 @@ class AgentRunner:
         if self._llm_gateway is None:
             try:
                 from services.llm_gateway import get_llm_gateway
+
                 self._llm_gateway = await get_llm_gateway()
                 logger.info("AgentRunner: LLM gateway connected")
             except Exception as e:
@@ -288,7 +359,9 @@ class AgentRunner:
         task = self._active_agents.get(investigation_id)
         return task is not None and not task.done()
 
-    async def start_agent(self, investigation: Dict[str, Any], shutdown_event: asyncio.Event):
+    async def start_agent(
+        self, investigation: Dict[str, Any], shutdown_event: asyncio.Event
+    ):
         """Start a sub-agent for an investigation."""
         inv_id = investigation["investigation_id"]
         if self.is_running(inv_id):
@@ -325,7 +398,9 @@ class AgentRunner:
             return steps[idx]["title"]
         return f"Step {step_num}"
 
-    async def _run_agent(self, investigation: Dict[str, Any], shutdown_event: asyncio.Event):
+    async def _run_agent(
+        self, investigation: Dict[str, Any], shutdown_event: asyncio.Event
+    ):
         """The main sub-agent loop for a single investigation."""
         inv_id = investigation["investigation_id"]
         start_time = time.time()
@@ -346,7 +421,9 @@ class AgentRunner:
                     kind=SpanKind.INTERNAL,
                     attributes={
                         "vigil.investigation.id": inv_id,
-                        "vigil.investigation.workflow_id": investigation.get("workflow_id", ""),
+                        "vigil.investigation.workflow_id": investigation.get(
+                            "workflow_id", ""
+                        ),
                     },
                 )
         except Exception:
@@ -355,7 +432,12 @@ class AgentRunner:
         try:
             while not shutdown_event.is_set():
                 state = self.workdir.read_state(inv_id)
-                if state.get("status") in ("completed", "failed", "sleeping", "review_submitted"):
+                if state.get("status") in (
+                    "completed",
+                    "failed",
+                    "sleeping",
+                    "review_submitted",
+                ):
                     break
 
                 if state.get("status") == "waiting_approval":
@@ -369,30 +451,43 @@ class AgentRunner:
 
                 iteration += 1
                 if iteration > self.config.max_iterations_per_agent:
-                    logger.warning(f"{inv_id}: Max iterations ({self.config.max_iterations_per_agent}) exceeded")
+                    logger.warning(
+                        f"{inv_id}: Max iterations ({self.config.max_iterations_per_agent}) exceeded"
+                    )
                     self._mark_failed(inv_id, "Max iterations exceeded")
                     break
 
                 if total_cost >= self.config.max_cost_per_investigation:
-                    logger.warning(f"{inv_id}: Cost budget (${self.config.max_cost_per_investigation}) exceeded")
+                    logger.warning(
+                        f"{inv_id}: Cost budget (${self.config.max_cost_per_investigation}) exceeded"
+                    )
                     self._mark_failed(inv_id, "Cost budget exceeded")
                     break
 
                 elapsed = time.time() - start_time
                 if elapsed > self.config.max_runtime_per_investigation:
-                    logger.warning(f"{inv_id}: Runtime limit ({self.config.max_runtime_per_investigation}s) exceeded")
+                    logger.warning(
+                        f"{inv_id}: Runtime limit ({self.config.max_runtime_per_investigation}s) exceeded"
+                    )
                     self._mark_failed(inv_id, "Runtime limit exceeded")
                     break
 
-                self.workdir.append_log(inv_id, {
-                    "event": "iteration_start",
-                    "iteration": iteration,
-                    "elapsed_seconds": round(elapsed, 1),
-                    "cost_usd": round(total_cost, 4),
-                })
+                self.workdir.append_log(
+                    inv_id,
+                    {
+                        "event": "iteration_start",
+                        "iteration": iteration,
+                        "elapsed_seconds": round(elapsed, 1),
+                        "cost_usd": round(total_cost, 4),
+                    },
+                )
 
-                workflow_id = investigation.get("workflow_id") or state.get("workflow_id", "")
-                step_title = self._get_step_title(workflow_id, state.get("current_step", 1))
+                workflow_id = investigation.get("workflow_id") or state.get(
+                    "workflow_id", ""
+                )
+                step_title = self._get_step_title(
+                    workflow_id, state.get("current_step", 1)
+                )
                 self._update_db_record(inv_id, {"current_activity": step_title})
 
                 plan = self.workdir.read_file(inv_id, "plan.md")
@@ -408,7 +503,9 @@ class AgentRunner:
                             attributes={
                                 "vigil.investigation.id": inv_id,
                                 "vigil.agent.iteration": iteration,
-                                "vigil.investigation.current_step": state.get("current_step", 1),
+                                "vigil.investigation.current_step": state.get(
+                                    "current_step", 1
+                                ),
                             },
                         )
                 except Exception:
@@ -419,7 +516,9 @@ class AgentRunner:
                 except Exception as e:
                     logger.error(
                         "%s: iteration %d failed: %s",
-                        inv_id, iteration, e,
+                        inv_id,
+                        iteration,
+                        e,
                         exc_info=True,
                     )
                     self.workdir.append_log(inv_id, {"event": "error", "error": str(e)})
@@ -438,14 +537,22 @@ class AgentRunner:
 
                 in_tokens = result.get("input_tokens", 0)
                 out_tokens = result.get("output_tokens", 0)
+                cache_read = result.get("cache_read_tokens", 0)
+                cache_creation = result.get("cache_creation_tokens", 0)
                 # GH #89: provider_type defaults to "anthropic" since the
                 # plan_model used here is resolved from ai_model_configs or
                 # the default Anthropic provider.
+                # #184 Phase 3: cache tokens priced at provider-specific
+                # multipliers — without this an investigation that hits
+                # the cache heavily under-bills cache reads (10×) and
+                # under-bills the cache-write premium (25%).
                 cost = compute_call_cost(
                     self.config.plan_model,
                     result.get("provider") or "anthropic",
                     in_tokens,
                     out_tokens,
+                    cache_read_tokens=cache_read,
+                    cache_creation_tokens=cache_creation,
                 )
                 total_input_tokens += in_tokens
                 total_output_tokens += out_tokens
@@ -453,36 +560,48 @@ class AgentRunner:
                 self.stats["total_iterations"] += 1
                 self.stats["total_cost_usd"] += cost
 
-                self.workdir.append_log(inv_id, {
-                    "event": "iteration_complete",
-                    "iteration": iteration,
-                    "input_tokens": in_tokens,
-                    "output_tokens": out_tokens,
-                    "cost_usd": round(cost, 4),
-                    "tool_calls": len(result.get("tool_calls", [])),
-                })
+                self.workdir.append_log(
+                    inv_id,
+                    {
+                        "event": "iteration_complete",
+                        "iteration": iteration,
+                        "input_tokens": in_tokens,
+                        "output_tokens": out_tokens,
+                        "cost_usd": round(cost, 4),
+                        "tool_calls": len(result.get("tool_calls", [])),
+                    },
+                )
 
                 refreshed = self.workdir.read_state(inv_id)
 
-                self._update_db_record(inv_id, {
-                    "iteration_count": iteration,
-                    "input_tokens": total_input_tokens,
-                    "output_tokens": total_output_tokens,
-                    "cost_usd": round(total_cost, 4),
-                    "last_activity_at": datetime.utcnow().isoformat(),
-                    "current_step": refreshed.get("current_step", 0),
-                })
+                self._update_db_record(
+                    inv_id,
+                    {
+                        "iteration_count": iteration,
+                        "input_tokens": total_input_tokens,
+                        "output_tokens": total_output_tokens,
+                        "cost_usd": round(total_cost, 4),
+                        "last_activity_at": datetime.utcnow().isoformat(),
+                        "current_step": refreshed.get("current_step", 0),
+                    },
+                )
 
                 # Close iteration span with token/cost summary
                 try:
                     if _iter_span is not None:
                         _iter_span.set_attribute("gen_ai.usage.input_tokens", in_tokens)
-                        _iter_span.set_attribute("gen_ai.usage.output_tokens", out_tokens)
+                        _iter_span.set_attribute(
+                            "gen_ai.usage.output_tokens", out_tokens
+                        )
                         _iter_span.end()
                 except Exception:
                     pass
 
-                if refreshed.get("status") in ("completed", "review_submitted", "failed"):
+                if refreshed.get("status") in (
+                    "completed",
+                    "review_submitted",
+                    "failed",
+                ):
                     break
 
                 await asyncio.sleep(self.config.agent_loop_delay)
@@ -502,16 +621,23 @@ class AgentRunner:
                 self.stats["agents_completed"] += 1
             elif final_state.get("status") == "failed":
                 self.stats["agents_failed"] += 1
-            self._update_db_record(inv_id, {
-                "current_step": final_state.get("current_step", 0),
-            })
+            self._update_db_record(
+                inv_id,
+                {
+                    "current_step": final_state.get("current_step", 0),
+                },
+            )
         finally:
             self._active_agents.pop(inv_id, None)
             try:
                 if _agent_span is not None:
                     _agent_span.set_attribute("vigil.agent.total_iterations", iteration)
-                    _agent_span.set_attribute("gen_ai.usage.input_tokens", total_input_tokens)
-                    _agent_span.set_attribute("gen_ai.usage.output_tokens", total_output_tokens)
+                    _agent_span.set_attribute(
+                        "gen_ai.usage.input_tokens", total_input_tokens
+                    )
+                    _agent_span.set_attribute(
+                        "gen_ai.usage.output_tokens", total_output_tokens
+                    )
                     _agent_span.end()
             except Exception:
                 pass
@@ -522,12 +648,18 @@ class AgentRunner:
         if len(context_md) > self.config.context_max_chars:
             keep_head = 2000
             keep_tail = self.config.context_max_chars - keep_head - 100
-            context_md = context_md[:keep_head] + "\n\n...(earlier context summarized)...\n\n" + context_md[-keep_tail:]
+            context_md = (
+                context_md[:keep_head]
+                + "\n\n...(earlier context summarized)...\n\n"
+                + context_md[-keep_tail:]
+            )
 
         current_step = state.get("current_step", 1)
         total_steps = state.get("total_steps", 0)
         workflow_id = state.get("workflow_id", "unknown")
-        budget_remaining = self.config.max_cost_per_investigation - state.get("cost_usd", 0.0)
+        budget_remaining = self.config.max_cost_per_investigation - state.get(
+            "cost_usd", 0.0
+        )
 
         case_id = state.get("case_id")
         is_case_review = workflow_id == "case-review"
@@ -626,19 +758,28 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
         all_tools = list(WORKDIR_TOOLS)
 
         try:
-            if self._claude_service and hasattr(self._claude_service, 'backend_tools') and self._claude_service.backend_tools:
+            if (
+                self._claude_service
+                and hasattr(self._claude_service, "backend_tools")
+                and self._claude_service.backend_tools
+            ):
                 all_tools.extend(self._claude_service.backend_tools)
         except Exception:
             pass
 
         try:
             from services.mcp_registry import get_mcp_registry
+
             registry = get_mcp_registry()
             mcp_schemas = registry.get_all_tools()
             if mcp_schemas:
                 backend_names = {t["name"] for t in all_tools}
                 for tool in mcp_schemas:
-                    raw_name = tool["name"].split("_", 1)[-1] if "_" in tool["name"] else tool["name"]
+                    raw_name = (
+                        tool["name"].split("_", 1)[-1]
+                        if "_" in tool["name"]
+                        else tool["name"]
+                    )
                     if raw_name not in backend_names:
                         all_tools.append(tool)
         except Exception:
@@ -648,11 +789,21 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
         tool_calls_made = []
         total_input = 0
         total_output = 0
+        total_cache_read = 0
+        total_cache_creation = 0
         max_turns = 25
 
-        thinking_enabled = getattr(self._claude_service, 'enable_thinking', False) if self._claude_service else True
+        thinking_enabled = (
+            getattr(self._claude_service, "enable_thinking", False)
+            if self._claude_service
+            else True
+        )
         _fallback = _default_thinking_budget()
-        thinking_budget = getattr(self._claude_service, 'thinking_budget', _fallback) if self._claude_service else _fallback
+        thinking_budget = (
+            getattr(self._claude_service, "thinking_budget", _fallback)
+            if self._claude_service
+            else _fallback
+        )
         max_tok = max(16000, thinking_budget + 4096) if thinking_enabled else 4096
 
         for turn in range(max_turns):
@@ -709,15 +860,23 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
 
             try:
                 if _llm_span is not None:
-                    _llm_span.set_attribute("gen_ai.usage.input_tokens", response.get("input_tokens", 0))
-                    _llm_span.set_attribute("gen_ai.usage.output_tokens", response.get("output_tokens", 0))
-                    _llm_span.set_attribute("gen_ai.finish_reason", response.get("stop_reason", ""))
+                    _llm_span.set_attribute(
+                        "gen_ai.usage.input_tokens", response.get("input_tokens", 0)
+                    )
+                    _llm_span.set_attribute(
+                        "gen_ai.usage.output_tokens", response.get("output_tokens", 0)
+                    )
+                    _llm_span.set_attribute(
+                        "gen_ai.finish_reason", response.get("stop_reason", "")
+                    )
                     _llm_span.end()
             except Exception:
                 pass
 
             total_input += response.get("input_tokens", 0)
             total_output += response.get("output_tokens", 0)
+            total_cache_read += response.get("cache_read_tokens", 0)
+            total_cache_creation += response.get("cache_creation_tokens", 0)
 
             # Heartbeat: an LLM turn just returned, so the agent is making
             # progress even though the outer iteration hasn't finished. Without
@@ -744,7 +903,9 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                 tool_input = tool_block["input"]
                 tool_calls_made.append({"tool": tool_name, "input": tool_input})
 
-                self._update_db_record(inv_id, {"current_activity": f"Calling {tool_name}"})
+                self._update_db_record(
+                    inv_id, {"current_activity": f"Calling {tool_name}"}
+                )
                 result = await self._execute_tool(inv_id, tool_name, tool_input)
                 # Heartbeat after each tool — same reason as the post-LLM update
                 # above. A burst of slow MCP calls inside one iteration must
@@ -752,17 +913,21 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                 self._update_db_record(
                     inv_id, {"last_activity_at": datetime.utcnow().isoformat()}
                 )
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": tool_block["id"],
-                    "content": str(result)[:10000],
-                })
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_block["id"],
+                        "content": str(result)[:10000],
+                    }
+                )
 
             messages.append({"role": "user", "content": tool_results})
 
         return {
             "input_tokens": total_input,
             "output_tokens": total_output,
+            "cache_read_tokens": total_cache_read,
+            "cache_creation_tokens": total_cache_creation,
             "tool_calls": tool_calls_made,
         }
 
@@ -773,11 +938,15 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                 return self.workdir.read_file(inv_id, tool_input["filename"])
 
             elif tool_name == "write_investigation_file":
-                self.workdir.write_file(inv_id, tool_input["filename"], tool_input["content"])
+                self.workdir.write_file(
+                    inv_id, tool_input["filename"], tool_input["content"]
+                )
                 return f"Written to {tool_input['filename']}"
 
             elif tool_name == "append_investigation_file":
-                self.workdir.append_file(inv_id, tool_input["filename"], tool_input["content"])
+                self.workdir.append_file(
+                    inv_id, tool_input["filename"], tool_input["content"]
+                )
                 return f"Appended to {tool_input['filename']}"
 
             elif tool_name == "list_investigation_files":
@@ -859,26 +1028,36 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
             review.append("## Proposed Actions")
             review.append("")
             for action in proposed:
-                approval = " [REQUIRES APPROVAL]" if action.get("requires_approval") else ""
-                review.append(f"- **{action.get('action', 'N/A')}** on {action.get('target', 'N/A')}: {action.get('reason', '')}{approval}")
+                approval = (
+                    " [REQUIRES APPROVAL]" if action.get("requires_approval") else ""
+                )
+                review.append(
+                    f"- **{action.get('action', 'N/A')}** on {action.get('target', 'N/A')}: {action.get('reason', '')}{approval}"
+                )
             review.append("")
 
         self.workdir.write_file(inv_id, "review.md", "\n".join(review))
 
-        self._update_db_record(inv_id, {
-            "status": "review_submitted",
-            "summary": summary,
-            "proposed_actions": proposed,
-            "completed_at": datetime.utcnow().isoformat(),
-            "current_step": state.get("total_steps", state.get("current_step", 0)),
-            "current_activity": "Complete",
-        })
+        self._update_db_record(
+            inv_id,
+            {
+                "status": "review_submitted",
+                "summary": summary,
+                "proposed_actions": proposed,
+                "completed_at": datetime.utcnow().isoformat(),
+                "current_step": state.get("total_steps", state.get("current_step", 0)),
+                "current_activity": "Complete",
+            },
+        )
 
         return "Investigation marked as complete. Awaiting master agent review."
 
-    async def _execute_external_tool(self, inv_id: str, tool_name: str, tool_input: Dict) -> str:
+    async def _execute_external_tool(
+        self, inv_id: str, tool_name: str, tool_input: Dict
+    ) -> str:
         """Route to backend or MCP tool execution, enforcing safety guardrails."""
         import time as _time
+
         tier = _get_tool_tier(tool_name)
 
         _tool_span = None
@@ -892,7 +1071,9 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                         "vigil.investigation.id": inv_id,
                         "vigil.tool.name": tool_name,
                         "vigil.tool.tier": tier,
-                        "vigil.tool.input_size": len(json.dumps(tool_input, default=str)),
+                        "vigil.tool.input_size": len(
+                            json.dumps(tool_input, default=str)
+                        ),
                     },
                 )
         except Exception:
@@ -901,9 +1082,14 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
         if tier == "forbidden":
             msg = f"Tool '{tool_name}' is forbidden for autonomous agents."
             logger.warning(f"{inv_id}: Blocked forbidden tool call: {tool_name}")
-            self.workdir.append_log(inv_id, {
-                "event": "tool_blocked", "tool": tool_name, "tier": "forbidden",
-            })
+            self.workdir.append_log(
+                inv_id,
+                {
+                    "event": "tool_blocked",
+                    "tool": tool_name,
+                    "tier": "forbidden",
+                },
+            )
             try:
                 if _tool_span is not None:
                     _tool_span.set_attribute("vigil.tool.success", False)
@@ -914,26 +1100,40 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
 
         if self.config.dry_run and tier in ("managed", "requires_approval"):
             msg = f"[DRY RUN] Would execute {tool_name} with {json.dumps(tool_input, default=str)}"
-            self.workdir.append_log(inv_id, {
-                "event": "dry_run_skip", "tool": tool_name, "tier": tier,
-            })
+            self.workdir.append_log(
+                inv_id,
+                {
+                    "event": "dry_run_skip",
+                    "tool": tool_name,
+                    "tier": tier,
+                },
+            )
             return msg
 
         if tier == "requires_approval":
             return await self._request_tool_approval(inv_id, tool_name, tool_input)
 
-        if self._claude_service and hasattr(self._claude_service, '_execute_backend_tool'):
+        if self._claude_service and hasattr(
+            self._claude_service, "_execute_backend_tool"
+        ):
             try:
                 result = await self._claude_service._execute_backend_tool(
                     tool_name, tool_input
                 )
                 if result is not None:
-                    _r = json.dumps(result, default=str) if not isinstance(result, str) else result
+                    _r = (
+                        json.dumps(result, default=str)
+                        if not isinstance(result, str)
+                        else result
+                    )
                     try:
                         if _tool_span is not None:
                             _tool_span.set_attribute("vigil.tool.success", True)
                             _tool_span.set_attribute("vigil.tool.output_size", len(_r))
-                            _tool_span.set_attribute("vigil.tool.duration_ms", round((_time.monotonic() - _t0) * 1000, 1))
+                            _tool_span.set_attribute(
+                                "vigil.tool.duration_ms",
+                                round((_time.monotonic() - _t0) * 1000, 1),
+                            )
                             _tool_span.end()
                     except Exception:
                         pass
@@ -943,6 +1143,7 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
 
         try:
             from services.mcp_client import get_mcp_client
+
             client = get_mcp_client()
             if client:
                 server_name = None
@@ -962,14 +1163,25 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                             break
 
                 if server_name:
-                    result = await client.call_tool(server_name, actual_tool_name, tool_input)
+                    result = await client.call_tool(
+                        server_name, actual_tool_name, tool_input
+                    )
                     if result is not None:
-                        _r = json.dumps(result, default=str) if not isinstance(result, str) else result
+                        _r = (
+                            json.dumps(result, default=str)
+                            if not isinstance(result, str)
+                            else result
+                        )
                         try:
                             if _tool_span is not None:
                                 _tool_span.set_attribute("vigil.tool.success", True)
-                                _tool_span.set_attribute("vigil.tool.output_size", len(_r))
-                                _tool_span.set_attribute("vigil.tool.duration_ms", round((_time.monotonic() - _t0) * 1000, 1))
+                                _tool_span.set_attribute(
+                                    "vigil.tool.output_size", len(_r)
+                                )
+                                _tool_span.set_attribute(
+                                    "vigil.tool.duration_ms",
+                                    round((_time.monotonic() - _t0) * 1000, 1),
+                                )
                                 _tool_span.end()
                         except Exception:
                             pass
@@ -981,16 +1193,21 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
         try:
             if _tool_span is not None:
                 _tool_span.set_attribute("vigil.tool.success", False)
-                _tool_span.set_attribute("vigil.tool.duration_ms", round((_time.monotonic() - _t0) * 1000, 1))
+                _tool_span.set_attribute(
+                    "vigil.tool.duration_ms", round((_time.monotonic() - _t0) * 1000, 1)
+                )
                 _tool_span.end()
         except Exception:
             pass
         return _result_str
 
-    async def _request_tool_approval(self, inv_id: str, tool_name: str, tool_input: Dict) -> str:
+    async def _request_tool_approval(
+        self, inv_id: str, tool_name: str, tool_input: Dict
+    ) -> str:
         """Create an approval request and put the agent into waiting_approval state."""
         try:
             from services.approval_service import get_approval_service, ActionType
+
             service = get_approval_service()
 
             try:
@@ -1002,7 +1219,9 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                 action_type=action_type,
                 title=f"Auto-investigation tool: {tool_name}",
                 description=f"Investigation {inv_id} requests execution of {tool_name}",
-                target=tool_input.get("target", tool_input.get("ip", tool_input.get("host", "unknown"))),
+                target=tool_input.get(
+                    "target", tool_input.get("ip", tool_input.get("host", "unknown"))
+                ),
                 confidence=0.7,
                 reason=f"Autonomous investigation {inv_id} needs to execute {tool_name}",
                 evidence=[inv_id],
@@ -1023,20 +1242,27 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
 
             self._update_db_record(inv_id, {"status": "waiting_approval"})
 
-            self.workdir.append_log(inv_id, {
-                "event": "approval_requested",
-                "tool": tool_name,
-                "action_id": action_id,
-            })
+            self.workdir.append_log(
+                inv_id,
+                {
+                    "event": "approval_requested",
+                    "tool": tool_name,
+                    "action_id": action_id,
+                },
+            )
 
-            logger.info(f"{inv_id}: Approval requested for {tool_name} (action_id={action_id})")
+            logger.info(
+                f"{inv_id}: Approval requested for {tool_name} (action_id={action_id})"
+            )
             return f"Tool '{tool_name}' requires approval. Approval request created (action_id={action_id}). The agent will pause until the request is resolved."
 
         except Exception as e:
             logger.error(f"{inv_id}: Failed to create approval for {tool_name}: {e}")
             return f"Error creating approval for '{tool_name}': {e}"
 
-    async def _check_approval(self, inv_id: str, state: Dict, start_time: float) -> Optional[bool]:
+    async def _check_approval(
+        self, inv_id: str, state: Dict, start_time: float
+    ) -> Optional[bool]:
         """Check if a pending approval has been resolved.
 
         Returns True if approved and agent should continue, False if still
@@ -1053,11 +1279,14 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
 
         elapsed = time.time() - start_time
         if elapsed > self.config.max_runtime_per_investigation:
-            self._mark_failed(inv_id, "Runtime limit exceeded while waiting for approval")
+            self._mark_failed(
+                inv_id, "Runtime limit exceeded while waiting for approval"
+            )
             return None
 
         try:
             from services.approval_service import get_approval_service, ActionStatus
+
             service = get_approval_service()
             action = service.get_action(action_id)
 
@@ -1074,17 +1303,24 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                 state.pop("pending_approval", None)
                 self.workdir.write_state(inv_id, state)
                 self._update_db_record(inv_id, {"status": "executing"})
-                self.workdir.append_log(inv_id, {
-                    "event": "approval_granted", "action_id": action_id,
-                    "tool": pending.get("tool_name"),
-                })
+                self.workdir.append_log(
+                    inv_id,
+                    {
+                        "event": "approval_granted",
+                        "action_id": action_id,
+                        "tool": pending.get("tool_name"),
+                    },
+                )
 
                 tool_name = pending.get("tool_name")
                 tool_input = pending.get("tool_input", {})
                 if tool_name:
                     result = await self._execute_approved_tool(tool_name, tool_input)
-                    self.workdir.append_file(inv_id, "context.md",
-                        f"\n\n### Approved tool result: {tool_name}\n```\n{result[:2000]}\n```\n")
+                    self.workdir.append_file(
+                        inv_id,
+                        "context.md",
+                        f"\n\n### Approved tool result: {tool_name}\n```\n{result[:2000]}\n```\n",
+                    )
                 return True
 
             if action.status == ActionStatus.REJECTED:
@@ -1095,18 +1331,26 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                 self.workdir.write_state(inv_id, state)
                 self._update_db_record(inv_id, {"status": "executing"})
 
-                self.workdir.append_file(inv_id, "context.md",
-                    f"\n\n### Approval REJECTED for {pending.get('tool_name', 'unknown')}\nReason: {reason}\nAgent must find an alternative approach.\n")
+                self.workdir.append_file(
+                    inv_id,
+                    "context.md",
+                    f"\n\n### Approval REJECTED for {pending.get('tool_name', 'unknown')}\nReason: {reason}\nAgent must find an alternative approach.\n",
+                )
 
                 plan = self.workdir.read_file(inv_id, "plan.md")
                 step = state.get("current_step", 1)
                 plan += f"\n\n> **Note (Step {step}):** Tool `{pending.get('tool_name')}` was rejected. Reason: {reason}\n"
                 self.workdir.write_file(inv_id, "plan.md", plan)
 
-                self.workdir.append_log(inv_id, {
-                    "event": "approval_rejected", "action_id": action_id,
-                    "tool": pending.get("tool_name"), "reason": reason,
-                })
+                self.workdir.append_log(
+                    inv_id,
+                    {
+                        "event": "approval_rejected",
+                        "action_id": action_id,
+                        "tool": pending.get("tool_name"),
+                        "reason": reason,
+                    },
+                )
                 return True
 
             return False
@@ -1117,22 +1361,33 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
 
     async def _execute_approved_tool(self, tool_name: str, tool_input: Dict) -> str:
         """Execute a tool that has already been approved, bypassing guardrails."""
-        if self._claude_service and hasattr(self._claude_service, '_execute_backend_tool'):
+        if self._claude_service and hasattr(
+            self._claude_service, "_execute_backend_tool"
+        ):
             try:
                 result = await self._claude_service._execute_backend_tool(
                     tool_name, tool_input
                 )
                 if result is not None:
-                    return json.dumps(result, default=str) if not isinstance(result, str) else result
+                    return (
+                        json.dumps(result, default=str)
+                        if not isinstance(result, str)
+                        else result
+                    )
             except Exception:
                 pass
         try:
             from services.mcp_client import get_mcp_client
+
             client = get_mcp_client()
             if client:
                 result = await client.call_tool(tool_name, tool_input)
                 if result is not None:
-                    return json.dumps(result, default=str) if not isinstance(result, str) else result
+                    return (
+                        json.dumps(result, default=str)
+                        if not isinstance(result, str)
+                        else result
+                    )
         except Exception as e:
             logger.debug(f"Approved tool {tool_name} failed: {e}")
         return f"Tool '{tool_name}' execution failed"
@@ -1144,11 +1399,14 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
         state["failed_at"] = datetime.utcnow().isoformat()
         self.workdir.write_state(inv_id, state)
         self.workdir.append_log(inv_id, {"event": "failed", "reason": reason})
-        self._update_db_record(inv_id, {
-            "status": "failed",
-            "last_error": reason,
-            "current_activity": "Failed",
-        })
+        self._update_db_record(
+            inv_id,
+            {
+                "status": "failed",
+                "last_error": reason,
+                "current_activity": "Failed",
+            },
+        )
 
     def _update_db_record(self, inv_id: str, updates: Dict[str, Any]):
         """Update the Investigation record in the database.
@@ -1179,6 +1437,4 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                             val = datetime.fromisoformat(val)
                         setattr(inv, key, val)
         except Exception as e:
-            logger.error(
-                f"DB update for {inv_id} failed: {e}", exc_info=True
-            )
+            logger.error(f"DB update for {inv_id} failed: {e}", exc_info=True)

--- a/daemon/federation/__init__.py
+++ b/daemon/federation/__init__.py
@@ -1,0 +1,23 @@
+"""Federated monitoring for the SOC daemon.
+
+Each adapter under :mod:`daemon.federation.adapters` polls one external data
+source on a configurable cadence and yields normalized findings. The
+:mod:`daemon.federation.registry` module enumerates available adapters, and
+:func:`daemon.federation.seed.seed_federation_sources` ensures a row exists in
+``federation_sources`` for every adapter whose underlying integration is
+configured (default disabled, opt-in).
+"""
+
+from daemon.federation.registry import (
+    FederationAdapter,
+    FetchResult,
+    get_adapter,
+    list_adapters,
+)
+
+__all__ = [
+    "FederationAdapter",
+    "FetchResult",
+    "get_adapter",
+    "list_adapters",
+]

--- a/daemon/federation/adapters/__init__.py
+++ b/daemon/federation/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Builtin federation source adapters.
+
+Each module here registers exactly one adapter against
+:func:`daemon.federation.registry.register_adapter` at import time.
+"""

--- a/daemon/federation/adapters/_base.py
+++ b/daemon/federation/adapters/_base.py
@@ -1,0 +1,30 @@
+"""Shared helpers for federation adapters."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+def parse_cursor_since(cursor: Dict[str, Any]) -> Optional[datetime]:
+    """Read the ``last_poll_at`` ISO timestamp from cursor, if present.
+
+    Returns ``None`` for first-run (empty cursor) — adapters MUST treat that
+    as "from now" rather than backfilling, per the federation MVP design.
+    """
+    raw = cursor.get("last_poll_at") if cursor else None
+    if not raw:
+        return None
+    try:
+        # Drop trailing Z if present (datetime.fromisoformat doesn't accept it
+        # before 3.11 in all cases).
+        if isinstance(raw, str) and raw.endswith("Z"):
+            raw = raw[:-1]
+        return datetime.fromisoformat(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def fresh_cursor() -> Dict[str, Any]:
+    """Cursor value to persist after a successful fetch."""
+    return {"last_poll_at": datetime.utcnow().isoformat()}

--- a/daemon/federation/adapters/_siem_base.py
+++ b/daemon/federation/adapters/_siem_base.py
@@ -1,0 +1,111 @@
+"""Shared adapter for sources that already implement ``SIEMIngestionService``.
+
+The four cloud SIEMs (Azure Sentinel, AWS Security Hub, Microsoft Defender,
+Elastic Security) all expose ``async fetch_alerts(start_time, limit)`` and
+``transform_alert_to_finding(alert)`` via the
+:class:`services.siem_ingestion_service.SIEMIngestionService` base class. This
+adapter wraps that contract so each concrete source needs only a one-line
+factory module.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Callable, Dict, Optional
+
+from core.config import is_integration_enabled
+from daemon.federation.adapters._base import fresh_cursor, parse_cursor_since
+from daemon.federation.registry import FetchResult
+
+logger = logging.getLogger(__name__)
+
+
+class SIEMIngestionAdapter:
+    """Adapter wrapping any ``SIEMIngestionService`` subclass.
+
+    The adapter is intentionally not generic over the integration_id — the
+    caller passes the source name, integration id (for the ``is_configured``
+    check), default interval, and a service factory. This keeps each concrete
+    adapter file under 30 lines.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        integration_id: str,
+        default_interval: int,
+        service_factory: Callable[[], Any],
+        external_id_prefix: str,
+    ) -> None:
+        self.name = name
+        self._integration_id = integration_id
+        self._default_interval = default_interval
+        self._service_factory = service_factory
+        self._service: Optional[Any] = None
+        self._external_id_prefix = external_id_prefix
+
+    def is_configured(self) -> bool:
+        return is_integration_enabled(self._integration_id)
+
+    def default_interval(self) -> int:
+        return self._default_interval
+
+    def _get_service(self):
+        if self._service is not None:
+            return self._service
+        if not self.is_configured():
+            return None
+        try:
+            self._service = self._service_factory()
+        except Exception as e:
+            logger.warning("%s service init failed: %s", self.name, e)
+            self._service = None
+        return self._service
+
+    async def fetch(
+        self,
+        *,
+        since: Optional[datetime],
+        cursor: Dict[str, Any],
+        max_items: int,
+    ) -> FetchResult:
+        svc = self._get_service()
+        if svc is None:
+            return FetchResult(findings=[], cursor=fresh_cursor())
+
+        start_time = parse_cursor_since(cursor) or since
+        if start_time is None:
+            # First run: small window so we don't backfill on enable.
+            start_time = datetime.utcnow() - timedelta(minutes=1)
+
+        try:
+            alerts = await svc.fetch_alerts(start_time=start_time, limit=max_items)
+        except Exception as e:
+            logger.debug("%s fetch_alerts failed: %s", self.name, e)
+            alerts = []
+
+        findings = []
+        for alert in (alerts or [])[:max_items]:
+            try:
+                finding = svc.transform_alert_to_finding(alert)
+            except Exception as e:
+                logger.debug("%s transform failed: %s", self.name, e)
+                continue
+            if not finding:
+                continue
+            # Backfill external_id from the prefix-stripped finding_id when
+            # the underlying service doesn't set it explicitly. We need
+            # external_id populated for the (data_source, external_id) UNIQUE
+            # dedup index to do its job.
+            if not finding.get("external_id"):
+                fid = finding.get("finding_id", "")
+                prefix = f"{self._external_id_prefix}-"
+                if fid.startswith(prefix):
+                    finding["external_id"] = fid[len(prefix) :]
+                else:
+                    finding["external_id"] = fid
+            findings.append(finding)
+
+        return FetchResult(findings=findings, cursor=fresh_cursor())

--- a/daemon/federation/adapters/aws_security_hub.py
+++ b/daemon/federation/adapters/aws_security_hub.py
@@ -1,0 +1,24 @@
+"""AWS Security Hub federation adapter."""
+
+from __future__ import annotations
+
+from daemon.federation.adapters._siem_base import SIEMIngestionAdapter
+from daemon.federation.registry import FederationAdapter, register_adapter
+
+
+def _factory() -> FederationAdapter:
+    def make_service():
+        from services.aws_security_hub_ingestion import AWSSecurityHubIngestion
+
+        return AWSSecurityHubIngestion()
+
+    return SIEMIngestionAdapter(
+        name="aws_security_hub",
+        integration_id="aws_security_hub",
+        default_interval=900,  # cloud cadence — Security Hub aggregates slowly
+        service_factory=make_service,
+        external_id_prefix="aws-securityhub",
+    )
+
+
+register_adapter("aws_security_hub", _factory)

--- a/daemon/federation/adapters/azure_sentinel.py
+++ b/daemon/federation/adapters/azure_sentinel.py
@@ -1,0 +1,24 @@
+"""Azure Sentinel federation adapter."""
+
+from __future__ import annotations
+
+from daemon.federation.adapters._siem_base import SIEMIngestionAdapter
+from daemon.federation.registry import FederationAdapter, register_adapter
+
+
+def _factory() -> FederationAdapter:
+    def make_service():
+        from services.azure_sentinel_ingestion import AzureSentinelIngestion
+
+        return AzureSentinelIngestion()
+
+    return SIEMIngestionAdapter(
+        name="azure_sentinel",
+        integration_id="azure_sentinel",
+        default_interval=300,  # cloud SIEM cadence
+        service_factory=make_service,
+        external_id_prefix="azure-sentinel",
+    )
+
+
+register_adapter("azure_sentinel", _factory)

--- a/daemon/federation/adapters/crowdstrike.py
+++ b/daemon/federation/adapters/crowdstrike.py
@@ -1,0 +1,138 @@
+"""CrowdStrike Falcon federation adapter."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from core.config import get_integration_config, is_integration_enabled
+from daemon.federation.adapters._base import fresh_cursor, parse_cursor_since
+from daemon.federation.registry import (
+    FederationAdapter,
+    FetchResult,
+    register_adapter,
+)
+
+logger = logging.getLogger(__name__)
+
+_SEVERITY_MAP = {
+    "Critical": "critical",
+    "High": "high",
+    "Medium": "medium",
+    "Low": "low",
+    "Informational": "low",
+}
+
+
+class CrowdStrikeAdapter:
+    name = "crowdstrike"
+
+    def __init__(self) -> None:
+        self._service = None
+
+    def is_configured(self) -> bool:
+        return is_integration_enabled("crowdstrike")
+
+    def default_interval(self) -> int:
+        return 60  # EDR cadence — sub-minute matters here
+
+    def _get_service(self):
+        if self._service is not None:
+            return self._service
+        if not self.is_configured():
+            return None
+        try:
+            from services.crowdstrike_service import CrowdStrikeService
+
+            cfg = get_integration_config("crowdstrike")
+            self._service = CrowdStrikeService(
+                client_id=cfg.get("client_id", ""),
+                client_secret=cfg.get("client_secret", ""),
+                base_url=cfg.get("base_url", "https://api.crowdstrike.com"),
+            )
+        except Exception as e:
+            logger.warning("CrowdStrike service init failed: %s", e)
+            self._service = None
+        return self._service
+
+    async def fetch(
+        self,
+        *,
+        since: Optional[datetime],
+        cursor: Dict[str, Any],
+        max_items: int,
+    ) -> FetchResult:
+        svc = self._get_service()
+        if svc is None:
+            return FetchResult(findings=[], cursor=fresh_cursor())
+
+        cutoff = parse_cursor_since(cursor) or since
+        if cutoff is None:
+            # First run: small window, no backfill.
+            cutoff = datetime.utcnow() - timedelta(minutes=1)
+
+        try:
+            detections = svc.get_detections(
+                filter_query=f"created_timestamp:>='{cutoff.isoformat()}Z'",
+                limit=max_items,
+            ) or []
+        except Exception as e:
+            logger.debug("CrowdStrike fetch failed: %s", e)
+            detections = []
+
+        findings = []
+        for det in detections[:max_items]:
+            f = _detection_to_finding(det)
+            if f is not None:
+                findings.append(f)
+
+        return FetchResult(findings=findings, cursor=fresh_cursor())
+
+
+def _detection_to_finding(detection: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    detection_id = detection.get("detection_id", "")
+    if not detection_id:
+        return None
+
+    external_id = str(detection_id)[:128]
+    finding_id = f"cs-{external_id[:32]}"
+
+    severity = _SEVERITY_MAP.get(detection.get("max_severity_displayname", "Medium"), "medium")
+
+    mitre_predictions: Dict[str, float] = {}
+    for behavior in detection.get("behaviors", []) or []:
+        technique = behavior.get("technique")
+        if technique:
+            mitre_predictions[technique] = 0.9
+
+    device = detection.get("device") or {}
+    entity_context = {
+        "src_ips": [device.get("local_ip")] if device.get("local_ip") else [],
+        "hostnames": [device.get("hostname")] if device.get("hostname") else [],
+        "usernames": [detection.get("user_name")] if detection.get("user_name") else [],
+        "device_id": device.get("device_id"),
+    }
+
+    return {
+        "finding_id": finding_id,
+        "data_source": "crowdstrike",
+        "external_id": external_id,
+        "timestamp": detection.get("created_timestamp") or datetime.utcnow().isoformat(),
+        "severity": severity,
+        "status": "new",
+        "title": detection.get("scenario") or "CrowdStrike Detection",
+        "description": detection.get("description", ""),
+        "entity_context": entity_context,
+        "raw_event": detection,
+        "anomaly_score": float(detection.get("max_confidence", 50)) / 100.0,
+        "mitre_predictions": mitre_predictions,
+        "embedding": [],
+    }
+
+
+def _factory() -> FederationAdapter:
+    return CrowdStrikeAdapter()
+
+
+register_adapter(CrowdStrikeAdapter.name, _factory)

--- a/daemon/federation/adapters/elastic.py
+++ b/daemon/federation/adapters/elastic.py
@@ -1,0 +1,26 @@
+"""Elastic Security federation adapter."""
+
+from __future__ import annotations
+
+from daemon.federation.adapters._siem_base import SIEMIngestionAdapter
+from daemon.federation.registry import FederationAdapter, register_adapter
+
+
+def _factory() -> FederationAdapter:
+    def make_service():
+        from services.elastic_ingestion import ElasticIngestion
+
+        return ElasticIngestion()
+
+    return SIEMIngestionAdapter(
+        name="elastic",
+        # Note: integration_id matches what core.config / settings UI use
+        # ("elastic-siem"); the adapter name is shorter for the source_id PK.
+        integration_id="elastic-siem",
+        default_interval=300,  # SIEM cadence
+        service_factory=make_service,
+        external_id_prefix="elastic",
+    )
+
+
+register_adapter("elastic", _factory)

--- a/daemon/federation/adapters/microsoft_defender.py
+++ b/daemon/federation/adapters/microsoft_defender.py
@@ -1,0 +1,24 @@
+"""Microsoft Defender for Endpoint federation adapter."""
+
+from __future__ import annotations
+
+from daemon.federation.adapters._siem_base import SIEMIngestionAdapter
+from daemon.federation.registry import FederationAdapter, register_adapter
+
+
+def _factory() -> FederationAdapter:
+    def make_service():
+        from services.microsoft_defender_ingestion import MicrosoftDefenderIngestion
+
+        return MicrosoftDefenderIngestion()
+
+    return SIEMIngestionAdapter(
+        name="microsoft_defender",
+        integration_id="microsoft_defender",
+        default_interval=60,  # EDR cadence
+        service_factory=make_service,
+        external_id_prefix="defender",
+    )
+
+
+register_adapter("microsoft_defender", _factory)

--- a/daemon/federation/adapters/splunk.py
+++ b/daemon/federation/adapters/splunk.py
@@ -1,0 +1,167 @@
+"""Splunk federation adapter."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from core.config import get_integration_config, is_integration_enabled
+from daemon.federation.adapters._base import fresh_cursor, parse_cursor_since
+from daemon.federation.registry import (
+    FederationAdapter,
+    FetchResult,
+    register_adapter,
+)
+
+logger = logging.getLogger(__name__)
+
+# Search candidates ported from the original poller.py loop. We try the more
+# specific notable index first, falling back to broader queries if it's empty
+# (matching pre-federation behavior).
+_QUERIES = [
+    "index=notable | head {limit}",
+    "index=security sourcetype=*:alert* | head {limit}",
+    "`notable` | head {limit}",
+]
+
+_SEVERITY_MAP = {
+    "critical": "critical",
+    "high": "high",
+    "medium": "medium",
+    "low": "low",
+    "info": "low",
+    "informational": "low",
+}
+
+
+class SplunkAdapter:
+    name = "splunk"
+
+    def __init__(self) -> None:
+        self._service = None
+
+    def is_configured(self) -> bool:
+        return is_integration_enabled("splunk")
+
+    def default_interval(self) -> int:
+        return 300  # 5 min — SIEM cadence
+
+    def _get_service(self):
+        if self._service is not None:
+            return self._service
+        if not self.is_configured():
+            return None
+        try:
+            from services.splunk_service import SplunkService
+
+            cfg = get_integration_config("splunk")
+            self._service = SplunkService(
+                server_url=cfg.get("server_url", ""),
+                username=cfg.get("username", ""),
+                password=cfg.get("password", ""),
+                verify_ssl=cfg.get("verify_ssl", False),
+            )
+        except Exception as e:
+            logger.warning("Splunk service init failed: %s", e)
+            self._service = None
+        return self._service
+
+    async def fetch(
+        self,
+        *,
+        since: Optional[datetime],
+        cursor: Dict[str, Any],
+        max_items: int,
+    ) -> FetchResult:
+        svc = self._get_service()
+        if svc is None:
+            return FetchResult(findings=[], cursor=fresh_cursor())
+
+        # Use cursor's last_poll_at when available; otherwise "now" sentinel
+        # (no cold-start backfill — see CLAUDE.md / federation MVP design).
+        last = parse_cursor_since(cursor) or since
+        if last is not None:
+            # Convert to relative Splunk earliest_time (rounded up to minute)
+            delta_minutes = max(int((datetime.utcnow() - last).total_seconds() // 60) + 1, 1)
+            earliest_time = f"-{delta_minutes}m"
+        else:
+            # First run: tiny window so we don't replay history.
+            earliest_time = "-1m"
+
+        events = []
+        for query_tmpl in _QUERIES:
+            query = query_tmpl.format(limit=max_items)
+            try:
+                results = svc.search(
+                    query=query,
+                    earliest_time=earliest_time,
+                    latest_time="now",
+                    max_count=max_items,
+                )
+                if results:
+                    events = results
+                    break
+            except Exception as e:
+                logger.debug("Splunk query failed (%s): %s", query, e)
+                continue
+
+        findings = []
+        for event in events[:max_items]:
+            f = _splunk_event_to_finding(event)
+            if f is not None:
+                findings.append(f)
+
+        return FetchResult(findings=findings, cursor=fresh_cursor())
+
+
+def _splunk_event_to_finding(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    raw_id = event.get("_cd") or event.get("event_id") or uuid.uuid4().hex
+    external_id = str(raw_id)[:64]
+    finding_id = f"splunk-{external_id[:32]}"
+
+    severity_raw = (event.get("urgency") or event.get("severity") or "medium").lower()
+    severity = _SEVERITY_MAP.get(severity_raw, "medium")
+
+    entity_context: Dict[str, Any] = {
+        "src_ips": [],
+        "dest_ips": [],
+        "hostnames": [],
+        "usernames": [],
+    }
+    for f in ("src_ip", "src", "source_ip"):
+        if event.get(f):
+            entity_context["src_ips"].append(event[f])
+    for f in ("dest_ip", "dest", "destination_ip"):
+        if event.get(f):
+            entity_context["dest_ips"].append(event[f])
+    for f in ("host", "hostname", "src_host", "dest_host"):
+        if event.get(f):
+            entity_context["hostnames"].append(event[f])
+    for f in ("user", "username", "src_user"):
+        if event.get(f):
+            entity_context["usernames"].append(event[f])
+
+    return {
+        "finding_id": finding_id,
+        "data_source": "splunk",
+        "external_id": external_id,
+        "timestamp": event.get("_time") or datetime.utcnow().isoformat(),
+        "severity": severity,
+        "status": "new",
+        "title": event.get("search_name") or event.get("rule_name") or "Splunk Alert",
+        "description": event.get("description") or event.get("_raw", "")[:500],
+        "entity_context": entity_context,
+        "raw_event": event,
+        "anomaly_score": 0.5,
+        "mitre_predictions": {},
+        "embedding": [],
+    }
+
+
+def _factory() -> FederationAdapter:
+    return SplunkAdapter()
+
+
+register_adapter(SplunkAdapter.name, _factory)

--- a/daemon/federation/registry.py
+++ b/daemon/federation/registry.py
@@ -1,0 +1,148 @@
+"""Adapter contract + registry for federated monitoring.
+
+Each adapter wraps one external data source (Splunk, CrowdStrike, etc.) behind
+a uniform fetch interface so the runner in :mod:`daemon.poller` can iterate
+over a registry instead of hardcoding per-source loops.
+
+Adapters are intentionally thin — they delegate to existing services in
+``services/*`` for the actual API calls. The contract here only normalizes:
+
+  * how the runner detects whether the underlying integration is configured
+    (so we can skip seeding/polling sources the user hasn't set up),
+  * the fetch shape (cursor in, findings + new cursor out),
+  * the default cadence each source class warrants (EDR is faster than SIEM).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FetchResult:
+    """One adapter fetch's output.
+
+    ``findings`` is the list of normalized finding dicts (same shape the rest
+    of the daemon already consumes — see ``services.ingestion_service``).
+    ``cursor`` is the new persisted cursor for the next fetch — the runner
+    writes it to ``federation_sources.cursor`` after a successful fetch.
+    """
+
+    findings: List[Dict[str, Any]] = field(default_factory=list)
+    cursor: Dict[str, Any] = field(default_factory=dict)
+
+
+class FederationAdapter(Protocol):
+    """Contract every federated-monitoring source adapter implements."""
+
+    #: Unique source identifier (also the federation_sources.source_id PK).
+    name: str
+
+    def is_configured(self) -> bool:
+        """True if the underlying integration is configured (e.g. credentials set)."""
+        ...
+
+    def default_interval(self) -> int:
+        """Default poll interval (seconds). Used when seeding a fresh row."""
+        ...
+
+    async def fetch(
+        self,
+        *,
+        since: Optional[datetime],
+        cursor: Dict[str, Any],
+        max_items: int,
+    ) -> FetchResult:
+        """Pull new findings since the cursor.
+
+        ``since`` is an absolute fallback for adapters that don't honor the
+        cursor on first run; ``cursor`` is the per-source state previously
+        returned by this adapter (empty dict on first run — adapters MUST
+        treat empty as "from now", we do not backfill on cold start).
+
+        Implementations should honor ``max_items`` to bound first-run blast
+        radius if the source happens to return everything in its history.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+# Adapter constructors are registered lazily so importing this module doesn't
+# pull in every service. The runner calls ``list_adapters()`` once at startup.
+_ADAPTER_FACTORIES: Dict[str, Callable[[], FederationAdapter]] = {}
+
+
+def register_adapter(name: str, factory: Callable[[], FederationAdapter]) -> None:
+    """Register an adapter factory under ``name``.
+
+    Called once per adapter module at import time. Re-registration overwrites
+    the prior factory (useful in tests).
+    """
+    _ADAPTER_FACTORIES[name] = factory
+
+
+def list_adapters() -> List[FederationAdapter]:
+    """Instantiate every registered adapter.
+
+    Adapters that fail to instantiate are skipped with a warning so one bad
+    integration can't break the rest of the federation poller.
+    """
+    _ensure_builtins_loaded()
+    out: List[FederationAdapter] = []
+    for name, factory in _ADAPTER_FACTORIES.items():
+        try:
+            out.append(factory())
+        except Exception as e:
+            logger.warning(
+                "Federation adapter %s failed to construct: %s", name, e
+            )
+    return out
+
+
+def get_adapter(name: str) -> Optional[FederationAdapter]:
+    """Look up a single adapter by source_id."""
+    _ensure_builtins_loaded()
+    factory = _ADAPTER_FACTORIES.get(name)
+    if factory is None:
+        return None
+    try:
+        return factory()
+    except Exception as e:
+        logger.warning("Federation adapter %s failed to construct: %s", name, e)
+        return None
+
+
+_BUILTINS_LOADED = False
+
+
+def _ensure_builtins_loaded() -> None:
+    """Import the builtin adapter modules so they self-register.
+
+    We do this lazily (rather than at module import) to avoid pulling in every
+    SIEM/EDR service when something like a unit test only wants the registry
+    type definitions.
+    """
+    global _BUILTINS_LOADED
+    if _BUILTINS_LOADED:
+        return
+    _BUILTINS_LOADED = True
+    # Import for side effects (each module calls register_adapter at module scope).
+    try:
+        from daemon.federation.adapters import (  # noqa: F401
+            aws_security_hub,
+            azure_sentinel,
+            crowdstrike,
+            elastic,
+            microsoft_defender,
+            splunk,
+        )
+    except Exception as e:
+        logger.warning("Failed to load builtin federation adapters: %s", e)

--- a/daemon/federation/runner.py
+++ b/daemon/federation/runner.py
@@ -1,0 +1,250 @@
+"""Federation poller — manages per-adapter loops driven by federation_sources.
+
+Spawned by :class:`daemon.poller.DataPoller` when the daemon starts. Owns one
+asyncio task per *configured* adapter; each task polls when the global toggle
+AND its row's ``enabled`` flag are both true. Tasks survive across enable/
+disable transitions — they just no-op while disabled.
+
+Design notes (locked decisions from MVP plan):
+
+* No backfill on cold start — first run yields nothing, only finds events
+  created after the source is enabled.
+* No auto-disable on errors — backoff up to 8x interval, no row mutation
+  beyond ``consecutive_errors`` and ``last_error``.
+* Per-source severity floor honored at ingest time (filter before enqueue).
+* "Poll now" is a Redis flag the loop checks each tick.
+* Live config changes (enable, interval, min_severity) are picked up on the
+  next tick — no daemon restart needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from daemon.dedup import RedisDedupSet
+from daemon.federation import registry, store
+from daemon.federation.seed import seed_federation_sources
+
+logger = logging.getLogger(__name__)
+
+_SEVERITY_RANK = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+
+
+def _severity_passes(finding_sev: Optional[str], floor: Optional[str]) -> bool:
+    if not floor:
+        return True
+    rank_finding = _SEVERITY_RANK.get((finding_sev or "").lower(), -1)
+    rank_floor = _SEVERITY_RANK.get(floor.lower(), 0)
+    return rank_finding >= rank_floor
+
+
+class FederationRunner:
+    """Top-level federation orchestrator hosted inside the data poller.
+
+    Holds one asyncio task per registered adapter. The DataPoller owns the
+    output queue we publish findings onto.
+    """
+
+    def __init__(self, output_queue: Optional[asyncio.Queue]) -> None:
+        self._output_queue = output_queue
+        self._adapter_tasks: Dict[str, asyncio.Task] = {}
+        self._dedup: Dict[str, RedisDedupSet] = {}
+        # Sources that are currently "polling" — used so a source toggled OFF
+        # then ON quickly doesn't double-fire while the old task winds down.
+        self._adapters: Dict[str, registry.FederationAdapter] = {}
+        # Stats for the metrics endpoint.
+        self.stats: Dict[str, Any] = {"polls": 0, "findings": 0, "errors": 0}
+
+    def set_output_queue(self, queue: asyncio.Queue) -> None:
+        self._output_queue = queue
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def run(self, shutdown_event: asyncio.Event) -> None:
+        """Main entry point — called as an asyncio task by DataPoller."""
+        # 1. Seed rows for adapters whose integration is configured.
+        try:
+            seed_federation_sources()
+        except Exception as e:
+            logger.warning("Federation seed failed: %s", e)
+
+        # 2. Spawn one task per registered adapter (instantiated once, reused).
+        for adapter in registry.list_adapters():
+            self._adapters[adapter.name] = adapter
+            self._dedup[adapter.name] = RedisDedupSet(f"federation:{adapter.name}")
+            self._adapter_tasks[adapter.name] = asyncio.create_task(
+                self._adapter_loop(adapter, shutdown_event)
+            )
+
+        if not self._adapter_tasks:
+            # No adapters at all — wait for shutdown.
+            await shutdown_event.wait()
+            return
+
+        try:
+            await asyncio.gather(*self._adapter_tasks.values(), return_exceptions=True)
+        except asyncio.CancelledError:
+            pass
+
+    def is_active_for(self, source_id: str) -> bool:
+        """True if federation owns polling for ``source_id`` right now.
+
+        Used by the legacy per-source loops in :mod:`daemon.poller` to decide
+        whether to skip — when federation is on for a source, the legacy loop
+        must back off so we don't double-pull.
+        """
+        if not store.is_globally_enabled():
+            return False
+        row = store.get_source(source_id)
+        return bool(row and row.get("enabled"))
+
+    # ------------------------------------------------------------------
+    # Per-adapter loop
+    # ------------------------------------------------------------------
+
+    async def _adapter_loop(
+        self,
+        adapter: registry.FederationAdapter,
+        shutdown_event: asyncio.Event,
+    ) -> None:
+        source_id = adapter.name
+        logger.info("Federation adapter %s loop started", source_id)
+        last_check = 0.0
+        # Smallest sane sleep when waiting for global+per-source enable.
+        idle_seconds = 5.0
+
+        while not shutdown_event.is_set():
+            # Re-read DB state on every tick. Cheap enough at MVP cadence.
+            row = store.get_source(source_id) or {}
+            global_on = store.is_globally_enabled()
+
+            if not (global_on and row.get("enabled")):
+                # Disabled (globally or per-source) — light sleep then re-check.
+                try:
+                    await asyncio.wait_for(shutdown_event.wait(), timeout=idle_seconds)
+                    break
+                except asyncio.TimeoutError:
+                    continue
+
+            interval = int(row.get("interval_seconds") or adapter.default_interval())
+            errors = int(row.get("consecutive_errors") or 0)
+            backoff_mult = min(2 ** errors, 8) if errors else 1
+            sleep_for = max(interval * backoff_mult, 5)
+
+            # Honor "poll now" — a redis flag the API sets when the user
+            # clicks the button. We check it each tick rather than wait.
+            if await self._consume_poll_now(source_id):
+                sleep_for = 0
+
+            await self._do_one_tick(adapter, row)
+
+            try:
+                await asyncio.wait_for(shutdown_event.wait(), timeout=sleep_for)
+                break
+            except asyncio.TimeoutError:
+                continue
+
+        logger.info("Federation adapter %s loop exited", source_id)
+
+    async def _do_one_tick(
+        self,
+        adapter: registry.FederationAdapter,
+        row: Dict[str, Any],
+    ) -> None:
+        source_id = adapter.name
+        max_items = int(row.get("max_items") or 100)
+        cursor = row.get("cursor") or {}
+        min_severity = row.get("min_severity")
+
+        self.stats["polls"] = self.stats.get("polls", 0) + 1
+        try:
+            result = await adapter.fetch(
+                since=None,
+                cursor=cursor if isinstance(cursor, dict) else {},
+                max_items=max_items,
+            )
+        except Exception as e:
+            logger.warning("Federation %s fetch raised: %s", source_id, e)
+            self.stats["errors"] = self.stats.get("errors", 0) + 1
+            store.record_failure(source_id, str(e))
+            return
+
+        new_count = 0
+        for finding in result.findings:
+            if not _severity_passes(finding.get("severity"), min_severity):
+                continue
+            ext = finding.get("external_id") or finding.get("finding_id")
+            if not ext:
+                continue
+            dedup = self._dedup[source_id]
+            if await dedup.is_processed(ext):
+                continue
+            await self._enqueue(finding, source_id)
+            await dedup.mark_processed(ext)
+            new_count += 1
+
+        if new_count:
+            self.stats["findings"] = self.stats.get("findings", 0) + new_count
+            logger.info("Federation %s ingested %d finding(s)", source_id, new_count)
+
+        store.record_success(source_id, cursor=result.cursor or {})
+
+    async def _enqueue(self, finding: Dict[str, Any], source_id: str) -> None:
+        if self._output_queue is None:
+            return
+        await self._output_queue.put(
+            {
+                "type": "finding",
+                "source": source_id,
+                "data": finding,
+                "timestamp": datetime.utcnow().isoformat(),
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Poll-now bypass (Redis flag set by the API)
+    # ------------------------------------------------------------------
+
+    async def _consume_poll_now(self, source_id: str) -> bool:
+        """Return True if the user clicked Poll Now since the last tick."""
+        try:
+            import os
+
+            import redis.asyncio as aioredis  # type: ignore
+
+            url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+            r = aioredis.from_url(url, decode_responses=True)
+            key = f"vigil:federation:trigger:{source_id}"
+            # GETDEL is atomic — flag is consumed on read.
+            val = await r.getdel(key)
+            await r.close()
+            return val is not None
+        except Exception:
+            return False
+
+
+def request_poll_now(source_id: str) -> bool:
+    """Set the Redis flag the runner consumes to trigger an immediate poll.
+
+    Returns True if the flag was successfully set. Used by the backend API.
+    Sync wrapper around redis-py's sync client so the FastAPI handler doesn't
+    need its own event loop dance.
+    """
+    try:
+        import os
+
+        import redis  # type: ignore
+
+        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        client = redis.from_url(url, decode_responses=True)
+        client.set(f"vigil:federation:trigger:{source_id}", str(int(time.time())), ex=300)
+        return True
+    except Exception as e:
+        logger.warning("request_poll_now(%s) failed: %s", source_id, e)
+        return False

--- a/daemon/federation/seed.py
+++ b/daemon/federation/seed.py
@@ -1,0 +1,51 @@
+"""Auto-seed ``federation_sources`` rows on daemon boot.
+
+For every adapter whose underlying integration is configured, ensure a row
+exists with sensible defaults (default disabled — opt-in feature). Rows
+already present are left untouched, so user edits in the Federation UI
+survive restarts.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from daemon.federation.registry import list_adapters
+from daemon.federation.store import upsert_source
+
+logger = logging.getLogger(__name__)
+
+
+def seed_federation_sources() -> List[str]:
+    """Insert a row for each configured-but-unseen adapter.
+
+    Returns the list of source_ids touched (created or already-existing).
+    Failures on individual sources are logged and skipped — a bad integration
+    config can't break the rest of the seed pass.
+    """
+    seeded: List[str] = []
+    for adapter in list_adapters():
+        try:
+            if not adapter.is_configured():
+                continue
+            row = upsert_source(
+                adapter.name,
+                {
+                    "enabled": False,
+                    "interval_seconds": adapter.default_interval(),
+                    "max_items": 100,
+                    "min_severity": None,
+                    "cursor": {},
+                    "consecutive_errors": 0,
+                },
+            )
+            if row:
+                seeded.append(adapter.name)
+        except Exception as e:
+            logger.warning(
+                "Federation seed failed for %s: %s", getattr(adapter, "name", "?"), e
+            )
+    if seeded:
+        logger.info("Federation seeded %d source(s): %s", len(seeded), seeded)
+    return seeded

--- a/daemon/federation/store.py
+++ b/daemon/federation/store.py
@@ -1,0 +1,162 @@
+"""DB helpers for federation_sources rows + the global federation toggle.
+
+Kept in a single module so both the daemon runner and the backend API can
+use the same code path (no re-implementation drift).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+GLOBAL_KEY = "federation.settings"
+
+
+# ---------------------------------------------------------------------------
+# Global toggle (system_config.federation.settings)
+# ---------------------------------------------------------------------------
+
+
+def get_global_settings() -> Dict[str, Any]:
+    """Return the federation.settings JSON, defaulting to ``{"enabled": False}``."""
+    try:
+        from database.config_service import get_config_service
+
+        cfg = get_config_service().get_system_config(GLOBAL_KEY)
+        if isinstance(cfg, dict):
+            return cfg
+    except Exception as e:
+        logger.debug("federation.settings read failed: %s", e)
+    return {"enabled": False}
+
+
+def set_global_settings(value: Dict[str, Any], updated_by: str = "api") -> None:
+    """Write ``federation.settings`` (read-modify-write so we don't drop fields)."""
+    try:
+        from database.config_service import get_config_service
+
+        current = get_global_settings()
+        current.update(value)
+        get_config_service(user_id=updated_by).set_system_config(
+            key=GLOBAL_KEY,
+            value=current,
+            description="Federated monitoring global on/off",
+            config_type="federation",
+        )
+    except Exception as e:
+        logger.error("federation.settings write failed: %s", e)
+        raise
+
+
+def is_globally_enabled() -> bool:
+    return bool(get_global_settings().get("enabled", False))
+
+
+# ---------------------------------------------------------------------------
+# Per-source row helpers (federation_sources table)
+# ---------------------------------------------------------------------------
+
+
+def list_sources() -> List[Dict[str, Any]]:
+    """All federation_sources rows as dicts."""
+    try:
+        from database.connection import get_db_manager
+        from database.models import FederationSource
+
+        with get_db_manager().session_scope() as session:
+            rows = session.query(FederationSource).all()
+            return [r.to_dict() for r in rows]
+    except Exception as e:
+        logger.debug("list federation_sources failed: %s", e)
+        return []
+
+
+def get_source(source_id: str) -> Optional[Dict[str, Any]]:
+    try:
+        from database.connection import get_db_manager
+        from database.models import FederationSource
+
+        with get_db_manager().session_scope() as session:
+            row = session.get(FederationSource, source_id)
+            return row.to_dict() if row else None
+    except Exception as e:
+        logger.debug("get federation_source(%s) failed: %s", source_id, e)
+        return None
+
+
+def upsert_source(source_id: str, defaults: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Ensure a row exists; if missing, insert with ``defaults``.
+
+    Returns the resulting row as dict. Used by the auto-seed step on daemon
+    boot — see :func:`daemon.federation.seed.seed_federation_sources`.
+    """
+    try:
+        from database.connection import get_db_manager
+        from database.models import FederationSource
+
+        with get_db_manager().session_scope() as session:
+            row = session.get(FederationSource, source_id)
+            if row is None:
+                row = FederationSource(source_id=source_id, **defaults)
+                session.add(row)
+                session.flush()
+            return row.to_dict()
+    except Exception as e:
+        logger.warning("upsert federation_source(%s) failed: %s", source_id, e)
+        return None
+
+
+def update_source(source_id: str, fields: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Patch arbitrary columns on a source row. Caller validates fields."""
+    try:
+        from database.connection import get_db_manager
+        from database.models import FederationSource
+
+        with get_db_manager().session_scope() as session:
+            row = session.get(FederationSource, source_id)
+            if row is None:
+                return None
+            for k, v in fields.items():
+                if hasattr(row, k):
+                    setattr(row, k, v)
+            session.flush()
+            return row.to_dict()
+    except Exception as e:
+        logger.warning("update federation_source(%s) failed: %s", source_id, e)
+        return None
+
+
+def record_success(
+    source_id: str, *, cursor: Dict[str, Any], when: Optional[datetime] = None
+) -> None:
+    when = when or datetime.utcnow()
+    update_source(
+        source_id,
+        {
+            "last_poll_at": when,
+            "last_success_at": when,
+            "last_error": None,
+            "consecutive_errors": 0,
+            "cursor": cursor or {},
+        },
+    )
+
+
+def record_failure(source_id: str, error: str) -> None:
+    """Increment consecutive_errors. We never auto-disable (per design)."""
+    try:
+        from database.connection import get_db_manager
+        from database.models import FederationSource
+
+        with get_db_manager().session_scope() as session:
+            row = session.get(FederationSource, source_id)
+            if row is None:
+                return
+            row.last_poll_at = datetime.utcnow()
+            row.last_error = (error or "")[:2000]
+            row.consecutive_errors = (row.consecutive_errors or 0) + 1
+    except Exception as e:
+        logger.debug("record_failure(%s) failed: %s", source_id, e)

--- a/daemon/poller.py
+++ b/daemon/poller.py
@@ -1,4 +1,19 @@
-"""Data source polling for the SOC daemon."""
+"""Data source polling for the SOC daemon.
+
+Two modes coexist here:
+
+* **Legacy per-source loops** (``_poll_<source>_loop``) — driven by env-var
+  intervals in :class:`daemon.config.PollingConfig`. These predate federation
+  and remain the path used when the global federation toggle is off.
+* **Federation runner** (:class:`daemon.federation.runner.FederationRunner`) —
+  spawned alongside the legacy loops. When ``federation.settings.enabled`` is
+  true and a source has a ``federation_sources`` row enabled, the legacy loop
+  for that source defers (skips that tick) so federation owns the pull.
+
+This co-existence keeps existing deployments working unchanged while the new
+opt-in feature is under MVP. Once federation is the default path we can
+delete the legacy loops in a follow-up.
+"""
 
 import asyncio
 import logging
@@ -8,6 +23,7 @@ from dataclasses import dataclass
 
 from daemon.config import PollingConfig
 from daemon.dedup import RedisDedupSet
+from daemon.federation.runner import FederationRunner
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +45,12 @@ class DataPoller:
     def __init__(self, config: PollingConfig):
         self.config = config
         self._output_queue: Optional[asyncio.Queue] = None
-        
+
+        # Federation runner — owns pull for sources with a federation_sources
+        # row when the global federation.settings toggle is on. Always
+        # constructed; idle while federation is off.
+        self._federation = FederationRunner(output_queue=None)
+
         # Polling cursors for each source
         self._splunk_state = PollState()
         self._crowdstrike_state = PollState()
@@ -78,6 +99,7 @@ class DataPoller:
     def set_output_queue(self, queue: asyncio.Queue):
         """Set the output queue for processed findings."""
         self._output_queue = queue
+        self._federation.set_output_queue(queue)
     
     def _init_services(self):
         """Initialize data source services."""
@@ -160,10 +182,14 @@ class DataPoller:
         """Run the polling loop."""
         logger.info("Data poller starting...")
         self._init_services()
-        
+
         # Create polling tasks
         tasks = []
-        
+
+        # Federation runner is always spawned. It self-gates on the global
+        # federation.settings toggle and per-source rows; idle while disabled.
+        tasks.append(asyncio.create_task(self._federation.run(shutdown_event)))
+
         if self._splunk_service:
             tasks.append(asyncio.create_task(
                 self._poll_splunk_loop(shutdown_event)
@@ -237,6 +263,8 @@ class DataPoller:
         """Poll Splunk for new security alerts."""
         if not self._splunk_service:
             return
+        if self._federation.is_active_for("splunk"):
+            return  # Federation owns this source while globally + per-source enabled
         
         self.stats["splunk_polls"] += 1
         logger.debug("Polling Splunk for new alerts...")
@@ -360,6 +388,8 @@ class DataPoller:
     async def _poll_crowdstrike(self):
         """Poll CrowdStrike for new detections."""
         if not self._crowdstrike_service:
+            return
+        if self._federation.is_active_for("crowdstrike"):
             return
         
         self.stats["crowdstrike_polls"] += 1
@@ -542,6 +572,8 @@ class DataPoller:
         """Poll Azure Sentinel for new incidents."""
         if not self._azure_sentinel_service:
             return
+        if self._federation.is_active_for("azure_sentinel"):
+            return
         
         self.stats["azure_sentinel_polls"] += 1
         logger.debug("Polling Azure Sentinel for new incidents...")
@@ -582,6 +614,8 @@ class DataPoller:
     async def _poll_aws_security_hub(self):
         """Poll AWS Security Hub for new findings."""
         if not self._aws_security_hub_service:
+            return
+        if self._federation.is_active_for("aws_security_hub"):
             return
         
         self.stats["aws_security_hub_polls"] += 1
@@ -624,6 +658,8 @@ class DataPoller:
         """Poll Microsoft Defender for new alerts."""
         if not self._microsoft_defender_service:
             return
+        if self._federation.is_active_for("microsoft_defender"):
+            return
         
         self.stats["microsoft_defender_polls"] += 1
         logger.debug("Polling Microsoft Defender for new alerts...")
@@ -663,6 +699,8 @@ class DataPoller:
     async def _poll_elastic(self):
         """Poll Elastic Security for new detection alerts."""
         if not self._elastic_service:
+            return
+        if self._federation.is_active_for("elastic"):
             return
 
         self.stats["elastic_polls"] += 1

--- a/database/init/15_federation.sql
+++ b/database/init/15_federation.sql
@@ -1,0 +1,45 @@
+-- 15_federation.sql
+-- Federated monitoring: per-source polling state + global toggle.
+--
+-- Each row represents one data source (Splunk, CrowdStrike, etc.) that the
+-- daemon's federation poller pulls from on a configurable cadence. Rows are
+-- auto-seeded on daemon boot from configured integrations (default disabled);
+-- the global on/off lives in `system_config` under key `federation.settings`.
+
+CREATE TABLE IF NOT EXISTS federation_sources (
+    source_id           VARCHAR(64)  PRIMARY KEY,
+    enabled             BOOLEAN      NOT NULL DEFAULT FALSE,
+    interval_seconds    INTEGER      NOT NULL DEFAULT 300,
+    max_items           INTEGER      NOT NULL DEFAULT 100,
+    min_severity        VARCHAR(16),                       -- nullable: "low"|"medium"|"high"|"critical"
+    cursor              JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    last_poll_at        TIMESTAMPTZ,
+    last_success_at     TIMESTAMPTZ,
+    last_error          TEXT,
+    consecutive_errors  INTEGER      NOT NULL DEFAULT 0,
+    created_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_federation_sources_enabled
+    ON federation_sources (enabled);
+
+-- Add external_id to findings to support a strong (data_source, external_id)
+-- dedup guarantee. Existing rows leave external_id NULL (the partial unique
+-- index below excludes NULLs), so legacy findings are not affected.
+ALTER TABLE findings
+    ADD COLUMN IF NOT EXISTS external_id VARCHAR(255);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_findings_source_extid
+    ON findings (data_source, external_id)
+    WHERE data_source IS NOT NULL AND external_id IS NOT NULL;
+
+-- Seed the global federation toggle (off by default — opt-in feature).
+INSERT INTO system_config (key, value, description, config_type)
+VALUES (
+    'federation.settings',
+    '{"enabled": false}'::jsonb,
+    'Federated monitoring global on/off (per-source toggles live in federation_sources)',
+    'federation'
+)
+ON CONFLICT (key) DO NOTHING;

--- a/database/models.py
+++ b/database/models.py
@@ -78,6 +78,9 @@ class Finding(Base):
     # Metadata
     timestamp: Mapped[datetime] = mapped_column(DateTime, nullable=False)
     data_source: Mapped[str] = mapped_column(String(50), nullable=False)
+    # Source-native ID. Combined with data_source it forms the dedup key
+    # for federated ingest (see uniq_findings_source_extid).
+    external_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     cluster_id: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     severity: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
     status: Mapped[str] = mapped_column(
@@ -118,6 +121,15 @@ class Finding(Base):
             postgresql_ops={"description": "gin_trgm_ops"},
             postgresql_using="gin",
         ),
+        Index(
+            "uniq_findings_source_extid",
+            "data_source",
+            "external_id",
+            unique=True,
+            postgresql_where=text(
+                "data_source IS NOT NULL AND external_id IS NOT NULL"
+            ),
+        ),
     )
 
     def to_dict(self) -> dict:
@@ -132,6 +144,7 @@ class Finding(Base):
             "evidence_links": self.evidence_links,
             "timestamp": self.timestamp.isoformat() if self.timestamp else None,
             "data_source": self.data_source,
+            "external_id": self.external_id,
             "cluster_id": self.cluster_id,
             "severity": self.severity,
             "status": self.status,
@@ -601,6 +614,87 @@ class IntegrationConfig(Base):
             "last_test_success": self.last_test_success,
             "last_error": self.last_error,
             "updated_by": self.updated_by,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+class FederationSource(Base):
+    """
+    Federation Source - Per-source state for the federated monitoring poller.
+
+    One row per data source the daemon pulls from on a configurable cadence.
+    Rows are auto-seeded on daemon boot from configured integrations (default
+    disabled). The global on/off lives in ``system_config`` under the key
+    ``federation.settings`` — a source only polls when both the global toggle
+    and its own ``enabled`` flag are true.
+    """
+
+    __tablename__ = "federation_sources"
+
+    # Primary key — matches integration ids (e.g. "splunk", "crowdstrike")
+    source_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+
+    # Toggle + cadence
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    interval_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=300, server_default="300"
+    )
+    max_items: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=100, server_default="100"
+    )
+
+    # Optional severity floor: only ingest findings >= this severity.
+    # Nullable means "no filter".
+    min_severity: Mapped[Optional[str]] = mapped_column(String(16), nullable=True)
+
+    # Adapter-defined cursor (e.g. {"earliest_time": "..."} for Splunk).
+    cursor: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+
+    # Health
+    last_poll_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    last_success_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime, nullable=True
+    )
+    last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    consecutive_errors: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, server_default=text("now()")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        server_default=text("now()"),
+    )
+
+    __table_args__ = (Index("idx_federation_sources_enabled", "enabled"),)
+
+    def to_dict(self) -> dict:
+        return {
+            "source_id": self.source_id,
+            "enabled": self.enabled,
+            "interval_seconds": self.interval_seconds,
+            "max_items": self.max_items,
+            "min_severity": self.min_severity,
+            "cursor": self.cursor,
+            "last_poll_at": (
+                self.last_poll_at.isoformat() if self.last_poll_at else None
+            ),
+            "last_success_at": (
+                self.last_success_at.isoformat() if self.last_success_at else None
+            ),
+            "last_error": self.last_error,
+            "consecutive_errors": self.consecutive_errors,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/database/service.py
+++ b/database/service.py
@@ -59,6 +59,7 @@ class DatabaseService:
                     anomaly_score=anomaly_score,
                     timestamp=timestamp,
                     data_source=data_source,
+                    external_id=kwargs.get('external_id'),
                     description=kwargs.get('description'),
                     entity_context=kwargs.get('entity_context'),
                     evidence_links=kwargs.get('evidence_links'),

--- a/frontend/src/components/claude/ClaudeDrawer.tsx
+++ b/frontend/src/components/claude/ClaudeDrawer.tsx
@@ -48,7 +48,14 @@ import {
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
 } from '@mui/icons-material'
-import { claudeApi, agentsApi, mcpApi, reasoningApi } from '../../services/api'
+import {
+  claudeApi,
+  agentsApi,
+  mcpApi,
+  reasoningApi,
+  analyticsApi,
+  type CostEstimate,
+} from '../../services/api'
 import { notificationService } from '../../services/notifications'
 import { createLogger } from '../../services/logger'
 
@@ -166,6 +173,10 @@ export default function ClaudeDrawer({ open, onClose, initialMessages, initialAg
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [mcpStatus, setMcpStatus] = useState<{ available: number; total: number } | null>(null)
   const [estimatedTokens, setEstimatedTokens] = useState(0)
+  // #184 Phase 2: pre-call USD estimate from /api/analytics/estimate-cost.
+  // Replaces the old client-side length/4 heuristic — that gave us tokens
+  // but no cost band, and undercounted multimodal/tool-call payloads.
+  const [costEstimate, setCostEstimate] = useState<CostEstimate | null>(null)
   const [streamingThinking, setStreamingThinking] = useState<string>('')
   const [isThinking, setIsThinking] = useState(false)
   const [streamingText, setStreamingText] = useState<string>('')
@@ -393,16 +404,48 @@ export default function ClaudeDrawer({ open, onClose, initialMessages, initialAg
 
   useEffect(() => { if (!open) setLastInvestigationId(null) }, [open])
 
+  // #184 Phase 2: ask the backend for an exact token count + USD estimate
+  // instead of doing the math client-side. The backend uses Anthropic's
+  // free count_tokens API for Anthropic models (so the number is exact,
+  // including system prompt + tools), and tiktoken for OpenAI. Debounced
+  // 400ms so we don't hammer the endpoint on every keystroke. The fetch
+  // is best-effort — on failure we keep the last good estimate rather
+  // than zeroing out the warning bar (which would mislead the user).
   useEffect(() => {
-    const msgs = tabs[currentTab]?.messages || []
-    let total = 0
-    msgs.forEach(msg => {
-      if (typeof msg.content === 'string') total += msg.content.length / 4
-      else msg.content.forEach(b => { if (b.type === 'text' && b.text) total += b.text.length / 4; else if (b.type === 'image') total += 85 })
-    })
-    total += input.length / 4 + (systemPrompt?.length || 0) / 4
-    setEstimatedTokens(Math.round(total))
-  }, [tabs, currentTab, input, systemPrompt])
+    const ctrl = new AbortController()
+    const debounce = setTimeout(async () => {
+      const msgs = tabs[currentTab]?.messages || []
+      const messagesPayload = [
+        ...msgs.map(m => ({ role: m.role, content: m.content })),
+        ...(input.trim() ? [{ role: 'user', content: input }] : []),
+      ]
+      // Nothing to estimate yet → reset so the warning bar disappears.
+      if (messagesPayload.length === 0 && !systemPrompt) {
+        setCostEstimate(null)
+        setEstimatedTokens(0)
+        return
+      }
+      try {
+        const res = await analyticsApi.estimateCost({
+          provider_type: 'anthropic',
+          model_id: model || 'claude-sonnet-4-5-20250929',
+          messages: messagesPayload,
+          system_prompt: systemPrompt || undefined,
+          max_tokens: maxTokens,
+        })
+        if (ctrl.signal.aborted) return
+        setCostEstimate(res.data)
+        setEstimatedTokens(res.data.input_tokens)
+      } catch {
+        // Keep previous estimate on failure — no point flashing $0 when
+        // the network blip resolves. Logged at debug elsewhere.
+      }
+    }, 400)
+    return () => {
+      clearTimeout(debounce)
+      ctrl.abort()
+    }
+  }, [tabs, currentTab, input, systemPrompt, model, maxTokens])
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files
@@ -842,6 +885,31 @@ export default function ClaudeDrawer({ open, onClose, initialMessages, initialAg
                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25 }}>
                   Output max: {maxTokens.toLocaleString()} tokens
                 </Typography>
+                {costEstimate && (
+                  <Tooltip
+                    title={
+                      // The band's bounds: low = no output (immediate stop),
+                      // high = max_tokens of output. Real cost lands in
+                      // between, and is typically much closer to low_usd
+                      // when prompt caching is hot.
+                      `${costEstimate.token_count_method === 'anthropic_count_tokens'
+                        ? 'Exact token count via Anthropic count_tokens API.'
+                        : costEstimate.token_count_method === 'tiktoken'
+                        ? 'Token count via tiktoken (OpenAI encoder).'
+                        : 'Approximate token count (chars ÷ 4 fallback).'} ` +
+                      `Pricing: ${costEstimate.pricing_source}.`
+                    }
+                  >
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block', mt: 0.25, fontFamily: 'monospace' }}
+                    >
+                      Est. cost: ${costEstimate.low_usd.toFixed(4)} – ${costEstimate.high_usd.toFixed(4)}
+                      {costEstimate.pricing_source !== 'exact' && ` · ${costEstimate.pricing_source}`}
+                    </Typography>
+                  </Tooltip>
+                )}
               </Box>
 
               {/* Model Settings Section */}

--- a/frontend/src/components/graph/VStrikeIframeHost.tsx
+++ b/frontend/src/components/graph/VStrikeIframeHost.tsx
@@ -375,6 +375,7 @@ export default function VStrikeIframeHost() {
                 value={ctx.selectedNetwork}
                 onChange={handleNetworkChange}
                 displayEmpty
+                MenuProps={{ sx: { zIndex: 1302 } }}
               >
                 <MenuItem value="">
                   <em>
@@ -402,6 +403,7 @@ export default function VStrikeIframeHost() {
                 value={ctx.selectedStoryline}
                 onChange={handleStorylineChange}
                 displayEmpty
+                MenuProps={{ sx: { zIndex: 1302 } }}
               >
                 <MenuItem value="">
                   <em>
@@ -440,6 +442,7 @@ export default function VStrikeIframeHost() {
                 value={ctx.selectedLegendRun}
                 onChange={handleLegendRunChange}
                 displayEmpty
+                MenuProps={{ sx: { zIndex: 1302 } }}
               >
                 <MenuItem value="">
                   <em>

--- a/frontend/src/components/settings/FederationTab.tsx
+++ b/frontend/src/components/settings/FederationTab.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import RefreshIcon from '@mui/icons-material/Refresh'
+import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import { federationApi, FederationSourceView } from '../../services/api'
+
+interface Props {
+  onMessage: (msg: { type: 'success' | 'error'; text: string }) => void
+}
+
+const SEVERITY_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: '', label: 'Any' },
+  { value: 'low', label: 'Low+' },
+  { value: 'medium', label: 'Medium+' },
+  { value: 'high', label: 'High+' },
+  { value: 'critical', label: 'Critical only' },
+]
+
+const SOURCE_LABELS: Record<string, string> = {
+  splunk: 'Splunk',
+  crowdstrike: 'CrowdStrike Falcon',
+  azure_sentinel: 'Azure Sentinel',
+  aws_security_hub: 'AWS Security Hub',
+  microsoft_defender: 'Microsoft Defender',
+  elastic: 'Elastic Security',
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return 'never'
+  const t = new Date(iso).getTime()
+  if (isNaN(t)) return 'never'
+  const sec = Math.floor((Date.now() - t) / 1000)
+  if (sec < 60) return `${sec}s ago`
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`
+  return `${Math.floor(sec / 86400)}d ago`
+}
+
+export default function FederationTab({ onMessage }: Props) {
+  const [globalEnabled, setGlobalEnabled] = useState(false)
+  const [sources, setSources] = useState<FederationSourceView[]>([])
+  const [loading, setLoading] = useState(true)
+  const [savingSource, setSavingSource] = useState<string | null>(null)
+
+  const loadAll = async () => {
+    try {
+      const res = await federationApi.listSources()
+      setSources(res.data.sources || [])
+      setGlobalEnabled(Boolean(res.data.global?.enabled))
+    } catch {
+      onMessage({ type: 'error', text: 'Failed to load federation sources' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadAll()
+    // Refresh health every 10s so the user sees last_success_at advance.
+    const t = setInterval(loadAll, 10_000)
+    return () => clearInterval(t)
+  }, [])
+
+  const toggleGlobal = async (enabled: boolean) => {
+    setGlobalEnabled(enabled)
+    try {
+      await federationApi.setSettings(enabled)
+      onMessage({
+        type: 'success',
+        text: `Federated monitoring ${enabled ? 'enabled' : 'disabled'}`,
+      })
+    } catch {
+      onMessage({ type: 'error', text: 'Failed to update global setting' })
+      setGlobalEnabled(!enabled)
+    }
+  }
+
+  const patchSource = async (
+    sourceId: string,
+    patch: Parameters<typeof federationApi.updateSource>[1],
+  ) => {
+    setSavingSource(sourceId)
+    try {
+      const res = await federationApi.updateSource(sourceId, patch)
+      setSources((prev) => prev.map((s) => (s.source_id === sourceId ? res.data : s)))
+    } catch {
+      onMessage({ type: 'error', text: `Failed to update ${sourceId}` })
+    } finally {
+      setSavingSource(null)
+    }
+  }
+
+  const pollNow = async (sourceId: string) => {
+    try {
+      await federationApi.pollNow(sourceId)
+      onMessage({ type: 'success', text: `Triggered poll for ${sourceId}` })
+    } catch {
+      onMessage({ type: 'error', text: `Failed to trigger poll for ${sourceId}` })
+    }
+  }
+
+  const counts = useMemo(() => {
+    const enabled = sources.filter((s) => s.enabled).length
+    const errors = sources.filter((s) => (s.consecutive_errors || 0) > 0).length
+    return { enabled, errors, total: sources.length }
+  }, [sources])
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, p: 2 }}>
+        <CircularProgress size={16} />
+        <Typography variant="body2">Loading federated monitoring…</Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box>
+      <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
+        Federated Monitoring
+      </Typography>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
+        Pull findings from external SIEM/EDR sources on a configurable cadence and
+        feed them into the auto-investigator. Global toggle disables all federation
+        polling; per-source rows control which sources are pulled and how often.
+        First-run on enable starts from "now" — no historical backfill.
+      </Typography>
+
+      <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+        <Stack direction="row" alignItems="center" spacing={2}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={globalEnabled}
+                onChange={(e) => toggleGlobal(e.target.checked)}
+              />
+            }
+            label={
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                Federated monitoring is {globalEnabled ? 'ON' : 'OFF'}
+              </Typography>
+            }
+          />
+          <Box sx={{ flex: 1 }} />
+          <Chip size="small" label={`${counts.enabled}/${counts.total} sources enabled`} />
+          {counts.errors > 0 && (
+            <Chip size="small" color="warning" label={`${counts.errors} with errors`} />
+          )}
+          <Tooltip title="Refresh">
+            <Button size="small" startIcon={<RefreshIcon />} onClick={loadAll}>
+              Refresh
+            </Button>
+          </Tooltip>
+        </Stack>
+      </Paper>
+
+      {!globalEnabled && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Federation is globally disabled. Enable the master switch above to begin
+          polling enabled sources. Per-source rows can still be configured below
+          while global is off.
+        </Alert>
+      )}
+
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Source</TableCell>
+              <TableCell>Enabled</TableCell>
+              <TableCell>Interval (s)</TableCell>
+              <TableCell>Min severity</TableCell>
+              <TableCell>Last success</TableCell>
+              <TableCell>Errors</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {sources.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={7}>
+                  <Typography variant="body2" color="text.secondary">
+                    No federation sources available. Configure an integration
+                    (Splunk, CrowdStrike, Sentinel, etc.) under Integrations / MCP
+                    first — adapters auto-seed when the daemon starts.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+            {sources.map((s) => {
+              const label = SOURCE_LABELS[s.source_id] || s.source_id
+              const lastErr = s.last_error
+              return (
+                <TableRow key={s.source_id} hover>
+                  <TableCell>
+                    <Stack>
+                      <Typography variant="body2">{label}</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {s.source_id}
+                        {!s.is_configured && ' · not configured'}
+                      </Typography>
+                    </Stack>
+                  </TableCell>
+                  <TableCell>
+                    <Switch
+                      size="small"
+                      checked={s.enabled}
+                      disabled={!s.is_configured || savingSource === s.source_id}
+                      onChange={(e) =>
+                        patchSource(s.source_id, { enabled: e.target.checked })
+                      }
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <TextField
+                      size="small"
+                      type="number"
+                      sx={{ width: 90 }}
+                      value={s.interval_seconds}
+                      onChange={(e) =>
+                        setSources((prev) =>
+                          prev.map((row) =>
+                            row.source_id === s.source_id
+                              ? { ...row, interval_seconds: Number(e.target.value) }
+                              : row,
+                          ),
+                        )
+                      }
+                      onBlur={() =>
+                        patchSource(s.source_id, { interval_seconds: s.interval_seconds })
+                      }
+                      inputProps={{ min: 10, max: 86400 }}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <FormControl size="small" sx={{ minWidth: 110 }}>
+                      <InputLabel>Floor</InputLabel>
+                      <Select
+                        label="Floor"
+                        value={s.min_severity || ''}
+                        onChange={(e) =>
+                          patchSource(s.source_id, {
+                            min_severity: e.target.value
+                              ? String(e.target.value)
+                              : null,
+                          })
+                        }
+                      >
+                        {SEVERITY_OPTIONS.map((opt) => (
+                          <MenuItem key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" color="text.secondary">
+                      {formatRelative(s.last_success_at)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    {(s.consecutive_errors || 0) > 0 ? (
+                      <Tooltip title={lastErr || ''}>
+                        <Chip
+                          size="small"
+                          color="warning"
+                          label={s.consecutive_errors}
+                        />
+                      </Tooltip>
+                    ) : (
+                      <Typography variant="caption" color="text.secondary">
+                        —
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell align="right">
+                    <Tooltip
+                      title={
+                        s.is_configured
+                          ? 'Trigger an immediate poll, bypassing the interval'
+                          : 'Configure the integration first'
+                      }
+                    >
+                      <span>
+                        <Button
+                          size="small"
+                          startIcon={<PlayArrowIcon />}
+                          disabled={!s.is_configured}
+                          onClick={() => pollNow(s.source_id)}
+                        >
+                          Poll now
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  )
+}

--- a/frontend/src/contexts/VStrikeIframeContext.tsx
+++ b/frontend/src/contexts/VStrikeIframeContext.tsx
@@ -403,10 +403,14 @@ export function VStrikeIframeProvider({ children }: ProviderProps) {
         return
       }
       try {
+        // eslint-disable-next-line no-console
+        console.log('[VStrike] fetching storylines for', networkId)
         const res = await vstrikeApi.listStorylines(networkId)
         // Cancel if user switched networks while we were in-flight.
         if (currentNetworkRef.current !== networkId) return
         const items = res.data?.storylines || []
+        // eslint-disable-next-line no-console
+        console.log('[VStrike] storylines response', items.length, 'items')
         const opts: Array<{ id: string; label: string; raw: Record<string, any> }> =
           []
         for (const raw of items) {
@@ -432,10 +436,14 @@ export function VStrikeIframeProvider({ children }: ProviderProps) {
         return
       }
       try {
+        // eslint-disable-next-line no-console
+        console.log('[VStrike] fetching legend runs for', networkId)
         const res = await vstrikeApi.listLegendRuns(networkId)
         // Cancel if user switched networks while we were in-flight.
         if (currentNetworkRef.current !== networkId) return
         const items = res.data?.legend_runs || []
+        // eslint-disable-next-line no-console
+        console.log('[VStrike] legend runs response', items.length, 'items')
         const opts: Array<{ id: string; label: string; raw: Record<string, any> }> =
           []
         for (const raw of items) {

--- a/frontend/src/pages/CostAnalytics.tsx
+++ b/frontend/src/pages/CostAnalytics.tsx
@@ -55,6 +55,12 @@ interface AgentBreakdown {
 
 interface ModelBreakdown {
   model: string
+  // #184 Phase 3: provider_type is inferred from the model id server-side
+  // when the row is built; pricing_source tells the UI whether cost_usd
+  // came from an exact catalog rate, a tier-regex heuristic, the
+  // self-hosted "$0" branch, or no data at all.
+  provider_type: string
+  pricing_source: 'exact' | 'heuristic' | 'zero' | 'unknown'
   calls: number
   input_tokens: number
   output_tokens: number
@@ -113,6 +119,46 @@ function formatCost(n: number): string {
 
 function formatPercent(n: number): string {
   return `${(n * 100).toFixed(1)}%`
+}
+
+// #184 Phase 3: turn the server's pricing_source string into a UI-visible
+// badge. The point is to distinguish a real $0 row (Ollama, self-hosted)
+// from a $0 row that's a missing-data fallback ("unknown") so an operator
+// can tell whether the dashboard is reporting reality or hiding gaps.
+function PricingSourceBadge({ source }: { source: ModelBreakdown['pricing_source'] }) {
+  const config: Record<
+    ModelBreakdown['pricing_source'],
+    { label: string; color: 'success' | 'warning' | 'info' | 'error'; tooltip: string }
+  > = {
+    exact: {
+      label: 'exact',
+      color: 'success',
+      tooltip: 'Pricing from hand-verified catalog entry.',
+    },
+    heuristic: {
+      label: 'heuristic',
+      color: 'warning',
+      tooltip:
+        'Pricing inferred from a tier regex (e.g. "any sonnet variant"). Approximate.',
+    },
+    zero: {
+      label: 'free',
+      color: 'info',
+      tooltip: 'Self-hosted (Ollama). No upstream API spend; compute cost not tracked.',
+    },
+    unknown: {
+      label: 'unknown',
+      color: 'error',
+      tooltip:
+        'No catalog entry matched. Cost recorded as $0 — real spend is hidden until pricing is added.',
+    },
+  }
+  const { label, color, tooltip } = config[source] || config.unknown
+  return (
+    <MuiTooltip title={tooltip}>
+      <Chip size="small" label={label} color={color} variant="outlined" />
+    </MuiTooltip>
+  )
 }
 
 export default function CostAnalytics() {
@@ -332,6 +378,67 @@ export default function CostAnalytics() {
               {(!data || data.by_agent.length === 0) && !loading && (
                 <TableRow>
                   <TableCell colSpan={8} align="center">
+                    <Typography color="text.secondary" sx={{ py: 2 }}>
+                      No LLM calls in this window.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+
+      <Paper sx={{ mb: 3 }}>
+        <Box sx={{ p: 2 }}>
+          <Typography variant="h6">Per-Model Breakdown</Typography>
+          <Typography variant="caption" color="text.secondary">
+            Rows badged "heuristic" or "unknown" use approximate pricing — see the
+            tooltip on each badge for what that means.
+          </Typography>
+        </Box>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Model</TableCell>
+                <TableCell>Provider</TableCell>
+                <TableCell>Pricing</TableCell>
+                <TableCell align="right">Calls</TableCell>
+                <TableCell align="right">Input</TableCell>
+                <TableCell align="right">Cache read</TableCell>
+                <TableCell align="right">Cache write</TableCell>
+                <TableCell align="right">Output</TableCell>
+                <TableCell align="right">Cache hit</TableCell>
+                <TableCell align="right">Cost</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {(data?.by_model || []).map((row) => (
+                <TableRow key={row.model} hover>
+                  <TableCell>
+                    <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                      {row.model}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Chip size="small" label={row.provider_type} variant="outlined" />
+                  </TableCell>
+                  <TableCell>
+                    <PricingSourceBadge source={row.pricing_source} />
+                  </TableCell>
+                  <TableCell align="right">{row.calls}</TableCell>
+                  <TableCell align="right">{formatTokens(row.input_tokens)}</TableCell>
+                  <TableCell align="right">{formatTokens(row.cache_read_tokens)}</TableCell>
+                  <TableCell align="right">{formatTokens(row.cache_creation_tokens)}</TableCell>
+                  <TableCell align="right">{formatTokens(row.output_tokens)}</TableCell>
+                  <TableCell align="right">{formatPercent(row.cache_hit_rate)}</TableCell>
+                  <TableCell align="right">{formatCost(row.cost_usd)}</TableCell>
+                </TableRow>
+              ))}
+              {(!data || data.by_model.length === 0) && !loading && (
+                <TableRow>
+                  <TableCell colSpan={10} align="center">
                     <Typography color="text.secondary" sx={{ py: 2 }}>
                       No LLM calls in this window.
                     </Typography>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -65,6 +65,7 @@ import { getAllIntegrations, loadCustomIntegrations } from '../config/integratio
 import UserManagementTab from '../components/settings/UserManagementTab'
 import DetectionRulesTab from '../components/settings/DetectionRulesTab'
 import AutoInvestigateTab from '../components/settings/AutoInvestigateTab'
+import FederationTab from '../components/settings/FederationTab'
 import KafkaTab from '../components/settings/KafkaTab'
 import LLMProvidersTab from '../components/settings/LLMProvidersTab'
 import ModelAssignmentTab from '../components/settings/ModelAssignmentTab'
@@ -100,6 +101,7 @@ const TAB_DEFS: { key: string; label: string; devOnly: boolean }[] = [
   { key: 'integrations', label: 'Integrations / MCP', devOnly: false },
   { key: 'users', label: 'Users', devOnly: false },
   { key: 'autoinvestigate', label: 'Auto Investigate', devOnly: false },
+  { key: 'federation', label: 'Federation', devOnly: false },
   { key: 'system', label: 'System', devOnly: false },
   { key: 'general', label: 'General', devOnly: false },
   { key: 'dev', label: 'Developer', devOnly: true },
@@ -1831,6 +1833,15 @@ export default function Settings() {
           <TabPanel value={currentTab} index={idx} key={tabKey}>
             <Box sx={{ maxWidth: 800 }}>
               <AutoInvestigateTab onMessage={setMessage} showConfirm={showConfirm} />
+            </Box>
+          </TabPanel>
+        )
+
+      case 'federation':
+        return (
+          <TabPanel value={currentTab} index={idx} key={tabKey}>
+            <Box sx={{ maxWidth: 1100 }}>
+              <FederationTab onMessage={setMessage} />
             </Box>
           </TabPanel>
         )

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1333,6 +1333,47 @@ export const orchestratorApi = {
   getCost: () => api.get('/orchestrator/cost'),
 }
 
+// Federation API (federated monitoring of external SIEM/EDR sources)
+export interface FederationSourceView {
+  source_id: string
+  enabled: boolean
+  interval_seconds: number
+  max_items: number
+  min_severity: string | null
+  last_poll_at: string | null
+  last_success_at: string | null
+  last_error: string | null
+  consecutive_errors: number
+  is_configured: boolean
+  default_interval_seconds: number
+}
+
+export interface FederationListResponse {
+  sources: FederationSourceView[]
+  global: { enabled: boolean }
+}
+
+export const federationApi = {
+  getSettings: () => api.get<{ enabled: boolean }>('/federation/settings'),
+  setSettings: (enabled: boolean) =>
+    api.put<{ enabled: boolean }>('/federation/settings', { enabled }),
+  listSources: () => api.get<FederationListResponse>('/federation/sources'),
+  updateSource: (
+    sourceId: string,
+    patch: Partial<{
+      enabled: boolean
+      interval_seconds: number
+      max_items: number
+      min_severity: string | null
+    }>,
+  ) => api.patch<FederationSourceView>(`/federation/sources/${sourceId}`, patch),
+  pollNow: (sourceId: string) =>
+    api.post<{ ok: boolean; source_id: string }>(
+      `/federation/sources/${sourceId}/poll-now`,
+    ),
+  getHealth: () => api.get('/federation/health'),
+}
+
 // Reasoning-trace API (GH #79 — LLM chain-of-thought visibility)
 export const reasoningApi = {
   getSessionSummary: (sessionId: string) =>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1054,6 +1054,32 @@ export const ingestionApi = {
   },
 }
 
+// Analytics API (#184 Phase 2)
+export interface CostEstimate {
+  provider_type: string
+  model_id: string
+  input_tokens: number
+  output_tokens_max: number
+  low_usd: number
+  high_usd: number
+  pricing_source: 'exact' | 'heuristic' | 'zero' | 'unknown'
+  token_count_method: 'anthropic_count_tokens' | 'tiktoken' | 'char_heuristic'
+}
+
+export const analyticsApi = {
+  // Pre-call USD/token estimate. The chat composer calls this (debounced)
+  // as the user types so they see what their message will cost before
+  // sending. token_count_method tells the UI how trustworthy the count is.
+  estimateCost: (payload: {
+    provider_type: string
+    model_id: string
+    messages: Array<{ role: string; content: any }>
+    system_prompt?: string
+    tools?: any[]
+    max_tokens?: number
+  }) => api.post<CostEstimate>('/analytics/estimate-cost', payload),
+}
+
 // Storage API
 export const storageApi = {
   getStatus: () => api.get('/storage/status'),

--- a/services/claude_service.py
+++ b/services/claude_service.py
@@ -1111,10 +1111,18 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
 
             try:
                 # GH #89: use the model registry for per-provider pricing.
+                # #184 Phase 3: include cache tokens so reads (0.1×) and
+                # writes (1.25×) are priced correctly instead of being
+                # treated as full-rate input.
                 from daemon.agent_runner import compute_call_cost
 
                 cost_usd = compute_call_cost(
-                    model, "anthropic", int(input_tokens or 0), int(output_tokens or 0)
+                    model,
+                    "anthropic",
+                    int(input_tokens or 0),
+                    int(output_tokens or 0),
+                    cache_read_tokens=int(cache_read_tokens or 0),
+                    cache_creation_tokens=int(cache_creation_tokens or 0),
                 )
             except Exception:
                 cost_usd = 0.0
@@ -2292,9 +2300,7 @@ Provide a structured summary preserving all critical context."""
                             {
                                 "type": "tool_result",
                                 "tool_use_id": tool_id,
-                                "content": [
-                                    {"type": "text", "text": err_text}
-                                ],
+                                "content": [{"type": "text", "text": err_text}],
                             }
                         )
                 else:
@@ -2536,12 +2542,21 @@ Provide a structured summary preserving all critical context."""
             if _OTEL_CS_AVAILABLE and _chat_span is not None:
                 try:
                     _duration = _time.monotonic() - _chat_t0
+                    _usage_otel = getattr(response, "usage", None)
                     _in_tok = (
-                        response.usage.input_tokens if hasattr(response, "usage") else 0
+                        getattr(_usage_otel, "input_tokens", 0) if _usage_otel else 0
                     )
                     _out_tok = (
-                        response.usage.output_tokens
-                        if hasattr(response, "usage")
+                        getattr(_usage_otel, "output_tokens", 0) if _usage_otel else 0
+                    )
+                    _cache_read_tok = (
+                        getattr(_usage_otel, "cache_read_input_tokens", 0)
+                        if _usage_otel
+                        else 0
+                    )
+                    _cache_creation_tok = (
+                        getattr(_usage_otel, "cache_creation_input_tokens", 0)
+                        if _usage_otel
                         else 0
                     )
                     _model_used = (
@@ -2568,10 +2583,17 @@ Provide a structured summary preserving all critical context."""
                         _out_tok, {**_labels, "gen_ai.token.type": "output"}
                     )
                     # GH #89: use the model registry for per-provider pricing.
+                    # #184 Phase 3: include cache tokens at provider-specific
+                    # rates (Anthropic: 0.1× read / 1.25× write).
                     from daemon.agent_runner import compute_call_cost
 
                     _cost = compute_call_cost(
-                        model, "anthropic", int(_in_tok or 0), int(_out_tok or 0)
+                        model,
+                        "anthropic",
+                        int(_in_tok or 0),
+                        int(_out_tok or 0),
+                        cache_read_tokens=int(_cache_read_tok or 0),
+                        cache_creation_tokens=int(_cache_creation_tok or 0),
                     )
                     _cs_genai_metrics["llm_cost_usd"].add(_cost, _labels)
                 except Exception:

--- a/services/cost_estimator.py
+++ b/services/cost_estimator.py
@@ -1,0 +1,318 @@
+"""Pre-call LLM cost estimation (#184 Phase 2).
+
+Lets callers (chat composer, daemon planner, workflow engine) ask
+"approximately what will this prompt cost on this model?" before
+spending money. Returns a low/high USD band rather than a point estimate
+because output length is unknown — the high bound assumes ``max_tokens``
+output, the low bound assumes a no-output completion (e.g. an
+immediately-stopped tool call).
+
+Token counting strategy by provider:
+
+  - **Anthropic**: uses the SDK's free ``client.messages.count_tokens()``
+    endpoint, routed through Bifrost like every other Anthropic call.
+    Returns exact prompt-token counts including system prompt and tools.
+
+  - **OpenAI**: uses ``tiktoken`` if available (encoder lookup by model
+    name), else falls back to a 4-chars-per-token heuristic. The heuristic
+    is good enough for budget gating but not for billing — callers see
+    ``pricing_source="heuristic"`` and can badge the estimate accordingly.
+
+  - **Ollama / unknown**: char heuristic + ``$0`` rates → returns ``$0``.
+    Self-hosted compute cost is out of scope (#184 explicitly defers it).
+
+Cache hits are not modeled in v1 — the estimator is for the cold-path
+"what will this cost if nothing's cached" question. Once the call lands,
+the actual cost (cache-aware via ``compute_call_cost``) will typically be
+lower than the high bound for cache-friendly workloads. That asymmetry is
+fine: estimates over-bound, actuals are exact.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    """Result of a pre-call cost estimate.
+
+    ``pricing_source`` propagates from the model registry plus a token-
+    counting flag — callers can show "approximate" badges when this is
+    anything other than ``"exact"``.
+    """
+
+    provider_type: str
+    model_id: str
+    input_tokens: int
+    output_tokens_max: int
+    low_usd: float
+    high_usd: float
+    pricing_source: str  # "exact" | "heuristic" | "zero" | "unknown"
+    token_count_method: str  # "anthropic_count_tokens" | "tiktoken" | "char_heuristic"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Token counting
+# ---------------------------------------------------------------------------
+
+
+_CHARS_PER_TOKEN_HEURISTIC = 4
+"""Rough English-text token density. Conservative for code (which packs
+denser) and for non-Latin scripts (which pack looser); good enough for
+budget gating, not good enough for billing."""
+
+
+def _flatten_message_text(messages: List[Dict[str, Any]]) -> str:
+    """Concatenate the text portion of every message into one string.
+
+    The estimator only needs character count, not structured content, so
+    multimodal blocks (images, tool_use, tool_result) are ignored — they
+    have their own token costs the heuristic can't capture and the
+    Anthropic ``count_tokens`` API handles natively.
+    """
+    parts: List[str] = []
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    text = block.get("text") or ""
+                    if text:
+                        parts.append(text)
+    return "\n".join(parts)
+
+
+def _char_heuristic_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return max(1, len(text) // _CHARS_PER_TOKEN_HEURISTIC)
+
+
+def _count_tokens_openai(model_id: str, text: str) -> tuple[int, str]:
+    """Return ``(token_count, method_used)``.
+
+    Tries ``tiktoken`` first, falls back to the char heuristic if the
+    encoder isn't installed or doesn't recognise the model. The fallback
+    is logged at debug — callers see the method label and can decide
+    whether to trust it.
+    """
+    if not text:
+        return (0, "char_heuristic")
+    try:
+        import tiktoken  # type: ignore
+    except ImportError:
+        return (_char_heuristic_tokens(text), "char_heuristic")
+
+    try:
+        enc = tiktoken.encoding_for_model(model_id)
+    except KeyError:
+        # Unknown model — fall back to the cl100k_base encoder used by
+        # all current OpenAI chat models. Not perfect for novel models
+        # but better than the char heuristic.
+        try:
+            enc = tiktoken.get_encoding("cl100k_base")
+        except Exception:  # noqa: BLE001
+            return (_char_heuristic_tokens(text), "char_heuristic")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("tiktoken lookup for %s failed: %s", model_id, exc)
+        return (_char_heuristic_tokens(text), "char_heuristic")
+
+    return (len(enc.encode(text)), "tiktoken")
+
+
+# ---------------------------------------------------------------------------
+# Per-provider estimators
+# ---------------------------------------------------------------------------
+
+
+async def estimate_anthropic(
+    *,
+    model_id: str,
+    messages: List[Dict[str, Any]],
+    system_prompt: Optional[str] = None,
+    tools: Optional[List[Dict[str, Any]]] = None,
+    max_tokens: int = 4096,
+) -> CostEstimate:
+    """Estimate USD cost of an Anthropic call by hitting count_tokens.
+
+    Routes through Bifrost via ``services.llm_clients.create_async_anthropic_client``
+    so the count_tokens call obeys the single-routing-path policy.
+    """
+    from services.model_registry import get_registry
+
+    registry = get_registry()
+    in_rate, out_rate = registry.get_cost_rates(model_id, "anthropic")
+    pricing_source = registry.get_pricing_source(model_id, "anthropic")
+
+    api_key = os.getenv("ANTHROPIC_API_KEY") or os.getenv("CLAUDE_API_KEY")
+    input_tokens = 0
+    method = "char_heuristic"
+
+    if api_key:
+        try:
+            from services.llm_clients import create_async_anthropic_client
+
+            client = create_async_anthropic_client(api_key, timeout=30.0)
+            kwargs: Dict[str, Any] = {"model": model_id, "messages": messages}
+            if system_prompt:
+                kwargs["system"] = system_prompt
+            if tools:
+                kwargs["tools"] = tools
+            resp = await client.messages.count_tokens(**kwargs)
+            input_tokens = int(getattr(resp, "input_tokens", 0) or 0)
+            method = "anthropic_count_tokens"
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "count_tokens for %s failed (%s) — falling back", model_id, exc
+            )
+
+    if method == "char_heuristic":
+        # No API key or count_tokens unavailable — fall back so the
+        # estimator is still useful in tests / offline contexts.
+        text = _flatten_message_text(messages)
+        if system_prompt:
+            text = system_prompt + "\n" + text
+        input_tokens = _char_heuristic_tokens(text)
+
+    low_usd = input_tokens * in_rate
+    high_usd = low_usd + max_tokens * out_rate
+    return CostEstimate(
+        provider_type="anthropic",
+        model_id=model_id,
+        input_tokens=input_tokens,
+        output_tokens_max=max_tokens,
+        low_usd=low_usd,
+        high_usd=high_usd,
+        pricing_source=pricing_source,
+        token_count_method=method,
+    )
+
+
+def estimate_openai(
+    *,
+    model_id: str,
+    messages: List[Dict[str, Any]],
+    system_prompt: Optional[str] = None,
+    max_tokens: int = 4096,
+) -> CostEstimate:
+    """Estimate USD cost of an OpenAI call using tiktoken (or char fallback).
+
+    Synchronous — no network calls. Cheap to use in a hot path.
+    """
+    from services.model_registry import get_registry
+
+    registry = get_registry()
+    in_rate, out_rate = registry.get_cost_rates(model_id, "openai")
+    pricing_source = registry.get_pricing_source(model_id, "openai")
+
+    text = _flatten_message_text(messages)
+    if system_prompt:
+        text = system_prompt + "\n" + text
+    input_tokens, method = _count_tokens_openai(model_id, text)
+
+    low_usd = input_tokens * in_rate
+    high_usd = low_usd + max_tokens * out_rate
+    return CostEstimate(
+        provider_type="openai",
+        model_id=model_id,
+        input_tokens=input_tokens,
+        output_tokens_max=max_tokens,
+        low_usd=low_usd,
+        high_usd=high_usd,
+        pricing_source=pricing_source,
+        token_count_method=method,
+    )
+
+
+def estimate_ollama(
+    *,
+    model_id: str,
+    messages: List[Dict[str, Any]],
+    system_prompt: Optional[str] = None,
+    max_tokens: int = 4096,
+) -> CostEstimate:
+    """Self-hosted → $0. Tokens estimated via char heuristic for context gating."""
+    text = _flatten_message_text(messages)
+    if system_prompt:
+        text = system_prompt + "\n" + text
+    input_tokens = _char_heuristic_tokens(text)
+    return CostEstimate(
+        provider_type="ollama",
+        model_id=model_id,
+        input_tokens=input_tokens,
+        output_tokens_max=max_tokens,
+        low_usd=0.0,
+        high_usd=0.0,
+        pricing_source="zero",
+        token_count_method="char_heuristic",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider-agnostic facade
+# ---------------------------------------------------------------------------
+
+
+async def estimate_cost(
+    *,
+    provider_type: str,
+    model_id: str,
+    messages: List[Dict[str, Any]],
+    system_prompt: Optional[str] = None,
+    tools: Optional[List[Dict[str, Any]]] = None,
+    max_tokens: int = 4096,
+) -> CostEstimate:
+    """Dispatch to the right provider-specific estimator.
+
+    Unknown ``provider_type`` falls back to the OpenAI estimator's char
+    heuristic with $0 rates — better than raising, since callers want a
+    best-effort number even for novel providers.
+    """
+    if provider_type == "anthropic":
+        return await estimate_anthropic(
+            model_id=model_id,
+            messages=messages,
+            system_prompt=system_prompt,
+            tools=tools,
+            max_tokens=max_tokens,
+        )
+    if provider_type == "openai":
+        return estimate_openai(
+            model_id=model_id,
+            messages=messages,
+            system_prompt=system_prompt,
+            max_tokens=max_tokens,
+        )
+    if provider_type == "ollama":
+        return estimate_ollama(
+            model_id=model_id,
+            messages=messages,
+            system_prompt=system_prompt,
+            max_tokens=max_tokens,
+        )
+
+    text = _flatten_message_text(messages)
+    if system_prompt:
+        text = system_prompt + "\n" + text
+    input_tokens = _char_heuristic_tokens(text)
+    return CostEstimate(
+        provider_type=provider_type,
+        model_id=model_id,
+        input_tokens=input_tokens,
+        output_tokens_max=max_tokens,
+        low_usd=0.0,
+        high_usd=0.0,
+        pricing_source="unknown",
+        token_count_method="char_heuristic",
+    )

--- a/services/ingestion_service.py
+++ b/services/ingestion_service.py
@@ -153,6 +153,7 @@ class IngestionService:
                     anomaly_score=float(finding_data.get('anomaly_score', 0.0)),
                     timestamp=timestamp,
                     data_source=finding_data.get('data_source', 'imported'),
+                    external_id=finding_data.get('external_id'),
                     description=finding_data.get('description'),
                     entity_context=finding_data.get('entity_context'),
                     evidence_links=finding_data.get('evidence_links'),

--- a/services/llm_worker.py
+++ b/services/llm_worker.py
@@ -160,9 +160,7 @@ async def llm_call(
             assistant_content = (
                 result.get("content", "") if isinstance(result, dict) else result
             )
-            updated = messages + [
-                {"role": "assistant", "content": assistant_content}
-            ]
+            updated = messages + [{"role": "assistant", "content": assistant_content}]
             await session_store.save(session_id, updated)
 
         return result
@@ -289,6 +287,7 @@ async def llm_call_raw(
 # Multi-provider routing (GH #88)
 # ---------------------------------------------------------------------------
 
+
 def _is_default_anthropic_spec(spec) -> bool:
     """True when ``spec`` is the seeded Anthropic provider row whose key
     lives under the legacy CLAUDE_API_KEY/ANTHROPIC_API_KEY env vars.
@@ -346,13 +345,16 @@ async def _maybe_dispatch_via_router(
 
     try:
         from services.llm_router import get_provider_spec
+
         spec = get_provider_spec(provider_id)
     except Exception as exc:  # noqa: BLE001
         logger.warning("Failed to resolve provider %s: %s", provider_id, exc)
         return None
 
     if spec is None:
-        logger.warning("Provider %s not found; falling back to ClaudeService", provider_id)
+        logger.warning(
+            "Provider %s not found; falling back to ClaudeService", provider_id
+        )
         return None
 
     # All traffic now routes through Bifrost (GH #84 PR-B). We still hand off
@@ -402,17 +404,24 @@ def _adapt_router_result_to_raw(router_result: Dict[str, Any]) -> Dict[str, Any]
         blocks.append({"type": "thinking", "thinking": thinking})
     tool_calls = router_result.get("tool_calls") or []
     for tc in tool_calls:
-        blocks.append({
-            "type": "tool_use",
-            "id": tc.get("id"),
-            "name": tc.get("name"),
-            "input": tc.get("input") or {},
-        })
+        blocks.append(
+            {
+                "type": "tool_use",
+                "id": tc.get("id"),
+                "name": tc.get("name"),
+                "input": tc.get("input") or {},
+            }
+        )
     return {
         "content": blocks,
         "stop_reason": "tool_use" if tool_calls else "end_turn",
         "input_tokens": router_result.get("input_tokens", 0),
         "output_tokens": router_result.get("output_tokens", 0),
+        # #184 Phase 3: surface cache tokens so the daemon can price them
+        # correctly. Anthropic returns cache_read/creation in the usage
+        # object; non-Anthropic providers report 0 (handled in router).
+        "cache_read_tokens": router_result.get("cache_read_tokens", 0),
+        "cache_creation_tokens": router_result.get("cache_creation_tokens", 0),
         "provider": router_result.get("provider"),
         "path": router_result.get("path"),
     }
@@ -566,6 +575,12 @@ def _serialize_raw_response(response: Any) -> Dict[str, Any]:
             "stop_reason": response.stop_reason,
             "input_tokens": response.usage.input_tokens,
             "output_tokens": response.usage.output_tokens,
+            # #184 Phase 3: surface cache tokens so the daemon can price
+            # them at provider-specific rates instead of full input rate.
+            "cache_read_tokens": getattr(response.usage, "cache_read_input_tokens", 0),
+            "cache_creation_tokens": getattr(
+                response.usage, "cache_creation_input_tokens", 0
+            ),
         }
     except Exception as e:
         logger.error(f"Failed to serialise raw response: {e}")
@@ -574,6 +589,8 @@ def _serialize_raw_response(response: Any) -> Dict[str, Any]:
             "stop_reason": "error",
             "input_tokens": 0,
             "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
             "error": str(e),
         }
 
@@ -632,8 +649,11 @@ async def on_startup(ctx: Dict[str, Any]):
     # mode and provider_id kwargs are silently ignored.
     try:
         from services.llm_router import LLMRouter
+
         ctx["llm_router"] = LLMRouter()
-        logger.info("LLM router initialized (Bifrost URL=%s)", ctx["llm_router"].bifrost_url)
+        logger.info(
+            "LLM router initialized (Bifrost URL=%s)", ctx["llm_router"].bifrost_url
+        )
     except Exception as _router_err:
         ctx["llm_router"] = None
         logger.warning("LLM router init skipped (non-fatal): %s", _router_err)

--- a/services/model_registry.py
+++ b/services/model_registry.py
@@ -226,6 +226,65 @@ _TIER_HEURISTIC: Dict[str, Tuple[_TierPattern, ...]] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Cache token pricing multipliers (#184 Phase 3)
+# ---------------------------------------------------------------------------
+# Cache token pricing is uniform across a provider's tier, not per-model, so
+# multipliers live here rather than in _CATALOG. Multiplier semantics:
+#   cache_read_cost     = cache_read_tokens     × input_per_token × read_mult
+#   cache_creation_cost = cache_creation_tokens × input_per_token × creation_mult
+#
+# Anthropic 5-minute ephemeral cache: write 1.25×, read 0.1× — the default for
+# every cache_control: {"type": "ephemeral"} block we send. The 1-hour cache
+# tier (write 2×) is a separate Anthropic feature we don't currently use; if
+# we adopt it, encode the choice in the call site, not here.
+#
+# OpenAI prompt caching: read 0.5×, write 0× (no premium — just regular input
+# tokens). Applies to gpt-4o family, o1, o3 when the prefix is reused.
+#
+# Ollama: self-hosted, $0 for all paths — multipliers are moot but defined
+# for symmetry.
+_CACHE_MULTIPLIERS: Dict[str, Tuple[float, float]] = {
+    # provider_type → (read_mult, creation_mult)
+    "anthropic": (0.10, 1.25),
+    "openai": (0.50, 0.0),
+    "ollama": (0.0, 0.0),
+}
+
+
+def get_cache_multipliers(provider_type: str) -> Tuple[float, float]:
+    """Return ``(read_mult, creation_mult)`` for ``provider_type``.
+
+    Unknown providers fall back to ``(1.0, 1.0)`` — i.e., charge cache
+    tokens at full input rate. That's a conservative over-estimate, which
+    is the right default when we don't know the provider's caching rules.
+    """
+    return _CACHE_MULTIPLIERS.get(provider_type, (1.0, 1.0))
+
+
+def infer_provider_type(model_id: str) -> str:
+    """Best-effort provider inference from a bare model id.
+
+    ``LLMInteractionLog`` only stores ``model``, not ``provider_type``,
+    so analytics needs to infer the provider when grouping by model to
+    look up pricing. This is good enough for cost-source badging — if it
+    misclassifies, the worst case is the badge shows ``"unknown"`` which
+    is exactly what we want a reader to see.
+    """
+    if not model_id:
+        return "unknown"
+    mid = model_id.lower()
+    if mid.startswith("claude-"):
+        return "anthropic"
+    if mid.startswith(("gpt-", "o1", "o3", "text-embedding")):
+        return "openai"
+    # Ollama has no canonical prefix; the remaining path is a soft match
+    # against common open-weight names.
+    if any(s in mid for s in ("llama", "mistral", "mixtral", "qwen", "gemma")):
+        return "ollama"
+    return "unknown"
+
+
 def _match_tier(provider_type: str, model_id: str) -> Optional[Tuple[float, float]]:
     for pattern, in_rate, out_rate in _TIER_HEURISTIC.get(provider_type, ()):
         if re.search(pattern, model_id, re.IGNORECASE):
@@ -594,6 +653,30 @@ class ModelRegistry:
         """
         entry = _catalog_entry(provider_type, model_id)
         return (entry["input_per_m"] / 1_000_000, entry["output_per_m"] / 1_000_000)
+
+    @staticmethod
+    def get_cache_rates(model_id: str, provider_type: str) -> Tuple[float, float]:
+        """Return ``(cache_read_per_token, cache_creation_per_token)`` in USD.
+
+        Built from the input rate × provider-specific multipliers so a
+        repricing of input automatically reprices cache tokens — there is
+        no second pricing table to keep in sync.
+        """
+        entry = _catalog_entry(provider_type, model_id)
+        input_per_token = entry["input_per_m"] / 1_000_000
+        read_mult, creation_mult = get_cache_multipliers(provider_type)
+        return (input_per_token * read_mult, input_per_token * creation_mult)
+
+    @staticmethod
+    def get_pricing_source(model_id: str, provider_type: str) -> str:
+        """Return the layer that resolved pricing for this model.
+
+        One of ``"exact"``, ``"heuristic"``, ``"zero"``, ``"unknown"``.
+        Lets callers (analytics, UI badges) tell the difference between a
+        $0 row that's accurate and a $0 row that's a missing-data
+        fallback.
+        """
+        return _catalog_entry(provider_type, model_id).get("pricing_source", "unknown")
 
     @staticmethod
     def get_model_info(

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1,0 +1,303 @@
+"""Unit tests for federated monitoring (daemon.federation.*).
+
+These cover the pure-Python pieces of the MVP — adapter contract, registry,
+severity floor, cursor parsing, and the runner's tick logic with a fake
+adapter. DB/Redis I/O is mocked; integration tests against a live database
+live elsewhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from unittest import mock
+
+import pytest
+
+from daemon.federation import registry as fed_registry
+from daemon.federation.adapters._base import fresh_cursor, parse_cursor_since
+from daemon.federation.runner import FederationRunner, _severity_passes
+
+
+# ---------------------------------------------------------------------------
+# Adapter contract / registry
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    """Minimal adapter used to exercise the runner without external services."""
+
+    name = "fake"
+
+    def __init__(self, *, configured: bool = True, default_interval: int = 30):
+        self._configured = configured
+        self._default_interval = default_interval
+        self.fetch_calls: List[Dict[str, Any]] = []
+        self.next_findings: List[Dict[str, Any]] = []
+
+    def is_configured(self) -> bool:
+        return self._configured
+
+    def default_interval(self) -> int:
+        return self._default_interval
+
+    async def fetch(self, *, since, cursor, max_items):
+        self.fetch_calls.append({"since": since, "cursor": cursor, "max_items": max_items})
+        from daemon.federation.registry import FetchResult
+
+        return FetchResult(findings=list(self.next_findings), cursor={"tick": len(self.fetch_calls)})
+
+
+def test_register_and_lookup_adapter():
+    fed_registry.register_adapter("fake-test-1", lambda: _FakeAdapter())
+    a = fed_registry.get_adapter("fake-test-1")
+    assert a is not None
+    assert a.name == "fake"
+    assert a.is_configured() is True
+    assert a.default_interval() == 30
+
+
+def test_get_adapter_unknown_returns_none():
+    assert fed_registry.get_adapter("does-not-exist-xyz") is None
+
+
+# ---------------------------------------------------------------------------
+# Severity floor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "finding_sev,floor,expected",
+    [
+        ("low", None, True),
+        ("low", "", True),
+        ("low", "low", True),
+        ("low", "medium", False),
+        ("medium", "medium", True),
+        ("medium", "high", False),
+        ("high", "high", True),
+        ("critical", "high", True),
+        ("CRITICAL", "high", True),  # case insensitive
+        (None, "low", False),  # unknown severity fails closed
+        ("", "medium", False),
+    ],
+)
+def test_severity_passes(finding_sev, floor, expected):
+    assert _severity_passes(finding_sev, floor) is expected
+
+
+# ---------------------------------------------------------------------------
+# Cursor helpers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_cursor_since_empty():
+    assert parse_cursor_since({}) is None
+    assert parse_cursor_since({"foo": "bar"}) is None
+
+
+def test_parse_cursor_since_iso():
+    cursor = {"last_poll_at": "2026-05-04T12:00:00"}
+    out = parse_cursor_since(cursor)
+    assert isinstance(out, datetime)
+    assert out.year == 2026 and out.month == 5 and out.day == 4
+
+
+def test_parse_cursor_since_iso_with_z():
+    cursor = {"last_poll_at": "2026-05-04T12:00:00Z"}
+    out = parse_cursor_since(cursor)
+    assert isinstance(out, datetime)
+
+
+def test_fresh_cursor_has_iso_timestamp():
+    c = fresh_cursor()
+    assert "last_poll_at" in c
+    # Round-trip through parse to confirm the format is what we read back
+    assert parse_cursor_since(c) is not None
+
+
+# ---------------------------------------------------------------------------
+# Runner tick: respects global toggle, severity floor, dedup, cursor write
+# ---------------------------------------------------------------------------
+
+
+class _FakeDedup:
+    def __init__(self):
+        self.processed: set = set()
+
+    async def is_processed(self, key: str) -> bool:
+        return key in self.processed
+
+    async def mark_processed(self, key: str) -> None:
+        self.processed.add(key)
+
+
+@pytest.mark.asyncio
+async def test_runner_do_one_tick_filters_by_severity(monkeypatch):
+    queue: asyncio.Queue = asyncio.Queue()
+    runner = FederationRunner(output_queue=queue)
+    fake = _FakeAdapter()
+    fake.next_findings = [
+        {
+            "finding_id": "f-1",
+            "external_id": "ext-1",
+            "severity": "low",
+            "data_source": "fake",
+        },
+        {
+            "finding_id": "f-2",
+            "external_id": "ext-2",
+            "severity": "high",
+            "data_source": "fake",
+        },
+    ]
+    runner._adapters[fake.name] = fake
+    runner._dedup[fake.name] = _FakeDedup()  # type: ignore[assignment]
+
+    record_success_calls = []
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.record_success",
+        lambda source_id, *, cursor: record_success_calls.append((source_id, cursor)),
+    )
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.record_failure",
+        lambda *args, **kwargs: pytest.fail("record_failure should not be called"),
+    )
+
+    # Floor "high" should drop the "low" finding.
+    row = {"max_items": 100, "cursor": {}, "min_severity": "high"}
+    await runner._do_one_tick(fake, row)
+
+    enqueued: List[Dict[str, Any]] = []
+    while not queue.empty():
+        enqueued.append(queue.get_nowait())
+
+    assert len(enqueued) == 1
+    assert enqueued[0]["data"]["external_id"] == "ext-2"
+    assert record_success_calls == [("fake", {"tick": 1})]
+
+
+@pytest.mark.asyncio
+async def test_runner_do_one_tick_dedups(monkeypatch):
+    queue: asyncio.Queue = asyncio.Queue()
+    runner = FederationRunner(output_queue=queue)
+    fake = _FakeAdapter()
+    fake.next_findings = [
+        {"finding_id": "f-1", "external_id": "ext-1", "severity": "high", "data_source": "fake"},
+        {"finding_id": "f-1", "external_id": "ext-1", "severity": "high", "data_source": "fake"},
+    ]
+    runner._adapters[fake.name] = fake
+    runner._dedup[fake.name] = _FakeDedup()  # type: ignore[assignment]
+
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.record_success", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.record_failure", lambda *a, **k: None
+    )
+
+    await runner._do_one_tick(fake, {"max_items": 100, "cursor": {}, "min_severity": None})
+    enqueued = []
+    while not queue.empty():
+        enqueued.append(queue.get_nowait())
+    assert len(enqueued) == 1, "Duplicate external_id should be deduplicated"
+
+
+@pytest.mark.asyncio
+async def test_runner_do_one_tick_records_failure(monkeypatch):
+    runner = FederationRunner(output_queue=asyncio.Queue())
+
+    class _RaisingAdapter(_FakeAdapter):
+        async def fetch(self, **kwargs):
+            raise RuntimeError("boom")
+
+    bad = _RaisingAdapter()
+    runner._adapters[bad.name] = bad
+    runner._dedup[bad.name] = _FakeDedup()  # type: ignore[assignment]
+
+    failures = []
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.record_failure",
+        lambda source_id, error: failures.append((source_id, error)),
+    )
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.record_success",
+        lambda *a, **k: pytest.fail("record_success should not be called"),
+    )
+
+    await runner._do_one_tick(bad, {"max_items": 100, "cursor": {}, "min_severity": None})
+    assert len(failures) == 1
+    assert failures[0][0] == "fake"
+    assert "boom" in failures[0][1]
+    assert runner.stats["errors"] == 1
+
+
+# ---------------------------------------------------------------------------
+# is_active_for: depends on global toggle AND per-source row enabled
+# ---------------------------------------------------------------------------
+
+
+def test_is_active_for_global_off(monkeypatch):
+    runner = FederationRunner(output_queue=None)
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.is_globally_enabled", lambda: False
+    )
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.get_source",
+        lambda sid: {"source_id": sid, "enabled": True},
+    )
+    assert runner.is_active_for("splunk") is False
+
+
+def test_is_active_for_global_on_source_off(monkeypatch):
+    runner = FederationRunner(output_queue=None)
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.is_globally_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.get_source",
+        lambda sid: {"source_id": sid, "enabled": False},
+    )
+    assert runner.is_active_for("splunk") is False
+
+
+def test_is_active_for_both_on(monkeypatch):
+    runner = FederationRunner(output_queue=None)
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.is_globally_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        "daemon.federation.runner.store.get_source",
+        lambda sid: {"source_id": sid, "enabled": True},
+    )
+    assert runner.is_active_for("splunk") is True
+
+
+# ---------------------------------------------------------------------------
+# Seed: only seeds adapters that report is_configured
+# ---------------------------------------------------------------------------
+
+
+def test_seed_only_inserts_configured_adapters(monkeypatch):
+    from daemon.federation import seed as fed_seed
+
+    configured = _FakeAdapter(configured=True)
+    configured.name = "configured-src"
+    unconfigured = _FakeAdapter(configured=False)
+    unconfigured.name = "unconfigured-src"
+
+    monkeypatch.setattr(
+        "daemon.federation.seed.list_adapters",
+        lambda: [configured, unconfigured],
+    )
+
+    upserts: List[str] = []
+    monkeypatch.setattr(
+        "daemon.federation.seed.upsert_source",
+        lambda source_id, defaults: (upserts.append(source_id) or {"source_id": source_id}),
+    )
+
+    out = fed_seed.seed_federation_sources()
+    assert out == ["configured-src"]
+    assert upserts == ["configured-src"]

--- a/tests/unit/test_compute_call_cost.py
+++ b/tests/unit/test_compute_call_cost.py
@@ -21,12 +21,25 @@ sys.path.insert(0, str(REPO / "backend"))
 pytestmark = pytest.mark.unit
 
 
-def _mock_registry(in_rate: float, out_rate: float):
-    """Build a fake get_registry() that returns the given rates."""
+def _mock_registry(
+    in_rate: float,
+    out_rate: float,
+    cache_read_rate: float = 0.0,
+    cache_creation_rate: float = 0.0,
+):
+    """Build a fake get_registry() that returns the given rates.
+
+    Cache rates default to zero so existing tests that don't pass cache
+    tokens behave identically to the pre-#184 cost math (input × in_rate
+    + output × out_rate).
+    """
 
     class _R:
         def get_cost_rates(self, model_id, provider_type):
             return (in_rate, out_rate)
+
+        def get_cache_rates(self, model_id, provider_type):
+            return (cache_read_rate, cache_creation_rate)
 
     return _R()
 
@@ -79,16 +92,16 @@ def test_registry_exception_returns_zero(caplog):
     def _explode():
         raise RuntimeError("registry unavailable")
 
-    with patch("services.model_registry.get_registry", side_effect=_explode), \
-         caplog.at_level("WARNING"):
+    with patch(
+        "services.model_registry.get_registry", side_effect=_explode
+    ), caplog.at_level("WARNING"):
         cost = compute_call_cost("claude-sonnet-4-5", "anthropic", 1_000, 500)
 
     assert cost == 0.0
     # Warning surfaces the provider + model so an operator can diagnose
     # silently-zero costs from the /analytics/cost dashboard.
     assert any(
-        "model_registry lookup failed" in r.message
-        and "anthropic" in r.message
+        "model_registry lookup failed" in r.message and "anthropic" in r.message
         for r in caplog.records
     )
 
@@ -99,3 +112,109 @@ def test_sonnet_constants_are_gone():
 
     assert not hasattr(agent_runner, "SONNET_INPUT_COST")
     assert not hasattr(agent_runner, "SONNET_OUTPUT_COST")
+
+
+# ---------------------------------------------------------------------------
+# #184 Phase 3 — cache-aware pricing
+# ---------------------------------------------------------------------------
+
+
+def test_cache_read_priced_at_anthropic_discount():
+    """Cache reads bill at 0.1× input rate, not full input rate.
+
+    Pre-#184 these tokens were ignored (priced at $0). After #184 we
+    multiply by the Anthropic ephemeral-cache read multiplier.
+    """
+    from daemon.agent_runner import compute_call_cost
+
+    in_rate = 3.0 / 1_000_000  # Sonnet input rate
+    cache_read_rate = in_rate * 0.10
+    with patch(
+        "services.model_registry.get_registry",
+        return_value=_mock_registry(
+            in_rate, 15.0 / 1_000_000, cache_read_rate=cache_read_rate
+        ),
+    ):
+        cost = compute_call_cost(
+            "claude-sonnet-4-5-20250929",
+            "anthropic",
+            1_000,
+            500,
+            cache_read_tokens=10_000,
+        )
+    expected = 1_000 * in_rate + 500 * (15.0 / 1_000_000) + 10_000 * cache_read_rate
+    assert cost == pytest.approx(expected, rel=1e-9)
+
+
+def test_cache_creation_priced_at_anthropic_premium():
+    """Cache writes bill at 1.25× input rate (the ephemeral premium)."""
+    from daemon.agent_runner import compute_call_cost
+
+    in_rate = 3.0 / 1_000_000
+    cache_creation_rate = in_rate * 1.25
+    with patch(
+        "services.model_registry.get_registry",
+        return_value=_mock_registry(
+            in_rate,
+            15.0 / 1_000_000,
+            cache_creation_rate=cache_creation_rate,
+        ),
+    ):
+        cost = compute_call_cost(
+            "claude-sonnet-4-5-20250929",
+            "anthropic",
+            1_000,
+            500,
+            cache_creation_tokens=2_000,
+        )
+    expected = 1_000 * in_rate + 500 * (15.0 / 1_000_000) + 2_000 * cache_creation_rate
+    assert cost == pytest.approx(expected, rel=1e-9)
+
+
+def test_zero_cache_tokens_match_pre_184_behavior():
+    """Backwards-compat: callers that don't pass cache tokens get the same
+    number they did before #184."""
+    from daemon.agent_runner import compute_call_cost
+
+    in_rate = 3.0 / 1_000_000
+    out_rate = 15.0 / 1_000_000
+    with patch(
+        "services.model_registry.get_registry",
+        return_value=_mock_registry(in_rate, out_rate, cache_read_rate=in_rate * 0.1),
+    ):
+        legacy = compute_call_cost("claude-sonnet-4-5", "anthropic", 1_000, 500)
+        explicit_zero = compute_call_cost(
+            "claude-sonnet-4-5",
+            "anthropic",
+            1_000,
+            500,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+        )
+    assert legacy == explicit_zero
+    assert legacy == pytest.approx(1_000 * in_rate + 500 * out_rate, rel=1e-9)
+
+
+def test_real_anthropic_multipliers_via_registry():
+    """End-to-end: hit the real ModelRegistry (no mock) and verify the
+    Anthropic multipliers (0.1× read / 1.25× creation) are applied."""
+    from daemon.agent_runner import compute_call_cost
+
+    # Sonnet 4.5 has exact pricing in _CATALOG: $3/MTok in, $15/MTok out.
+    cost = compute_call_cost(
+        "claude-sonnet-4-5-20250929",
+        "anthropic",
+        1_000,
+        500,
+        cache_read_tokens=10_000,
+        cache_creation_tokens=2_000,
+    )
+    in_rate = 3.0 / 1_000_000
+    out_rate = 15.0 / 1_000_000
+    expected = (
+        1_000 * in_rate
+        + 500 * out_rate
+        + 10_000 * in_rate * 0.10
+        + 2_000 * in_rate * 1.25
+    )
+    assert cost == pytest.approx(expected, rel=1e-9)

--- a/tests/unit/test_cost_estimator.py
+++ b/tests/unit/test_cost_estimator.py
@@ -1,0 +1,173 @@
+"""Unit tests for ``services.cost_estimator`` (#184 Phase 2).
+
+Covers the synchronous OpenAI / Ollama / unknown branches and the
+Anthropic branch's fallback path (no API key set → char heuristic).
+The Anthropic ``count_tokens`` API path is tested via mocked client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "backend"))
+
+pytestmark = pytest.mark.unit
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_openai_estimator_uses_registry_rates():
+    from services.cost_estimator import estimate_openai
+
+    est = estimate_openai(
+        model_id="gpt-4o",
+        messages=[{"role": "user", "content": "hello"}],
+        max_tokens=1000,
+    )
+    # gpt-4o has exact pricing: $2.50/MTok in, $10/MTok out.
+    in_rate = 2.50 / 1_000_000
+    out_rate = 10.0 / 1_000_000
+
+    assert est.provider_type == "openai"
+    assert est.model_id == "gpt-4o"
+    assert est.input_tokens > 0
+    assert est.low_usd == pytest.approx(est.input_tokens * in_rate, rel=1e-9)
+    assert est.high_usd == pytest.approx(
+        est.input_tokens * in_rate + 1000 * out_rate, rel=1e-9
+    )
+    assert est.pricing_source == "exact"
+
+
+def test_openai_estimator_falls_back_to_heuristic_when_tiktoken_missing():
+    """If tiktoken isn't installed, the char heuristic kicks in and
+    ``token_count_method`` reflects that. Forces the import to fail."""
+    import builtins
+
+    from services.cost_estimator import estimate_openai
+
+    real_import = builtins.__import__
+
+    def _fail_tiktoken(name, *args, **kwargs):
+        if name == "tiktoken":
+            raise ImportError("tiktoken not installed in this test")
+        return real_import(name, *args, **kwargs)
+
+    with patch.object(builtins, "__import__", _fail_tiktoken):
+        est = estimate_openai(
+            model_id="gpt-4o",
+            messages=[{"role": "user", "content": "hello world"}],
+        )
+    assert est.token_count_method == "char_heuristic"
+    assert est.input_tokens >= 1
+
+
+def test_ollama_estimator_returns_zero_cost():
+    from services.cost_estimator import estimate_ollama
+
+    est = estimate_ollama(
+        model_id="llama3.1",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert est.low_usd == 0.0
+    assert est.high_usd == 0.0
+    assert est.pricing_source == "zero"
+
+
+def test_unknown_provider_returns_zero_with_unknown_source():
+    from services.cost_estimator import estimate_cost
+
+    est = _run(
+        estimate_cost(
+            provider_type="some-future-vendor",
+            model_id="some-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+    )
+    assert est.low_usd == 0.0
+    assert est.high_usd == 0.0
+    assert est.pricing_source == "unknown"
+
+
+def test_anthropic_estimator_uses_count_tokens_when_available(monkeypatch):
+    """Mock the Bifrost-routed Anthropic client so the test doesn't
+    depend on a real API key or network.
+
+    Verifies that:
+      1. count_tokens is called on the routed client
+      2. token_count_method == "anthropic_count_tokens"
+      3. the cost band is built from registry rates × returned count
+    """
+    from services import cost_estimator
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    class _FakeMessages:
+        async def count_tokens(self, **kwargs):  # noqa: D401
+            class _R:
+                input_tokens = 1234
+
+            return _R()
+
+    class _FakeClient:
+        def __init__(self):
+            self.messages = _FakeMessages()
+
+    monkeypatch.setattr(
+        "services.llm_clients.create_async_anthropic_client",
+        lambda api_key, timeout=None: _FakeClient(),
+    )
+
+    est = _run(
+        cost_estimator.estimate_anthropic(
+            model_id="claude-sonnet-4-5-20250929",
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=2048,
+        )
+    )
+
+    in_rate = 3.0 / 1_000_000
+    out_rate = 15.0 / 1_000_000
+    assert est.token_count_method == "anthropic_count_tokens"
+    assert est.input_tokens == 1234
+    assert est.low_usd == pytest.approx(1234 * in_rate, rel=1e-9)
+    assert est.high_usd == pytest.approx(1234 * in_rate + 2048 * out_rate, rel=1e-9)
+    assert est.pricing_source == "exact"
+
+
+def test_anthropic_estimator_falls_back_when_count_tokens_raises(monkeypatch):
+    """If the Bifrost-routed count_tokens call raises, we still return
+    a useful estimate via the char heuristic instead of bubbling the error."""
+    from services import cost_estimator
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    class _BrokenMessages:
+        async def count_tokens(self, **kwargs):
+            raise RuntimeError("bifrost is sad")
+
+    class _BrokenClient:
+        def __init__(self):
+            self.messages = _BrokenMessages()
+
+    monkeypatch.setattr(
+        "services.llm_clients.create_async_anthropic_client",
+        lambda api_key, timeout=None: _BrokenClient(),
+    )
+
+    est = _run(
+        cost_estimator.estimate_anthropic(
+            model_id="claude-sonnet-4-5-20250929",
+            messages=[{"role": "user", "content": "hello world"}],
+        )
+    )
+    assert est.token_count_method == "char_heuristic"
+    assert est.input_tokens >= 1

--- a/tests/unit/test_model_registry_pricing.py
+++ b/tests/unit/test_model_registry_pricing.py
@@ -1,0 +1,120 @@
+"""Tests for the model_registry pricing helpers added in #184.
+
+Covers:
+  - get_cache_multipliers (provider-level lookup)
+  - get_cache_rates (composed: input rate × multiplier)
+  - get_pricing_source (visibility into which catalog layer answered)
+  - infer_provider_type (used by analytics to badge rows)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "backend"))
+
+pytestmark = pytest.mark.unit
+
+
+def test_anthropic_cache_multipliers():
+    from services.model_registry import get_cache_multipliers
+
+    read_mult, creation_mult = get_cache_multipliers("anthropic")
+    # Anthropic 5-min ephemeral cache: 0.1× read, 1.25× creation.
+    assert read_mult == pytest.approx(0.10)
+    assert creation_mult == pytest.approx(1.25)
+
+
+def test_openai_cache_multipliers():
+    from services.model_registry import get_cache_multipliers
+
+    read_mult, creation_mult = get_cache_multipliers("openai")
+    # OpenAI: 0.5× cached read, no write premium.
+    assert read_mult == pytest.approx(0.50)
+    assert creation_mult == pytest.approx(0.0)
+
+
+def test_unknown_provider_falls_back_to_full_input_rate():
+    """Unknown providers should over-bound, not under-bound — charge cache
+    tokens at full input rate so we don't silently miss costs."""
+    from services.model_registry import get_cache_multipliers
+
+    assert get_cache_multipliers("future-vendor") == (1.0, 1.0)
+
+
+def test_get_cache_rates_uses_input_rate_times_multiplier():
+    """The cache rate is derived from the input rate, so a repricing of
+    input automatically reprices cache — no second table to maintain."""
+    from services.model_registry import get_registry
+
+    registry = get_registry()
+    in_rate, _ = registry.get_cost_rates("claude-sonnet-4-5-20250929", "anthropic")
+    cache_read, cache_creation = registry.get_cache_rates(
+        "claude-sonnet-4-5-20250929", "anthropic"
+    )
+    assert cache_read == pytest.approx(in_rate * 0.10)
+    assert cache_creation == pytest.approx(in_rate * 1.25)
+
+
+def test_pricing_source_exact_for_catalog_models():
+    from services.model_registry import get_registry
+
+    src = get_registry().get_pricing_source("claude-sonnet-4-5-20250929", "anthropic")
+    assert src == "exact"
+
+
+def test_pricing_source_heuristic_for_unknown_anthropic_variant():
+    """A model id we haven't catalog'd but matches a tier regex (e.g.
+    a future Sonnet variant) should resolve via heuristic."""
+    from services.model_registry import get_registry
+
+    src = get_registry().get_pricing_source("claude-sonnet-9-99-future", "anthropic")
+    assert src == "heuristic"
+
+
+def test_pricing_source_zero_for_ollama():
+    from services.model_registry import get_registry
+
+    assert get_registry().get_pricing_source("llama3.1", "ollama") == "zero"
+
+
+def test_pricing_source_unknown_for_novel_provider():
+    from services.model_registry import get_registry
+
+    assert get_registry().get_pricing_source("foo-1", "future-vendor") == "unknown"
+
+
+def test_infer_provider_type_anthropic():
+    from services.model_registry import infer_provider_type
+
+    assert infer_provider_type("claude-sonnet-4-5-20250929") == "anthropic"
+    assert infer_provider_type("claude-opus-4-7") == "anthropic"
+
+
+def test_infer_provider_type_openai():
+    from services.model_registry import infer_provider_type
+
+    assert infer_provider_type("gpt-4o") == "openai"
+    assert infer_provider_type("gpt-4o-mini") == "openai"
+    assert infer_provider_type("o1-mini") == "openai"
+    assert infer_provider_type("o3") == "openai"
+
+
+def test_infer_provider_type_ollama_soft_match():
+    from services.model_registry import infer_provider_type
+
+    assert infer_provider_type("llama3.1") == "ollama"
+    assert infer_provider_type("mistral-7b") == "ollama"
+    assert infer_provider_type("qwen2.5") == "ollama"
+
+
+def test_infer_provider_type_unknown():
+    from services.model_registry import infer_provider_type
+
+    assert infer_provider_type("") == "unknown"
+    assert infer_provider_type("some-novel-thing") == "unknown"


### PR DESCRIPTION
## Linked issues

- **Closes #184** — *Improve LLM cost tracking & estimation accuracy*. Commit
  `30a3033` lands Phase 2 (pre-call estimation surface + cache-token
  pricing); the umbrella issue is closed on merge. Phase 1 (`#185`) and
  Phase 4 (`#186`) remain tracked separately and continue independently.
- **Refs #24** — *Research federated search (Quick Wit, Cribl, …)*. Adjacent
  but not the same scope: this PR adds **federated pull** (configured SIEM/EDR
  APIs on a cadence into the local `findings` table). Quick Wit-style
  distributed query remains unaddressed, so the research issue stays open.

---

Three independent threads of work landed in parallel on this branch.
Splitting into separate PRs would create three near-empty diffs against
shared scaffolding files (api.ts, models.py register sites), so they're
bundled here as one PR with three logical commits.

## Summary

- **Federated monitoring (`beb3179`)** — opt-in per-source pull layer that
  feeds findings from Splunk / CrowdStrike / Azure Sentinel / AWS Security
  Hub / Microsoft Defender / Elastic into the existing
  `processor → orchestrator.investigation_queue` path. Settings → Federation
  tab gives the user a global toggle, per-source enable / interval /
  min-severity / Poll-now, and live health.
- **Pre-call cost estimation + cache-aware pricing (`30a3033`)** — Phase 2
  of #184. Replaces the client-side `length / 4` token heuristic in
  ClaudeDrawer with a USD low/high band from the new
  `POST /analytics/estimate-cost` endpoint, and folds prompt-cache-creation
  / cache-read tokens into `compute_call_cost()` so heavy cache users see
  accurate spend.
- **VStrike picker z-index fix (`12faf59`)** — Network / Storyline /
  Legend-run Select dropdowns on the VStrike host page were rendering
  behind the iframe (z-index 1300). Forces dropdown menu z-index to 1302.
  No tracking issue — drive-by fix.

## Federation — design notes

- **No cold-start backfill**: first run after enable starts from "now" so
  enabling a noisy source doesn't replay history.
- **No auto-disable on errors**: exponential backoff up to 8× the configured
  interval, but the source stays enabled so transient outages self-recover.
- **Severity floor per source**: drop low-severity findings at ingest time
  rather than spending downstream cycles filtering them.
- **Strong dedup**: new partial UNIQUE index on
  `(findings.data_source, findings.external_id)` closes the webhook
  finding_id collision risk. Backfilled by `15_federation.sql` for new
  deploys; existing rows leave `external_id` NULL (excluded by the partial
  index).
- **Backwards-compat**: legacy per-source loops in `daemon/poller.py` defer
  to the federation runner only when both the global toggle and the source
  row are enabled. Existing env-var-driven setups keep working unchanged.
- **No new LLM surface** — federation is pure I/O ingestion; the triage
  LLM call still happens in `processor.py` via the Bifrost-routed gateway.

## Cost estimation — design notes

- Anthropic uses the SDK's free `client.messages.count_tokens()` so the
  prompt-token count is exact (system + tools included).
- OpenAI uses tiktoken; Ollama is treated as zero-cost.
- The estimate is a USD band (low / high), not a point estimate — output
  length is unknown, so the high bound assumes `max_tokens` and the low
  bound assumes a no-output completion.
- Removes the silent "fall back to Sonnet pricing" behavior — under #89's
  per-component model selection, that misattributed costs to the wrong
  provider on unresolved models.

## Test plan

- [x] `pytest tests/test_federation.py` — 24 passed
- [x] `pytest tests/unit/test_compute_call_cost.py tests/unit/test_cost_estimator.py tests/unit/test_model_registry_pricing.py`
- [x] `tsc --noEmit` — clean
- [ ] Apply `database/init/15_federation.sql` against an existing dev DB
      (fresh deploys pick it up automatically) and verify the
      `federation_sources` table + `findings.external_id` column appear
- [ ] Daemon: flip global toggle in Settings → Federation, enable Splunk,
      confirm a finding flows through the Federation runner into the
      `findings` table and the orchestrator picks it up
- [ ] Chat composer: type into ClaudeDrawer and confirm the warning bar
      shows a USD band that updates after the 400ms debounce
- [ ] VStrike: open one of the three picker dropdowns on a viewport where
      the iframe was previously occluding them and confirm options render
      above the iframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)