### PR TITLE
feat: promote redesign to root, legacy to /old

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,21 @@
 import { lazy, Suspense } from 'react'
-import { Routes, Route, Navigate } from 'react-router-dom'
+import { Routes, Route, Navigate, Outlet } from 'react-router-dom'
 import { Box, CircularProgress } from '@mui/material'
 import { AuthProvider } from './contexts/AuthContext'
 import ProtectedRoute from './components/auth/ProtectedRoute'
 import MainLayout from './components/layout/MainLayout'
 import SetupGate from './components/setup/SetupGate'
 // Eager (never suspends) so it can serve as the redesign's own Suspense
-// fallback while the lazy /redesign chunk loads.
+// fallback while the lazy redesign chunk loads.
 import RedesignLoader from './redesign/shell/Loader'
 
 // Lazy-load every page so a refresh on any route only pulls that page's
 // module graph (plus shared deps). Previously every page was eagerly
 // imported, forcing ~1 MB of JS + all its MUI/recharts/x-data-grid deps
 // on every cold load.
-const Login = lazy(() => import('./pages/Login'))
+//
+// The legacy MUI UI is now archived under /old/* — the redesign SOC console
+// (below) is the primary surface and owns the root.
 const Dashboard = lazy(() => import('./pages/Dashboard'))
 const Cases = lazy(() => import('./pages/Cases'))
 const CaseMetrics = lazy(() => import('./pages/CaseMetrics'))
@@ -25,7 +27,7 @@ const Analytics = lazy(() => import('./pages/Analytics'))
 const Skills = lazy(() => import('./pages/Skills'))
 const Orchestrator = lazy(() => import('./pages/Orchestrator'))
 const BuilderTool = lazy(() => import('./pages/BuilderTool'))
-// UI redesign preview (Claude Design handoff) — full-screen, mock data.
+// Redesign SOC console — the primary UI, served at the root.
 const SocConsole = lazy(() => import('./redesign/SocConsole'))
 const SocLogin = lazy(() => import('./redesign/screens/login/LoginScreen'))
 // Standalone /setup screen (no console shell).
@@ -37,7 +39,7 @@ const PageFallback = () => (
   </Box>
 )
 
-// Wrap the lazy /redesign elements in their own Suspense so they show the
+// Wrap the lazy redesign elements in their own Suspense so they show the
 // redesign-styled loader (not the legacy MUI spinner) while loading.
 const redesign = (el: JSX.Element) => <Suspense fallback={<RedesignLoader />}>{el}</Suspense>
 
