### PR TITLE
fix(release): check out submodules during image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -136,6 +138,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Compute image name (lowercase)
         id: image


### PR DESCRIPTION
## Summary

`release.yml`'s checkout step didn't fetch git submodules, so when the
v0.1.2 tag fired off the Docker build it saw an empty `./mempalace`
directory. `requirements.txt` has `-e ./mempalace` (mempalace is a
first-class component per #129), and pip errored:
ERROR: ./mempalace is not a valid editable requirement.

Add `submodules: true` to both checkout steps in `release.yml`
(`build-production-images` and `deploy-production`). Matches the
pattern `ci-cd.yml` already uses on its Python jobs.
## Why this only surfaced now
Image builds in `ci-cd.yml` already fetch submodules correctly. The
release-time build in `release.yml` had this latent bug since
mempalace landed, but never fired in anger — earlier release.yml runs
failed on the GHCR casing/v-prefix bugs before they reached the build
step. Now that those are fixed and v0.1.2 actually tried to build,
this surfaced.