### PR TITLE
fix(release): unblock image build and green the release workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,6 +46,13 @@ LICENSE
 # requirements.txt is needed by Dockerfile.backend + Dockerfile.daemon;
 # the wildcard above would otherwise exclude it.
 !requirements.txt
+# The submodule packages are pip-installed during the image build, and their
+# build backends read README.md for metadata (mempalace's pyproject declares
+# `readme = "README.md"`, which hard-fails if the file is absent). The `*.md`
+# wildcard above would otherwise strip them from the build context.
+!deeptempo-core/README.md
+!mcp-servers/README.md
+!mempalace/README.md
 
 # Logs
 logs/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,28 @@ permissions:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # Resolve the release version once, for every downstream job.
+  # The pushed image tags use docker/metadata-action's {{version}}, which
+  # strips the leading "v" (vX.Y.Z → X.Y.Z). github.ref_name keeps the "v",
+  # so jobs that pull/inspect the images must use this stripped value or they
+  # reference a tag that was never pushed.
+  # ---------------------------------------------------------------------------
+  version:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - id: v
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+  # ---------------------------------------------------------------------------
   # Build + push: backend (also used by llm-worker)
   # ---------------------------------------------------------------------------
   build-backend:
     name: Build backend image
     runs-on: ubuntu-latest
+    needs: [version]
     permissions:
       contents: read
       packages: write          # push to ghcr.io
@@ -157,7 +174,7 @@ jobs:
   smoke-test:
     name: Smoke test images
     runs-on: ubuntu-latest
-    needs: [build-backend, build-daemon]
+    needs: [version, build-backend, build-daemon]
     permissions:
       packages: read
 
@@ -175,14 +192,21 @@ jobs:
             -e DEV_MODE=true \
             -e DATABASE_URL=postgresql://x:x@localhost/x \
             -e REDIS_URL=redis://localhost:6379 \
-            ghcr.io/vigil-soc/vigil-backend:${{ github.ref_name }} \
+            ghcr.io/vigil-soc/vigil-backend:${{ needs.version.outputs.version }} \
             python -c "import backend; print('backend version:', backend.__version__)"
+
+      - name: Backend — SPA present
+        run: |
+          docker run --rm \
+            ghcr.io/vigil-soc/vigil-backend:${{ needs.version.outputs.version }} \
+            test -f /app/frontend/build/index.html \
+            || { echo "::error::SPA missing from image — frontend not copied to /app/frontend/build"; exit 1; }
 
       - name: Daemon — import check
         run: |
           docker run --rm \
             -e DEV_MODE=true \
-            ghcr.io/vigil-soc/vigil-daemon:${{ github.ref_name }} \
+            ghcr.io/vigil-soc/vigil-daemon:${{ needs.version.outputs.version }} \
             python -c "import daemon; print('daemon ok')"
 
   # ---------------------------------------------------------------------------
@@ -191,7 +215,7 @@ jobs:
   update-release:
     name: Annotate GitHub Release
     runs-on: ubuntu-latest
-    needs: [smoke-test]
+    needs: [version, smoke-test]
     permissions:
       contents: write    # edit release body
       packages: read
@@ -207,9 +231,9 @@ jobs:
       - name: Fetch digests
         id: digests
         run: |
