### PR TITLE
feat(auth): harden authentication for production readiness

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -190,8 +190,14 @@ async def login(
             )
 
     # Generate tokens
-    access_token = AuthService.generate_jwt_token(user, "access")
-    refresh_token = AuthService.generate_jwt_token(user, "refresh")
+    _ip = request.client.host if request.client else None
+    _ua = request.headers.get("user-agent")
+    access_token = AuthService.generate_jwt_token(
+        user, "access", request_ip=_ip, user_agent=_ua
+    )
+    refresh_token = AuthService.generate_jwt_token(
+        user, "refresh", request_ip=_ip, user_agent=_ua
+    )
 
     # Extract exp claims so the cookie Max-Age matches the JWT lifetime.
     access_payload = AuthService.verify_jwt_token(access_token) or {}
@@ -348,8 +354,14 @@ async def refresh_token(
         )
 
     # Generate new tokens
-    access_token = AuthService.generate_jwt_token(user, "access")
-    refresh_token = AuthService.generate_jwt_token(user, "refresh")
+    _ip = request.client.host if request.client else None
+    _ua = request.headers.get("user-agent")
+    access_token = AuthService.generate_jwt_token(
+        user, "access", request_ip=_ip, user_agent=_ua
+    )
+    refresh_token = AuthService.generate_jwt_token(
+        user, "refresh", request_ip=_ip, user_agent=_ua
+    )
 
     access_payload = AuthService.verify_jwt_token(access_token) or {}
     refresh_payload = AuthService.verify_jwt_token(refresh_token) or {}

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -7,7 +7,7 @@ Handles login, logout, token refresh, password management, and MFA.
 import logging
 import os
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 from fastapi import APIRouter, HTTPException, Depends, Header, Request, Response, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
@@ -89,6 +89,13 @@ class MFASetupResponse(BaseModel):
 
     secret: str
     qr_uri: str
+
+
+class RecoveryCodesResponse(BaseModel):
+    """One-time MFA recovery codes (shown once, cannot be retrieved again)."""
+
+    recovery_codes: List[str]
+    message: Optional[str] = None
 
 
 class MFAVerifyRequest(BaseModel):
@@ -199,14 +206,9 @@ async def login(
             )
 
     # Generate tokens
-    _ip = request.client.host if request.client else None
     _ua = request.headers.get("user-agent")
-    access_token = AuthService.generate_jwt_token(
-        user, "access", request_ip=_ip, user_agent=_ua
-    )
-    refresh_token = AuthService.generate_jwt_token(
-        user, "refresh", request_ip=_ip, user_agent=_ua
-    )
+    access_token = AuthService.generate_jwt_token(user, "access", user_agent=_ua)
+    refresh_token = AuthService.generate_jwt_token(user, "refresh", user_agent=_ua)
 
     # Extract exp claims so the cookie Max-Age matches the JWT lifetime.
     access_payload = AuthService.verify_jwt_token(access_token) or {}
@@ -359,14 +361,9 @@ async def refresh_token(
         )
 
     # Generate new tokens
-    _ip = request.client.host if request.client else None
     _ua = request.headers.get("user-agent")
-    access_token = AuthService.generate_jwt_token(
-        user, "access", request_ip=_ip, user_agent=_ua
-    )
-    refresh_token = AuthService.generate_jwt_token(
-        user, "refresh", request_ip=_ip, user_agent=_ua
-    )
+    access_token = AuthService.generate_jwt_token(user, "access", user_agent=_ua)
+    refresh_token = AuthService.generate_jwt_token(user, "refresh", user_agent=_ua)
 
     access_payload = AuthService.verify_jwt_token(access_token) or {}
     refresh_payload = AuthService.verify_jwt_token(refresh_token) or {}
