### PR TITLE
fix: unblock first automated release (chart, helm bundle, image tags)

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -31,6 +31,11 @@
           "type": "yaml",
           "path": "helm/vigil/Chart.yaml",
           "jsonpath": "$.appVersion"
+        },
+        {
+          "type": "yaml",
+          "path": "helm/vigil/Chart.yaml",
+          "jsonpath": "$.version"
         }
       ]
     }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -30,7 +30,7 @@ The workflows are currently configured for **Continuous Integration** only - the
 
 ### 2. `release-please.yml` - Automated Release PRs
 - **Triggers**: Push to `main`, manual dispatch
-- **Purpose**: Read Conventional Commits since the last tag; open or update a release PR that bumps `VERSION`, `helm/vigil/Chart.yaml` `appVersion`, and `frontend/package.json`, and updates `CHANGELOG.md`. On merge, push the `vX.Y.Z` tag and create the GitHub Release. See `RELEASING.md`.
+- **Purpose**: Read Conventional Commits since the last tag; open or update a release PR that bumps `VERSION`, `helm/vigil/Chart.yaml` (both `appVersion` and `version`, in lockstep), `frontend/package.json`, and `frontend/package-lock.json`, and updates `CHANGELOG.md`. On merge, push the `vX.Y.Z` tag and create the GitHub Release. See `RELEASING.md`.
 - **Deployment**: None (tagging only — downstream `release.yml` handles deploys)
 
 ### 3. `release.yml` - Tag-Triggered Production Pipeline

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -59,8 +59,8 @@ After the CI builds your images, you can run them anywhere:
 
 ```bash
 # Pull the built images
-docker pull ghcr.io/deeptempo/ai-opensoc-backend:main
-docker pull ghcr.io/deeptempo/ai-opensoc-daemon:main
+docker pull ghcr.io/vigil-soc/vigil-backend:main
+docker pull ghcr.io/vigil-soc/vigil-daemon:main
 
 # Run with docker-compose
 docker-compose up -d

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -114,5 +114,15 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1
 
+      - name: Add chart repositories
+        # `ct lint` runs `helm dependency build` under the hood, which
+        # requires the upstream repos in `Chart.yaml` to be registered.
+        # Repo additions don't carry across jobs, so we add them here
+        # too (the lint job above adds the same set).
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm repo update
+
       - name: Run chart-testing (lint)
         run: ct lint --target-branch ${{ github.event.repository.default_branch }} --chart-dirs helm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,10 @@ env:
   PYTHON_VERSION: '3.10'
   NODE_VERSION: '18'
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  # Image name is computed per-job via `Compute image name (lowercase)` —
+  # github.repository preserves owner casing (e.g. "Vigil-SOC/vigil"), and
+  # OCI/GHCR requires fully lowercase paths. Don't reintroduce a workflow-
+  # level env that uses ${{ github.repository }} directly.
 
 jobs:
   # ============================================================================
@@ -38,11 +41,20 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
+      - name: Compute image name (lowercase)
+        id: image
+        # OCI/GHCR requires repository paths to be entirely lowercase.
+        # github.repository preserves the casing of the owner/repo names
+        # (e.g. "Vigil-SOC/vigil"), so we lowercase here before using it
+        # as part of an image tag. docker/metadata-action does this
+        # automatically; we don't use it in this workflow, so do it manually.
+        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Extract version
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-      
+
       - name: Build and push backend image
         uses: docker/build-push-action@v5
         with:
@@ -50,15 +62,15 @@ jobs:
           file: docker/Dockerfile.backend
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend:v${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend:latest
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-backend:v${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-backend:latest
           labels: |
             org.opencontainers.image.title=AI-OpenSOC Backend
             org.opencontainers.image.version=v${{ steps.version.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      
+
       - name: Build and push daemon image
         uses: docker/build-push-action@v5
         with:
@@ -66,8 +78,8 @@ jobs:
           file: docker/Dockerfile.daemon
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-daemon:v${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-daemon:latest
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-daemon:v${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-daemon:latest
           labels: |
             org.opencontainers.image.title=AI-OpenSOC Daemon
             org.opencontainers.image.version=v${{ steps.version.outputs.version }}
@@ -83,23 +95,29 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-production-images]
     steps:
+      - name: Compute image name (lowercase)
+        id: image
+        # Mirrors the lowercasing step in build-production-images so Trivy
+        # references the same tag that was pushed. See note there.
+        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Get version
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-      
+
       - name: Run Trivy scanner on backend
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend:v${{ steps.version.outputs.version }}
+          image-ref: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-backend:v${{ steps.version.outputs.version }}
           format: 'table'
           exit-code: '1'
           severity: 'CRITICAL,HIGH'
         continue-on-error: true
-      
+
       - name: Run Trivy scanner on daemon
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-daemon:v${{ steps.version.outputs.version }}
+          image-ref: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-daemon:v${{ steps.version.outputs.version }}
           format: 'table'
           exit-code: '1'
           severity: 'CRITICAL,HIGH'
@@ -118,11 +136,17 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
-      
+
+      - name: Compute image name (lowercase)
+        id: image
+        # Mirrors the lowercasing step in build-production-images so deploy
+        # scripts pull the same tag that was pushed. See note there.
+        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Get version
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-      
+
       - name: Configure SSH
         run: |
           mkdir -p ~/.ssh
@@ -147,7 +171,7 @@ jobs:
           VM_HOST: ${{ secrets.PROD_VM_HOST }}
           VM_USER: ${{ secrets.PROD_VM_USER }}
           REGISTRY: ${{ env.REGISTRY }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
           IMAGE_TAG: v${{ steps.version.outputs.version }}
       
       - name: Health check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-backend:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-backend:latest
           labels: |
-            org.opencontainers.image.title=AI-OpenSOC Backend
+            org.opencontainers.image.title=Vigil Backend
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha
@@ -81,7 +81,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-daemon:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-daemon:latest
           labels: |
-            org.opencontainers.image.title=AI-OpenSOC Daemon
+            org.opencontainers.image.title=Vigil Daemon
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,11 @@ jobs:
           file: docker/Dockerfile.backend
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-backend:v${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-backend:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-backend:latest
           labels: |
             org.opencontainers.image.title=AI-OpenSOC Backend
-            org.opencontainers.image.version=v${{ steps.version.outputs.version }}
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -78,11 +78,11 @@ jobs:
           file: docker/Dockerfile.daemon
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-daemon:v${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-daemon:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-daemon:latest
           labels: |
             org.opencontainers.image.title=AI-OpenSOC Daemon
-            org.opencontainers.image.version=v${{ steps.version.outputs.version }}
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -108,7 +108,7 @@ jobs:
       - name: Run Trivy scanner on backend
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-backend:v${{ steps.version.outputs.version }}
+          image-ref: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-backend:${{ steps.version.outputs.version }}
           format: 'table'
           exit-code: '1'
           severity: 'CRITICAL,HIGH'
@@ -117,7 +117,7 @@ jobs:
       - name: Run Trivy scanner on daemon
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-daemon:v${{ steps.version.outputs.version }}
+          image-ref: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-daemon:${{ steps.version.outputs.version }}
           format: 'table'
           exit-code: '1'
           severity: 'CRITICAL,HIGH'
@@ -172,7 +172,7 @@ jobs:
           VM_USER: ${{ secrets.PROD_VM_USER }}
           REGISTRY: ${{ env.REGISTRY }}
           IMAGE_NAME: ${{ steps.image.outputs.name }}
-          IMAGE_TAG: v${{ steps.version.outputs.version }}
+          IMAGE_TAG: ${{ steps.version.outputs.version }}
       
       - name: Health check
         id: health_check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ vigil/
 ├── mcp-servers/          # Git submodule: MCP server implementations
 ├── deeptempo-core/       # Git submodule: core AI/detection library
 ├── database/
-│   └── init/             # PostgreSQL init SQL (runs in order 01-06)
+│   └── init/             # PostgreSQL init SQL (ordering set by helm/vigil/values.yaml dbInit.sqlFiles)
 ├── core/                 # Config, secrets management, rate limiting
 ├── data/                 # Schemas, MITRE taxonomy, detection registry
 ├── tests/                # pytest + vitest test suites
@@ -199,9 +199,21 @@ Agents access external tools through the MCP protocol. Tool definitions live in 
 ### Database
 
 - PostgreSQL 16 via SQLAlchemy ORM (`services/models.py`)
-- Schema initialized by `database/init/` SQL files (executed in numeric order)
+- Schema initialized by `database/init/` SQL files (executed in the order
+  defined by `helm/vigil/values.yaml` `dbInit.sqlFiles`, not by filename
+  prefix)
 - pgvector extension for embeddings
 - Use `services/database_data_service.py` for data access — do not query the DB directly from API handlers
+
+**When adding or modifying an init SQL file under `database/init/`:** the
+chart bundles a *copy* under `helm/vigil/files/database-init/` (Helm can
+only read files inside the chart directory). You must (1) copy the file
+into the chart bundle, (2) add it to `helm/vigil/values.yaml`
+`dbInit.sqlFiles` in the correct execution order, and (3) verify with
+`helm template` that the dbInit Job script references it. CI catches step
+1 (`Helm Chart / Lint and Template` runs `diff -r` between the two
+directories); steps 2 and 3 are silent if missed. See
+[`database/init/README.md`](database/init/README.md).
 
 ### Authentication
 
@@ -302,7 +314,7 @@ GitHub Actions workflows in `.github/workflows/`:
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
 | `ci-cd.yml` | Push/PR to main, develop | Lint → Unit Tests → Integration Tests → Security Scan → Docker Build |
-| `release-please.yml` | Push to `main`, manual | Read Conventional Commits since last tag → open/update a release PR with bumped `VERSION` / `Chart.yaml` `appVersion` / `frontend/package.json` + `CHANGELOG.md`. On merge, push `vX.Y.Z` tag and create the GitHub Release. See `RELEASING.md`. |
+| `release-please.yml` | Push to `main`, manual | Read Conventional Commits since last tag → open/update a release PR with bumped `VERSION` / `Chart.yaml` (`appVersion` + `version`, lockstep) / `frontend/package.json` / `frontend/package-lock.json` + `CHANGELOG.md`. On merge, push `vX.Y.Z` tag and create the GitHub Release. See `RELEASING.md`. |
 | `release.yml` | Version tags (`v*.*.*`) | Build production images → Trivy scan → deploy to production VM → post-deploy validation. Does **not** create the GitHub Release (release-please owns it). |
 | `nightly.yml` | Daily 2 AM UTC | Comprehensive security & performance audits |
 
@@ -326,7 +338,7 @@ All CI checks must pass before merging.
 | `services/claude_service.py` | Central AI/agent orchestration (~124KB) |
 | `services/soc_agents.py` | All agent system prompts |
 | `services/mcp_service.py` | MCP protocol coordination |
-| `database/init/` | Schema SQL (01–06, applied in order) |
+| `database/init/` | Schema SQL — see Database section for the add/modify checklist |
 | `mcp-config.json` | All MCP server definitions |
 | `env.example` | Every supported environment variable |
 | `docker/docker-compose.yml` | Full local stack definition |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,9 +220,11 @@ the ConfigMap key and the SQL header comment). CI catches step 1
 (`Helm Chart / Lint and Template` runs `diff -r` between the two
 directories). Skipping step 2 is silent (the file is in the ConfigMap
 but never applied); skipping step 1 while keeping the file in
-`dbInit.sqlFiles` makes the Job hard-fail at runtime (the `apply()`
-function refuses listed-but-missing files — added in this PR to prevent
-silent ghost rows in `_vigil_schema_versions`). See
+`dbInit.sqlFiles` makes the Job hard-fail at runtime — *unless* the
+filename already has a row in `_vigil_schema_versions`, in which case
+it SKIPs as already-applied (the marker-table check runs before the
+file-existence check, so legacy `003_*` ghost rows on v0.1.x upgrades
+don't break `helm upgrade --reuse-values`). See
 [`database/init/README.md`](database/init/README.md), which also lists
 two filenames that are reserved and must never be reused.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,10 +214,17 @@ chart bundles a *copy* under `helm/vigil/files/database-init/` (Helm can
 only read files inside the chart directory). You must (1) copy the file
 into the chart bundle, (2) add it to `helm/vigil/values.yaml`
 `dbInit.sqlFiles` in the correct execution order, and (3) verify with
-`helm template` that the dbInit Job script references it. CI catches step
-1 (`Helm Chart / Lint and Template` runs `diff -r` between the two
-directories); steps 2 and 3 are silent if missed. See
-[`database/init/README.md`](database/init/README.md).
+`helm template ... | grep -E '^[[:space:]]*apply "NEWFILE\.sql"'` that
+the dbInit Job script applies it (a bare `grep NEWFILE.sql` false-matches
+the ConfigMap key and the SQL header comment). CI catches step 1
+(`Helm Chart / Lint and Template` runs `diff -r` between the two
+directories). Skipping step 2 is silent (the file is in the ConfigMap
+but never applied); skipping step 1 while keeping the file in
+`dbInit.sqlFiles` makes the Job hard-fail at runtime (the `apply()`
+function refuses listed-but-missing files — added in this PR to prevent
+silent ghost rows in `_vigil_schema_versions`). See
+[`database/init/README.md`](database/init/README.md), which also lists
+two filenames that are reserved and must never be reused.
 
 ### Authentication
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ vigil/
 ├── mcp-servers/          # Git submodule: MCP server implementations
 ├── deeptempo-core/       # Git submodule: core AI/detection library
 ├── database/
-│   └── init/             # PostgreSQL init SQL (ordering set by helm/vigil/values.yaml dbInit.sqlFiles)
+│   └── init/             # PostgreSQL init SQL (docker-compose: lex order by filename; Helm: values.yaml dbInit.sqlFiles)
 ├── core/                 # Config, secrets management, rate limiting
 ├── data/                 # Schemas, MITRE taxonomy, detection registry
 ├── tests/                # pytest + vitest test suites
@@ -199,9 +199,13 @@ Agents access external tools through the MCP protocol. Tool definitions live in 
 ### Database
 
 - PostgreSQL 16 via SQLAlchemy ORM (`services/models.py`)
-- Schema initialized by `database/init/` SQL files (executed in the order
-  defined by `helm/vigil/values.yaml` `dbInit.sqlFiles`, not by filename
-  prefix)
+- Schema initialized by `database/init/` SQL files. **Execution order
+  differs by deploy path:** docker-compose mounts the directory at
+  `/docker-entrypoint-initdb.d`, where Postgres runs files in
+  **lexicographic filename order** (the `01_`/`04_`/…/`16_` prefixes
+  are authoritative there). The Helm chart, by contrast, iterates
+  `helm/vigil/values.yaml`'s `dbInit.sqlFiles` list in the **order
+  written there** — prefixes are decorative for the chart path
 - pgvector extension for embeddings
 - Use `services/database_data_service.py` for data access — do not query the DB directly from API handlers
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,12 +21,12 @@ Vigil follows [Semantic Versioning](https://semver.org/).
 |-------------------------------|------------------------------------|-------------------------------|
 | `VERSION`                     | (whole file)                       | yes                           |
 | `helm/vigil/Chart.yaml`       | `appVersion`                       | yes                           |
+| `helm/vigil/Chart.yaml`       | `version`                          | yes (lockstep with appVersion)|
 | `frontend/package.json`       | `version`                          | yes                           |
 | `frontend/package-lock.json`  | `version` (root + `packages['']`)  | yes                           |
-| `helm/vigil/Chart.yaml`       | `version`                          | **no** — bump manually in PR  |
 
-See "Chart version vs appVersion" below for why the chart's `version` is
-managed separately.
+See "Chart version vs appVersion" below for why both chart fields are
+bumped together.
 
 The Python backend reads `VERSION` directly at import time (see
 `backend/__init__.py`), so the FastAPI app version, the
@@ -57,8 +57,9 @@ automated.
      contribute to version selection
 3. It opens (or updates) a single **release PR** titled
    `chore(main): release X.Y.Z`. The PR bumps `VERSION`,
-   `Chart.yaml` `appVersion`, `frontend/package.json` `version`, and
-   updates `CHANGELOG.md`.
+   `Chart.yaml` `appVersion` and `version`, `frontend/package.json`
+   `version`, `frontend/package-lock.json` (both `$.version` and
+   `$.packages[''].version`), and updates `CHANGELOG.md`.
 4. The release PR stays open and accumulates more commits as they merge.
    This is the grouping mechanism — every commit since the last release
    lives in one PR until you ship.
@@ -72,16 +73,30 @@ The only human decision per release is **when to merge the release PR**.
 
 ## Chart Version vs appVersion
 
-The Helm chart's `version:` (chart packaging version) is independent of
-`appVersion:` (the Vigil release the chart deploys). release-please only
-manages `appVersion`. Bump chart `version` manually in your PR when the
-chart itself changes — templates, values schema, dependencies.
+The Helm chart has two version fields:
+
+- **`appVersion`** — the Vigil release the chart deploys.
+- **`version`** — the chart packaging version. Helm clients, `helm package`
+  tarball names (`vigil-X.Y.Z.tgz`), Helm's local cache, and ArtifactHub all
+  key off this field, not `appVersion`. If chart contents change without a
+  `version` bump, consumers see "no new chart" even though the bytes
+  differ — silent breakage.
+
+release-please bumps **both fields in lockstep** with every release. This
+is a deliberate trade-off: it gives up the (rarely-used) ability to ship a
+chart-only patch with a chart `version` bump but no app version bump, in
+exchange for eliminating a drift footgun that's hard to catch in review
+(release-please's YAML library reformats `Chart.yaml` when it edits, which
+can produce semantically-equivalent but byte-different output).
 
 | Change                              | `appVersion` | chart `version` |
 |-------------------------------------|--------------|-----------------|
-| New Vigil release, no chart change  | bumps        | unchanged       |
-| Helm template fix, no app change    | unchanged    | bump manually   |
-| Both at once                        | bumps        | bump manually   |
+| Any release-please release          | bumps        | bumps           |
+
+If you ever need a chart-only fix between app releases (e.g. a Helm
+template hotfix with no app code change), edit `helm/vigil/Chart.yaml`'s
+`version` manually in a separate PR outside the release-please flow. This
+is the escape hatch, not the default path.
 
 ## GitHub App Setup
 
@@ -110,6 +125,7 @@ that overwrites it.
    all of the following:
    - `VERSION`
    - `helm/vigil/Chart.yaml` `appVersion`
+   - `helm/vigil/Chart.yaml` `version` (lockstep with `appVersion`)
    - `frontend/package.json` `version`
    - `frontend/package-lock.json` — both `$.version` and
      `$.packages[''].version`

--- a/database/init/15_federation.sql
+++ b/database/init/15_federation.sql
@@ -24,15 +24,18 @@ CREATE TABLE IF NOT EXISTS federation_sources (
 CREATE INDEX IF NOT EXISTS idx_federation_sources_enabled
     ON federation_sources (enabled);
 
--- Add external_id to findings to support a strong (data_source, external_id)
--- dedup guarantee. Existing rows leave external_id NULL (the partial unique
--- index below excludes NULLs), so legacy findings are not affected.
-ALTER TABLE findings
-    ADD COLUMN IF NOT EXISTS external_id VARCHAR(255);
-
-CREATE UNIQUE INDEX IF NOT EXISTS uniq_findings_source_extid
-    ON findings (data_source, external_id)
-    WHERE data_source IS NOT NULL AND external_id IS NOT NULL;
+-- NOTE: the `external_id` column and the `uniq_findings_source_extid`
+-- partial unique index on `findings` are declared on the ORM model
+-- (`database/models.py` `Finding`) and materialized by SQLAlchemy's
+-- create_all() at backend startup — not here. An earlier revision of
+-- this file ran `ALTER TABLE findings ADD COLUMN ...` + `CREATE UNIQUE
+-- INDEX ... ON findings ...` at init time, but `findings` doesn't exist
+-- yet when init SQL runs (the table is created by the ORM after the
+-- backend boots). docker-compose's postgres entrypoint runs init files
+-- under `set -Eeo pipefail` with `psql -v ON_ERROR_STOP=1`, so the ALTER
+-- aborted the entrypoint before the system_config seed below could land
+-- — leaving the federation feature silently unconfigured on every fresh
+-- docker-compose stack.
 
 -- Seed the global federation toggle (off by default — opt-in feature).
 INSERT INTO system_config (key, value, description, config_type)

--- a/database/init/16_llm_budgets.sql
+++ b/database/init/16_llm_budgets.sql
@@ -7,11 +7,12 @@
 -- `virtual_key_id` column lands now to future-proof per-tenant attribution
 -- once tenancy ships (#165).
 
-ALTER TABLE llm_interaction_logs
-    ADD COLUMN IF NOT EXISTS virtual_key_id VARCHAR(64);
-
-CREATE INDEX IF NOT EXISTS idx_llm_interaction_vk
-    ON llm_interaction_logs (virtual_key_id, created_at);
+-- NOTE: the `virtual_key_id` column and `idx_llm_interaction_vk` index on
+-- `llm_interaction_logs` are declared on the ORM model
+-- (`database/models.py` `LLMInteractionLog`) and materialized by
+-- SQLAlchemy's create_all() at backend startup — not here. See
+-- `15_federation.sql` for the long explanation of why init-time ALTER
+-- against an ORM-owned table breaks docker-compose's first-boot.
 
 -- Seed the single bifrost.virtual_keys settings row. Empty default_vk
 -- means "no enforcement yet" — Bifrost will accept calls without

--- a/database/init/README.md
+++ b/database/init/README.md
@@ -75,7 +75,7 @@ the Job will check `_vigil_schema_versions`, see the ghost row, and
 **SKIP** the file on every pre-existing deployment. The schema change
 silently never runs in production.
 
-Pick any other prefix. The rest of this directory uses non-zero-padded
+Pick any other prefix. The rest of this directory uses two-digit
 `NN_` (`01_`, `04_`, …, `16_`); follow that convention.
 
 ## When you modify an existing init SQL file

--- a/database/init/README.md
+++ b/database/init/README.md
@@ -1,0 +1,53 @@
+# Database init SQL — source of truth
+
+These `*.sql` files are the canonical schema initialization scripts. The
+docker-compose stack reads them directly from this directory; the Helm
+chart reads from a **copy** under `helm/vigil/files/database-init/`
+(Helm can only load files from inside the chart directory).
+
+## When you add a new init SQL file here
+
+You must do all three of the following — CI catches step 1, but **not**
+steps 2 and 3:
+
+1. **Copy the file into the chart bundle**:
+   ```bash
+   cp database/init/NEWFILE.sql helm/vigil/files/database-init/
+   ```
+   The `Helm Chart / Lint and Template` workflow runs
+   `diff -r database/init helm/vigil/files/database-init` on every PR and
+   will fail if these two directories drift.
+
+2. **Add the filename to `helm/vigil/values.yaml`** under
+   `dbInit.sqlFiles` in the **correct execution order**. The order in
+   that list is authoritative — filename prefixes (`01_`, `02_`, …) are
+   a convention, not enforcement. Without this step, the chart deploys
+   without your schema change and `helm install` succeeds silently.
+
+3. **Verify with `helm template`** that the rendered dbInit Job script
+   includes a `psql` invocation for your new file:
+   ```bash
+   helm template release-check helm/vigil \
+     --set secrets.anthropicApiKey=test \
+     --set secrets.postgresPassword=test \
+     | grep NEWFILE.sql
+   ```
+
+## When you modify an existing init SQL file
+
+Same drill — copy the updated file to `helm/vigil/files/database-init/`
+so the chart bundle stays in sync. The `diff -r` lint check will fail
+otherwise.
+
+## Why this isn't automated
+
+A pre-commit hook or `make` target that auto-syncs the bundle would
+remove the footgun entirely. Filed as a follow-up — until then, the
+manual three-step process is what we have.
+
+## See also
+
+- [`helm/vigil/files/database-init/README.md`](../../helm/vigil/files/database-init/README.md)
+  — chart-side notes on the same convention.
+- [`.github/workflows/helm-chart.yml`](../../.github/workflows/helm-chart.yml)
+  — the CI check that enforces directory parity.

--- a/database/init/README.md
+++ b/database/init/README.md
@@ -5,6 +5,24 @@ docker-compose stack reads them directly from this directory; the Helm
 chart reads from a **copy** under `helm/vigil/files/database-init/`
 (Helm can only load files from inside the chart directory).
 
+## Execution order — two different rules
+
+The two deploy paths order these files differently. When you add a new
+file, you need to satisfy both.
+
+- **docker-compose (local dev)** — the postgres image runs every file
+  it finds under `/docker-entrypoint-initdb.d` in **lexicographic
+  filename order**. So `01_*.sql` runs before `04_*.sql` runs before
+  `16_*.sql`. The `NN_` prefix on each filename **is** the ordering
+  mechanism here. Pick a prefix that sorts correctly relative to any
+  files your script depends on. (Note: zero-padded prefixes like `003_`
+  sort *before* `01_` lexicographically.)
+- **Helm chart** — the `db-init` Job iterates over
+  `helm/vigil/values.yaml`'s `dbInit.sqlFiles` list in the **order
+  written there**. Filename prefixes are decorative for this path; the
+  list is authoritative. Files in `helm/vigil/files/database-init/`
+  that aren't listed are bundled into the ConfigMap but never run.
+
 ## When you add a new init SQL file here
 
 You must do all three of the following — CI catches step 1, but **not**
@@ -19,19 +37,24 @@ steps 2 and 3:
    will fail if these two directories drift.
 
 2. **Add the filename to `helm/vigil/values.yaml`** under
-   `dbInit.sqlFiles` in the **correct execution order**. The order in
-   that list is authoritative — filename prefixes (`01_`, `02_`, …) are
-   a convention, not enforcement. Without this step, the chart deploys
-   without your schema change and `helm install` succeeds silently.
+   `dbInit.sqlFiles` in the correct position for the Helm execution
+   order (see above). Without this step, the chart bundles the file
+   into the ConfigMap but the `db-init` Job never runs it — `helm
+   install` succeeds and the schema is silently incomplete.
 
 3. **Verify with `helm template`** that the rendered dbInit Job script
-   includes a `psql` invocation for your new file:
+   has an `apply` line for your new file. Match the Job script's apply
+   line specifically — a bare `grep NEWFILE.sql` will match the
+   ConfigMap data key and the SQL file's own header comment too, both
+   of which are emitted regardless of whether the file is in
+   `dbInit.sqlFiles`, so it will green-light a forgotten step 2:
    ```bash
    helm template release-check helm/vigil \
      --set secrets.anthropicApiKey=test \
      --set secrets.postgresPassword=test \
