### PR TITLE
Fix Mempalace "Disconnected" status and env-var substitution

### DIFF
--- a/services/mcp_service.py
+++ b/services/mcp_service.py
@@ -257,7 +257,7 @@ class MCPService:
             logger.error(f"Could not save MCP enabled state: {e}")
     
     # Internal/platform servers that should be on by default
-    _DEFAULT_ENABLED = {"deeptempo-findings", "tempo-flow", "security-detections", "approval", "attack-layer"}
+    _DEFAULT_ENABLED = {"deeptempo-findings", "tempo-flow", "security-detections", "approval", "attack-layer", "mempalace"}
 
     def is_server_enabled(self, server_name: str) -> bool:
         """Check whether a server is enabled. Internal platform servers default to True; all others default to False."""
@@ -286,25 +286,34 @@ class MCPService:
     def _substitute_env_vars(self, value: str) -> str:
         """
         Substitute environment variables in a string.
-        Supports ${VAR_NAME} format.
-        
+        Supports ${VAR_NAME} and ${VAR_NAME:-default} formats.
+
         Args:
             value: String that may contain environment variable references
-            
+
         Returns:
             String with environment variables substituted
         """
         import re
-        
-        # Pattern to match ${VAR_NAME}
-        pattern = r'\$\{([^}]+)\}'
-        
+
+        pattern = r'\$\{([^}:]+)(?::-((?:\$\{[^}]+\}|[^{}])*))?\}'
+
         def replace_var(match):
             var_name = match.group(1)
-            # Try to get from environment, return empty string if not found
-            return os.environ.get(var_name, '')
-        
-        return re.sub(pattern, replace_var, value)
+            default = match.group(2)
+            env_val = os.environ.get(var_name)
+            if env_val is not None:
+                return env_val
+            if default is not None:
+                return self._substitute_env_vars(default)
+            return ''
+
+        prev = None
+        while prev != value:
+            prev = value
+            value = re.sub(pattern, replace_var, value)
+
+        return value
     
     def _detect_server_type(self, args: List[str]) -> str:
         """

--- a/tests/unit/test_mcp_required_env.py
+++ b/tests/unit/test_mcp_required_env.py
@@ -147,6 +147,72 @@ class TestCredentialGate:
         assert client._missing_credentials_for(server) == []
 
 
+class TestSubstituteEnvVars:
+    """_substitute_env_vars must handle plain ${VAR} and bash-style ${VAR:-default}."""
+
+    def test_plain_substitution_when_set(self, monkeypatch):
+        from services.mcp_service import MCPService
+
+        service = MCPService()
+        monkeypatch.setenv("MY_VAR", "hello")
+        assert service._substitute_env_vars("${MY_VAR}") == "hello"
+
+    def test_plain_substitution_when_unset(self):
+        from services.mcp_service import MCPService
+
+        service = MCPService()
+        assert service._substitute_env_vars("${UNSET_VAR_XYZ}") == ""
+
+    def test_default_value_when_unset(self):
+        from services.mcp_service import MCPService
+
+        service = MCPService()
+        assert service._substitute_env_vars("${UNSET_VAR_XYZ:-default}") == "default"
+
+    def test_default_value_ignored_when_set(self, monkeypatch):
+        from services.mcp_service import MCPService
+
+        service = MCPService()
+        monkeypatch.setenv("MY_VAR", "override")
+        assert service._substitute_env_vars("${MY_VAR:-default}") == "override"
+
+    def test_nested_substitution_in_default(self, monkeypatch):
+        from services.mcp_service import MCPService
+
+        service = MCPService()
+        monkeypatch.setenv("HOME", "/Users/test")
+        assert (
+            service._substitute_env_vars("${UNSET_VAR_XYZ:-${HOME}/.vigil/palace}")
+            == "/Users/test/.vigil/palace"
+        )
+
+    def test_nested_default_when_both_unset(self):
+        from services.mcp_service import MCPService
+
+        service = MCPService()
+        assert (
+            service._substitute_env_vars("${A:-${B:-fallback}}") == "fallback"
+        )
+
+    def test_mempalace_config_path(self, monkeypatch):
+        """Real-world shape from mcp-config.json."""
+        from services.mcp_service import MCPService
+
+        service = MCPService()
+        monkeypatch.setenv("HOME", "/Users/test")
+        result = service._substitute_env_vars(
+            "${MEMPALACE_PALACE_PATH:-${HOME}/.vigil/mempalace/palace}"
+        )
+        assert result == "/Users/test/.vigil/mempalace/palace"
+
+        # When the env var is explicitly set, it wins.
+        monkeypatch.setenv("MEMPALACE_PALACE_PATH", "/custom/palace")
+        result = service._substitute_env_vars(
+            "${MEMPALACE_PALACE_PATH:-${HOME}/.vigil/mempalace/palace}"
+        )
+        assert result == "/custom/palace"
+
+
 class TestRetryDormantIfReady:
     """`retry_dormant_if_ready` should only retry servers whose creds now resolve."""
 


### PR DESCRIPTION
## Summary

- **Bug 1:** Mempalace was not in `_DEFAULT_ENABLED`, so `MCPClient.connect_to_server()` silently skipped it even though the UI describes it as "Always on — not toggleable from the Integrations tab."
- **Bug 2:** `_substitute_env_vars` used a naive regex that couldn't handle bash-style default values (`${VAR:-default}`). For mempalace, this meant `MEMPALACE_PALACE_PATH` resolved to an empty string when the env var was unset.

## Changes

- Add `"mempalace"` to `_DEFAULT_ENABLED` in `services/mcp_service.py`
- Rewrite `_substitute_env_vars` to support `${VAR:-default}` and nested `${VAR:-${OTHER}/path}` syntax
- Add `TestSubstituteEnvVars` in `tests/unit/test_mcp_required_env.py` with 7 tests covering plain substitution, defaults, and nested defaults (including the exact mempalace config path shape)

## Test plan

- [x] `pytest tests/unit/test_mcp_required_env.py` — 23 passed
- [x] `pytest tests/test_backend_mempalace_health.py` — 5 passed
- [x] `pytest tests/integration/test_mcp_enable_transactional.py` — 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)