@@ -47,8 +49,8 @@ function App() {
       <Box sx={{ display: 'flex', height: '100vh' }}>
         <Suspense fallback={<PageFallback />}>
         <Routes>
-          {/* Public routes */}
-          <Route path="/login" element={<Login />} />
+          {/* Public — the redesign login is the single sign-in surface. */}
+          <Route path="/login" element={redesign(<SocLogin />)} />
 
           {/* OUTSIDE SetupGate so it stays reachable while unconfigured (no redirect loop). */}
           <Route
@@ -56,19 +58,32 @@ function App() {
             element={<ProtectedRoute>{redesign(<SetupScreen />)}</ProtectedRoute>}
           />
 
-          {/* UI redesign preview — standalone, full-screen, illustrative mock data.
-              Each screen owns a URL (/redesign/<screen>); cases deep-link to a
-              specific case via the ?case=<caseId> query param. */}
-          <Route path="/redesign" element={<Navigate to="/redesign/dashboard" replace />} />
-          <Route path="/redesign/login" element={redesign(<SocLogin />)} />
-          <Route path="/redesign/:screen" element={redesign(<SocConsole />)} />
-          {/* deeper junk paths (/redesign/a/b/…) fall through to the in-shell 404 */}
-          <Route path="/redesign/*" element={redesign(<SocConsole />)} />
-
-
-          {/* Protected routes */}
+          {/* Primary app — the redesign SOC console, served at the root and gated
+              behind auth + first-run setup (same protection the legacy UI had).
+              Each screen owns a URL (/<screen>); cases deep-link to a specific
+              case via the ?case=<caseId> query param. */}
           <Route
-            path="/"
+            element={
+              <ProtectedRoute>
+                <SetupGate>
+                  <Outlet />
+                </SetupGate>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<Navigate to="/dashboard" replace />} />
+            <Route path=":screen" element={redesign(<SocConsole />)} />
+            {/* deeper junk paths (/a/b/…) fall through to the in-shell 404 */}
+            <Route path="*" element={redesign(<SocConsole />)} />
+          </Route>
+
+          {/* Back-compat — the redesign used to live under /redesign/*. */}
+          <Route path="/redesign" element={<Navigate to="/" replace />} />
+          <Route path="/redesign/*" element={<Navigate to="/" replace />} />
+
+          {/* Legacy MUI UI — archived under /old/*, same auth + setup gating. */}
+          <Route
+            path="/old"
             element={
               <ProtectedRoute>
                 <SetupGate>
@@ -90,10 +105,10 @@ function App() {
             <Route path="investigation" element={<Investigation />} />
             <Route path="timesketch" element={<Timesketch />} />
             <Route path="analytics" element={<Analytics />} />
-            <Route path="analytics/cost" element={<Navigate to="/settings?tab=general" replace />} />
+            <Route path="analytics/cost" element={<Navigate to="/old/settings?tab=general" replace />} />
             <Route path="skills" element={<Skills />} />
             <Route path="builder" element={<BuilderTool />} />
-            <Route path="workflow-builder" element={<Navigate to="/builder" replace />} />
+            <Route path="workflow-builder" element={<Navigate to="/old/builder" replace />} />
             <Route path="orchestrator" element={<Orchestrator />} />
             <Route
               path="ai-decisions"
@@ -115,7 +130,7 @@ function App() {
               path="users"
               element={
                 <ProtectedRoute requiredPermission="users.read">
-                  <Navigate to="/settings?tab=users" replace />
+                  <Navigate to="/old/settings?tab=users" replace />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/components/auth/UserMenu.tsx
+++ b/frontend/src/components/auth/UserMenu.tsx
@@ -41,12 +41,12 @@ export default function UserMenu() {
   const handleProfile = () => {
     handleClose();
     // Navigate to profile page (to be implemented)
-    navigate('/profile');
+    navigate('/old/profile');
   };
 
   const handleSettings = () => {
     handleClose();
-    navigate('/settings');
+    navigate('/old/settings');
   };
 
   const handleLogout = async () => {

--- a/frontend/src/components/graph/VStrikeIframeHost.tsx
+++ b/frontend/src/components/graph/VStrikeIframeHost.tsx
@@ -347,10 +347,10 @@ export default function VStrikeIframeHost() {
           {ctx.error.missingCredentials ? (
             <Button
               variant="outlined"
-              href="/settings"
+              href="/old/settings"
               onClick={(e) => {
                 e.preventDefault()
-                window.location.assign('/settings')
+                window.location.assign('/old/settings')
               }}
             >
               Open Settings

--- a/frontend/src/components/layout/NavigationRail.tsx
+++ b/frontend/src/components/layout/NavigationRail.tsx
@@ -39,17 +39,18 @@ interface NavItem {
   path: string
 }
 
+// The legacy UI is archived under /old/*, so every nav target carries that prefix.
 const navItems: NavItem[] = [
-  { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon />, path: '/' },
-  { id: 'cases', label: 'Cases', icon: <FolderIcon />, path: '/cases' },
-  { id: 'case-metrics', label: 'Case Metrics', icon: <MetricsIcon />, path: '/case-metrics' },
-  { id: 'analytics', label: 'Analytics', icon: <AnalyticsIcon />, path: '/analytics' },
-  { id: 'ai-decisions', label: 'AI Decisions', icon: <AIIcon />, path: '/ai-decisions' },
-  { id: 'skills', label: 'Skills', icon: <SkillsIcon />, path: '/skills' },
-  { id: 'builder', label: 'Builder Tool', icon: <BuilderIcon />, path: '/builder' },
-  { id: 'orchestrator', label: 'Auto Ops', icon: <OrchestratorIcon />, path: '/orchestrator' },
-  { id: 'timesketch', label: 'Timesketch', icon: <TimelineIcon />, path: '/timesketch' },
-  { id: 'settings', label: 'Settings', icon: <SettingsIcon />, path: '/settings' },
+  { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon />, path: '/old' },
+  { id: 'cases', label: 'Cases', icon: <FolderIcon />, path: '/old/cases' },
+  { id: 'case-metrics', label: 'Case Metrics', icon: <MetricsIcon />, path: '/old/case-metrics' },
+  { id: 'analytics', label: 'Analytics', icon: <AnalyticsIcon />, path: '/old/analytics' },
+  { id: 'ai-decisions', label: 'AI Decisions', icon: <AIIcon />, path: '/old/ai-decisions' },
+  { id: 'skills', label: 'Skills', icon: <SkillsIcon />, path: '/old/skills' },
+  { id: 'builder', label: 'Builder Tool', icon: <BuilderIcon />, path: '/old/builder' },
+  { id: 'orchestrator', label: 'Auto Ops', icon: <OrchestratorIcon />, path: '/old/orchestrator' },
+  { id: 'timesketch', label: 'Timesketch', icon: <TimelineIcon />, path: '/old/timesketch' },
+  { id: 'settings', label: 'Settings', icon: <SettingsIcon />, path: '/old/settings' },
 ]
 
 interface NavigationRailProps {

--- a/frontend/src/pages/AIDecisions.tsx
+++ b/frontend/src/pages/AIDecisions.tsx
@@ -441,7 +441,7 @@ export default function AIDecisionsPage() {
                                 component="button"
                                 variant="body2"
                                 sx={{ fontFamily: 'monospace', fontSize: '0.7rem', cursor: 'pointer' }}
-                                onClick={() => navigate(`/orchestrator?highlight=${invId}`)}
+                                onClick={() => navigate(`/old/orchestrator?highlight=${invId}`)}
                               >
                                 {invId.slice(0, 12)}...
                               </Link>
@@ -549,7 +549,7 @@ export default function AIDecisionsPage() {
                                 }}
                                 onClick={() =>
                                   navigate(
-                                    `/workflows?run_id=${action.workflow_run_id}`,
+                                    `/old/workflows?run_id=${action.workflow_run_id}`,
                                   )
                                 }
                               >

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -179,14 +179,14 @@ export default function Dashboard() {
   const handleTimelineEventClick = (event: any) => {
     if (event.metadata?.finding_id) {
       // Navigate to investigation with this finding
-      navigate(`/investigation?finding_ids=${event.metadata.finding_id}`)
+      navigate(`/old/investigation?finding_ids=${event.metadata.finding_id}`)
     }
   }
 
   const handleGraphNodeClick = (node: any) => {
     // Navigate to investigation with this entity's findings
     if (node.metadata?.findings && node.metadata.findings.length > 0) {
-      navigate(`/investigation?finding_ids=${node.metadata.findings.join(',')}`)
+      navigate(`/old/investigation?finding_ids=${node.metadata.findings.join(',')}`)
     } else {
       // Show a snackbar for entities without linked findings
       setSnackbar({ open: true, message: `Entity: ${node.label} (${node.type})`, severity: 'success' })
@@ -269,7 +269,7 @@ export default function Dashboard() {
             subtitle={`${stats?.cases?.by_status?.open || 0} open`}
             icon={<FolderIcon />}
             color={theme.palette.primary.main}
-            onClick={() => navigate('/cases')}
+            onClick={() => navigate('/old/cases')}
           />
         </Grid>
         <Grid item xs={12} sm={6} md={3}>

--- a/frontend/src/pages/Orchestrator.tsx
+++ b/frontend/src/pages/Orchestrator.tsx
@@ -280,7 +280,7 @@ export default function Orchestrator() {
 
   const handleCardClick = (label: string) => {
     if (label === 'Total Cost') {
-      navigate('/analytics/cost')
+      navigate('/old/analytics/cost')
       return
     }
     const filters = CARD_FILTERS[label]
@@ -666,7 +666,7 @@ export default function Orchestrator() {
                 size="small"
                 variant="outlined"
                 startIcon={<DecisionsIcon />}
-                onClick={() => navigate(`/ai-decisions?agent_id=orchestrator&investigation_id=${selectedInv}`)}
+                onClick={() => navigate(`/old/ai-decisions?agent_id=orchestrator&investigation_id=${selectedInv}`)}
               >
                 AI Decisions
               </Button>

--- a/frontend/src/redesign/SocConsole.test.tsx
+++ b/frontend/src/redesign/SocConsole.test.tsx
@@ -21,17 +21,17 @@ vi.mock('../contexts/AuthContext', () => ({
   }),
 }))
 
-// SocConsole is URL-driven (each screen owns /redesign/<screen>, cases deep-link
-// to /redesign/cases?case=<caseId>), so mount it inside a router with that route.
+// SocConsole is URL-driven (each screen owns /<screen>, cases deep-link to
+// /cases?case=<caseId>), so mount it inside a router with that route.
 // SocConsole's theme provider bridges the app-wide ThemeContext (mode is
 // backend-persisted), so it must mount inside a real ThemeProvider — same as
 // production (main.tsx wraps the whole app).
-function renderConsole(path = '/redesign/dashboard') {
+function renderConsole(path = '/dashboard') {
   return render(
     <ThemeProvider>
       <MemoryRouter initialEntries={[path]}>
         <Routes>
-          <Route path="/redesign/:screen" element={<SocConsole />} />
+          <Route path="/:screen" element={<SocConsole />} />
         </Routes>
       </MemoryRouter>
     </ThemeProvider>,
@@ -208,7 +208,7 @@ describe('SocConsole redesign', () => {
   })
 
   it('renders the 404 screen for an unknown path and routes home', () => {
-    renderConsole('/redesign/does-not-exist')
+    renderConsole('/does-not-exist')
     expect(title()).toBe('Page not found')
     expect(screen.getByText('404')).toBeInTheDocument()
     // the in-shell "Back to dashboard" action returns to a real screen
@@ -288,7 +288,7 @@ describe('SocConsole redesign', () => {
   })
 
   it('applies an accent + light mode from the Appearance settings page', () => {
-    renderConsole('/redesign/settings')
+    renderConsole('/settings')
     // Settings opens on the Appearance section (first nav item)
     fireEvent.click(screen.getByRole('button', { name: 'Appearance' }))
     // pick the cyan accent preset

--- a/frontend/src/redesign/SocConsole.tsx
+++ b/frontend/src/redesign/SocConsole.tsx
@@ -65,12 +65,12 @@ export default function SocConsole() {
 }
 
 function SocConsoleInner() {
-  // the active screen comes from the URL (/redesign/<screen>); the cases
-  // screen additionally carries its open case in a ?case=<id> query param.
+  // the active screen comes from the URL (/<screen>); the cases screen
+  // additionally carries its open case in a ?case=<id> query param.
   const navigate = useNavigate()
   const { hasPermission } = useAuth()
   const { screen } = useParams<{ screen?: string }>()
-  // an unknown segment (e.g. /redesign/foo) renders the 404 screen; `current`
+  // an unknown segment (e.g. /foo) renders the 404 screen; `current`
   // falls back to dashboard only so the chrome has a valid key to render.
   const valid = isScreenKey(screen)
   const current: ScreenKey = valid ? screen : 'dashboard'
@@ -122,7 +122,7 @@ function SocConsoleInner() {
   const go = useCallback(
     (next: ScreenKey) => {
       if (valid && next === current) return
-      navigate(`/redesign/${next}`)
+      navigate(`/${next}`)
     },
     [valid, current, navigate],
   )

--- a/frontend/src/redesign/screens/autoops/InvestigationDetail.tsx
+++ b/frontend/src/redesign/screens/autoops/InvestigationDetail.tsx
@@ -86,7 +86,7 @@ export default function InvestigationDetail({ id, onBack, openChat, busy, wake, 
           </button>
         )}
         <button className="btn ghost" onClick={handleExport}><Icon name="download" /> Export</button>
-        <button className="btn ghost" title="View AI decisions" onClick={() => navigate('/redesign/decisions')}>
+        <button className="btn ghost" title="View AI decisions" onClick={() => navigate('/decisions')}>
           <Icon name="brain" /> AI Decisions
         </button>
         <button

--- a/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
+++ b/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
@@ -7,7 +7,7 @@
    Ports the production FindingDetailDialog's enrichment surface
    (REDESIGN_GAPS.md §8); the embedded VStrike NetworkContextPanel
    is intentionally not ported — it depends on the VStrike provider
-   that isn't mounted under the standalone /redesign shell.
+   that isn't mounted under the SOC console shell.
    ============================================================ */
 import { useEffect, useState } from 'react'
 import { findingsApi } from '../../../services/api'

--- a/frontend/src/redesign/screens/login/LoginScreen.test.tsx
+++ b/frontend/src/redesign/screens/login/LoginScreen.test.tsx
@@ -33,7 +33,7 @@ vi.mock('react-router-dom', async () => {
 function renderLogin() {
   return render(
     <ThemeProvider>
-      <MemoryRouter initialEntries={['/redesign/login']}>
+      <MemoryRouter initialEntries={['/login']}>
         <LoginScreen />
       </MemoryRouter>
     </ThemeProvider>,
@@ -60,7 +60,7 @@ describe('LoginScreen', () => {
     fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'admin123' } })
     fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
     await waitFor(() => expect(login).toHaveBeenCalledWith('admin', 'admin123', undefined))
-    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/redesign/dashboard'))
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/dashboard'))
   })
 
   it('reveals the MFA step when the backend requires it', async () => {

--- a/frontend/src/redesign/screens/login/LoginScreen.tsx
+++ b/frontend/src/redesign/screens/login/LoginScreen.tsx
@@ -50,8 +50,8 @@ function LoginInner() {
     setLoading(true)
     try {
       await login(usernameOrEmail, password, showMfa ? mfaCode : undefined)
-      // land in the redesign console (this is the redesign's sign-in surface)
-      navigate('/redesign/dashboard')
+      // land in the SOC console (the primary surface)
+      navigate('/dashboard')
     } catch (err: any) {
       if (err?.message === 'MFA_REQUIRED') {
         setShowMfa(true)

--- a/frontend/src/redesign/screens/notfound/NotFoundScreen.tsx
+++ b/frontend/src/redesign/screens/notfound/NotFoundScreen.tsx
@@ -1,5 +1,5 @@
 /* ============================================================
-   404 — shown inside the SOC console shell when a /redesign/<screen>
+   404 — shown inside the SOC console shell when a /<screen>
    path doesn't match a known screen. The nav rail stays available so
    the user can jump elsewhere; this also offers a direct route home.
    ============================================================ */
@@ -13,7 +13,7 @@ export default function NotFoundScreen({ path, onHome }: { path?: string; onHome
       <p className="nf-sub">
         {path ? (
           <>
-            There’s nothing at <span className="mono nf-path">/redesign/{path}</span>.
+            There’s nothing at <span className="mono nf-path">/{path}</span>.
           </>
         ) : (
           'That page doesn’t exist.'

--- a/frontend/src/redesign/shell/ErrorBoundary.tsx
+++ b/frontend/src/redesign/shell/ErrorBoundary.tsx
@@ -1,8 +1,8 @@
 /* ============================================================
-   Scoped error boundary for the redesign preview. A render throw
-   in any screen would otherwise blank the whole /redesign route;
-   this catches it and shows a recoverable fallback. React error
-   boundaries must be class components.
+   Scoped error boundary for the SOC console. A render throw in any
+   screen would otherwise blank the whole console; this catches it
+   and shows a recoverable fallback. React error boundaries must be
+   class components.
    ============================================================ */
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 

--- a/frontend/src/redesign/shell/UserMenu.tsx
+++ b/frontend/src/redesign/shell/UserMenu.tsx
@@ -85,7 +85,7 @@ export default function UserMenu() {
           <div className="user-pop-role">Role: {role}</div>
         </div>
         <div className="user-pop-sep" />
-        <button role="menuitem" onClick={() => { setOpen(false); navigate('/redesign/settings') }}>
+        <button role="menuitem" onClick={() => { setOpen(false); navigate('/settings') }}>
           <Icon name="gear" size={15} /> Settings
         </button>
         {user.mfa_enabled && (


### PR DESCRIPTION
Makes the redesign SOC console the primary UI served at the root (gated by auth + first-run setup, with the redesign login at `/login`), and archives the legacy MUI UI under `/old/*` with its internal links re-prefixed. `/redesign` and `/redesign/*` redirect to `/` for back-compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)