-     | grep NEWFILE.sql
+     | grep -E '^[[:space:]]*apply "NEWFILE\.sql"'
    ```
+   No matches → the file is in the ConfigMap but the Job won't run it.
 
 ## When you modify an existing init SQL file
 

--- a/database/init/README.md
+++ b/database/init/README.md
@@ -56,6 +56,28 @@ steps 2 and 3:
    ```
    No matches → the file is in the ConfigMap but the Job won't run it.
 
+## Reserved filenames — do not use
+
+**Don't name a file `003_add_ai_enrichment.sql` or `003_ai_decision_logs.sql`.**
+
+Earlier versions of `helm/vigil/values.yaml` listed these as ghost
+entries in `dbInit.sqlFiles` — files that didn't exist on disk. The
+chart's `db-init` Job ran psql against them, got "file not found,"
+treated that as a benign warning (it has to, because some real
+migrations legitimately fail when SQLAlchemy hasn't created their
+target tables yet), then unconditionally inserted the filename into
+`_vigil_schema_versions` to mark it "applied." So every v0.1.x Helm
+deployment now has rows in that table claiming those two filenames
+have been applied.
+
+If a future PR ever ships a real file with one of those exact names,
+the Job will check `_vigil_schema_versions`, see the ghost row, and
+**SKIP** the file on every pre-existing deployment. The schema change
+silently never runs in production.
+
+Pick any other prefix. The rest of this directory uses non-zero-padded
+`NN_` (`01_`, `04_`, …, `16_`); follow that convention.
+
 ## When you modify an existing init SQL file
 
 Same drill — copy the updated file to `helm/vigil/files/database-init/`

