### PR TITLE
fix(chart): add startupProbes for slow first boot

### DIFF
--- a/helm/vigil/templates/backend-deployment.yaml
+++ b/helm/vigil/templates/backend-deployment.yaml
@@ -54,6 +54,20 @@ spec:
             {{- with .Values.backend.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          # Gate liveness/readiness on a slow first boot. Startup work (MCP
+          # server connection retries, model-registry warmup) can push the
+          # first successful /api/health past the liveness initialDelaySeconds
+          # and trip a kill-restart loop before the app ever serves. While this
+          # probe is in progress the kubelet suppresses liveness AND readiness;
+          # once it passes, they take over. Allows up to
+          # failureThreshold * periodSeconds = 300s for first serve.
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /api/health

--- a/helm/vigil/templates/daemon-statefulset.yaml
+++ b/helm/vigil/templates/daemon-statefulset.yaml
@@ -70,6 +70,18 @@ spec:
             {{- end }}
           # Probes target /health on port 9091. /metrics on 9090 only serves
           # when VIGIL_OTEL_ENABLED=true, so it's unsafe for readiness.
+          # Gate liveness/readiness on a slow first boot (orchestrator + agent
+          # warmup, MCP connection retries) so a slow start can't trip the
+          # liveness kill-restart loop before the daemon serves /health. While
+          # this probe runs, liveness AND readiness are suppressed; it allows up
+          # to failureThreshold * periodSeconds = 300s for first serve.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: health
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Closes #363.

## Problem

The `vigil-backend` Deployment and `vigil-daemon` StatefulSet define a `livenessProbe` but no `startupProbe`. Their liveness budgets before a kubelet restart are ~60s (backend) and ~75s (daemon). On a loaded node, startup work — MCP server connection retries to optional/absent servers plus model-registry/orchestrator warmup — can push the first successful health check past that window, so the kubelet SIGTERMs the container (exit 0, not a crash) and restarts it in a loop before it ever serves traffic.

Observed on GKE Autopilot: a backend pod restarted 3× during boot, then stabilised. Redeploying with the `startupProbe` brought both replicas up with **0 restarts**.

## Change

Add a `startupProbe` to both workloads, hitting the same health endpoint as the existing probes, with a 300s budget (`failureThreshold=30 × periodSeconds=10`):

- `helm/vigil/templates/backend-deployment.yaml` → `/api/health` on `http`
- `helm/vigil/templates/daemon-statefulset.yaml` → `/health` on `health`

While the startupProbe runs, the kubelet suppresses liveness **and** readiness; once it passes, both engage with their existing strict settings. Steady-state behaviour is unchanged — this only affects the cold-start window.

## Notes

- Timings are hardcoded to match the existing (hardcoded) liveness/readiness blocks, keeping the diff minimal. Making probe timings `values.yaml`-configurable would be a reasonable follow-up but is out of scope here.
- No chart `version`/`appVersion` bump included (assumed release-please owns that).

## Testing

- `helm lint ./helm/vigil` — passes.
- `helm template … --show-only templates/backend-deployment.yaml` / `daemon-statefulset.yaml` — `startupProbe` renders correctly ahead of `livenessProbe`.
- Deployed to a live GKE Autopilot cluster: rollout succeeded, both backend replicas `1/1` with 0 restarts; `startupProbe` confirmed present on the running pod spec.
