### PR TITLE
feat(llm): native OpenAI-format agent loop for Ollama/OpenAI providers

### DIFF
--- a/backend/api/claude.py
+++ b/backend/api/claude.py
@@ -188,6 +188,19 @@ ROUTER_NO_TOOLS_SYSTEM_PROMPT = (
     "step. Write the final investigation analysis directly."
 )
 
+# Counterpart prompt for the agentic router path: models that DO support tool
+# calling run the full OpenAIAgentService loop, so they are told to use tools.
+ROUTER_AGENT_TOOLS_SYSTEM_PROMPT = (
+    "You are Vigil, an AI-native SOC analyst. You have access to security "
+    "tools for investigating findings, searching detections, querying cases, "
+    "and integrating with external security platforms via MCP. Use tools when "
+    "the user asks you to look something up, enrich data, or take action. Be "
+    "concise and precise. IMPORTANT: Only state facts you can verify with "
+    "tools or the provided context. If you cannot answer from available "
+    "context or tool results, say so. Never fabricate data, code, or "
+    "detection content."
+)
+
 
 def _select_active_provider(provider_id: Optional[str]):
     """Pick the provider a chat request should route through.
@@ -672,6 +685,10 @@ async def chat_stream(
     enable_thinking = request.enable_thinking
     max_tokens = request.max_tokens
     thinking_budget = request.thinking_budget
+    # Per-agent tool subset, forwarded to the OpenAI-format agent loop on the
+    # non-Anthropic router path so Ollama/OpenAI agents get the same tool
+    # filtering ClaudeService applies.
+    recommended_tools = None
 
     if request.agent_id:
         from services.soc_agents import AgentManager
@@ -680,6 +697,7 @@ async def chat_stream(
         agent = agent_manager.agents.get(request.agent_id)
         if agent:
             system_prompt = agent.system_prompt
+            recommended_tools = agent.recommended_tools
             # Per GH #79: request wins verbatim (no downgrade/upgrade from agent default)
             if max_tokens is None:
                 max_tokens = agent.max_tokens
@@ -809,26 +827,89 @@ async def chat_stream(
             # Non-Anthropic path — stream via LLMRouter / Bifrost's OpenAI
             # surface. No tools here, so use the no-tools guardrail prompt.
             if use_router and active_provider is not None:
-                from services.llm_router import LLMRouter
+                # Non-Anthropic path. A model that supports tool calling runs the
+                # full agentic loop (OpenAIAgentService, multi-turn + tools);
+                # anything else falls back to a plain no-tools router stream.
+                # Both branches preserve history tracking below.
+                model_id = request.model or active_provider.default_model
+                enable_agent_tools = False
+                try:
+                    from services.model_registry import ModelRegistry
+
+                    model_info = ModelRegistry().get_model_info(
+                        active_provider.provider_id,
+                        active_provider.provider_type,
+                        model_id,
+                    )
+                    enable_agent_tools = bool(
+                        getattr(model_info, "supports_tools", False)
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("model tool-support lookup failed: %s", exc)
+
+                agent = None
+                if enable_agent_tools:
+                    from services.openai_agent_service import OpenAIAgentService
+
+                    agent = OpenAIAgentService(recommended_tools=recommended_tools)
+                    # Claims tool support but nothing loadable — fall back to the
+                    # no-tools stream rather than send an empty tools=[] that some
+                    # providers reject.
+                    if not agent.tools_available():
+                        logger.info(
+                            "Model %s supports tools but none available; "
+                            "using no-tools router stream",
+                            model_id,
+                        )
+                        agent = None
+                        enable_agent_tools = False
 
                 text_chunks = 0
                 total_text_length = 0
                 logger.info(
-                    f"🚀 [RequestID: {request_id}] Starting router stream ({active_provider.provider_type}) "
+                    f"🚀 [RequestID: {request_id}] Starting router stream "
+                    f"({active_provider.provider_type}, tools={enable_agent_tools}) "
                     f"with {len(messages)} messages"
                 )
-                async for chunk in LLMRouter().dispatch_openai_stream(
-                    provider=active_provider,
-                    messages=messages,
-                    system_prompt=ROUTER_NO_TOOLS_SYSTEM_PROMPT,
-                    model=request.model,
-                    max_tokens=max_tokens,
-                    interaction_id=request_id,
-                ):
-                    text_chunks += 1
-                    total_text_length += len(chunk.get("content", ""))
-                    history_assistant_parts.append(chunk.get("content", ""))
-                    yield f"data: {json.dumps(chunk)}\n\n"
+
+                if enable_agent_tools and agent is not None:
+                    # Always include the tool-use guardrail. When an agent
+                    # supplies its own system prompt, prepend the guardrail so
+                    # the tool/anti-fabrication instructions are never dropped.
+                    agent_system_prompt = (
+                        f"{ROUTER_AGENT_TOOLS_SYSTEM_PROMPT}\n\n{system_prompt}"
+                        if system_prompt
+                        else ROUTER_AGENT_TOOLS_SYSTEM_PROMPT
+                    )
+                    async for chunk in agent.stream(
+                        provider=active_provider,
+                        messages=messages,
+                        system_prompt=agent_system_prompt,
+                        model=model_id,
+                        max_tokens=max_tokens,
+                        enable_tools=True,
+                        session_id=request.session_id,
+                        agent_id=request.agent_id,
+                    ):
+                        text_chunks += 1
+                        total_text_length += len(chunk.get("content", ""))
+                        history_assistant_parts.append(chunk.get("content", ""))
+                        yield f"data: {json.dumps(chunk)}\n\n"
+                else:
+                    from services.llm_router import LLMRouter
+
+                    async for chunk in LLMRouter().dispatch_openai_stream(
+                        provider=active_provider,
+                        messages=messages,
+                        system_prompt=ROUTER_NO_TOOLS_SYSTEM_PROMPT,
+                        model=model_id,
+                        max_tokens=max_tokens,
+                        interaction_id=request_id,
+                    ):
+                        text_chunks += 1
+                        total_text_length += len(chunk.get("content", ""))
+                        history_assistant_parts.append(chunk.get("content", ""))
+                        yield f"data: {json.dumps(chunk)}\n\n"
                 history_reached_end = True
                 elapsed_time = time.time() - start_time
                 logger.info(

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -60,16 +60,13 @@ def _is_otel_enabled() -> bool:
     return val in ("true", "1", "yes")
 
 
-def _should_record_llm_content() -> bool:
-    """Return True only when the operator has explicitly opted in."""
-    val = os.environ.get("VIGIL_OTEL_RECORD_LLM_CONTENT", "").lower()
-    return val in ("true", "1", "yes")
-
-
-def _should_record_ioc_values() -> bool:
-    """Return True only when the operator has explicitly opted in."""
-    val = os.environ.get("VIGIL_OTEL_RECORD_IOC_VALUES", "").lower()
-    return val in ("true", "1", "yes")
+# Opt-in flag helpers live in core.telemetry_config so the sanitizer can
+# read them without importing this module (breaks the import cycle).
+# Re-exported here for backwards compatibility with existing callers/tests.
+from core.telemetry_config import (  # noqa: E402
+    _should_record_ioc_values,
+    _should_record_llm_content,
+)
 
 
 # ---------------------------------------------------------------------------

--- a/core/telemetry_config.py
+++ b/core/telemetry_config.py
@@ -1,0 +1,22 @@
+"""
+core/telemetry_config.py — shared telemetry configuration helpers.
+
+Extracted so both ``core.telemetry`` and ``core.telemetry_sanitizer`` can
+read operator opt-in flags without importing each other (avoids an import
+cycle between the bootstrap and the span-scrubbing processor).
+"""
+from __future__ import annotations
+
+import os
+
+
+def _should_record_llm_content() -> bool:
+    """Return True only when the operator has explicitly opted in."""
+    val = os.environ.get("VIGIL_OTEL_RECORD_LLM_CONTENT", "").lower()
+    return val in ("true", "1", "yes")
+
+
+def _should_record_ioc_values() -> bool:
+    """Return True only when the operator has explicitly opted in."""
+    val = os.environ.get("VIGIL_OTEL_RECORD_IOC_VALUES", "").lower()
+    return val in ("true", "1", "yes")

--- a/core/telemetry_sanitizer.py
+++ b/core/telemetry_sanitizer.py
@@ -167,7 +167,10 @@ class SensitiveAttributeScrubber(SpanProcessor):  # type: ignore[misc]
                 return
 
             # Check operator opt-in flags for LLM content and IOC values
-            from core.telemetry import _should_record_llm_content, _should_record_ioc_values
+            from core.telemetry_config import (
+                _should_record_ioc_values,
+                _should_record_llm_content,
+            )
 
             record_llm = _should_record_llm_content()
             record_ioc = _should_record_ioc_values()

--- a/daemon/agent_runner.py
+++ b/daemon/agent_runner.py
@@ -15,6 +15,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+# Tool safety tiers live in services.tool_manager so every agent loop (daemon,
+# interactive OpenAI agent, workflows) shares one policy. Aliased to the
+# historical name so call sites — and the test that patches
+# ``daemon.agent_runner._get_tool_tier`` — stay unchanged.
+from services.tool_manager import get_tool_tier as _get_tool_tier
+
 
 def _default_thinking_budget() -> int:
     """Default extended-thinking budget for the autonomous runner (GH #84 PR-D).
@@ -31,14 +37,15 @@ def _default_thinking_budget() -> int:
 
 
 from daemon.config import OrchestratorConfig
-from daemon.plan_generator import WORKFLOW_STEP_MAP, DEFAULT_STEPS
+from daemon.plan_generator import DEFAULT_STEPS, WORKFLOW_STEP_MAP
 from daemon.workdir import WorkdirManager
 
 logger = logging.getLogger(__name__)
 
 try:
-    from core.telemetry import get_tracer, extract_traceparent
     from opentelemetry.trace import SpanKind
+
+    from core.telemetry import extract_traceparent, get_tracer
 
     _tracer = get_tracer("vigil.daemon.agent_runner")
 except Exception:
@@ -102,80 +109,6 @@ def compute_call_cost(
         + cache_read_tokens * cache_read_rate
         + cache_creation_tokens * cache_creation_rate
     )
-
-
-TOOL_TIERS = {
-    "safe": [
-        "list_findings",
-        "get_finding",
-        "search_findings",
-        "nearest_neighbors",
-        "get_findings_stats",
-        "semantic_search_findings",
-        "technique_rollup",
-        "list_cases",
-        "get_case",
-        "get_case_comments",
-        "get_case_iocs",
-        "get_case_tasks",
-        "search_detections",
-        "get_coverage_stats",
-        "get_detection_count",
-        "analyze_coverage",
-        "identify_gaps",
-        "create_attack_layer",
-        "get_attack_layer",
-    ],
-    "managed": [
-        "create_case",
-        "update_case",
-        "add_finding_to_case",
-        "bulk_add_findings_to_case",
-        "remove_finding_from_case",
-        "add_case_activity",
-        "add_case_timeline_entry",
-        "add_case_mitre_techniques",
-        "add_resolution_step",
-        "add_case_comment",
-        "add_case_evidence",
-        "add_case_ioc",
-        "bulk_add_iocs",
-        "add_case_task",
-        "update_case_task",
-        "link_related_cases",
-        "escalate_case",
-        "create_approval_action",
-    ],
-    "requires_approval": [
-        "isolate_host",
-        "block_ip",
-        "disable_user",
-        "quarantine_file",
-        "close_case",
-    ],
-    "forbidden": [
-        "delete_case",
-        "delete_finding",
-        "approve_action",
-        "reject_action",
-    ],
-}
-
-_TOOL_TIER_LOOKUP: Dict[str, str] = {}
-for _tier, _tools in TOOL_TIERS.items():
-    for _t in _tools:
-        _TOOL_TIER_LOOKUP[_t] = _tier
-
-
-def _get_tool_tier(tool_name: str) -> str:
-    """Get the safety tier for a tool. Strips MCP server prefixes."""
-    if tool_name in _TOOL_TIER_LOOKUP:
-        return _TOOL_TIER_LOOKUP[tool_name]
-    short = tool_name.split("_", 1)[-1] if "_" in tool_name else tool_name
-    for tier, tools in TOOL_TIERS.items():
-        if short in tools:
-            return tier
-    return "unknown"
 
 
 WORKDIR_TOOLS = [
@@ -326,8 +259,9 @@ class AgentRunner:
         # kills as 'failed' (issue #147 follow-up).
         if not self._db_smoke_checked:
             try:
-                from database.connection import get_db_manager
                 from sqlalchemy import text
+
+                from database.connection import get_db_manager
 
                 with get_db_manager().session_scope() as session:
                     session.execute(text("SELECT 1"))
@@ -339,6 +273,34 @@ class AgentRunner:
                     f"fail and investigations may be stale-killed: {e}",
                     exc_info=True,
                 )
+
+    def _plan_provider_is_anthropic(self) -> bool:
+        """True when the configured plan provider is Anthropic (or unset).
+
+        Non-Anthropic providers (Ollama/OpenAI/Groq) don't support extended
+        thinking, so the daemon disables it for them. Resolved once and cached;
+        an unresolvable provider_id defaults to Anthropic to preserve the
+        historical assumption. ``provider_id is None`` also means the default
+        Anthropic provider.
+        """
+        cached = getattr(self, "_plan_is_anthropic_cache", "unset")
+        if cached != "unset":
+            return cached
+        provider_id = self.config.plan_provider_id
+        result = True
+        if provider_id:
+            try:
+                from services.llm_router import get_provider_spec
+
+                spec = get_provider_spec(provider_id)
+                if spec is not None:
+                    result = spec.provider_type == "anthropic"
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "plan provider lookup failed (%s); assuming anthropic", exc
+                )
+        self._plan_is_anthropic_cache = result
+        return result
 
     async def _ensure_gateway(self):
         """Lazily initialise the LLM gateway."""
@@ -429,7 +391,11 @@ class AgentRunner:
         except Exception:
             pass
 
-        self._log_investigation_event(inv_id, "agent_started", {"workflow_id": investigation.get("workflow_id", "")})
+        self._log_investigation_event(
+            inv_id,
+            "agent_started",
+            {"workflow_id": investigation.get("workflow_id", "")},
+        )
 
         try:
             while not shutdown_event.is_set():
@@ -660,7 +626,9 @@ class AgentRunner:
             state["status"] = "sleeping"
             self.workdir.write_state(inv_id, state)
             self._log_investigation_event(
-                inv_id, "status_change", {"status": "sleeping", "reason": "agent_cancelled"}
+                inv_id,
+                "status_change",
+                {"status": "sleeping", "reason": "agent_cancelled"},
             )
         except Exception as e:
             logger.error(f"{inv_id}: Unexpected agent error: {e}", exc_info=True)
@@ -726,14 +694,17 @@ class AgentRunner:
         try:
             from services.cost_estimator import estimate_cost
         except Exception as e:
-            logger.debug("%s: estimate_cost import failed (%s); skipping gate", inv_id, e)
+            logger.debug(
+                "%s: estimate_cost import failed (%s); skipping gate", inv_id, e
+            )
             return False
 
         # Match the max_token sizing _call_claude uses so the high_usd
         # bound reflects the actual ceiling we'd request.
         thinking_enabled = (
             getattr(self._claude_service, "enable_thinking", False)
-            if self._claude_service else True
+            if self._claude_service
+            else True
         )
         thinking_budget = (
             getattr(
@@ -741,7 +712,8 @@ class AgentRunner:
                 "thinking_budget",
                 _default_thinking_budget(),
             )
-            if self._claude_service else _default_thinking_budget()
+            if self._claude_service
+            else _default_thinking_budget()
         )
         max_tok = max(16000, thinking_budget + 4096) if thinking_enabled else 4096
 
@@ -953,6 +925,11 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
             if self._claude_service
             else True
         )
+        # Extended thinking is Anthropic-only; a non-Anthropic plan provider
+        # routes through Bifrost's OpenAI surface where the flag is ignored, so
+        # disable it here to keep max_tokens sized for the actual response.
+        if not self._plan_provider_is_anthropic():
+            thinking_enabled = False
         _fallback = _default_thinking_budget()
         thinking_budget = (
             getattr(self._claude_service, "thinking_budget", _fallback)
@@ -989,6 +966,10 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                     thinking_budget=thinking_budget,
                     tools=all_tools if all_tools else None,
                     timeout=180,
+                    # Route through the model's actual provider. When this is a
+                    # non-Anthropic provider the worker dispatches via Bifrost's
+                    # OpenAI surface; None keeps the default-Anthropic path.
+                    provider_id=self.config.plan_provider_id,
                 )
             except Exception as e:
                 try:
@@ -1361,7 +1342,7 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
     ) -> str:
         """Create an approval request and put the agent into waiting_approval state."""
         try:
-            from services.approval_service import get_approval_service, ActionType
+            from services.approval_service import ActionType, get_approval_service
 
             service = get_approval_service()
 
@@ -1445,7 +1426,7 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
             return None
 
         try:
-            from services.approval_service import get_approval_service, ActionStatus
+            from services.approval_service import ActionStatus, get_approval_service
 
             service = get_approval_service()
             action = service.get_action(action_id)
@@ -1567,9 +1548,7 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
         state["failed_at"] = datetime.utcnow().isoformat()
         self.workdir.write_state(inv_id, state)
         self.workdir.append_log(inv_id, {"event": "failed", "reason": reason})
