### PR TITLE
fix: chat drawer works when Anthropic is configured only via the UI (#292)

### DIFF
--- a/backend/api/agents.py
+++ b/backend/api/agents.py
@@ -269,7 +269,9 @@ Use the get_case tool first to retrieve full details, then investigate all assoc
         )
         
         if not claude_service.has_api_key():
-            raise HTTPException(status_code=503, detail="Claude API not configured")
+            from backend.api.claude import NO_PROVIDER_DETAIL
+
+            raise HTTPException(status_code=503, detail=NO_PROVIDER_DETAIL)
         
         # Build allowed tools: combine agent's recommended tools with
         # dynamically discovered MCP tools from the registry

--- a/backend/api/claude.py
+++ b/backend/api/claude.py
@@ -23,6 +23,24 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
+# Structured payload returned when no Anthropic provider is configured.
+# The chat drawer matches on ``code`` and renders a "Configure a provider"
+# CTA instead of a generic ``Error: ...`` bubble.
+NO_PROVIDER_DETAIL: Dict[str, str] = {
+    "code": "no_llm_provider_configured",
+    "message": (
+        "No Anthropic LLM provider is configured. "
+        "Add one in Settings → AI / LLM Providers, then try again."
+    ),
+    "settings_path": "/settings#llm-providers",
+}
+
+
+def _raise_no_provider() -> None:
+    """Raise the canonical 503 for an unconfigured chat backend."""
+    raise HTTPException(status_code=503, detail=NO_PROVIDER_DETAIL)
+
+
 def _resolve_model_for_request(
     requested_model: Optional[str], agent_id: Optional[str]
 ) -> str:
@@ -213,7 +231,7 @@ async def chat(request: ChatRequest):
     )
 
     if not claude_service.has_api_key():
-        raise HTTPException(status_code=503, detail="Claude API not configured")
+        _raise_no_provider()
 
     try:
         # Convert messages to format expected by Claude
@@ -491,7 +509,7 @@ async def chat_stream(request: ChatRequest):
 
     # Check if API key is configured (works for both implementations)
     if not claude_service.has_api_key():
-        raise HTTPException(status_code=503, detail="Claude API not configured")
+        _raise_no_provider()
 
     async def generate():
         try:
@@ -669,7 +687,7 @@ async def websocket_chat(websocket: WebSocket):
 
     # Check if API key is configured (works for both implementations)
     if not claude_service.has_api_key():
-        await websocket.send_json({"error": "Claude API not configured"})
+        await websocket.send_json({"error": NO_PROVIDER_DETAIL})
         await websocket.close()
         return
 
@@ -806,7 +824,7 @@ async def summarize_conversation(request: SummarizeRequest):
     claude_service = ClaudeService(use_backend_tools=False, enable_thinking=False)
 
     if not claude_service.has_api_key():
-        raise HTTPException(status_code=503, detail="Claude API not configured")
+        _raise_no_provider()
 
     # Build a flat text representation of the conversation
     conversation_text = []
@@ -937,7 +955,7 @@ async def run_agent_task(request: AgentTaskRequest):
     claude_service = ClaudeService(use_backend_tools=True, use_agent_sdk=True)
 
     if not claude_service.has_api_key():
