### PR TITLE
docs: stop telling users to put ANTHROPIC_API_KEY in .env

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,17 +113,23 @@ cd frontend && npm run dev
 
 ### Environment Variables
 
-Copy `env.example` to `.env` and populate as needed. Key variables:
+Copy `env.example` to `.env` and populate as needed. `.env` is for
+bootstrap-only settings (DB URL, ports, dev flags). LLM provider keys,
+integration credentials, and other secrets are configured in the web UI
+(Settings → AI / LLM Providers, Settings → Integrations) and stored
+encrypted at `~/.vigil/secrets.enc` — see [docs/STATE.md](docs/STATE.md).
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `DEV_MODE` | Bypass all authentication | `true` |
-| `ANTHROPIC_API_KEY` | Claude API access | required for AI features |
 | `DATABASE_URL` | PostgreSQL connection | auto-set by docker-compose |
 | `REDIS_URL` | ARQ job queue | `redis://localhost:6379/0` |
-| `SPLUNK_URL` / credentials | Splunk SIEM | optional |
-| `CROWDSTRIKE_CLIENT_ID/SECRET` | CrowdStrike EDR | optional |
-| `VIRUSTOTAL_API_KEY` | Threat intel | optional |
+| `BIFROST_URL` | LLM gateway address | `http://bifrost:8080` |
+| `SECRETS_BACKEND` | Where new secrets are written | `encrypted` |
+
+> ⚠️ Do **not** put `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, Splunk
+> credentials, etc. in `.env`. Use the UI. Placeholder values in `.env`
+> are ignored when the encrypted store has a value.
 
 Default dev login: **admin / admin123** (when `DEV_MODE=false`)
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ git submodule update --init --recursive
 
 # Environment (DEV_MODE enabled by default)
 cp env.example .env
-# Edit .env and add your ANTHROPIC_API_KEY (optional for testing)
+# LLM provider keys (Anthropic / OpenAI / Ollama) are configured in the
+# web UI at Settings → AI / LLM Providers — not in .env.
 
 # Backend setup
 python3 -m venv venv

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,12 +138,18 @@ Autonomous response workflow:
 
 ## Configuration
 
+LLM provider credentials (Anthropic / OpenAI / Ollama) are configured in
+the web UI under **Settings → AI / LLM Providers** and stored in the
+encrypted secret store at `~/.vigil/secrets.enc`. The backend pushes them
+to Bifrost over its admin API in the same request. See
+[CONFIGURATION.md](CONFIGURATION.md) and [STATE.md](STATE.md) for the
+full split between bootstrap config and secrets.
+
 ### Environment Variables (.env)
 
-```bash
-# Claude API
-ANTHROPIC_API_KEY=sk-ant-...
+Bootstrap-only — nothing sensitive belongs here.
 
+```bash
 # Detection Rules
 SIGMA_PATHS="${HOME}/security-detections/sigma/rules"
 SPLUNK_PATHS="${HOME}/security-detections/security_content/detections"
@@ -152,6 +158,9 @@ KQL_PATHS="${HOME}/security-detections/Hunting-Queries-Detection-Rules"
 
 # Database
 DATABASE_URL="postgresql://deeptempo:deeptempo_secure_password_change_me@localhost:5432/deeptempo_soc"
+
+# LLM gateway (Bifrost) — provider keys are NOT set here
+BIFROST_URL="http://bifrost:8080"
 ```
 
 ### Backend Tool Initialization

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,45 +1,59 @@
 # Configuration
 
-## Environment Variables
+## Where do secrets live?
 
-Copy `env.example` to `.env` in the project root and configure:
+Vigil splits configuration into two stores:
+
+1. **`.env`** — bootstrap-only settings the backend needs before the DB is
+   reachable (URLs, ports, dev flags). Nothing sensitive belongs here.
+2. **The encrypted secret store** at `~/.vigil/secrets.enc` — every API key,
+   token, and password. Written by the web UI (Settings → AI / LLM Providers
+   and Settings → Integrations) or by `set_secret()` programmatically. The
+   master key sits next to it at `~/.vigil/master.key`.
+
+LLM provider keys (Anthropic, OpenAI, Ollama) are managed entirely through
+the UI — they land in the encrypted store and are pushed to Bifrost via its
+admin API in the same request. See [STATE.md](STATE.md) for the full secret
+inventory.
+
+## `.env`
+
+Copy `env.example` to `.env`:
 
 ```bash
 cp env.example .env
 chmod 600 .env
 ```
 
