### PR TITLE
Auto-recover DatabaseDataService from transient Postgres outages

### DIFF
--- a/services/database_data_service.py
+++ b/services/database_data_service.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from pathlib import Path
 from typing import Optional, List, Dict, Tuple
 from datetime import datetime
@@ -32,14 +33,20 @@ def _cosine_sim(a, b):
 
 
 class DatabaseDataService:
+    # Minimum seconds between reconnection attempts when DB is unreachable.
+    # Without this, a Postgres outage during startup would trap the singleton
+    # in JSON-file fallback for the rest of the process lifetime.
+    _RECONNECT_INTERVAL_SECONDS = 10.0
+
     def __init__(self, require_db: bool = False):
         self._db_service = None
-        self._db_available = False
+        self._db_connected = False
         self._use_json_fallback = False
+        self._last_reconnect_attempt = 0.0
         self._demo_mode = is_demo_mode()
         self._demo_service = None
         self._s3_service = None
-        
+
         if self._demo_mode:
             logger.info("Demo mode enabled - using generated sample data")
             from services.demo_data_service import get_demo_service
@@ -47,7 +54,7 @@ class DatabaseDataService:
         else:
             self._init_database(require_db)
         DATA_DIR.mkdir(exist_ok=True)
-    
+
     def _init_database(self, require_db: bool = False):
         try:
             init_database(echo=False, create_tables=True)
@@ -55,14 +62,40 @@ class DatabaseDataService:
             if not db_manager.health_check():
                 raise DatabaseError("Database health check failed")
             self._db_service = DatabaseService()
-            self._db_available = True
-            logger.info("PostgreSQL connection established")
+            self._db_connected = True
+            if self._use_json_fallback:
+                logger.info("PostgreSQL reconnected - exiting JSON file fallback")
+                self._use_json_fallback = False
+            else:
+                logger.info("PostgreSQL connection established")
         except Exception as e:
+            self._db_connected = False
+            self._db_service = None
             logger.warning(f"PostgreSQL not available: {e}")
             if require_db:
                 raise DatabaseError(f"Failed to connect to PostgreSQL: {e}")
-            self._use_json_fallback = True
-            logger.info("Using JSON file fallback for data storage")
+            if not self._use_json_fallback:
+                self._use_json_fallback = True
+                logger.info("Using JSON file fallback for data storage")
+
+    @property
+    def _db_available(self) -> bool:
+        """True when the Postgres connection is healthy.
+
+        If currently disconnected, transparently retries `_init_database`
+        at most once per `_RECONNECT_INTERVAL_SECONDS` so the service
+        recovers automatically when Postgres becomes reachable again.
+        """
+        if self._db_connected:
+            return True
+        if self._demo_mode:
+            return False
+        now = time.monotonic()
+        if now - self._last_reconnect_attempt < self._RECONNECT_INTERVAL_SECONDS:
+            return False
+        self._last_reconnect_attempt = now
+        self._init_database(require_db=False)
+        return self._db_connected
     
     def is_using_database(self) -> bool:
         return self._db_available and self._db_service is not None

