### PR TITLE
fix(llm-providers): reconcile shared Bifrost key on provider delete/clear

### DIFF
--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -20,15 +20,18 @@ from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from secrets_manager import delete_secret, get_secret, set_secret
+from secrets_manager import delete_secret, get_secret, set_secret  # noqa: E402
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-from backend.middleware.auth import get_current_active_user
-from backend.services.auth_service import AuthService
-from database.connection import get_db, get_db_session
-from database.models import LLMProviderConfig, User
-from services.bifrost_admin import push_provider_key
-from services.url_safety import UrlSafetyError, validate_provider_url
+from backend.middleware.auth import get_current_active_user  # noqa: E402
+from backend.services.auth_service import AuthService  # noqa: E402
+from database.connection import get_db  # noqa: E402
+from database.models import LLMProviderConfig, User  # noqa: E402
+from services.bifrost_admin import push_provider_key  # noqa: E402
+from services.url_safety import (  # noqa: E402
+    UrlSafetyError,
+    validate_provider_url,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -40,7 +43,7 @@ _SLUG_RE = re.compile(r"[^a-z0-9-]+")
 # ``services.provider_model_discovery``; the fallback tuple here is the
 # cold-boot list used only when the live call fails (e.g. no API key
 # was provided at /discover-models time).
-from services.model_registry import _FALLBACK_MODELS_BY_PROVIDER
+from services.model_registry import _FALLBACK_MODELS_BY_PROVIDER  # noqa: E402
 
 ANTHROPIC_FALLBACK_MODELS = list(_FALLBACK_MODELS_BY_PROVIDER["anthropic"])
 
@@ -170,6 +173,42 @@ def _clear_other_defaults(db: Session, provider_type: str, keep_id: str) -> None
     )
 
 