--- a/docs/CI_CD_GUIDE.md
+++ b/docs/CI_CD_GUIDE.md
@@ -373,7 +373,7 @@ docker images | grep vigil
 
 # Rollback to previous version
 cd /opt/vigil
-export IMAGE_TAG=v1.2.2  # Previous version
+export IMAGE_TAG=1.2.2  # Previous version (image tags are pushed without the v prefix; git tags still use v)
 docker-compose up -d --force-recreate
 ```
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -633,7 +633,7 @@ sudo systemctl start fail2ban
 docker-compose down
 
 # Pull previous version
-export IMAGE_TAG=v1.2.2
+export IMAGE_TAG=1.2.2  # image tags are pushed without the v prefix (git tags still use v)
 docker-compose pull
 docker-compose up -d
 
@@ -654,7 +654,7 @@ gunzip -c backups/pre-v1.2.3.sql.gz | docker-compose exec -T postgres psql -U de
 git checkout v1.2.2
 
 # 4. Deploy previous version
-export IMAGE_TAG=v1.2.2
+export IMAGE_TAG=1.2.2  # image tags are pushed without the v prefix (git tags still use v)
 docker-compose up -d
 
 # 5. Verify

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -165,11 +165,20 @@ cp database/init/NEW.sql helm/vigil/files/database-init/
 ## Upgrades
 
 ```bash
