### PR TITLE
fix(settings): recover redesign provider-delete UX and repair reset-setup

### DIFF
--- a/frontend/src/redesign/screens/settings/AiConfigSection.tsx
+++ b/frontend/src/redesign/screens/settings/AiConfigSection.tsx
@@ -94,7 +94,7 @@ function ProvidersPanel({ notify }: SectionProps) {
     setDeleting(true)
     try {
       await remove(confirmDel.provider_id)
-      notify('ok', `Deleted ${confirmDel.provider_id}.`)
+      notify('ok', `Deleted ${confirmDel.name}.`)
       setConfirmDel(null)
     } catch (e) {
       notify('err', (e as { message?: string })?.message || 'Delete failed.')
@@ -102,6 +102,34 @@ function ProvidersPanel({ notify }: SectionProps) {
       setDeleting(false)
     }
   }
+
+  const hasOtherActiveOfType = (p: LLMProvider) =>
+    providers.some(
+      (q) => q.provider_id !== p.provider_id && q.provider_type === p.provider_type && q.is_active,
+    )
+
+  const requestDelete = (p: LLMProvider) => {
+    // The API blocks deleting the only active provider of a type (it has no
+    // sibling to promote to default), so surface that up front instead of a
+    // confirm dialog that implies an auto-promotion that won't happen.
+    if (p.is_default && !hasOtherActiveOfType(p)) {
+      notify(
+        'err',
+        `"${p.name}" is the only active ${p.provider_type} provider and can't be deleted. ` +
+          `Add or activate another ${p.provider_type} provider first.`,
+      )
+      return
+    }
+    setConfirmDel(p)
+  }
+
+  // Mirror the warning to what deletion actually does: default providers
+  // trigger a promotion; either way the provider's model assignments and
+  // stored API key are removed.
+  const deleteBody = (p: LLMProvider) =>
+    p.is_default
+      ? `"${p.name}" is the primary ${p.provider_type} provider. Deleting it promotes the next active ${p.provider_type} provider to primary. Its model assignments and stored API key are also removed.`
+      : `Delete "${p.name}"? Its model assignments and stored API key are also removed.`
 
   const statusChip = (p: LLMProvider) => {
     if (!p.is_active) return <span className="chip">Inactive</span>
@@ -170,7 +198,7 @@ function ProvidersPanel({ notify }: SectionProps) {
                       <button className="btn ghost icon" title="Edit" onClick={() => { setEditing(p); setDialogOpen(true) }}>
                         <Icon name="edit" size={15} />
                       </button>
-                      <button className="btn ghost icon" title="Delete" onClick={() => setConfirmDel(p)}>
+                      <button className="btn ghost icon" title="Delete" onClick={() => requestDelete(p)}>
                         <Icon name="trash" size={15} />
                       </button>
                     </div>
@@ -192,7 +220,7 @@ function ProvidersPanel({ notify }: SectionProps) {
       <ConfirmDialog
         open={!!confirmDel}
         title="Delete provider?"
-        body={`Delete "${confirmDel?.provider_id}"? This also removes its stored API key.`}
+        body={confirmDel ? deleteBody(confirmDel) : ''}
         confirmLabel="Delete"
         busy={deleting}
         onConfirm={handleDelete}

--- a/scripts/reset-setup.sh
+++ b/scripts/reset-setup.sh
@@ -13,7 +13,9 @@
 #   ./scripts/reset-setup.sh --all -y        # everything, no confirmation prompt
 #
 # Options:
-#   --providers          Delete every LLM provider (the hard gate — this alone re-shows the wizard)
+#   --providers          Clear every LLM provider — deletes what it can, deactivates the
+#                        last active default per type (the single-default guard 409s on it).
+#                        This alone re-shows the wizard.
 #   --assignments        Clear all per-agent model assignments
 #   --budget             Clear the Bifrost virtual key + spend cap
 #   --autonomy           Disable the autonomous orchestrator (preserves its cost caps)
@@ -47,6 +49,10 @@ command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; 
 
 get()  { curl -fsS "${AUTH[@]}" "$B$1"; }
 del()  { curl -fsS "${AUTH[@]}" -X DELETE "$B$1"; }
+# DELETE that prints the HTTP status instead of aborting on 4xx. The provider
+# delete endpoint legitimately 409s on the last active default of a type (the
+# single-default guard added in #336) — we detect that and deactivate instead.
+del_code() { curl -s -o /dev/null -w '%{http_code}' "${AUTH[@]}" -X DELETE "$B$1"; }
 put()  { curl -fsS "${AUTH[@]}" -X PUT  -H 'Content-Type: application/json' -d "$2" "$B$1"; }
 post() { curl -fsS "${AUTH[@]}" -X POST -H 'Content-Type: application/json' -d "$2" "$B$1"; }
 
@@ -98,7 +104,7 @@ if [ "$status_only" = true ]; then exit 0; fi
 
 # --- confirm --------------------------------------------------------------
 planned=()
-[ "$do_providers"   = true ] && planned+=("delete all LLM providers (re-fires the hard gate)")
+[ "$do_providers"   = true ] && planned+=("delete LLM providers, deactivating the last default per type (re-fires the hard gate)")
 [ "$do_assignments" = true ] && planned+=("clear all model assignments")
 [ "$do_budget"      = true ] && planned+=("clear the budget / virtual key")
 [ "$do_autonomy"    = true ] && planned+=("disable the orchestrator")
@@ -126,9 +132,23 @@ if [ "$do_assignments" = true ]; then
 fi
 
 if [ "$do_providers" = true ]; then
-  ids=$(get /llm/providers/ | python3 -c "import sys,json;[print(p['provider_id']) for p in json.load(sys.stdin)]")
+  # Delete non-defaults first (sort by is_default asc) so each type drains down
+  # to its single default last. The backend refuses (409) to delete the only
+  # active default of a type — that's the single-default guard (#336). When we
+  # hit it, deactivate instead: the wizard gate is `is_active && is_default`
+  # (frontend/src/setup/setupSteps.ts), so an inactive provider re-fires it.
+  ids=$(get /llm/providers/ | python3 -c "import sys,json;rows=json.load(sys.stdin);[print(p['provider_id']) for p in sorted(rows,key=lambda p:bool(p.get('is_default')))]")
   if [ -z "$ids" ]; then echo "  providers: already empty"; else
-    while read -r id; do [ -n "$id" ] && { del "/llm/providers/$id" >/dev/null; echo -e "  ${GREEN}deleted provider${NC} $id"; }; done <<< "$ids"
+    while read -r id; do
+      [ -n "$id" ] || continue
+      code=$(del_code "/llm/providers/$id")
+      case "$code" in
+        200|204) echo -e "  ${GREEN}deleted provider${NC} $id" ;;
+        409)     put "/llm/providers/$id" '{"is_active":false}' >/dev/null
+                 echo -e "  ${YELLOW}deactivated provider${NC} $id ${DIM}(only active default of its type — can't delete; gate still re-fires)${NC}" ;;
+        *)       echo -e "  ${RED}unexpected HTTP $code deleting $id${NC}" >&2; exit 1 ;;
+      esac
+    done <<< "$ids"
   fi
 fi
 


### PR DESCRIPTION
## Recover redesign provider-delete UX + repair reset-setup.sh

#336 added a single-default guard: `DELETE /llm/providers/{id}` now returns **409** for the only active default of a provider type. Two things broke as a result.

### 1. `scripts/reset-setup.sh` aborted on the 409
The script deletes providers one-by-one with `curl -fsS`; the `-f` turned the 409 into exit 22 and `set -e` killed the run, so the onboarding wizard could never be reset. It now deletes everything deletable (non-defaults first), and when it hits the guarded last default of a type it **deactivates** it (`is_active:false`). The wizard gate is `is_active && is_default` (`frontend/src/setup/setupSteps.ts`), so an inactive provider still re-fires onboarding — no backend change, stays pure-API.

### 2. The live redesign delete path never got #336's UX fix
#336 added the delete pre-check + clear message to the **archived** MUI `LLMProvidersTab` (`/old/*`), but the **live** redesign list (`AiConfigSection`, root `/`) showed a raw `Request failed with status code 409` with no pre-check. The fix _was_ written — commit `c96f6a7` — but it was **orphaned when #357 was squash-rebased** (the model-discovery sibling survived the squash; this AiConfigSection commit was dropped). This PR recovers `c96f6a7` (authored by @mattmorr1): adds `requestDelete` pre-check, `hasOtherActiveOfType`, and a tailored `deleteBody` confirm.