### PR TITLE
docs(release): adopt Conventional Commits + document Release-As trailer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,9 +73,11 @@ minor version bumps may include breaking changes to agent prompts, workflow
 schemas, and MCP integration interfaces. Patch bumps are always backward
 compatible. See [`RELEASING.md`](RELEASING.md) for the full release process.
 
-The Helm chart at `helm/vigil/` is versioned independently of the
-application — `appVersion` tracks the Vigil release; chart `version` bumps
-when the chart itself changes.
+The Helm chart at `helm/vigil/` has two version fields: `appVersion`
+(the Vigil release the chart deploys) and chart `version` (the chart
+packaging version). release-please bumps **both in lockstep** on every
+release. See [`RELEASING.md`](RELEASING.md) for the rationale and the
+escape hatch for chart-only changes between app releases.
 
 ## What to Work On
 
@@ -188,9 +190,6 @@ docs(workflows): clarify threat-hunt phase ordering
 chore(deps): bump fastapi to 0.110.0
 feat(agents)!: rename Triage agent prompt schema
 ```
-
-Don't sweat it if you forget — the format is a preference, not a gate. The
-only hard requirement is the DCO sign-off.
 
 ## Pull Request Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,16 +132,50 @@ New features should include tests. Place them in `tests/` following existing nam
 
 ### Commit Messages
 
-Write clear, descriptive commit messages. Format:
+We **prefer** [Conventional Commits](https://www.conventionalcommits.org/) so we
+can automate changelogs and version bumps as the project grows. It is not
+strictly enforced — if your commits don't match the format, a maintainer will
+adjust the squash-merge title before merging. The DCO sign-off
+(`git commit -s`), however, is required on every commit.
+
+The preferred format is:
 
 ```
-Short summary (50 chars or less)
+<type>(<optional scope>): <short summary>
 
-Longer description if needed. Explain what changed and why,
-not how (the code shows how). Wrap at 72 characters.
+<optional body explaining what and why>
 
 Signed-off-by: Your Name <your@email.com>
 ```
+
+**Common types:**
+
+- `feat:` — a new feature (triggers a minor version bump)
+- `fix:` — a bug fix (triggers a patch bump)
+- `docs:` — documentation only
+- `chore:` — tooling, build, dependency bumps
+- `refactor:` — code change that neither fixes a bug nor adds a feature
+- `test:` — adding or fixing tests
+- `perf:` — performance improvement
+
+**Common scopes for Vigil:** `agents`, `workflows`, `mcp`, `frontend`,
+`daemon`, `helm`, `api`, `db`.
+
+**Breaking changes:** add `!` after the type/scope (`feat!:`) or include
+`BREAKING CHANGE:` in the body.
+
+**Examples:**
+
+```
+feat(mcp): add SentinelOne integration
+fix(daemon): prevent double-processing of correlated alerts
+docs(workflows): clarify threat-hunt phase ordering
+chore(deps): bump fastapi to 0.110.0
+feat(agents)!: rename Triage agent prompt schema
+```
+
+Don't sweat it if you forget — the format is a preference, not a gate. The
+only hard requirement is the DCO sign-off.
 
 ## Pull Request Guidelines
 
@@ -150,6 +184,13 @@ Signed-off-by: Your Name <your@email.com>
 - Update relevant documentation
 - Reference related issues: "Closes #123" or "Part of #456"
 - Keep PRs reviewable — if a feature is large, break it into smaller PRs
+
+### Pull Request Titles
+
+Because we squash-merge PRs, the PR title becomes the commit message on
+`main`. Please title your PR using the same Conventional Commits format
+described above (e.g., `feat(mcp): add SentinelOne integration`). If you
+forget, a maintainer will adjust it before merging.
 
 ## Community
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,17 @@ git config user.name "Your Name"
 git config user.email "your@email.com"
 ```
 
