### PR TITLE
PR C: Bifrost VK budget enforcement + #184/#185 cleanup (#186)

### DIFF
--- a/backend/api/budgets.py
+++ b/backend/api/budgets.py
@@ -1,0 +1,114 @@
+"""Budgets API — read/write Vigil's Bifrost VK config + show live quota.
+
+Lives at ``/api/analytics/budget*`` (mounted under analytics so the cost
+dashboard can call it from the same axios client as the other cost
+endpoints).
+
+This is the read/write surface for the Settings → LLM Providers →
+Budgets sub-panel. Three endpoints:
+
+* ``GET  /api/analytics/budget``       — current persisted settings
+                                          (default_vk, ceiling, mode).
+* ``PUT  /api/analytics/budget``       — admin-intent write of the same.
+* ``GET  /api/analytics/budget/quota`` — live spend/quota for the
+                                          configured VK, proxied from
+                                          Bifrost's governance API.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+class BudgetSettingsResponse(BaseModel):
+    default_vk: str = ""
+    budget_limit_usd: float = 0.0
+    enforcement_mode: str = "warning"
+
+
+class BudgetSettingsUpdate(BaseModel):
+    """Admin-intent body for PUT /budget. All fields required so the API
+    can't be used to silently drop a setting via an empty PATCH."""
+
+    default_vk: str = Field(default="")
+    budget_limit_usd: float = Field(default=0.0, ge=0)
+    enforcement_mode: str = Field(default="warning")
+
+
+@router.get("/analytics/budget", response_model=BudgetSettingsResponse)
+async def get_budget_settings() -> Dict[str, Any]:
+    """Return the persisted Bifrost VK + budget config."""
+    from services.budget_service import get_settings
+
+    return get_settings()
+
+
+@router.put("/analytics/budget", response_model=BudgetSettingsResponse)
+async def put_budget_settings(payload: BudgetSettingsUpdate) -> Dict[str, Any]:
+    """Update the Bifrost VK + budget config.
+
+    Admin operation. The dispatch path picks up the change on the next
+    runtime-config TTL tick (~60s). When ``DEV_MODE=true`` or
+    ``LLM_BUDGET_UNLIMITED=true`` is set, the dispatch ignores the VK
+    regardless of what's stored here.
+    """
+    from services.budget_service import set_settings
+
+    try:
+        return set_settings(
+            default_vk=payload.default_vk.strip(),
+            budget_limit_usd=payload.budget_limit_usd,
+            enforcement_mode=payload.enforcement_mode,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("budget settings write failed: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to persist settings")
+
+
+@router.get("/analytics/budget/quota")
+async def get_budget_quota() -> Dict[str, Any]:
+    """Live spend/quota for the configured VK, proxied from Bifrost."""
+    from services.bifrost_cost_client import get_vk_quota
+    from services.budget_service import get_active_vk
+
+    vk = get_active_vk()
+    if not vk:
+        return {
+            "configured": False,
+            "message": (
+                "No Bifrost virtual key configured. Set one in Settings → "
+                "LLM Providers → Budgets to enable spend tracking."
+            ),
+        }
+
+    quota = get_vk_quota(vk)
+    if quota is None:
+        # Soft failure — Bifrost unreachable or VK invalid. The settings
+        # endpoint is still useful (lets the operator fix the config),
+        # so we surface a 200 with diagnostic info instead of 502.
+        return {
+            "configured": True,
+            "virtual_key_id": vk,
+            "available": False,
+            "message": (
+                "Could not reach Bifrost or VK was rejected. Check that "
+                "Bifrost is up and the configured VK exists in Bifrost's "
+                "governance settings."
+            ),
+        }
+
+    return {
+        "configured": True,
+        "available": True,
+        "virtual_key_id": vk,
+        "quota": quota,
+    }

--- a/backend/api/claude.py
+++ b/backend/api/claude.py
@@ -371,6 +371,37 @@ async def chat(request: ChatRequest):
 
     except Exception as e:
         elapsed_time = time.time() - start_time
+        # #186: surface budget/rate-limit blocks as a typed 402 instead of a
+        # generic 500 so the chat UI can render a "budget exceeded" banner
+        # rather than a useless error toast. We catch both our own
+        # BudgetExceeded (from llm_router) and the SDK-native exceptions
+        # whose `status_code` is 402/429 — the SDK exception path covers
+        # the direct claude_service.client.messages.create call sites that
+        # don't go through llm_router yet.
+        try:
+            from services.budget_service import BudgetExceeded as _BE
+        except Exception:
+            _BE = None  # type: ignore[assignment]
+
+        status_code = getattr(e, "status_code", None)
+        if (_BE is not None and isinstance(e, _BE)) or status_code in (402, 429):
+            tier = getattr(e, "tier", None) or (
+                "rate_limit" if status_code == 429 else "virtual_key"
+            )
+            logger.warning(
+                "[RequestID: %s] Chat blocked by budget enforcement after %.2fs: tier=%s",
+                request_id,
+                elapsed_time,
+                tier,
+            )
+            raise HTTPException(
+                status_code=402,
+                detail={
+                    "code": "budget_exceeded",
+                    "tier": tier,
+                    "message": str(e) or "LLM budget exceeded",
+                },
+            )
         logger.error(
             f"❌ [RequestID: {request_id}] Chat error after {elapsed_time:.2f}s: {e}",
             exc_info=True,

--- a/backend/main.py
+++ b/backend/main.py
@@ -91,6 +91,9 @@ from api.orchestrator import router as orchestrator_router
 # Federation router (federated monitoring of external SIEM/EDR sources)
 from api.federation import router as federation_router
 
+# Budgets (Bifrost VK config + live quota — #186)
+from api.budgets import router as budgets_router
+
 # Kafka ingestion router
 from api.kafka import router as kafka_router
 
@@ -196,6 +199,10 @@ app.include_router(jira_export_router, prefix="/api", tags=["jira-export"])
 
 # Analytics
 app.include_router(analytics_router, prefix="/api", tags=["analytics"])
+# Budgets — same prefix as analytics so /api/analytics/budget* lives next
+# to /api/analytics/cost. The router itself owns the /analytics path
+# segment per its endpoint definitions.
+app.include_router(budgets_router, prefix="/api", tags=["budgets"])
 
 # Core API endpoints
 app.include_router(findings_router, prefix="/api/findings", tags=["findings"])

--- a/database/init/16_llm_budgets.sql
+++ b/database/init/16_llm_budgets.sql
@@ -1,0 +1,32 @@
+-- 16_llm_budgets.sql
+-- Per-tenant LLM budget enforcement via Bifrost virtual keys (#186).
+--
+-- This migration is intentionally minimal: a single global VK MVP per the
+-- locked design decision. Vigil has no tenant model today (per-user RBAC
+-- only), so all calls share one Bifrost VK and one budget. The
+-- `virtual_key_id` column lands now to future-proof per-tenant attribution
+-- once tenancy ships (#165).
+
+ALTER TABLE llm_interaction_logs
+    ADD COLUMN IF NOT EXISTS virtual_key_id VARCHAR(64);
+
+CREATE INDEX IF NOT EXISTS idx_llm_interaction_vk
+    ON llm_interaction_logs (virtual_key_id, created_at);
+
+-- Seed the single bifrost.virtual_keys settings row. Empty default_vk
+-- means "no enforcement yet" — Bifrost will accept calls without
+-- x-bf-vk while we're in the bootstrap window. The Settings → LLM
+-- Providers → Budgets sub-panel writes the configured VK ID here once
+-- the operator provisions one in the Bifrost UI.
+INSERT INTO system_config (key, value, description, config_type)
+VALUES (
+    'bifrost.virtual_keys',
+    '{
+        "default_vk": "",
+        "budget_limit_usd": 0,
+        "enforcement_mode": "warning"
+    }'::jsonb,
+    'Bifrost virtual-key configuration and budget settings (#186)',
+    'ai'
+)
+ON CONFLICT (key) DO NOTHING;

--- a/database/models.py
+++ b/database/models.py
@@ -2131,12 +2131,18 @@ class LLMInteractionLog(Base):
     cost_usd: Mapped[float] = mapped_column(Numeric(10, 6), nullable=False, default=0)
     duration_ms: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # Bifrost virtual-key attribution (#186). Stores the VK the call was
+    # made under so we can group spend per-tenant once Vigil grows a
+    # tenant model. Empty / NULL for calls made before the budget feature
+    # was enabled or while running in DEV_MODE / LLM_BUDGET_UNLIMITED.
+    virtual_key_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
 
     __table_args__ = (
         Index("idx_llm_interaction_session", "session_id"),
         Index("idx_llm_interaction_agent", "agent_id"),
         Index("idx_llm_interaction_investigation", "investigation_id"),
         Index("idx_llm_interaction_created", "created_at"),
+        Index("idx_llm_interaction_vk", "virtual_key_id", "created_at"),
     )
 
     def to_summary_dict(self) -> dict:

--- a/env.example
+++ b/env.example
@@ -20,6 +20,13 @@
 # See DEV_MODE.md for full details
 DEV_MODE=true
 
+# Bypass Bifrost virtual-key budget enforcement (#186) without disabling
+# auth. Useful for free-tier deployments or sentinel "unlimited" VKs
+# where you want auth on but no budget ceiling. DEV_MODE=true also
+# bypasses budgets — this is the explicit knob for the case where you
+# *want* auth but *don't* want budgets.
+# LLM_BUDGET_UNLIMITED=false
+
 # -----------------------------------------------------------------------------
 # Core AI Configuration
 # -----------------------------------------------------------------------------

--- a/frontend/src/components/claude/ClaudeDrawer.tsx
+++ b/frontend/src/components/claude/ClaudeDrawer.tsx
@@ -641,11 +641,28 @@ export default function ClaudeDrawer({ open, onClose, initialMessages, initialAg
         timestamp: new Date().toISOString(),
         fullError: e
       })
+      // #186: render a typed inline message for budget-exceeded responses
+      // (HTTP 402, body.detail.code == 'budget_exceeded') so the user
+      // sees "budget exceeded — tier: virtual_key" instead of a generic
+      // error toast. Backend builds this body in backend/api/claude.py's
+      // chat handler.
+      const detail = e?.response?.data?.detail
+      const isBudgetBlock =
+        e?.response?.status === 402 &&
+        detail &&
+        typeof detail === 'object' &&
+        detail.code === 'budget_exceeded'
+      const userMessage = isBudgetBlock
+        ? `⚠️ LLM budget exceeded (tier: **${detail.tier || 'unknown'}**). ${
+            detail.message ||
+            'Bifrost rejected the call upstream of the model. Update the budget in Settings → LLM Providers → Budgets, or set DEV_MODE / LLM_BUDGET_UNLIMITED to bypass.'
+          }`
+        : `Error: ${typeof detail === 'string' ? detail : detail?.message || e?.message || 'Failed'}`
       setTabs(prevTabs => {
         const updatedTabs = [...prevTabs]
         updatedTabs[currentTab] = {
           ...updatedTabs[currentTab],
-          messages: [...updatedTabs[currentTab].messages, { role: 'assistant', content: `Error: ${e?.response?.data?.detail || e?.message || 'Failed'}` }]
+          messages: [...updatedTabs[currentTab].messages, { role: 'assistant', content: userMessage }]
         }
         return updatedTabs
       })

--- a/frontend/src/components/settings/BudgetsSection.tsx
+++ b/frontend/src/components/settings/BudgetsSection.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  InputAdornment,
+  InputLabel,
+  LinearProgress,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import RefreshIcon from '@mui/icons-material/Refresh'
+import SaveIcon from '@mui/icons-material/Save'
+import { budgetsApi, BudgetSettings, BudgetQuotaResponse } from '../../services/api'
+
+interface Props {
+  setMessage: (m: { type: 'success' | 'error'; text: string } | null) => void
+}
+
+// Mask all but the last 4 chars of the VK so the UI doesn't leak the full
+// secret in screenshots / shared screens. The ID prefix `sk-bf-...` is
+// already a public marker so showing it is fine.
+function maskVk(vk: string): string {
+  if (!vk) return ''
+  if (vk.length <= 8) return vk
+  return `${vk.slice(0, 6)}…${vk.slice(-4)}`
+}
+
+export default function BudgetsSection({ setMessage }: Props) {
+  const [settings, setSettings] = useState<BudgetSettings>({
+    default_vk: '',
+    budget_limit_usd: 0,
+    enforcement_mode: 'warning',
+  })
+  const [draft, setDraft] = useState<BudgetSettings>({
+    default_vk: '',
+    budget_limit_usd: 0,
+    enforcement_mode: 'warning',
+  })
+  const [quota, setQuota] = useState<BudgetQuotaResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [showVk, setShowVk] = useState(false)
+
+  const load = async () => {
+    try {
+      const [settingsRes, quotaRes] = await Promise.all([
+        budgetsApi.get(),
+        budgetsApi.getQuota().catch(() => ({ data: null })),
+      ])
+      setSettings(settingsRes.data)
+      setDraft(settingsRes.data)
+      setQuota(quotaRes.data)
+    } catch {
+      setMessage({ type: 'error', text: 'Failed to load budget settings' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const dirty =
+    draft.default_vk !== settings.default_vk ||
+    draft.budget_limit_usd !== settings.budget_limit_usd ||
+    draft.enforcement_mode !== settings.enforcement_mode
+
+  const handleSave = async () => {
+    setSaving(true)
+    try {
+      const res = await budgetsApi.set({
+        default_vk: draft.default_vk.trim(),
+        budget_limit_usd: Number(draft.budget_limit_usd) || 0,
+        enforcement_mode: draft.enforcement_mode,
+      })
+      setSettings(res.data)
+      setDraft(res.data)
+      setMessage({ type: 'success', text: 'Budget settings saved' })
+      // Refresh quota since the VK might have changed.
+      const q = await budgetsApi.getQuota().catch(() => ({ data: null }))
+      setQuota(q.data)
+    } catch (e: any) {
+      setMessage({ type: 'error', text: e?.response?.data?.detail || 'Save failed' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 2 }}>
+        <CircularProgress size={16} />
+        <Typography variant="body2">Loading budget settings…</Typography>
+      </Box>
+    )
+  }
+
+  // Pull the first budget tier out of the quota response (Bifrost can return
+  // multiple — for MVP we only render the first; per-tier breakdown is a
+  // post-MVP enhancement when we have multi-tenant scoping).
+  const firstBudget = quota?.quota?.budgets?.[0]
+  const spendPct =
+    firstBudget && firstBudget.max_limit > 0
+      ? Math.min(
+          100,
+          Math.round((firstBudget.current_usage / firstBudget.max_limit) * 100),
+        )
+      : 0
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2.5, mt: 4 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, flexGrow: 1 }}>
+          Budgets (Bifrost virtual key)
+        </Typography>
+        <Tooltip title="Refresh quota from Bifrost">
+          <Button size="small" startIcon={<RefreshIcon />} onClick={load}>
+            Refresh
+          </Button>
+        </Tooltip>
+      </Box>
+
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
+        Bifrost enforces a USD budget per virtual key, upstream of every LLM
+        call. Set the global VK and ceiling here. <code>DEV_MODE=true</code> or{' '}
+        <code>LLM_BUDGET_UNLIMITED=true</code> in the environment bypasses
+        enforcement; useful for local development without reconfiguring
+        Bifrost.
+      </Typography>
+
+      {/* Live quota — only renders when Bifrost is reachable AND a VK is set */}
+      {quota?.configured && quota.available && firstBudget && (
+        <Box sx={{ mb: 3 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+            <Typography variant="body2">
+              <strong>${firstBudget.current_usage.toFixed(2)}</strong> spent of{' '}
+              <strong>${firstBudget.max_limit.toFixed(2)}</strong>
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {firstBudget.reset_duration} cycle · resets {firstBudget.last_reset || '—'}
+            </Typography>
+          </Box>
+          <LinearProgress
+            variant="determinate"
+            value={spendPct}
+            color={spendPct >= 90 ? 'error' : spendPct >= 75 ? 'warning' : 'primary'}
+          />
+        </Box>
+      )}
+
+      {quota?.configured && !quota.available && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          {quota.message ||
+            "Bifrost is unreachable or the configured VK doesn't exist."}
+        </Alert>
+      )}
+
+      {!quota?.configured && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          {quota?.message ||
+            'No virtual key configured. Provision one in the Bifrost UI, then paste its ID below.'}
+        </Alert>
+      )}
+
+      <Stack spacing={2} sx={{ maxWidth: 640 }}>
+        <TextField
+          label="Default virtual key (sk-bf-…)"
+          value={showVk ? draft.default_vk : maskVk(draft.default_vk)}
+          onChange={(e) => setDraft({ ...draft, default_vk: e.target.value })}
+          onFocus={() => setShowVk(true)}
+          onBlur={() => setShowVk(false)}
+          size="small"
+          fullWidth
+          helperText="The VK Bifrost reads from `x-bf-vk` on every upstream LLM call. Empty = bootstrap mode (no enforcement)."
+        />
+        <TextField
+          label="Monthly budget ceiling"
+          type="number"
+          size="small"
+          value={draft.budget_limit_usd}
+          onChange={(e) =>
+            setDraft({ ...draft, budget_limit_usd: Number(e.target.value) })
+          }
+          InputProps={{
+            startAdornment: <InputAdornment position="start">$</InputAdornment>,
+          }}
+          helperText="Reference value used by the dashboard. Bifrost enforces its own ceiling on the VK; keep them in sync to avoid surprises."
+          sx={{ maxWidth: 280 }}
+        />
+        <FormControl size="small" sx={{ maxWidth: 280 }}>
+          <InputLabel>Enforcement mode</InputLabel>
+          <Select
+            label="Enforcement mode"
+            value={draft.enforcement_mode}
+            onChange={(e) =>
+              setDraft({
+                ...draft,
+                enforcement_mode: e.target.value as 'warning' | 'hard_stop',
+              })
+            }
+          >
+            <MenuItem value="warning">Warning only — log but allow</MenuItem>
+            <MenuItem value="hard_stop">Hard stop — block on exceed</MenuItem>
+          </Select>
+        </FormControl>
+
+        <Box>
+          <Button
+            variant="contained"
+            startIcon={<SaveIcon />}
+            disabled={!dirty || saving}
+            onClick={handleSave}
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </Box>
+      </Stack>
+    </Paper>
+  )
+}

--- a/frontend/src/components/settings/LLMProvidersTab.tsx
+++ b/frontend/src/components/settings/LLMProvidersTab.tsx
@@ -25,6 +25,7 @@ import {
 } from '@mui/icons-material'
 import { llmProviderApi, LLMProvider } from '../../services/api'
 import LLMProviderDialog from './LLMProviderDialog'
+import BudgetsSection from './BudgetsSection'
 
 interface Props {
   setMessage: (m: { type: 'success' | 'error'; text: string } | null) => void
@@ -230,6 +231,11 @@ export default function LLMProvidersTab({ setMessage }: Props) {
           onError={(msg) => setMessage({ type: 'error', text: msg })}
         />
       )}
+
+      {/* Bifrost virtual-key budget config (#186) lives next to providers
+          since it gates the same upstream calls — operators set up a
+          provider and immediately want to know "how do I cap my spend". */}
+      <BudgetsSection setMessage={setMessage} />
     </Box>
   )
 }

--- a/frontend/src/components/settings/__tests__/BudgetsSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/BudgetsSection.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+vi.mock('../../../services/api', () => ({
+  budgetsApi: {
+    get: vi.fn(),
+    set: vi.fn(),
+    getQuota: vi.fn(),
+  },
+}))
+
+import BudgetsSection from '../BudgetsSection'
+import { budgetsApi } from '../../../services/api'
+
+const baseSettings = {
+  default_vk: 'sk-bf-abcdef-12345678',
+  budget_limit_usd: 100,
+  enforcement_mode: 'warning' as const,
+}
+
+const baseQuota = {
+  configured: true,
+  available: true,
+  virtual_key_id: 'sk-bf-abcdef-12345678',
+  message: null,
+  quota: {
+    virtual_key_name: 'default',
+    is_active: true,
+    budgets: [
+      {
+        id: 'b1',
+        max_limit: 100,
+        current_usage: 42,
+        reset_duration: '1mo',
+        calendar_aligned: true,
+        last_reset: '2026-04-01T00:00:00Z',
+      },
+    ],
+    rate_limit: null,
+  },
+}
+
+describe('BudgetsSection (#186)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(budgetsApi.get as any).mockResolvedValue({ data: baseSettings })
+    ;(budgetsApi.getQuota as any).mockResolvedValue({ data: baseQuota })
+    ;(budgetsApi.set as any).mockResolvedValue({ data: baseSettings })
+  })
+
+  it('renders the live quota line when Bifrost returns budget data', async () => {
+    render(<BudgetsSection setMessage={() => {}} />)
+
+    // The "$X spent of $Y" line is the visual signal that Bifrost is
+    // reachable and the VK is provisioned. Catching its absence in CI
+    // is the whole point of this test — silent quota loss = no UI signal.
+    await waitFor(() =>
+      expect(budgetsApi.getQuota).toHaveBeenCalled(),
+    )
+    expect(await screen.findByText(/spent of/i)).toBeInTheDocument()
+    expect(screen.getByText(/\$42\.00/)).toBeInTheDocument()
+    expect(screen.getByText(/\$100\.00/)).toBeInTheDocument()
+  })
+
+  it('shows a warning alert when configured VK is unreachable', async () => {
+    ;(budgetsApi.getQuota as any).mockResolvedValue({
+      data: {
+        ...baseQuota,
+        available: false,
+        message: 'Bifrost: VK not found',
+        quota: undefined,
+      },
+    })
+    render(<BudgetsSection setMessage={() => {}} />)
+    expect(await screen.findByText(/VK not found/i)).toBeInTheDocument()
+  })
+
+  it('shows an info alert when no VK is configured (bootstrap mode)', async () => {
+    ;(budgetsApi.get as any).mockResolvedValue({
+      data: { ...baseSettings, default_vk: '' },
+    })
+    ;(budgetsApi.getQuota as any).mockResolvedValue({
+      data: { configured: false, message: 'No VK configured' },
+    })
+    render(<BudgetsSection setMessage={() => {}} />)
+    expect(await screen.findByText(/No VK configured/i)).toBeInTheDocument()
+  })
+
+  it('saves the form payload on Save', async () => {
+    const setMessage = vi.fn()
+    render(<BudgetsSection setMessage={setMessage} />)
+
+    // Wait for initial load.
+    await screen.findByText(/spent of/i)
+
+    // Bump the budget ceiling and save.
+    const ceilingInput = screen.getByLabelText(/Monthly budget ceiling/i)
+    fireEvent.change(ceilingInput, { target: { value: '250' } })
+
+    const saveButton = screen.getByRole('button', { name: /^Save$/i })
+    fireEvent.click(saveButton)
+
+    await waitFor(() => expect(budgetsApi.set).toHaveBeenCalled())
+    const payload = (budgetsApi.set as any).mock.calls[0][0]
+    expect(payload.budget_limit_usd).toBe(250)
+    expect(payload.default_vk).toBe(baseSettings.default_vk)
+    expect(payload.enforcement_mode).toBe('warning')
+  })
+})

