### PR TITLE
fix(helm): expose POSTGRES_* env vars to pods

### DIFF
--- a/helm/vigil/templates/_env.tpl
+++ b/helm/vigil/templates/_env.tpl
@@ -26,6 +26,14 @@ chart-templated).
 {{- define "vigil.env" -}}
 - name: DATABASE_URL
   value: {{ printf "postgresql://%s:$(POSTGRES_PASSWORD)@%s:%s/%s" (include "vigil.postgres.username" .) (include "vigil.postgres.host" .) (include "vigil.postgres.port" . | toString) (include "vigil.postgres.database" .) | quote }}
+- name: POSTGRES_HOST
+  value: {{ include "vigil.postgres.host" . | quote }}
+- name: POSTGRES_PORT
+  value: {{ include "vigil.postgres.port" . | toString | quote }}
+- name: POSTGRES_DB
+  value: {{ include "vigil.postgres.database" . | quote }}
+- name: POSTGRES_USER
+  value: {{ include "vigil.postgres.username" . | quote }}
 {{- if .Values.redis.bitnami.enabled }}
 {{- if .Values.redis.bitnami.auth.enabled }}
 - name: REDIS_PASSWORD


### PR DESCRIPTION
## What

Adds `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, and `POSTGRES_USER` to the templated pod environment in `helm/vigil/templates/_env.tpl`.

## Why

Components that read discrete Postgres connection settings (rather than the full `DATABASE_URL`) had no way to connect under the Helm deploy. These vars are derived from the same `vigil.postgres.*` template helpers already used to build `DATABASE_URL`, so they stay consistent.