### PR TITLE
drop legacy v2.0 branding and wire start.sh version from release

### DIFF
--- a/DEV_MODE.md
+++ b/DEV_MODE.md
@@ -51,7 +51,7 @@ cp .env.example .env
 
 That's it! **One file, one setting** - both backend and frontend will bypass authentication. 🚀
 
-### ✨ New in v2.0: Unified DEV_MODE Configuration
+### ✨ New: Unified DEV_MODE Configuration
 
 You now only need to set `DEV_MODE=true` in the **root `.env` file**!
 

--- a/archive/old-docs/CHANGELOG_DEV_MODE.md
+++ b/archive/old-docs/CHANGELOG_DEV_MODE.md
@@ -14,7 +14,7 @@ Simplified DEV_MODE configuration to use a **single environment variable** in th
 - Easy to forget to configure one or the other
 - Inconsistent dev mode state between backend and frontend
 
-### After (v2.0)
+### After
 - **One unified configuration:**
   - Set `DEV_MODE=true` in root `.env` file
   - Both backend AND frontend automatically use it

--- a/archive/old-docs/NATIVE_SCRIPTS_GUIDE.md
+++ b/archive/old-docs/NATIVE_SCRIPTS_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## ✅ Scripts Retrieved & Updated
 
-Your original Linux-native startup scripts have been retrieved from GitHub and updated for AI SOC v2.0!
+Your original Linux-native startup scripts have been retrieved from GitHub and updated for AI SOC!
 
 ---
 
@@ -78,7 +78,7 @@ All scripts are now **executable** and ready to use! ✅
 **What you'll see:**
 ```
 ==========================================
-Vigil SOC v2.0 - Startup
+Vigil SOC - Startup
 ==========================================
 ✓ Loading environment variables from .env
 ✓ PostgreSQL is already running
@@ -88,7 +88,7 @@ Starting backend API server...
 Starting frontend dev server...
 
 ==========================================
-✅ Vigil SOC v2.0 - Ready!
+✅ Vigil SOC - Ready!
 ==========================================
 Backend API:   http://localhost:6987
 Frontend UI:   http://localhost:6988

--- a/services/agent_ai_generator.py
+++ b/services/agent_ai_generator.py
@@ -1,14 +1,3 @@
-"""
-AI-assisted custom SOC agent generator (issue #80, Phase 2).
-
-Takes a natural-language description of an agent's purpose — and optionally a
-current draft plus user feedback — and produces a draft agent configuration by
-prompting Claude with context about the platform's existing agents, available
-MCP tools, and the shape of the Vigil base prompt.
-
-Routes through ClaudeService, which flows through Bifrost per GH #84.
-"""
-
 import json
 import logging
 import re
@@ -268,10 +257,7 @@ class AgentAIGenerator:
             "{methodology}"
         )
 
-    # --- Response parsing --------------------------------------------------
-
     def _extract_json(self, text: str) -> Optional[Dict[str, Any]]:
-        """Extract the first valid JSON object from the response."""
         fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
         if fence:
             candidate = fence.group(1)
@@ -284,7 +270,6 @@ class AgentAIGenerator:
             return None
 
     def _normalize_draft(self, draft: Dict[str, Any]) -> Dict[str, Any]:
-        """Fill in defaults and sanitize values so the draft is safe to save."""
         name = (draft.get("name") or "").strip() or "Untitled Agent"
         icon_raw = (draft.get("icon") or "C").strip()
         icon = (icon_raw[:1] or "C").upper()

--- a/services/workflow_run_service.py
+++ b/services/workflow_run_service.py
@@ -1,18 +1,3 @@
-"""CRUD + lifecycle service for workflow run history (#127).
-
-Before this service, workflows executed and vanished — there was no
-way to answer "what was the last run of incident-response on case X?"
-or "why did this workflow fail yesterday?". This module owns the
-`workflow_runs` table lifecycle: insert a row at execute-start with
-``status='running'``, update at execute-end with the final status,
-result summary, error, and duration. Runs are surfaced through the
-API by ``backend/api/workflows.py``.
-
-Per-phase rows (``workflow_run_phases``) are reserved for phase-by-
-phase execution (#128) and aren't written yet — the parent row alone
-carries the run's audit story for the current "composite prompt" path.
-"""
-
 from __future__ import annotations
 
 import logging

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,9 @@
 # Usage: ./start.sh [-d|--daemon]
 source "$(dirname "$0")/scripts/lib.sh"
 
+# Version shown in the startup banner, read from the repo VERSION file.
+VERSION="$(cat "$(dirname "$0")/VERSION" 2>/dev/null || echo "dev")"
+
 DAEMON=0
 for arg in "$@"; do
     case "$arg" in
@@ -64,7 +67,7 @@ export PYTHONPATH="${PWD}:${PYTHONPATH:-}"
 print_ready() {
     echo ""
     echo "=========================================="
-    echo "Vigil SOC - Ready"
+    echo "Vigil SOC v$VERSION - Ready"
     echo "=========================================="
     echo "Backend:  http://localhost:6987"
     echo "Frontend: http://localhost:6988"


### PR DESCRIPTION
simple aesthetic change (no conflicts)
-> VIGIL startup gives actual version #  on startup 
(good for traceability) 