### PR TITLE
Add 'Clear All Investigations' button to Auto Investigate settings

### DIFF
--- a/backend/api/orchestrator.py
+++ b/backend/api/orchestrator.py
@@ -177,6 +177,33 @@ async def kill_orchestrator():
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.post("/investigations/purge")
+async def purge_investigations():
+    """Hard reset: stop all running agents, delete every investigation
+    record (and its cascading logs), and wipe the on-disk workdir tree.
+
+    Triggered from the Settings → Auto Investigate "Clear All
+    Investigations" button.
+    """
+    try:
+        orch = _get_orchestrator()
+        if not orch:
+            raise HTTPException(
+                status_code=503, detail="Orchestrator not available"
+            )
+        result = await orch.purge_all_investigations()
+        return {
+            "success": True,
+            "deleted": result.get("deleted", 0),
+            "message": f"Purged {result.get('deleted', 0)} investigations",
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error purging investigations: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 # ---- Investigations ----
 
 @router.get("/investigations")

--- a/daemon/orchestrator.py
+++ b/daemon/orchestrator.py
@@ -1272,6 +1272,45 @@ class Orchestrator:
             "per_investigation_limit": self.config.max_cost_per_investigation,
         }
 
+    async def purge_all_investigations(self) -> Dict[str, Any]:
+        """Stop all running agents, delete every investigation row, and wipe
+        the on-disk workdir tree. Used by the Settings UI's "Clear All
+        Investigations" button as a hard reset for the auto-investigate
+        subsystem.
+        """
+        await self.agent_runner.stop_all()
+
+        deleted = 0
+        try:
+            from database.connection import get_db_manager
+            from database.models import Investigation
+
+            with get_db_manager().session_scope() as session:
+                deleted = session.query(Investigation).delete(
+                    synchronize_session=False
+                )
+        except Exception as e:
+            logger.error(f"Failed to delete investigations from DB: {e}")
+            raise
+
+        try:
+            base = self.workdir.base_dir
+            if base.is_dir():
+                import shutil
+
+                shutil.rmtree(base, ignore_errors=True)
+            base.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            logger.warning(f"Workdir cleanup failed after purge: {e}")
+
+        self.shared_intel = SharedIntelligence()
+        self._hourly_costs = []
+
+        logger.warning(
+            f"Purged {deleted} investigations and reset workdir tree at {self.workdir.base_dir}"
+        )
+        return {"deleted": deleted}
+
     # -------------------------------------------------------------------------
     # Utilities
     # -------------------------------------------------------------------------

