### PR TITLE
fix(api): move unauthenticated VStrike routes to authenticated_router

### DIFF
--- a/backend/api/vstrike.py
+++ b/backend/api/vstrike.py
@@ -675,7 +675,7 @@ class VStrikeNetworkGraphRequest(_PassthroughModel):
     network_id: Optional[str] = None
 
 
-@router.post("/network-graph")
+@authenticated_router.post("/network-graph")
 async def network_graph(request: VStrikeNetworkGraphRequest) -> dict:
     """Fetch the active network graph: {label, nodes, edges, bbox}."""
     service = _ui_service_or_503()
@@ -697,7 +697,7 @@ class VStrikeLegendApplyRequest(_PassthroughModel):
     network_id: Optional[str] = None
 
 
-@router.post("/ui/legend-apply")
+@authenticated_router.post("/ui/legend-apply")
 async def ui_legend_apply(request: VStrikeLegendApplyRequest) -> dict:
     """Apply a legend run inside the active VStrike iframe session."""
     service = _ui_service_or_503()
@@ -725,7 +725,7 @@ class VStrikeRightpanelFocusRequest(_PassthroughModel):
     """
 
 
-@router.post("/ui/rightpanel-focus")
+@authenticated_router.post("/ui/rightpanel-focus")
 async def ui_rightpanel_focus(
     request: VStrikeRightpanelFocusRequest = VStrikeRightpanelFocusRequest(),
 ) -> dict:

--- a/tests/security/test_unauth_endpoints.py
+++ b/tests/security/test_unauth_endpoints.py
@@ -123,6 +123,10 @@ PROTECTED_ROUTES = [
     ("GET", "/api/integrations/vstrike/ui/networks", None),
     ("POST", "/api/integrations/vstrike/ui/iframe-token", None),
     ("GET", "/api/integrations/vstrike/topology/asset/test-asset", None),
+    # Routes that were on bare `router` (no auth) — fixed in issue #286.
+    ("POST", "/api/integrations/vstrike/network-graph", {"network_id": "test"}),
+    ("POST", "/api/integrations/vstrike/ui/legend-apply", {"legend_run_id": "test"}),
+    ("POST", "/api/integrations/vstrike/ui/rightpanel-focus", None),
 ]
 
 


### PR DESCRIPTION
POST /network-graph, POST /ui/legend-apply, and POST /ui/rightpanel-focus were registered on the bare `router` (no session auth) instead of `authenticated_router`. Any unauthenticated caller could reach these endpoints and trigger VStrike UI-state changes or graph data exfiltration.

Moves all three decorators to `authenticated_router`, which carries `Depends(get_current_active_user)`, matching the auth posture of every other VStrike management/UI route.

Also adds the three routes to PROTECTED_ROUTES in
tests/security/test_unauth_endpoints.py so CI enforces the auth gate going forward.

Closes #286