### PR TITLE
Fix(backend): auth basics secure

### DIFF
--- a/backend/api/ai_config.py
+++ b/backend/api/ai_config.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-from database.connection import get_db_session  # noqa: E402
+from database.connection import get_db, get_db_session
 from database.models import AIModelConfig, LLMProviderConfig  # noqa: E402
 from services.model_registry import (  # noqa: E402
     COMPONENTS,
@@ -81,7 +81,7 @@ class ModelsListResponse(BaseModel):
 
 
 @router.get("/config", response_model=AIConfigResponse)
-def get_ai_config(db: Session = Depends(get_db_session)):
+def get_ai_config(db: Session = Depends(get_db)):
     rows = db.query(AIModelConfig).all()
     assignments = {
         r.component: ComponentAssignmentResponse(
@@ -101,7 +101,7 @@ def get_ai_config(db: Session = Depends(get_db_session)):
 def set_component_assignment(
     component: str,
     payload: ComponentAssignmentUpdate,
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
 ):
     if not is_valid_component(component):
         raise HTTPException(status_code=400, detail=f"unknown component: {component}")
@@ -145,7 +145,7 @@ def set_component_assignment(
 
 
 @router.delete("/config/{component}")
-def clear_component_assignment(component: str, db: Session = Depends(get_db_session)):
+def clear_component_assignment(component: str, db: Session = Depends(get_db)):
     if not is_valid_component(component):
         raise HTTPException(status_code=400, detail=f"unknown component: {component}")
     row = db.get(AIModelConfig, component)

--- a/backend/api/analytics.py
+++ b/backend/api/analytics.py
@@ -19,7 +19,7 @@ from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
 from database.models import Finding, Case, CaseClosureInfo, LLMInteractionLog
-from database.connection import get_db_session
+from database.connection import get_db, get_db_session
 from backend.services.ai_insights_service import AIInsightsService
 from services.mitre_lookup import get_time_range, resolve_technique  # noqa: F401
 
@@ -32,7 +32,7 @@ ai_insights_service = AIInsightsService()
 @router.get("/analytics")
 async def get_analytics(
     time_range: str = Query("7d", regex="^(24h|7d|30d|all)$"),
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """
     Get comprehensive analytics data for the specified time range.
@@ -120,7 +120,7 @@ async def _collect_insights_inputs(
 @router.get("/analytics/insights")
 async def get_analytics_insights(
     time_range: str = Query("7d", pattern="^(24h|7d|30d|all)$"),
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Return cached AI insights for the given time_range.
 
@@ -156,7 +156,7 @@ async def get_analytics_insights(
 @router.post("/analytics/insights/refresh")
 async def refresh_analytics_insights(
     time_range: str = Query("7d", pattern="^(24h|7d|30d|all)$"),
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Force a background regeneration of insights for the given time_range.
 
@@ -734,7 +734,7 @@ async def get_mitre_technique_distribution(
 @router.get("/analytics/cost")
 async def get_cost_analytics(
     time_range: str = Query("7d", pattern="^(24h|7d|30d|all)$"),
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Return LLM cost + token breakdown for the given window.
 

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -41,7 +41,7 @@ from backend.services.token_blacklist import (
 from backend.middleware.auth import get_current_user, get_current_active_user
 from backend.middleware.rate_limit import limiter
 from database.models import User
-from database.connection import get_db_session
+from database.connection import get_db, get_db_session
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +132,7 @@ async def login(
     request: Request,
     response: Response,
     payload: LoginRequest,
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Authenticate user and issue tokens.
@@ -263,6 +263,29 @@ async def logout(
                         exc,
                     )
 
+    # Blacklist the refresh token JTI too so a captured copy cannot be
+    # used to mint new access tokens after logout.
+    raw_refresh: Optional[str] = request.cookies.get(REFRESH_COOKIE_NAME)
+    if raw_refresh:
+        refresh_payload = AuthService.verify_jwt_token(raw_refresh)
+        if refresh_payload:
+            refresh_jti = refresh_payload.get("jti")
+            refresh_exp_ts = refresh_payload.get("exp")
+            refresh_exp_dt = (
+                datetime.utcfromtimestamp(refresh_exp_ts)
+                if refresh_exp_ts is not None
+                else None
+            )
+            if refresh_jti:
+                try:
+                    await blacklist_jti(refresh_jti, refresh_exp_dt)
+                except Exception as exc:
+                    logger.error(
+                        "Failed to blacklist refresh token for %s: %s",
+                        current_user.username,
+                        exc,
+                    )
+
     clear_auth_cookies(response)
 
     logger.info(f"User logged out: {current_user.username}")
@@ -275,7 +298,7 @@ async def refresh_token(
     request: Request,
     response: Response,
     body: Optional[RefreshTokenRequest] = None,
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Refresh access token using refresh token.
@@ -346,22 +369,23 @@ async def refresh_token(
 
 
 @router.get("/me")
-async def get_current_user_info(current_user: User = Depends(get_current_active_user)):
+async def get_current_user_info(
+    current_user: User = Depends(get_current_active_user),
+    session: Session = Depends(get_db),
+):
     """
     Get current user information.
-    
+
     Args:
         current_user: Current authenticated user
-    
+        session: Database session
+
     Returns:
         User information with permissions
     """
     user_dict = current_user.to_dict()
-    
-    # Add permissions
-    permissions = AuthService.get_user_permissions(current_user.user_id)
+    permissions = AuthService.get_user_permissions(current_user.user_id, session)
     user_dict["permissions"] = permissions
-    
     return user_dict
 
 
@@ -370,7 +394,7 @@ async def update_current_user(
     full_name: Optional[str] = None,
     email: Optional[EmailStr] = None,
     current_user: User = Depends(get_current_active_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Update current user profile.
@@ -385,31 +409,43 @@ async def update_current_user(
         Updated user information
     """
     try:
+        email_changed = False
         if full_name:
             current_user.full_name = full_name
-        
+
         if email:
             # Check if email is already taken
             existing = session.query(User).filter(
                 User.email == email,
                 User.user_id != current_user.user_id
             ).first()
-            
+
             if existing:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Email already in use"
                 )
-            
+
             current_user.email = email
-            current_user.is_verified = False  # Require re-verification
-        
+            current_user.is_verified = False
+            email_changed = True
+
         session.commit()
         session.refresh(current_user)
-        
+
+        if email_changed:
+            try:
+                await revoke_all_for_user(current_user.user_id)
+            except Exception as exc:
+                logger.error(
+                    "Email changed for %s but revoke_all_for_user failed: %s",
+                    current_user.username,
+                    exc,
+                )
+
         logger.info(f"User profile updated: {current_user.username}")
         return current_user.to_dict()
-    
+
     except HTTPException:
         raise
     except Exception as e:
@@ -425,9 +461,10 @@ async def update_current_user(
 @limiter.limit("5/minute")
 async def change_password(
     request: Request,
+    response: Response,
     body: ChangePasswordRequest,
     current_user: User = Depends(get_current_active_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Change user password.
@@ -474,8 +511,9 @@ async def change_password(
                 exc,
             )
 
+        clear_auth_cookies(response)
         logger.info(f"Password changed for user: {current_user.username}")
-        return {"message": "Password changed successfully"}
+        return {"message": "Password changed successfully. Please log in again."}
     
     except Exception as e:
         logger.error(f"Password change error: {e}")
@@ -489,7 +527,7 @@ async def change_password(
 @router.post("/mfa/setup", response_model=MFASetupResponse)
 async def setup_mfa(
     current_user: User = Depends(get_current_active_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Setup MFA for current user.
@@ -522,7 +560,7 @@ async def setup_mfa(
 async def verify_mfa(
     request: MFAVerifyRequest,
     current_user: User = Depends(get_current_active_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Verify MFA code and enable MFA.
@@ -549,7 +587,7 @@ async def verify_mfa(
 @router.delete("/mfa")
 async def disable_mfa(
     current_user: User = Depends(get_current_active_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Disable MFA for current user.
@@ -588,7 +626,7 @@ async def disable_mfa(
 async def password_reset_request(
     request: Request,
     body: PasswordResetRequest,
-    session: Session = Depends(get_db_session),
+    session: Session = Depends(get_db),
 ):
     """
     Begin a password reset. Always returns 200 regardless of whether the
@@ -640,7 +678,7 @@ async def password_reset_request(
 async def password_reset_confirm(
     request: Request,
     body: PasswordResetConfirm,
-    session: Session = Depends(get_db_session),
+    session: Session = Depends(get_db),
 ):
     """
     Complete a password reset. Validates the signed token, enforces the

--- a/backend/api/jira_export.py
+++ b/backend/api/jira_export.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 from backend.middleware.auth import get_current_user
 from backend.services.auth_service import AuthService
 from database.models import User, Case, Finding
-from database.connection import get_db_session
+from database.connection import get_db, get_db_session
 from core.config import get_integration_config
 import requests
 
@@ -50,7 +50,7 @@ async def export_case_to_jira(
     case_id: str,
     request: JiraExportRequest,
     current_user: User = Depends(get_current_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Export a case to JIRA as a ticket with findings as subtasks.
@@ -216,7 +216,7 @@ async def export_remediation_to_jira(
     case_id: str,
     request: JiraRemediationExportRequest,
     current_user: User = Depends(get_current_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Export remediation steps to JIRA as subtasks.

--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -25,7 +25,7 @@ from secrets_manager import delete_secret, get_secret, set_secret
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from backend.middleware.auth import get_current_active_user
 from backend.services.auth_service import AuthService
-from database.connection import get_db_session
+from database.connection import get_db, get_db_session
 from database.models import LLMProviderConfig, User
 from services.bifrost_admin import push_provider_key
 from services.url_safety import UrlSafetyError, validate_provider_url
@@ -195,7 +195,7 @@ def _schedule_catalog_resync(reason: str) -> None:
 @router.get("", response_model=List[LLMProviderResponse])
 @router.get("/", response_model=List[LLMProviderResponse])
 async def list_providers(
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
     rows = db.query(LLMProviderConfig).order_by(LLMProviderConfig.created_at).all()
@@ -206,7 +206,7 @@ async def list_providers(
 @router.post("/", response_model=LLMProviderResponse, status_code=201)
 async def create_provider(
     payload: LLMProviderCreate,
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
     _require_settings_admin(current_user)
@@ -254,7 +254,7 @@ async def create_provider(
 async def update_provider(
     provider_id: str,
     payload: LLMProviderUpdate,
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
     _require_settings_admin(current_user)
@@ -304,7 +304,7 @@ async def update_provider(
 @router.delete("/{provider_id}")
 async def delete_provider(
     provider_id: str,
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
     _require_settings_admin(current_user)
@@ -329,7 +329,7 @@ async def delete_provider(
 @router.post("/{provider_id}/set-default", response_model=LLMProviderResponse)
 async def set_default_provider(
     provider_id: str,
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
     _require_settings_admin(current_user)
@@ -352,7 +352,7 @@ async def _resolve_api_key(row: LLMProviderConfig) -> Optional[str]:
 @router.post("/{provider_id}/test")
 async def test_provider(
     provider_id: str,
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
     _require_settings_admin(current_user)
@@ -542,7 +542,7 @@ async def discover_models(
 @router.get("/{provider_id}/models")
 async def list_models(
     provider_id: str,
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
     row = db.get(LLMProviderConfig, provider_id)
@@ -564,7 +564,7 @@ async def list_models(
 @router.post("/{provider_id}/refresh-models")
 async def refresh_provider_models(
     provider_id: str,
-    db: Session = Depends(get_db_session),
+    db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
     """Force a live rediscovery for one provider and push the union of

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -12,8 +12,10 @@ from sqlalchemy.orm import Session
 
 from backend.services.auth_service import AuthService
 from backend.middleware.auth import get_current_user
+from backend.services.password_validator import PasswordPolicyError, validate_password_strength
+from backend.services.token_blacklist import revoke_all_for_user
 from database.models import User, Role
-from database.connection import get_db_session
+from database.connection import get_db, get_db_session
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +45,19 @@ class ChangeUserRoleRequest(BaseModel):
     role_id: str
 
 
+def _can_assign_role(current_user: User, target_role: Role, session: Session) -> bool:
+    """Return True only if current_user holds every permission granted by target_role.
+
+    Prevents a user with users.write from assigning a role that grants
+    more privileges than they themselves have.
+    """
+    current_perms = AuthService.get_user_permissions(current_user.user_id, session)
+    for perm, granted in (target_role.permissions or {}).items():
+        if granted and not current_perms.get(perm, False):
+            return False
+    return True
+
+
 @router.get("/")
 async def list_users(
     skip: int = Query(0, ge=0),
@@ -51,7 +66,7 @@ async def list_users(
     is_active: Optional[bool] = None,
     search: Optional[str] = None,
     current_user: User = Depends(get_current_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     List all users (requires users.read permission).
@@ -118,7 +133,7 @@ async def list_users(
 async def get_user(
     user_id: str,
     current_user: User = Depends(get_current_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Get user by ID (requires users.read permission).
@@ -163,7 +178,7 @@ async def get_user(
 async def create_user(
     request: CreateUserRequest,
     current_user: User = Depends(get_current_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Create a new user (requires users.write permission).
@@ -183,19 +198,27 @@ async def create_user(
             detail="Permission denied: users.write required"
         )
     
-    # Validate password
-    if len(request.password) < 8:
+    # Validate password against the full strength policy
+    try:
+        validate_password_strength(request.password)
+    except PasswordPolicyError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Password must be at least 8 characters"
+            detail=str(exc),
         )
-    
+
     # Verify role exists
     role = session.query(Role).filter(Role.role_id == request.role_id).first()
     if not role:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid role ID"
+        )
+
+    if not _can_assign_role(current_user, role, session):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot assign a role with more privileges than your own",
         )
     
     # Create user
@@ -223,7 +246,7 @@ async def update_user(
     user_id: str,
     request: UpdateUserRequest,
     current_user: User = Depends(get_current_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Update user information (requires users.write permission).
@@ -254,25 +277,27 @@ async def update_user(
     
     try:
         # Update fields
+        email_changed = False
         if request.full_name is not None:
             user.full_name = request.full_name
-        
+
         if request.email is not None:
             # Check if email is already taken
             existing = session.query(User).filter(
                 User.email == request.email,
                 User.user_id != user_id
             ).first()
-            
+
             if existing:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Email already in use"
                 )
-            
+
             user.email = request.email
             user.is_verified = False
-        
+            email_changed = True
+
         if request.role_id is not None:
             # Verify role exists
             role = session.query(Role).filter(Role.role_id == request.role_id).first()
@@ -281,17 +306,32 @@ async def update_user(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Invalid role ID"
                 )
+            if not _can_assign_role(current_user, role, session):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Cannot assign a role with more privileges than your own",
+                )
             user.role_id = request.role_id
-        
+
         if request.is_active is not None:
             user.is_active = request.is_active
-        
+
         session.commit()
         session.refresh(user)
-        
+
+        if email_changed:
+            try:
+                await revoke_all_for_user(user.user_id)
+            except Exception as exc:
+                logger.error(
+                    "Email changed for %s but revoke_all_for_user failed: %s",
+                    user.username,
+                    exc,
+                )
+
         logger.info(f"User updated by {current_user.username}: {user.username}")
         return user.to_dict()
-    
+
     except HTTPException:
         raise
     except Exception as e:
@@ -307,7 +347,7 @@ async def update_user(
 async def delete_user(
     user_id: str,
     current_user: User = Depends(get_current_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Delete a user (requires users.delete permission).
@@ -364,7 +404,7 @@ async def change_user_role(
     user_id: str,
     request: ChangeUserRoleRequest,
     current_user: User = Depends(get_current_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     Change user role (requires users.write permission).
@@ -400,7 +440,13 @@ async def change_user_role(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid role ID"
         )
-    
+
+    if not _can_assign_role(current_user, role, session):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot assign a role with more privileges than your own",
+        )
+
     try:
         old_role_id = user.role_id
         user.role_id = request.role_id
@@ -436,18 +482,23 @@ async def change_user_role(
 @router.get("/roles/list")
 async def list_roles(
     current_user: User = Depends(get_current_user),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ):
     """
     List all available roles.
-    
+
     Args:
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         List of roles
     """
+    if not AuthService.check_permission(current_user.user_id, "users.read"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permission denied: users.read required",
+        )
     try:
         roles = session.query(Role).all()
         return {

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -16,7 +16,7 @@ from backend.services.auth_cookies import ACCESS_COOKIE_NAME
 from backend.services.auth_service import AuthService
 from backend.services.token_blacklist import is_token_revoked
 from database.models import User
-from database.connection import get_db_session
+from database.connection import get_db, get_db_session
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ def _get_dev_user(session: Session) -> User:
 async def get_current_user(
     request: Request,
     authorization: Optional[str] = Header(None),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ) -> User:
     """
     Resolve the authenticated user from either the access_token HttpOnly
@@ -285,7 +285,7 @@ def require_role(role_name: str):
     """
     def decorator(func: Callable):
         @wraps(func)
-        async def wrapper(*args, current_user: User = Depends(get_current_user), session: Session = Depends(get_db_session), **kwargs):
+        async def wrapper(*args, current_user: User = Depends(get_current_user), session: Session = Depends(get_db), **kwargs):
             from database.models import Role
             
             # Get user's role
@@ -307,7 +307,7 @@ def require_role(role_name: str):
 async def get_optional_user(
     request: Request,
     authorization: Optional[str] = Header(None),
-    session: Session = Depends(get_db_session)
+    session: Session = Depends(get_db)
 ) -> Optional[User]:
     """
     Dependency to optionally get the current user.

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -209,11 +209,11 @@ class AuthService:
             ).first()
 
             if not user:
-                logger.warning(f"User not found: {username_or_email}")
+                logger.warning("Login attempt for unknown identifier")
                 return None
 
             if not user.is_active:
-                logger.warning(f"User is inactive: {username_or_email}")
+                logger.warning("Login attempt for inactive account: %s", user.username)
                 return None
 
             # Reject while locked. Lockout is authoritative even over a correct
@@ -222,8 +222,9 @@ class AuthService:
             now = datetime.utcnow()
             if user.locked_until and user.locked_until > now:
                 logger.warning(
-                    f"Login rejected, account locked: {username_or_email} "
-                    f"until {user.locked_until.isoformat()}"
+                    "Login rejected, account locked: %s until %s",
+                    user.username,
+                    user.locked_until.isoformat(),
                 )
                 raise AccountLockedError(user.locked_until)
 
@@ -233,11 +234,12 @@ class AuthService:
                 if user.failed_login_count >= LOCKOUT_THRESHOLD:
                     user.locked_until = now + timedelta(minutes=LOCKOUT_DURATION_MINUTES)
                     logger.warning(
-                        f"Account locked after {user.failed_login_count} failed "
-                        f"attempts: {username_or_email}"
+                        "Account locked after %d failed attempts: %s",
+                        user.failed_login_count,
+                        user.username,
                     )
                 session.commit()
-                logger.warning(f"Invalid password for user: {username_or_email}")
+                logger.warning("Invalid password for user: %s", user.username)
                 return None
 
             # Success — reset lockout state and update session tracking

--- a/backend/services/password_reset.py
+++ b/backend/services/password_reset.py
@@ -56,16 +56,21 @@ def _token_hash(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
+_reset_redis_client = None
+
+
 def _redis_client():
-    # Reuse the helper pattern from token_blacklist; keep imports local
-    # so a missing redis dep doesn't break module import.
+    global _reset_redis_client
+    if _reset_redis_client is not None:
+        return _reset_redis_client
     try:
         from redis import asyncio as redis_asyncio
     except Exception as exc:
         logger.warning("redis.asyncio unavailable: %s — reset single-use check disabled", exc)
         return None
     url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-    return redis_asyncio.from_url(url, decode_responses=True)
+    _reset_redis_client = redis_asyncio.from_url(url, decode_responses=True)
+    return _reset_redis_client
 
 
 def generate_reset_token(user_id: str) -> str:

--- a/database/connection.py
+++ b/database/connection.py
@@ -125,8 +125,8 @@ class DatabaseConfig:
         )
 
         # Connection pool settings
-        self.pool_size = int(os.getenv("DB_POOL_SIZE", "5"))
-        self.max_overflow = int(os.getenv("DB_MAX_OVERFLOW", "10"))
+        self.pool_size = int(os.getenv("DB_POOL_SIZE", "10"))
+        self.max_overflow = int(os.getenv("DB_MAX_OVERFLOW", "20"))
         self.pool_timeout = int(os.getenv("DB_POOL_TIMEOUT", "30"))
         self.pool_recycle = int(os.getenv("DB_POOL_RECYCLE", "3600"))
 
@@ -377,13 +377,26 @@ def get_db_session() -> Session:
     """
     Get a new database session.
 
-    This is a convenience function for dependency injection in FastAPI.
-
     Returns:
         SQLAlchemy session
     """
     db_manager = get_db_manager()
     return db_manager.get_session()
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Generator dependency for FastAPI — always closes the session after the request.
+
+    Use this with ``Depends(get_db)`` instead of ``Depends(get_db_session)``.
+    ``get_db_session`` returns a plain Session; FastAPI only calls cleanup for
+    generator dependencies, so ``Depends(get_db_session)`` leaks a connection
+    on every request.
+    """
+    session = get_db_manager().get_session()
+    try:
+        yield session
+    finally:
+        session.close()
 
 
 def get_session() -> Session:


### PR DESCRIPTION
    fix(auth): close privilege escalation, refresh-token reuse, and session leaks

    Security fixes:
    - Role escalation: create_user, update_user, change_user_role now verify that
      the assigning user holds every permission granted by the target role, blocking
      a users.write holder from promoting accounts to admin
    - Refresh token JTI is blacklisted on logout alongside the access token, so a
      captured refresh token cannot mint new access tokens after the victim logs out
    - create_user now applies validate_password_strength() (12-char min, letter +
      digit, blocklist) instead of a bare 8-character check
    - GET /api/users/roles/list now requires users.read permission
    - Email changes in update_current_user and update_user call revoke_all_for_user
      so stale JWT claims don't linger for up to 24 hours
    - change_password clears auth cookies so the browser doesn't silently hold dead tokens
    - Auth failure log lines use user.username from the DB record instead of the raw
      credential input, preventing accidental password exposure in logs

    Session management fixes:
    - Swap Depends(get_db_session) for Depends(get_db) across all auth routes,
      middleware, and related API modules — get_db_session returned a plain Session
      that FastAPI never cleaned up, leaking a connection on every request
    - /me passes the request session to get_user_permissions, eliminating the
      implicit second session opened per call
    - password_reset._redis_client() now caches its client (was creating a new
      Redis connection on every verify call)
    - Pool defaults raised to pool_size=10 / max_overflow=20 to accommodate the
      higher concurrency now that connections are properly returned