-helm upgrade vigil ./helm/vigil \
-  -n vigil --reuse-values \
-  --set backend.image.tag=v0.2.0 \
-  --set daemon.image.tag=v0.2.0 \
-  --wait
+helm upgrade vigil ./helm/vigil -n vigil --reuse-values --wait
+```
+
+The chart's default image tag resolves to `Chart.AppVersion`, which
+release-please bumps in lockstep with the chart `version` on every
+release — so a `helm upgrade` after pulling the new chart picks up the
+matching images automatically. Override only if you need to pin to a
+different tag than the chart's `appVersion` (for example, to deploy a
+`:latest` build for testing):
+
+```bash
+helm upgrade vigil ./helm/vigil -n vigil --reuse-values --wait \
+  --set backend.image.tag=latest \
+  --set daemon.image.tag=latest
 ```
 
 Pod checksums on the ConfigMap + Secret force pod restarts when config

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -185,6 +185,25 @@ Pod checksums on the ConfigMap + Secret force pod restarts when config
 changes, so `helm upgrade --set config.X=Y --reuse-values` will do the right
 thing.
 
+> ⚠️ **First upgrade when `dbInit.sqlFiles` has changed** — `helm
+> upgrade --reuse-values` reuses the *previous release's* coalesced
+> values, which means a longer `dbInit.sqlFiles` list in the new chart
+> is silently overwritten by the previous (shorter) one. Any new SQL
+> files in the bump won't run, and code that touches their tables
+> crashes at runtime. On the first upgrade after a chart bump that
+> added init SQL, use one of:
+>
+> ```bash
+> # Helm 3.14+ — reset to new defaults, then layer user overrides on top
+> helm upgrade vigil ./helm/vigil -n vigil --reset-then-reuse-values --wait
+>
+> # Or pass an explicit values file so the new defaults aren't lost
+> helm upgrade vigil ./helm/vigil -n vigil -f my-values.yaml --wait
+> ```
+>
+> Subsequent upgrades that don't touch `dbInit.sqlFiles` can go back to
+> plain `--reuse-values`.
+
 ## Uninstall
 
 ```bash