-          BACKEND=$(docker manifest inspect ghcr.io/vigil-soc/vigil-backend:${{ github.ref_name }} \
+          BACKEND=$(docker manifest inspect ghcr.io/vigil-soc/vigil-backend:${{ needs.version.outputs.version }} \
             | python3 -c "import sys,json; m=json.load(sys.stdin); print(m.get('config',{}).get('digest','unknown'))")
-          DAEMON=$(docker manifest inspect ghcr.io/vigil-soc/vigil-daemon:${{ github.ref_name }} \
+          DAEMON=$(docker manifest inspect ghcr.io/vigil-soc/vigil-daemon:${{ needs.version.outputs.version }} \
             | python3 -c "import sys,json; m=json.load(sys.stdin); print(m.get('config',{}).get('digest','unknown'))")
           echo "backend=$BACKEND" >> "$GITHUB_OUTPUT"
           echo "daemon=$DAEMON"   >> "$GITHUB_OUTPUT"
@@ -225,11 +249,11 @@ jobs:
 
             | Image | Tag | Digest |
             |-------|-----|--------|
-            | `ghcr.io/vigil-soc/vigil-backend` | `${{ github.ref_name }}` | `${{ steps.digests.outputs.backend }}` |
-            | `ghcr.io/vigil-soc/vigil-daemon`  | `${{ github.ref_name }}` | `${{ steps.digests.outputs.daemon }}`  |
+            | `ghcr.io/vigil-soc/vigil-backend` | `${{ needs.version.outputs.version }}` | `${{ steps.digests.outputs.backend }}` |
+            | `ghcr.io/vigil-soc/vigil-daemon`  | `${{ needs.version.outputs.version }}` | `${{ steps.digests.outputs.daemon }}`  |
 
             ```bash
             # Pull by tag
-            docker pull ghcr.io/vigil-soc/vigil-backend:${{ github.ref_name }}
-            docker pull ghcr.io/vigil-soc/vigil-daemon:${{ github.ref_name }}
+            docker pull ghcr.io/vigil-soc/vigil-backend:${{ needs.version.outputs.version }}
+            docker pull ghcr.io/vigil-soc/vigil-daemon:${{ needs.version.outputs.version }}
             ```

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -3,7 +3,7 @@
 # Multi-stage build: React SPA → Python FastAPI backend
 #
 # Final image runs:  uvicorn backend.main:app --host 0.0.0.0 --port 6987
-# Serves static SPA at /app/frontend/dist  (via FastAPI StaticFiles mount)
+# Serves static SPA at /app/frontend/build  (via FastAPI StaticFiles mount)
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -19,7 +19,7 @@ RUN npm ci --prefer-offline
 
 COPY frontend/ .
 RUN npm run build
-# Output: /build/frontend/dist
+# Output: /build/frontend/build
 
 # ---------------------------------------------------------------------------
 # Stage 2: install Python dependencies
@@ -34,8 +34,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# requirements.txt pins the submodules as editable installs (`-e ./<dir>`)
+# for local development. In the image we install them as regular packages
+# from the copied source, so the runtime stage needs only /usr/local and no
+# editable source tree (an `-e` install writes a .pth pointing at the build
+# path, which won't exist in the runtime stage). Keep this COPY list in sync
+# with the `-e ./` lines in requirements.txt: deeptempo-core, mcp-servers,
+# mempalace.
 COPY requirements.txt .
-RUN pip install --no-cache-dir --prefix=/install/deps -r requirements.txt
+COPY deeptempo-core/ ./deeptempo-core/
+COPY mcp-servers/    ./mcp-servers/
+COPY mempalace/      ./mempalace/
+RUN grep -vE '^[[:space:]]*-e[[:space:]]+\./' requirements.txt > requirements.runtime.txt \
+    && pip install --no-cache-dir --prefix=/install/deps \
+         -r requirements.runtime.txt \
+         ./deeptempo-core ./mcp-servers ./mempalace
 
 # ---------------------------------------------------------------------------
 # Stage 3: runtime image
@@ -74,7 +87,7 @@ COPY --chown=vigil:vigil VERSION      ./VERSION
 COPY --chown=vigil:vigil setup.cfg    ./setup.cfg
 
 # Built SPA — served by FastAPI StaticFiles (or nginx sidecar)
-COPY --from=frontend-builder --chown=vigil:vigil /build/frontend/dist ./frontend/dist/
+COPY --from=frontend-builder --chown=vigil:vigil /build/frontend/build ./frontend/build/
 
 # Writable dirs the app needs at runtime
 RUN mkdir -p /app/data/investigations /app/data/mempalace \

--- a/docker/Dockerfile.daemon
+++ b/docker/Dockerfile.daemon
@@ -21,8 +21,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# requirements.txt pins the submodules as editable installs (`-e ./<dir>`)
+# for local development. In the image we install them as regular packages
+# from the copied source, so the runtime stage needs only /usr/local and no
+# editable source tree (an `-e` install writes a .pth pointing at the build
+# path, which won't exist in the runtime stage). Keep this COPY list in sync
+# with the `-e ./` lines in requirements.txt: deeptempo-core, mcp-servers,
+# mempalace.
 COPY requirements.txt .
-RUN pip install --no-cache-dir --prefix=/install/deps -r requirements.txt
+COPY deeptempo-core/ ./deeptempo-core/
+COPY mcp-servers/    ./mcp-servers/
+COPY mempalace/      ./mempalace/
+RUN grep -vE '^[[:space:]]*-e[[:space:]]+\./' requirements.txt > requirements.runtime.txt \
+    && pip install --no-cache-dir --prefix=/install/deps \
+         -r requirements.runtime.txt \
+         ./deeptempo-core ./mcp-servers ./mempalace
 
 # ---------------------------------------------------------------------------
 # Stage 2: runtime image


### PR DESCRIPTION
## What

The release workflow has never produced a green run — images failed to
build, and the verify/annotate tail referenced tags that were never
pushed. This fixes the whole chain.

### Fixes
- **Build crash (`pip install`)** — the multi-stage `python-deps` stage
  copied only `requirements.txt`, but it pins the submodules as editable
  (`-e ./deeptempo-core`, etc.), whose source dirs weren't present →
  `not a valid editable requirement`. Now the submodule sources are
  copied in and installed **non-editable**, so they bake into
  site-packages and survive the stage copy. (`.dockerignore` also
  un-ignores the submodule `README.md`s, which their build backends read.)
- **Missing SPA** — backend image copied the frontend to
  `frontend/dist`, but `backend/main.py` serves from `frontend/build`.
  Corrected the path (vite's `outDir` is `build`).
- **Tag mismatch** — images push as `0.2.3` (metadata-action strips the
  `v`) but smoke-test / digests / release notes pulled `:v0.2.3`
  (`github.ref_name`). Added a `version` job and switched all pull-side
  refs to the stripped value; this also un-breaks the backend `:latest`
  tag, whose enable already referenced the (previously missing) version job.

### Added
- Smoke check asserting the bundled SPA exists at
  `/app/frontend/build/index.html`.

## Validation
Built both images locally end-to-end:
- ✅ `import deeptempo_core, mempalace` resolve from site-packages
- ✅ `import backend` / `import daemon`
- ✅ SPA present at `/app/frontend/build/index.html`