-        self._log_investigation_event(
-            inv_id, "failed", {"reason": reason}
-        )
+        self._log_investigation_event(inv_id, "failed", {"reason": reason})
         self._update_db_record(
             inv_id,
             {

--- a/daemon/config.py
+++ b/daemon/config.py
@@ -96,6 +96,12 @@ class OrchestratorConfig:
     context_max_chars: int = 10000
     plan_model: str = DEFAULT_MODEL
     review_model: str = DEFAULT_MODEL
+    # Provider that owns plan_model/review_model. Resolved alongside the model
+    # from ai_model_configs so autonomous investigations can run on
+    # non-Anthropic providers (Ollama/OpenAI/Groq). None means "the default
+    # Anthropic provider" and preserves pre-multi-provider behavior.
+    plan_provider_id: Optional[str] = None
+    review_provider_id: Optional[str] = None
 
 
 @dataclass
@@ -284,9 +290,14 @@ class DaemonConfig:
             registry = get_registry()
             plan_pick = registry.resolve_model_for_component('orchestrator_plan')
             review_pick = registry.resolve_model_for_component('orchestrator_review')
+            # resolve_model_for_component returns (provider_id, model_id). Keep
+            # BOTH: the provider_id is what lets the daemon route a non-Anthropic
+            # model through Bifrost instead of silently assuming Anthropic.
             if plan_pick is not None:
+                config.orchestrator.plan_provider_id = plan_pick[0]
                 config.orchestrator.plan_model = plan_pick[1]
             if review_pick is not None:
+                config.orchestrator.review_provider_id = review_pick[0]
                 config.orchestrator.review_model = review_pick[1]
             if plan_pick or review_pick:
                 logger.info(

--- a/daemon/federation/adapters/_siem_base.py
+++ b/daemon/federation/adapters/_siem_base.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, Optional
 
 from core.config import is_integration_enabled
 from daemon.federation.adapters._base import fresh_cursor, parse_cursor_since
-from daemon.federation.registry import FetchResult
+from daemon.federation.contract import FetchResult
 
 logger = logging.getLogger(__name__)
 

--- a/daemon/federation/adapters/aws_security_hub.py
+++ b/daemon/federation/adapters/aws_security_hub.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from daemon.federation.adapters._siem_base import SIEMIngestionAdapter
-from daemon.federation.registry import FederationAdapter, register_adapter
+from daemon.federation.contract import FederationAdapter, register_adapter
 
 
 def _factory() -> FederationAdapter:

--- a/daemon/federation/adapters/azure_sentinel.py
+++ b/daemon/federation/adapters/azure_sentinel.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from daemon.federation.adapters._siem_base import SIEMIngestionAdapter
-from daemon.federation.registry import FederationAdapter, register_adapter
+from daemon.federation.contract import FederationAdapter, register_adapter
 
 
 def _factory() -> FederationAdapter:

--- a/daemon/federation/adapters/crowdstrike.py
+++ b/daemon/federation/adapters/crowdstrike.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 
 from core.config import get_integration_config, is_integration_enabled
 from daemon.federation.adapters._base import fresh_cursor, parse_cursor_since
-from daemon.federation.registry import (
+from daemon.federation.contract import (
     FederationAdapter,
     FetchResult,
     register_adapter,

--- a/daemon/federation/adapters/elastic.py
+++ b/daemon/federation/adapters/elastic.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from daemon.federation.adapters._siem_base import SIEMIngestionAdapter
-from daemon.federation.registry import FederationAdapter, register_adapter
+from daemon.federation.contract import FederationAdapter, register_adapter
 
 
 def _factory() -> FederationAdapter:

--- a/daemon/federation/adapters/microsoft_defender.py
+++ b/daemon/federation/adapters/microsoft_defender.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from daemon.federation.adapters._siem_base import SIEMIngestionAdapter
-from daemon.federation.registry import FederationAdapter, register_adapter
+from daemon.federation.contract import FederationAdapter, register_adapter
 
 
 def _factory() -> FederationAdapter:

--- a/daemon/federation/adapters/splunk.py
+++ b/daemon/federation/adapters/splunk.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional
 
 from core.config import get_integration_config, is_integration_enabled
 from daemon.federation.adapters._base import fresh_cursor, parse_cursor_since
-from daemon.federation.registry import (
+from daemon.federation.contract import (
     FederationAdapter,
     FetchResult,
     register_adapter,

--- a/daemon/federation/contract.py
+++ b/daemon/federation/contract.py
@@ -1,0 +1,84 @@
+"""Adapter contract + registration primitives for federated monitoring.
+
+Split out from :mod:`daemon.federation.registry` so adapter modules can import
+the contract (``FetchResult``, ``FederationAdapter``, ``register_adapter``)
+without depending on the registry — which in turn lazily imports every adapter
+in :func:`daemon.federation.registry._ensure_builtins_loaded`. Keeping the
+contract here (a module that imports nothing from ``daemon.federation``) breaks
+what would otherwise be an adapter <-> registry import cycle.
+
+The registry re-exports these names, so existing
+``from daemon.federation.registry import FetchResult`` imports keep working.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Protocol
+
+
+@dataclass
+class FetchResult:
+    """One adapter fetch's output.
+
+    ``findings`` is the list of normalized finding dicts (same shape the rest
+    of the daemon already consumes — see ``services.ingestion_service``).
+    ``cursor`` is the new persisted cursor for the next fetch — the runner
+    writes it to ``federation_sources.cursor`` after a successful fetch.
+    """
+
+    findings: List[Dict[str, Any]] = field(default_factory=list)
+    cursor: Dict[str, Any] = field(default_factory=dict)
+
+
+class FederationAdapter(Protocol):
+    """Contract every federated-monitoring source adapter implements."""
+
+    #: Unique source identifier (also the federation_sources.source_id PK).
+    name: str
+
+    def is_configured(self) -> bool:
+        """True if the underlying integration is configured (e.g. credentials set)."""
+        ...
+
+    def default_interval(self) -> int:
+        """Default poll interval (seconds). Used when seeding a fresh row."""
+        ...
+
+    async def fetch(
+        self,
+        *,
+        since: Optional[datetime],
+        cursor: Dict[str, Any],
+        max_items: int,
+    ) -> FetchResult:
+        """Pull new findings since the cursor.
+
+        ``since`` is an absolute fallback for adapters that don't honor the
+        cursor on first run; ``cursor`` is the per-source state previously
+        returned by this adapter (empty dict on first run — adapters MUST
+        treat empty as "from now", we do not backfill on cold start).
+
+        Implementations should honor ``max_items`` to bound first-run blast
+        radius if the source happens to return everything in its history.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+# Adapter constructors are registered lazily so importing the registry doesn't
+# pull in every service. The runner calls ``list_adapters()`` once at startup.
+_ADAPTER_FACTORIES: Dict[str, Callable[[], FederationAdapter]] = {}
+
+
+def register_adapter(name: str, factory: Callable[[], FederationAdapter]) -> None:
+    """Register an adapter factory under ``name``.
+
+    Called once per adapter module at import time. Re-registration overwrites
+    the prior factory (useful in tests).
+    """
+    _ADAPTER_FACTORIES[name] = factory

--- a/daemon/federation/registry.py
+++ b/daemon/federation/registry.py
@@ -1,92 +1,37 @@
-"""Adapter contract + registry for federated monitoring.
+"""Adapter registry for federated monitoring.
 
 Each adapter wraps one external data source (Splunk, CrowdStrike, etc.) behind
 a uniform fetch interface so the runner in :mod:`daemon.poller` can iterate
 over a registry instead of hardcoding per-source loops.
 
-Adapters are intentionally thin — they delegate to existing services in
-``services/*`` for the actual API calls. The contract here only normalizes:
-
-  * how the runner detects whether the underlying integration is configured
-    (so we can skip seeding/polling sources the user hasn't set up),
-  * the fetch shape (cursor in, findings + new cursor out),
-  * the default cadence each source class warrants (EDR is faster than SIEM).
+The adapter contract itself (``FetchResult``, ``FederationAdapter``,
+``register_adapter``) lives in :mod:`daemon.federation.contract` so adapter
+modules can import it without depending on this module — which lazily imports
+every adapter in :func:`_ensure_builtins_loaded` and would otherwise form an
+import cycle. Those names are re-exported here for backward compatibility.
 """
 
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Protocol
+from typing import List, Optional
+
+from daemon.federation.contract import (
+    _ADAPTER_FACTORIES,
+    FederationAdapter,
+    FetchResult,
+    register_adapter,
+)
 
 logger = logging.getLogger(__name__)
 
-
-@dataclass
-class FetchResult:
-    """One adapter fetch's output.
-
-    ``findings`` is the list of normalized finding dicts (same shape the rest
-    of the daemon already consumes — see ``services.ingestion_service``).
-    ``cursor`` is the new persisted cursor for the next fetch — the runner
-    writes it to ``federation_sources.cursor`` after a successful fetch.
-    """
-
-    findings: List[Dict[str, Any]] = field(default_factory=list)
-    cursor: Dict[str, Any] = field(default_factory=dict)
-
-
-class FederationAdapter(Protocol):
-    """Contract every federated-monitoring source adapter implements."""
-
-    #: Unique source identifier (also the federation_sources.source_id PK).
-    name: str
-
-    def is_configured(self) -> bool:
-        """True if the underlying integration is configured (e.g. credentials set)."""
-        ...
-
-    def default_interval(self) -> int:
-        """Default poll interval (seconds). Used when seeding a fresh row."""
-        ...
-
-    async def fetch(
-        self,
-        *,
-        since: Optional[datetime],
-        cursor: Dict[str, Any],
-        max_items: int,
-    ) -> FetchResult:
-        """Pull new findings since the cursor.
-
-        ``since`` is an absolute fallback for adapters that don't honor the
-        cursor on first run; ``cursor`` is the per-source state previously
-        returned by this adapter (empty dict on first run — adapters MUST
-        treat empty as "from now", we do not backfill on cold start).
-
-        Implementations should honor ``max_items`` to bound first-run blast
-        radius if the source happens to return everything in its history.
-        """
-        ...
-
-
-# ---------------------------------------------------------------------------
-# Registry
-# ---------------------------------------------------------------------------
-
-# Adapter constructors are registered lazily so importing this module doesn't
-# pull in every service. The runner calls ``list_adapters()`` once at startup.
-_ADAPTER_FACTORIES: Dict[str, Callable[[], FederationAdapter]] = {}
-
-
-def register_adapter(name: str, factory: Callable[[], FederationAdapter]) -> None:
-    """Register an adapter factory under ``name``.
-
-    Called once per adapter module at import time. Re-registration overwrites
-    the prior factory (useful in tests).
-    """
-    _ADAPTER_FACTORIES[name] = factory
+__all__ = [
+    "FederationAdapter",
+    "FetchResult",
+    "register_adapter",
+    "list_adapters",
+    "get_adapter",
+]
 
 
 def list_adapters() -> List[FederationAdapter]:

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,13 @@
+{
+  "//": "backend/ is added to sys.path at runtime (backend/main.py), so modules like `secrets_manager` are imported bare (`from secrets_manager import ...`). Tell static analysis (Pylance / pyright) the same so those imports resolve.",
+  "extraPaths": ["backend"],
+  "exclude": [
+    "**/node_modules",
+    "**/__pycache__",
+    "**/.*",
+    "venv",
+    "frontend",
+    "build",
+    "dist"
+  ]
+}

--- a/services/claude_service.py
+++ b/services/claude_service.py
@@ -2598,7 +2598,6 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
             content_blocks = []
             # Add images first
             content_blocks.extend(images)
-            # Add text message
             content_blocks.append({"type": "text", "text": message})
             return content_blocks
 

--- a/services/llm_format.py
+++ b/services/llm_format.py
@@ -1,0 +1,196 @@
+"""Anthropic <-> OpenAI wire-format translation.
+
+The interactive chat path (``OpenAIAgentService``), the daemon's autonomous
+tool loop (``daemon/agent_runner`` via ``LLMRouter``), and the workflow engine
+all build conversations in **Anthropic** shape — messages whose ``content`` is a
+list of typed blocks (``text``, ``thinking``, ``tool_use``, ``tool_result``)
+and tools described as ``{"name", "description", "input_schema"}``.
+
+Non-Anthropic providers (Ollama, OpenAI, Groq) are reached through Bifrost's
+OpenAI-compatible ``/v1`` surface, which expects a different shape: assistant
+``tool_calls`` arrays, standalone ``role: "tool"`` result messages, and tools
+described as ``{"type": "function", "function": {...}}``.
+
+Centralizing the translation here keeps the router and the agent loops from
+drifting. Both translators are **idempotent / tolerant**: a message whose
+``content`` is already a plain string (the ordinary OpenAI shape) passes
+through untouched, so callers that never used Anthropic blocks are unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Dict, List
+
+
+def anthropic_tools_to_openai(
+    tools: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Convert Anthropic tool schemas to OpenAI function-calling format.
+
+    Anthropic: ``{"name", "description", "input_schema": {json-schema}}``
+    OpenAI:    ``{"type": "function", "function": {"name", "description",
+               "parameters": {json-schema}}}``
+
+    A tool that is already in OpenAI shape (has a ``function`` key) is passed
+    through unchanged so this is safe to call on mixed/pre-converted lists.
+    """
+    converted: List[Dict[str, Any]] = []
+    for tool in tools:
+        if "function" in tool and tool.get("type") == "function":
+            converted.append(tool)
+            continue
+        converted.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "parameters": tool.get(
+                        "input_schema",
+                        {"type": "object", "properties": {}},
+                    ),
+                },
+            }
+        )
+    return converted
+
+
+def _flatten_tool_result_content(content: Any) -> str:
+    """Reduce an Anthropic ``tool_result`` block's content to plain text.
+
+    The content may be a string, or a list of blocks (``{"type": "text",
+    "text": ...}``). OpenAI ``tool`` messages carry a single string body.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    parts.append(str(block.get("text", "")))
+                else:
+                    parts.append(json.dumps(block, default=str))
+            else:
+                parts.append(str(block))
+        return "\n".join(parts)
+    return str(content)
+
+
+def _assistant_block_message(content: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Translate an Anthropic assistant block list to one OpenAI message."""
+    text_parts: List[str] = []
+    tool_calls: List[Dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype == "text":
+            text_parts.append(str(block.get("text", "")))
+        elif btype == "tool_use":
+            tool_calls.append(
+                {
+                    "id": block.get("id") or f"call_{uuid.uuid4().hex[:12]}",
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name", ""),
+                        "arguments": json.dumps(block.get("input") or {}),
+                    },
+                }
+            )
+        # 'thinking' blocks have no OpenAI equivalent — drop them.
+    msg: Dict[str, Any] = {"role": "assistant"}
+    text = "".join(text_parts)
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+        # OpenAI requires content present (may be null) alongside tool_calls.
+        msg["content"] = text or None
+    else:
+        # An assistant turn with neither text nor tool calls is invalid; emit
+        # an empty string rather than a key-less message.
+        msg["content"] = text
+    return msg
+
+
+def _user_block_messages(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Translate an Anthropic user block list to OpenAI message(s).
+
+    ``tool_result`` blocks become standalone ``role: "tool"`` messages; any
+    plain ``text``/``image`` content becomes a regular user message. Tool
+    results are emitted first so they immediately follow the assistant
+    ``tool_calls`` turn they answer (OpenAI ordering requirement).
+    """
+    tool_messages: List[Dict[str, Any]] = []
+    user_parts: List[Dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            user_parts.append({"type": "text", "text": str(block)})
+            continue
+        btype = block.get("type")
+        if btype == "tool_result":
+            tool_messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": block.get("tool_use_id"),
+                    "content": _flatten_tool_result_content(block.get("content")),
+                }
+            )
+        elif btype == "text":
+            user_parts.append({"type": "text", "text": str(block.get("text", ""))})
+        elif btype == "image":
+            source = block.get("source", {})
+            if isinstance(source, dict) and source.get("type") == "base64":
+                media_type = source.get("media_type", "image/jpeg")
+                data = source.get("data", "")
+                user_parts.append({
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{media_type};base64,{data}"}
+                })
+            else:
+                user_parts.append(block)
+        else:
+            user_parts.append({"type": "text", "text": json.dumps(block, default=str)})
+
+    out: List[Dict[str, Any]] = list(tool_messages)
+    if user_parts:
+        # Collapse a single text part to a plain string (the common case) so
+        # the output matches what simple callers already send.
+        if len(user_parts) == 1 and user_parts[0].get("type") == "text":
+            out.append({"role": "user", "content": user_parts[0]["text"]})
+        else:
+            out.append({"role": "user", "content": user_parts})
+    return out
+
+
+def anthropic_messages_to_openai(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Translate Anthropic-shape messages to OpenAI chat-completion messages.
+
+    Idempotent for messages whose ``content`` is already a string: those are
+    returned unchanged, so this is safe to apply to conversations that never
+    used Anthropic content blocks.
+    """
+    out: List[Dict[str, Any]] = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        content = msg.get("content")
+        if not isinstance(content, list):
+            # String content (or anything non-block) — pass through verbatim.
+            out.append(msg)
+            continue
+        if role == "assistant":
+            out.append(_assistant_block_message(content))
+        elif role == "user":
+            out.extend(_user_block_messages(content))
+        else:
+            # system / tool / unknown roles with block content: flatten to text.
+            text = _flatten_tool_result_content(content)
+            out.append({"role": role, "content": text})
+    return out

--- a/services/llm_router.py
+++ b/services/llm_router.py
@@ -1,29 +1,6 @@
-"""LLM router: dispatches calls through the Bifrost gateway.
-
-Per GH #84 PR-B, Vigil routes **all** LLM traffic through Bifrost —
-Anthropic, OpenAI, Ollama, and any future providers — so that caching,
-cost tracking, and budget enforcement live in exactly one place.
-
-Anthropic traffic (including extended-thinking calls) hits Bifrost's
-Anthropic-compatible passthrough at ``{BIFROST_URL}/anthropic`` using
-the regular Anthropic SDK with a swapped ``base_url``. Non-Anthropic
-providers use Bifrost's OpenAI-format surface at ``{BIFROST_URL}/v1``.
-
-Before this PR ships, ``scripts/bifrost_capability_probe.py`` must pass
-against a live Bifrost — it verifies extended thinking, ``cache_control``
-blocks, and cache-token usage counters round-trip unchanged.
-
-Usage::
-
-    from services.llm_router import LLMRouter
-
-    router = LLMRouter()
-    provider = router.resolve_provider(provider_id)   # DB lookup
-    result = await router.dispatch(messages=..., provider=provider, enable_thinking=True)
-"""
-
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
@@ -33,10 +10,6 @@ from typing import Any, Dict, List, Literal, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Repo path setup — secrets_manager lives under backend/, which isn't on
-# sys.path in the worker/daemon. Mirror the pattern used elsewhere.
-# ---------------------------------------------------------------------------
 _REPO = Path(__file__).resolve().parent.parent
 if str(_REPO / "backend") not in sys.path:
     sys.path.insert(0, str(_REPO / "backend"))
@@ -48,25 +21,10 @@ try:  # soft imports — router is usable in tests without a DB
 except Exception:  # noqa: BLE001
     get_secret = None  # type: ignore
 
-
-# DispatchPath retained as a single-value literal so downstream code that
-# branches on it keeps working without edits. If we add another gateway
-# later, this grows back into a union.
 DispatchPath = Literal["bifrost"]
 
 
-# ---------------------------------------------------------------------------
-# Budget-error mapping (#186)
-# ---------------------------------------------------------------------------
-
-
 def _is_budget_status(status_code: Optional[int]) -> bool:
-    """Bifrost returns 429 when the VK rate limit is hit and 402 when a
-    budget tier is exceeded. We map both to ``BudgetExceeded`` so callers
-    can render a typed error rather than a generic 500. Some providers
-    map "insufficient quota" to 429 too, so the line between rate-limit
-    and budget-exceeded is fuzzy — we surface ``tier`` in the exception
-    so the UI can disambiguate when Bifrost adds richer error bodies."""
     return status_code in (402, 429)
 
 
@@ -139,8 +97,6 @@ def _bifrost_url() -> str:
 
 
 def _block_on_injection() -> bool:
-    """Honoured by the pre-dispatch hook (issue #87). Off by default —
-    we observe before enforcing. Promote via env, not by editing code."""
     return os.getenv("PROMPT_INJECTION_BLOCK", "false").lower() in ("true", "1", "yes")
 
 
@@ -152,9 +108,26 @@ def select_path(
     return "bifrost"
 
 
-# ---------------------------------------------------------------------------
-# Pre-dispatch sanitization (issue #87)
-# ---------------------------------------------------------------------------
+def _normalize_openai_tool_calls(tool_calls: Any) -> Optional[List[Dict[str, Any]]]:
+    if not tool_calls:
+        return None
+    normalized: List[Dict[str, Any]] = []
+    for tc in tool_calls:
+        fn = getattr(tc, "function", None)
+        name = getattr(fn, "name", None) if fn is not None else None
+        raw_args = getattr(fn, "arguments", None) if fn is not None else None
+        try:
+            parsed = json.loads(raw_args) if raw_args else {}
+        except (json.JSONDecodeError, TypeError):
+            parsed = {}
+        normalized.append(
+            {
+                "id": getattr(tc, "id", None),
+                "name": name,
+                "input": parsed if isinstance(parsed, dict) else {},
+            }
+        )
+    return normalized or None
 
 
 def _wrap_tool_results_in_messages(
@@ -233,6 +206,23 @@ def _scan_messages_for_injection(messages: List[Dict[str, Any]]) -> List[str]:
     return patterns
 
 
+def _bifrost_headers(interaction_id: Optional[str] = None) -> Dict[str, str]:
+    """Log-correlation and budget-VK headers every Bifrost call carries."""
+    headers: Dict[str, str] = {}
+    if interaction_id:
+        headers["x-bf-lh-vigil-interaction-id"] = interaction_id
+    try:
+        from services.budget_service import get_active_vk, should_enforce
+
+        if should_enforce():
+            vk = get_active_vk()
+            if vk:
+                headers["x-bf-vk"] = vk
+    except Exception as exc:
+        logger.debug("budget_service unavailable (%s); proceeding without x-bf-vk", exc)
+    return headers
+
+
 def _pre_dispatch_sanitize(
     messages: List[Dict[str, Any]],
     system_prompt: Optional[str],
@@ -243,10 +233,7 @@ def _pre_dispatch_sanitize(
     Returns the (possibly rewritten) ``messages`` and the system prompt
     (returned as-is — we never silently mutate user system prompts).
     """
-    from services.prompt_security import (
-        PromptInjectionBlocked,
-        scan_for_injection,
-    )
+    from services.prompt_security import PromptInjectionBlocked, scan_for_injection
 
     wrapped = _wrap_tool_results_in_messages(messages)
 
@@ -320,26 +307,7 @@ class LLMRouter:
         messages, system_prompt = _pre_dispatch_sanitize(messages, system_prompt)
         model = model or provider.default_model
 
-        # #185: correlation header for Bifrost log lookup.
-        # #186: VK header so Bifrost's governance layer enforces budgets.
-        # Both share the extra_headers kwarg the SDKs forward to the upstream
-        # request. Only attach x-bf-vk when budget enforcement is on; while
-        # DEV_MODE / LLM_BUDGET_UNLIMITED is set, omit the header entirely
-        # so Bifrost's bootstrap "no VK" path applies.
-        extra_headers: Dict[str, str] = {}
-        if interaction_id:
-            extra_headers["x-bf-lh-vigil-interaction-id"] = interaction_id
-        try:
-            from services.budget_service import get_active_vk, should_enforce
-
-            if should_enforce():
-                vk = get_active_vk()
-                if vk:
-                    extra_headers["x-bf-vk"] = vk
-        except Exception as _be:
-            logger.debug(
-                "budget_service unavailable (%s); proceeding without x-bf-vk", _be
-            )
+        extra_headers = _bifrost_headers(interaction_id)
         # Convert empty dict back to None so the dispatch helpers can use a
         # truthy check for "should I send any extra headers" without leaking
         # an empty dict into the SDK call.
@@ -389,10 +357,20 @@ class LLMRouter:
     ) -> Dict[str, Any]:
         from openai import AsyncOpenAI  # lazy — avoids hard dep for tests
 
+        from services.llm_format import (
+            anthropic_messages_to_openai,
+            anthropic_tools_to_openai,
+        )
+
+        # Callers (the daemon tool loop, workflows) build conversations in
+        # Anthropic shape — assistant tool_use blocks, user tool_result blocks,
+        # and tools with `input_schema`. Translate both to OpenAI shape so the
+        # multi-turn tool loop round-trips; string-content messages and already
+        # OpenAI-shaped tools pass through untouched.
         oai_messages: List[Dict[str, Any]] = []
         if system_prompt:
             oai_messages.append({"role": "system", "content": system_prompt})
-        oai_messages.extend(messages)
+        oai_messages.extend(anthropic_messages_to_openai(messages))
 
         client = AsyncOpenAI(
             base_url=f"{self.bifrost_url}/v1",
@@ -406,7 +384,7 @@ class LLMRouter:
         if temperature is not None:
             kwargs["temperature"] = temperature
         if tools:
-            kwargs["tools"] = tools
+            kwargs["tools"] = anthropic_tools_to_openai(tools)
         if extra_headers:
             kwargs["extra_headers"] = extra_headers
 
@@ -428,7 +406,13 @@ class LLMRouter:
                     cache_read = getattr(details, "cached_tokens", 0) or 0
             return {
                 "content": choice.content or "",
-                "tool_calls": getattr(choice, "tool_calls", None),
+                # Normalize OpenAI tool-call objects to {id, name, input} dicts
+                # so _adapt_router_result_to_raw can build Anthropic tool_use
+                # blocks without touching SDK-object internals. Arguments arrive
+                # as a JSON string; parse to a dict (empty on malformed JSON).
+                "tool_calls": _normalize_openai_tool_calls(
+                    getattr(choice, "tool_calls", None)
+                ),
                 "model": resp.model,
                 "input_tokens": getattr(usage, "prompt_tokens", 0) if usage else 0,
                 "output_tokens": getattr(usage, "completion_tokens", 0) if usage else 0,
@@ -441,6 +425,69 @@ class LLMRouter:
             # AsyncOpenAI holds an httpx connection pool; close it so file
             # descriptors / connections don't leak per call (chat()'s
             # non-streaming path routes through here).
+            await client.close()
+
+    async def stream_openai_raw(
+        self,
+        *,
+        provider: ProviderSpec,
+        messages: List[Dict[str, Any]],
+        system_prompt: Optional[str] = None,
+        model: Optional[str] = None,
+        max_tokens: int = 4096,
+        temperature: Optional[float] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        interaction_id: Optional[str] = None,
+        include_usage: bool = False,
+    ):
+        """Yield raw OpenAI stream chunks (tool-call deltas, finish_reason,
+        usage) for non-Anthropic Bifrost providers."""
+        from openai import AsyncOpenAI
+
+        from services.llm_format import (
+            anthropic_messages_to_openai,
+            anthropic_tools_to_openai,
+        )
+
+        messages, system_prompt = _pre_dispatch_sanitize(messages, system_prompt)
+        model = model or provider.default_model
+
+        oai_messages: List[Dict[str, Any]] = []
+        if system_prompt:
+            oai_messages.append({"role": "system", "content": system_prompt})
+        oai_messages.extend(anthropic_messages_to_openai(messages))
+
+        client = AsyncOpenAI(
+            base_url=f"{self.bifrost_url}/v1",
+            api_key="bifrost",
+        )
+        kwargs: Dict[str, Any] = {
+            "model": f"{provider.provider_type}/{model}",
+            "messages": oai_messages,
+            "max_tokens": max_tokens,
+            "stream": True,
+        }
+        if include_usage:
+            kwargs["stream_options"] = {"include_usage": True}
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+        if tools:
+            kwargs["tools"] = anthropic_tools_to_openai(tools)
+        extra_headers = _bifrost_headers(interaction_id)
+        if extra_headers:
+            kwargs["extra_headers"] = extra_headers
+
+        try:
+            stream = await client.chat.completions.create(**kwargs)
+            async for chunk in stream:
+                yield chunk
+        except Exception as exc:
+            await _wrap_budget_errors(_raise_async(exc))
+        finally:
+            # AsyncOpenAI holds an httpx connection pool; close it on normal
+            # completion, error, AND consumer disconnect (GeneratorExit, e.g.
+            # the SSE client goes away mid-stream) so file descriptors /
+            # connections don't accumulate under load.
             await client.close()
 
     async def dispatch_openai_stream(
@@ -456,65 +503,21 @@ class LLMRouter:
         interaction_id: Optional[str] = None,
     ):
         """Yield OpenAI-format text chunks for non-Anthropic Bifrost providers."""
-        from openai import AsyncOpenAI
-
-        messages, system_prompt = _pre_dispatch_sanitize(messages, system_prompt)
-        model = model or provider.default_model
-
-        extra_headers: Dict[str, str] = {}
-        if interaction_id:
-            extra_headers["x-bf-lh-vigil-interaction-id"] = interaction_id
-        try:
-            from services.budget_service import get_active_vk, should_enforce
-
-            if should_enforce():
-                vk = get_active_vk()
-                if vk:
-                    extra_headers["x-bf-vk"] = vk
-        except Exception as _be:
-            logger.debug(
-                "budget_service unavailable (%s); proceeding without x-bf-vk", _be
-            )
-
-        oai_messages: List[Dict[str, Any]] = []
-        if system_prompt:
-            oai_messages.append({"role": "system", "content": system_prompt})
-        oai_messages.extend(messages)
-
-        client = AsyncOpenAI(
-            base_url=f"{self.bifrost_url}/v1",
-            api_key="bifrost",
-        )
-        kwargs: Dict[str, Any] = {
-            "model": f"{provider.provider_type}/{model}",
-            "messages": oai_messages,
-            "max_tokens": max_tokens,
-            "stream": True,
-        }
-        if temperature is not None:
-            kwargs["temperature"] = temperature
-        if tools:
-            kwargs["tools"] = tools
-        if extra_headers:
-            kwargs["extra_headers"] = extra_headers
-
-        try:
-            stream = await client.chat.completions.create(**kwargs)
-            async for chunk in stream:
-                if not chunk.choices:
-                    continue
-                delta = chunk.choices[0].delta
-                content = getattr(delta, "content", None)
-                if content:
-                    yield {"type": "text", "content": content}
-        except Exception as exc:
-            await _wrap_budget_errors(_raise_async(exc))
-        finally:
-            # AsyncOpenAI holds an httpx connection pool; close it on normal
-            # completion, error, AND consumer disconnect (GeneratorExit, e.g.
-            # the SSE client goes away mid-stream) so file descriptors /
-            # connections don't accumulate under load.
-            await client.close()
+        async for chunk in self.stream_openai_raw(
+            provider=provider,
+            messages=messages,
+            system_prompt=system_prompt,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tools=tools,
+            interaction_id=interaction_id,
+        ):
+            if not chunk.choices:
+                continue
+            content = getattr(chunk.choices[0].delta, "content", None)
+            if content:
+                yield {"type": "text", "content": content}
 
     async def _dispatch_anthropic(
         self,
@@ -622,15 +625,10 @@ def provider_spec_from_row(row) -> ProviderSpec:
 
 
 def get_provider_spec(provider_id: Optional[str]) -> Optional[ProviderSpec]:
-    """Load a provider by id (or the default Anthropic row if id is None).
-
-    Returns None if the DB is unavailable — callers should fall back to the
-    legacy ClaudeService path in that case.
-    """
     try:
         from database.connection import get_db_session
         from database.models import LLMProviderConfig
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("provider spec DB lookup skipped: %s", exc)
         return None
 
@@ -655,16 +653,6 @@ def get_provider_spec(provider_id: Optional[str]) -> Optional[ProviderSpec]:
 
 
 def get_default_provider_spec() -> Optional[ProviderSpec]:
-    """Load the default active provider of any type.
-
-    Preference order:
-    1. Any provider with ``is_default=True`` and ``is_active=True``
-    2. Any provider with ``is_active=True`` (first row, arbitrary order)
-
-    Returns None when no provider is configured or the DB is unavailable.
-    Used by the chat endpoint to route non-Anthropic providers through the
-    OpenAI-format Bifrost surface rather than requiring an Anthropic key.
-    """
     try:
         from database.connection import get_db_session
         from database.models import LLMProviderConfig

--- a/services/llm_worker.py
+++ b/services/llm_worker.py
@@ -22,10 +22,7 @@ from arq.connections import RedisSettings
 # Ensure project root is importable
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from services.llm_gateway import (
-    QUEUE_NAME,
-    RedisSessionStore,
-)
+from services.llm_gateway import QUEUE_NAME, RedisSessionStore
 
 logger = logging.getLogger(__name__)
 
@@ -85,8 +82,9 @@ async def llm_call(
 
     # Restore parent span context propagated across the ARQ/Redis boundary
     try:
-        from core.telemetry import extract_traceparent, get_tracer
         from opentelemetry.trace import SpanKind
+
+        from core.telemetry import extract_traceparent, get_tracer
 
         parent_ctx = extract_traceparent({"traceparent": traceparent})
         _tracer = get_tracer("vigil.services.llm_worker")
@@ -201,8 +199,9 @@ async def llm_call_raw(
 
     # Restore parent span context propagated across the ARQ/Redis boundary
     try:
-        from core.telemetry import extract_traceparent, get_tracer
         from opentelemetry.trace import SpanKind
+
+        from core.telemetry import extract_traceparent, get_tracer
 
         parent_ctx = extract_traceparent({"traceparent": traceparent})
         _tracer = get_tracer("vigil.services.llm_worker")
@@ -594,6 +593,10 @@ def _serialize_raw_response(response: Any) -> Dict[str, Any]:
             "cache_creation_tokens": getattr(
                 response.usage, "cache_creation_input_tokens", 0
             ),
+            # This path is only taken for the shared (default Anthropic)
+            # ClaudeService; make the provider explicit so cost accounting
+            # doesn't rely on a downstream ``or "anthropic"`` fallback.
+            "provider": "anthropic",
         }
     except Exception as e:
         logger.error(f"Failed to serialise raw response: {e}")

--- a/services/model_registry.py
+++ b/services/model_registry.py
@@ -991,3 +991,15 @@ def invalidate_model_cache(provider_id: Optional[str] = None) -> None:
     except Exception:  # noqa: BLE001
         pass
     clear_live_meta()
+
+
+def find_provider_for_model(model_id: str) -> Optional[str]:
+    """Reverse-lookup: find which provider_id owns a model from the cache.
+
+    Returns the first provider_id whose cached model list contains model_id,
+    or None if not found.
+    """
+    for pid, models in _MODEL_LIST_CACHE._entries.items():
+        if model_id in models:
+            return pid
+    return None

--- a/services/openai_agent_service.py
+++ b/services/openai_agent_service.py
@@ -1,0 +1,842 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from collections import deque
+from typing import Any, AsyncIterator, Dict, List, Optional, Set
+
+from services import tool_manager
+from services.llm_format import anthropic_tools_to_openai
+from services.llm_router import LLMRouter, ProviderSpec
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["OpenAIAgentService", "anthropic_tools_to_openai"]
+
+_MAX_TOOL_ITERATIONS = 30
+_MAX_PROCESSING_TIME_S = 300.0
+_TOOL_TIMEOUT_S = 30.0
+_MAX_TOOL_RESPONSE_CHARS = 50_000
+_HISTORY_WINDOW_DEFAULT = 20
+_LOOP_DETECT_WINDOW = 5
+_LOOP_DETECT_THRESHOLD = 3
+_BASE_INTER_ITERATION_DELAY_S = 0.5
+_MAX_INTER_ITERATION_DELAY_S = 3.0
+_BACKOFF_ITERATION_THRESHOLD = 15
+_APPROVAL_POLL_INTERVAL_S = 5.0
+_APPROVAL_WAIT_TIMEOUT_S = 600.0
+
+
+class PendingApprovalError(Exception):
+    """Tool call blocked pending human approval; action_id is the queue row to
+    poll, or None when the request could not be created."""
+
+    def __init__(self, message: str, action_id: Optional[str] = None):
+        super().__init__(message)
+        self.action_id = action_id
+
+
+def _truncate(text: str, max_chars: int = _MAX_TOOL_RESPONSE_CHARS) -> str:
+    if len(text) <= max_chars:
+        return text
+    omitted = len(text) - max_chars
+    return text[:max_chars] + f"\n...[truncated, {omitted} chars omitted]"
+
+
+def _inter_iteration_delay(iteration: int) -> float:
+    """Exponential backoff matching ClaudeService: 500ms base, ramp after 15."""
+    if iteration <= _BACKOFF_ITERATION_THRESHOLD:
+        return _BASE_INTER_ITERATION_DELAY_S
+    exp = iteration - _BACKOFF_ITERATION_THRESHOLD
+    delay = _BASE_INTER_ITERATION_DELAY_S * (1.5**exp)
+    return min(delay, _MAX_INTER_ITERATION_DELAY_S)
+
+
+def _canonical_args(raw: str) -> str:
+    """Canonicalize tool-call argument JSON for stable loop detection.
+
+    Parse and re-serialize with sorted keys so cosmetic streaming
+    differences (whitespace, key ordering) don't make a repeated call look
+    distinct and defeat the infinite-loop guard. Falls back to the stripped
+    raw string when the arguments aren't valid JSON.
+    """
+    try:
+        return json.dumps(
+            json.loads(raw or "{}"), sort_keys=True, separators=(",", ":")
+        )
+    except (json.JSONDecodeError, TypeError):
+        return (raw or "").strip()
+
+
+class OpenAIAgentService:
+    """Streaming agent loop for OpenAI-compatible providers via Bifrost.
+
+    Mirrors ClaudeService.chat_stream capabilities:
+      - Multi-turn tool calling with streaming
+      - Infinite loop detection
+      - Context window management
+      - Per-iteration audit logging
+      - Agent-specific tool filtering
+    """
+
+    def __init__(
+        self,
+        *,
+        backend_tools: Optional[List[Dict[str, Any]]] = None,
+        include_mcp_tools: bool = True,
+        recommended_tools: Optional[List[str]] = None,
+    ):
+        self._backend_tools = backend_tools or self._load_backend_tools()
+        self._include_mcp_tools = include_mcp_tools
+        self._recommended_tools = recommended_tools
+        self._backend_tool_names: Set[str] = {t["name"] for t in self._backend_tools}
+        # Attribution context for approval requests; set per-run in stream().
+        self._session_id: Optional[str] = None
+        self._agent_id: Optional[str] = None
+        self._refresh_skill_tools()
+
+    @staticmethod
+    def _load_backend_tools() -> List[Dict[str, Any]]:
+        return tool_manager.load_backend_tools()
+
+    def _refresh_skill_tools(self) -> None:
+        """Load DB-backed skill tools via the shared tool manager."""
+        skill_tools, self._skill_tool_index = tool_manager.load_skill_tools()
+        self._backend_tools.extend(skill_tools)
+        self._backend_tool_names.update(t["name"] for t in skill_tools)
+
+    def _get_mcp_tools(self) -> List[Dict[str, Any]]:
+        if not self._include_mcp_tools:
+            return []
+        try:
+            from services.mcp_client import get_mcp_client
+
+            client = get_mcp_client()
+            if client:
+                return client.get_tools_for_claude()
+        except Exception as exc:
+            logger.debug("MCP tools unavailable: %s", exc)
+        return []
+
+    def _filter_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Filter tools by recommended_tools list (agent-specific subset)."""
+        return tool_manager.filter_tools_by_recommended(tools, self._recommended_tools)
+
+    def _all_tools_openai_format(self) -> List[Dict[str, Any]]:
+        """Collect backend + MCP tools, filter, and convert to OpenAI format."""
+        anthropic_tools = list(self._backend_tools) + self._get_mcp_tools()
+        anthropic_tools = self._filter_tools(anthropic_tools)
+        if not anthropic_tools:
+            return []
+        return anthropic_tools_to_openai(anthropic_tools)
+
+    def tools_available(self) -> bool:
+        """True if any tool is exposed to the model after filtering.
+
+        Lets the router fall back to the no-tools stream path when the model
+        claims tool support but nothing is actually loadable.
+        """
+        return bool(self._all_tools_openai_format())
+
+    @staticmethod
+    def _apply_history_window(
+        messages: List[Dict[str, Any]],
+        window: int = _HISTORY_WINDOW_DEFAULT,
+    ) -> List[Dict[str, Any]]:
+        """Enforce a sliding history window (configurable max turns).
+
+        Keeps the system message (if first) + the most recent `window * 2`
+        messages. Matches ClaudeService._apply_history_window behavior.
+        """
+        if window <= 0:
+            return messages
+        max_msgs = window * 2
+        if len(messages) <= max_msgs:
+            return messages
+        # Preserve system message at index 0 if present
+        if messages and messages[0].get("role") == "system":
+            keep = max_msgs - 1
+            return [messages[0]] + messages[-keep:]
+        return messages[-max_msgs:]
+
+    async def stream(
+        self,
+        *,
+        provider: ProviderSpec,
+        messages: List[Dict[str, Any]],
+        system_prompt: Optional[str] = None,
+        model: Optional[str] = None,
+        max_tokens: int = 4096,
+        temperature: Optional[float] = None,
+        enable_tools: bool = True,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        history_window: int = _HISTORY_WINDOW_DEFAULT,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """Stream a multi-turn agentic conversation with tool calling.
+
+        Yields SSE-compatible event dicts matching the frontend protocol:
+            {"type": "text", "content": "..."}
+            {"type": "tool_processing", "tool_name": "...",
+             "tool_id": "..."}
+            {"type": "tool_result", "tool_name": "...",
+             "tool_id": "...", "result": "..."}
+            {"type": "error", "content": "..."}
+
+        Matches ClaudeService.chat_stream guardrails:
+            - 30 tool iterations max
+            - 300s wall-clock timeout
+            - Exponential inter-iteration backoff
+            - Infinite loop detection (3 repeated identical tool sets)
+        """
+        # Stash attribution context for tool gating (approval requests) raised
+        # deep in the loop without threading it through every call.
+        self._session_id = session_id
+        self._agent_id = agent_id
+
+        router = LLMRouter()
+        model = model or provider.default_model
+
+        tools = self._all_tools_openai_format() if enable_tools else []
+
+        from services.llm_format import anthropic_messages_to_openai
+
+        # The loop appends assistant/tool turns in OpenAI shape, so normalize
+        # the incoming history up front; the router re-converts idempotently.
+        oai_messages = anthropic_messages_to_openai(messages)
+        oai_messages = self._apply_history_window(oai_messages, history_window)
+
+        start_time = asyncio.get_event_loop().time()
+
+        # Infinite loop detection state
+        tool_call_history: deque = deque(maxlen=_LOOP_DETECT_WINDOW)
+
+        for iteration in range(_MAX_TOOL_ITERATIONS):
+            elapsed = asyncio.get_event_loop().time() - start_time
+            if elapsed > _MAX_PROCESSING_TIME_S:
+                yield {
+                    "type": "text",
+                    "content": (
+                        "\n\n[Maximum processing time "
+                        f"({_MAX_PROCESSING_TIME_S:.0f}s) exceeded "
+                        f"after {iteration} iterations.]"
+                    ),
+                }
+                break
+
+            if iteration > 0:
+                delay = _inter_iteration_delay(iteration)
+                await asyncio.sleep(delay)
+
+            interaction_id = str(uuid.uuid4())
+
+            # Accumulate streamed response
+            text_buffer = ""
+            tool_calls_buffer: Dict[int, Dict[str, Any]] = {}
+            finish_reason: Optional[str] = None
+            input_tokens = 0
+            output_tokens = 0
+            iter_start = time.monotonic()
+
+            try:
+                async for chunk in router.stream_openai_raw(
+                    provider=provider,
+                    messages=oai_messages,
+                    system_prompt=system_prompt,
+                    model=model,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    tools=tools or None,
+                    interaction_id=interaction_id,
+                    # Ask for a final usage-only chunk so token counts (and thus
+                    # cost) are recorded — without this, streamed responses carry
+                    # no usage and analytics would show $0 for OpenAI/Groq/Ollama.
+                    include_usage=True,
+                ):
+                    # The usage-only chunk (include_usage) arrives with an
+                    # empty ``choices`` list, so read usage before skipping it.
+                    usage = getattr(chunk, "usage", None)
+                    if usage:
+                        input_tokens = getattr(usage, "prompt_tokens", 0) or 0
+                        output_tokens = getattr(usage, "completion_tokens", 0) or 0
+                    if not chunk.choices:
+                        continue
+                    choice = chunk.choices[0]
+                    delta = choice.delta
+                    finish_reason = choice.finish_reason or finish_reason
+
+                    if delta and delta.content:
+                        text_buffer += delta.content
+                        yield {"type": "text", "content": delta.content}
+
+                    if delta and delta.tool_calls:
+                        for tc_delta in delta.tool_calls:
+                            idx = tc_delta.index
+                            if idx not in tool_calls_buffer:
+                                tool_calls_buffer[idx] = {
+                                    "id": tc_delta.id or "",
+                                    "name": "",
+                                    "arguments": "",
+                                }
+                            entry = tool_calls_buffer[idx]
+                            if tc_delta.id:
+                                entry["id"] = tc_delta.id
+                            if tc_delta.function:
+                                if tc_delta.function.name:
+                                    entry["name"] += tc_delta.function.name
+                                if tc_delta.function.arguments:
+                                    entry["arguments"] += tc_delta.function.arguments
+
+            except Exception as exc:
+                logger.error("OpenAI stream error iteration %d: %s", iteration, exc)
+                yield {"type": "error", "content": str(exc)}
+                break
+
+            iter_duration_ms = int((time.monotonic() - iter_start) * 1000)
+            cost_usd = self._compute_cost(
+                model, provider.provider_type, input_tokens, output_tokens
+            )
+
+            # Persist interaction log (non-fatal)
+            self._log_interaction(
+                session_id=session_id,
+                agent_id=agent_id,
+                model=f"{provider.provider_type}/{model}",
+                iteration=iteration,
+                interaction_id=interaction_id,
+                duration_ms=iter_duration_ms,
+                text_content=text_buffer,
+                tool_calls_count=len(tool_calls_buffer),
+                finish_reason=finish_reason,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=cost_usd,
+            )
+
+            # No tool calls → done
+            if finish_reason != "tool_calls" or not tool_calls_buffer:
+                # Detect malformed tool calls dumped as text (common with
+                # smaller models that attempt tool use but fail at structured
+                # output). Filter it rather than passing hallucinated JSON.
+                if (
+                    text_buffer
+                    and iteration == 0
+                    and (
+                        '{"type":"function"' in text_buffer
+                        or (
+                            '"function"' in text_buffer
+                            and '"parameters"' in text_buffer
+                        )
+                    )
+                ):
+                    logger.warning(
+                        "Model output contains raw tool-call JSON in text "
+                        "(model may not support structured tool calling)"
+                    )
+                    yield {
+                        "type": "text",
+                        "content": (
+                            "I attempted to use tools but this model doesn't "
+                            "reliably support structured tool calling. Please "
+                            "select a more capable model in Settings > AI Config "
+                            "(e.g., sec8-tools, gpt-4o, or any 7B+ model with "
+                            "tool support)."
+                        ),
+                    }
+                break
+
+            # Build assistant message with tool_calls
+            assistant_msg: Dict[str, Any] = {"role": "assistant"}
+            if text_buffer:
+                assistant_msg["content"] = text_buffer
+            assistant_tool_calls = []
+            for idx in sorted(tool_calls_buffer.keys()):
+                tc = tool_calls_buffer[idx]
+                name = (tc["name"] or "").strip()
+                if not name:
+                    # A tool-call slot that never received a function name is
+                    # unusable — skip it rather than emit a malformed call the
+                    # provider will reject.
+                    logger.warning(
+                        "Skipping tool call %d with empty name (id=%r)", idx, tc["id"]
+                    )
+                    continue
+                assistant_tool_calls.append(
+                    {
+                        # Some providers omit the streamed id; synthesize a stable
+                        # one so tool results can be correlated back to the call.
+                        "id": tc["id"] or f"call_{uuid.uuid4().hex[:12]}",
+                        "type": "function",
+                        "function": {"name": name, "arguments": tc["arguments"]},
+                    }
+                )
+
+            if not assistant_tool_calls:
+                # Every tool-call slot was malformed. Surface any assistant
+                # text and stop rather than loop on an empty turn.
+                if "content" in assistant_msg:
+                    oai_messages.append(assistant_msg)
+                break
+
+            assistant_msg["tool_calls"] = assistant_tool_calls
+            oai_messages.append(assistant_msg)
+
+            # Infinite loop detection (canonicalized args so cosmetic
+            # streaming differences don't defeat repeat detection)
+            call_signature = frozenset(
+                "{}:{}".format(
+                    tc["function"]["name"],
+                    _canonical_args(tc["function"]["arguments"]),
+                )
+                for tc in assistant_tool_calls
+            )
+            tool_call_history.append(call_signature)
+            if self._detect_infinite_loop(tool_call_history):
+                yield {
+                    "type": "text",
+                    "content": (
+                        "\n\n[Stopping: repeated identical tool calls "
+                        "detected (possible infinite loop).]"
+                    ),
+                }
+                break
+
+            # Execute each tool and append results
+            halt = False
+            for tc in assistant_tool_calls:
+                tool_name = tc["function"]["name"]
+                tool_call_id = tc["id"]
+                raw_args = tc["function"]["arguments"]
+
+                yield {
+                    "type": "tool_processing",
+                    "tool_name": tool_name,
+                    "tool_id": tool_call_id,
+                }
+
+                try:
+                    result_text, is_error = await self._execute_tool(
+                        tool_name, raw_args
+                    )
+                except PendingApprovalError as exc:
+                    # Hold the run here until an operator decides, so a run
+                    # never completes with the action un-taken.
+                    yield {
+                        "type": "approval_required",
+                        "tool_name": tool_name,
+                        "tool_id": tool_call_id,
+                        "action_id": exc.action_id,
+                        "content": str(exc),
+                    }
+                    yield {"type": "text", "content": f"\n\n_{exc}_\n\n"}
+                    if not exc.action_id:
+                        # No action to poll — fail closed rather than hang.
+                        yield {"type": "error", "content": str(exc)}
+                        halt = True
+                        break
+                    decision, detail, waited = await self._await_approval(exc.action_id)
+                    # Human think-time isn't LLM processing time.
+                    start_time += waited
+                    if decision == "approved":
+                        result_text, is_error = await self._execute_tool(
+                            tool_name, raw_args, approved=True
+                        )
+                        self._mark_action_executed(exc.action_id, result_text, is_error)
+                    elif decision == "rejected":
+                        result_text, is_error = (
+                            f"Operator REJECTED this action. Reason: {detail}. "
+                            "Do not retry it; continue with another approach or "
+                            "report that the step could not be completed.",
+                            True,
+                        )
+                    else:
+                        yield {"type": "error", "content": detail}
+                        halt = True
+                        break
+
+                preview = result_text[:500] + ("…" if len(result_text) > 500 else "")
+                yield {
+                    "type": "tool_result",
+                    "tool_name": tool_name,
+                    "tool_id": tool_call_id,
+                    "result": preview,
+                    "is_error": is_error,
+                }
+
+                # OpenAI tool messages carry no is_error field, so mark failures
+                # inline — otherwise the model treats an error as a valid result.
+                oai_messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call_id,
+                        "content": (
+                            f"ERROR: {result_text}" if is_error else result_text
+                        ),
+                    }
+                )
+            if halt:
+                return
+        else:
+            # for/else: loop exhausted without break
+            yield {
+                "type": "text",
+                "content": (
+                    f"\n\n[Tool iteration limit ({_MAX_TOOL_ITERATIONS}) "
+                    "reached. Stopping.]"
+                ),
+            }
+
+    async def run(
+        self,
+        *,
+        provider: ProviderSpec,
+        messages: List[Dict[str, Any]],
+        system_prompt: Optional[str] = None,
+        model: Optional[str] = None,
+        max_tokens: int = 4096,
+        temperature: Optional[float] = None,
+        enable_tools: bool = True,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        history_window: int = _HISTORY_WINDOW_DEFAULT,
+    ) -> str:
+        """Run the agentic loop to completion and return the final text.
+
+        Non-streaming convenience for callers (the workflow engine) that want a
+        single string the way ``ClaudeService.chat`` returns one. Tool
+        processing/result events are consumed internally; only assistant text
+        is accumulated. A surfaced ``error`` event is raised so the caller can
+        fall back or report failure rather than silently returning "".
+        """
+        parts: List[str] = []
+        async for event in self.stream(
+            provider=provider,
+            messages=messages,
+            system_prompt=system_prompt,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            enable_tools=enable_tools,
+            session_id=session_id,
+            agent_id=agent_id,
+            history_window=history_window,
+        ):
+            etype = event.get("type")
+            if etype == "text":
+                parts.append(event.get("content", ""))
+            elif etype == "error":
+                raise RuntimeError(event.get("content", "OpenAI agent run failed"))
+        return "".join(parts)
+
+    @staticmethod
+    def _detect_infinite_loop(history: deque) -> bool:
+        """Detect if the same tool call set repeats >= threshold times."""
+        if len(history) < _LOOP_DETECT_THRESHOLD:
+            return False
+        recent = list(history)[-_LOOP_DETECT_THRESHOLD:]
+        return len(set(recent)) == 1
+
+    async def _execute_tool(
+        self, tool_name: str, raw_arguments: str, *, approved: bool = False
+    ) -> tuple[str, bool]:
+        """Dispatch a tool call to the backend or MCP layer, returning
+        ``(result_text, is_error)``. ``approved`` skips the approval gate (never
+        the forbidden check) to re-run a call an operator has cleared."""
+        try:
+            arguments = json.loads(raw_arguments) if raw_arguments else {}
+        except json.JSONDecodeError:
+            return f"invalid JSON arguments: {raw_arguments[:200]}", True
+
+        # Safety gating — same tier policy the daemon enforces. Action tools
+        # must never execute on the OpenAI path without a decision: forbidden
+        # tools are refused outright, requires_approval tools raise so the
+        # caller can hold the run until a human resolves the request.
+        tier = tool_manager.get_tool_tier(tool_name)
+        if tier == "forbidden":
+            logger.warning("Blocked forbidden tool call: %s", tool_name)
+            return (
+                f"Tool '{tool_name}' is forbidden for autonomous agents and "
+                "was not executed.",
+                True,
+            )
+        if tier == "requires_approval" and not approved:
+            msg, action_id = await self._request_approval(tool_name, arguments)
+            raise PendingApprovalError(msg, action_id)
+
+        if tool_name in self._backend_tool_names:
+            return await self._execute_backend_tool(tool_name, arguments)
+        return await self._execute_mcp_tool(tool_name, arguments)
+
+    async def _request_approval(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> tuple[str, Optional[str]]:
+        """Queue a pending approval instead of executing the tool, returning the
+        message for the model and the action id to poll (None if not created)."""
+        try:
+            from services.approval_service import ActionType, get_approval_service
+
+            service = get_approval_service()
+            try:
+                action_type = ActionType(tool_name)
+            except ValueError:
+                action_type = ActionType.CUSTOM
+
+            target = arguments.get(
+                "target", arguments.get("ip", arguments.get("host", "unknown"))
+            )
+            pending = await asyncio.to_thread(
+                service.create_action,
+                action_type=action_type,
+                title=f"Agent tool: {tool_name}",
+                description=(
+                    f"Agent (session={self._session_id}, agent={self._agent_id}) "
+                    f"requests execution of {tool_name}"
+                ),
+                target=target,
+                confidence=0.7,
+                reason=f"Agent needs to execute {tool_name}",
+                evidence=[self._session_id or self._agent_id or "chat"],
+                created_by=self._agent_id or "openai_agent",
+                parameters=arguments,
+            )
+            return (
+                f"Tool '{tool_name}' requires human approval before it can run. "
+                f"An approval request was created (action_id={pending.action_id}); "
+                "the run is paused until an operator decides.",
+                pending.action_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to create approval for %s: %s", tool_name, exc)
+            return (
+                f"Tool '{tool_name}' requires approval, but the approval request "
+                f"could not be created ({exc}). The action was not executed.",
+                None,
+            )
+
+    async def _await_approval(
+        self, action_id: str, *, timeout: float = _APPROVAL_WAIT_TIMEOUT_S
+    ) -> tuple[str, str, float]:
+        """Poll the approval queue until an operator decides, returning
+        ``(decision, detail, waited_seconds)``. A vanished action reads as a
+        rejection so an uncleared action never executes."""
+        from services.approval_service import ActionStatus, get_approval_service
+
+        service = get_approval_service()
+        started = time.monotonic()
+        deadline = started + timeout
+        while True:
+            try:
+                action = await asyncio.to_thread(service.get_action, action_id)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Approval poll failed for %s: %s", action_id, exc)
+                action = None
+            waited = time.monotonic() - started
+            if action is None:
+                return (
+                    "rejected",
+                    f"approval request {action_id} is no longer available",
+                    waited,
+                )
+            # PendingAction.status is the ActionStatus *value*, not the enum.
+            status = str(action.status)
+            if status == ActionStatus.REJECTED.value:
+                return (
+                    "rejected",
+                    action.rejection_reason or "no reason given",
+                    waited,
+                )
+            if status in (
+                ActionStatus.APPROVED.value,
+                ActionStatus.EXECUTED.value,
+            ):
+                return "approved", status, waited
+            if time.monotonic() >= deadline:
+                return (
+                    "timeout",
+                    f"Timed out after {timeout:.0f}s waiting for approval of "
+                    f"action {action_id}. The action was not executed; the run "
+                    "is stopping with the step incomplete.",
+                    waited,
+                )
+            await asyncio.sleep(_APPROVAL_POLL_INTERVAL_S)
+
+    @staticmethod
+    def _mark_action_executed(
+        action_id: Optional[str], result_text: str, is_error: bool
+    ) -> None:
+        """Close out an approved action so the queue reflects what ran."""
+        if not action_id:
+            return
+        try:
+            from services.approval_service import get_approval_service
+
+            service = get_approval_service()
+            if is_error:
+                service.mark_failed(action_id, result_text[:2000])
+            else:
+                service.mark_executed(action_id, {"result": result_text[:2000]})
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not close out action %s: %s", action_id, exc)
+
+    async def _execute_backend_tool(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> tuple[str, bool]:
+        """Execute a backend tool via the shared dispatch (same as ClaudeService).
+
+        Delegates to ``tool_manager.execute_backend_tool`` so the tool-name ->
+        handler mapping stays identical across both agent loops.
+        """
+        try:
+            result, handled = await tool_manager.execute_backend_tool(
+                tool_name, arguments, skill_index=self._skill_tool_index
+            )
+            if not handled:
+                return f"Unknown backend tool: {tool_name}", True
+            from services.prompt_security import wrap_tool_result
+
+            text = _truncate(json.dumps(result, default=str))
+            return wrap_tool_result(text, source="backend", tool=tool_name), False
+        except Exception as exc:
+            logger.error("Backend tool %s failed: %s", tool_name, exc)
+            return f"Error executing {tool_name}: {exc}", True
+
+    async def _execute_mcp_tool(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> tuple[str, bool]:
+        """Execute an MCP tool via the shared MCP client."""
+        try:
+            from services.mcp_client import get_mcp_client
+            from services.prompt_security import wrap_tool_result
+
+            client = get_mcp_client()
+            if not client:
+                return f"MCP client unavailable for tool: {tool_name}", True
+
+            parts = tool_name.split("_", 1)
+            if len(parts) == 2:
+                server_name, actual_tool = parts
+            else:
+                server_name = self._find_tool_server(client, tool_name)
+                actual_tool = tool_name
+
+            if not server_name:
+                return f"No MCP server found for tool: {tool_name}", True
+
+            result = await client.call_tool(
+                server_name,
+                actual_tool,
+                arguments,
+                timeout=_TOOL_TIMEOUT_S,
+            )
+
+            if isinstance(result, dict):
+                content_blocks = result.get(
+                    "content",
+                    [{"type": "text", "text": str(result)}],
+                )
+            else:
+                content_blocks = [{"type": "text", "text": str(result)}]
+
+            texts = []
+            for block in content_blocks:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = _truncate(block["text"])
+                    text = wrap_tool_result(text, source=server_name, tool=actual_tool)
+                    texts.append(text)
+
+            return ("\n".join(texts) if texts else str(result)), False
+
+        except Exception as exc:
+            logger.error("MCP tool %s failed: %s", tool_name, exc)
+            return f"Error executing {tool_name}: {exc}", True
+
+    @staticmethod
+    def _find_tool_server(client: Any, tool_name: str) -> Optional[str]:
+        for srv_name, tools in client.tools_cache.items():
+            if any(t["name"] == tool_name for t in tools):
+                return srv_name
+        return None
+
+    @staticmethod
+    def _compute_cost(
+        model: str,
+        provider_type: str,
+        input_tokens: int,
+        output_tokens: int,
+    ) -> float:
+        """USD cost for a single call via the shared pricing helper.
+
+        Uses the same ``compute_call_cost`` (model-registry pricing) the
+        Anthropic path uses, so OpenAI/Groq/Ollama spend lands in the same
+        analytics buckets. Returns 0.0 if pricing can't be resolved.
+        """
+        try:
+            from daemon.agent_runner import compute_call_cost
+
+            return compute_call_cost(
+                model,
+                provider_type,
+                int(input_tokens or 0),
+                int(output_tokens or 0),
+            )
+        except Exception:
+            return 0.0
+
+    @staticmethod
+    def _log_interaction(
+        *,
+        session_id: Optional[str],
+        agent_id: Optional[str],
+        model: str,
+        iteration: int,
+        interaction_id: str,
+        duration_ms: int,
+        text_content: str,
+        tool_calls_count: int,
+        finish_reason: Optional[str],
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cost_usd: float = 0.0,
+    ) -> None:
+        """Persist an LLMInteractionLog row (non-fatal, fire-and-forget)."""
+        try:
+            from database.connection import get_db_session
+            from database.models import LLMInteractionLog
+
+            session = get_db_session()
+            try:
+                log = LLMInteractionLog(
+                    interaction_id=interaction_id,
+                    session_id=session_id,
+                    agent_id=agent_id,
+                    model=model,
+                    request_messages=[],
+                    thinking_enabled=False,
+                    response_content=(text_content[:2000] if text_content else None),
+                    tool_calls=(
+                        [{"iteration": iteration}] if tool_calls_count > 0 else []
+                    ),
+                    tool_results=[],
+                    stop_reason=finish_reason,
+                    input_tokens=int(input_tokens or 0),
+                    output_tokens=int(output_tokens or 0),
+                    cache_read_tokens=0,
+                    cache_creation_tokens=0,
+                    cost_usd=float(cost_usd or 0.0),
+                    duration_ms=duration_ms,
+                )
+                session.add(log)
+                session.commit()
+            except Exception as exc:
+                # DB is reachable but the insert failed — worth surfacing,
+                # since it means audit/cost rows are being silently dropped.
+                logger.warning("Interaction log insert failed: %s", exc)
+                session.rollback()
+            finally:
+                session.close()
+        except Exception as exc:
+            # DB simply unavailable (e.g. dev without Postgres) — expected.
+            logger.debug("Interaction log skipped: %s", exc)

--- a/services/provider_model_discovery.py
+++ b/services/provider_model_discovery.py
@@ -31,13 +31,14 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
 
-from services.url_safety import SafeUrl, UrlSafetyError, validate_provider_url
+from services.url_safety import UrlSafetyError, validate_provider_url
 
 logger = logging.getLogger(__name__)
 
@@ -326,6 +327,132 @@ def _ollama_context_from_show(show_payload: Dict[str, Any]) -> int:
     return 0
 
 
+# Ollama model families known to support OpenAI-style tool calling.
+# Derived from Ollama docs and empirical testing. The model name (or its
+# architecture family from /api/show) is matched case-insensitively.
+_OLLAMA_TOOL_CAPABLE_FAMILIES = frozenset(
+    (
+        "llama3.1",
+        "llama3.2",
+        "llama3.3",
+        "llama4",
+        "qwen2.5",
+        "qwen3",
+        "qwq",
+        "mistral",
+        "mixtral",
+        "mistral-nemo",
+        "mistral-small",
+        "mistral-large",
+        "command-r",
+        "command-r-plus",
+        "deepseek-r1",
+        "deepseek-v2",
+        "deepseek-v3",
+        "deepseek-coder-v2",
+        "nemotron",
+        "granite3",
+        "phi4",
+        "glm4",
+        "glm-4",
+        "hermes3",
+        "athene",
+        "firefunction",
+    )
+)
+
+_OLLAMA_VISION_CAPABLE_FAMILIES = frozenset(
+    (
+        "llava",
+        "llava-llama3",
+        "llava-phi3",
+        "llama3.2-vision",
+        "moondream",
+        "bakllava",
+        "minicpm-v",
+    )
+)
+
+
+def _ollama_env_tool_allowlist() -> frozenset:
+    """Operator-supplied tool-capable model names/prefixes.
+
+    ``OLLAMA_EXTRA_TOOL_MODELS`` (comma-separated) lets a deployment mark
+    custom/local models as tool-capable when neither /api/tags nor the
+    built-in family list knows them.
+    """
+    raw = os.getenv("OLLAMA_EXTRA_TOOL_MODELS", "")
+    return frozenset(p.strip().lower() for p in raw.split(",") if p.strip())
+
+
+def _name_matches_family(name_lower: str, families) -> bool:
+    return any(name_lower.startswith(f) or name_lower == f for f in families)
+
+
+def _ollama_capabilities_from_show(
+    model_name: str,
+    show_payload: Dict[str, Any],
+    live_caps: Optional[List[str]] = None,
+) -> Dict[str, bool]:
+    """Infer model capabilities from Ollama metadata.
+
+    Precedence for tool support: the live ``/api/tags`` capabilities are
+    authoritative; then an operator allowlist (``OLLAMA_EXTRA_TOOL_MODELS``);
+    then name/architecture-family heuristics (logged, since they can lag new
+    model releases).
+    """
+    name_lower = model_name.lower().split(":")[0]
+    info = show_payload.get("model_info") or {}
+    live_caps = live_caps or []
+
+    families_in_info = set()
+    for key in info:
+        parts = key.split(".")
+        if parts:
+            families_in_info.add(parts[0].lower())
+
+    # Tool support, in order of authority.
+    if "tools" in live_caps:
+        supports_tools = True
+    elif _name_matches_family(name_lower, _ollama_env_tool_allowlist()):
+        supports_tools = True
+        logger.info(
+            "ollama: %s marked tool-capable via OLLAMA_EXTRA_TOOL_MODELS",
+            model_name,
+        )
+    else:
+        supports_tools = _name_matches_family(name_lower, _OLLAMA_TOOL_CAPABLE_FAMILIES)
+        if not supports_tools:
+            for arch_family in families_in_info:
+                if arch_family in ("general", "tokenizer"):
+                    continue
+                for known in _OLLAMA_TOOL_CAPABLE_FAMILIES:
+                    normalized = known.replace("-", "").replace(".", "")
+                    if arch_family.startswith(normalized):
+                        supports_tools = True
+                        break
+                if supports_tools:
+                    break
+        if supports_tools:
+            logger.debug(
+                "ollama: %s tool support inferred from name/arch heuristic "
+                "(not reported by /api/tags)",
+                model_name,
+            )
+
+    # Vision support: prefer live capability, else name heuristic.
+    supports_vision = "vision" in live_caps or _name_matches_family(
+        name_lower, _OLLAMA_VISION_CAPABLE_FAMILIES
+    )
+
+    # Ollama models don't have native extended thinking in the Anthropic sense
+    return {
+        "supports_tools": supports_tools,
+        "supports_thinking": False,
+        "supports_vision": supports_vision,
+    }
+
+
 async def fetch_ollama_models(
     base_url: Optional[str] = None,
     *,
@@ -377,34 +504,45 @@ async def fetch_ollama_models(
     if cached is not None:
         return cached
 
-    async def _list() -> List[str]:
+    async def _list() -> List[Dict[str, Any]]:
         async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
             resp = await client.get(f"{base}/api/tags")
             resp.raise_for_status()
-            # ``resp.content`` is bytes on real httpx responses. Test
-            # fakes may omit it — gate the cap on attribute presence so
-            # unit tests using minimal stubs don't have to mock it.
             if len(getattr(resp, "content", b"") or b"") > _MAX_RESPONSE_BYTES:
                 raise RuntimeError("upstream response exceeded size cap")
             payload = resp.json()
-        return [m.get("name") for m in payload.get("models", []) if m.get("name")]
+        return [m for m in payload.get("models", []) if m.get("name")]
 
-    names = await _with_retry("ollama tags fetch", _list)
+    tag_entries = await _with_retry("ollama tags fetch", _list)
+    names = [m["name"] for m in tag_entries]
+    # Build a lookup for capabilities reported by /api/tags
+    tags_caps: Dict[str, List[str]] = {}
+    for entry in tag_entries:
+        tags_caps[entry["name"]] = entry.get("capabilities") or []
 
     async def _show(client: httpx.AsyncClient, name: str) -> ModelMeta:
         try:
             resp = await client.post(f"{base}/api/show", json={"name": name})
             resp.raise_for_status()
-            # ``resp.content`` is bytes on real httpx responses. Test
-            # fakes may omit it — gate the cap on attribute presence so
-            # unit tests using minimal stubs don't have to mock it.
             if len(getattr(resp, "content", b"") or b"") > _MAX_RESPONSE_BYTES:
                 raise RuntimeError("upstream response exceeded size cap")
-            ctx = _ollama_context_from_show(resp.json())
+            payload = resp.json()
+            ctx = _ollama_context_from_show(payload)
+            caps = _ollama_capabilities_from_show(
+                name, payload, live_caps=tags_caps.get(name, [])
+            )
         except Exception as exc:  # noqa: BLE001
             logger.debug("ollama /api/show %s failed: %s", name, exc)
             ctx = 0
-        return ModelMeta(id=name, display_name=name, context_window=ctx)
+            caps = _ollama_capabilities_from_show(
+                name, {}, live_caps=tags_caps.get(name, [])
+            )
+        return ModelMeta(
+            id=name,
+            display_name=name,
+            context_window=ctx,
+            capabilities=caps,
+        )
 
     async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
         models = await asyncio.gather(*(_show(client, n) for n in names))

--- a/services/tool_manager.py
+++ b/services/tool_manager.py
@@ -1,0 +1,491 @@
+"""Shared tool loading + filtering for the agent loops.
+
+Both ``ClaudeService`` (Anthropic path) and ``OpenAIAgentService`` (OpenAI-
+format path) load the same backend tool schemas and DB-backed skill tools and
+apply the same per-agent ``recommended_tools`` filter. Centralizing that logic
+here keeps the two loops from drifting (a bug fixed in one used to need fixing
+in the other).
+
+All functions are stateless and best-effort: they degrade to empty results
+rather than raising, so a missing backend-schema import or an unavailable
+skills DB never breaks a chat request.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def load_backend_tools() -> List[Dict[str, Any]]:
+    """Return the static backend tool schemas (empty list if unavailable)."""
+    try:
+        from backend.schemas.tool_schemas import ALL_TOOLS
+
+        return list(ALL_TOOLS)
+    except ImportError:
+        logger.debug("Backend tool schemas unavailable")
+        return []
+
+
+def load_skill_tools() -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Return ``(skill_tools, skill_index)`` for active DB-backed skills.
+
+    Best-effort — returns ``([], {})`` when the skill bridge or its DB is
+    unavailable.
+    """
+    try:
+        from services.skill_tools_bridge import list_active_skill_tools
+
+        tools, index = list_active_skill_tools()
+        return list(tools), index
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Skill tools unavailable: %s", exc)
+        return [], {}
+
+
+def filter_tools_by_recommended(
+    tools: List[Dict[str, Any]], recommended: Optional[List[str]]
+) -> List[Dict[str, Any]]:
+    """Keep only tools whose name is in ``recommended``; no-op when falsy.
+
+    MCP/server tools arrive prefixed as ``<server>_<tool>`` while per-agent
+    recommended lists (``soc_agents.py``) use bare names, so a tool matches if
+    either its full name or its post-first-underscore suffix is recommended.
+    """
+    if not recommended:
+        return tools
+    wanted = set(recommended)
+    out: List[Dict[str, Any]] = []
+    for t in tools:
+        name = t.get("name", "")
+        if name in wanted:
+            out.append(t)
+        elif "_" in name and name.split("_", 1)[1] in wanted:
+            out.append(t)
+    return out
+
+
+# --- Tool safety tiers ----------------------------------------------------
+#
+# Single source of truth for the action-safety classification an agent's tool
+# calls are gated against. Owned here (not in the daemon) so every agent loop —
+# the daemon's autonomous investigator, the interactive OpenAI agent, and the
+# workflow engine — enforces the *same* policy. ``requires_approval`` tools
+# never execute without a human decision; ``forbidden`` tools never execute
+# under autonomous control at all.
+
+TOOL_TIERS: Dict[str, List[str]] = {
+    "safe": [
+        "list_findings",
+        "get_finding",
+        "search_findings",
+        "nearest_neighbors",
+        "get_findings_stats",
+        "semantic_search_findings",
+        "technique_rollup",
+        "list_cases",
+        "get_case",
+        "get_case_comments",
+        "get_case_iocs",
+        "get_case_tasks",
+        "search_detections",
+        "get_coverage_stats",
+        "get_detection_count",
+        "analyze_coverage",
+        "identify_gaps",
+        "create_attack_layer",
+        "get_attack_layer",
+    ],
+    "managed": [
+        "create_case",
+        "update_case",
+        "add_finding_to_case",
+        "bulk_add_findings_to_case",
+        "remove_finding_from_case",
+        "add_case_activity",
+        "add_case_timeline_entry",
+        "add_case_mitre_techniques",
+        "add_resolution_step",
+        "add_case_comment",
+        "add_case_evidence",
+        "add_case_ioc",
+        "bulk_add_iocs",
+        "add_case_task",
+        "update_case_task",
+        "link_related_cases",
+        "escalate_case",
+        "create_approval_action",
+    ],
+    "requires_approval": [
+        "isolate_host",
+        "block_ip",
+        "disable_user",
+        "quarantine_file",
+        "close_case",
+    ],
+    "forbidden": [
+        "delete_case",
+        "delete_finding",
+        "approve_action",
+        "reject_action",
+    ],
+}
+
+_TOOL_TIER_LOOKUP: Dict[str, str] = {}
+for _tier, _tier_tools in TOOL_TIERS.items():
+    for _tier_tool in _tier_tools:
+        _TOOL_TIER_LOOKUP[_tier_tool] = _tier
+
+
+def get_tool_tier(tool_name: str) -> str:
+    """Return the safety tier for ``tool_name`` (strips MCP server prefixes).
+
+    Returns ``"unknown"`` for tools not in any tier — callers treat unknown as
+    executable-but-uncategorized (the historical daemon behavior).
+    """
+    if tool_name in _TOOL_TIER_LOOKUP:
+        return _TOOL_TIER_LOOKUP[tool_name]
+    short = tool_name.split("_", 1)[-1] if "_" in tool_name else tool_name
+    return _TOOL_TIER_LOOKUP.get(short, "unknown")
+
+
+# --- Backend tool dispatch ------------------------------------------------
+#
+# Single source of truth for executing built-in (non-MCP) backend tools.
+# Currently used by OpenAIAgentService. (ClaudeService and the daemon loop
+# still use their own dispatch table for now, but will be consolidated here
+# in the future).
+
+_FINDINGS_CASE_TOOLS = frozenset(
+    {
+        "list_findings",
+        "get_finding",
+        "nearest_neighbors",
+        "search_findings",
+        "get_findings_stats",
+        "list_cases",
+        "get_case",
+        "create_case",
+        "add_finding_to_case",
+        "update_case",
+        "add_resolution_step",
+    }
+)
+_SECURITY_TOOLS = frozenset(
+    {
+        "analyze_coverage",
+        "search_detections",
+        "identify_gaps",
+        "get_coverage_stats",
+        "get_detection_count",
+    }
+)
+_ATTACK_TOOLS = frozenset({"get_attack_layer", "get_technique_rollup"})
+_APPROVAL_TOOLS = frozenset(
+    {
+        "list_pending_approvals",
+        "get_approval_action",
+        "approve_action",
+        "reject_action",
+        "get_approval_stats",
+    }
+)
+
+
+async def execute_backend_tool(
+    tool_name: str,
+    arguments: Optional[Dict[str, Any]],
+    *,
+    skill_index: Optional[Dict[str, Any]] = None,
+) -> Tuple[Any, bool]:
+    """Execute a built-in backend tool, returning ``(result, handled)``.
+
+    ``handled`` is ``True`` when ``tool_name`` matched a backend handler (even
+    if that handler returned an ``{"error": ...}`` payload). When ``False`` the
+    caller should fall back to the MCP layer.
+
+    Sync data/case/approval handlers run inline; async security-detection
+    handlers are awaited. All optional imports are best-effort so a missing
+    dependency degrades to an error payload rather than raising into the loop.
+    """
+    arguments = arguments or {}
+
+    # DB-backed Skills (Issue #82) get a dedicated dispatch so we don't bury
+    # user-created tools in the ladder below. On dispatch failure we fall
+    # through so a name that merely *looks* like a skill still tries the rest
+    # of the chain.
+    try:
+        from services.skill_tools_bridge import execute_skill_tool, is_skill_tool_name
+
+        if is_skill_tool_name(tool_name):
+            return (
+                execute_skill_tool(
+                    tool_name, arguments, skills_by_tool_name=skill_index
+                ),
+                True,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Skill tool dispatch failed for %s: %s", tool_name, exc)
+
+    if tool_name in _FINDINGS_CASE_TOOLS:
+        from services.database_data_service import DatabaseDataService
+
+        return _execute_findings_case_tool(DatabaseDataService(), tool_name, arguments)
+
+    if tool_name in _SECURITY_TOOLS:
+        from tools.security_detections import get_security_detection_tools
+
+        handler = getattr(get_security_detection_tools(), tool_name, None)
+        if handler is None:
+            return {"error": f"Unknown tool: {tool_name}"}, True
+        return await handler(**arguments), True
+
+    if tool_name in _ATTACK_TOOLS:
+        from services.database_data_service import DatabaseDataService
+
+        return _execute_attack_tool(DatabaseDataService(), tool_name, arguments), True
+
+    if tool_name in _APPROVAL_TOOLS:
+        return _execute_approval_tool(tool_name, arguments), True
+
+    return None, False
+
+
+def _compact_finding(f: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "finding_id": f.get("finding_id"),
+        "severity": f.get("severity"),
+        "anomaly_score": float(f.get("anomaly_score") or 0),
+        "data_source": f.get("data_source"),
+        "cluster_id": f.get("cluster_id"),
+        "timestamp": f.get("timestamp"),
+        "status": f.get("status"),
+        "summary": (f.get("description") or "")[:200],
+    }
+
+
+def _execute_findings_case_tool(
+    data_service: Any, tool_name: str, args: Dict[str, Any]
+) -> Tuple[Any, bool]:
+    if tool_name == "list_findings":
+        limit = args.get("limit", 20)
+        offset = args.get("offset", 0)
+        severity = args.get("severity")
+        data_source = args.get("data_source")
+        status = args.get("status")
+        total = data_service.count_findings(
+            severity=severity, data_source=data_source, status=status
+        )
+        findings = data_service.get_findings(
+            limit=limit,
+            offset=offset,
+            severity=severity,
+            data_source=data_source,
+            status=status,
+            sort_by=args.get("sort_by", "timestamp"),
+            sort_order=args.get("sort_order", "desc"),
+        )
+        return {
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+            "has_more": (offset + limit) < total,
+            "findings": [_compact_finding(f) for f in findings],
+        }, True
+
+    if tool_name == "search_findings":
+        query = args.get("query", "")
+        limit = args.get("limit", 20)
+        offset = args.get("offset", 0)
+        severity = args.get("severity")
+        data_source = args.get("data_source")
+        status = args.get("status")
+        total = data_service.count_findings(
+            severity=severity,
+            data_source=data_source,
+            status=status,
+            search_query=query,
+        )
+        findings = data_service.get_findings(
+            limit=limit,
+            offset=offset,
+            severity=severity,
+            data_source=data_source,
+            status=status,
+            search_query=query,
+            sort_by=args.get("sort_by", "anomaly_score"),
+            sort_order=args.get("sort_order", "desc"),
+        )
+        return {
+            "query": query,
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+            "has_more": (offset + limit) < total,
+            "findings": [_compact_finding(f) for f in findings],
+        }, True
+
+    if tool_name == "get_findings_stats":
+        findings = data_service.get_findings(limit=10000)
+        severity_counts: Dict[str, int] = {}
+        data_source_counts: Dict[str, int] = {}
+        status_counts: Dict[str, int] = {}
+        for f in findings:
+            sev = f.get("severity") or "unknown"
+            severity_counts[sev] = severity_counts.get(sev, 0) + 1
+            ds = f.get("data_source") or "unknown"
+            data_source_counts[ds] = data_source_counts.get(ds, 0) + 1
+            st = f.get("status") or "unknown"
+            status_counts[st] = status_counts.get(st, 0) + 1
+        return {
+            "total_findings": len(findings),
+            "by_severity": severity_counts,
+            "by_data_source": data_source_counts,
+            "by_status": status_counts,
+        }, True
+
+    if tool_name == "get_finding":
+        return data_service.get_finding(**args), True
+
+    if tool_name == "nearest_neighbors":
+        return data_service.get_nearest_neighbors(**args), True
+
+    if tool_name == "list_cases":
+        limit = args.get("limit", 50)
+        status = args.get("status")
+        severity = args.get("severity")
+        cases = data_service.get_cases(limit=limit * 2)
+        if status:
+            cases = [c for c in cases if c.get("status") == status]
+        if severity:
+            cases = [c for c in cases if c.get("severity") == severity]
+        return cases[:limit], True
+
+    if tool_name == "get_case":
+        return data_service.get_case(**args), True
+
+    if tool_name == "create_case":
+        return (
+            data_service.create_case(
+                title=args["title"],
+                finding_ids=args.get("finding_ids", []),
+                priority=args.get("severity", "medium"),
+                description=args.get("description", ""),
+            ),
+            True,
+        )
+
+    if tool_name == "add_finding_to_case":
+        return (
+            data_service.add_finding_to_case(
+                case_id=args["case_id"], finding_id=args["finding_id"]
+            ),
+            True,
+        )
+
+    if tool_name == "update_case":
+        uc_args = dict(args)
+        case_id = uc_args.pop("case_id")
+        success = data_service.update_case(case_id, **uc_args)
+        return {"success": success, "case_id": case_id}, True
+
+    if tool_name == "add_resolution_step":
+        from datetime import datetime as _dt
+
+        case = data_service.get_case(args["case_id"])
+        if not case:
+            return {"error": f"Case {args['case_id']} not found"}, True
+        steps = case.get("resolution_steps", [])
+        steps.append(
+            {
+                "timestamp": _dt.utcnow().isoformat() + "Z",
+                "description": args["description"],
+                "action_taken": args["action_taken"],
+                "result": args.get("result"),
+            }
+        )
+        data_service.update_case(args["case_id"], resolution_steps=steps)
+        return {
+            "success": True,
+            "case_id": args["case_id"],
+            "total_steps": len(steps),
+        }, True
+
+    return {"error": f"Unknown tool: {tool_name}"}, True
+
+
+def _execute_attack_tool(
+    data_service: Any, tool_name: str, args: Dict[str, Any]
+) -> Any:
+    if tool_name == "get_attack_layer":
+        return {
+            "success": True,
+            "layer": {
+                "name": "DeepTempo Findings",
+                "version": "4.5",
+                "domain": "enterprise-attack",
+                "description": "ATT&CK techniques from findings",
+                "techniques": [],
+            },
+        }
+
+    # get_technique_rollup
+    min_conf = args.get("min_confidence", 0.0) if args else 0.0
+    findings = data_service.get_findings(limit=1000)
+    counts: Dict[str, int] = {}
+    severities: Dict[str, Dict[str, int]] = {}
+    for f in findings:
+        for tech in f.get("predicted_techniques", []) or []:
+            tid = tech.get("technique_id")
+            conf = tech.get("confidence", 0)
+            if conf < min_conf or not tid:
+                continue
+            counts[tid] = counts.get(tid, 0) + 1
+            if tid not in severities:
+                severities[tid] = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+            sev = f.get("severity") or "medium"
+            severities[tid][sev] = severities[tid].get(sev, 0) + 1
+    techniques = [
+        {"technique_id": t, "count": c, "severities": severities[t]}
+        for t, c in counts.items()
+    ]
+    techniques.sort(key=lambda x: x["count"], reverse=True)
+    return {
+        "success": True,
+        "total_techniques": len(techniques),
+        "techniques": techniques,
+    }
+
+
+def _execute_approval_tool(tool_name: str, args: Dict[str, Any]) -> Any:
+    from dataclasses import asdict
+
+    from services.approval_service import ApprovalService
+
+    approval_service = ApprovalService()
+
+    if tool_name == "list_pending_approvals":
+        actions = approval_service.list_pending_approvals()
+        return [asdict(a) for a in actions[: args.get("limit", 50)]]
+    if tool_name == "get_approval_action":
+        action = approval_service.get_action(args["action_id"])
+        return asdict(action) if action else {"error": "Action not found"}
+    if tool_name == "approve_action":
+        action = approval_service.approve_action(**args)
+        return (
+            asdict(action)
+            if action
+            else {"error": "Action not found or cannot be approved"}
+        )
+    if tool_name == "reject_action":
+        action = approval_service.reject_action(**args)
+        return (
+            asdict(action)
+            if action
+            else {"error": "Action not found or cannot be rejected"}
+        )
+    # get_approval_stats
+    return approval_service.get_stats()

--- a/services/workflows_service.py
+++ b/services/workflows_service.py
@@ -3,9 +3,9 @@
 import asyncio
 import logging
 import re
-from typing import Dict, List, Optional, Any
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from services.defaults import DEFAULT_MODEL
 
@@ -590,6 +590,76 @@ For each phase:
     # Internal execution helpers
     # ------------------------------------------------------------------
 
+    def _resolve_agent_provider(self, component: str):
+        """Resolve ``(provider_spec, model_id)`` for a workflow agent.
+
+        Uses the same ``ai_model_configs`` chain the daemon and Model
+        Assignment UI use (component → chat_default → default Anthropic).
+        Returns ``(None, model_id)`` when the resolved provider is Anthropic —
+        that path stays on ``ClaudeService.chat``. A non-Anthropic provider
+        returns its ``ProviderSpec`` so the caller runs the OpenAI agent loop.
+        Any failure degrades to ``(None, DEFAULT_MODEL)`` (legacy behavior).
+        """
+        try:
+            from services.llm_router import get_provider_spec
+            from services.model_registry import get_registry
+
+            pick = get_registry().resolve_model_for_component(component)
+            if not pick:
+                return None, DEFAULT_MODEL
+            provider_id, model_id = pick
+            spec = get_provider_spec(provider_id)
+            if spec is None or spec.provider_type == "anthropic":
+                return None, model_id
+            return spec, model_id
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Provider resolution failed (%s); using default", exc)
+            return None, DEFAULT_MODEL
+
+    async def _run_agent_turn(
+        self,
+        *,
+        claude_service,
+        component: str,
+        message: str,
+        system_prompt: Optional[str],
+        recommended_tools: Optional[List[str]],
+        max_tokens: int,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Run one workflow agent turn on the correct provider.
+
+        Anthropic → the existing ``ClaudeService.chat`` loop (unchanged).
+        Non-Anthropic → ``OpenAIAgentService`` (full multi-turn tool loop with
+        the same tier/approval gating), returning the final text like ``chat``.
+        """
+        spec, model_id = self._resolve_agent_provider(component)
+
+        if spec is None:
+            return await asyncio.to_thread(
+                claude_service.chat,
+                message=message,
+                system_prompt=system_prompt,
+                model=model_id,
+                max_tokens=max_tokens,
+                recommended_tools=recommended_tools,
+            )
+
+        from services.openai_agent_service import OpenAIAgentService
+
+        agent = OpenAIAgentService(recommended_tools=recommended_tools)
+        return await agent.run(
+            provider=spec,
+            messages=[{"role": "user", "content": message}],
+            system_prompt=system_prompt,
+            model=model_id,
+            max_tokens=max_tokens,
+            enable_tools=True,
+            session_id=session_id,
+            agent_id=agent_id,
+        )
+
     async def _execute_oneshot(
         self,
         workflow: "WorkflowDefinition",
@@ -624,7 +694,11 @@ For each phase:
             use_agent_sdk=False,
             enable_thinking=True,
         )
-        if not claude_service.has_api_key():
+        # The oneshot composite call runs on the workflow-default assignment
+        # (chat_default). Only require an Anthropic key when that resolves to
+        # Anthropic — a non-Anthropic provider carries its own Bifrost key.
+        oneshot_provider, oneshot_model = self._resolve_agent_provider("chat_default")
+        if oneshot_provider is None and not claude_service.has_api_key():
             return {"success": False, "error": "Claude API not configured"}
 
         workflow_dict = workflow.to_dict(include_body=False)
@@ -639,8 +713,10 @@ For each phase:
             from services.cost_estimator import estimate_cost
 
             _est = await estimate_cost(
-                provider_type="anthropic",
-                model_id=DEFAULT_MODEL,
+                provider_type=(
+                    oneshot_provider.provider_type if oneshot_provider else "anthropic"
+                ),
+                model_id=oneshot_model,
                 messages=[{"role": "user", "content": prompt}],
                 system_prompt=system_prompt,
                 max_tokens=8192,
@@ -665,16 +741,17 @@ For each phase:
         )
 
         try:
-            response_text = await asyncio.to_thread(
-                claude_service.chat,
+            response_text = await self._run_agent_turn(
+                claude_service=claude_service,
+                component="chat_default",
                 message=prompt,
                 system_prompt=system_prompt,
-                model=DEFAULT_MODEL,
-                max_tokens=8192,
                 recommended_tools=all_tools if all_tools else None,
+                max_tokens=8192,
+                session_id=run_id,
             )
             success = response_text is not None
-            error = None if success else "Claude returned no response"
+            error = None if success else "LLM returned no response"
         except Exception as exc:  # noqa: BLE001
             response_text = ""
             success = False
@@ -764,12 +841,9 @@ For each phase:
         """Shared phase-loop body used by both initial execute and
         resume. Walks phases from ``start_index``; pauses or completes
         the run as appropriate."""
+        from services.approval_service import ActionType, get_approval_service
         from services.claude_service import ClaudeService
         from services.soc_agents import SOCAgentLibrary
-        from services.approval_service import (
-            ActionType,
-            get_approval_service,
-        )
         from services.workflow_run_service import get_workflow_run_service
 
         run_service = get_workflow_run_service()
@@ -871,12 +945,20 @@ For each phase:
             # projected USD band. No gating — Bifrost VK is the budget
             # gate. Best-effort, never blocks the phase.
             phase_input_context: Dict[str, Any] = {"prior_outputs": accumulated}
+            phase_component = (
+                getattr(profile, "component_category", None) or "chat_default"
+            )
             try:
                 from services.cost_estimator import estimate_cost
 
+                _est_provider, _est_model = self._resolve_agent_provider(
+                    phase_component
+                )
                 _phase_est = await estimate_cost(
-                    provider_type="anthropic",
-                    model_id=DEFAULT_MODEL,
+                    provider_type=(
+                        _est_provider.provider_type if _est_provider else "anthropic"
+                    ),
+                    model_id=_est_model,
                     messages=[{"role": "user", "content": phase_prompt}],
                     system_prompt=system_prompt,
                     max_tokens=8192,
@@ -902,16 +984,18 @@ For each phase:
             )
 
             try:
-                response_text = await asyncio.to_thread(
-                    claude_service.chat,
+                response_text = await self._run_agent_turn(
+                    claude_service=claude_service,
+                    component=phase_component,
                     message=phase_prompt,
                     system_prompt=system_prompt,
-                    model=DEFAULT_MODEL,
-                    max_tokens=8192,
                     recommended_tools=phase_tools or None,
+                    max_tokens=8192,
+                    session_id=run_id,
+                    agent_id=agent_id,
                 )
                 phase_ok = response_text is not None
-                phase_error = None if phase_ok else "Claude returned no response"
+                phase_error = None if phase_ok else "LLM returned no response"
             except Exception as exc:  # noqa: BLE001
                 response_text = ""
                 phase_ok = False
@@ -1167,14 +1251,16 @@ You have access to SOC tools and must ground every conclusion in tool output.
                         if techniques
                         else "None"
                     )
-                    parts.append(f"""**Target Finding:**
+                    parts.append(
+                        f"""**Target Finding:**
 - Finding ID: {finding.get('finding_id')}
 - Severity: {finding.get('severity')}
 - Data Source: {finding.get('data_source')}
 - Timestamp: {finding.get('timestamp')}
 - Anomaly Score: {finding.get('anomaly_score', 'N/A')}
 - Description: {finding.get('description', 'N/A')}
-- MITRE ATT&CK Techniques: {technique_str}""")
+- MITRE ATT&CK Techniques: {technique_str}"""
+                    )
                 else:
                     parts.append(
                         f"**Target Finding ID:** {finding_id} (details will be retrieved during execution)"
@@ -1191,13 +1277,15 @@ You have access to SOC tools and must ground every conclusion in tool output.
                 data_service = DatabaseDataService()
                 case = data_service.get_case(case_id)
                 if case:
-                    parts.append(f"""**Target Case:**
+                    parts.append(
+                        f"""**Target Case:**
 - Case ID: {case.get('case_id')}
 - Title: {case.get('title')}
 - Status: {case.get('status')}
 - Priority: {case.get('priority')}
 - Description: {case.get('description', 'N/A')}
-- Finding Count: {len(case.get('finding_ids', []))}""")
+- Finding Count: {len(case.get('finding_ids', []))}"""
+                    )
                 else:
                     parts.append(
                         f"**Target Case ID:** {case_id} (details will be retrieved during execution)"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,13 @@
 [flake8]
 max-line-length = 88
-exclude = 
+exclude =
     .git,
     __pycache__,
     build,
     dist
-    
+
+[mypy]
+# backend/ is on sys.path at runtime (backend/main.py), so modules there are
+# imported bare (e.g. `from secrets_manager import get_secret`). Mirror that
+# here so mypy resolves them instead of reporting missing imports.
+mypy_path = backend

--- a/tests/unit/test_claude_service.py
+++ b/tests/unit/test_claude_service.py
@@ -320,12 +320,6 @@ class TestClaudeServiceInitialization:
             elif not original_exists and cache_file.exists():
                 cache_file.unlink()
 
-    @pytest.mark.xfail(
-        reason="Pre-existing: brittle coupling to _load_mcp_tools cache-loading "
-        "internals; mcp_tools loads empty here. strict=True so an unexpected pass "
-        "fails CI — that's the signal the loader was rewritten; remove the marker.",
-        strict=True,
-    )
     @patch('services.claude_service.get_secret')
     def test_no_event_loop_creation(self, mock_get_secret):
         """_load_mcp_tools never calls asyncio.new_event_loop."""
@@ -351,7 +345,12 @@ class TestClaudeServiceInitialization:
             cache_file.parent.mkdir(parents=True, exist_ok=True)
             cache_file.write_text(json.dumps(cache_data))
 
-            with patch('asyncio.new_event_loop') as mock_new_loop:
+            with patch('asyncio.new_event_loop') as mock_new_loop, \
+                 patch('services.mcp_client.get_mcp_client') as mock_get_client:
+                # Cached tools only surface for servers connected this boot.
+                mock_get_client.return_value.get_connection_status.return_value = {
+                    "splunk": True
+                }
                 with patch.object(ClaudeService, '_populate_mcp_registry'):
                     service = ClaudeService(use_mcp_tools=True)
                 mock_new_loop.assert_not_called()
@@ -1307,13 +1306,6 @@ class TestLoadMcpToolsCache:
         assert tool["input_schema"]["type"] == "object"
         assert "query" in tool["input_schema"]["properties"]
 
-    @pytest.mark.xfail(
-        reason="Pre-existing: brittle coupling to _load_mcp_tools cache-loading "
-        "internals (Path/open mocking); mcp_tools loads empty here. strict=True so "
-        "an unexpected pass fails CI — the signal the loader was rewritten; remove "
-        "the marker.",
-        strict=True,
-    )
     def test_cache_file_load_with_real_file(self, tmp_path):
         """_load_mcp_tools reads tools correctly from a real cache file on disk."""
         import json as _json
@@ -1345,7 +1337,12 @@ class TestLoadMcpToolsCache:
                 return real_open(path, *args, **kwargs)
 
             with patch('builtins.open', side_effect=selective_open), \
+                 patch('services.mcp_client.get_mcp_client') as mock_get_client, \
                  patch.object(service, '_populate_mcp_registry', lambda d: None):
+                # Cached tools only surface for servers connected this boot.
+                mock_get_client.return_value.get_connection_status.return_value = {
+                    "splunk": True
+                }
                 service._load_mcp_tools()
 
         assert len(service.mcp_tools) == 1

--- a/tests/unit/test_llm_format.py
+++ b/tests/unit/test_llm_format.py
@@ -1,0 +1,168 @@
+"""Unit tests for services/llm_format.py — Anthropic <-> OpenAI translation.
+
+These are the wire-format converters the daemon tool loop and the workflow
+engine rely on to run non-Anthropic providers. Pure functions, no I/O.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from services.llm_format import (
+    anthropic_messages_to_openai,  # noqa: E402
+    anthropic_tools_to_openai,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestToolConversion:
+    def test_input_schema_becomes_parameters(self):
+        out = anthropic_tools_to_openai(
+            [
+                {
+                    "name": "isolate_host",
+                    "description": "d",
+                    "input_schema": {"type": "object"},
+                }
+            ]
+        )
+        assert out == [
+            {
+                "type": "function",
+                "function": {
+                    "name": "isolate_host",
+                    "description": "d",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ]
+
+    def test_already_openai_shape_passes_through(self):
+        tool = {"type": "function", "function": {"name": "x", "parameters": {}}}
+        assert anthropic_tools_to_openai([tool]) == [tool]
+
+    def test_missing_schema_defaults(self):
+        out = anthropic_tools_to_openai([{"name": "x"}])
+        assert out[0]["function"]["parameters"] == {"type": "object", "properties": {}}
+
+
+class TestMessageConversion:
+    def test_string_content_passes_through_unchanged(self):
+        msgs = [{"role": "user", "content": "hi"}]
+        assert anthropic_messages_to_openai(msgs) == msgs
+
+    def test_assistant_tool_use_becomes_tool_calls(self):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "let me check"},
+                    {
+                        "type": "tool_use",
+                        "id": "call_1",
+                        "name": "list_findings",
+                        "input": {"limit": 5},
+                    },
+                ],
+            }
+        ]
+        out = anthropic_messages_to_openai(msgs)
+        assert len(out) == 1
+        msg = out[0]
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "let me check"
+        assert len(msg["tool_calls"]) == 1
+        tc = msg["tool_calls"][0]
+        assert tc["id"] == "call_1"
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "list_findings"
+        assert json.loads(tc["function"]["arguments"]) == {"limit": 5}
+
+    def test_thinking_block_is_dropped(self):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "secret"},
+                    {"type": "text", "text": "answer"},
+                ],
+            }
+        ]
+        out = anthropic_messages_to_openai(msgs)
+        assert out[0]["content"] == "answer"
+        assert "tool_calls" not in out[0]
+
+    def test_tool_result_becomes_tool_role_message(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_1",
+                        "content": "42 findings",
+                    }
+                ],
+            }
+        ]
+        out = anthropic_messages_to_openai(msgs)
+        assert out == [
+            {"role": "tool", "tool_call_id": "call_1", "content": "42 findings"}
+        ]
+
+    def test_tool_result_with_block_list_content_is_flattened(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "c1",
+                        "content": [{"type": "text", "text": "line"}],
+                    }
+                ],
+            }
+        ]
+        out = anthropic_messages_to_openai(msgs)
+        assert out[0]["content"] == "line"
+
+    def test_multi_turn_roundtrip_ordering(self):
+        # assistant(tool_use) then user(tool_result) -> assistant(tool_calls),
+        # tool message, in that order (OpenAI requires results right after call).
+        msgs = [
+            {"role": "user", "content": "investigate"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "c1", "name": "get_case", "input": {}}
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "c1", "content": "case data"}
+                ],
+            },
+        ]
+        out = anthropic_messages_to_openai(msgs)
+        assert [m["role"] for m in out] == ["user", "assistant", "tool"]
+        assert out[1]["tool_calls"][0]["id"] == "c1"
+        assert out[2]["tool_call_id"] == "c1"
+
+    def test_synthesizes_id_when_tool_use_id_missing(self):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "name": "x", "input": {}}],
+            }
+        ]
+        out = anthropic_messages_to_openai(msgs)
+        assert out[0]["tool_calls"][0]["id"]  # non-empty synthesized id

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -135,6 +135,74 @@ async def test_dispatch_bifrost_for_ollama():
     mock_client.close.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_dispatch_bifrost_translates_anthropic_tools_and_messages():