--- a/helm/vigil/Chart.lock
+++ b/helm/vigil/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.108.0
-digest: sha256:34e5cb4cff273986bf40cbf48a008dff6e73b5a9e0c8bd853a4a11e24657d9d8
-generated: "2026-04-22T09:19:31.333343-04:00"
+digest: sha256:8c3e43f2e6c1aed9eb63acc905e615d146dd92245462c1f6ff873afac6dea0f1
+generated: "2026-05-18T17:39:17.6291-07:00"

--- a/helm/vigil/Chart.yaml
+++ b/helm/vigil/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vigil
 description: Vigil SOC — open-source, AI-native Security Operations Center
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/Vigil-SOC/vigil

--- a/helm/vigil/Chart.yaml
+++ b/helm/vigil/Chart.yaml
@@ -9,8 +9,8 @@ home: https://github.com/Vigil-SOC/vigil
 sources:
   - https://github.com/Vigil-SOC/vigil
 maintainers:
-  - name: Vigil SOC maintainers
-    url: https://github.com/Vigil-SOC/vigil
+  - name: Vigil-SOC
+    url: https://github.com/Vigil-SOC
 keywords:
   - security
   - soc

--- a/helm/vigil/README.md
+++ b/helm/vigil/README.md
@@ -109,6 +109,25 @@ helm upgrade vigil ./helm/vigil -n vigil --reuse-values \
 The `db-init` Job re-runs on every upgrade but is idempotent — it tracks
 applied files in a `_vigil_schema_versions` table.
 
+> ⚠️ **First upgrade when `dbInit.sqlFiles` has changed** — `helm
+> upgrade --reuse-values` reuses the *previous release's* coalesced
+> values, which means a longer `dbInit.sqlFiles` list in the new chart
+> is silently overwritten by the previous (shorter) one. Any new SQL
+> files in the bump won't run, and code that touches their tables
+> crashes at runtime. On the first upgrade after a chart bump that
+> added init SQL, use one of:
+>
+> ```bash
+> # Helm 3.14+ — reset to new defaults, then layer user overrides on top
+> helm upgrade vigil ./helm/vigil -n vigil --reset-then-reuse-values
+>
+> # Or pass an explicit values file so the new defaults aren't lost
+> helm upgrade vigil ./helm/vigil -n vigil -f my-values.yaml
+> ```
+>
+> Subsequent upgrades that don't touch `dbInit.sqlFiles` can go back to
+> plain `--reuse-values`.
+
 ## Values reference
 
 See `values.yaml` for the full schema. Non-obvious choices:

--- a/helm/vigil/README.md
+++ b/helm/vigil/README.md
@@ -90,10 +90,20 @@ integration creds you use (`SPLUNK_PASSWORD`, `SLACK_BOT_TOKEN`, …).
 ## Upgrades
 
 ```bash
-helm upgrade vigil ./helm/vigil \
-  -n vigil --reuse-values \
-  --set backend.image.tag=v0.2.0 \
-  --set daemon.image.tag=v0.2.0
+helm upgrade vigil ./helm/vigil -n vigil --reuse-values
+```
+
+The chart's default image tag resolves to `Chart.AppVersion`, which
+release-please bumps in lockstep with the chart `version` on every
+release — so a `helm upgrade` after pulling the new chart version
+picks up the matching images automatically. Override only if you need
+to pin to a different tag than the chart's `appVersion` (for example,
+to deploy a `:latest` build for testing):
+
+```bash
+helm upgrade vigil ./helm/vigil -n vigil --reuse-values \
+  --set backend.image.tag=latest \
+  --set daemon.image.tag=latest
 ```
 
 The `db-init` Job re-runs on every upgrade but is idempotent — it tracks