--- a/tests/unit/test_database_data_service_reconnect.py
+++ b/tests/unit/test_database_data_service_reconnect.py
@@ -1,0 +1,85 @@
+"""Tests for DatabaseDataService recovery from transient Postgres outages.
+
+Before the fix, a Postgres outage at backend startup would set
+`_use_json_fallback = True` permanently, trapping the singleton in
+JSON-file-fallback for the rest of the process lifetime even after
+Postgres came back. These tests verify the rate-limited auto-reconnect.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+from services.database_data_service import DatabaseDataService
+
+
+def _make_service_in_fallback() -> DatabaseDataService:
+    """Construct a service that failed its initial DB connection."""
+    with patch(
+        "services.database_data_service.init_database",
+        side_effect=RuntimeError("postgres down"),
+    ):
+        svc = DatabaseDataService()
+    assert svc._db_connected is False
+    assert svc._use_json_fallback is True
+    return svc
+
+
+def test_db_available_retries_when_disconnected_after_interval():
+    svc = _make_service_in_fallback()
+    # Pretend the cooldown has elapsed so the next read triggers a retry.
+    svc._last_reconnect_attempt = 0.0
+
+    fake_manager = MagicMock()
+    fake_manager.health_check.return_value = True
+
+    with patch("services.database_data_service.init_database") as fake_init, patch(
+        "services.database_data_service.get_db_manager", return_value=fake_manager
+    ), patch("services.database_data_service.DatabaseService"):
+        assert svc._db_available is True
+        fake_init.assert_called_once()
+
+    assert svc._db_connected is True
+    assert svc._use_json_fallback is False
+
+
+def test_db_available_rate_limits_reconnect_attempts():
+    svc = _make_service_in_fallback()
+    # Force a recent attempt so the cooldown should suppress the next try.
+    svc._last_reconnect_attempt = float("inf")
+
+    with patch("services.database_data_service.init_database") as fake_init:
+        assert svc._db_available is False
+        fake_init.assert_not_called()
+
+
+def test_db_available_short_circuits_when_already_connected():
+    """When already connected, reading the property must NOT touch init_database."""
+    fake_manager = MagicMock()
+    fake_manager.health_check.return_value = True
+    with patch("services.database_data_service.init_database"), patch(
+        "services.database_data_service.get_db_manager", return_value=fake_manager
+    ), patch("services.database_data_service.DatabaseService"):
+        svc = DatabaseDataService()
+
+    assert svc._db_connected is True
+
+    with patch("services.database_data_service.init_database") as fake_init:
+        assert svc._db_available is True
+        fake_init.assert_not_called()
+
+
+def test_demo_mode_never_attempts_reconnect():
+    with patch("services.database_data_service.is_demo_mode", return_value=True), patch(
+        "services.database_data_service.get_demo_service", create=True
+    ):
+        # Stub out the demo service factory used inside the constructor.
+        import services.database_data_service as mod
+
+        mod.get_demo_service = lambda: MagicMock()  # type: ignore[attr-defined]
+        svc = DatabaseDataService()
+
+    svc._last_reconnect_attempt = 0.0
+    with patch("services.database_data_service.init_database") as fake_init:
+        assert svc._db_available is False
+        fake_init.assert_not_called()


### PR DESCRIPTION
## Summary
- `DatabaseDataService` is a module-level singleton in [backend/api/findings.py](backend/api/findings.py:13) and several other API routers. When its `__init__` couldn't reach Postgres at backend startup (e.g. Postgres still booting, or Docker runtime not up after a host reboot), it set `_use_json_fallback = True` for the rest of the process lifetime — silently serving stale data from `data/findings.json` even after Postgres recovered. Users had to manually restart the backend before findings/cases/investigations came back.
- This PR refactors `_db_available` into a property that retries `_init_database` at most once per `_RECONNECT_INTERVAL_SECONDS` (10s) when the DB is currently disconnected. On successful reconnect it clears `_use_json_fallback` and resumes serving from Postgres. All ~17 existing call sites continue to work unchanged.
- Adds focused unit tests covering: auto-reconnect after the cooldown, rate-limited retry, short-circuit when already connected, and the demo-mode no-op.

## How it fails today
1. Reboot host → Docker runtime doesn't auto-start → Postgres container down.
2. `start_web.sh` runs anyway and the backend's first `DatabaseDataService()` import fails to reach Postgres.
3. From that point on, every `if self._db_available:` check sees `False`, every query falls through to the JSON fallback branch, and `/api/findings/` returns whatever happens to be in `data/findings.json` — often empty or weeks stale.
4. Starting Postgres back up does *not* heal the service. Only a backend process restart does.

After this change, the very next query (or in the worst case, the one after the 10s cooldown elapses) calls `_init_database` again, which reconnects cleanly and flips the singleton out of fallback mode.

## Test plan
- [x] `pytest tests/unit/test_database_data_service_reconnect.py` — 4 new tests pass
- [x] `pytest tests/integration/test_vstrike_ingest.py tests/test_finding_sanitization.py` — existing related tests still pass (19 passed)
- [x] `black --check` and `flake8 --max-line-length=88` clean on the new test file; the edits to `services/database_data_service.py` introduce no new lint violations
- [x] Live smoke test: instantiate service, force `_db_connected = False` + `_use_json_fallback = True`, read `_db_available` → returns `True`, fallback flag cleared, `count_findings()` returns the real 70 rows from Postgres
- [ ] Reviewer manual check: stop Postgres, hit `/api/findings/`, restart Postgres, hit `/api/findings/` again — second call should return real data within ~10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)