-        raise HTTPException(status_code=503, detail="Claude API not configured")
+        _raise_no_provider()
 
     try:
         result = await claude_service.run_agent_task(
@@ -999,7 +1017,7 @@ async def stream_agent_task(request: AgentTaskRequest):
     claude_service = ClaudeService(use_backend_tools=True, use_agent_sdk=True)
 
     if not claude_service.has_api_key():
-        raise HTTPException(status_code=503, detail="Claude API not configured")
+        _raise_no_provider()
 
     async def generate():
         try:
@@ -1039,9 +1057,7 @@ async def websocket_agent(websocket: WebSocket):
     claude_service = ClaudeService(use_backend_tools=True, use_agent_sdk=True)
 
     if not claude_service.has_api_key():
-        await websocket.send_json(
-            {"type": "error", "content": "Claude API not configured"}
-        )
+        await websocket.send_json({"type": "error", "content": NO_PROVIDER_DETAIL})
         await websocket.close()
         return
 
@@ -1184,7 +1200,7 @@ async def analyze_finding(finding_id: str, context: Optional[str] = None):
 
     # Check if API key is configured (works for both implementations)
     if not claude_service.has_api_key():
-        raise HTTPException(status_code=503, detail="Claude API not configured")
+        _raise_no_provider()
 
     # Construct analysis prompt
     prompt = f"""Please analyze this security finding:

--- a/backend/api/findings.py
+++ b/backend/api/findings.py
@@ -357,10 +357,9 @@ async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Q
         
         # Check if API key is configured
         if not claude_service.has_api_key():
-            raise HTTPException(
-                status_code=503, 
-                detail="Claude API not configured. AI enrichment requires Claude API key."
-            )
+            from backend.api.claude import NO_PROVIDER_DETAIL
+
+            raise HTTPException(status_code=503, detail=NO_PROVIDER_DETAIL)
         
         # Extract finding details (use `or` to guard against keys present with None values)
         severity = finding.get('severity') or 'unknown'

--- a/frontend/src/components/claude/ClaudeDrawer.tsx
+++ b/frontend/src/components/claude/ClaudeDrawer.tsx
@@ -646,18 +646,34 @@ export default function ClaudeDrawer({ open, onClose, initialMessages, initialAg
       // sees "budget exceeded — tier: virtual_key" instead of a generic
       // error toast. Backend builds this body in backend/api/claude.py's
       // chat handler.
+      //
+      // #292: same pattern for "no LLM provider configured" — backend
+      // returns 503 with detail.code == 'no_llm_provider_configured'
+      // and a settings_path. We render an actionable line that points
+      // users at Settings → AI / LLM Providers instead of a bare
+      // "Error: ..." bubble.
       const detail = e?.response?.data?.detail
       const isBudgetBlock =
         e?.response?.status === 402 &&
         detail &&
         typeof detail === 'object' &&
         detail.code === 'budget_exceeded'
-      const userMessage = isBudgetBlock
-        ? `⚠️ LLM budget exceeded (tier: **${detail.tier || 'unknown'}**). ${
-            detail.message ||
-            'Bifrost rejected the call upstream of the model. Update the budget in Settings → LLM Providers → Budgets, or set DEV_MODE / LLM_BUDGET_UNLIMITED to bypass.'
-          }`
-        : `Error: ${typeof detail === 'string' ? detail : detail?.message || e?.message || 'Failed'}`
+      const isMissingProvider =
+        e?.response?.status === 503 &&
+        detail &&
+        typeof detail === 'object' &&
+        detail.code === 'no_llm_provider_configured'
+      let userMessage: string
+      if (isBudgetBlock) {
+        userMessage = `⚠️ LLM budget exceeded (tier: **${detail.tier || 'unknown'}**). ${
+          detail.message ||
+          'Bifrost rejected the call upstream of the model. Update the budget in Settings → LLM Providers → Budgets, or set DEV_MODE / LLM_BUDGET_UNLIMITED to bypass.'
+        }`
+      } else if (isMissingProvider) {
+        userMessage = `🔌 ${detail.message || 'No LLM provider configured.'} Open **Settings → AI / LLM Providers** to add one.`
+      } else {
+        userMessage = `Error: ${typeof detail === 'string' ? detail : detail?.message || e?.message || 'Failed'}`
+      }
       setTabs(prevTabs => {
         const updatedTabs = [...prevTabs]
         updatedTabs[currentTab] = {

--- a/services/claude_service.py
+++ b/services/claude_service.py
@@ -315,10 +315,17 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
     def _load_api_key(self) -> bool:
         """Load API key from secure storage.
 
-        When ``provider_api_key_ref`` is set (GH #88), the secret named by
-        that ref is tried first. This lets LLMRouter instantiate ClaudeService
-        with a non-default Anthropic provider row. Falls back to the legacy
-        CLAUDE_API_KEY / ANTHROPIC_API_KEY chain for backward compatibility.
+        Resolution order:
+
+        1. ``provider_api_key_ref`` when explicitly passed at init (GH #88).
+        2. Legacy ``CLAUDE_API_KEY`` / ``ANTHROPIC_API_KEY`` env / secret names.
+        3. UI-saved Anthropic provider rows in ``llm_provider_configs``.
+
+        Step 3 was the missing piece behind the "Claude API not configured"
+        chat-drawer error reported when users configured Anthropic only
+        through Settings → AI / LLM Providers: that path writes the key to
+        ``llm_provider_<id>_api_key`` (see ``backend/api/llm_providers.py``)
+        — not to the legacy names this method used to check.
         """
         try:
             # Use secrets manager with fallback to legacy names
@@ -334,6 +341,18 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                 or get_secret("claude_api_key")
                 or get_secret("anthropic_api_key")
             )
+
+            # Fallback: pick up keys saved by the LLM Providers UI. Lazy
+            # import keeps the legacy/no-DB code path (and the unit tests
+            # that pre-date this fallback) working when database.connection
+            # isn't importable.
+            if not self.api_key:
+                try:
+                    from services.llm_router import discover_anthropic_api_key
+
+                    self.api_key = discover_anthropic_api_key()
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("UI-provider key discovery skipped: %s", exc)
 
             if self.api_key and ANTHROPIC_AVAILABLE:
                 # Set longer timeout for operations that may take more than 10 minutes

--- a/services/llm_router.py
+++ b/services/llm_router.py
@@ -333,7 +333,9 @@ class LLMRouter:
                 if vk:
                     extra_headers["x-bf-vk"] = vk
         except Exception as _be:
-            logger.debug("budget_service unavailable (%s); proceeding without x-bf-vk", _be)
+            logger.debug(
+                "budget_service unavailable (%s); proceeding without x-bf-vk", _be
+            )
         # Convert empty dict back to None so the dispatch helpers can use a
         # truthy check for "should I send any extra headers" without leaking
         # an empty dict into the SDK call.
@@ -560,5 +562,63 @@ def get_provider_spec(provider_id: Optional[str]) -> Optional[ProviderSpec]:
         if row is None:
             return None
         return provider_spec_from_row(row)
+    finally:
+        session.close()
+
+
+def discover_anthropic_api_key() -> Optional[str]:
+    """Resolve an Anthropic API key from the UI-saved provider rows.
+
+    Looks up rows in ``llm_provider_configs`` (the table populated by the
+    Settings → AI / LLM Providers UI) and resolves the secret each row
+    points at via ``api_key_ref``. Preference order:
+
+    1. The default Anthropic provider row.
+    2. Any active Anthropic row that has an ``api_key_ref`` set.
+
+    Returns ``None`` if the DB is unreachable, no Anthropic provider has
+    been configured via the UI, or the referenced secret is missing.
+
+    Callers should use this as a fallback after the legacy
+    ``CLAUDE_API_KEY`` / ``ANTHROPIC_API_KEY`` chain. The point is that
+    a user who configured Anthropic via the UI shouldn't get a
+    ``"Claude API not configured"`` error from chat endpoints just
+    because those endpoints went through ``ClaudeService`` instead of
+    ``LLMRouter``.
+    """
+    if get_secret is None:
+        return None
+    try:
+        from database.connection import get_db_session
+        from database.models import LLMProviderConfig
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("anthropic key discovery: DB unavailable (%s)", exc)
+        return None
+
+    session = get_db_session()
+    try:
+        # Default-active first, then any active row with a key ref.
+        candidates = (
+            session.query(LLMProviderConfig)
+            .filter(
+                LLMProviderConfig.provider_type == "anthropic",
+                LLMProviderConfig.is_active.is_(True),
+                LLMProviderConfig.api_key_ref.isnot(None),
+            )
+            .order_by(LLMProviderConfig.is_default.desc())
+            .all()
+        )
+        for row in candidates:
+            value = get_secret(row.api_key_ref)
+            if value:
+                logger.debug(
+                    "Resolved Anthropic API key from provider row %s",
+                    row.provider_id,
+                )
+                return value
+        return None
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("anthropic key discovery failed: %s", exc)
+        return None
     finally:
         session.close()

--- a/start_daemon.sh
+++ b/start_daemon.sh
@@ -184,6 +184,21 @@ if command -v docker &> /dev/null; then
         echo "✓ Redis started"
     fi
 
+    # Start Bifrost (LLM gateway — see issue #292).
+    if docker ps --format '{{.Names}}' | grep -q "deeptempo-bifrost"; then
+        echo "✓ Bifrost is already running"
+    else
+        echo "Starting Bifrost (LLM gateway)..."
+        cd docker
+        $DOCKER_COMPOSE up -d bifrost
+        cd ..
+        echo "✓ Bifrost started"
+    fi
+    if [ -z "${BIFROST_URL+x}" ] || [ "${BIFROST_URL}" = "http://bifrost:8080" ]; then
+        export BIFROST_URL="http://localhost:8080"
+        echo "✓ BIFROST_URL set to ${BIFROST_URL} for native run"
+    fi
+
     # Initialize default admin user
     echo ""
     echo "Initializing default admin user..."

--- a/start_web.sh
+++ b/start_web.sh
@@ -183,7 +183,29 @@ if command -v docker &> /dev/null; then
         sleep 2
         echo "✓ Redis started"
     fi
-    
+
+    # Start Bifrost (LLM gateway — single path for all model traffic).
+    # Issue #292: without this, the backend's Anthropic SDK is pointed at
+    # http://bifrost:8080/anthropic and any chat call dies on a connection
+    # error to a host that isn't running. Bring it up alongside Postgres
+    # and Redis so a fresh dev install just works.
+    if docker ps --format '{{.Names}}' | grep -q "deeptempo-bifrost"; then
+        echo "✓ Bifrost is already running"
+    else
+        echo "Starting Bifrost (LLM gateway)..."
+        cd docker
+        $DOCKER_COMPOSE up -d bifrost
+        cd ..
+        echo "✓ Bifrost started"
+    fi
+    # The container publishes :8080 to the host; native uvicorn can't
+    # resolve the docker-internal hostname `bifrost`. If the user hasn't
+    # explicitly set BIFROST_URL, point at the host-published port.
+    if [ -z "${BIFROST_URL+x}" ] || [ "${BIFROST_URL}" = "http://bifrost:8080" ]; then
+        export BIFROST_URL="http://localhost:8080"
+        echo "✓ BIFROST_URL set to ${BIFROST_URL} for native run"
+    fi
+
     # Initialize database schema (SQLAlchemy Base.metadata.create_all)
     # Runs BEFORE init_default_user.py because user/role tables and all
     # case_* tables must exist before any bootstrap or API query.
@@ -253,7 +275,7 @@ cleanup() {
     echo "✓ Servers stopped"
     echo ""
     echo "Database and Redis are still running. To stop:"
-    echo "  cd docker && $DOCKER_COMPOSE stop postgres redis"
+    echo "  cd docker && $DOCKER_COMPOSE stop postgres redis bifrost"
     exit 0
 }
 

--- a/tests/integration/test_claude_api.py
+++ b/tests/integration/test_claude_api.py
@@ -150,7 +150,13 @@ class TestChatEndpoint:
             )
 
             assert response.status_code == 503
-            assert "not configured" in response.json()["detail"].lower()
+            # #292: the 503 detail is now a structured payload the chat
+            # drawer renders as a CTA, not a bare string.
+            detail = response.json()["detail"]
+            assert isinstance(detail, dict)
+            assert detail["code"] == "no_llm_provider_configured"
+            assert "settings_path" in detail
+            assert "settings" in detail["message"].lower()
 
     def test_chat_endpoint_with_agent_id(self, test_client, mock_claude_service):
         """Test chat request with agent_id."""

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -23,7 +23,6 @@ from services.llm_router import (
     select_path,
 )
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -86,9 +85,8 @@ def test_path_ollama_always_uses_bifrost():
 def test_router_class_method_matches_free_function():
     spec = _anthropic_spec()
     router = LLMRouter()
-    assert (
-        router.select_path(spec, enable_thinking=True)
-        == select_path(spec, enable_thinking=True)
+    assert router.select_path(spec, enable_thinking=True) == select_path(
+        spec, enable_thinking=True
     )
 
 
@@ -102,9 +100,7 @@ async def test_dispatch_bifrost_for_ollama():
     router = LLMRouter(bifrost_url="http://test-bifrost:8080")
     fake_resp = SimpleNamespace(
         choices=[
-            SimpleNamespace(
-                message=SimpleNamespace(content="hello", tool_calls=None)
-            )
+            SimpleNamespace(message=SimpleNamespace(content="hello", tool_calls=None))
         ],
         model="ollama/llama3.1:8b",
         usage=SimpleNamespace(prompt_tokens=5, completion_tokens=7),
@@ -165,9 +161,9 @@ async def test_dispatch_anthropic_with_thinking_routes_through_bifrost():
 
     # Router builds its Anthropic client via services.llm_clients.create_async_anthropic_client,
     # which in turn instantiates anthropic.AsyncAnthropic with base_url=<bifrost>/anthropic.
-    with patch("anthropic.AsyncAnthropic", return_value=mock_client) as ac_ctor, \
-         patch("services.llm_router.get_secret", return_value="sk-ant-fake"), \
-         patch.dict("os.environ", {"BIFROST_URL": "http://test-bifrost:8080"}):
+    with patch("anthropic.AsyncAnthropic", return_value=mock_client) as ac_ctor, patch(
+        "services.llm_router.get_secret", return_value="sk-ant-fake"
+    ), patch.dict("os.environ", {"BIFROST_URL": "http://test-bifrost:8080"}):
         out = await router.dispatch(
             provider=_anthropic_spec(),
             messages=[{"role": "user", "content": "ponder"}],
@@ -206,9 +202,7 @@ async def test_dispatch_bifrost_openai_extracts_cache_read_tokens():
     router = LLMRouter(bifrost_url="http://test-bifrost:8080")
     fake_resp = SimpleNamespace(
         choices=[
-            SimpleNamespace(
-                message=SimpleNamespace(content="cached!", tool_calls=None)
-            )
+            SimpleNamespace(message=SimpleNamespace(content="cached!", tool_calls=None))
         ],
         model="openai/gpt-4o",
         usage=SimpleNamespace(
@@ -266,7 +260,9 @@ async def test_dispatch_propagates_interaction_id_as_bifrost_log_header_openai()
     captured into LogEntry.metadata."""
     router = LLMRouter(bifrost_url="http://test-bifrost:8080")
     fake_resp = SimpleNamespace(
-        choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None))],
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None))
+        ],
         model="openai/gpt-4o-mini",
         usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
     )