--- a/helm/vigil/files/database-init/14_threat_indicators.sql
+++ b/helm/vigil/files/database-init/14_threat_indicators.sql
@@ -1,0 +1,35 @@
+-- 14_threat_indicators.sql
+-- Global threat-indicator pool sourced from external feeds (Cloudforce One STIX/TAXII,
+-- and any future feed-driven sources). Distinct from `case_iocs`, which is case-scoped.
+-- Indicators are pulled by daemon/threat_feed_poller.py and used during finding
+-- enrichment in daemon/processor.py.
+
+CREATE TABLE IF NOT EXISTS threat_indicators (
+    id              BIGSERIAL PRIMARY KEY,
+    indicator_type  VARCHAR(32)  NOT NULL,         -- ip, domain, url, hash_md5, hash_sha1, hash_sha256, email
+    indicator_value VARCHAR(2048) NOT NULL,
+    source          VARCHAR(64)  NOT NULL,         -- 'cloudforce_one', etc.
+    collection_id   VARCHAR(128),                  -- TAXII collection that emitted this indicator
+    confidence      NUMERIC(5,2),                  -- 0..100, normalized from STIX confidence
+    threat_level    VARCHAR(16),                   -- critical, high, medium, low, info
+    labels          TEXT[]        DEFAULT ARRAY[]::TEXT[],
+    valid_from      TIMESTAMP,
+    valid_until     TIMESTAMP,
+    raw_stix        JSONB,
+    first_seen      TIMESTAMP    NOT NULL DEFAULT NOW(),
+    last_seen       TIMESTAMP    NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT threat_indicators_unique UNIQUE (source, indicator_type, indicator_value)
+);
+
+CREATE INDEX IF NOT EXISTS idx_threat_indicators_type_value
+    ON threat_indicators (indicator_type, indicator_value);
+
+CREATE INDEX IF NOT EXISTS idx_threat_indicators_source
+    ON threat_indicators (source);
+
+CREATE INDEX IF NOT EXISTS idx_threat_indicators_last_seen
+    ON threat_indicators (last_seen DESC);
+
+CREATE INDEX IF NOT EXISTS idx_threat_indicators_valid_until
+    ON threat_indicators (valid_until);