+def _reconcile_bifrost_key_for_type(
+    db: Session, provider_type: str, exclude_provider_id: str
+) -> None:
+    """Reconcile Bifrost's shared per-type key after a provider loses its key.
+
+    Bifrost stores a single key per ``provider_type`` (see
+    ``bifrost_admin.push_provider_key`` — keyed by type, not by row), so
+    blindly blanking that key whenever one provider of the type is deleted
+    or cleared would knock out every same-type sibling that still relies on
+    it (``_schedule_catalog_resync`` only re-syncs the model allow-list, not
+    the keys, so the type would stay keyless until a restart).
+
+    So: only blank Bifrost's key when this was the last provider of its type
+    with a key; otherwise re-push a surviving sibling's key.
+    ``exclude_provider_id`` is the row being deleted/cleared, so it never
+    counts as a survivor.
+    """
+    survivors = [
+        r
+        for r in db.query(LLMProviderConfig).all()
+        if r.provider_type == provider_type
+        and r.provider_id != exclude_provider_id
+        and r.api_key_ref
+    ]
+    # Prefer the default provider, then any active one, for a stable choice.
+    survivors.sort(key=lambda r: (not r.is_default, not r.is_active))
+    for survivor in survivors:
+        value = get_secret(survivor.api_key_ref)
+        if value:
+            push_provider_key(provider_type, value)
+            return
+    # No surviving provider of this type has a usable key — it was the last
+    # one, so clear the stale credential on Bifrost.
+    push_provider_key(provider_type, "")
+
+
 def _schedule_catalog_resync(reason: str) -> None:
     """Invalidate the model-list cache and fire a background sync.
 
@@ -280,9 +319,10 @@ async def update_provider(
         if payload.api_key == "":
             delete_secret(ref)
             row.api_key_ref = None
-            # Clearing the key: push an empty value to Bifrost so it stops
-            # trying to authenticate with a stale credential.
-            push_provider_key(row.provider_type, "")
+            # Bifrost's key is shared per provider_type, so only blank it if
+            # no same-type sibling still has a key — otherwise re-push the
+            # survivor's so the type keeps a working credential.
+            _reconcile_bifrost_key_for_type(db, row.provider_type, provider_id)
         else:
             if not set_secret(ref, payload.api_key):
                 raise HTTPException(status_code=500, detail="Failed to persist API key")
@@ -317,8 +357,11 @@ async def delete_provider(
             delete_secret(row.api_key_ref)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Failed to delete secret %s: %s", row.api_key_ref, exc)
-        # Wipe the corresponding value on Bifrost too.
-        push_provider_key(row.provider_type, "")
+        # Bifrost's key is shared per provider_type. Only wipe it if this was
+        # the last keyed provider of its type; otherwise re-push a surviving
+        # sibling's key so the type isn't left without a working credential.
+        # (``row`` is still in the session here — exclude it explicitly.)
+        _reconcile_bifrost_key_for_type(db, row.provider_type, provider_id)
 
     db.delete(row)
     db.commit()

--- a/tests/unit/test_llm_providers_api.py
+++ b/tests/unit/test_llm_providers_api.py
@@ -7,6 +7,7 @@ are exercised.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from typing import Dict, Optional
@@ -16,13 +17,17 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-REPO = Path(__file__).resolve().parent.parent
+# Importing the router pulls in auth_service, which raises at import time if
+# DEV_MODE is false and JWT_SECRET_KEY is unset. Default to dev for tests.
+os.environ.setdefault("DEV_MODE", "true")
+
+REPO = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO))
 sys.path.insert(0, str(REPO / "backend"))
 
 from backend.api.llm_providers import router as llm_providers_router
 from backend.middleware.auth import get_current_active_user
-from database.connection import get_db_session
+from database.connection import get_db
 from database.models import LLMProviderConfig, User
 
 
@@ -110,7 +115,7 @@ def client(session):
     def _get_session():
         return session
 
-    app.dependency_overrides[get_db_session] = _get_session
+    app.dependency_overrides[get_db] = _get_session
     # Bypass cookie/JWT auth for unit tests — the security-coverage tests
     # in tests/security/ exercise the real path.
     app.dependency_overrides[get_current_active_user] = _fake_admin_user
@@ -138,9 +143,9 @@ def secrets_store():
         store.pop(key, None)
         return True
 
-    with patch("backend.api.llm_providers.set_secret", side_effect=fake_set), \
-         patch("backend.api.llm_providers.get_secret", side_effect=fake_get), \
-         patch("backend.api.llm_providers.delete_secret", side_effect=fake_delete):
+    with patch("backend.api.llm_providers.set_secret", side_effect=fake_set), patch(
+        "backend.api.llm_providers.get_secret", side_effect=fake_get
+    ), patch("backend.api.llm_providers.delete_secret", side_effect=fake_delete):
         yield store
 
 
@@ -252,6 +257,132 @@ def test_delete_removes_secret(client, secrets_store):
     r = client.delete("/api/llm/providers/openai-prod")
     assert r.status_code == 200
     assert "llm_provider_openai-prod_api_key" not in secrets_store
+
+
+@pytest.fixture()
+def bifrost_pushes():
+    """Capture every push_provider_key(provider_type, value) call."""
+    calls = []
+
+    def fake_push(provider_type: str, value: str) -> bool:
+        calls.append((provider_type, value))
+        return True
+
+    with patch("backend.api.llm_providers.push_provider_key", side_effect=fake_push):
+        yield calls
+
+
+def test_delete_last_of_type_clears_bifrost_key(client, secrets_store, bifrost_pushes):
+    """Deleting the only provider of a type blanks the shared Bifrost key."""
+    client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_id": "openai-prod",
+            "provider_type": "openai",
+            "name": "OpenAI",
+            "default_model": "gpt-4o",
+            "api_key": "sk-only",
+        },
+    )
+    bifrost_pushes.clear()  # drop the create-time push
+
+    r = client.delete("/api/llm/providers/openai-prod")
+    assert r.status_code == 200
+    # Last provider of its type → clear the credential.
+    assert ("openai", "") in bifrost_pushes
+    assert ("openai", "sk-only") not in bifrost_pushes
+
+
+def test_delete_with_sibling_repushes_sibling_key(
+    client, secrets_store, bifrost_pushes
+):
+    """Deleting one provider re-pushes a same-type sibling's key, never blank."""
+    client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_id": "openai-a",
+            "provider_type": "openai",
+            "name": "A",
+            "default_model": "gpt-4o",
+            "api_key": "sk-aaa",
+        },
+    )
+    client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_id": "openai-b",
+            "provider_type": "openai",
+            "name": "B",
+            "default_model": "gpt-4o",
+            "api_key": "sk-bbb",
+        },
+    )
+    bifrost_pushes.clear()
+
+    r = client.delete("/api/llm/providers/openai-a")
+    assert r.status_code == 200
+    # Sibling b survives with its key → re-push it, do NOT blank the type.
+    assert ("openai", "sk-bbb") in bifrost_pushes
+    assert ("openai", "") not in bifrost_pushes
+    # The deleted provider's own secret is still removed.
+    assert "llm_provider_openai-a_api_key" not in secrets_store
+
+
+def test_update_clear_with_sibling_repushes_sibling_key(
+    client, secrets_store, bifrost_pushes
+):
+    """Clearing one provider's key re-pushes a same-type sibling's key."""
+    client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_id": "openai-a",
+            "provider_type": "openai",
+            "name": "A",
+            "default_model": "gpt-4o",
+            "api_key": "sk-aaa",
+        },
+    )
+    client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_id": "openai-b",
+            "provider_type": "openai",
+            "name": "B",
+            "default_model": "gpt-4o",
+            "api_key": "sk-bbb",
+        },
+    )
+    bifrost_pushes.clear()
+
+    r = client.put("/api/llm/providers/openai-a", json={"api_key": ""})
+    assert r.status_code == 200
+    assert r.json()["has_api_key"] is False
+    # openai-a's own secret is gone, but the shared Bifrost key falls back
+    # to sibling b's rather than being blanked.
+    assert "llm_provider_openai-a_api_key" not in secrets_store
+    assert ("openai", "sk-bbb") in bifrost_pushes
+    assert ("openai", "") not in bifrost_pushes
+
+
+def test_update_clear_last_of_type_blanks_bifrost_key(
+    client, secrets_store, bifrost_pushes
+):
+    """Clearing the only provider's key blanks the shared Bifrost key."""
+    client.post(
+        "/api/llm/providers/",
+        json={
+            "provider_id": "openai-solo",
+            "provider_type": "openai",
+            "name": "Solo",
+            "default_model": "gpt-4o",
+            "api_key": "sk-solo",
+        },
+    )
+    bifrost_pushes.clear()
+
+    r = client.put("/api/llm/providers/openai-solo", json={"api_key": ""})
+    assert r.status_code == 200
+    assert ("openai", "") in bifrost_pushes
 
 
 def test_set_default_enforces_single_default(client, secrets_store, session):


### PR DESCRIPTION
Fixes the #336 review comment. Bifrost stores one key per `provider_type`, so blanking it on every provider delete/clear knocked out same-type siblings (and `_schedule_catalog_resync` only re-syncs the model allow-list, not keys — so the type stayed keyless until a restart).

`_reconcile_bifrost_key_for_type` re-pushes a surviving sibling's key and only blanks Bifrost's key when the deleted/cleared provider was the last keyed one of its type. Applied to `delete_provider` and the `update_provider` clear-path; also tidies the module imports.

as per @nestor-deeptempo comment.