@@ -292,7 +288,9 @@ async def test_dispatch_omits_extra_headers_when_no_interaction_id():
     accidentally inject empty headers into every call."""
     router = LLMRouter(bifrost_url="http://test-bifrost:8080")
     fake_resp = SimpleNamespace(
-        choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None))],
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None))
+        ],
         model="openai/gpt-4o-mini",
         usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
     )
@@ -327,8 +325,9 @@ async def test_dispatch_propagates_interaction_id_anthropic():
     mock_client.messages.create = AsyncMock(return_value=fake_resp)
 
     interaction_id = "uuid-bbbb-2222"
-    with patch("anthropic.AsyncAnthropic", return_value=mock_client), \
-         patch("services.llm_router.get_secret", return_value="sk-ant-fake"):
+    with patch("anthropic.AsyncAnthropic", return_value=mock_client), patch(
+        "services.llm_router.get_secret", return_value="sk-ant-fake"
+    ):
         await router.dispatch(
             provider=_anthropic_spec(),
             messages=[{"role": "user", "content": "hi"}],
@@ -347,16 +346,18 @@ async def test_dispatch_attaches_vk_header_when_budget_enforce_active():
     governance layer enforces the budget upstream of the call."""
     router = LLMRouter(bifrost_url="http://test-bifrost:8080")
     fake_resp = SimpleNamespace(
-        choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None))],
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None))
+        ],
         model="openai/gpt-4o-mini",
         usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
     )
     mock_client = MagicMock()
     mock_client.chat.completions.create = AsyncMock(return_value=fake_resp)
 
