### PR TITLE
feat(theme): add Background tweak deriving full ramp from base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,10 @@ __pycache__/
 
 # C extensions
 *.so
-
+node_modules/
 # Distribution / packaging
 .Python
+desktop/
 build/
 develop-eggs/
 dist/

--- a/frontend/src/redesign/SocConsole.tsx
+++ b/frontend/src/redesign/SocConsole.tsx
@@ -11,6 +11,7 @@ import { configApi, orchestratorApi } from '../services/api'
 import { Icon } from './shared/icons'
 import { NAV, TITLES, type ScreenKey } from './data/data'
 import { accentVars } from './shell/accent'
+import { bgVars, isDarkBase } from './shell/bg'
 import Chat from './shell/Chat'
 import UserMenu from './shell/UserMenu'
 import ErrorBoundary from './shell/ErrorBoundary'
@@ -54,8 +55,8 @@ const SCREEN_PERMS: Partial<Record<ScreenKey, string>> = {
 }
 
 export default function SocConsole() {
-  // the theme provider is the single source of truth for mode + accent, read
-  // here and written from the Appearance settings page; it must wrap the inner
+  // the theme provider is the single source of truth for mode + accent + bg,
+  // read here and written from the Appearance settings page; it must wrap the inner
   // shell (which both styles .soc-console and renders the settings screen).
   return (
     <RedesignThemeProvider>
@@ -78,7 +79,7 @@ function SocConsoleInner() {
   const currentPerm = valid ? SCREEN_PERMS[current] : undefined
   const allowed = !currentPerm || hasPermission(currentPerm)
 
-  const { mode, accent } = useSocTheme()
+  const { accent, bg } = useSocTheme()
   const [chatOpen, setChatOpen] = useState(false)
   const [chatSeed, setChatSeed] = useState<string | null>(null)
   const [viewFull, setViewFull] = useState(false)
@@ -161,7 +162,11 @@ function SocConsoleInner() {
   const mainClass = ['main', chatOpen ? 'chat-open' : ''].filter(Boolean).join(' ')
 
   return (
-    <div className={wrapperClass} data-theme={mode} style={accentVars(accent.a, accent.b)}>
+    <div
+      className={wrapperClass}
+      data-theme={isDarkBase(bg.base) ? 'dark' : 'light'}
+      style={{ ...bgVars(bg.base), ...accentVars(accent.a, accent.b) }}
+    >
       <ToastProvider>
       <div className="shell">
         {/* nav rail */}

--- a/frontend/src/redesign/screens/settings/AppearanceSection.tsx
+++ b/frontend/src/redesign/screens/settings/AppearanceSection.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Icon } from '../../shared/icons'
 import { SettingsCard } from '../../shared/ui'
 import { ACCENT_SWATCHES } from '../../shell/accent'
+import { BG_SWATCHES } from '../../shell/bg'
 import { useSocTheme } from '../../shell/theme'
 import type { SectionProps } from './types'
 
@@ -18,10 +19,14 @@ const MODES = [
 ] as const
 
 export default function AppearanceSection({ notify }: SectionProps) {
-  const { mode, setMode, accent, setPreset, setHex } = useSocTheme()
+  const { mode, setMode, accent, setPreset, setHex, bg, setBgPreset, setBgHex } = useSocTheme()
   const [hexText, setHexText] = useState(accent.a.replace(/^#/, ''))
   const [bad, setBad] = useState(false)
   const hexRef = useRef<HTMLInputElement>(null)
+
+  const [bgHexText, setBgHexText] = useState(bg.base.replace(/^#/, ''))
+  const [bgBad, setBgBad] = useState(false)
+  const bgHexRef = useRef<HTMLInputElement>(null)
 
   // mirror the live accent into the hex field unless the user is typing in it
   useEffect(() => {
@@ -31,9 +36,23 @@ export default function AppearanceSection({ notify }: SectionProps) {
     }
   }, [accent.a])
 
+  // mirror the live background base into its hex field unless it's focused
+  useEffect(() => {
+    if (document.activeElement !== bgHexRef.current) {
+      setBgHexText(bg.base.replace(/^#/, ''))
+      setBgBad(false)
+    }
+  }, [bg.base])
+
   const tryHex = (v: string) => {
     const ok = setHex(v)
     setBad(!ok)
+    return ok
+  }
+
+  const tryBgHex = (v: string) => {
+    const ok = setBgHex(v)
+    setBgBad(!ok)
     return ok
   }
 
@@ -103,6 +122,61 @@ export default function AppearanceSection({ notify }: SectionProps) {
                   if (e.key === 'Enter') {
                     tryHex(hexText)
                     hexRef.current?.blur()
+                  }
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      </SettingsCard>
+
+      <SettingsCard
+        title="Background"
+        desc="Pick a preset or set a custom base color — the whole surface and text ramp is derived from it. Light vs. dark mode follows the base you choose. Saved to this browser."
+      >
+        <div className="appr-accent">
+          <div className="appr-sw-row" role="group" aria-label="Background presets">
+            {BG_SWATCHES.map((s) => (
+              <button
+                key={s.key}
+                className={`appr-sw appr-bg-sw${bg.key === s.key ? ' active' : ''}`}
+                style={{ background: s.color }}
+                onClick={() => setBgPreset(s.key)}
+                aria-label={`background ${s.key}`}
+                aria-pressed={bg.key === s.key}
+              />
+            ))}
+          </div>
+          <div className="appr-custom">
+            <label className="appr-color">
+              <span className="appr-color-dot" style={{ background: bg.base }} />
+              <input
+                type="color"
+                value={bg.base}
+                onChange={(e) => tryBgHex(e.target.value)}
+                aria-label="Custom background color"
+              />
+            </label>
+            <div className={`appr-hex${bgBad ? ' bad' : ''}`}>
+              <span>#</span>
+              <input
+                ref={bgHexRef}
+                type="text"
+                maxLength={6}
+                spellCheck={false}
+                placeholder="0c0f14"
+                value={bgHexText}
+                aria-label="Custom background hex"
+                onChange={(e) => {
+                  setBgHexText(e.target.value)
+                  setBgBad(false)
+                  tryBgHex(e.target.value)
+                }}
+                onBlur={() => tryBgHex(bgHexText)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    tryBgHex(bgHexText)
+                    bgHexRef.current?.blur()
                   }
                 }}
               />

--- a/frontend/src/redesign/shell/bg.ts
+++ b/frontend/src/redesign/shell/bg.ts
@@ -1,0 +1,108 @@
+/* Background palette + ramp helpers — parallel to accent.ts, but instead of
+   painting just the accent it derives the WHOLE surface + line + text ramp from
+   a single base color the user picks. Dark vs. light is decided by the base's
+   relative luminance; every other token is the base mixed toward white/black. */
+import type { CSSProperties } from 'react'
+import { normHex } from './accent'
+
+/** base hex for each named preset */
+export const BG_PRESETS: Record<string, string> = {
+  slate: '#0c0f14',
+  ink: '#08090c',
+  navy: '#0b1020',
+  espresso: '#14110d',
+  light: '#f4f5f7',
+}
+
+/** preset swatches shown in the tweaks panel, in order (first = default) */
+export const BG_SWATCHES: { key: string; color: string }[] = [
+  { key: 'slate', color: '#0c0f14' },
+  { key: 'ink', color: '#08090c' },
+  { key: 'navy', color: '#0b1020' },
+  { key: 'espresso', color: '#14110d' },
+  { key: 'light', color: '#f4f5f7' },
+]
+
+/** base whose luminance is below this is treated as a dark base */
+export const BG_DARK_CUTOFF = 0.42
+
+/** per-channel lerp between two hex colors: mix(a,b,0)=a, mix(a,b,1)=b */
+export function mix(a: string, b: string, t: number): string {
+  const na = parseInt(a.slice(1), 16)
+  const nb = parseInt(b.slice(1), 16)
+  const ch = (shift: number) => {
+    const ca = (na >> shift) & 255
+    const cb = (nb >> shift) & 255
+    return Math.round(ca + (cb - ca) * t)
+  }
+  return '#' + [ch(16), ch(8), ch(0)].map((c) => c.toString(16).padStart(2, '0')).join('')
+}
+
+/** sRGB-linearized relative luminance (0..1): 0.2126r + 0.7152g + 0.0722b */
+export function lum(hex: string): number {
+  const n = parseInt(hex.slice(1), 16)
+  const lin = (c: number) => {
+    const s = c / 255
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4)
+  }
+  return 0.2126 * lin(n >> 16) + 0.7152 * lin((n >> 8) & 255) + 0.0722 * lin(n & 255)
+}
+
+/** whether a base hex should produce the dark ramp */
+export function isDarkBase(base: string): boolean {
+  return lum(base) < BG_DARK_CUTOFF
+}
+
+const WHITE = '#ffffff'
+const BLACK = '#000000'
+
+/** build the inline CSS-var style block that paints the surface/line/text ramp
+   from a single base color. Dark/light is chosen by the base's luminance.
+   --shadow + color-scheme are intentionally NOT set here — they come from
+   data-theme, which the theme context keeps aligned with the base's lightness. */
+export function bgVars(base: string): CSSProperties {
+  if (isDarkBase(base)) {
+    return {
+      '--bg': base,
+      '--bg-1': mix(base, WHITE, 0.035),
+      '--bg-2': mix(base, WHITE, 0.07),
+      '--bg-3': mix(base, WHITE, 0.12),
+      '--panel': mix(base, WHITE, 0.045),
+      '--hover': mix(base, WHITE, 0.09),
+      '--line': mix(base, WHITE, 0.14),
+      '--line-soft': mix(base, WHITE, 0.075),
+      // not enumerated in the spec, but a real line token — derived just above
+      // --line so the ramp stays coherent under a custom base.
+      '--line-strong': mix(base, WHITE, 0.2),
+      '--tx': '#e8ebf0',
+      '--tx-2': '#aeb6c2',
+      '--tx-3': '#7c8593',
+      '--tx-faint': '#58616e',
+    } as CSSProperties
+  }
+  return {
+    '--bg': base,
+    '--bg-1': mix(base, BLACK, 0.03),
+    '--bg-2': mix(base, BLACK, 0.055),
+    '--bg-3': mix(base, BLACK, 0.09),
+    '--panel': mix(base, WHITE, 0.55),
+    '--hover': mix(base, BLACK, 0.05),
+    '--line': mix(base, BLACK, 0.13),
+    '--line-soft': mix(base, BLACK, 0.07),
+    '--line-strong': mix(base, BLACK, 0.2),
+    '--tx': '#1a1d24',
+    '--tx-2': '#464d59',
+    '--tx-3': '#6c7480',
+    '--tx-faint': '#99a1ad',
+  } as CSSProperties
+}
+
+/** the default base for a given mode (used when snapping base ↔ mode) */
+export function defaultBaseForMode(mode: 'light' | 'dark'): { key: string; base: string } {
+  return mode === 'dark'
+    ? { key: 'slate', base: BG_PRESETS.slate }
+    : { key: 'light', base: BG_PRESETS.light }
+}
+
+/** normalize a free-typed/picked hex (re-exported for the bg control) */
+export { normHex }

--- a/frontend/src/redesign/shell/theme.tsx
+++ b/frontend/src/redesign/shell/theme.tsx
@@ -150,9 +150,10 @@ export function RedesignThemeProvider({ children }: { children: ReactNode }) {
       const base = BG_PRESETS[key]
       if (!base) return
       setBg({ key, base })
-      setMode(isDarkBase(base) ? 'dark' : 'light')
+      const next = isDarkBase(base) ? 'dark' : 'light'
+      if (next !== mode) setMode(next)
     },
-    [setMode],
+    [mode, setMode],
   )
 
   const setBgHex = useCallback(
@@ -160,10 +161,11 @@ export function RedesignThemeProvider({ children }: { children: ReactNode }) {
       const base = normBgHex(input)
       if (!base) return false
       setBg({ key: null, base })
-      setMode(isDarkBase(base) ? 'dark' : 'light')
+      const next = isDarkBase(base) ? 'dark' : 'light'
+      if (next !== mode) setMode(next)
       return true
     },
-    [setMode],
+    [mode, setMode],
   )
 
   const value = useMemo<SocThemeValue>(

--- a/frontend/src/redesign/shell/theme.tsx
+++ b/frontend/src/redesign/shell/theme.tsx
@@ -20,6 +20,7 @@ import {
 } from 'react'
 import { useTheme } from '../../contexts/ThemeContext'
 import { ACCENTS, lighten, normHex } from './accent'
+import { BG_PRESETS, defaultBaseForMode, isDarkBase, normHex as normBgHex } from './bg'
 
 export interface AccentState {
   /** preset key, or null when a custom hex is in use */
@@ -30,18 +31,33 @@ export interface AccentState {
   b: string
 }
 
+export interface BgState {
+  /** preset key, or null when a custom hex is in use */
+  key: string | null
+  /** base color (--bg); the rest of the ramp is derived from it */
+  base: string
+}
+
 interface SocThemeValue {
   mode: 'light' | 'dark'
   setMode: (mode: 'light' | 'dark') => void
   accent: AccentState
-  /** apply a named preset from ACCENTS */
+  /** apply a named accent preset from ACCENTS */
   setPreset: (key: string) => void
-  /** apply a free-typed/picked hex; returns true if it was valid */
+  /** apply a free-typed/picked accent hex; returns true if it was valid */
   setHex: (hex: string) => boolean
+  bg: BgState
+  /** apply a named background preset from BG_PRESETS (also drives mode) */
+  setBgPreset: (key: string) => void
+  /** apply a free-typed/picked background hex (also drives mode); true if valid */
+  setBgHex: (hex: string) => boolean
 }
 
 const DEFAULT_ACCENT: AccentState = { key: 'violet', a: '#7d74f3', b: '#9a92f7' }
 const ACCENT_KEY = 'soc.accent'
+
+const DEFAULT_BG: BgState = { key: 'slate', base: BG_PRESETS.slate }
+const BG_KEY = 'soc.bg'
 
 function loadAccent(): AccentState {
   try {
@@ -58,6 +74,21 @@ function loadAccent(): AccentState {
   return DEFAULT_ACCENT
 }
 
+function loadBg(): BgState {
+  try {
+    const raw = localStorage.getItem(BG_KEY)
+    if (raw) {
+      const p = JSON.parse(raw) as Partial<BgState>
+      if (p && typeof p.base === 'string') {
+        return { key: typeof p.key === 'string' ? p.key : null, base: p.base }
+      }
+    }
+  } catch {
+    /* malformed / unavailable localStorage — fall back to the default */
+  }
+  return DEFAULT_BG
+}
+
 const SocThemeContext = createContext<SocThemeValue | undefined>(undefined)
 
 export function useSocTheme(): SocThemeValue {
@@ -69,6 +100,7 @@ export function useSocTheme(): SocThemeValue {
 export function RedesignThemeProvider({ children }: { children: ReactNode }) {
   const { mode, setMode } = useTheme()
   const [accent, setAccent] = useState<AccentState>(loadAccent)
+  const [bg, setBg] = useState<BgState>(loadBg)
 
   useEffect(() => {
     try {
@@ -77,6 +109,27 @@ export function RedesignThemeProvider({ children }: { children: ReactNode }) {
       /* localStorage unavailable — keep the in-memory accent only */
     }
   }, [accent])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(BG_KEY, JSON.stringify(bg))
+    } catch {
+      /* localStorage unavailable — keep the in-memory background only */
+    }
+  }, [bg])
+
+  // Keep the base coherent with the shared light/dark mode. The bg setters push
+  // mode to match the base they apply; this effect handles the other direction —
+  // when mode changes from outside the redesign (legacy MUI toggle, backend load)
+  // and disagrees with the base's lightness, snap the base to that mode's default.
+  // No-ops whenever a setter already aligned them, so it can't loop with mode.
+  useEffect(() => {
+    if (isDarkBase(bg.base) !== (mode === 'dark')) {
+      setBg(defaultBaseForMode(mode))
+    }
+    // intentionally only reacts to `mode`; reacting to `bg` would fight the setters
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode])
 
   const setPreset = useCallback((key: string) => {
     const preset = ACCENTS[key]
@@ -92,9 +145,30 @@ export function RedesignThemeProvider({ children }: { children: ReactNode }) {
     return true
   }, [])
 
+  const setBgPreset = useCallback(
+    (key: string) => {
+      const base = BG_PRESETS[key]
+      if (!base) return
+      setBg({ key, base })
+      setMode(isDarkBase(base) ? 'dark' : 'light')
+    },
+    [setMode],
+  )
+
+  const setBgHex = useCallback(
+    (input: string): boolean => {
+      const base = normBgHex(input)
+      if (!base) return false
+      setBg({ key: null, base })
+      setMode(isDarkBase(base) ? 'dark' : 'light')
+      return true
+    },
+    [setMode],
+  )
+
   const value = useMemo<SocThemeValue>(
-    () => ({ mode, setMode, accent, setPreset, setHex }),
-    [mode, setMode, accent, setPreset, setHex],
+    () => ({ mode, setMode, accent, setPreset, setHex, bg, setBgPreset, setBgHex }),
+    [mode, setMode, accent, setPreset, setHex, bg, setBgPreset, setBgHex],
   )
 
   return <SocThemeContext.Provider value={value}>{children}</SocThemeContext.Provider>

--- a/frontend/src/redesign/styles.css
+++ b/frontend/src/redesign/styles.css
@@ -3226,6 +3226,12 @@
       border-color: var(--tx);
    }
 
+   /* background swatches: a faint inset ring so the very dark bases stay
+      visible against the panel */
+   .appr-bg-sw {
+      box-shadow: inset 0 0 0 1px #ffffff26;
+   }
+
    .appr-custom {
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Summary
Adds a **Background** tweak on Settings → Appearance that works like the existing accent tweak, but recolors the entire surface/line/text ramp from a single base color. Presets (slate/ink/navy/espresso/light) + custom color picker + hex field, mirroring the accent control 1:1. The whole ramp is derived by mixing the base toward white/black, with dark vs. light chosen by relative luminance. Per the chosen design, the background base drives light/dark mode (and stays in lockstep with the existing mode toggle). The accent tweak is untouched; the two compose independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)