-### Required
+### What goes in `.env`
 
 | Variable | Description |
 |----------|-------------|
-| `CLAUDE_API_KEY` | Anthropic Claude API key ([get one](https://console.anthropic.com/)) |
-| `POSTGRESQL_CONNECTION_STRING` | PostgreSQL connection (default in docker-compose) |
+| `DEV_MODE` | Bypass auth for local development |
+| `DATABASE_URL` | PostgreSQL connection (default in docker-compose) |
+| `REDIS_URL` | ARQ job queue connection |
+| `BIFROST_URL` | LLM gateway address (default `http://bifrost:8080`) |
+| `BIND_HOST` / port numbers | Network binding |
+| `SECRETS_BACKEND` | `encrypted` (default), `dotenv`, `env`, `keyring` — where new secrets are written |
+| `ENABLE_KEYRING` | `false` (default), `true` — include OS keyring in read chain |
+| `SENTRY_DSN` | Error reporting endpoint |
 
-### Optional Integrations
+### What does NOT go in `.env`
 
-| Variable | Service |
-|----------|---------|
-| `AWS_ACCESS_KEY_ID` | S3 storage |
-| `AWS_SECRET_ACCESS_KEY` | S3 storage |
-| `TIMESKETCH_PASSWORD` | Timeline analysis |
-| `SPLUNK_PASSWORD` | SIEM integration |
-| `CRIBL_PASSWORD` | Data pipeline |
-| `GITHUB_TOKEN` | MCP GitHub server |
+- `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / Ollama config — Settings → AI / LLM Providers
+- `SPLUNK_PASSWORD`, `CROWDSTRIKE_CLIENT_SECRET`, `VIRUSTOTAL_API_KEY`, etc. — Settings → Integrations
+- Any password, token, or private key
 
-### Secrets Backend
+Placeholder values for these in `.env` are ignored once the encrypted store
+has a value, and a stale placeholder can mask the real key.
 
-| Variable | Values | Description |
-|----------|--------|-------------|
-| `SECRETS_BACKEND` | `dotenv` (default), `env`, `keyring` | Where to write secrets |
-| `ENABLE_KEYRING` | `false` (default), `true` | Enable OS keyring for reading |
-
-## Secrets Priority
+## Secrets read priority
 
 When reading, backends are checked in order:
-1. Process environment variables
-2. `.env` file in the project root
-3. OS keyring (only if `ENABLE_KEYRING=true`)
+1. Encrypted file (`~/.vigil/secrets.enc`)
+2. Process environment variables
+3. `.env` file (legacy / interoperability)
+4. OS keyring (only if `ENABLE_KEYRING=true`)
 
 ## Deployment Examples
 
@@ -77,9 +91,13 @@ ExecStart=/opt/vigil/venv/bin/uvicorn backend.main:app --host 0.0.0.0 --port 698
 
 ### Kubernetes
 
+For server-side deployments, LLM provider keys can be injected as
+environment variables at pod start (operator path — distinct from
+the local-dev UI path). See [HELM.md](HELM.md) for the recommended
+Helm chart values, including `secrets.anthropicApiKey`.
+
 ```bash
 kubectl create secret generic vigil-secrets \
-  --from-literal=ANTHROPIC_API_KEY="sk-ant-..." \
   --from-literal=DATABASE_URL="postgresql://..."
 ```
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -243,30 +243,29 @@ docker-compose ps
 
 **File**: `/opt/vigil/.env`
 
+`.env` is for bootstrap-only settings. LLM provider keys, SIEM
+credentials, and other secrets are configured through the web UI
+(Settings → AI / LLM Providers, Settings → Integrations) and stored
+encrypted at `~/.vigil/secrets.enc`. For server-side / orchestrated
+deployments where the UI isn't available at first boot, inject secrets
+via the Helm chart values (see [HELM.md](HELM.md)) or your secret
+manager of choice.
+
 ```bash
 # Database
 DATABASE_URL=postgresql://deeptempo:secure_password@postgres:5432/deeptempo_soc
 POSTGRES_PASSWORD=secure_password_change_me
 
-# API Keys
-ANTHROPIC_API_KEY=sk-ant-your-key-here
-
 # Backend
 SECRET_KEY=your-secret-key-here
 ENVIRONMENT=production
 
+# LLM gateway (Bifrost) — provider keys are NOT set here
+BIFROST_URL=http://bifrost:8080
+
 # Monitoring
 SENTRY_DSN=https://your-sentry-dsn
 RELEASE_VERSION=v1.2.3
-
-# SIEM Integrations
-SPLUNK_URL=https://splunk.example.com:8089
-SPLUNK_USERNAME=admin
-SPLUNK_PASSWORD=splunk_password
-
-# External Services
-SLACK_BOT_TOKEN=xoxb-your-token
-SLACK_DEFAULT_CHANNEL=#soc-alerts
 ```
 
 ### Docker Compose Configuration
@@ -293,9 +292,13 @@ services:
     container_name: deeptempo-backend
     environment:
       - DATABASE_URL
-      - ANTHROPIC_API_KEY
       - SECRET_KEY
       - SENTRY_DSN
+      - BIFROST_URL
+    volumes:
+      # Persist the encrypted secret store across container restarts so
+      # provider keys configured via the UI survive image upgrades.
+      - vigil_secrets:/root/.vigil
     ports:
       - "6987:6987"
     depends_on:
@@ -307,7 +310,9 @@ services:
     container_name: deeptempo-daemon
     environment:
       - DATABASE_URL
-      - ANTHROPIC_API_KEY
+      - BIFROST_URL
+    volumes:
+      - vigil_secrets:/root/.vigil
     ports:
       - "8081:8081"  # Webhook
       - "9090:9090"  # Metrics
@@ -317,6 +322,7 @@ services:
 
 volumes:
   postgres_data:
+  vigil_secrets:
 ```
 
 ### Nginx Reverse Proxy (Optional)

--- a/docs/SPLUNK_TESTING_GUIDE.md
+++ b/docs/SPLUNK_TESTING_GUIDE.md
@@ -92,16 +92,14 @@ python scripts/test_splunk_claude_integration.py \
 ```
 
 **Prerequisites:**
-- Splunk configured in `.env`:
+- Splunk integration configured in the UI (Settings → Integrations → Splunk),
+  or via env vars for headless test runs:
   ```
   SPLUNK_URL=https://your-splunk:8089
   SPLUNK_USERNAME=admin
   SPLUNK_PASSWORD=your_password
   ```
-- Claude API key in `.env`:
-  ```
-  ANTHROPIC_API_KEY=sk-ant-api03-...
-  ```
+- An LLM provider configured in the UI (Settings → AI / LLM Providers)
 - Database running (`./scripts/start_database.sh`)
 
 ## Script Reference
@@ -195,13 +193,13 @@ Here's a complete end-to-end testing workflow:
 # Ensure database is running
 ./scripts/start_database.sh
 
-# Configure Splunk credentials
-cat >> .env << EOF
-SPLUNK_URL=https://your-splunk-server:8089
-SPLUNK_USERNAME=admin
-SPLUNK_PASSWORD=your_password
-ANTHROPIC_API_KEY=sk-ant-api03-your-key
-EOF
+# Configure Splunk credentials and an LLM provider via the web UI:
+#   Settings → Integrations → Splunk
+#   Settings → AI / LLM Providers → Add provider
+# For headless/CI runs you can still export Splunk env vars:
+export SPLUNK_URL=https://your-splunk-server:8089
+export SPLUNK_USERNAME=admin
+export SPLUNK_PASSWORD=your_password
 ```
 
 ### Step 2: Generate and Upload Test Data

--- a/env.example
+++ b/env.example
@@ -30,7 +30,12 @@ DEV_MODE=true
 # -----------------------------------------------------------------------------
 # Core AI Configuration
 # -----------------------------------------------------------------------------
-ANTHROPIC_API_KEY="sk-ant-api03-..."
+# LLM provider keys (Anthropic, OpenAI, Ollama) are configured in the web UI:
+#   Settings → AI / LLM Providers → "Add provider"
+# The UI writes them to the encrypted secret store at ~/.vigil/secrets.enc and
+# pushes them live to Bifrost — no restart needed. Do NOT add ANTHROPIC_API_KEY
+# or similar to this file; placeholder values here are ignored once the
+# encrypted store has a value, and a stale placeholder can mask the real key.
 
 # Extra model IDs to always include in the Settings dropdown, on top of
 # whatever upstream /v1/models returns. Intended for IDs the provider

--- a/start_daemon.sh
+++ b/start_daemon.sh
@@ -128,7 +128,7 @@ if [ -f ".env" ]; then
 elif [ -f "env.example" ]; then
     echo "⚠️  .env not found. Creating from env.example..."
     cp env.example .env
-    echo "✓ Created .env — edit to add your ANTHROPIC_API_KEY"
+    echo "✓ Created .env — configure LLM provider keys in Settings → AI / LLM Providers"
     set -a
     source .env
     set +a

--- a/start_web.sh
+++ b/start_web.sh
@@ -124,7 +124,8 @@ else
     if [ -f "env.example" ]; then
         cp env.example .env
         echo "✓ Created .env from env.example"
-        echo "   Edit .env to add your ANTHROPIC_API_KEY and customize settings"
+        echo "   Configure LLM provider keys in the web UI:"
+        echo "   Settings → AI / LLM Providers → Add provider"
         set -a
         source .env
         set +a


### PR DESCRIPTION
## Summary

Doc-only follow-up to the support reports of "deeptempo errors" when configuring Claude either via `.env` **or** via the web UI for Ollama-only setups. **Tier 1** of the RCA — the docs/config cleanup. **Tier 2** is the matching code fix at #293.

## RCA recap

- The "DeepTempo error" in the chat drawer is whatever 4xx/5xx the `/api/claude/chat` endpoint returns, rendered inside a `DeepTempo:` assistant bubble (the assistant-name label in [ClaudeDrawer.tsx:1120](frontend/src/components/claude/ClaudeDrawer.tsx#L1120)).
- The runtime intent (per [docs/STATE.md](docs/STATE.md)) is "do not put API keys in `.env` — store via the UI." But `env.example`, `README.md`, `start_web.sh`, `start_daemon.sh`, `CLAUDE.md`, and four `docs/*.md` files **still told users to put it in `.env`**. So new users follow the README, get a stale `.env` placeholder, the encrypted store wins (or doesn't exist), and the chat path explodes.
- The actual code fix lives in #293: `ClaudeService` now discovers UI-saved keys, the 503 carries a structured payload the chat drawer renders as a CTA, and `start_web.sh` starts Bifrost so the LLM gateway is actually reachable.

## What this PR changes (docs/config only)

- `env.example` — removed the `ANTHROPIC_API_KEY="sk-ant-api03-..."` line; replaced with a comment pointing to **Settings → AI / LLM Providers**.
- `README.md` — fixed the "Edit .env and add your ANTHROPIC_API_KEY" line in the manual-install block.
- `CLAUDE.md` — dropped `ANTHROPIC_API_KEY` from the env-vars table; added an explicit "do not put secrets in .env" callout.
- `start_web.sh` / `start_daemon.sh` — fixed the post-`cp env.example .env` prompt to direct users to the UI.
- `docs/CONFIGURATION.md` — rewrote around the two-store model (`.env` for bootstrap, `~/.vigil/secrets.enc` for secrets).
- `docs/ARCHITECTURE.md`, `docs/DEPLOYMENT_GUIDE.md`, `docs/SPLUNK_TESTING_GUIDE.md` — removed `ANTHROPIC_API_KEY=...` from example `.env` blocks; added pointers to the UI; added the `vigil_secrets` volume to the Docker Compose example so the encrypted store survives container restarts.

Operator-facing docs (Helm chart values, GitHub Actions secrets, Bifrost's own container env) are intentionally untouched — those are legitimate server-side injection paths.

## Test plan

- [ ] Fresh clone, run `./start_web.sh` — startup prompt now directs to the UI, no `.env` ANTHROPIC_API_KEY mention.
- [ ] `cp env.example .env` — no `ANTHROPIC_API_KEY` template line present.
- [ ] `grep -rn "ANTHROPIC_API_KEY\|CLAUDE_API_KEY" --include="*.md" | grep -v archive | grep -v docs/HELM | grep -v docs/CI_CD | grep -v helm/vigil | grep -v docs/STATE | grep -v docs/secrets-audit | grep -v bifrost/README` — only the new "do NOT put this in .env" warnings remain.

Refs: #292, #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)