--- a/frontend/src/components/settings/AutoInvestigateTab.tsx
+++ b/frontend/src/components/settings/AutoInvestigateTab.tsx
@@ -26,6 +26,7 @@ import {
 import RestoreIcon from '@mui/icons-material/Restore'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import TuneIcon from '@mui/icons-material/Tune'
+import DeleteSweepIcon from '@mui/icons-material/DeleteSweep'
 import { aiConfigApi, AIModelInfo, configApi, orchestratorApi } from '../../services/api'
 
 interface OrchestratorConfig {
@@ -136,12 +137,10 @@ const detectActivePreset = (cfg: OrchestratorConfig): PresetKey | 'custom' => {
 
 interface Props {
   onMessage: (msg: { type: 'success' | 'error'; text: string }) => void
-  // Kept for backwards compatibility with Settings.tsx wiring; no longer used
-  // now that the tab auto-saves. Safe to remove if Settings.tsx is updated.
   showConfirm?: (title: string, msg: string, onConfirm: () => void) => void
 }
 
-export default function AutoInvestigateTab({ onMessage }: Props) {
+export default function AutoInvestigateTab({ onMessage, showConfirm }: Props) {
   const [config, setConfig] = useState<OrchestratorConfig>(DEFAULTS)
   const [loading, setLoading] = useState(true)
   const [status, setStatus] = useState<any>(null)
@@ -207,6 +206,32 @@ export default function AutoInvestigateTab({ onMessage }: Props) {
   const handleReset = () => {
     setConfig(DEFAULTS)
     persist(DEFAULTS)
+  }
+
+  const handlePurgeAll = () => {
+    const doPurge = async () => {
+      try {
+        const res = await orchestratorApi.purgeAll()
+        const deleted = res.data?.deleted ?? 0
+        onMessage({
+          type: 'success',
+          text: `Cleared ${deleted} investigation${deleted === 1 ? '' : 's'}`,
+        })
+        setTimeout(() => onMessage({ type: 'success', text: '' }), 3000)
+        await loadConfig()
+      } catch {
+        onMessage({ type: 'error', text: 'Failed to clear investigations' })
+      }
+    }
+    if (showConfirm) {
+      showConfirm(
+        'Clear all auto-investigations?',
+        'This will kill any running investigations and permanently delete all investigation records, logs, and working directories. This cannot be undone.',
+        doPurge,
+      )
+    } else {
+      doPurge()
+    }
   }
 
   // 0 is the sentinel for "unlimited" across all bounded numeric fields.
@@ -389,14 +414,41 @@ export default function AutoInvestigateTab({ onMessage }: Props) {
         within ~60 seconds (the runtime-config cache TTL).
       </Typography>
 
-      {status && (
-        <Alert severity={status.enabled ? 'success' : 'info'} sx={{ mb: 3 }}>
-          Orchestrator is <strong>{status.enabled ? 'ENABLED' : 'DISABLED'}</strong>
-          {status.active_agents !== undefined && ` · ${status.active_agents} active agent(s)`}
-          {status.cost?.total_cost_usd !== undefined &&
-            ` · Total cost: $${status.cost.total_cost_usd.toFixed(2)}`}
-        </Alert>
-      )}
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={1.5}
+        alignItems={{ xs: 'stretch', sm: 'flex-start' }}
+        sx={{ mb: 3 }}
+      >
+        {status ? (
+          <Alert severity={status.enabled ? 'success' : 'info'} sx={{ flex: 1, m: 0 }}>
+            Orchestrator is <strong>{status.enabled ? 'ENABLED' : 'DISABLED'}</strong>
+            {status.active_agents !== undefined && ` · ${status.active_agents} active agent(s)`}
+            {status.total_investigations !== undefined &&
+              ` · ${status.total_investigations} investigation(s)`}
+            {status.cost?.total_cost_usd !== undefined &&
+              ` · Total cost: $${status.cost.total_cost_usd.toFixed(2)}`}
+          </Alert>
+        ) : (
+          <Box sx={{ flex: 1 }} />
+        )}
+        <Tooltip
+          title="Kill any running investigations and delete all investigation records, logs, and workdirs."
+          placement="top"
+          arrow
+        >
+          <Button
+            variant="outlined"
+            color="error"
+            size="small"
+            startIcon={<DeleteSweepIcon />}
+            onClick={handlePurgeAll}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            Clear All Investigations
+          </Button>
+        </Tooltip>
+      </Stack>
 
       {/* Master Controls */}
       <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1.5 }}>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1400,6 +1400,7 @@ export const orchestratorApi = {
   enable: () => api.post('/orchestrator/enable'),
   disable: () => api.post('/orchestrator/disable'),
   kill: () => api.post('/orchestrator/kill'),
+  purgeAll: () => api.post('/orchestrator/investigations/purge'),
   
   listInvestigations: (status?: string) =>
     api.get('/orchestrator/investigations', { params: status ? { status } : {} }),


### PR DESCRIPTION
## Summary
- Adds a destructive **Clear All Investigations** button to Settings → Auto Investigate that kills any running agents, deletes every row in the `investigations` table (logs cascade via FK), and wipes the on-disk workdir tree under `data/investigations/`.
- New endpoint `POST /orchestrator/investigations/purge` delegates to `Orchestrator.purge_all_investigations()` (services hold business logic, route stays thin per CLAUDE.md).
- Reuses the existing Settings `showConfirm` dialog — no new dialog component.

## Why
Operators build up a long tail of stale auto-investigation records across runs with no UI affordance to wipe them; existing controls only kill a single investigation or stop running agents.

## Test plan
- [ ] `./start_web.sh`; toggle orchestrator on; trigger a couple of auto-investigations (or insert dummy rows).
- [ ] `GET /api/orchestrator/status` shows non-zero `total_investigations`; `ls data/investigations/` non-empty.
- [ ] Open **Settings → Auto Investigate**, click **Clear All Investigations**. Cancel — nothing changes. Confirm — toast reads `Cleared N investigations`.
- [ ] `SELECT count(*) FROM investigations;` and `SELECT count(*) FROM investigation_logs;` both return `0` (cascade fired).
- [ ] `ls data/investigations/` is empty.
- [ ] Repeat with an investigation in `executing` status — confirms running agent is killed before the row is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)