--- a/frontend/src/components/settings/__tests__/LLMProvidersTab.test.tsx
+++ b/frontend/src/components/settings/__tests__/LLMProvidersTab.test.tsx
@@ -13,6 +13,16 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+// LLMProvidersTab now renders <BudgetsSection /> as a child (#186).
+// BudgetsSection's mount kicks off async budgetsApi calls and re-renders
+// that race with the click-test below, making the find-by-label index
+// unstable. Stub the section to a no-op so this test stays focused on
+// LLMProvidersTab's own behavior. BudgetsSection has its own dedicated
+// test file (BudgetsSection.test.tsx).
+vi.mock('../BudgetsSection', () => ({
+  default: () => null,
+}))
+
 import LLMProvidersTab from '../LLMProvidersTab'
 import { llmProviderApi } from '../../../services/api'
 

--- a/frontend/src/pages/__tests__/CostAnalytics.test.tsx
+++ b/frontend/src/pages/__tests__/CostAnalytics.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+// Mock recharts before importing the component — recharts pulls in
+// SVG/canvas APIs that jsdom doesn't provide and isn't what we're
+// asserting on anyway. Just stub the bits CostAnalytics references.
+vi.mock('recharts', () => {
+  const Stub = ({ children }: { children?: any }) => <div>{children}</div>
+  return {
+    Bar: Stub,
+    BarChart: Stub,
+    CartesianGrid: Stub,
+    Cell: Stub,
+    Legend: Stub,
+    ResponsiveContainer: Stub,
+    Tooltip: Stub,
+    XAxis: Stub,
+    YAxis: Stub,
+  }
+})
+
+// vi.mock factories are hoisted above all imports; vi.hoisted lets us
+// share a mock fn between the factory and the test body without tripping
+// the "cannot access before initialization" hoist-order trap.
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }))
+
+vi.mock('../../services/api', () => ({
+  default: { get: mockGet },
+  analyticsApi: {
+    estimateCost: vi.fn(),
+    recalculateCost: vi.fn(),
+  },
+}))
+
+import CostAnalytics from '../CostAnalytics'
+
+const samplePayload = {
+  window: { start: '2026-04-28T00:00:00', end: '2026-05-05T00:00:00', seconds: 604800 },
+  totals: {
+    calls: 42,
+    input_tokens: 100_000,
+    output_tokens: 10_000,
+    cache_read_tokens: 50_000,
+    cache_creation_tokens: 5_000,
+    cost_usd: 1.234,
+    cache_hit_rate: 0.33,
+  },
+  by_agent: [],
+  by_model: [
+    {
+      model: 'claude-sonnet-4-5-20250929',
+      provider_type: 'anthropic',
+      pricing_source: 'exact',
+      calls: 30,
+      input_tokens: 80_000,
+      output_tokens: 8_000,
+      cache_read_tokens: 40_000,
+      cache_creation_tokens: 4_000,
+      cost_usd: 1.0,
+      cache_hit_rate: 0.33,
+    },
+    {
+      model: 'some-future-model',
+      provider_type: 'unknown',
+      pricing_source: 'unknown',
+      calls: 12,
+      input_tokens: 20_000,
+      output_tokens: 2_000,
+      cache_read_tokens: 10_000,
+      cache_creation_tokens: 1_000,
+      cost_usd: 0.0,
+      cache_hit_rate: 0.33,
+    },
+  ],
+  top_investigations: [],
+  time_series: null,
+}
+
+describe('CostAnalytics — pricing_source surfacing (#184)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGet.mockResolvedValue({ data: samplePayload })
+  })
+
+  it('renders the per-model table with pricing badges and provider chips', async () => {
+    render(<CostAnalytics />)
+
+    await waitFor(() =>
+      expect(mockGet).toHaveBeenCalledWith('/analytics/cost', expect.any(Object)),
+    )
+
+    // Both model rows present.
+    expect(
+      await screen.findByText('claude-sonnet-4-5-20250929'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('some-future-model')).toBeInTheDocument()
+
+    // Provider chip — anthropic appears exactly once. (The "unknown"
+    // string appears in both the provider chip and the pricing badge,
+    // so we use getAllByText for it and assert at least 2 matches.)
+    expect(screen.getByText('anthropic')).toBeInTheDocument()
+    expect(screen.getAllByText('unknown').length).toBeGreaterThanOrEqual(2)
+
+    // Pricing badges — `exact` for catalogued model. The point of #184
+    // Phase 3 surfacing: a $0 unknown row is visually distinguishable
+    // from a $0 zero-pricing (Ollama) row.
+    expect(screen.getByText('exact')).toBeInTheDocument()
+  })
+
+  it('shows the "free" label for zero-pricing rows instead of $0 ambiguity', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        ...samplePayload,
+        by_model: [
+          {
+            ...samplePayload.by_model[0],
+            model: 'llama3.1',
+            provider_type: 'ollama',
+            pricing_source: 'zero',
+            cost_usd: 0,
+          },
+        ],
+      },
+    })
+    render(<CostAnalytics />)
+    expect(await screen.findByText('llama3.1')).toBeInTheDocument()
+    expect(screen.getByText('free')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1073,6 +1073,52 @@ export interface RecalculateCostResult {
   remaining: number
 }
 
+// Budgets (Bifrost virtual-key config + live quota — #186)
+export interface BudgetSettings {
+  default_vk: string
+  budget_limit_usd: number
+  enforcement_mode: 'warning' | 'hard_stop'
+}
+
+export interface BifrostBudgetTier {
+  id: string
+  max_limit: number
+  current_usage: number
+  reset_duration: string
+  calendar_aligned: boolean
+  last_reset: string
+}
+
+export interface BifrostRateLimit {
+  id: string
+  token_max_limit: number
+  token_current_usage: number
+  token_reset_duration: string
+  request_max_limit: number | null
+  request_current_usage: number
+  request_reset_duration: string | null
+}
+
+export interface BudgetQuotaResponse {
+  configured: boolean
+  available?: boolean
+  virtual_key_id?: string
+  message?: string
+  quota?: {
+    virtual_key_name: string
+    is_active: boolean
+    budgets: BifrostBudgetTier[]
+    rate_limit?: BifrostRateLimit
+  }
+}
+
+export const budgetsApi = {
+  get: () => api.get<BudgetSettings>('/analytics/budget'),
+  set: (payload: BudgetSettings) =>
+    api.put<BudgetSettings>('/analytics/budget', payload),
+  getQuota: () => api.get<BudgetQuotaResponse>('/analytics/budget/quota'),
+}
+
 export const analyticsApi = {
   // Pre-call USD/token estimate. The chat composer calls this (debounced)
   // as the user types so they see what their message will cost before

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,6 +8,19 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
+    // Don't pick up test files inside agent worktrees — those copies of
+    // the repo lack node_modules and crash the run with "Cannot find
+    // package '@testing-library/react'". The .claude directory sits one
+    // level up from frontend/ so we need both relative-up and bare-glob
+    // patterns to catch it. Vitest's default excludes skip node_modules
+    // and .git only.
+    exclude: [
+      '**/node_modules/**',
+      '**/.git/**',
+      '**/.claude/**',
+      '../.claude/**',
+      '**/worktrees/**',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],

--- a/scripts/bifrost_capability_probe.py
+++ b/scripts/bifrost_capability_probe.py
@@ -66,7 +66,9 @@ async def probe_basic() -> bool:
             messages=[{"role": "user", "content": "Reply with the single word: ping"}],
         )
         text = "".join(
-            getattr(b, "text", "") for b in resp.content if getattr(b, "type", "") == "text"
+            getattr(b, "text", "")
+            for b in resp.content
+            if getattr(b, "type", "") == "text"
         )
         if not text.strip():
             _fail("basic round-trip: empty response text")
@@ -98,7 +100,9 @@ async def probe_extended_thinking() -> bool:
                 }
             ],
         )
