### PR TITLE
fix:helm-lint

### DIFF
--- a/helm/vigil/Chart.yaml
+++ b/helm/vigil/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vigil
 description: Vigil SOC — open-source, AI-native Security Operations Center
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/Vigil-SOC/vigil
 sources:

--- a/helm/vigil/Chart.yaml
+++ b/helm/vigil/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vigil
 description: Vigil SOC — open-source, AI-native Security Operations Center
 type: application
-version: 0.1.1
+version: 0.1.0
 appVersion: "0.1.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/Vigil-SOC/vigil


### PR DESCRIPTION
version fix to resolve release blocker
 
 ✖︎ vigil => (version: "0.1.1", path: "helm/vigil") > chart version not ok. Needs a version bump! 
------------------------------------------------------------------------------------------------------------------------ failed linting charts: failed processing charts