-    with patch("openai.AsyncOpenAI", return_value=mock_client), \
-         patch("services.budget_service.should_enforce", return_value=True), \
-         patch("services.budget_service.get_active_vk", return_value="sk-bf-test-vk"):
+    with patch("openai.AsyncOpenAI", return_value=mock_client), patch(
+        "services.budget_service.should_enforce", return_value=True
+    ), patch("services.budget_service.get_active_vk", return_value="sk-bf-test-vk"):
         await router.dispatch(
             provider=_openai_spec(),
             messages=[{"role": "user", "content": "hi"}],
@@ -373,16 +374,18 @@ async def test_dispatch_omits_vk_header_when_enforcement_off():
     don't attach x-bf-vk so Bifrost's bootstrap (no-VK) path applies."""
     router = LLMRouter(bifrost_url="http://test-bifrost:8080")
     fake_resp = SimpleNamespace(
-        choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None))],
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None))
+        ],
         model="openai/gpt-4o-mini",
         usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
     )
     mock_client = MagicMock()
     mock_client.chat.completions.create = AsyncMock(return_value=fake_resp)
 
-    with patch("openai.AsyncOpenAI", return_value=mock_client), \
-         patch("services.budget_service.should_enforce", return_value=False), \
-         patch("services.budget_service.get_active_vk", return_value="sk-bf-test-vk"):
+    with patch("openai.AsyncOpenAI", return_value=mock_client), patch(
+        "services.budget_service.should_enforce", return_value=False
+    ), patch("services.budget_service.get_active_vk", return_value="sk-bf-test-vk"):
         await router.dispatch(
             provider=_openai_spec(),
             messages=[{"role": "user", "content": "hi"}],
@@ -409,9 +412,9 @@ async def test_dispatch_translates_402_into_budget_exceeded():
     mock_client = MagicMock()
     mock_client.chat.completions.create = AsyncMock(side_effect=raise_err)
 
-    with patch("openai.AsyncOpenAI", return_value=mock_client), \
-         patch("services.budget_service.should_enforce", return_value=True), \
-         patch("services.budget_service.get_active_vk", return_value="sk-bf-test"):
+    with patch("openai.AsyncOpenAI", return_value=mock_client), patch(
+        "services.budget_service.should_enforce", return_value=True
+    ), patch("services.budget_service.get_active_vk", return_value="sk-bf-test"):
         with pytest.raises(BudgetExceeded) as excinfo:
             await router.dispatch(
                 provider=_openai_spec(),
@@ -472,8 +475,9 @@ async def test_dispatch_does_not_swallow_non_budget_errors():
 @pytest.mark.asyncio
 async def test_anthropic_dispatch_raises_when_no_key():
     router = LLMRouter()
-    with patch("services.llm_router.get_secret", return_value=None), \
-         patch.dict("os.environ", {"ANTHROPIC_API_KEY": "", "CLAUDE_API_KEY": ""}, clear=False):
+    with patch("services.llm_router.get_secret", return_value=None), patch.dict(
+        "os.environ", {"ANTHROPIC_API_KEY": "", "CLAUDE_API_KEY": ""}, clear=False
+    ):
         with pytest.raises(RuntimeError, match="no resolvable API key"):
             await router.dispatch(
                 provider=_anthropic_spec(),
@@ -556,12 +560,19 @@ async def test_non_default_anthropic_with_thinking_dispatches_via_router(monkeyp
 
     mock_router = MagicMock()
     mock_router.select_path = MagicMock(return_value="bifrost")
-    mock_router.dispatch = AsyncMock(return_value={
-        "content": "ok", "path": "bifrost", "provider": "anthropic",
-        "input_tokens": 1, "output_tokens": 1, "model": "x",
-    })
+    mock_router.dispatch = AsyncMock(
+        return_value={
+            "content": "ok",
+            "path": "bifrost",
+            "provider": "anthropic",
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "model": "x",
+        }
+    )
 
     import asyncio
+
     ctx = {
         "llm_router": mock_router,
         "rate_limiter": asyncio.Semaphore(1),
@@ -617,6 +628,7 @@ async def test_default_anthropic_with_thinking_still_falls_back():
     mock_router.dispatch = AsyncMock()
 
     import asyncio
+
     ctx = {
         "llm_router": mock_router,
         "rate_limiter": asyncio.Semaphore(1),
@@ -657,3 +669,87 @@ def test_provider_spec_from_row_copies_fields():
     assert spec.api_key_ref == "ref"
     assert spec.default_model == "gpt-4o"
     assert spec.config == {"organization": "o"}
+    assert spec.config == {"organization": "o"}
+
+
+# ---------------------------------------------------------------------------
+# discover_anthropic_api_key — fallback path so the chat drawer works for
+# users who only configured Anthropic through the Settings UI (#292).
+# ---------------------------------------------------------------------------
+
+
+def _stub_session(rows):
+    """Build a fake SQLAlchemy session that returns *rows* from .query(...).all()."""
+    session = MagicMock()
+    chain = session.query.return_value.filter.return_value.order_by.return_value
+    chain.all.return_value = rows
+    return session
+
+
+def test_discover_anthropic_api_key_returns_secret_for_default_row():
+    from services import llm_router
+
+    default_row = SimpleNamespace(
+        provider_id="anthropic-default",
+        api_key_ref="llm_provider_anthropic-default_api_key",
+    )
+    session = _stub_session([default_row])
+
+    with patch.object(llm_router, "get_secret", return_value="sk-ant-ui-saved"), patch(
+        "database.connection.get_db_session", return_value=session
+    ):
+        assert llm_router.discover_anthropic_api_key() == "sk-ant-ui-saved"
+
+
+def test_discover_anthropic_api_key_falls_through_to_active_row():
+    """If the default row's secret is missing, the next active row wins."""
+    from services import llm_router
+
+    default_row = SimpleNamespace(
+        provider_id="anthropic-default",
+        api_key_ref="llm_provider_anthropic-default_api_key",
+    )
+    other_row = SimpleNamespace(
+        provider_id="anthropic-team",
+        api_key_ref="llm_provider_anthropic-team_api_key",
+    )
+    session = _stub_session([default_row, other_row])
+
+    def fake_get_secret(ref):
+        # Default row's secret missing; team's secret resolves.
+        return None if "default" in ref else "sk-ant-team-key"
+
+    with patch.object(llm_router, "get_secret", side_effect=fake_get_secret), patch(
+        "database.connection.get_db_session", return_value=session
+    ):
+        assert llm_router.discover_anthropic_api_key() == "sk-ant-team-key"
+
+
+def test_discover_anthropic_api_key_returns_none_when_no_rows():
+    from services import llm_router
+
+    session = _stub_session([])
+    with patch.object(llm_router, "get_secret", return_value=None), patch(
+        "database.connection.get_db_session", return_value=session
+    ):
+        assert llm_router.discover_anthropic_api_key() is None
+
+
+def test_discover_anthropic_api_key_returns_none_when_db_unavailable():
+    """DB import error => silent None, so the legacy chain stays usable
+    in environments where database.connection can't import."""
+    from services import llm_router
+
+    # Patch ``get_db_session`` to raise on import. Easiest: make the
+    # entire ``database.connection`` import fail by patching builtins.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def boom_import(name, *args, **kwargs):
+        if name == "database.connection":
+            raise ImportError("simulated")
+        return real_import(name, *args, **kwargs)
+
+    with patch.object(builtins, "__import__", side_effect=boom_import):
+        assert llm_router.discover_anthropic_api_key() is None

--- a/tests/unit/test_claude_service.py
+++ b/tests/unit/test_claude_service.py
@@ -68,6 +68,45 @@ class TestClaudeServiceInitialization:
         assert service.client is None
         assert service.async_client is None
 
+    @patch('services.llm_router.discover_anthropic_api_key')
+    @patch('services.claude_service.get_secret')
+    def test_init_discovers_ui_saved_key(self, mock_get_secret, mock_discover):
+        """Issue #292: when neither CLAUDE_API_KEY nor ANTHROPIC_API_KEY
+        is set in secrets/env, ClaudeService falls back to looking up an
+        Anthropic provider row in llm_provider_configs (the UI-saved
+        path) and reads its api_key_ref from the secrets manager.
+
+        Before this fix, a user who configured Anthropic only through
+        Settings → AI / LLM Providers got "Claude API not configured" in
+        the chat drawer because _load_api_key only checked the legacy
+        env/secret names.
+        """
+        # Legacy lookups all return None — simulates the user who only
+        # added a provider through the UI and never touched .env.
+        mock_get_secret.return_value = None
+        mock_discover.return_value = "sk-ant-ui-saved-key"
+
+        service = ClaudeService()
+
+        assert service.api_key == "sk-ant-ui-saved-key"
+        # Discovery should only be tried after the legacy chain comes up empty.
+        assert mock_discover.call_count == 1
+
+    @patch('services.llm_router.discover_anthropic_api_key')
+    @patch('services.claude_service.get_secret')
+    def test_init_does_not_call_discovery_when_legacy_key_present(
+        self, mock_get_secret, mock_discover
+    ):
+        """If CLAUDE_API_KEY is already in the secrets chain, the
+        UI-provider fallback is skipped — no spurious DB lookups on the
+        hot path."""
+        mock_get_secret.return_value = "sk-ant-legacy-env-key"
+
+        service = ClaudeService()
+
+        assert service.api_key == "sk-ant-legacy-env-key"
+        mock_discover.assert_not_called()
+
     # ------------------------------------------------------------------
     # MCP tools cache loading tests
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the chat-drawer error reported in support (the "deeptempo" error) for users who follow the documented UI-configures-the-provider path. Tier 2 of the [issue #292](https://github.com/Vigil-SOC/vigil/issues/292) RCA; [PR #291](https://github.com/Vigil-SOC/vigil/pull/291) is the matching docs/`.env` cleanup.

Three coordinated changes, each pointed at one leg of the failure:

### 1. `ClaudeService` discovers UI-saved Anthropic keys

[`_load_api_key()`](services/claude_service.py) previously only knew about `CLAUDE_API_KEY` / `ANTHROPIC_API_KEY`. The Settings → AI / LLM Providers UI stores keys under `llm_provider_<id>_api_key` refs (see [backend/api/llm_providers.py:50](backend/api/llm_providers.py#L50)) — which the legacy chain never touched. A user who configured Anthropic via the UI got `"Claude API not configured"` from `/api/claude/chat` even though the key was right there.

New helper in [services/llm_router.py](services/llm_router.py): `discover_anthropic_api_key()` walks `llm_provider_configs` (default row first, then any active Anthropic row with an `api_key_ref`) and resolves the secret. Called as a final fallback so the env / legacy / hot-path behaviour is unchanged when those names are already set.

### 2. Structured `503` instead of `"Claude API not configured"`

The bare string detail rendered in the chat drawer as a generic `Error: ...` bubble with no next step. Detail is now a typed payload:

```json
{
  "code": "no_llm_provider_configured",
  "message": "No Anthropic LLM provider is configured. Add one in Settings → AI / LLM Providers, then try again.",
  "settings_path": "/settings#llm-providers"
}
```

`ClaudeDrawer.tsx` matches on `code` (same pattern used for the existing budget-exceeded 402 case at #186) and renders a `🔌 …` line directing the user at the right Settings tab instead of `Error: ...`. The same payload is reused by the WebSocket and SSE error frames, and by the `findings.py` / `agents.py` gates that previously emitted the bare-string detail.

### 3. `start_web.sh` / `start_daemon.sh` start Bifrost

Bifrost is the gateway every LLM call routes through ([services/llm_clients.py:37](services/llm_clients.py#L37)). The startup scripts already brought up Postgres and Redis but skipped Bifrost — so the Anthropic SDK was pointed at a host that didn't resolve and every chat call exploded on a `ConnectionError`. Both scripts now bring it up the same way they bring up Postgres + Redis, and default `BIFROST_URL` to `http://localhost:8080` for native runs that can't resolve the docker-internal hostname `bifrost:8080`. PR #182 documented the same trap for the auto-ops path.

## Tests

- [tests/unit/test_claude_service.py](tests/unit/test_claude_service.py) — two cases for the new discovery fallback (called when the legacy chain is empty; not called when a legacy key is present).
- [tests/test_llm_router.py](tests/test_llm_router.py) — four cases for `discover_anthropic_api_key()` (default row, fallthrough to a non-default active row, no rows, DB unavailable).
- [tests/integration/test_claude_api.py](tests/integration/test_claude_api.py) — `no_api_key` case updated to assert the structured payload shape.

```
tests/test_llm_router.py: 26 passed
tests/unit/test_claude_service.py::TestClaudeServiceInitialization: 11 passed (1 pre-existing unrelated fail)
tests/integration/test_claude_api.py::TestChatEndpoint::test_chat_endpoint_no_api_key: passed
```

## Test plan

- [ ] Fresh dev install, add **only** an Anthropic provider via Settings UI — chat drawer should work without setting `ANTHROPIC_API_KEY` anywhere.
- [ ] Fresh dev install with no provider at all — chat drawer shows the `🔌 No Anthropic LLM provider is configured…` CTA, not `Error: Failed`.
- [ ] `./start_web.sh` brings up the `deeptempo-bifrost` container alongside Postgres and Redis; `docker ps` confirms.
- [ ] `BIFROST_URL` env var is exported as `http://localhost:8080` (visible in `start_web.sh` output) when not already set.

## Out of scope (separate follow-up)

Migrating the chat endpoints onto `LLMRouter` so Ollama-only setups can drive the chat drawer. That's a wider refactor (tools, streaming, extended thinking, prompt caching). After this PR, Ollama-only users see the clear "add an Anthropic provider" CTA instead of a cryptic error — which fixes the user-facing complaint while we plan the larger change. Tracked in #292.

Refs: #292, #291, #182
🤖 Generated with [Claude Code](https://claude.com/claude-code)