-        has_thinking_block = any(getattr(b, "type", "") == "thinking" for b in resp.content)
+        has_thinking_block = any(
+            getattr(b, "type", "") == "thinking" for b in resp.content
+        )
         if not has_thinking_block:
             _fail(
                 "extended thinking: response contained no `thinking` block — "
@@ -188,6 +192,99 @@ async def probe_prompt_caching() -> Tuple[bool, bool]:
         return False, False
 
 
+async def probe_logging_metadata() -> bool:
+    """Probe 4 — Bifrost's logging plugin must persist requests and capture
+    arbitrary ``x-bf-lh-*`` headers as log metadata (#185).
+
+    Vigil tags every Anthropic call with ``x-bf-lh-vigil-interaction-id`` so
+    the dashboard can correlate Bifrost log rows back to a specific Vigil
+    interaction. If the logging plugin is off, or the persistence backend
+    isn't writing, the dashboard's Bifrost-sourced time series silently goes
+    dark and we fall back to local cost math without anyone noticing.
+    Catching this regression here is cheaper than catching it in prod.
+
+    Strategy:
+      1. Send a minimal Anthropic call carrying ``x-bf-lh-vigil-probe-id``
+         set to a fresh UUID (cache-busting, attribution-bearing).
+      2. Wait briefly for the log row to flush.
+      3. Hit Bifrost's admin ``GET /api/logs`` endpoint and scan the
+         ``metadata`` field of recent rows for the probe id.
+
+    Pass = the row exists AND ``vigil-probe-id`` round-tripped intact.
+    """
+    import httpx
+
+    bifrost_url = os.environ["BIFROST_URL"].rstrip("/")
+    probe_id = uuid.uuid4().hex
+    probe_marker = f"probe-{probe_id[:8]}"
+
+    try:
+        client = await _client()
+        await client.messages.create(
+            model=MODEL,
+            max_tokens=16,
+            messages=[
+                {
+                    "role": "user",
+                    "content": f"Reply with the word: {probe_marker}",
+                }
+            ],
+            extra_headers={"x-bf-lh-vigil-probe-id": probe_id},
+        )
+    except Exception as exc:  # noqa: BLE001
+        _fail(f"logging metadata: probe call raised: {exc}")
+        return False
+
+    # Logs land asynchronously — give Bifrost a couple seconds to flush.
+    await asyncio.sleep(2)
+
+    try:
+        with httpx.Client(timeout=10.0) as http:
+            r = http.get(f"{bifrost_url}/api/logs", params={"limit": 50})
+            if r.status_code == 404:
+                _fail(
+                    "logging metadata: GET /api/logs returned 404 — "
+                    "the logging plugin is off. Set client.enable_logging "
+                    "and configure logs_store in docker/bifrost/config.json."
+                )
+                return False
+            if r.status_code >= 400:
+                _fail(
+                    f"logging metadata: GET /api/logs returned {r.status_code}: "
+                    f"{r.text[:200]}"
+                )
+                return False
+            payload = r.json()
+    except Exception as exc:  # noqa: BLE001
+        _fail(f"logging metadata: GET /api/logs failed: {exc}")
+        return False
+
+    # Bifrost's response shape: { "logs": [...], "pagination": {...} } per
+    # docs.getbifrost.ai. Scan the most recent rows for the probe id.
+    rows = payload.get("logs") if isinstance(payload, dict) else None
+    if not rows:
+        _fail(
+            "logging metadata: /api/logs returned no rows — backend "
+            "persistence isn't writing (check logs_store config + volume)"
+        )
+        return False
+
+    for row in rows:
+        meta = row.get("metadata") or {}
+        # Bifrost strips the `x-bf-lh-` prefix when it stores the header,
+        # leaving the suffix as the metadata key.
+        if meta.get("vigil-probe-id") == probe_id:
+            _ok(f"logging metadata round-tripped (probe-id={probe_id[:8]}…)")
+            return True
+
+    _fail(
+        "logging metadata: probe id never appeared in /api/logs metadata. "
+        "Either x-bf-lh-* headers aren't being captured or the row hasn't "
+        "flushed yet — try increasing the post-call sleep."
+    )
+    return False
+
+
 async def main() -> int:
     if not os.getenv("BIFROST_URL"):
         _fail("BIFROST_URL is not set")
@@ -201,6 +298,7 @@ async def main() -> int:
     basic = await probe_basic()
     thinking = await probe_extended_thinking()
     cache_create, cache_read = await probe_prompt_caching()
+    logging_ok = await probe_logging_metadata()
 
     print()
     results = {
@@ -208,6 +306,7 @@ async def main() -> int:
         "extended thinking passthrough": thinking,
         "prompt cache creation": cache_create,
         "prompt cache read": cache_read,
+        "logging plugin metadata round-trip": logging_ok,
     }
     for name, passed in results.items():
         mark = "✅" if passed else "❌"

--- a/services/bifrost_cost_client.py
+++ b/services/bifrost_cost_client.py
@@ -266,11 +266,54 @@ def recalculate_cost(
 # ---------------------------------------------------------------------------
 
 
-def _get_json(path: str, *, params: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+# ---------------------------------------------------------------------------
+# Governance / virtual-key quota (#186)
+# ---------------------------------------------------------------------------
+
+
+def get_vk_quota(vk: str) -> Optional[Dict[str, Any]]:
+    """Return the budget + rate-limit quota for a virtual key.
+
+    Path: ``GET /api/governance/virtual-keys/quota``. Bifrost authenticates
+    this endpoint using the ``x-bf-vk`` header (the same header dispatch
+    attaches on every upstream call). Response shape:
+
+    .. code-block:: json
+
+        {
+          "virtual_key_name": "...",
+          "is_active": true,
+          "budgets": [
+            {"id": "...", "max_limit": 100.0, "current_usage": 42.0,
+             "reset_duration": "1mo", "calendar_aligned": true,
+             "last_reset": "..."}
+          ],
+          "rate_limit": {"id": "...", "token_max_limit": 1000000,
+                         "token_current_usage": 12345, ...}
+        }
+
+    The Settings → LLM Providers → Budgets sub-panel uses this directly
+    to render "$X of $Y consumed" without round-tripping through Vigil's
+    aggregations.
+    """
+    if not vk:
+        return None
+    return _get_json(
+        "/api/governance/virtual-keys/quota",
+        headers={"x-bf-vk": vk},
+    )
+
+
+def _get_json(
+    path: str,
+    *,
+    params: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, str]] = None,
+) -> Optional[Dict[str, Any]]:
     url = f"{_bifrost_base_url()}{path}"
     try:
         with httpx.Client(timeout=_DEFAULT_TIMEOUT) as client:
-            r = client.get(url, params=params or {})
+            r = client.get(url, params=params or {}, headers=headers or {})
             if r.status_code >= 400:
                 logger.warning(
                     "bifrost_cost_client: GET %s returned %s: %s",

--- a/services/budget_service.py
+++ b/services/budget_service.py
@@ -1,0 +1,141 @@
+"""Bifrost virtual-key budget enforcement (#186).
+
+The single point of truth for "which VK should this LLM call use" and
+"should we enforce the budget right now". Two bypass envs cover the
+free-tier / dev story:
+
+  * ``DEV_MODE=true``        — already gates the rest of the auth stack;
+                               implicitly disables budget enforcement so
+                               local development isn't accidentally
+                               blocked by a stale VK ceiling.
+  * ``LLM_BUDGET_UNLIMITED=true`` — explicit budget bypass without
+                               disabling auth (free-tier / sentinel VK).
+
+Configuration lives in ``system_config['bifrost.virtual_keys']`` so
+operators edit it from the Settings → LLM Providers → Budgets sub-panel.
+The 60s runtime-config TTL the rest of Vigil uses applies here too.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+GLOBAL_KEY = "bifrost.virtual_keys"
+
+
+# ---------------------------------------------------------------------------
+# Typed exception — surfaces from llm_router when Bifrost returns 429/402
+# ---------------------------------------------------------------------------
+
+
+class BudgetExceeded(Exception):
+    """Bifrost rejected an upstream call because a budget tier was hit.
+
+    The chat UI catches this and renders a typed banner (instead of a
+    generic 500 toast). The agent loop catches it as a terminal failure
+    for the investigation rather than retrying.
+    """
+
+    def __init__(self, *, tier: str, message: str = "", status_code: Optional[int] = None):
+        super().__init__(message or f"LLM budget exceeded ({tier})")
+        self.tier = tier  # "virtual_key" | "team" | "customer" | "rate_limit" | "unknown"
+        self.status_code = status_code
+        self.message = message
+
+
+# ---------------------------------------------------------------------------
+# Bypass detection
+# ---------------------------------------------------------------------------
+
+
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").lower() in ("true", "1", "yes")
+
+
+def should_enforce() -> bool:
+    """True if we should attach the VK header and respect Bifrost's gating.
+
+    Returns False when DEV_MODE or LLM_BUDGET_UNLIMITED is on, OR when
+    no default VK is configured (bootstrap window — accept calls without
+    enforcement until the operator provisions a key).
+    """
+    if _env_truthy("DEV_MODE"):
+        return False
+    if _env_truthy("LLM_BUDGET_UNLIMITED"):
+        return False
+    if not get_active_vk():
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# VK config lookup
+# ---------------------------------------------------------------------------
+
+
+def get_active_vk() -> Optional[str]:
+    """Return the configured global VK ID, or None if not set.
+
+    Lazily reads from ``system_config['bifrost.virtual_keys']``. Returns
+    None on any DB error so a misconfigured persistence layer can never
+    block LLM traffic — Vigil falls back to no-VK mode and the operator
+    sees the bootstrap behavior.
+    """
+    settings = _get_settings()
+    if not isinstance(settings, dict):
+        return None
+    vk = settings.get("default_vk")
+    if not isinstance(vk, str) or not vk.strip():
+        return None
+    return vk.strip()
+
+
+def get_settings() -> dict:
+    """Public read of the full settings dict (for the Budgets UI)."""
+    val = _get_settings() or {}
+    if not isinstance(val, dict):
+        return {}
+    return {
+        "default_vk": val.get("default_vk", "") or "",
+        "budget_limit_usd": float(val.get("budget_limit_usd") or 0),
+        "enforcement_mode": str(val.get("enforcement_mode") or "warning"),
+    }
+
+
+def set_settings(*, default_vk: str, budget_limit_usd: float, enforcement_mode: str) -> dict:
+    """Persist the VK + budget config. Caller (API handler) is admin-gated."""
+    if enforcement_mode not in ("warning", "hard_stop"):
+        raise ValueError(
+            f"enforcement_mode must be 'warning' or 'hard_stop', got {enforcement_mode!r}"
+        )
+    try:
+        from database.config_service import get_config_service
+
+        get_config_service(user_id="api").set_system_config(
+            key=GLOBAL_KEY,
+            value={
+                "default_vk": default_vk or "",
+                "budget_limit_usd": float(budget_limit_usd),
+                "enforcement_mode": enforcement_mode,
+            },
+            description="Bifrost virtual-key configuration and budget settings",
+            config_type="ai",
+        )
+    except Exception as e:
+        logger.error("budget_service: failed to write settings: %s", e)
+        raise
+    return get_settings()
+
+
+def _get_settings():
+    try:
+        from database.config_service import get_config_service
+
+        return get_config_service().get_system_config(GLOBAL_KEY)
+    except Exception as e:
+        logger.debug("budget_service: settings read failed: %s", e)
+        return None

--- a/services/claude_service.py
+++ b/services/claude_service.py
@@ -1128,6 +1128,15 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
             except Exception:
                 cost_usd = 0.0
 
+            # #186: capture which Bifrost VK serviced this call so we can
+            # group spend per-VK in analytics. Empty in dev / bypass mode.
+            try:
+                from services.budget_service import get_active_vk
+
+                _vk = get_active_vk()
+            except Exception:
+                _vk = None
+
             row = LLMInteractionLog(
                 # Caller-supplied interaction_id (#185 Bifrost correlation)
                 # falls back to a fresh UUID for legacy callers that don't
@@ -1153,6 +1162,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                 cost_usd=float(cost_usd or 0.0),
                 duration_ms=int(duration_ms or 0),
                 error=error,
+                virtual_key_id=_vk,
             )
             db_manager = get_db_manager()
             with db_manager.session_scope() as session:

--- a/services/llm_router.py
+++ b/services/llm_router.py
@@ -55,6 +55,65 @@ except Exception:  # noqa: BLE001
 DispatchPath = Literal["bifrost"]
 
 
+# ---------------------------------------------------------------------------
+# Budget-error mapping (#186)
+# ---------------------------------------------------------------------------
+
+
+def _is_budget_status(status_code: Optional[int]) -> bool:
+    """Bifrost returns 429 when the VK rate limit is hit and 402 when a
+    budget tier is exceeded. We map both to ``BudgetExceeded`` so callers
+    can render a typed error rather than a generic 500. Some providers
+    map "insufficient quota" to 429 too, so the line between rate-limit
+    and budget-exceeded is fuzzy — we surface ``tier`` in the exception
+    so the UI can disambiguate when Bifrost adds richer error bodies."""
+    return status_code in (402, 429)
+
+
+def _classify_tier(status_code: Optional[int], body: str) -> str:
+    body_lc = (body or "").lower()
+    if status_code == 402 or "budget" in body_lc:
+        return "virtual_key"
+    if status_code == 429 or "rate" in body_lc:
+        return "rate_limit"
+    return "unknown"
+
+
+async def _wrap_budget_errors(coro):
+    """Run ``coro`` and translate Bifrost's budget/rate-limit responses
+    into ``services.budget_service.BudgetExceeded``.
+
+    Both the Anthropic and OpenAI SDKs raise their own ``APIStatusError``
+    subclasses with a ``status_code`` attribute. We don't import either
+    SDK here (lazy at call sites) so the catch is duck-typed.
+    """
+    try:
+        return await coro
+    except Exception as e:
+        status_code = getattr(e, "status_code", None)
+        if not _is_budget_status(status_code):
+            raise
+        # Best-effort body extraction. SDKs vary: some have .response.text,
+        # some .message, some neither.
+        body = ""
+        for attr in ("message", "body"):
+            v = getattr(e, attr, None)
+            if v:
+                body = str(v)
+                break
+        if not body:
+            resp = getattr(e, "response", None)
+            if resp is not None:
+                body = getattr(resp, "text", "") or ""
+        from services.budget_service import BudgetExceeded
+
+        raise BudgetExceeded(
+            tier=_classify_tier(status_code, body),
+            message=body or f"Bifrost returned {status_code}",
+            status_code=status_code,
+        ) from e
+
+
 @dataclass(frozen=True)
 class ProviderSpec:
     """Minimal view of a row from llm_provider_configs.
@@ -256,32 +315,56 @@ class LLMRouter:
         """
         messages, system_prompt = _pre_dispatch_sanitize(messages, system_prompt)
         model = model or provider.default_model
-        extra_headers = (
-            {"x-bf-lh-vigil-interaction-id": interaction_id}
-            if interaction_id
-            else None
+
+        # #185: correlation header for Bifrost log lookup.
+        # #186: VK header so Bifrost's governance layer enforces budgets.
+        # Both share the extra_headers kwarg the SDKs forward to the upstream
+        # request. Only attach x-bf-vk when budget enforcement is on; while
+        # DEV_MODE / LLM_BUDGET_UNLIMITED is set, omit the header entirely
+        # so Bifrost's bootstrap "no VK" path applies.
+        extra_headers: Dict[str, str] = {}
+        if interaction_id:
+            extra_headers["x-bf-lh-vigil-interaction-id"] = interaction_id
+        try:
+            from services.budget_service import get_active_vk, should_enforce
+
+            if should_enforce():
+                vk = get_active_vk()
+                if vk:
+                    extra_headers["x-bf-vk"] = vk
+        except Exception as _be:
+            logger.debug("budget_service unavailable (%s); proceeding without x-bf-vk", _be)
+        # Convert empty dict back to None so the dispatch helpers can use a
+        # truthy check for "should I send any extra headers" without leaking
+        # an empty dict into the SDK call.
+        extra_headers_or_none: Optional[Dict[str, str]] = (
+            extra_headers if extra_headers else None
         )
         if provider.provider_type == "anthropic":
-            return await self._dispatch_anthropic(
+            return await _wrap_budget_errors(
+                self._dispatch_anthropic(
+                    provider=provider,
+                    messages=messages,
+                    system_prompt=system_prompt,
+                    model=model,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    enable_thinking=enable_thinking,
+                    thinking_budget=thinking_budget,
+                    extra_headers=extra_headers_or_none,
+                )
+            )
+        return await _wrap_budget_errors(
+            self._dispatch_bifrost_openai(
                 provider=provider,
                 messages=messages,
                 system_prompt=system_prompt,
                 model=model,
                 max_tokens=max_tokens,
+                temperature=temperature,
                 tools=tools,
-                enable_thinking=enable_thinking,
-                thinking_budget=thinking_budget,
-                extra_headers=extra_headers,
+                extra_headers=extra_headers_or_none,
             )
-        return await self._dispatch_bifrost_openai(
-            provider=provider,
-            messages=messages,
-            system_prompt=system_prompt,
-            model=model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            tools=tools,
-            extra_headers=extra_headers,
         )
 
     # ---- backends --------------------------------------------------------

--- a/services/workflows_service.py
+++ b/services/workflows_service.py
@@ -626,13 +626,38 @@ For each phase:
             return {"success": False, "error": "Claude API not configured"}
 
         workflow_dict = workflow.to_dict(include_body=False)
+
+        # #184 Phase 2: pre-call cost estimate for the run record. Workflows
+        # don't have a per-run budget cap (Bifrost VK enforcement is the
+        # gate), but stashing the projected USD band into trigger_context
+        # gives operators an audit trail of expected vs. actual spend.
+        # Best-effort — telemetry never blocks a workflow.
+        trigger_context = dict(parameters or {})
+        try:
+            from services.cost_estimator import estimate_cost
+
+            _est = await estimate_cost(
+                provider_type="anthropic",
+                model_id="claude-sonnet-4-5-20250929",
+                messages=[{"role": "user", "content": prompt}],
+                system_prompt=system_prompt,
+                max_tokens=8192,
+            )
+            trigger_context["cost_estimate"] = _est.to_dict()
+        except Exception as _est_err:  # noqa: BLE001
+            logger.debug(
+                "Workflow %s pre-flight estimate failed (%s); proceeding",
+                workflow.id,
+                _est_err,
+            )
+
         run_service = get_workflow_run_service()
         run_id = run_service.begin_run(
             workflow_id=workflow.id,
             workflow_name=workflow.name,
             workflow_source=workflow_dict.get("source", "file"),
             workflow_version=workflow_dict.get("version"),
-            trigger_context=dict(parameters or {}),
+            trigger_context=trigger_context,
             triggered_by=triggered_by,
             skill_tools_available=skill_tool_names,
         )
@@ -774,8 +799,7 @@ For each phase:
 
             prior_row = existing_phases.get(phase_id)
             already_approved = (
-                prior_row is not None
-                and prior_row.get("approval_state") == "approved"
+                prior_row is not None and prior_row.get("approval_state") == "approved"
             )
 
             # Pre-phase approval gate (#128). Skipped if the phase row
@@ -828,17 +852,6 @@ For each phase:
                     "executed_at": datetime.now().isoformat(),
                 }
 
-            # Run the phase.
-            run_service.upsert_phase(
-                run_id,
-                phase_id,
-                phase_order=phase_order,
-                agent_id=agent_id,
-                status="running",
-                input_context={"prior_outputs": accumulated},
-                started_at=datetime.utcnow(),
-            )
-
             profile = all_agents.get(agent_id)
             phase_prompt = self._build_phase_prompt(
                 workflow=workflow,
@@ -850,6 +863,41 @@ For each phase:
                 workflow, skill_tools_available, single_phase=phase
             )
             phase_tools = self._tools_for_phase(phase, profile, skill_tools_available)
+
+            # #184 Phase 2: per-phase pre-call estimate stashed into the
+            # phase's input_context so each phase row carries its own
+            # projected USD band. No gating — Bifrost VK is the budget
+            # gate. Best-effort, never blocks the phase.
+            phase_input_context: Dict[str, Any] = {"prior_outputs": accumulated}
+            try:
+                from services.cost_estimator import estimate_cost
+
+                _phase_est = await estimate_cost(
+                    provider_type="anthropic",
+                    model_id="claude-sonnet-4-5-20250929",
+                    messages=[{"role": "user", "content": phase_prompt}],
+                    system_prompt=system_prompt,
+                    max_tokens=8192,
+                )
+                phase_input_context["cost_estimate"] = _phase_est.to_dict()
+            except Exception as _phase_est_err:  # noqa: BLE001
+                logger.debug(
+                    "Workflow run %s phase %s estimate failed (%s); proceeding",
+                    run_id,
+                    phase_id,
+                    _phase_est_err,
+                )
+
+            # Run the phase.
+            run_service.upsert_phase(
+                run_id,
+                phase_id,
+                phase_order=phase_order,
+                agent_id=agent_id,
+                status="running",
+                input_context=phase_input_context,
+                started_at=datetime.utcnow(),
+            )
 
             try:
                 response_text = await asyncio.to_thread(
@@ -1027,7 +1075,7 @@ For each phase:
             else "multi-phase workflow"
         )
         header = (
-            f'You are the Vigil SOC Workflow Engine executing the '
+            f"You are the Vigil SOC Workflow Engine executing the "
             f'"{workflow.name}" {scope}.'
         )
         return f"""{header}

--- a/tests/test_budget_service.py
+++ b/tests/test_budget_service.py
@@ -1,0 +1,154 @@
+"""Unit tests for ``services.budget_service`` (#186).
+
+Tests focus on the bypass logic — VK header injection only happens when
+should_enforce() returns True, so the priority is making sure that
+function never wedges an entire deployment in "no LLM traffic" mode by
+accident. Three bypass paths must work: DEV_MODE, LLM_BUDGET_UNLIMITED,
+and "no VK configured yet" (bootstrap).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# should_enforce — the gating function
+# ---------------------------------------------------------------------------
+
+
+def test_should_enforce_false_when_dev_mode_on(monkeypatch):
+    monkeypatch.setenv("DEV_MODE", "true")
+    monkeypatch.setenv("LLM_BUDGET_UNLIMITED", "false")
+    with patch(
+        "services.budget_service._get_settings", return_value={"default_vk": "sk-bf-x"}
+    ):
+        from services.budget_service import should_enforce
+
+        assert should_enforce() is False
+
+
+def test_should_enforce_false_when_unlimited_env_on(monkeypatch):
+    monkeypatch.setenv("DEV_MODE", "false")
+    monkeypatch.setenv("LLM_BUDGET_UNLIMITED", "true")
+    with patch(
+        "services.budget_service._get_settings", return_value={"default_vk": "sk-bf-x"}
+    ):
+        from services.budget_service import should_enforce
+
+        assert should_enforce() is False
+
+
+def test_should_enforce_false_when_no_vk_configured(monkeypatch):
+    """Bootstrap window: no VK set → don't try to enforce. The dispatch
+    omits the x-bf-vk header and Bifrost's no-VK path applies."""
+    monkeypatch.setenv("DEV_MODE", "false")
+    monkeypatch.setenv("LLM_BUDGET_UNLIMITED", "false")
+    with patch(
+        "services.budget_service._get_settings", return_value={"default_vk": ""}
+    ):
+        from services.budget_service import should_enforce
+
+        assert should_enforce() is False
+
+
+def test_should_enforce_true_when_vk_set_and_no_bypass(monkeypatch):
+    monkeypatch.setenv("DEV_MODE", "false")
+    monkeypatch.setenv("LLM_BUDGET_UNLIMITED", "false")
+    with patch(
+        "services.budget_service._get_settings",
+        return_value={"default_vk": "sk-bf-real-key"},
+    ):
+        from services.budget_service import should_enforce
+
+        assert should_enforce() is True
+
+
+def test_get_active_vk_strips_whitespace():
+    """Operator pastes a VK with surrounding whitespace from a config file
+    — strip it so the header doesn't get mangled."""
+    with patch(
+        "services.budget_service._get_settings",
+        return_value={"default_vk": "  sk-bf-padded   "},
+    ):
+        from services.budget_service import get_active_vk
+
+        assert get_active_vk() == "sk-bf-padded"
+
+
+def test_get_active_vk_returns_none_when_db_unavailable():
+    """A misconfigured persistence layer must not block LLM traffic.
+    The internal _get_settings catches DB errors and returns None;
+    get_active_vk passes that through to the dispatch path which then
+    falls back to bootstrap (no-VK) mode."""
+    with patch(
+        "services.budget_service._get_settings",
+        return_value=None,
+    ):
+        from services.budget_service import get_active_vk
+
+        assert get_active_vk() is None
+
+
+def test_internal_get_settings_swallows_db_errors():
+    """The actual error-handling layer: _get_settings wraps the
+    config_service call in try/except so callers can't surface a DB
+    failure as a hard error."""
+    with patch(
+        "database.config_service.get_config_service",
+        side_effect=RuntimeError("DB exploded"),
+    ):
+        from services.budget_service import _get_settings
+
+        # Must not raise.
+        result = _get_settings()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_settings / set_settings — config persistence
+# ---------------------------------------------------------------------------
+
+
+def test_get_settings_returns_normalized_defaults():
+    """Empty / missing settings should normalize to safe defaults."""
+    with patch("services.budget_service._get_settings", return_value=None):
+        from services.budget_service import get_settings
+
+        s = get_settings()
+        assert s == {
+            "default_vk": "",
+            "budget_limit_usd": 0.0,
+            "enforcement_mode": "warning",
+        }
+
+
+def test_set_settings_validates_enforcement_mode():
+    from services.budget_service import set_settings
+
+    with pytest.raises(ValueError, match="enforcement_mode must be"):
+        set_settings(default_vk="sk-bf-x", budget_limit_usd=10.0, enforcement_mode="bogus")
+
+
+# ---------------------------------------------------------------------------
+# BudgetExceeded — typed exception
+# ---------------------------------------------------------------------------
+
+
+def test_budget_exceeded_carries_tier_and_status():
+    from services.budget_service import BudgetExceeded
+
+    err = BudgetExceeded(tier="virtual_key", message="$10 spent of $10", status_code=402)
+    assert err.tier == "virtual_key"
+    assert err.status_code == 402
+    assert "10 spent" in str(err)

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -341,6 +341,135 @@ async def test_dispatch_propagates_interaction_id_anthropic():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_attaches_vk_header_when_budget_enforce_active():
+    """#186: when budget_service.should_enforce() is True and a VK is
+    configured, dispatch must attach `x-bf-vk: <vk>` so Bifrost's
+    governance layer enforces the budget upstream of the call."""
+    router = LLMRouter(bifrost_url="http://test-bifrost:8080")
+    fake_resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None))],
+        model="openai/gpt-4o-mini",
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=fake_resp)
+
+    with patch("openai.AsyncOpenAI", return_value=mock_client), \
+         patch("services.budget_service.should_enforce", return_value=True), \
+         patch("services.budget_service.get_active_vk", return_value="sk-bf-test-vk"):
+        await router.dispatch(
+            provider=_openai_spec(),
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    headers = mock_client.chat.completions.create.call_args.kwargs.get("extra_headers")
+    assert headers is not None
+    assert headers.get("x-bf-vk") == "sk-bf-test-vk"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_omits_vk_header_when_enforcement_off():
+    """DEV_MODE / LLM_BUDGET_UNLIMITED → should_enforce() is False →
+    don't attach x-bf-vk so Bifrost's bootstrap (no-VK) path applies."""
+    router = LLMRouter(bifrost_url="http://test-bifrost:8080")
+    fake_resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None))],
+        model="openai/gpt-4o-mini",
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=fake_resp)
+
+    with patch("openai.AsyncOpenAI", return_value=mock_client), \
+         patch("services.budget_service.should_enforce", return_value=False), \
+         patch("services.budget_service.get_active_vk", return_value="sk-bf-test-vk"):
+        await router.dispatch(
+            provider=_openai_spec(),
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    kwargs = mock_client.chat.completions.create.call_args.kwargs
+    # No interaction_id and no enforcement → no extra_headers at all.
+    assert "extra_headers" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_dispatch_translates_402_into_budget_exceeded():
+    """Bifrost returns 402 when the VK budget is exhausted. The router
+    must translate that into the typed BudgetExceeded so the chat UI
+    can render a banner instead of a 500 toast."""
+    from services.budget_service import BudgetExceeded
+
+    router = LLMRouter(bifrost_url="http://test-bifrost:8080")
+    err = SimpleNamespace(status_code=402, message="$5 of $5 spent")
+    raise_err = type("FakeAPIErr", (Exception,), {})("budget hit")
+    raise_err.status_code = 402  # type: ignore[attr-defined]
+    raise_err.message = "$5 of $5 spent"  # type: ignore[attr-defined]
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(side_effect=raise_err)
+
+    with patch("openai.AsyncOpenAI", return_value=mock_client), \
+         patch("services.budget_service.should_enforce", return_value=True), \
+         patch("services.budget_service.get_active_vk", return_value="sk-bf-test"):
+        with pytest.raises(BudgetExceeded) as excinfo:
+            await router.dispatch(
+                provider=_openai_spec(),
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+    assert excinfo.value.status_code == 402
+    assert excinfo.value.tier == "virtual_key"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_translates_429_into_budget_exceeded_rate_tier():
+    from services.budget_service import BudgetExceeded
+
+    router = LLMRouter(bifrost_url="http://test-bifrost:8080")
+    raise_err = type("FakeAPIErr", (Exception,), {})("rate limited")
+    raise_err.status_code = 429  # type: ignore[attr-defined]
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(side_effect=raise_err)
+
+    with patch("openai.AsyncOpenAI", return_value=mock_client):
+        with pytest.raises(BudgetExceeded) as excinfo:
+            await router.dispatch(
+                provider=_openai_spec(),
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+    assert excinfo.value.status_code == 429
+    assert excinfo.value.tier == "rate_limit"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_does_not_swallow_non_budget_errors():
+    """Only 402/429 map to BudgetExceeded. A 500 should propagate as-is
+    so the caller sees the real error and doesn't think it's a budget
+    issue."""
+    router = LLMRouter(bifrost_url="http://test-bifrost:8080")
+    raise_err = type("FakeAPIErr", (Exception,), {})("upstream blew up")
+    raise_err.status_code = 500  # type: ignore[attr-defined]
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(side_effect=raise_err)
+
+    with patch("openai.AsyncOpenAI", return_value=mock_client):
+        with pytest.raises(Exception) as excinfo:
+            await router.dispatch(
+                provider=_openai_spec(),
+                messages=[{"role": "user", "content": "hi"}],
+            )
+    assert getattr(excinfo.value, "status_code", None) == 500
+    # Must not have been wrapped into BudgetExceeded.
+    from services.budget_service import BudgetExceeded
+
+    assert not isinstance(excinfo.value, BudgetExceeded)
+
+
+@pytest.mark.asyncio
 async def test_anthropic_dispatch_raises_when_no_key():
     router = LLMRouter()
     with patch("services.llm_router.get_secret", return_value=None), \

--- a/tests/unit/test_cost_analytics.py
+++ b/tests/unit/test_cost_analytics.py
@@ -86,6 +86,9 @@ async def test_get_cost_analytics_response_shape(monkeypatch):
         "by_agent",
         "by_model",
         "top_investigations",
+        # #185: time_series block sourced from Bifrost's
+        # /api/logs/histogram/cost; None when Bifrost is unreachable.
+        "time_series",
     }
     assert result["totals"] == fake_totals
     assert result["by_agent"] == fake_agents


### PR DESCRIPTION
Third and final PR in the LLM cost-tracking integration. Stacks on PR B (#189) which stacks on PR A (#188).

Closes #186.

## What this PR does

Vigil's existing `max_cost_per_investigation` daemon-side cap fires *post-hoc* — by the time it triggers, the call has already happened. This PR adds upstream-of-call budget enforcement via Bifrost virtual keys: every LLM call carries `x-bf-vk: <vk>`, Bifrost checks the VK's budget before forwarding to the provider, and on exhaustion returns a 402 that we translate into a typed `BudgetExceeded` error with a banner in the chat UI.

**Single-global-VK MVP** per the locked design. Vigil has no tenant model today (per-user RBAC only), so all calls share one Bifrost VK. `virtual_key_id` lands on `LLMInteractionLog` to future-proof per-tenant attribution once tenancy ships (#165).

### What's wired

| Layer | Change |
|---|---|
| Schema | `database/init/16_llm_budgets.sql`: adds `virtual_key_id` column + index, seeds `system_config['bifrost.virtual_keys']` row. |
| Service | `services/budget_service.py` (new): `get_active_vk`, `should_enforce` (DEV_MODE / LLM_BUDGET_UNLIMITED bypasses), `BudgetExceeded` typed exception. |
| Dispatch | `services/llm_router.py`: attaches `x-bf-vk` when enforcement is active; new `_wrap_budget_errors` translates Bifrost 402/429 into `BudgetExceeded`. |
| Persistence | `services/claude_service.py:_persist_interaction` records the active VK on every interaction log row. |
| Bifrost client | `services/bifrost_cost_client.py:get_vk_quota(vk)` wraps `GET /api/governance/virtual-keys/quota` (auth via `x-bf-vk` header). |
| Backend API | `backend/api/budgets.py` (new): GET/PUT `/api/analytics/budget`, GET `/api/analytics/budget/quota`. |
| Chat handler | `backend/api/claude.py`: catches `BudgetExceeded` and SDK-native 402/429, returns typed 402 with `{code: "budget_exceeded", tier, message}`. |
| Settings UI | `BudgetsSection.tsx` (new) inside `LLMProvidersTab`. Masked VK input, monthly ceiling, enforcement-mode dropdown, live spend bar (color-coded green/orange/red, % used). |
| Chat UI | `ClaudeDrawer.tsx` renders typed BudgetExceeded as an inline banner instead of a generic error toast. |
| Env | `env.example` documents `LLM_BUDGET_UNLIMITED` for the free-tier / sentinel-VK case. |

### Bifrost integration confirmed against docs

- Header name: `x-bf-vk` (Bifrost Virtual Key, prefixed `sk-bf-*`).
- Quota endpoint: `GET /api/governance/virtual-keys/quota` — VK passed via `x-bf-vk` header (self-service, no admin needed).
- Quota response shape: `virtual_key_name`, `is_active`, `budgets[]` (with `current_usage` / `max_limit` / `reset_duration`), `rate_limit{}`.
- Budget-exceeded HTTP status: not formally documented, so we handle both 402 (budget) and 429 (rate limit) with separate `tier` values on the typed exception.

### Bypasses

- **`DEV_MODE=true`** — already gates the rest of auth; implicitly disables budget enforcement so local dev isn't blocked by a stale ceiling.
- **`LLM_BUDGET_UNLIMITED=true`** — explicit budget bypass without disabling auth (free-tier / sentinel VK use case).
- **No VK configured** — bootstrap window. Dispatch omits `x-bf-vk` and Bifrost's no-VK path applies.

### Daemon `max_cost_per_investigation` stays

VK budgets are tenant-level; the daemon's per-investigation cap (#184 PR A's pre-flight gate) is workflow-level. Both useful, neither redundant. Order on a budget-exceeded call: pre-flight gate → dispatch → 429/402 from Bifrost → typed BudgetExceeded surfaces.

## Test plan

- [x] 77 tests pass
- New: `tests/test_budget_service.py` — three-way bypass logic, VK whitespace stripping, DB-error swallow, enforcement_mode validation, BudgetExceeded shape.
- Extended: `tests/test_llm_router.py` — five new cases:
  - VK header attached when enforcement active
  - VK header omitted when off
  - 402 → `BudgetExceeded(tier="virtual_key")`
  - 429 → `BudgetExceeded(tier="rate_limit")`
  - 500 propagates unchanged (must NOT wrap into BudgetExceeded)
- All PR A and PR B tests still pass.
- [x] `tsc --noEmit` clean.
- [ ] Manual: provision a VK in Bifrost UI with $1 monthly budget, paste it into Settings → LLM Providers → Budgets, set enforcement_mode = `hard_stop`. Run a few Claude calls, watch the spend bar climb. Hit $1, verify next call surfaces a typed banner in ClaudeDrawer.
- [ ] Manual: `DEV_MODE=true` bypasses; `LLM_BUDGET_UNLIMITED=true` bypasses without DEV_MODE.
- [ ] Manual: `virtual_key_id` populated on `llm_interaction_logs` rows for non-bypass calls.

## Apply the migration

`database/init/16_llm_budgets.sql` runs automatically on a fresh Postgres init. Existing dev DBs need:

```bash
psql -h localhost -U deeptempo -d deeptempo_soc -f database/init/16_llm_budgets.sql
```

## Stack

Based on `feat/llm-cost-pr-b` (PR #189). Will rebase to `main` once #188 and #189 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Cleanup commits (added 2026-05-05)

Three follow-up commits closing the last #184/#185 acceptance criteria and adding test backstop for the cost-tracking UI surfaces. None of these change PR C's core VK-budget contract; they're cleanup that belongs on the same branch since it touches the same files and the same review surface.

| SHA | Subject |
|---|---|
| `5d82cbf` | Add pre-call cost estimation to workflow runs (#184) |
| `cbc3fc7` | Add Bifrost logging-plugin probe + reconcile cost-shape test |
| `6674705` | Add frontend tests for cost-tracking UI + fix vitest worktree pollution |

### What each cleanup commit does

**`5d82cbf` — Workflow pre-flight estimation.** Closes the last #184 acceptance bullet ("Pre-call estimation API exists for chat, daemon, **and workflow** paths"). `services/workflows_service.py` now runs `cost_estimator.estimate_cost` before each `claude_service.chat` call in both `_execute_oneshot` and `_run_phase_loop`, stashing the projected USD band into `trigger_context["cost_estimate"]` (run-level) and `phase_input_context["cost_estimate"]` (phase-level). No gating — Bifrost VK enforcement (this PR) is the upstream gate; a second client-side gate would split policy across two sources of truth. Best-effort: estimator failures log at debug and proceed.

**`cbc3fc7` — Bifrost logging-plugin probe + cost-shape test reconcile.** `scripts/bifrost_capability_probe.py` now has a fourth probe (`probe_logging_metadata`) that issues an Anthropic call with a fresh `x-bf-lh-vigil-probe-id` UUID, polls `/api/logs`, and asserts the metadata round-tripped. Distinguishes "plugin off" (404) from "plugin on but persistence broken" (200 with empty rows) for actionable error messages. Wired into `main()`'s aggregator so it counts toward the merge-gate. Also fixes `tests/unit/test_cost_analytics.py:test_get_cost_analytics_response_shape` which was missing `time_series` in the expected response keys after PR B added it.

**`6674705` — Frontend tests + vitest config.** Adds two new test files:
- `frontend/src/pages/__tests__/CostAnalytics.test.tsx` — covers `pricing_source` / `provider_type` rendering (the whole point of #184 Phase 3: a /bin/zsh `unknown` row must not look like a /bin/zsh Ollama `zero` row).
- `frontend/src/components/settings/__tests__/BudgetsSection.test.tsx` — covers the VK budget panel: live quota line, configured-but-unreachable warning, bootstrap mode, save payload.

Plus two infra fixes that had become silent regressions:
- `vitest.config.ts` excludes `.claude/worktrees/**` so agent worktree copies don't crash the test run with "Cannot find package '@testing-library/react'".
- `LLMProvidersTab.test.tsx` stubs `<BudgetsSection />` to a no-op. After this PR added BudgetsSection as a child of LLMProvidersTab, the section's mount kicked off async API calls that raced with the click-test below and made it intermittently fail. Mocking the section out keeps that test focused on LLMProvidersTab's own behavior; BudgetsSection has its own dedicated test file now.

### Updated test counts

- Backend pytest: 533 pass / 6 fail (all 6 pre-existing on this branch — `test_claude_service` MCP loading + `test_password_reset` token expiry; verified pre-existing via `git stash` at the start of the cleanup session).
- Frontend vitest: 21 pass / 1 pre-existing fail (the LLMProvidersTab "invokes test API" click-test still has a separate timing issue not addressed by this PR).

### Out of scope, filed as follow-up

- **#191** — Separate cost attribution for extended-thinking tokens. Gated on Anthropic SDK exposing a `thinking_tokens` field; today it's lumped into `output_tokens`.