+    """The daemon builds tools/messages in Anthropic shape. The OpenAI Bifrost
+    dispatch must translate both (input_schema->parameters, tool_use->tool_calls,
+    tool_result->role:tool) and normalize the response tool_calls back to
+    {id,name,input} dicts, or the daemon's multi-turn tool loop breaks on
+    non-Anthropic providers.
+    """
+    router = LLMRouter(bifrost_url="http://test-bifrost:8080")
+    returned_tc = SimpleNamespace(
+        id="call_9",
+        function=SimpleNamespace(name="get_case", arguments='{"case_id": "C1"}'),
+    )
+    fake_resp = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="", tool_calls=[returned_tc])
+            )
+        ],
+        model="ollama/llama3.1:8b",
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=fake_resp)
+
+    anthropic_tools = [
+        {"name": "get_case", "description": "d", "input_schema": {"type": "object"}}
+    ]
+    anthropic_messages = [
+        {"role": "user", "content": "investigate"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": "call_9", "name": "get_case", "input": {}}
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "call_9", "content": "case data"}
+            ],
+        },
+    ]
+
+    with patch("openai.AsyncOpenAI", return_value=mock_client):
+        out = await router.dispatch(
+            provider=_ollama_spec(),
+            messages=anthropic_messages,
+            tools=anthropic_tools,
+        )
+
+    kwargs = mock_client.chat.completions.create.call_args.kwargs
+    # Tools translated to OpenAI function shape.
+    assert kwargs["tools"][0]["type"] == "function"
+    assert kwargs["tools"][0]["function"]["name"] == "get_case"
+    assert kwargs["tools"][0]["function"]["parameters"] == {"type": "object"}
+    # Messages translated: user text, assistant tool_calls, tool result message.
+    roles = [m["role"] for m in kwargs["messages"]]
+    assert roles == ["user", "assistant", "tool"]
+    assert kwargs["messages"][1]["tool_calls"][0]["id"] == "call_9"
+    assert kwargs["messages"][2]["tool_call_id"] == "call_9"
+    # Response tool_calls normalized to {id,name,input} dicts.
+    assert out["tool_calls"] == [
+        {"id": "call_9", "name": "get_case", "input": {"case_id": "C1"}}
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Dispatch — Anthropic direct branch
 # ---------------------------------------------------------------------------
@@ -780,11 +848,11 @@ def test_discover_anthropic_api_key_returns_none_when_no_rows():
 def test_discover_anthropic_api_key_returns_none_when_db_unavailable():
     """DB import error => silent None, so the legacy chain stays usable
     in environments where database.connection can't import."""
-    from services import llm_router
-
     # Patch ``get_db_session`` to raise on import. Easiest: make the
     # entire ``database.connection`` import fail by patching builtins.
     import builtins
+
+    from services import llm_router
 
     real_import = builtins.__import__
 

--- a/tests/unit/test_openai_agent_service.py
+++ b/tests/unit/test_openai_agent_service.py
@@ -1,0 +1,474 @@
+"""Unit tests for the OpenAI-format agent loop (services/openai_agent_service.py).
+
+Covers the schema converter, loop-detection signature canonicalization, and the
+streaming tool loop (tool-call, error flag, malformed tool call) with a mocked
+AsyncOpenAI client — no network or DB required.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from services.openai_agent_service import (  # noqa: E402
+    _LOOP_DETECT_THRESHOLD,
+    OpenAIAgentService,
+    PendingApprovalError,
+    _canonical_args,
+    anthropic_tools_to_openai,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# Pure helpers
+# --------------------------------------------------------------------------
+class TestSchemaConverter:
+    def test_basic_conversion(self):
+        out = anthropic_tools_to_openai(
+            [{"name": "search", "description": "d", "input_schema": {"type": "object"}}]
+        )
+        assert out[0] == {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "d",
+                "parameters": {"type": "object"},
+            },
+        }
+
+    def test_missing_input_schema_falls_back(self):
+        out = anthropic_tools_to_openai([{"name": "x"}])
+        assert out[0]["function"]["parameters"] == {"type": "object", "properties": {}}
+        assert out[0]["function"]["description"] == ""
+
+    def test_empty_list(self):
+        assert anthropic_tools_to_openai([]) == []
+
+
+class TestCanonicalArgs:
+    def test_key_order_and_whitespace_equivalent(self):
+        assert _canonical_args('{"b": 1, "a": 2}') == _canonical_args('{"a":2,"b":1}')
+
+    def test_invalid_json_falls_back_to_stripped_raw(self):
+        assert _canonical_args("  not json  ") == "not json"
+
+
+class TestLoopDetection:
+    def test_below_threshold_not_a_loop(self):
+        assert OpenAIAgentService._detect_infinite_loop(deque(["a"], maxlen=5)) is False
+
+    def test_identical_repeats_is_a_loop(self):
+        hist = deque(["sig"] * _LOOP_DETECT_THRESHOLD, maxlen=5)
+        assert OpenAIAgentService._detect_infinite_loop(hist) is True
+
+    def test_alternating_calls_not_a_loop(self):
+        hist = deque(["a", "b", "a"], maxlen=5)
+        assert OpenAIAgentService._detect_infinite_loop(hist) is False
+
+
+class TestToolFiltering:
+    def _svc(self, recommended):
+        return OpenAIAgentService(
+            backend_tools=[{"name": "splunk_search", "input_schema": {}}],
+            include_mcp_tools=False,
+            recommended_tools=recommended,
+        )
+
+    def test_no_recommended_keeps_all(self):
+        assert self._svc(None).tools_available() is True
+
+    def test_recommended_server_tool_suffix_match(self):
+        # "splunk_search" should match a recommendation of bare "search"
+        assert self._svc(["search"]).tools_available() is True
+
+    def test_recommended_no_match_hides_tools(self):
+        assert self._svc(["nonexistent"]).tools_available() is False
+
+
+# --------------------------------------------------------------------------
+# Streaming loop with a mocked AsyncOpenAI client
+# --------------------------------------------------------------------------
+def _chunk(content=None, tool_calls=None, finish_reason=None):
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta, finish_reason=finish_reason)]
+    )
+
+
+def _tc(index, tc_id=None, name=None, arguments=None):
+    return SimpleNamespace(
+        index=index,
+        id=tc_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+class _FakeStream:
+    def __init__(self, chunks):
+        self._it = iter(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class _FakeCompletions:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self._i = 0
+
+    async def create(self, **_kwargs):
+        resp = self._responses[min(self._i, len(self._responses) - 1)]
+        self._i += 1
+        return _FakeStream(resp)
+
+
+def _fake_openai_factory(responses):
+    # The router builds (and closes) a client per iteration, so the response
+    # queue is shared across constructions to let the script advance.
+    completions = _FakeCompletions(responses)
+
+    def _factory(**_kwargs):
+        return SimpleNamespace(
+            chat=SimpleNamespace(completions=completions),
+            close=AsyncMock(),
+        )
+
+    return _factory
+
+
+def _agent():
+    return OpenAIAgentService(
+        backend_tools=[{"name": "mytool", "input_schema": {"type": "object"}}],
+        include_mcp_tools=False,
+    )
+
+
+async def _collect(agent, responses, provider):
+    """Drive agent.stream with a faked SDK client; dispatch runs through the
+    real LLMRouter so sanitize/header/conversion wiring is covered too."""
+    events = []
+    with patch("openai.AsyncOpenAI", _fake_openai_factory(responses)):
+        async for ev in agent.stream(
+            provider=provider, messages=[{"role": "user", "content": "hi"}]
+        ):
+            events.append(ev)
+    return events
+
+
+@pytest.fixture()
+def provider():
+    return SimpleNamespace(provider_type="ollama", default_model="llama3.1:8b")
+
+
+@pytest.mark.asyncio
+async def test_text_only_response_streams_text_and_stops(provider):
+    responses = [
+        [_chunk(content="hello "), _chunk(content="world", finish_reason="stop")]
+    ]
+    events = await _collect(_agent(), responses, provider)
+    texts = [e["content"] for e in events if e["type"] == "text"]
+    assert "".join(texts) == "hello world"
+    assert not any(e["type"] == "tool_processing" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_tool_call_executes_then_finishes(provider):
+    responses = [
+        [
+            _chunk(
+                tool_calls=[_tc(0, "call1", "mytool", '{"q":"x"}')],
+                finish_reason="tool_calls",
+            )
+        ],
+        [_chunk(content="done", finish_reason="stop")],
+    ]
+    agent = _agent()
+    agent._execute_tool = AsyncMock(return_value=("RESULT", False))
+    events = await _collect(agent, responses, provider)
+
+    proc = [e for e in events if e["type"] == "tool_processing"]
+    res = [e for e in events if e["type"] == "tool_result"]
+    assert proc and proc[0]["tool_name"] == "mytool"
+    assert res and res[0]["is_error"] is False and res[0]["result"].startswith("RESULT")
+    agent._execute_tool.assert_awaited_once()
+    assert any(e["type"] == "text" and e["content"] == "done" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_tool_error_flag_propagates(provider):
+    responses = [
+        [
+            _chunk(
+                tool_calls=[_tc(0, "call1", "mytool", "{}")], finish_reason="tool_calls"
+            )
+        ],
+        [_chunk(content="ok", finish_reason="stop")],
+    ]
+    agent = _agent()
+    agent._execute_tool = AsyncMock(return_value=("boom", True))
+    events = await _collect(agent, responses, provider)
+    res = [e for e in events if e["type"] == "tool_result"]
+    assert res and res[0]["is_error"] is True
+
+
+@pytest.mark.asyncio
+async def test_empty_tool_name_is_skipped_no_crash(provider):
+    # A tool-call slot that never receives a name must be skipped, not emitted.
+    responses = [
+        [_chunk(tool_calls=[_tc(0, "call1", None, "{}")], finish_reason="tool_calls")]
+    ]
+    agent = _agent()
+    agent._execute_tool = AsyncMock(return_value=("x", False))
+    events = await _collect(agent, responses, provider)
+    assert not any(e["type"] == "tool_processing" for e in events)
+    agent._execute_tool.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------
+# Tool safety gating (parity with the daemon tier policy)
+# --------------------------------------------------------------------------
+class TestToolGating:
+    @pytest.mark.asyncio
+    async def test_forbidden_tool_is_refused_not_executed(self):
+        agent = OpenAIAgentService(include_mcp_tools=False)
+        agent._execute_backend_tool = AsyncMock()
+        agent._execute_mcp_tool = AsyncMock()
+        result, is_error = await agent._execute_tool("delete_case", "{}")
+        assert is_error is True
+        assert "forbidden" in result.lower()
+        agent._execute_backend_tool.assert_not_awaited()
+        agent._execute_mcp_tool.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_requires_approval_creates_action_and_does_not_execute(self):
+        agent = OpenAIAgentService(include_mcp_tools=False)
+        agent._execute_backend_tool = AsyncMock()
+        agent._execute_mcp_tool = AsyncMock()
+
+        created = {}
+
+        def _create_action(**kwargs):
+            created.update(kwargs)
+            return SimpleNamespace(action_id="ACT-1")
+
+        fake_service = SimpleNamespace(create_action=_create_action)
+        with patch(
+            "services.approval_service.get_approval_service",
+            return_value=fake_service,
+        ), patch("services.approval_service.ActionType", side_effect=ValueError):
+            with pytest.raises(PendingApprovalError) as exc_info:
+                await agent._execute_tool("isolate_host", '{"host": "h1"}')
+
+        result = str(exc_info.value)
+        assert "ACT-1" in result and "approval" in result.lower()
+        assert exc_info.value.action_id == "ACT-1"
+        assert created["parameters"] == {"host": "h1"}
+        agent._execute_backend_tool.assert_not_awaited()
+        agent._execute_mcp_tool.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_approved_flag_bypasses_gate_and_executes(self):
+        agent = OpenAIAgentService(
+            backend_tools=[{"name": "isolate_host", "input_schema": {}}],
+            include_mcp_tools=False,
+        )
+        agent._execute_backend_tool = AsyncMock(return_value=("isolated", False))
+        result, is_error = await agent._execute_tool(
+            "isolate_host", '{"host": "h1"}', approved=True
+        )
+        assert result == "isolated" and is_error is False
+        agent._execute_backend_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_approved_flag_does_not_bypass_forbidden(self):
+        agent = OpenAIAgentService(include_mcp_tools=False)
+        agent._execute_backend_tool = AsyncMock()
+        agent._execute_mcp_tool = AsyncMock()
+        result, is_error = await agent._execute_tool("delete_case", "{}", approved=True)
+        assert is_error is True and "forbidden" in result.lower()
+        agent._execute_backend_tool.assert_not_awaited()
+        agent._execute_mcp_tool.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_safe_tool_still_executes(self):
+        agent = OpenAIAgentService(
+            backend_tools=[{"name": "list_findings", "input_schema": {}}],
+            include_mcp_tools=False,
+        )
+        agent._execute_backend_tool = AsyncMock(return_value=("ok", False))
+        result, is_error = await agent._execute_tool("list_findings", "{}")
+        assert result == "ok" and is_error is False
+        agent._execute_backend_tool.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------
+# Approval gate — the run must not proceed past a requires_approval tool
+# until an operator decides (mirrors the daemon's waiting_approval halt).
+# --------------------------------------------------------------------------
+def _action(status, rejection_reason=None):
+    return SimpleNamespace(
+        action_id="ACT-1", status=status, rejection_reason=rejection_reason
+    )
+
+
+class TestApprovalGate:
+    @pytest.mark.asyncio
+    async def test_approved_action_executes_then_run_continues(self, provider):
+        responses = [
+            [
+                _chunk(
+                    tool_calls=[_tc(0, "call1", "isolate_host", '{"host":"h1"}')],
+                    finish_reason="tool_calls",
+                )
+            ],
+            [_chunk(content="contained", finish_reason="stop")],
+        ]
+        agent = _agent()
+        agent._await_approval = AsyncMock(return_value=("approved", "approved", 0.0))
+        agent._mark_action_executed = MagicMock()
+        agent._execute_tool = AsyncMock(
+            side_effect=[
+                PendingApprovalError("needs approval", "ACT-1"),
+                ("isolated", False),
+            ]
+        )
+        events = await _collect(agent, responses, provider)
+
+        assert [e["action_id"] for e in events if e["type"] == "approval_required"] == [
+            "ACT-1"
+        ]
+        res = [e for e in events if e["type"] == "tool_result"]
+        assert res and res[0]["result"].startswith("isolated")
+        # Re-run with approved=True, and the run carried on to the next turn.
+        assert agent._execute_tool.await_args_list[-1].kwargs == {"approved": True}
+        agent._mark_action_executed.assert_called_once()
+        assert any(e["type"] == "text" and e["content"] == "contained" for e in events)
+
+    @pytest.mark.asyncio
+    async def test_rejected_action_is_not_executed_and_model_is_told(self, provider):
+        responses = [
+            [
+                _chunk(
+                    tool_calls=[_tc(0, "call1", "isolate_host", '{"host":"h1"}')],
+                    finish_reason="tool_calls",
+                )
+            ],
+            [_chunk(content="understood", finish_reason="stop")],
+        ]
+        agent = _agent()
+        agent._await_approval = AsyncMock(return_value=("rejected", "too risky", 0.0))
+        agent._execute_tool = AsyncMock(
+            side_effect=PendingApprovalError("needs approval", "ACT-1")
+        )
+        events = await _collect(agent, responses, provider)
+
+        res = [e for e in events if e["type"] == "tool_result"]
+        assert res and res[0]["is_error"] is True
+        assert "REJECTED" in res[0]["result"] and "too risky" in res[0]["result"]
+        # Only the gated attempt ran — never a second, approved execution.
+        agent._execute_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_timeout_halts_the_run_with_an_error(self, provider):
+        responses = [
+            [
+                _chunk(
+                    tool_calls=[_tc(0, "call1", "isolate_host", '{"host":"h1"}')],
+                    finish_reason="tool_calls",
+                )
+            ],
+            [_chunk(content="should never be reached", finish_reason="stop")],
+        ]
+        agent = _agent()
+        agent._await_approval = AsyncMock(return_value=("timeout", "timed out", 0.0))
+        agent._execute_tool = AsyncMock(
+            side_effect=PendingApprovalError("needs approval", "ACT-1")
+        )
+        events = await _collect(agent, responses, provider)
+
+        assert events[-1] == {"type": "error", "content": "timed out"}
+        assert not any(
+            e["type"] == "text" and "should never" in e.get("content", "")
+            for e in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_uncreatable_approval_fails_closed(self, provider):
+        responses = [
+            [
+                _chunk(
+                    tool_calls=[_tc(0, "call1", "isolate_host", '{"host":"h1"}')],
+                    finish_reason="tool_calls",
+                )
+            ],
+            [_chunk(content="should never be reached", finish_reason="stop")],
+        ]
+        agent = _agent()
+        agent._await_approval = AsyncMock()
+        agent._execute_tool = AsyncMock(
+            side_effect=PendingApprovalError("queue is down", None)
+        )
+        events = await _collect(agent, responses, provider)
+
+        assert events[-1]["type"] == "error"
+        # Nothing to poll, so we must not wait — just stop.
+        agent._await_approval.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_await_approval_polls_until_operator_decides(self):
+        agent = _agent()
+        fake_service = SimpleNamespace(
+            get_action=MagicMock(
+                side_effect=[
+                    _action("pending"),
+                    _action("pending"),
+                    _action("approved"),
+                ]
+            )
+        )
+        with patch(
+            "services.approval_service.get_approval_service", return_value=fake_service
+        ), patch("services.openai_agent_service._APPROVAL_POLL_INTERVAL_S", 0.0):
+            decision, _detail, _waited = await agent._await_approval("ACT-1")
+        assert decision == "approved"
+        assert fake_service.get_action.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_await_approval_treats_vanished_action_as_rejected(self):
+        agent = _agent()
+        fake_service = SimpleNamespace(get_action=MagicMock(return_value=None))
+        with patch(
+            "services.approval_service.get_approval_service", return_value=fake_service
+        ):
+            decision, _detail, _waited = await agent._await_approval("ACT-1")
+        assert decision == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_await_approval_times_out_when_nobody_decides(self):
+        agent = _agent()
+        fake_service = SimpleNamespace(
+            get_action=MagicMock(return_value=_action("pending"))
+        )
+        with patch(
+            "services.approval_service.get_approval_service", return_value=fake_service
+        ), patch("services.openai_agent_service._APPROVAL_POLL_INTERVAL_S", 0.0):
+            decision, detail, _waited = await agent._await_approval(
+                "ACT-1", timeout=0.0
+            )
+        assert decision == "timeout" and "ACT-1" in detail

--- a/tests/unit/test_vstrike_service.py
+++ b/tests/unit/test_vstrike_service.py
@@ -940,7 +940,7 @@ def test_list_networks_parses_sse_with_structured_content():
     assert networks[1]["label"] == "DeepTempo AI SoC Demo"
 
 
-def test_call_mcp_tool_raises_on_tool_isError():
+def test_call_mcp_tool_raises_on_tool_is_error():
     """A tool result with isError=true is surfaced as a RuntimeError."""
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)


### PR DESCRIPTION
Agentic OLLAMA + OPENAI SUPPORT

KEY FEATURES: 

-> `OpenAIAgentService` — agent loop for OpenAI-format providers
New `services/openai_agent_service.py`: streaming multi-turn tool calling spoken in native OpenAI chat-completions wire format end-to-end. Tool execution reuses the same MCP + backend dispatch as `ClaudeService`, so Ollama/OpenAI agents get the full Vigil toolset. Structurally parallel to the Anthropic loop, with matching guardrails:
- Multi-turn tool loop (max 30 iterations) with a 300s wall-clock timeout
- Exponential backoff between late iterations
- Infinite-loop detection (identical tool signatures ×3)
- Per-agent `recommended_tools` filtering
- Context-window management (history window + token-based trimming)
- Per-iteration `LLMInteractionLog` logging + Bifrost correlation UUID
- Tool-result truncation + prompt-injection wrapping
- Budget enforcement via VK headers
- `anthropic_tools_to_openai()` schema converter

-> Chat routing wiring (`backend/api/claude.py`)
The `/chat/stream` path now branches on provider type:
- **Non-Anthropic + tool-capable model** → `OpenAIAgentService.stream()` (full agent loop)
- **Non-Anthropic + no tool support** → `LLMRouter.dispatch_openai_stream()` with a context-only, no-fabrication system prompt
- **Anthropic** → `ClaudeService.chat_stream()` (unchanged path)

Tool capability is resolved per-model via `ModelRegistry`, including **Ollama capability inference** (tool-use + vision detection) in `services/provider_model_discovery.py` / `services/model_registry.py`.

-> ClaudeService.chat_stream parity
Brought the Anthropic loop up to the same feature set: prompt caching, refusal handling, an explicit max-iteration message, and `recommended_tools` filtering.

Also updated wording for vigil login + added profile icon for username/email signing box.