@@ -555,7 +552,9 @@ async def setup_mfa(
         session: Database session
 
     Returns:
-        MFA secret and QR code URI
+        MFA secret and QR code URI. Recovery codes are not issued here —
+        they are returned by POST /mfa/verify once the first TOTP code is
+        confirmed.
     """
     secret = AuthService.setup_mfa(current_user.user_id, session)
     if not secret:
@@ -574,14 +573,14 @@ async def setup_mfa(
     return MFASetupResponse(secret=secret, qr_uri=qr_uri)
 
 
-@router.post("/mfa/verify")
+@router.post("/mfa/verify", response_model=RecoveryCodesResponse)
 async def verify_mfa(
     request: MFAVerifyRequest,
     current_user: User = Depends(get_current_active_user),
     session: Session = Depends(get_db),
 ):
     """
-    Verify MFA code and enable MFA.
+    Verify the first TOTP code and enable MFA.
 
     Args:
         request: MFA code
@@ -589,16 +588,40 @@ async def verify_mfa(
         session: Database session
 
     Returns:
-        Success message
+        Success message and one-time recovery codes (shown only once).
     """
-    is_valid = AuthService.verify_mfa_code(current_user.user_id, request.code, session)
+    codes = AuthService.enable_mfa(current_user.user_id, request.code, session)
 
-    if not is_valid:
+    if codes is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid MFA code"
         )
 
-    return {"message": "MFA enabled successfully"}
+    return RecoveryCodesResponse(
+        recovery_codes=codes, message="MFA enabled successfully"
+    )
+
+
+@router.post("/mfa/recovery-codes", response_model=RecoveryCodesResponse)
+async def regenerate_recovery_codes(
+    current_user: User = Depends(get_current_active_user),
+    session: Session = Depends(get_db),
+):
+    """
+    Generate a fresh set of one-time MFA recovery codes, invalidating any
+    previous codes. Requires MFA to already be set up.
+
+    Returns:
+        The new plaintext recovery codes, shown only once.
+    """
+    codes = AuthService.get_mfa_recovery_codes(current_user.user_id, session)
+    if codes is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="MFA is not set up for this user",
+        )
+
+    return RecoveryCodesResponse(recovery_codes=codes)
 
 
 @router.delete("/mfa")

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -38,10 +38,10 @@ from backend.services.token_blacklist import (
     is_token_revoked,
     revoke_all_for_user,
 )
-from backend.middleware.auth import get_current_user, get_current_active_user
+from backend.middleware.auth import get_current_active_user
 from backend.middleware.rate_limit import limiter
 from database.models import User
-from database.connection import get_db, get_db_session
+from database.connection import get_db
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +51,7 @@ router = APIRouter()
 # Request/Response Models
 class LoginRequest(BaseModel):
     """Login request."""
+
     username_or_email: str
     password: str
     mfa_code: Optional[str] = None
@@ -58,6 +59,7 @@ class LoginRequest(BaseModel):
 
 class LoginResponse(BaseModel):
     """Login response."""
+
     access_token: str
     refresh_token: str
     token_type: str = "bearer"
@@ -66,6 +68,7 @@ class LoginResponse(BaseModel):
 
 class ChangePasswordRequest(BaseModel):
     """Change password request."""
+
     current_password: str
     new_password: str
 
@@ -77,27 +80,32 @@ class RefreshTokenRequest(BaseModel):
     HttpOnly refresh_token cookie. The body field stays for API/CLI
     clients that haven't migrated to the cookie flow.
     """
+
     refresh_token: Optional[str] = None
 
 
 class MFASetupResponse(BaseModel):
     """MFA setup response."""
+
     secret: str
     qr_uri: str
 
 
 class MFAVerifyRequest(BaseModel):
     """MFA verification request."""
+
     code: str
 
 
 class PasswordResetRequest(BaseModel):
     """Password reset initiation."""
+
     email: EmailStr
 
 
 class PasswordResetConfirm(BaseModel):
     """Password reset completion."""
+
     token: str
     new_password: str
 
@@ -106,7 +114,8 @@ def _apply_new_password(user: User, plaintext: str) -> None:
     """Enforce history, hash, set, update history + changed_at in one place.
     Caller is responsible for session.commit()."""
     if password_matches_any(plaintext, user.password_history or []) or (
-        user.password_hash and AuthService.verify_password(plaintext, user.password_hash)
+        user.password_hash
+        and AuthService.verify_password(plaintext, user.password_hash)
     ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -132,7 +141,7 @@ async def login(
     request: Request,
     response: Response,
     payload: LoginRequest,
-    session: Session = Depends(get_db)
+    session: Session = Depends(get_db),
 ):
     """
     Authenticate user and issue tokens.
@@ -155,12 +164,12 @@ async def login(
     # Authenticate user
     try:
         user = AuthService.authenticate_user(
-            payload.username_or_email,
-            payload.password,
-            session
+            payload.username_or_email, payload.password, session
         )
     except AccountLockedError as exc:
-        retry_after = max(1, int((exc.locked_until - datetime.utcnow()).total_seconds()))
+        retry_after = max(
+            1, int((exc.locked_until - datetime.utcnow()).total_seconds())
+        )
         raise HTTPException(
             status_code=status.HTTP_423_LOCKED,
             detail="Account locked due to repeated failed login attempts",
@@ -213,9 +222,7 @@ async def login(
     logger.info(f"User logged in: {user.username}")
 
     return LoginResponse(
-        access_token=access_token,
-        refresh_token=refresh_token,
-        user=user.to_dict()
+        access_token=access_token, refresh_token=refresh_token, user=user.to_dict()
     )
 
 
@@ -253,9 +260,7 @@ async def logout(
         if payload:
             jti = payload.get("jti")
             exp_ts = payload.get("exp")
-            exp_dt = (
-                datetime.utcfromtimestamp(exp_ts) if exp_ts is not None else None
-            )
+            exp_dt = datetime.utcfromtimestamp(exp_ts) if exp_ts is not None else None
             if jti:
                 try:
                     await blacklist_jti(jti, exp_dt)
@@ -304,7 +309,7 @@ async def refresh_token(
     request: Request,
     response: Response,
     body: Optional[RefreshTokenRequest] = None,
-    session: Session = Depends(get_db)
+    session: Session = Depends(get_db),
 ):
     """
     Refresh access token using refresh token.
@@ -374,9 +379,7 @@ async def refresh_token(
     )
 
     return LoginResponse(
-        access_token=access_token,
-        refresh_token=refresh_token,
-        user=user.to_dict()
+        access_token=access_token, refresh_token=refresh_token, user=user.to_dict()
     )
 
 
@@ -406,17 +409,17 @@ async def update_current_user(
     full_name: Optional[str] = None,
     email: Optional[EmailStr] = None,
     current_user: User = Depends(get_current_active_user),
-    session: Session = Depends(get_db)
+    session: Session = Depends(get_db),
 ):
     """
     Update current user profile.
-    
+
     Args:
         full_name: New full name
         email: New email
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         Updated user information
     """
@@ -427,15 +430,16 @@ async def update_current_user(
 
         if email:
             # Check if email is already taken
-            existing = session.query(User).filter(
-                User.email == email,
-                User.user_id != current_user.user_id
-            ).first()
+            existing = (
+                session.query(User)
+                .filter(User.email == email, User.user_id != current_user.user_id)
+                .first()
+            )
 
             if existing:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Email already in use"
+                    detail="Email already in use",
                 )
 
             current_user.email = email
@@ -465,7 +469,7 @@ async def update_current_user(
         session.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to update profile"
+            detail="Failed to update profile",
         )
 
 
@@ -476,7 +480,7 @@ async def change_password(
     response: Response,
     body: ChangePasswordRequest,
     current_user: User = Depends(get_current_active_user),
-    session: Session = Depends(get_db)
+    session: Session = Depends(get_db),
 ):
     """
     Change user password.
@@ -491,10 +495,12 @@ async def change_password(
         Success message
     """
     # Verify current password
-    if not AuthService.verify_password(body.current_password, current_user.password_hash):
+    if not AuthService.verify_password(
+        body.current_password, current_user.password_hash
+    ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Current password is incorrect"
+            detail="Current password is incorrect",
         )
 
     # Validate new password against the strength policy
@@ -526,28 +532,28 @@ async def change_password(
         clear_auth_cookies(response)
         logger.info(f"Password changed for user: {current_user.username}")
         return {"message": "Password changed successfully. Please log in again."}
-    
+
     except Exception as e:
         logger.error(f"Password change error: {e}")
         session.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to change password"
+            detail="Failed to change password",
         )
 
 
 @router.post("/mfa/setup", response_model=MFASetupResponse)
 async def setup_mfa(
     current_user: User = Depends(get_current_active_user),
-    session: Session = Depends(get_db)
+    session: Session = Depends(get_db),
 ):
     """
     Setup MFA for current user.
-    
+
     Args:
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         MFA secret and QR code URI
     """
@@ -555,16 +561,16 @@ async def setup_mfa(
     if not secret:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to setup MFA"
+            detail="Failed to setup MFA",
         )
-    
+
     qr_uri = AuthService.get_mfa_qr_uri(current_user.user_id, session)
     if not qr_uri:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to generate QR code"
+            detail="Failed to generate QR code",
         )
-    
+
     return MFASetupResponse(secret=secret, qr_uri=qr_uri)
 
 
@@ -572,42 +578,41 @@ async def setup_mfa(
 async def verify_mfa(
     request: MFAVerifyRequest,
     current_user: User = Depends(get_current_active_user),
-    session: Session = Depends(get_db)
+    session: Session = Depends(get_db),
 ):
     """
     Verify MFA code and enable MFA.
-    
+
     Args:
         request: MFA code
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         Success message
     """
     is_valid = AuthService.verify_mfa_code(current_user.user_id, request.code, session)
-    
+
     if not is_valid:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid MFA code"
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid MFA code"
         )
-    
+
     return {"message": "MFA enabled successfully"}
 
 
 @router.delete("/mfa")
 async def disable_mfa(
     current_user: User = Depends(get_current_active_user),
-    session: Session = Depends(get_db)
+    session: Session = Depends(get_db),
 ):
     """
     Disable MFA for current user.
-    
+
     Args:
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         Success message
     """
@@ -615,16 +620,16 @@ async def disable_mfa(
         current_user.mfa_enabled = False
         current_user.mfa_secret = None
         session.commit()
-        
+
         logger.info(f"MFA disabled for user: {current_user.username}")
         return {"message": "MFA disabled successfully"}
-    
+
     except Exception as e:
         logger.error(f"MFA disable error: {e}")
         session.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to disable MFA"
+            detail="Failed to disable MFA",
         )
 
 
@@ -747,5 +752,3 @@ async def password_reset_confirm(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to reset password",
         )
-
-

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -138,10 +138,9 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Validate session fingerprint (IP + UA binding).
+    # Validate session fingerprint (user-agent binding).
     if not AuthService.verify_session_fingerprint(
         payload,
-        request_ip=request.client.host if request.client else None,
         user_agent=request.headers.get("user-agent"),
     ):
         raise HTTPException(

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -131,11 +131,22 @@ async def get_current_user(
         )
 
     # Reject revoked tokens (logout / password change / role change).
-    # Fail-open if Redis is down — see token_blacklist.is_token_revoked.
     if await is_token_revoked(payload):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token has been revoked",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # Validate session fingerprint (IP + UA binding).
+    if not AuthService.verify_session_fingerprint(
+        payload,
+        request_ip=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session fingerprint mismatch",
             headers={"WWW-Authenticate": "Bearer"},
         )
 

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -9,7 +9,7 @@ import os
 import secrets
 import uuid
 from datetime import datetime, timedelta
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 import bcrypt
 import jwt
 import pyotp
@@ -58,8 +58,8 @@ def _load_jwt_secret() -> str:
 # JWT Configuration
 JWT_SECRET_KEY = _load_jwt_secret()
 JWT_ALGORITHM = "HS256"
-JWT_EXPIRATION_HOURS = 24
-JWT_REFRESH_EXPIRATION_DAYS = 30
+JWT_ACCESS_EXPIRATION_MINUTES = int(os.getenv("JWT_ACCESS_EXPIRATION_MINUTES", "30"))
+JWT_REFRESH_EXPIRATION_DAYS = int(os.getenv("JWT_REFRESH_EXPIRATION_DAYS", "7"))
 
 # Account lockout configuration
 LOCKOUT_THRESHOLD = int(os.getenv("AUTH_LOCKOUT_THRESHOLD", "5"))
@@ -134,21 +134,19 @@ class AuthService:
             return False
     
     @staticmethod
-    def generate_jwt_token(user: User, token_type: str = "access") -> str:
-        """
-        Generate a JWT token for a user.
-        
-        Args:
-            user: User object
-            token_type: "access" or "refresh"
-        
-        Returns:
-            JWT token string
-        """
+    def generate_jwt_token(
+        user: User,
+        token_type: str = "access",
+        request_ip: Optional[str] = None,
+        user_agent: Optional[str] = None,
+    ) -> str:
+        """Generate a JWT token for a user with optional session binding."""
         expiration = timedelta(
-            hours=JWT_EXPIRATION_HOURS if token_type == "access" else JWT_REFRESH_EXPIRATION_DAYS * 24
+            minutes=JWT_ACCESS_EXPIRATION_MINUTES
+        ) if token_type == "access" else timedelta(
+            days=JWT_REFRESH_EXPIRATION_DAYS
         )
-        
+
         now = datetime.utcnow()
         payload = {
             "user_id": user.user_id,
@@ -160,9 +158,33 @@ class AuthService:
             "exp": now + expiration,
             "iat": now,
         }
-        
+
+        # Bind token to session context when available
+        if request_ip or user_agent:
+            import hashlib
+            fp_data = f"{request_ip or ''}|{user_agent or ''}"
+            payload["sfp"] = hashlib.sha256(fp_data.encode()).hexdigest()[:16]
+
         token = jwt.encode(payload, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
         return token
+
+    @staticmethod
+    def verify_session_fingerprint(
+        payload: Dict[str, Any],
+        request_ip: Optional[str] = None,
+        user_agent: Optional[str] = None,
+    ) -> bool:
+        """Check that a token's session fingerprint matches the request context.
+
+        Returns True if no fingerprint is bound (backwards compat) or if it matches.
+        """
+        sfp = payload.get("sfp")
+        if not sfp:
+            return True
+        import hashlib
+        fp_data = f"{request_ip or ''}|{user_agent or ''}"
+        expected = hashlib.sha256(fp_data.encode()).hexdigest()[:16]
+        return secrets.compare_digest(sfp, expected)
     
     @staticmethod
     def verify_jwt_token(token: str) -> Optional[Dict[str, Any]]:
@@ -265,84 +287,158 @@ class AuthService:
     
     @staticmethod
     def setup_mfa(user_id: str, session: Optional[Session] = None) -> Optional[str]:
-        """
-        Setup MFA for a user.
-        
-        Args:
-            user_id: User ID
-            session: Database session (optional)
-        
-        Returns:
-            MFA secret (base32 encoded) or None
-        """
+        """Setup MFA. Returns TOTP secret and generates recovery codes."""
         should_close_session = session is None
         if session is None:
             session = get_db_session()
-        
+
         try:
             user = session.query(User).filter(User.user_id == user_id).first()
             if not user:
                 return None
-            
-            # Generate MFA secret
+
             secret = pyotp.random_base32()
-            user.mfa_secret = secret
-            user.mfa_enabled = False  # Will be enabled after verification
+            user.mfa_secret = AuthService._encrypt_mfa_secret(secret)
+            user.mfa_enabled = False
+            # Generate 10 recovery codes, store bcrypt-hashed
+            codes = [secrets.token_hex(4).upper() for _ in range(10)]
+            user.mfa_recovery_codes = [
+                bcrypt.hashpw(c.encode(), bcrypt.gensalt()).decode()
+                for c in codes
+            ]
             session.commit()
-            
+
             logger.info(f"MFA setup initiated for user: {user.username}")
+            # Return plaintext secret; recovery codes returned separately
             return secret
-        
+
         except Exception as e:
             logger.error(f"MFA setup error: {e}")
             session.rollback()
             return None
-        
+
         finally:
             if should_close_session:
                 session.close()
-    
+
     @staticmethod
-    def verify_mfa_code(user_id: str, code: str, session: Optional[Session] = None) -> bool:
-        """
-        Verify an MFA code.
-        
-        Args:
-            user_id: User ID
-            code: 6-digit MFA code
-            session: Database session (optional)
-        
-        Returns:
-            True if code is valid
+    def get_mfa_recovery_codes(
+        user_id: str, session: Optional[Session] = None
+    ) -> Optional[List[str]]:
+        """Generate fresh recovery codes for a user (re-setup).
+
+        Returns plaintext codes. Caller must display them once; they cannot
+        be retrieved again.
         """
         should_close_session = session is None
         if session is None:
             session = get_db_session()
-        
+
+        try:
+            user = session.query(User).filter(User.user_id == user_id).first()
+            if not user or not user.mfa_secret:
+                return None
+
+            codes = [secrets.token_hex(4).upper() for _ in range(10)]
+            user.mfa_recovery_codes = [
+                bcrypt.hashpw(c.encode(), bcrypt.gensalt()).decode()
+                for c in codes
+            ]
+            session.commit()
+            return codes
+
+        except Exception as e:
+            logger.error(f"Recovery code generation error: {e}")
+            session.rollback()
+            return None
+
+        finally:
+            if should_close_session:
+                session.close()
+
+    @staticmethod
+    def verify_mfa_code(
+        user_id: str, code: str, session: Optional[Session] = None
+    ) -> bool:
+        """Verify a TOTP code or a one-time recovery code."""
+        should_close_session = session is None
+        if session is None:
+            session = get_db_session()
+
         try:
             user = session.query(User).filter(User.user_id == user_id).first()
             if not user or not user.mfa_secret:
                 return False
-            
-            # Verify TOTP code
-            totp = pyotp.TOTP(user.mfa_secret)
-            is_valid = totp.verify(code, valid_window=1)  # Allow 1 time step window
-            
-            if is_valid and not user.mfa_enabled:
-                # First successful verification - enable MFA
-                user.mfa_enabled = True
-                session.commit()
-                logger.info(f"MFA enabled for user: {user.username}")
-            
-            return is_valid
-        
+
+            # Try TOTP first
+            decrypted_secret = AuthService._decrypt_mfa_secret(user.mfa_secret)
+            totp = pyotp.TOTP(decrypted_secret)
+            if totp.verify(code, valid_window=1):
+                if not user.mfa_enabled:
+                    user.mfa_enabled = True
+                    session.commit()
+                    logger.info(f"MFA enabled for user: {user.username}")
+                return True
+
+            # Try recovery codes (one-time use)
+            recovery_codes = list(user.mfa_recovery_codes or [])
+            code_bytes = code.strip().upper().encode()
+            for i, hashed in enumerate(recovery_codes):
+                try:
+                    if bcrypt.checkpw(code_bytes, hashed.encode()):
+                        recovery_codes.pop(i)
+                        user.mfa_recovery_codes = recovery_codes
+                        session.commit()
+                        logger.info(
+                            "Recovery code used for user: %s (%d remaining)",
+                            user.username,
+                            len(recovery_codes),
+                        )
+                        return True
+                except Exception:
+                    continue
+
+            return False
+
         except Exception as e:
             logger.error(f"MFA verification error: {e}")
             return False
-        
+
         finally:
             if should_close_session:
                 session.close()
+
+    @staticmethod
+    def _encrypt_mfa_secret(secret: str) -> str:
+        """Encrypt MFA secret at rest using the JWT key as a derived key.
+
+        Uses Fernet symmetric encryption. The encryption key is derived from
+        JWT_SECRET_KEY via SHA-256 + base64 to produce a valid 32-byte Fernet key.
+        """
+        import base64
+        import hashlib
+        from cryptography.fernet import Fernet
+
+        key = base64.urlsafe_b64encode(
+            hashlib.sha256(JWT_SECRET_KEY.encode()).digest()
+        )
+        return Fernet(key).encrypt(secret.encode()).decode()
+
+    @staticmethod
+    def _decrypt_mfa_secret(encrypted: str) -> str:
+        """Decrypt MFA secret from storage."""
+        import base64
+        import hashlib
+        from cryptography.fernet import Fernet
+
+        key = base64.urlsafe_b64encode(
+            hashlib.sha256(JWT_SECRET_KEY.encode()).digest()
+        )
+        try:
+            return Fernet(key).decrypt(encrypted.encode()).decode()
+        except Exception:
+            # Fallback: secret may be stored unencrypted (pre-migration rows)
+            return encrypted
     
     @staticmethod
     def get_mfa_qr_uri(user_id: str, session: Optional[Session] = None) -> Optional[str]:

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -140,18 +140,21 @@ class AuthService:
             return False
 
     @staticmethod
-    def _session_fingerprint(
-        request_ip: Optional[str], user_agent: Optional[str]
-    ) -> str:
-        """Short SHA-256 fingerprint binding a token to its IP + user-agent."""
-        fp = f"{request_ip or ''}|{user_agent or ''}"
-        return hashlib.sha256(fp.encode()).hexdigest()[:16]
+    def _session_fingerprint(user_agent: Optional[str]) -> str:
+        """Short SHA-256 fingerprint binding a token to its user-agent.
+
+        Deliberately excludes the client IP: NAT, VPNs and mobile roaming
+        change a client's IP within a token's lifetime (forcing spurious
+        re-logins), and behind a reverse proxy every client presents the
+        proxy's IP, so it adds no signal. The user-agent is a stable,
+        defense-in-depth check on top of the JWT signature.
+        """
+        return hashlib.sha256((user_agent or "").encode()).hexdigest()[:16]
 
     @staticmethod
     def generate_jwt_token(
         user: User,
         token_type: str = "access",
-        request_ip: Optional[str] = None,
         user_agent: Optional[str] = None,
     ) -> str:
         """Generate a JWT token for a user with optional session binding."""
@@ -174,8 +177,8 @@ class AuthService:
         }
 
         # Bind token to session context when available
-        if request_ip or user_agent:
-            payload["sfp"] = AuthService._session_fingerprint(request_ip, user_agent)
+        if user_agent:
+            payload["sfp"] = AuthService._session_fingerprint(user_agent)
 
         token = jwt.encode(payload, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
         return token
@@ -183,7 +186,6 @@ class AuthService:
     @staticmethod
     def verify_session_fingerprint(
         payload: Dict[str, Any],
-        request_ip: Optional[str] = None,
         user_agent: Optional[str] = None,
     ) -> bool:
         """Check that a token's session fingerprint matches the request context.
@@ -193,7 +195,7 @@ class AuthService:
         sfp = payload.get("sfp")
         if not sfp:
             return True
-        expected = AuthService._session_fingerprint(request_ip, user_agent)
+        expected = AuthService._session_fingerprint(user_agent)
         return secrets.compare_digest(sfp, expected)
 
     @staticmethod
@@ -221,17 +223,6 @@ class AuthService:
     def authenticate_user(
         username_or_email: str, password: str, session: Optional[Session] = None
     ) -> Optional[User]:
-        """
-        Authenticate a user with username/email and password.
-
-        Args:
-            username_or_email: Username or email
-            password: Plain text password
-            session: Database session (optional)
-
-        Returns:
-            User object if authentication successful, None otherwise
-        """
         should_close_session = session is None
         session = session or get_db_session()
 
@@ -305,7 +296,6 @@ class AuthService:
 
     @staticmethod
     def setup_mfa(user_id: str, session: Optional[Session] = None) -> Optional[str]:
-        """Setup MFA. Returns TOTP secret and generates recovery codes."""
         should_close_session = session is None
         session = session or get_db_session()
 
@@ -317,17 +307,61 @@ class AuthService:
             secret = pyotp.random_base32()
             user.mfa_secret = AuthService._encrypt_mfa_secret(secret)
             user.mfa_enabled = False
-            # Generate 10 recovery codes, store bcrypt-hashed (plaintext
-            # is surfaced via get_mfa_recovery_codes, not here)
-            _, user.mfa_recovery_codes = AuthService._generate_recovery_codes()
+            # Clear any stale codes from a prior setup attempt; fresh codes
+            # are issued at enable time.
+            user.mfa_recovery_codes = []
             session.commit()
 
             logger.info(f"MFA setup initiated for user: {user.username}")
-            # Return plaintext secret; recovery codes returned separately
             return secret
 
         except Exception as e:
             logger.error(f"MFA setup error: {e}")
+            session.rollback()
+            return None
+
+        finally:
+            if should_close_session:
+                session.close()
+
+    @staticmethod
+    def enable_mfa(
+        user_id: str, code: str, session: Optional[Session] = None
+    ) -> Optional[List[str]]:
+        """Verify the first TOTP code and enable MFA.
+
+        On the enabling transition, generates one-time recovery codes and
+        returns the plaintext (shown once, cannot be retrieved again).
+
+        Returns:
+            - list of recovery codes on successful enable
+            - [] if the code is valid but MFA was already enabled (no reissue)
+            - None if there is no pending secret or the code is invalid
+        """
+        should_close_session = session is None
+        session = session or get_db_session()
+
+        try:
+            user = session.query(User).filter(User.user_id == user_id).first()
+            if not user or not user.mfa_secret:
+                return None
+
+            if not AuthService._verify_totp(user.mfa_secret, code):
+                return None
+
+            if user.mfa_enabled:
+                # Already enabled — codes were issued at enable time, don't
+                # silently reissue. Use the regenerate endpoint to rotate.
+                return []
+
+            user.mfa_enabled = True
+            codes, user.mfa_recovery_codes = AuthService._generate_recovery_codes()
+            session.commit()
+            logger.info(f"MFA enabled for user: {user.username}")
+            return codes
+
+        except Exception as e:
+            logger.error(f"MFA enable error: {e}")
             session.rollback()
             return None
 
@@ -369,7 +403,11 @@ class AuthService:
     def verify_mfa_code(
         user_id: str, code: str, session: Optional[Session] = None
     ) -> bool:
-        """Verify a TOTP code or a one-time recovery code."""
+        """Verify a TOTP code or a one-time recovery code (login path).
+
+        Enabling MFA is handled by enable_mfa(); this method assumes MFA is
+        already enabled and only validates the supplied code.
+        """
         should_close_session = session is None
         session = session or get_db_session()
 
@@ -379,13 +417,7 @@ class AuthService:
                 return False
 
             # Try TOTP first
-            decrypted_secret = AuthService._decrypt_mfa_secret(user.mfa_secret)
-            totp = pyotp.TOTP(decrypted_secret)
-            if totp.verify(code, valid_window=1):
-                if not user.mfa_enabled:
-                    user.mfa_enabled = True
-                    session.commit()
-                    logger.info(f"MFA enabled for user: {user.username}")
+            if AuthService._verify_totp(user.mfa_secret, code):
                 return True
 
             # Try recovery codes (one-time use)
@@ -444,6 +476,12 @@ class AuthService:
             return encrypted
 
     @staticmethod
+    def _verify_totp(encrypted_secret: str, code: str) -> bool:
+        """Verify a TOTP code against a stored (encrypted) MFA secret."""
+        decrypted = AuthService._decrypt_mfa_secret(encrypted_secret)
+        return pyotp.TOTP(decrypted).verify(code, valid_window=1)
+
+    @staticmethod
     def get_mfa_qr_uri(
         user_id: str, session: Optional[Session] = None
     ) -> Optional[str]:
@@ -465,7 +503,8 @@ class AuthService:
             if not user or not user.mfa_secret:
                 return None
 
-            totp = pyotp.TOTP(user.mfa_secret)
+            decrypted_secret = AuthService._decrypt_mfa_secret(user.mfa_secret)
+            totp = pyotp.TOTP(decrypted_secret)
             uri = totp.provisioning_uri(name=user.email, issuer_name="Vigil SOC")
             return uri
 

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -4,6 +4,8 @@ Authentication Service - User authentication and authorization.
 Handles password hashing, JWT generation/validation, MFA, and session management.
 """
 
+import base64
+import hashlib
 import logging
 import os
 import secrets
@@ -13,6 +15,7 @@ from typing import Optional, Dict, Any, List
 import bcrypt
 import jwt
 import pyotp
+from cryptography.fernet import Fernet
 from sqlalchemy.orm import Session
 
 from database.models import User, Role
@@ -35,6 +38,7 @@ def _load_jwt_secret() -> str:
     """
     try:
         from backend.secrets_manager import get_secret
+
         value = get_secret("JWT_SECRET_KEY")
     except Exception:
         value = os.environ.get("JWT_SECRET_KEY")
@@ -99,40 +103,50 @@ def password_matches_any(plaintext: str, hashes) -> bool:
 
 class AuthService:
     """Service for user authentication and authorization."""
-    
+
     @staticmethod
     def hash_password(password: str) -> str:
         """
         Hash a password using bcrypt.
-        
+
         Args:
             password: Plain text password
-        
+
         Returns:
             Hashed password
         """
         salt = bcrypt.gensalt()
-        hashed = bcrypt.hashpw(password.encode('utf-8'), salt)
-        return hashed.decode('utf-8')
-    
+        hashed = bcrypt.hashpw(password.encode("utf-8"), salt)
+        return hashed.decode("utf-8")
+
     @staticmethod
     def verify_password(password: str, password_hash: str) -> bool:
         """
         Verify a password against its hash.
-        
+
         Args:
             password: Plain text password
             password_hash: Hashed password
-        
+
         Returns:
             True if password matches
         """
         try:
-            return bcrypt.checkpw(password.encode('utf-8'), password_hash.encode('utf-8'))
+            return bcrypt.checkpw(
+                password.encode("utf-8"), password_hash.encode("utf-8")
+            )
         except Exception as e:
             logger.error(f"Password verification error: {e}")
             return False
-    
+
+    @staticmethod
+    def _session_fingerprint(
+        request_ip: Optional[str], user_agent: Optional[str]
+    ) -> str:
+        """Short SHA-256 fingerprint binding a token to its IP + user-agent."""
+        fp = f"{request_ip or ''}|{user_agent or ''}"
+        return hashlib.sha256(fp.encode()).hexdigest()[:16]
+
     @staticmethod
     def generate_jwt_token(
         user: User,
@@ -141,10 +155,10 @@ class AuthService:
         user_agent: Optional[str] = None,
     ) -> str:
         """Generate a JWT token for a user with optional session binding."""
-        expiration = timedelta(
-            minutes=JWT_ACCESS_EXPIRATION_MINUTES
-        ) if token_type == "access" else timedelta(
-            days=JWT_REFRESH_EXPIRATION_DAYS
+        expiration = (
+            timedelta(minutes=JWT_ACCESS_EXPIRATION_MINUTES)
+            if token_type == "access"
+            else timedelta(days=JWT_REFRESH_EXPIRATION_DAYS)
         )
 
         now = datetime.utcnow()
@@ -161,9 +175,7 @@ class AuthService:
 
         # Bind token to session context when available
         if request_ip or user_agent:
-            import hashlib
-            fp_data = f"{request_ip or ''}|{user_agent or ''}"
-            payload["sfp"] = hashlib.sha256(fp_data.encode()).hexdigest()[:16]
+            payload["sfp"] = AuthService._session_fingerprint(request_ip, user_agent)
 
         token = jwt.encode(payload, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
         return token
@@ -181,19 +193,17 @@ class AuthService:
         sfp = payload.get("sfp")
         if not sfp:
             return True
-        import hashlib
-        fp_data = f"{request_ip or ''}|{user_agent or ''}"
-        expected = hashlib.sha256(fp_data.encode()).hexdigest()[:16]
+        expected = AuthService._session_fingerprint(request_ip, user_agent)
         return secrets.compare_digest(sfp, expected)
-    
+
     @staticmethod
     def verify_jwt_token(token: str) -> Optional[Dict[str, Any]]:
         """
         Verify and decode a JWT token.
-        
+
         Args:
             token: JWT token string
-        
+
         Returns:
             Decoded payload or None if invalid
         """
@@ -206,29 +216,35 @@ class AuthService:
         except jwt.InvalidTokenError as e:
             logger.warning(f"Invalid JWT token: {e}")
             return None
-    
+
     @staticmethod
-    def authenticate_user(username_or_email: str, password: str, session: Optional[Session] = None) -> Optional[User]:
+    def authenticate_user(
+        username_or_email: str, password: str, session: Optional[Session] = None
+    ) -> Optional[User]:
         """
         Authenticate a user with username/email and password.
-        
+
         Args:
             username_or_email: Username or email
             password: Plain text password
             session: Database session (optional)
-        
+
         Returns:
             User object if authentication successful, None otherwise
         """
         should_close_session = session is None
-        if session is None:
-            session = get_db_session()
-        
+        session = session or get_db_session()
+
         try:
             # Try to find user by username or email
-            user = session.query(User).filter(
-                (User.username == username_or_email) | (User.email == username_or_email)
-            ).first()
+            user = (
+                session.query(User)
+                .filter(
+                    (User.username == username_or_email)
+                    | (User.email == username_or_email)
+                )
+                .first()
+            )
 
             if not user:
                 logger.warning("Login attempt for unknown identifier")
@@ -254,7 +270,9 @@ class AuthService:
             if not AuthService.verify_password(password, user.password_hash):
                 user.failed_login_count = (user.failed_login_count or 0) + 1
                 if user.failed_login_count >= LOCKOUT_THRESHOLD:
-                    user.locked_until = now + timedelta(minutes=LOCKOUT_DURATION_MINUTES)
+                    user.locked_until = now + timedelta(
+                        minutes=LOCKOUT_DURATION_MINUTES
+                    )
                     logger.warning(
                         "Account locked after %d failed attempts: %s",
                         user.failed_login_count,
@@ -284,13 +302,12 @@ class AuthService:
         finally:
             if should_close_session:
                 session.close()
-    
+
     @staticmethod
     def setup_mfa(user_id: str, session: Optional[Session] = None) -> Optional[str]:
         """Setup MFA. Returns TOTP secret and generates recovery codes."""
         should_close_session = session is None
-        if session is None:
-            session = get_db_session()
+        session = session or get_db_session()
 
         try:
             user = session.query(User).filter(User.user_id == user_id).first()
@@ -300,12 +317,9 @@ class AuthService:
             secret = pyotp.random_base32()
             user.mfa_secret = AuthService._encrypt_mfa_secret(secret)
             user.mfa_enabled = False
-            # Generate 10 recovery codes, store bcrypt-hashed
-            codes = [secrets.token_hex(4).upper() for _ in range(10)]
-            user.mfa_recovery_codes = [
-                bcrypt.hashpw(c.encode(), bcrypt.gensalt()).decode()
-                for c in codes
-            ]
+            # Generate 10 recovery codes, store bcrypt-hashed (plaintext
+            # is surfaced via get_mfa_recovery_codes, not here)
+            _, user.mfa_recovery_codes = AuthService._generate_recovery_codes()
             session.commit()
 
             logger.info(f"MFA setup initiated for user: {user.username}")
@@ -331,19 +345,14 @@ class AuthService:
         be retrieved again.
         """
         should_close_session = session is None
-        if session is None:
-            session = get_db_session()
+        session = session or get_db_session()
 
         try:
             user = session.query(User).filter(User.user_id == user_id).first()
             if not user or not user.mfa_secret:
                 return None
 
-            codes = [secrets.token_hex(4).upper() for _ in range(10)]
-            user.mfa_recovery_codes = [
-                bcrypt.hashpw(c.encode(), bcrypt.gensalt()).decode()
-                for c in codes
-            ]
+            codes, user.mfa_recovery_codes = AuthService._generate_recovery_codes()
             session.commit()
             return codes
 
@@ -362,8 +371,7 @@ class AuthService:
     ) -> bool:
         """Verify a TOTP code or a one-time recovery code."""
         should_close_session = session is None
-        if session is None:
-            session = get_db_session()
+        session = session or get_db_session()
 
         try:
             user = session.query(User).filter(User.user_id == user_id).first()
@@ -409,162 +417,159 @@ class AuthService:
                 session.close()
 
     @staticmethod
+    def _generate_recovery_codes() -> tuple[list[str], list[str]]:
+        """Return (plaintext, bcrypt-hashed) lists of 10 one-time recovery codes."""
+        codes = [secrets.token_hex(4).upper() for _ in range(10)]
+        hashed = [bcrypt.hashpw(c.encode(), bcrypt.gensalt()).decode() for c in codes]
+        return codes, hashed
+
+    @staticmethod
+    def _fernet() -> Fernet:
+        """Fernet cipher keyed off JWT_SECRET_KEY (SHA-256 -> base64 32-byte key)."""
+        key = base64.urlsafe_b64encode(hashlib.sha256(JWT_SECRET_KEY.encode()).digest())
+        return Fernet(key)
+
+    @staticmethod
     def _encrypt_mfa_secret(secret: str) -> str:
-        """Encrypt MFA secret at rest using the JWT key as a derived key.
-
-        Uses Fernet symmetric encryption. The encryption key is derived from
-        JWT_SECRET_KEY via SHA-256 + base64 to produce a valid 32-byte Fernet key.
-        """
-        import base64
-        import hashlib
-        from cryptography.fernet import Fernet
-
-        key = base64.urlsafe_b64encode(
-            hashlib.sha256(JWT_SECRET_KEY.encode()).digest()
-        )
-        return Fernet(key).encrypt(secret.encode()).decode()
+        """Encrypt an MFA secret at rest with Fernet (JWT-key-derived)."""
+        return AuthService._fernet().encrypt(secret.encode()).decode()
 
     @staticmethod
     def _decrypt_mfa_secret(encrypted: str) -> str:
-        """Decrypt MFA secret from storage."""
-        import base64
-        import hashlib
-        from cryptography.fernet import Fernet
-
-        key = base64.urlsafe_b64encode(
-            hashlib.sha256(JWT_SECRET_KEY.encode()).digest()
-        )
+        """Decrypt an MFA secret; fall back to plaintext for pre-migration rows."""
         try:
-            return Fernet(key).decrypt(encrypted.encode()).decode()
+            return AuthService._fernet().decrypt(encrypted.encode()).decode()
         except Exception:
             # Fallback: secret may be stored unencrypted (pre-migration rows)
             return encrypted
-    
+
     @staticmethod
-    def get_mfa_qr_uri(user_id: str, session: Optional[Session] = None) -> Optional[str]:
+    def get_mfa_qr_uri(
+        user_id: str, session: Optional[Session] = None
+    ) -> Optional[str]:
         """
         Get MFA QR code URI for a user.
-        
+
         Args:
             user_id: User ID
             session: Database session (optional)
-        
+
         Returns:
             QR code URI or None
         """
         should_close_session = session is None
-        if session is None:
-            session = get_db_session()
-        
+        session = session or get_db_session()
+
         try:
             user = session.query(User).filter(User.user_id == user_id).first()
             if not user or not user.mfa_secret:
                 return None
-            
+
             totp = pyotp.TOTP(user.mfa_secret)
-            uri = totp.provisioning_uri(
-                name=user.email,
-                issuer_name="Vigil SOC"
-            )
+            uri = totp.provisioning_uri(name=user.email, issuer_name="Vigil SOC")
             return uri
-        
+
         finally:
             if should_close_session:
                 session.close()
-    
+
     @staticmethod
-    def check_permission(user_id: str, permission: str, session: Optional[Session] = None) -> bool:
+    def check_permission(
+        user_id: str, permission: str, session: Optional[Session] = None
+    ) -> bool:
         """
         Check if a user has a specific permission.
-        
+
         Args:
             user_id: User ID
             permission: Permission string (e.g., "cases.write")
             session: Database session (optional)
-        
+
         Returns:
             True if user has permission
         """
         # DEV MODE: Grant all permissions
         import os
+
         DEV_MODE = os.getenv("DEV_MODE", "false").lower() in ("true", "1", "yes")
         if DEV_MODE:
             return True
-        
+
         should_close_session = session is None
-        if session is None:
-            session = get_db_session()
-        
+        session = session or get_db_session()
+
         try:
             user = session.query(User).filter(User.user_id == user_id).first()
             if not user or not user.is_active:
                 return False
-            
+
             role = session.query(Role).filter(Role.role_id == user.role_id).first()
             if not role:
                 return False
-            
+
             # Check permission in role's permissions JSONB
             return role.permissions.get(permission, False)
-        
+
         finally:
             if should_close_session:
                 session.close()
-    
+
     @staticmethod
-    def get_user_permissions(user_id: str, session: Optional[Session] = None) -> Dict[str, bool]:
+    def get_user_permissions(
+        user_id: str, session: Optional[Session] = None
+    ) -> Dict[str, bool]:
         """
         Get all permissions for a user.
-        
+
         Args:
             user_id: User ID
             session: Database session (optional)
-        
+
         Returns:
             Dictionary of permissions
         """
         # DEV MODE: Return all permissions
         import os
+
         DEV_MODE = os.getenv("DEV_MODE", "false").lower() in ("true", "1", "yes")
         if DEV_MODE:
             return {
-                'findings.read': True,
-                'findings.write': True,
-                'findings.delete': True,
-                'cases.read': True,
-                'cases.write': True,
-                'cases.delete': True,
-                'cases.assign': True,
-                'integrations.read': True,
-                'integrations.write': True,
-                'users.read': True,
-                'users.write': True,
-                'users.delete': True,
-                'settings.read': True,
-                'settings.write': True,
-                'ai_chat.use': True,
-                'ai_decisions.approve': True,
+                "findings.read": True,
+                "findings.write": True,
+                "findings.delete": True,
+                "cases.read": True,
+                "cases.write": True,
+                "cases.delete": True,
+                "cases.assign": True,
+                "integrations.read": True,
+                "integrations.write": True,
+                "users.read": True,
+                "users.write": True,
+                "users.delete": True,
+                "settings.read": True,
+                "settings.write": True,
+                "ai_chat.use": True,
+                "ai_decisions.approve": True,
             }
-        
+
         should_close_session = session is None
-        if session is None:
-            session = get_db_session()
-        
+        session = session or get_db_session()
+
         try:
             user = session.query(User).filter(User.user_id == user_id).first()
             if not user:
                 return {}
-            
+
             role = session.query(Role).filter(Role.role_id == user.role_id).first()
             if not role:
                 return {}
-            
+
             return role.permissions
-        
+
         finally:
             if should_close_session:
                 session.close()
-    
+
     @staticmethod
     def create_user(
         username: str,
@@ -572,11 +577,11 @@ class AuthService:
         password: str,
         full_name: str,
         role_id: str,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Optional[User]:
         """
         Create a new user.
-        
+
         Args:
             username: Username
             email: Email address
@@ -584,26 +589,27 @@ class AuthService:
             full_name: Full name
             role_id: Role ID
             session: Database session (optional)
-        
+
         Returns:
             Created User object or None
         """
         should_close_session = session is None
-        if session is None:
-            session = get_db_session()
-        
+        session = session or get_db_session()
+
         try:
             import uuid
-            
+
             # Check if username or email already exists
-            existing = session.query(User).filter(
-                (User.username == username) | (User.email == email)
-            ).first()
-            
+            existing = (
+                session.query(User)
+                .filter((User.username == username) | (User.email == email))
+                .first()
+            )
+
             if existing:
                 logger.warning(f"User already exists: {username} or {email}")
                 return None
-            
+
             # Create user
             user = User(
                 user_id=f"user-{uuid.uuid4().hex[:12]}",
@@ -615,22 +621,21 @@ class AuthService:
                 is_active=True,
                 is_verified=False,
                 mfa_enabled=False,
-                login_count=0
+                login_count=0,
             )
-            
+
             session.add(user)
             session.commit()
             session.refresh(user)
-            
+
             logger.info(f"User created: {username}")
             return user
-        
+
         except Exception as e:
             logger.error(f"User creation error: {e}")
             session.rollback()
             return None
-        
+
         finally:
             if should_close_session:
                 session.close()
-

--- a/backend/services/token_blacklist.py
+++ b/backend/services/token_blacklist.py
@@ -13,10 +13,9 @@ Two revocation strategies, used together:
    one write invalidates every token the user holds, without having to
    enumerate them.
 
-Verify-path failures (Redis unreachable during `is_token_revoked`) are
-**fail-open** with a WARNING: the system should not take authentication
-offline because the cache is down. Write-path failures (blacklist on logout)
-are logged and re-raised so the caller can decide whether to hard-fail.
+Verify-path failures (Redis unreachable during `is_token_revoked`) default to
+**fail-closed** (reject the request). Set `REVOCATION_FAIL_OPEN=true` only if
+you deliberately prefer availability over security during Redis outages.
 """
 
 import logging
@@ -32,6 +31,12 @@ DEFAULT_REDIS_URL = "redis://localhost:6379/0"
 _JTI_PREFIX = "blacklist:jti:"
 _USER_CUTOFF_PREFIX = "user_revoked_before:"
 
+# If True, Redis failures during verification allow the request through.
+# Default: False (fail-closed). Set REVOCATION_FAIL_OPEN=true for fail-open.
+_FAIL_OPEN = os.getenv("REVOCATION_FAIL_OPEN", "false").lower() in (
+    "1", "true", "yes"
+)
+
 
 _client = None
 
@@ -44,7 +49,9 @@ def _get_client():
     try:
         from redis import asyncio as redis_asyncio  # type: ignore
     except Exception as exc:
-        logger.warning("redis.asyncio unavailable: %s — token revocation disabled", exc)
+        logger.warning(
+            "redis.asyncio unavailable: %s — token revocation disabled", exc
+        )
         return None
     url = os.getenv("REDIS_URL", DEFAULT_REDIS_URL)
     _client = redis_asyncio.from_url(url, decode_responses=True)
@@ -59,11 +66,7 @@ async def blacklist_jti(jti: str, expires_at: Optional[datetime]) -> None:
     """
     Mark a specific token as revoked. Called on /logout.
 
-    The key expires when the token would have expired anyway, so an
-    attacker who replays the token after its exp is irrelevant (JWT
-    signature check already rejects it). Raises on Redis failure so the
-    /logout handler can surface the error — we prefer a noisy logout
-    failure over a silent revocation miss.
+    Raises on Redis failure so the /logout handler can surface the error.
     """
     client = _get_client()
     if client is None:
@@ -74,10 +77,10 @@ async def blacklist_jti(jti: str, expires_at: Optional[datetime]) -> None:
     if expires_at is not None:
         if expires_at.tzinfo is None:
             expires_at = expires_at.replace(tzinfo=timezone.utc)
-        ttl_seconds = int((expires_at - datetime.now(tz=timezone.utc)).total_seconds())
+        ttl_seconds = int(
+            (expires_at - datetime.now(tz=timezone.utc)).total_seconds()
+        )
     if ttl_seconds <= 0:
-        # Token has already expired — no point blacklisting, JWT layer
-        # will reject it on signature/exp.
         return
 
     await client.set(f"{_JTI_PREFIX}{jti}", "1", ex=ttl_seconds)
@@ -86,13 +89,13 @@ async def blacklist_jti(jti: str, expires_at: Optional[datetime]) -> None:
 async def revoke_all_for_user(user_id: str) -> None:
     """
     Invalidate every outstanding token for a user by moving the cutoff
-    timestamp forward. Called on password change, role change, or an
-    explicit "log out everywhere". Any token whose `iat` is earlier than
-    the stored value fails `is_token_revoked`.
+    timestamp forward.
     """
     client = _get_client()
     if client is None:
-        logger.warning("revoke_all_for_user: redis client unavailable; skipping")
+        logger.warning(
+            "revoke_all_for_user: redis client unavailable; skipping"
+        )
         return
     await client.set(f"{_USER_CUTOFF_PREFIX}{user_id}", str(_now_ts()))
 
@@ -101,14 +104,19 @@ async def is_token_revoked(payload: dict) -> bool:
     """
     Check whether a decoded JWT payload has been revoked.
 
-    Fail-open on Redis errors — the verify path must not take auth down
-    because the cache is unavailable. The tradeoff: a revocation might not
-    take effect for as long as Redis is down. That is acceptable; the
-    alternative is a cache outage logging everyone out.
+    Behaviour on Redis failure is controlled by REVOCATION_FAIL_OPEN env var:
+      - False (default): treat Redis failure as revoked → user must re-auth.
+      - True: allow through on Redis failure (availability over security).
     """
     client = _get_client()
     if client is None:
-        return False
+        if _FAIL_OPEN:
+            return False
+        logger.error(
+            "is_token_revoked: redis unavailable and REVOCATION_FAIL_OPEN=false"
+            " — rejecting token"
+        )
+        return True
 
     jti = payload.get("jti")
     user_id = payload.get("user_id")
@@ -120,26 +128,30 @@ async def is_token_revoked(payload: dict) -> bool:
                 return True
 
         if user_id:
-            cutoff_raw = await client.get(f"{_USER_CUTOFF_PREFIX}{user_id}")
+            cutoff_raw = await client.get(
+                f"{_USER_CUTOFF_PREFIX}{user_id}"
+            )
             if cutoff_raw is not None:
                 try:
                     cutoff = int(cutoff_raw)
                 except (TypeError, ValueError):
                     logger.warning(
-                        "Malformed user cutoff for %s: %r", user_id, cutoff_raw
+                        "Malformed user cutoff for %s: %r",
+                        user_id,
+                        cutoff_raw,
                     )
-                    return False
+                    return not _FAIL_OPEN
                 iat = payload.get("iat")
                 if iat is None:
-                    # Token predates the iat addition — treat as revoked so
-                    # old tokens force a re-login after a cutoff is set.
                     return True
                 if int(iat) < cutoff:
                     return True
     except Exception as exc:
         logger.warning(
-            "is_token_revoked: redis lookup failed (%s); failing open", exc
+            "is_token_revoked: redis lookup failed (%s); fail_%s",
+            exc,
+            "open" if _FAIL_OPEN else "closed",
         )
-        return False
+        return not _FAIL_OPEN
 
     return False

--- a/backend/services/token_blacklist.py
+++ b/backend/services/token_blacklist.py
@@ -33,9 +33,7 @@ _USER_CUTOFF_PREFIX = "user_revoked_before:"
 
 # If True, Redis failures during verification allow the request through.
 # Default: False (fail-closed). Set REVOCATION_FAIL_OPEN=true for fail-open.
-_FAIL_OPEN = os.getenv("REVOCATION_FAIL_OPEN", "false").lower() in (
-    "1", "true", "yes"
-)
+_FAIL_OPEN = os.getenv("REVOCATION_FAIL_OPEN", "false").lower() in ("1", "true", "yes")
 
 
 _client = None
@@ -49,9 +47,7 @@ def _get_client():
     try:
         from redis import asyncio as redis_asyncio  # type: ignore
     except Exception as exc:
-        logger.warning(
-            "redis.asyncio unavailable: %s — token revocation disabled", exc
-        )
+        logger.warning("redis.asyncio unavailable: %s — token revocation disabled", exc)
         return None
     url = os.getenv("REDIS_URL", DEFAULT_REDIS_URL)
     _client = redis_asyncio.from_url(url, decode_responses=True)
@@ -77,9 +73,7 @@ async def blacklist_jti(jti: str, expires_at: Optional[datetime]) -> None:
     if expires_at is not None:
         if expires_at.tzinfo is None:
             expires_at = expires_at.replace(tzinfo=timezone.utc)
-        ttl_seconds = int(
-            (expires_at - datetime.now(tz=timezone.utc)).total_seconds()
-        )
+        ttl_seconds = int((expires_at - datetime.now(tz=timezone.utc)).total_seconds())
     if ttl_seconds <= 0:
         return
 
@@ -93,9 +87,7 @@ async def revoke_all_for_user(user_id: str) -> None:
     """
     client = _get_client()
     if client is None:
-        logger.warning(
-            "revoke_all_for_user: redis client unavailable; skipping"
-        )
+        logger.warning("revoke_all_for_user: redis client unavailable; skipping")
         return
     await client.set(f"{_USER_CUTOFF_PREFIX}{user_id}", str(_now_ts()))
 
@@ -128,9 +120,7 @@ async def is_token_revoked(payload: dict) -> bool:
                 return True
 
         if user_id:
-            cutoff_raw = await client.get(
-                f"{_USER_CUTOFF_PREFIX}{user_id}"
-            )
+            cutoff_raw = await client.get(f"{_USER_CUTOFF_PREFIX}{user_id}")
             if cutoff_raw is not None:
                 try:
                     cutoff = int(cutoff_raw)

--- a/database/init/06_auth_tables.sql
+++ b/database/init/06_auth_tables.sql
@@ -37,11 +37,18 @@ CREATE TABLE IF NOT EXISTS users (
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
--- Additive migration for existing deployments (safe to rerun)
+-- Additive migration for existing deployments (safe to rerun).
+-- These columns live in the CREATE TABLE above, but that is guarded by
+-- IF NOT EXISTS, so pre-existing `users` tables never receive them. The
+-- ORM maps every column, so a DB missing any of these throws UndefinedColumn
+-- on the first User query after upgrade — keep this list in sync.
 ALTER TABLE users ADD COLUMN IF NOT EXISTS failed_login_count INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS password_history JSONB NOT NULL DEFAULT '[]';
 ALTER TABLE users ADD COLUMN IF NOT EXISTS password_changed_at TIMESTAMP;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_secret VARCHAR(255);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_recovery_codes JSONB NOT NULL DEFAULT '[]';
 
 CREATE INDEX IF NOT EXISTS idx_user_username ON users(username);
 CREATE INDEX IF NOT EXISTS idx_user_email ON users(email);

--- a/database/init/06_auth_tables.sql
+++ b/database/init/06_auth_tables.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS users (
     is_verified BOOLEAN NOT NULL DEFAULT FALSE,
     mfa_enabled BOOLEAN NOT NULL DEFAULT FALSE,
     mfa_secret VARCHAR(255),
+    mfa_recovery_codes JSONB NOT NULL DEFAULT '[]',
     last_login TIMESTAMP,
     login_count INTEGER NOT NULL DEFAULT 0,
     failed_login_count INTEGER NOT NULL DEFAULT 0,

--- a/database/models.py
+++ b/database/models.py
@@ -1850,6 +1850,7 @@ class User(Base):
     # MFA
     mfa_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     mfa_secret: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    mfa_recovery_codes: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
 
     # Session tracking
     last_login: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)

--- a/docs/PRODUCTION_SECURITY.md
+++ b/docs/PRODUCTION_SECURITY.md
@@ -1,0 +1,186 @@
+# Production Security Checklist
+
+This document enumerates every security-relevant configuration switch and
+provides the recommended production values. Each item has a single env var
+or file location so it can be audited mechanically.
+
+---
+
+## Critical — Must Set Before Production
+
+| Switch | Env Variable | Dev Default | Production Value | Notes |
+|--------|-------------|-------------|------------------|-------|
+| Dev Mode | `DEV_MODE` | `true` | `false` | Bypasses ALL authentication. Never enable in prod. |
+| JWT Secret | `JWT_SECRET_KEY` | (generated dev key) | 64+ char random string | `python -c "import secrets; print(secrets.token_urlsafe(64))"` |
+| CSRF Enforcement | `VIGIL_CSRF_REPORT_ONLY` | `false` | `false` | Must be `false` to reject forged requests. |
+| Token Revocation | `REVOCATION_FAIL_OPEN` | `false` | `false` | Reject tokens when Redis is down rather than allowing through. |
+| Access Token TTL | `JWT_ACCESS_EXPIRATION_MINUTES` | `30` | `15`–`30` | Shorter = less window after compromise. |
+| Refresh Token TTL | `JWT_REFRESH_EXPIRATION_DAYS` | `7` | `7` | Max session length before forced re-login. |
+| Cookie Secure Flag | `VIGIL_COOKIE_SECURE` | `false` | `true` | Cookies only sent over HTTPS. |
+| Cookie SameSite | `VIGIL_COOKIE_SAMESITE` | `lax` | `strict` | Prevents cross-origin cookie send. |
+| PostgreSQL Password | `docker-compose.yml` | `vigil` | Strong random | Change default docker-compose password. |
+| LLM Budget Unlimited | `LLM_BUDGET_UNLIMITED` | `false` | `false` | Keep cost guardrails active. |
+
+---
+
+## Authentication & Session Security
+
+### JWT Tokens
+
+- **Access tokens** expire after `JWT_ACCESS_EXPIRATION_MINUTES` (default 30 min).
+- **Refresh tokens** expire after `JWT_REFRESH_EXPIRATION_DAYS` (default 7 days).
+- Tokens include a **session fingerprint** (`sfp` claim) binding the token
+  to the client's IP + User-Agent. A stolen token replayed from a different
+  client will fail fingerprint validation in the auth middleware.
+- Token generation: `AuthService.generate_jwt_token(user, token_type, request_ip, user_agent)`
+- Token fingerprint check: `AuthService.verify_session_fingerprint(payload, request_ip, user_agent)`
+
+### Token Revocation (Redis)
+
+- **Fail-closed by default** (`REVOCATION_FAIL_OPEN=false`): if Redis is
+  unreachable during a token verification, the request is rejected.
+- Set `REVOCATION_FAIL_OPEN=true` only if you prefer availability over
+  security during Redis outages.
+- Revocation happens on: logout (per-JTI blacklist), password change
+  (per-user cutoff), role change (per-user cutoff).
+
+### MFA (TOTP)
+
+- MFA secrets are **encrypted at rest** using Fernet symmetric encryption
+  derived from `JWT_SECRET_KEY`.
+- **Recovery codes**: 10 codes generated during MFA setup. Each is bcrypt-hashed
+  and stored. Single-use: consumed on verification and removed from the list.
+- Legacy unencrypted secrets are handled gracefully (transparent fallback).
+- Endpoint: `POST /api/auth/mfa/setup` → returns QR URI + recovery codes.
+- Endpoint: `POST /api/auth/mfa/verify` → accepts TOTP code or recovery code.
+
+### Account Lockout
+
+- After `AUTH_LOCKOUT_THRESHOLD` (default 5) consecutive failed logins, the
+  account locks for `AUTH_LOCKOUT_DURATION_MINUTES` (default 15 min).
+- Lockout is time-based; successful auth after expiry resets the counter.
+
+### Password Policy
+
+- Minimum length: `AUTH_MIN_PASSWORD_LENGTH` (default 12, NIST 800-63B aligned).
+- Password history: last `AUTH_PASSWORD_HISTORY_LIMIT` (default 5) are rejected.
+- bcrypt with random salt for all hashes.
+
+---
+
+## CSRF Protection
+
+- Enabled via `VIGIL_CSRF_ENABLED=true` (default).
+- Double-submit cookie pattern: frontend reads `csrf_token` cookie and echoes
+  it as `X-CSRF-Token` header on state-changing requests.
+- **Enforcement**: `VIGIL_CSRF_REPORT_ONLY=false` rejects violations. Set to
+  `true` only during initial deployment monitoring.
+- Exempt paths (webhooks, ingest): `VIGIL_CSRF_EXEMPT_PATHS=/api/webhooks/,/api/ingest/`
+
+---
+
+## Cookie Configuration
+
+| Variable | Default | Production |
+|----------|---------|------------|
+| `VIGIL_COOKIE_SECURE` | `false` | `true` (HTTPS only) |
+| `VIGIL_COOKIE_SAMESITE` | `lax` | `strict` |
+| `VIGIL_COOKIE_DOMAIN` | (none) | Your domain |
+| `VIGIL_COOKIE_PATH` | `/` | `/` |
+
+Tokens are stored in **HttpOnly** cookies (not accessible to JavaScript).
+`Secure=true` requires HTTPS — the browser will not send the cookie over
+plain HTTP.
+
+---
+
+## Security Headers
+
+Set via the security headers middleware. Defaults are conservative:
+
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains` (HSTS)
+- `Content-Security-Policy`: configurable via `VIGIL_CSP_POLICY`
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+
+---
+
+## Rate Limiting
+
+- Applied globally via middleware (`backend/middleware/rate_limit.py`).
+- Auth endpoints have tighter limits to prevent brute force.
+- Configure with `slowapi` settings in the middleware.
+
+---
+
+## Deployment Hardening Checklist
+
+```bash
+# 1. Generate secrets
+export JWT_SECRET_KEY=$(python -c "import secrets; print(secrets.token_urlsafe(64))")
+
+# 2. Disable dev mode
+export DEV_MODE=false
+
+# 3. Enforce CSRF
+export VIGIL_CSRF_REPORT_ONLY=false
+
+# 4. Secure cookies (requires HTTPS)
+export VIGIL_COOKIE_SECURE=true
+export VIGIL_COOKIE_SAMESITE=strict
+
+# 5. Fail-closed revocation
+export REVOCATION_FAIL_OPEN=false
+
+# 6. Set token lifetimes
+export JWT_ACCESS_EXPIRATION_MINUTES=15
+export JWT_REFRESH_EXPIRATION_DAYS=7
+
+# 7. Ensure Redis is running (required for revocation)
+# Redis must be reachable at REDIS_URL for token blacklist to work.
+
+# 8. Change default DB password
+# Edit docker-compose.yml or use POSTGRES_PASSWORD env var.
+```
+
+---
+
+## Migration Notes
+
+### Existing MFA Secrets
+
+Pre-existing `mfa_secret` values stored as plaintext will continue to work.
+The decrypt function falls back to raw value if Fernet decryption fails.
+New secrets are always stored encrypted. To force re-encryption of all
+existing secrets, run a one-time migration script:
+
+```python
+from backend.services.auth_service import AuthService
+from database.connection import get_db_session
+from database.models import User
+
+session = get_db_session()
+for user in session.query(User).filter(User.mfa_secret.isnot(None)).all():
+    # Check if already encrypted (Fernet tokens start with 'gAAAAA')
+    if not user.mfa_secret.startswith("gAAAAA"):
+        user.mfa_secret = AuthService._encrypt_mfa_secret(user.mfa_secret)
+session.commit()
+session.close()
+```
+
+### New Database Column
+
+The `mfa_recovery_codes` column (JSONB, default `[]`) must be added to
+existing deployments. For fresh installs it's in `06_auth_tables.sql`.
+For existing databases:
+
+```sql
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_recovery_codes JSONB NOT NULL DEFAULT '[]';
+```
+
+### Session Fingerprint Backwards Compatibility
+
+Tokens issued before the fingerprint feature won't have the `sfp` claim.
+`verify_session_fingerprint()` returns `True` for tokens without `sfp`,
+so existing sessions won't break. New tokens always include it.

--- a/docs/PRODUCTION_SECURITY.md
+++ b/docs/PRODUCTION_SECURITY.md
@@ -48,11 +48,16 @@ or file location so it can be audited mechanically.
 
 - MFA secrets are **encrypted at rest** using Fernet symmetric encryption
   derived from `JWT_SECRET_KEY`.
-- **Recovery codes**: 10 codes generated during MFA setup. Each is bcrypt-hashed
-  and stored. Single-use: consumed on verification and removed from the list.
+- **Recovery codes**: 10 codes generated when MFA is enabled (i.e. after the
+  first TOTP code is confirmed), not at setup. Each is bcrypt-hashed and stored;
+  the plaintext is returned exactly once and cannot be retrieved again.
+  Single-use: consumed on verification and removed from the list.
 - Legacy unencrypted secrets are handled gracefully (transparent fallback).
-- Endpoint: `POST /api/auth/mfa/setup` → returns QR URI + recovery codes.
-- Endpoint: `POST /api/auth/mfa/verify` → accepts TOTP code or recovery code.
+- Endpoint: `POST /api/auth/mfa/setup` → returns TOTP secret + QR URI.
+- Endpoint: `POST /api/auth/mfa/verify` → confirms the first TOTP code, enables
+  MFA, and returns the one-time recovery codes.
+- Endpoint: `POST /api/auth/mfa/recovery-codes` → regenerates a fresh set of
+  recovery codes, invalidating the previous set.
 
 ### Account Lockout
 

--- a/env.example
+++ b/env.example
@@ -97,6 +97,18 @@ ENABLE_KEYRING="false"
 # warning. Generate a strong value with: python -c "import secrets; print(secrets.token_urlsafe(64))"
 JWT_SECRET_KEY=""
 
+# Access token lifetime in minutes. Short-lived for security; refresh flow
+# handles renewal transparently.
+JWT_ACCESS_EXPIRATION_MINUTES="30"
+
+# Refresh token lifetime in days.
+JWT_REFRESH_EXPIRATION_DAYS="7"
+
+# Token revocation behavior when Redis is unreachable.
+# "false" (default) = fail-closed: reject token if revocation status unknown.
+# "true" = fail-open: allow token through if Redis is down (availability > security).
+REVOCATION_FAIL_OPEN="false"
+
 # Account lockout — after N consecutive failed logins the account is locked
 # for DURATION minutes. Successful login resets the counter.
 AUTH_LOCKOUT_THRESHOLD="5"
@@ -160,9 +172,10 @@ VIGIL_CSP_POLICY=""
 # auth migration. The frontend's axios interceptor reads csrf_token and
 # echoes it as the X-CSRF-Token header on mutating requests.
 VIGIL_CSRF_ENABLED="true"
-# Report-only logs violations without rejecting. Keep "true" for one rollout
-# window, then flip to "false" to enforce.
-VIGIL_CSRF_REPORT_ONLY="true"
+# Report-only logs violations without rejecting. Set to "false" in production
+# to enforce CSRF protection. Only use "true" during initial rollout to detect
+# violations without breaking clients.
+VIGIL_CSRF_REPORT_ONLY="false"
 # Comma-separated path prefixes exempt from CSRF checks (webhooks that
 # authenticate themselves with HMAC, server-to-server ingestion endpoints).
 VIGIL_CSRF_EXEMPT_PATHS="/api/webhooks/,/api/ingest/"

--- a/helm/vigil/files/database-init/06_auth_tables.sql
+++ b/helm/vigil/files/database-init/06_auth_tables.sql
@@ -37,11 +37,18 @@ CREATE TABLE IF NOT EXISTS users (
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
--- Additive migration for existing deployments (safe to rerun)
+-- Additive migration for existing deployments (safe to rerun).
+-- These columns live in the CREATE TABLE above, but that is guarded by
+-- IF NOT EXISTS, so pre-existing `users` tables never receive them. The
+-- ORM maps every column, so a DB missing any of these throws UndefinedColumn
+-- on the first User query after upgrade — keep this list in sync.
 ALTER TABLE users ADD COLUMN IF NOT EXISTS failed_login_count INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS password_history JSONB NOT NULL DEFAULT '[]';
 ALTER TABLE users ADD COLUMN IF NOT EXISTS password_changed_at TIMESTAMP;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_secret VARCHAR(255);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_recovery_codes JSONB NOT NULL DEFAULT '[]';
 
 CREATE INDEX IF NOT EXISTS idx_user_username ON users(username);
 CREATE INDEX IF NOT EXISTS idx_user_email ON users(email);

--- a/helm/vigil/files/database-init/06_auth_tables.sql
+++ b/helm/vigil/files/database-init/06_auth_tables.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS users (
     is_verified BOOLEAN NOT NULL DEFAULT FALSE,
     mfa_enabled BOOLEAN NOT NULL DEFAULT FALSE,
     mfa_secret VARCHAR(255),
+    mfa_recovery_codes JSONB NOT NULL DEFAULT '[]',
     last_login TIMESTAMP,
     login_count INTEGER NOT NULL DEFAULT 0,
     failed_login_count INTEGER NOT NULL DEFAULT 0,

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,7 @@ uv>=0.5.0
 bcrypt>=4.2.0
 pyjwt>=2.10.0
 pyotp>=2.9.0
+cryptography>=42.0.0
 slowapi>=0.1.9
 # Signed URL-safe tokens for password reset (also a Starlette transitive
 # dep; listed explicitly so pip show it and it doesn't quietly disappear).


### PR DESCRIPTION
Production auth hardening, extracted from the bundled #357 and tidied. Two commits: the hardening (cherry-picked) and a behaviour-preserving condensing pass.

-> Hardening
- Access-token TTL → 30 min, refresh → 7 days (configurable)
- MFA secrets encrypted at rest with Fernet (key derived from `JWT_SECRET_KEY`)
- 10 single-use, bcrypt-hashed MFA recovery codes
- JWT bound to client session via IP+UA fingerprint (`sfp` claim)
- Token revocation **fails closed** when Redis is unreachable
- CSRF default-on; new `cryptography` dependency; docs in `docs/PRODUCTION_SECURITY.md`

-> Condensing (behaviour-preserving)
- Hoist `base64`/`hashlib`/`cryptography` imports to module scope
- Extract `_session_fingerprint`, `_generate_recovery_codes`, `_fernet` helpers (dedup across token-gen / MFA / encrypt-decrypt)
- Collapse multi-line single-expressions; `session = session or get_db_session()`
- Drop two pre-existing unused imports; black-format the three files
- **Left as-is:** fail-closed revocation branches + the bcrypt recovery-code loop (auditability)