### PR TITLE
fix(docker): include daemon/ in backend image

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -81,6 +81,7 @@ COPY --chown=vigil:vigil tools/       ./tools/
 COPY --chown=vigil:vigil database/    ./database/
 COPY --chown=vigil:vigil data/        ./data/
 COPY --chown=vigil:vigil workflows/   ./workflows/
+COPY --chown=vigil:vigil daemon/      ./daemon/
 COPY --chown=vigil:vigil mcp-servers/ ./mcp-servers/
 COPY --chown=vigil:vigil mempalace/   ./mempalace/
 COPY --chown=vigil:vigil VERSION      ./VERSION


### PR DESCRIPTION
backend/api/federation.py imports daemon.federation at module load,
but Dockerfile.backend did not copy daemon/ into the runtime image,
causing ModuleNotFoundError: No module named 'daemon' at startup and
a failing /api/health.

This was discovered during a deployment to AWS.  The terraform used to deploy is available here:

https://github.com/jamessmoore/vigil-bedrock-deploy

The failing health check caused the smoke test to fail as the UI did not return 200.  After adding the module,rebuilding the docker images and pushing the rebuilt images to ECR the issue was resolved and the re-deployment passed a smoke test successfully.