### PR TITLE
fix(release-please): drop component prefix from tag names

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -9,6 +9,7 @@
   "packages": {
     ".": {
       "package-name": "vigil",
+      "include-component-in-tag": false,
       "version-file": "VERSION",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [


### PR DESCRIPTION
## Summary
One-line release-please config fix: add `"include-component-in-tag": false`
to drop the `vigil-` prefix from generated tag names. Affected pr commit description

## What the fix changes
| Component | Before fix | After fix |
|---|---|---|
| release-please expected tag | `vigil-v0.2.0` | `v0.2.0` |
| `release.yml` trigger | `v*.*.*` ✓ | `v*.*.*` ✓ |
| Existing `v0.1.0` tag | Not detected | Detected, anchors changelog |
