### PR TITLE
Fix/ollama sync and startup race

### DIFF
--- a/services/bifrost_admin.py
+++ b/services/bifrost_admin.py
@@ -447,7 +447,14 @@ async def _fetch_meta_for_row(row_dict: Dict[str, Any], discovery) -> Optional[l
         )
 
     if provider_type == "ollama":
-        return await discovery.fetch_ollama_models(base_url)
+        # ``base_url`` comes from a persisted provider row, which only a
+        # ``settings.write`` admin can create/update (shape-validated at
+        # save time). Self-hosted Ollama on a loopback/private address is
+        # the expected deployment, so skip the SSRF IP gate here — the
+        # same trust anchor as the admin-gated test and discover-models
+        # endpoints. Without this, sync fails for any RFC1918 host even
+        # though the UI dropdown populated fine.
+        return await discovery.fetch_ollama_models(base_url, allow_loopback=True)
 
     logger.debug("Bifrost sync: unsupported provider_type %s", provider_type)
     return None

--- a/start.sh
+++ b/start.sh
@@ -306,6 +306,25 @@ fi
 export PYTHONPATH="${PWD}:${PYTHONPATH}"
 BIND_HOST="${BIND_HOST:-127.0.0.1}"
 
+# Poll the backend health endpoint until it responds, so the frontend
+# isn't started while uvicorn is still importing the app (the browser's
+# initial API burst would otherwise spam vite proxy ECONNREFUSED errors).
+wait_for_backend() {
+    local host="$BIND_HOST"
+    [ "$host" = "0.0.0.0" ] && host="127.0.0.1"
+    local url="http://${host}:6987/api/health"
+    echo "Waiting for backend to be ready..."
+    for i in {1..60}; do
+        if curl -sf --max-time 2 "$url" > /dev/null 2>&1; then
+            echo "✓ Backend is ready"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "⚠️  Backend not ready after 60s — starting frontend anyway"
+    return 1
+}
+
 if [ "$DAEMON_MODE" -eq 0 ]; then
     # ------------------------------------------------------------------
     # FOREGROUND MODE
@@ -366,6 +385,7 @@ if [ "$DAEMON_MODE" -eq 0 ]; then
 
     # Start frontend (skip when Node.js prereq unmet)
     if [ "$SKIP_FRONTEND" -eq 0 ] && [ -d "frontend/node_modules" ]; then
+        wait_for_backend || true
         echo "Starting frontend dev server..."
         cd frontend
         npm run dev &
@@ -446,6 +466,7 @@ else
 
     # Start frontend if available (skip when Node.js prereq unmet)
     if [ "$SKIP_FRONTEND" -eq 0 ] && [ -d "frontend/node_modules" ]; then
+        wait_for_backend || true
         echo "Starting frontend server..."
         cd frontend
         nohup npm run dev > ../logs/frontend-app.log 2>&1 &

--- a/tests/test_bifrost_admin.py
+++ b/tests/test_bifrost_admin.py
@@ -421,3 +421,42 @@ def test_cache_has_no_ttl(monkeypatch):
     finally:
         _time.time = original  # type: ignore[assignment]
     _MODEL_LIST_CACHE.invalidate()
+
+
+def test_fetch_meta_for_row_ollama_bypasses_ssrf_ip_gate():
+    """The ollama branch must pass ``allow_loopback=True``.
+
+    The row's ``base_url`` was persisted by a ``settings.write`` admin
+    (shape-validated at save time), and self-hosted Ollama on a
+    loopback/private address is the expected deployment. Without the
+    flag, the scheduled sync re-runs the SSRF IP gate and fails with
+    "resolved address ... is disallowed: private address" for any
+    RFC1918 host — even though the admin-gated discover-models and
+    test endpoints reach the same URL fine.
+    """
+    import asyncio
+
+    calls: Dict[str, Any] = {}
+
+    class _FakeDiscovery:
+        @staticmethod
+        async def fetch_ollama_models(base_url=None, *, allow_loopback=False):
+            calls["base_url"] = base_url
+            calls["allow_loopback"] = allow_loopback
+            return []
+
+    row = {
+        "provider_id": "ollama",
+        "provider_type": "ollama",
+        "base_url": "http://10.64.201.1:11434",
+        "api_key_ref": None,
+        "config": {},
+    }
+
+    out = asyncio.run(bifrost_admin._fetch_meta_for_row(row, _FakeDiscovery))
+
+    assert out == []
+    assert calls == {
+        "base_url": "http://10.64.201.1:11434",
+        "allow_loopback": True,
+    }


### PR DESCRIPTION
### 1. Ollama model sync fails for private/LAN hosts
   `sync_all_provider_models` re-ran the SSRF private-IP gate
   against admin-persisted Ollama base URLs, so the
   scheduled/startup sync failed with:

   ```
   sync_all_provider_models: discovery failed for ollama (ollama):
   resolved address 10.0.0.11 is disallowed: private address
   ```

   …even though the admin-gated discover-models and test endpoints
   reach the same URL fine (the UI dropdown populated, but the
   Bifrost allow-list and model cache never got the real models).

   Fix: pass `allow_loopback=True` for ollama rows in
   `services/bifrost_admin.py` — the `base_url` comes from a
   `settings.write`-gated row that was shape-validated at save
   time, the same trust anchor the test endpoint already uses.
   Adds a regression test.

   ### 2. Vite proxy ECONNREFUSED spam on startup
   `start.sh` launched vite ~3s after uvicorn, but the backend
   takes much longer to bind :6987 (router imports, MCP server
  backend never comes up it warns and starts the frontend anyway, so
  behavior degrades to what you have today rather than blocking. I
  verified the script syntax with bash -n and that the poll succeeds
  against your currently running backend.