### PR TITLE
fix(docker): copy mempalace into image before pip install

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -36,11 +36,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements + editable-install sources first for better caching.
-# requirements.txt references `-e ./deeptempo-core` and `-e ./mcp-servers`,
-# so those directories must exist at pip-install time.
+# Every `-e ./<dir>` line in requirements.txt needs its source tree
+# present at pip-install time. Keep this COPY list in sync with the
+# editable entries in requirements.txt — currently:
+#   - deeptempo-core
+#   - mcp-servers
+#   - mempalace
 COPY requirements.txt .
 COPY deeptempo-core/ ./deeptempo-core/
 COPY mcp-servers/ ./mcp-servers/
+COPY mempalace/ ./mempalace/
 
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt

--- a/docker/Dockerfile.daemon
+++ b/docker/Dockerfile.daemon
@@ -13,11 +13,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements + editable-install sources first for better caching.
-# requirements.txt references `-e ./deeptempo-core` and `-e ./mcp-servers`,
-# so those directories must exist at pip-install time.
+# Every `-e ./<dir>` line in requirements.txt needs its source tree
+# present at pip-install time. Keep this COPY list in sync with the
+# editable entries in requirements.txt — currently:
+#   - deeptempo-core
+#   - mcp-servers
+#   - mempalace
 COPY requirements.txt .
 COPY deeptempo-core/ ./deeptempo-core/
 COPY mcp-servers/ ./mcp-servers/
+COPY mempalace/ ./mempalace/
 
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Summary

Fix the v0.2.0 release.yml run that's been failing at the Docker build step.

`requirements.txt` has had `-e ./mempalace` since #129 (mempalace
promoted to first-class component), but `Dockerfile.backend` and
`Dockerfile.daemon` only `COPY` `deeptempo-core/` and `mcp-servers/`
before the pip install — mempalace was never added. pip can't resolve
the editable path → image build aborts.
ERROR: ./mempalace is not a valid editable requirement.

This is the **second** layer of the same root issue:
- #303 added `submodules: true` to release.yml's checkout (fetches the
  submodule from git)
- This PR adds the matching `COPY mempalace/` to both Dockerfiles
  (gets the directory into the build context before pip install)
Both fixes are needed; submodule checkout alone wasn't enough.
## What changed
- `docker/Dockerfile.backend` — `COPY mempalace/ ./mempalace/` before
  the `pip install` step
- `docker/Dockerfile.daemon` — same fix
- Comment in both files rewritten from naming individual submodules
  ("deeptempo-core and mcp-servers") to a maintainable rule ("keep in
  sync with editable entries in requirements.txt") so the next
  submodule addition doesn't repeat this exact bug
  
## Why this only surfaces now
Nobody had run `docker build` end-to-end against this Dockerfile since
mempalace landed — local dev uses `./start_web.sh` which bypasses the
Dockerfile, and `ci-cd.yml`'s `Build Docker Images` job has been
failing on this same issue but wasn't a required status check, so the
red X was advisory. v0.2.0 fired `release.yml` for the first time in
anger, surfacing the gap.