### PR TITLE
ci(helm): disable ct lint version-increment check

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -125,4 +125,4 @@ jobs:
           helm repo update
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --chart-dirs helm
+        run: ct lint --check-version-increment=false --target-branch ${{ github.event.repository.default_branch }} --chart-dirs helm


### PR DESCRIPTION
## Problem

The `chart-testing` job in `helm-chart.yml` runs `ct lint` with its default `--check-version-increment=true`. That check requires: *any PR that changes a file under the chart must bump `Chart.yaml`'s `version` above the target branch.* Any helm-touching PR that doesn't hand-bump the version fails with:

```
✖︎ vigil ... chart version not ok. Needs a version bump!
Old chart version: 0.2.3
New chart version: 0.2.3
failed linting charts: failed processing charts
```

This bites every feature/fix PR that touches `helm/**` (the `ct lint` job was added in #294; this is the first non-release helm PR since, so it's the first to hit it).

## Why the check is wrong for this repo

`release-please` **owns** the chart version. `Chart.yaml`'s `version` and `appVersion` are both listed in `.github/release-please-config.json`'s `extra-files`, and are bumped in lockstep at release time inside release-please's **own** PR. Contributors are explicitly told not to hand-bump (see `CLAUDE.md`).

So the two policies are incompatible:
- `ct`'s default assumes **humans bump** the chart version on each chart-changing PR.
- This repo's design has a **bot bump** it, after merge, in a separate PR.

`ct lint` is only a *checker* — it never bumps anything. Leaving the check on means every helm PR is blocked on a version bump that no contributor is allowed to make.

## Fix

Pass `--check-version-increment=false` to `ct lint`. This disables only the version-increment assertion; all other `ct lint` checks (template validity, schema, dependency build) stay on. Real version bumping continues to be driven by release-please.