+### Versioning and Releases
+
+Vigil follows [Semantic Versioning](https://semver.org/). While in `0.x`,
+minor version bumps may include breaking changes to agent prompts, workflow
+schemas, and MCP integration interfaces. Patch bumps are always backward
+compatible. See [`RELEASING.md`](RELEASING.md) for the full release process.
+
+The Helm chart at `helm/vigil/` is versioned independently of the
+application — `appVersion` tracks the Vigil release; chart `version` bumps
+when the chart itself changes.
+
 ## What to Work On
 
 ### Good First Issues
@@ -133,9 +144,13 @@ New features should include tests. Place them in `tests/` following existing nam
 ### Commit Messages
 
 We **prefer** [Conventional Commits](https://www.conventionalcommits.org/) so we
-can automate changelogs and version bumps as the project grows. It is not
-strictly enforced — if your commits don't match the format, a maintainer will
-adjust the squash-merge title before merging. The DCO sign-off
+can automate changelogs and version bumps via
+[release-please](https://github.com/googleapis/release-please) (see
+[`RELEASING.md`](RELEASING.md)). It is not strictly enforced at the
+per-commit level — if your individual commits don't match the format, please
+update your **PR title** to follow the convention before requesting review
+(since we squash-merge, the PR title becomes the commit on `main`). If you
+forget, a maintainer may adjust the title before merging. The DCO sign-off
 (`git commit -s`), however, is required on every commit.
 
 The preferred format is:
@@ -188,9 +203,12 @@ only hard requirement is the DCO sign-off.
 ### Pull Request Titles
 
 Because we squash-merge PRs, the PR title becomes the commit message on
-`main`. Please title your PR using the same Conventional Commits format
-described above (e.g., `feat(mcp): add SentinelOne integration`). If you
-forget, a maintainer will adjust it before merging.
+`main` — which is what `release-please` reads to decide version bumps and
+changelog entries. **Setting a Conventional Commits-style PR title is the
+author's responsibility** (e.g., `feat(mcp): add SentinelOne integration`).
+You can update the title at any point before merge by editing the PR. If
+you forget, a maintainer may adjust it before merging, but please don't
+rely on that.
 
 ## Community
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,6 +71,37 @@ automated.
 
 The only human decision per release is **when to merge the release PR**.
 
+## Forcing a specific version
+
+release-please normally picks the next version from Conventional Commit
+prefixes — highest bump wins (`feat:` → minor, `fix:` → patch, etc.).
+Sometimes you need to override that: to unstick a stalled release PR,
+to reserve a milestone version, or to skip a number on purpose. Push
+an empty commit to `main` with a `Release-As:` trailer:
+
+```bash
+git commit --allow-empty \
+  -m "chore: release 0.1.2" \
+  -m "Release-As: 0.1.2"
+git push origin main
+```
+
+The next release-please run reads the trailer and forces the release
+PR to use that exact version, regardless of what the Conventional
+Commits in the window would otherwise compute. The override is
+one-shot — subsequent merged commits go back to normal accounting.
+
+A common reason to reach for this: `ct lint` is blocking the release
+PR because the chart `version` field "didn't bump" — release-please
+computed the same patch number that's already on disk (e.g. after a
+manual chart-version bump in an earlier PR). Forcing the next patch
+gives the chart-testing job a real diff to validate and unblocks the
+release.
+
+The opposite trailer also exists: `Release-As: skip` tells
+release-please to ignore the commit entirely — useful for `chore:` or
+similar commits you don't want appearing in any release's changelog.
+
 ## Chart Version vs appVersion
 
 The Helm chart has two version fields:


### PR DESCRIPTION
## Summary

Two release-process doc additions for `release-please`:

- **`CONTRIBUTING.md`** — adopt Conventional Commits as the preferred
  PR title format (soft, not enforced). Adds a "Versioning and
  Releases" subsection pointing at `RELEASING.md`, a rewritten
  "Commit Messages" section with types/scopes/examples, and an
  explicit "Pull Request Titles" subsection making author
  responsibility clear (since we squash-merge, PR title = commit on
  main = what release-please reads for version bumps).

- **`RELEASING.md`** — document the `Release-As: X.Y.Z` trailer that
  forces release-please's next version, regardless of Conventional
  Commit accounting. Also documents the inverse `Release-As: skip` for excluding commits