--- a/helm/vigil/files/database-init/15_federation.sql
+++ b/helm/vigil/files/database-init/15_federation.sql
@@ -1,0 +1,45 @@
+-- 15_federation.sql
+-- Federated monitoring: per-source polling state + global toggle.
+--
+-- Each row represents one data source (Splunk, CrowdStrike, etc.) that the
+-- daemon's federation poller pulls from on a configurable cadence. Rows are
+-- auto-seeded on daemon boot from configured integrations (default disabled);
+-- the global on/off lives in `system_config` under key `federation.settings`.
+
+CREATE TABLE IF NOT EXISTS federation_sources (
+    source_id           VARCHAR(64)  PRIMARY KEY,
+    enabled             BOOLEAN      NOT NULL DEFAULT FALSE,
+    interval_seconds    INTEGER      NOT NULL DEFAULT 300,
+    max_items           INTEGER      NOT NULL DEFAULT 100,
+    min_severity        VARCHAR(16),                       -- nullable: "low"|"medium"|"high"|"critical"
+    cursor              JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    last_poll_at        TIMESTAMPTZ,
+    last_success_at     TIMESTAMPTZ,
+    last_error          TEXT,
+    consecutive_errors  INTEGER      NOT NULL DEFAULT 0,
+    created_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_federation_sources_enabled
+    ON federation_sources (enabled);
+
+-- Add external_id to findings to support a strong (data_source, external_id)
+-- dedup guarantee. Existing rows leave external_id NULL (the partial unique
+-- index below excludes NULLs), so legacy findings are not affected.
+ALTER TABLE findings
+    ADD COLUMN IF NOT EXISTS external_id VARCHAR(255);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_findings_source_extid
+    ON findings (data_source, external_id)
+    WHERE data_source IS NOT NULL AND external_id IS NOT NULL;
+
+-- Seed the global federation toggle (off by default — opt-in feature).
+INSERT INTO system_config (key, value, description, config_type)
+VALUES (
+    'federation.settings',
+    '{"enabled": false}'::jsonb,
+    'Federated monitoring global on/off (per-source toggles live in federation_sources)',
+    'federation'
+)
+ON CONFLICT (key) DO NOTHING;

--- a/helm/vigil/files/database-init/15_federation.sql
+++ b/helm/vigil/files/database-init/15_federation.sql
@@ -24,15 +24,18 @@ CREATE TABLE IF NOT EXISTS federation_sources (
 CREATE INDEX IF NOT EXISTS idx_federation_sources_enabled
     ON federation_sources (enabled);
 
--- Add external_id to findings to support a strong (data_source, external_id)
--- dedup guarantee. Existing rows leave external_id NULL (the partial unique
--- index below excludes NULLs), so legacy findings are not affected.
-ALTER TABLE findings
-    ADD COLUMN IF NOT EXISTS external_id VARCHAR(255);
-
-CREATE UNIQUE INDEX IF NOT EXISTS uniq_findings_source_extid
-    ON findings (data_source, external_id)
-    WHERE data_source IS NOT NULL AND external_id IS NOT NULL;
+-- NOTE: the `external_id` column and the `uniq_findings_source_extid`
+-- partial unique index on `findings` are declared on the ORM model
+-- (`database/models.py` `Finding`) and materialized by SQLAlchemy's
+-- create_all() at backend startup — not here. An earlier revision of
+-- this file ran `ALTER TABLE findings ADD COLUMN ...` + `CREATE UNIQUE
+-- INDEX ... ON findings ...` at init time, but `findings` doesn't exist
+-- yet when init SQL runs (the table is created by the ORM after the
+-- backend boots). docker-compose's postgres entrypoint runs init files
+-- under `set -Eeo pipefail` with `psql -v ON_ERROR_STOP=1`, so the ALTER
+-- aborted the entrypoint before the system_config seed below could land
+-- — leaving the federation feature silently unconfigured on every fresh
+-- docker-compose stack.
 
 -- Seed the global federation toggle (off by default — opt-in feature).
 INSERT INTO system_config (key, value, description, config_type)

--- a/helm/vigil/files/database-init/16_llm_budgets.sql
+++ b/helm/vigil/files/database-init/16_llm_budgets.sql
@@ -1,0 +1,32 @@
+-- 16_llm_budgets.sql
+-- Per-tenant LLM budget enforcement via Bifrost virtual keys (#186).
+--
+-- This migration is intentionally minimal: a single global VK MVP per the
+-- locked design decision. Vigil has no tenant model today (per-user RBAC
+-- only), so all calls share one Bifrost VK and one budget. The
+-- `virtual_key_id` column lands now to future-proof per-tenant attribution
+-- once tenancy ships (#165).
+
+ALTER TABLE llm_interaction_logs
+    ADD COLUMN IF NOT EXISTS virtual_key_id VARCHAR(64);
+
+CREATE INDEX IF NOT EXISTS idx_llm_interaction_vk
+    ON llm_interaction_logs (virtual_key_id, created_at);
+
+-- Seed the single bifrost.virtual_keys settings row. Empty default_vk
+-- means "no enforcement yet" — Bifrost will accept calls without
+-- x-bf-vk while we're in the bootstrap window. The Settings → LLM
+-- Providers → Budgets sub-panel writes the configured VK ID here once
+-- the operator provisions one in the Bifrost UI.
+INSERT INTO system_config (key, value, description, config_type)
+VALUES (
+    'bifrost.virtual_keys',
+    '{
+        "default_vk": "",
+        "budget_limit_usd": 0,
+        "enforcement_mode": "warning"
+    }'::jsonb,
+    'Bifrost virtual-key configuration and budget settings (#186)',
+    'ai'
+)
+ON CONFLICT (key) DO NOTHING;

--- a/helm/vigil/files/database-init/16_llm_budgets.sql
+++ b/helm/vigil/files/database-init/16_llm_budgets.sql
@@ -7,11 +7,12 @@
 -- `virtual_key_id` column lands now to future-proof per-tenant attribution
 -- once tenancy ships (#165).
 
-ALTER TABLE llm_interaction_logs
-    ADD COLUMN IF NOT EXISTS virtual_key_id VARCHAR(64);
-
-CREATE INDEX IF NOT EXISTS idx_llm_interaction_vk
-    ON llm_interaction_logs (virtual_key_id, created_at);
+-- NOTE: the `virtual_key_id` column and `idx_llm_interaction_vk` index on
+-- `llm_interaction_logs` are declared on the ORM model
+-- (`database/models.py` `LLMInteractionLog`) and materialized by
+-- SQLAlchemy's create_all() at backend startup — not here. See
+-- `15_federation.sql` for the long explanation of why init-time ALTER
+-- against an ORM-owned table breaks docker-compose's first-boot.
 
 -- Seed the single bifrost.virtual_keys settings row. Empty default_vk
 -- means "no enforcement yet" — Bifrost will accept calls without

--- a/helm/vigil/files/database-init/README.md
+++ b/helm/vigil/files/database-init/README.md
@@ -13,4 +13,9 @@ When a new init SQL file lands under `database/init/`:
 3. Verify `helm template` produces a Job script that sources it.
 
 CI check `.github/workflows/helm-chart.yml` will fail if these copies drift
-from the source-of-truth files under `database/init/`.
+from the source-of-truth files under `database/init/`. Note: that check only
+catches directory drift — if you forget step 2 (`values.yaml`), the chart
+deploys without your schema change and the failure is silent.
+
+See also: [`database/init/README.md`](../../../../database/init/README.md)
+for the same convention from the source side.

--- a/helm/vigil/files/database-init/README.md
+++ b/helm/vigil/files/database-init/README.md
@@ -7,15 +7,32 @@ to live here for the `db-init` Job's ConfigMap to pick it up.
 When a new init SQL file lands under `database/init/`:
 
 1. Copy it here: `cp database/init/NEWFILE.sql helm/vigil/files/database-init/`
-2. Add its filename to `values.yaml` under `dbInit.sqlFiles` **in the correct
-   execution order** — the ordering is authoritative, not the filename prefix
-   (the `003_` collision in the source is a hazard).
-3. Verify `helm template` produces a Job script that sources it.
+2. Add its filename to `values.yaml` under `dbInit.sqlFiles` **in the order
+   it should execute** — for the chart path, the list order is authoritative
+   and filename prefixes are decorative (this differs from the docker-compose
+   path, which runs files lexicographically). Don't pick a filename that
+   collides with the reserved-filenames list documented in the source-side
+   README.
+3. Verify with `helm template ... | grep -E '^[[:space:]]*apply "NEWFILE\.sql"'`
+   that the rendered Job script applies your file. A bare `grep NEWFILE.sql`
+   gives false positives — the ConfigMap key and the SQL file's own header
+   comment both match — so use the tighter pattern.
 
-CI check `.github/workflows/helm-chart.yml` will fail if these copies drift
-from the source-of-truth files under `database/init/`. Note: that check only
-catches directory drift — if you forget step 2 (`values.yaml`), the chart
-deploys without your schema change and the failure is silent.
+Two failure modes to know about:
+
+- **Filename listed in `dbInit.sqlFiles` but missing from this directory**
+  (e.g. ghost entries from a values.yaml typo or a `cp` that never ran):
+  the `db-init` Job's `apply()` function **hard-fails** the install/upgrade
+  with a clear error. Loud, immediate, easy to fix.
+- **File present in this directory but missing from `dbInit.sqlFiles`**
+  (e.g. step 1 done, step 2 forgotten): silent on `helm install` —
+  the file ships in the ConfigMap but the Job never applies it. The
+  verification grep in step 3 is the only check that catches this.
+
+The CI check at `.github/workflows/helm-chart.yml` runs
+`diff -r database/init helm/vigil/files/database-init` and fails on
+directory drift between the source and the bundle, but doesn't check
+either against `dbInit.sqlFiles`.
 
 See also: [`database/init/README.md`](../../../../database/init/README.md)
 for the same convention from the source side.

--- a/helm/vigil/files/database-init/README.md
+++ b/helm/vigil/files/database-init/README.md
@@ -21,9 +21,13 @@ When a new init SQL file lands under `database/init/`:
 Two failure modes to know about:
 
 - **Filename listed in `dbInit.sqlFiles` but missing from this directory**
-  (e.g. ghost entries from a values.yaml typo or a `cp` that never ran):
-  the `db-init` Job's `apply()` function **hard-fails** the install/upgrade
-  with a clear error. Loud, immediate, easy to fix.
+  (e.g. a values.yaml typo or a `cp` that never ran): the `db-init` Job's
+  `apply()` function **hard-fails** the install/upgrade with a clear error
+  — *unless* the filename already has a row in `_vigil_schema_versions`,
+  in which case it's SKIPped as already-applied (so existing v0.1.x
+  upgrades don't trip on the historical `003_*` ghost rows). Loud and
+  immediate for genuinely new drift; quietly idempotent for the legacy
+  ghost-row case.
 - **File present in this directory but missing from `dbInit.sqlFiles`**
   (e.g. step 1 done, step 2 forgotten): silent on `helm install` —
   the file ships in the ConfigMap but the Job never applies it. The

--- a/helm/vigil/templates/db-init-job.yaml
+++ b/helm/vigil/templates/db-init-job.yaml
@@ -78,26 +78,44 @@ spec:
               # works on upgrade.
               apply() {
                 local f="$1"
-                # Fail loudly if values.yaml's dbInit.sqlFiles lists a file
-                # that isn't in the chart bundle. The previous behavior
-                # (silently log "applied with warnings" and still INSERT
-                # into _vigil_schema_versions) is what produced the
-                # historical ghost rows for the phantom
+                # Marker-table check goes FIRST so already-applied filenames
+                # short-circuit before the file-existence check below.
+                #
+                # This ordering matters for `helm upgrade --reuse-values`
+                # from v0.1.x: those deployments have ghost rows in
+                # _vigil_schema_versions for the phantom
                 # 003_add_ai_enrichment.sql / 003_ai_decision_logs.sql
-                # entries — see database/init/README.md for the long
-                # story and the reserved-filenames warning.
+                # entries from the original values.yaml drift. Helm
+                # `--reuse-values` reuses the previous release's coalesced
+                # values regardless of the new chart's defaults, so those
+                # ghost entries persist in dbInit.sqlFiles on first upgrade
+                # — and we want them to SKIP cleanly via the marker rather
+                # than hard-fail at the file check. The marker says "the
+                # cluster already accepted these as applied," which is
+                # exactly the contract upgrade-time idempotency relies on.
+                # See database/init/README.md for the reserved-filenames
+                # warning that prevents these names being reused.
+                local marker
+                marker=$(psql -tA -c "SELECT 1 FROM _vigil_schema_versions WHERE filename='$f' LIMIT 1" || true)
+                if [ "$marker" = "1" ]; then
+                  echo "SKIP $f (already applied)"
+                  return 0
+                fi
+                # File-existence check only fires for entries that have
+                # NOT been recorded as applied. Genuinely new drift (a
+                # filename added to dbInit.sqlFiles without being copied
+                # into the chart bundle) still hard-fails loudly. The
+                # previous behavior — silently logging "applied with
+                # warnings" + INSERTing into _vigil_schema_versions — is
+                # what produced the historical ghost rows in the first
+                # place; refusing to extend the bug is the whole point of
+                # this guard.
                 if [ ! -f "/sql/$f" ]; then
                   echo "ERROR: $f is listed in dbInit.sqlFiles but not present in the chart bundle." >&2
                   echo "  helm/vigil/values.yaml dbInit.sqlFiles has likely drifted from" >&2
                   echo "  helm/vigil/files/database-init/. Either copy the file into the" >&2
                   echo "  bundle or remove the entry from values.yaml." >&2
                   return 1
-                fi
-                local marker
-                marker=$(psql -tA -c "SELECT 1 FROM _vigil_schema_versions WHERE filename='$f' LIMIT 1" || true)
-                if [ "$marker" = "1" ]; then
-                  echo "SKIP $f (already applied)"
-                  return 0
                 fi
                 echo "APPLY $f"
                 if psql -f "/sql/$f"; then

--- a/helm/vigil/templates/db-init-job.yaml
+++ b/helm/vigil/templates/db-init-job.yaml
@@ -78,6 +78,21 @@ spec:
               # works on upgrade.
               apply() {
                 local f="$1"
+                # Fail loudly if values.yaml's dbInit.sqlFiles lists a file
+                # that isn't in the chart bundle. The previous behavior
+                # (silently log "applied with warnings" and still INSERT
+                # into _vigil_schema_versions) is what produced the
+                # historical ghost rows for the phantom
+                # 003_add_ai_enrichment.sql / 003_ai_decision_logs.sql
+                # entries — see database/init/README.md for the long
+                # story and the reserved-filenames warning.
+                if [ ! -f "/sql/$f" ]; then
+                  echo "ERROR: $f is listed in dbInit.sqlFiles but not present in the chart bundle." >&2
+                  echo "  helm/vigil/values.yaml dbInit.sqlFiles has likely drifted from" >&2
+                  echo "  helm/vigil/files/database-init/. Either copy the file into the" >&2
+                  echo "  bundle or remove the entry from values.yaml." >&2
+                  return 1
+                fi
                 local marker
                 marker=$(psql -tA -c "SELECT 1 FROM _vigil_schema_versions WHERE filename='$f' LIMIT 1" || true)
                 if [ "$marker" = "1" ]; then

--- a/helm/vigil/values.yaml
+++ b/helm/vigil/values.yaml
@@ -295,8 +295,6 @@ dbInit:
   # Update this list when new init SQL lands.
   sqlFiles:
     - 01_init_schema.sql
-    - 003_add_ai_enrichment.sql
-    - 003_ai_decision_logs.sql
     - 04_config_tables.sql
     - 05_case_management_extended.sql
     - 06_auth_tables.sql
@@ -304,6 +302,10 @@ dbInit:
     - 07_skills.sql
     - 08_custom_workflows.sql
     - 09_llm_providers.sql
+    - 10_ai_model_configs.sql
+    - 11_custom_agent_component_category.sql
+    - 12_workflow_runs.sql
+    - 13_approval_actions.sql
     - 14_threat_indicators.sql
     - 15_federation.sql
     - 16_llm_budgets.sql

--- a/helm/vigil/values.yaml
+++ b/helm/vigil/values.yaml
@@ -304,6 +304,9 @@ dbInit:
     - 07_skills.sql
     - 08_custom_workflows.sql
     - 09_llm_providers.sql
+    - 14_threat_indicators.sql
+    - 15_federation.sql
+    - 16_llm_budgets.sql
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
## Summary

Four targeted fixes to unblock the first automated release (v0.2.0)
after the release-please plumbing landed in #283.

- **fix(release):** lowercase the GHCR image name in `release.yml`.
  `${{ github.repository }}` preserves `Vigil-SOC` casing, and OCI/GHCR
  rejects mixed-case repo paths — this is what broke the v0.1.0 tag's
  `release.yml` run.
- **fix(release-please):** bump Helm chart `version` in lockstep with
  `appVersion`. Without this, the chart re-emits `vigil-0.1.0.tgz` on
  every release with different bytes — silent breakage for chart
  consumers. RELEASING.md updated to document the lockstep policy and
  the manual escape hatch.
- **fix(helm):** copy three SQL files into `helm/vigil/files/database-init/`
  that drifted in from `database/init/` across several prior PRs. The
  Helm Chart lint check has been failing on every PR that re-triggers
  it; this clears that.
- **docs:** add a `database/init/README.md` and cross-reference it from
  the chart-side README + CLAUDE.md, so future contributors (and
  Claude-assisted ones) see the three-step sync convention before they
  add an init SQL file.

## Why these are bundled

All four block the same thing — PR #287 / the first v0.2.0 release.
Each is small in isolation; opening four PRs would have been more
review overhead than the changes deserve.

## Follow-ups (not in this PR)

- **`values.yaml` `dbInit.sqlFiles` drift** — 2 ghost entries + 7
  missing entries (files 10–16). The chart deploys incomplete schema
  today. Separate issue.
- **Make Helm Chart lint a required status check** on `main` so future
  drift can't merge through (admin/settings, not code).
- **Auto-sync the chart bundle** via a pre-commit hook or `make` target
  so the manual three-step convention becomes one step.