### PR TITLE
[codex] improve finding investigation UI

### DIFF
--- a/frontend/src/redesign/SocConsole.tsx
+++ b/frontend/src/redesign/SocConsole.tsx
@@ -81,6 +81,7 @@ function SocConsoleInner() {
   const { mode, accent } = useSocTheme()
   const [chatOpen, setChatOpen] = useState(false)
   const [chatSeed, setChatSeed] = useState<string | null>(null)
+  const [chatSeedAgentId, setChatSeedAgentId] = useState<string | undefined>()
   const [viewFull, setViewFull] = useState(false)
   // runtime-dynamic rail membership (mirrors production NavigationRail):
   // integrations are fetched once, orchestrator status is polled every 10s. No
@@ -113,9 +114,12 @@ function SocConsoleInner() {
     })
   }, [])
 
-  const openChat = useCallback((prompt?: string) => {
+  const openChat = useCallback<ScreenProps['openChat']>((prompt, options) => {
     setChatOpen(true)
-    if (prompt) setChatSeed(prompt)
+    if (prompt) {
+      setChatSeed(prompt)
+      setChatSeedAgentId(options?.agentId)
+    }
   }, [])
   const closeChat = useCallback(() => setChatOpen(false), [])
 
@@ -232,7 +236,16 @@ function SocConsoleInner() {
         </div>
 
         {/* Vigil chat dock */}
-        <Chat open={chatOpen} onClose={closeChat} seed={chatSeed} onSeedConsumed={() => setChatSeed(null)} />
+        <Chat
+          open={chatOpen}
+          onClose={closeChat}
+          seed={chatSeed}
+          seedAgentId={chatSeedAgentId}
+          onSeedConsumed={() => {
+            setChatSeed(null)
+            setChatSeedAgentId(undefined)
+          }}
+        />
       </div>
 
       {/* floating Vigil assistant button — hidden while the chat dock is open

--- a/frontend/src/redesign/screens/dashboard/DashboardScreen.tsx
+++ b/frontend/src/redesign/screens/dashboard/DashboardScreen.tsx
@@ -7,13 +7,16 @@ import { Icon } from '../../shared/icons'
 import { Pie, Hbars } from '../../shared/charts'
 import { useFindings, useDashboardKpis } from './useFindings'
 import type { Finding } from '../../data/data'
+import { agentsApi, findingsApi } from '../../../services/api'
+import { notificationService } from '../../../services/notifications'
 import { useAttack } from './useAttack'
 import { useTimeline } from './useTimeline'
-import { FilterButton, FilterGroup } from '../../shared/ui'
+import { FilterButton, FilterGroup, Popup } from '../../shared/ui'
 import FindingPopup from './FindingPopup'
 import AttackTechniqueFindings from './AttackTechniqueFindings'
 import { SEV_COLOR, TL_MONTHS, type TimelineEvent } from './attackData'
 import type { ScreenProps } from '../../shared/types'
+import EntityGraph, { type GraphLink, type GraphNode } from '../../../components/graph/EntityGraph'
 
 type DashTab = 'findings' | 'attack' | 'timeline' | 'entity'
 
@@ -45,7 +48,7 @@ export default function DashboardScreen({ openChat }: ScreenProps) {
       {tab === 'findings' && <FindingsTab openChat={openChat} />}
       {tab === 'attack' && <AttackTab />}
       {tab === 'timeline' && <TimelineTab />}
-      {tab === 'entity' && <EntityStub />}
+      {tab === 'entity' && <EntityTab />}
     </>
   )
 }
@@ -104,9 +107,21 @@ function findingPrompt(f: Finding): string {
   return `Investigate finding ${f.id} — ${parts.join(', ')}. What happened and what should I do next?`
 }
 
-function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
+interface AgentOption {
+  id: string
+  name: string
+  specialization?: string
+  description?: string
+}
+
+function FindingsTab({ openChat }: { openChat: ScreenProps['openChat'] }) {
   const { rows, phase, error, reload } = useFindings()
   const { kpis, reload: reloadKpis } = useDashboardKpis()
+  const [agents, setAgents] = useState<AgentOption[]>([])
+  const [agentTarget, setAgentTarget] = useState<Finding | null>(null)
+  const [bulkAgentOpen, setBulkAgentOpen] = useState(false)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
+  const [agentBusy, setAgentBusy] = useState(false)
   const [query, setQuery] = useState('')
   const [sev, setSev] = useState('any')
   const [src, setSrc] = useState('any')
@@ -118,6 +133,16 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
     setSort((s) => (s.key === key
       ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
       : { key, dir: DEFAULT_DIR[key] }))
+
+  useEffect(() => {
+    agentsApi
+      .listAgents()
+      .then((res) => {
+        const list = (res.data?.agents || []) as AgentOption[]
+        setAgents(list)
+      })
+      .catch(() => setAgents([]))
+  }, [])
 
   // source options derive from the data
   const srcOptions = useMemo(() => {
@@ -164,9 +189,95 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
   const refresh = () => {
     reload()
     reloadKpis()
+    setSelectedIds(new Set())
   }
 
   const kpi = (n: number | undefined) => (kpis ? String(n ?? 0) : NDASH)
+  const visibleIds = paged.map((f) => f.id)
+  const allVisibleSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedIds.has(id))
+  const selectedFindings = sorted.filter((f) => selectedIds.has(f.id))
+
+  const toggleSelected = (findingId: string) => {
+    setSelectedIds((cur) => {
+      const next = new Set(cur)
+      if (next.has(findingId)) next.delete(findingId)
+      else next.add(findingId)
+      return next
+    })
+  }
+
+  const toggleVisibleSelected = () => {
+    setSelectedIds((cur) => {
+      const next = new Set(cur)
+      if (allVisibleSelected) visibleIds.forEach((id) => next.delete(id))
+      else visibleIds.forEach((id) => next.add(id))
+      return next
+    })
+  }
+
+  const startFindingInvestigation = async (finding: Finding, agentId?: string) => {
+    const agent = agents.find((a) => a.id === agentId)
+    setAgentBusy(true)
+    try {
+      let prompt = findingPrompt(finding)
+      if (agentId) {
+        const res = await agentsApi.startInvestigation({
+          finding_id: finding.id,
+          agent_id: agentId,
+        })
+        prompt = res.data?.prompt || prompt
+      }
+      openChat(prompt, { agentId })
+      notificationService.notifyGeneric(
+        'Investigation started',
+        `${agent?.name || 'Vigil'} is investigating ${finding.id.substring(0, 12)}…`,
+        { severity: 'success' },
+      )
+    } catch (e) {
+      notificationService.notifyGeneric(
+        'Investigation failed',
+        (e as { message?: string })?.message || 'Could not start the agent.',
+        { severity: 'error' },
+      )
+    } finally {
+      setAgentBusy(false)
+      setAgentTarget(null)
+    }
+  }
+
+  const startBulkInvestigation = (agentId?: string) => {
+    if (selectedFindings.length === 0) return
+    const agent = agents.find((a) => a.id === agentId)
+    const prompt = [
+      `Investigate these ${selectedFindings.length} selected findings as a correlated incident.`,
+      'Focus on shared entities, timeline order, likely root cause, and next actions.',
+      '',
+      ...selectedFindings.slice(0, 25).map((f) => `- ${findingPrompt(f)}`),
+    ].join('\n')
+    openChat(prompt, { agentId })
+    notificationService.notifyGeneric(
+      'Bulk investigation started',
+      `${agent?.name || 'Vigil'} is correlating ${selectedFindings.length} findings.`,
+      { severity: 'success' },
+    )
+  }
+
+  const exportFindings = async () => {
+    try {
+      const res = await findingsApi.export('json')
+      notificationService.notifyGeneric(
+        'Findings exported',
+        res.data?.file_path || 'Export complete.',
+        { severity: 'success' },
+      )
+    } catch (e) {
+      notificationService.notifyGeneric(
+        'Export failed',
+        (e as { message?: string })?.message || 'Could not export findings.',
+        { severity: 'error' },
+      )
+    }
+  }
 
   return (
     <>
@@ -217,14 +328,32 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
           <FilterGroup label="Source" value={src} onSelect={setSrc} options={srcOptions} />
         </FilterButton>
         <div className="flex-1" />
+        {selectedIds.size > 0 && (
+          <>
+            <button className="btn ghost" onClick={() => setBulkAgentOpen(true)}>
+              <Icon name="brain" /> Investigate {selectedIds.size}
+            </button>
+            <button className="btn ghost" onClick={() => setSelectedIds(new Set())}>
+              Clear selection
+            </button>
+          </>
+        )}
         <button className="btn ghost icon" title="Refresh" onClick={refresh}><Icon name="refresh" /></button>
-        <button className="btn primary"><Icon name="download" /> Export</button>
+        <button className="btn primary" onClick={exportFindings}><Icon name="download" /> Export</button>
       </div>
 
       <div className="table-wrap list-scroll list-scroll-kpi">
         <table className="tbl findings-tbl">
           <thead>
             <tr>
+              <th>
+                <input
+                  type="checkbox"
+                  aria-label="Select visible findings"
+                  checked={allVisibleSelected}
+                  onChange={toggleVisibleSelected}
+                />
+              </th>
               <th>Finding ID</th>
               <SortHeader label="Severity" col="sev" sort={sort} onSort={toggleSort} />
               <th>MITRE Technique</th><th>Tactic</th>
@@ -237,10 +366,10 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
           </thead>
           <tbody>
             {phase === 'loading' && (
-              <tr><td colSpan={11} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>Loading findings…</td></tr>
+              <tr><td colSpan={12} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>Loading findings…</td></tr>
             )}
             {phase === 'error' && (
-              <tr><td colSpan={11} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
+              <tr><td colSpan={12} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
                   <span>Couldn’t load findings: {error}</span>
                   <button className="btn ghost" onClick={refresh}>Retry</button>
@@ -248,12 +377,21 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
               </td></tr>
             )}
             {phase === 'ready' && filtered.length === 0 && (
-              <tr><td colSpan={11} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
+              <tr><td colSpan={12} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
                 {rows.length === 0 ? 'No findings found.' : 'No findings match your filters.'}
               </td></tr>
             )}
             {phase === 'ready' && paged.map((f) => (
               <tr key={f.id} className="clickable" onClick={() => setDetailId(f.id)}>
+                <td>
+                  <input
+                    type="checkbox"
+                    aria-label={`Select ${f.id}`}
+                    checked={selectedIds.has(f.id)}
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={() => toggleSelected(f.id)}
+                  />
+                </td>
                 <td><span className="id-cell">{f.id}</span></td>
                 <td><span className={`sev ${f.sev.toLowerCase()}`}><span className="dot" />{f.sev}</span></td>
                 <td><span className="tag">{f.tech}</span> <span className="muted">{f.conf}%</span></td>
@@ -272,7 +410,7 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
                 <td>
                   <span className="row-act">
                     <button title="View" onClick={(e) => { e.stopPropagation(); setDetailId(f.id) }}><Icon name="eye" /></button>
-                    <button title="Investigate with Vigil" onClick={(e) => { e.stopPropagation(); openChat(findingPrompt(f)) }}><Icon name="brain" /></button>
+                    <button title="Investigate with agent" onClick={(e) => { e.stopPropagation(); setAgentTarget(f) }}><Icon name="brain" /></button>
                   </span>
                 </td>
               </tr>
@@ -308,8 +446,71 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
           ><Icon name="chevR" size={14} /></button>
         </span>
       </div>
-      <FindingPopup id={detailId} onClose={() => setDetailId(null)} onChanged={() => { reload(); reloadKpis() }} />
+      <FindingPopup
+        id={detailId}
+        onClose={() => setDetailId(null)}
+        onChanged={() => { reload(); reloadKpis() }}
+        onInvestigate={(f) => {
+          setDetailId(null)
+          setAgentTarget(f)
+        }}
+      />
+      <AgentPicker
+        open={agentTarget !== null}
+        title={agentTarget ? `Investigate ${agentTarget.id}` : 'Investigate finding'}
+        agents={agents}
+        busy={agentBusy}
+        onClose={() => { if (!agentBusy) setAgentTarget(null) }}
+        onSelect={(agentId) => agentTarget && startFindingInvestigation(agentTarget, agentId)}
+      />
+      <AgentPicker
+        open={bulkAgentOpen}
+        title="Investigate selected findings"
+        agents={agents}
+        busy={false}
+        onClose={() => setBulkAgentOpen(false)}
+        onSelect={(agentId) => {
+          startBulkInvestigation(agentId)
+          setSelectedIds(new Set())
+          setBulkAgentOpen(false)
+        }}
+      />
     </>
+  )
+}
+
+function AgentPicker({
+  open,
+  title,
+  agents,
+  busy,
+  onClose,
+  onSelect,
+}: {
+  open: boolean
+  title: string
+  agents: AgentOption[]
+  busy: boolean
+  onClose: () => void
+  onSelect: (agentId?: string) => void
+}) {
+  return (
+    <Popup open={open} onClose={onClose} title={title} width={440}>
+      <div className="agent-pick-list">
+        <button className="agent-pick-row" disabled={busy} onClick={() => onSelect(undefined)}>
+          <span className="am-name">Default agent</span>
+          <span className="am-spec">Use Vigil’s default routing</span>
+        </button>
+        {agents.map((a) => (
+          <button className="agent-pick-row" key={a.id} disabled={busy} onClick={() => onSelect(a.id)}>
+            <span className="am-name">{a.name}</span>
+            {a.specialization && <span className="am-spec">{a.specialization}</span>}
+            {a.description && <span className="am-desc">{a.description}</span>}
+          </button>
+        ))}
+        {agents.length === 0 && <div className="muted">No agents available.</div>}
+      </div>
+    </Popup>
   )
 }
 
@@ -440,23 +641,123 @@ function AttackTab() {
   )
 }
 
-/* ---------------- Entity Graph (stub) ---------------- */
-function EntityStub() {
-  return (
-    <div className="entity-empty">
-      <div className="ee-graphic">
-        <svg viewBox="0 0 220 150" fill="none">
-          <line x1="110" y1="75" x2="40" y2="36" /><line x1="110" y1="75" x2="186" y2="42" />
-          <line x1="110" y1="75" x2="52" y2="120" /><line x1="110" y1="75" x2="172" y2="116" />
-          <line x1="40" y1="36" x2="186" y2="42" /><line x1="52" y1="120" x2="172" y2="116" />
-          <circle cx="110" cy="75" r="13" className="n-core" />
-          <circle cx="40" cy="36" r="8" /><circle cx="186" cy="42" r="8" />
-          <circle cx="52" cy="120" r="8" /><circle cx="172" cy="116" r="8" />
-        </svg>
+/* ---------------- Entity Graph ---------------- */
+function graphNodeId(type: GraphNode['type'], value: string) {
+  return `${type}:${value}`
+}
+
+function entityTypeLabel(type: GraphNode['type']) {
+  switch (type) {
+    case 'hostname': return 'Hosts'
+    case 'user': return 'Users'
+    case 'domain': return 'Sources'
+    default: return type
+  }
+}
+
+function EntityTab() {
+  const { rows, phase, error, reload } = useFindings()
+  const graph = useMemo(() => {
+    const nodes = new Map<string, GraphNode>()
+    const links = new Map<string, GraphLink>()
+
+    const addNode = (type: GraphNode['type'], value: string, finding: Finding) => {
+      if (!value || value === NDASH) return undefined
+      const id = graphNodeId(type, value)
+      const existing = nodes.get(id)
+      const severity = finding.sev.toLowerCase() as GraphNode['severity']
+      if (existing) {
+        existing.findingCount = (existing.findingCount || 0) + 1
+        if (!existing.severity || SEV_RANK[finding.sev] > SEV_RANK[(existing.severity[0].toUpperCase() + existing.severity.slice(1)) as Finding['sev']]) {
+          existing.severity = severity
+        }
+        return id
+      }
+      nodes.set(id, {
+        id,
+        label: value,
+        type,
+        severity,
+        findingCount: 1,
+        metadata: { firstFindingId: finding.id, source: finding.src },
+      })
+      return id
+    }
+
+    const addLink = (source: string | undefined, target: string | undefined, finding: Finding) => {
+      if (!source || !target || source === target) return
+      const [a, b] = source < target ? [source, target] : [target, source]
+      const key = `${a}->${b}`
+      const existing = links.get(key)
+      if (existing) {
+        existing.value = (existing.value || 1) + 1
+        existing.techniques = Array.from(new Set([...(existing.techniques || []), finding.tech]))
+        return
+      }
+      links.set(key, {
+        source: a,
+        target: b,
+        value: 1,
+        label: finding.id,
+        techniques: [finding.tech],
+      })
+    }
+
+    rows.forEach((finding) => {
+      const host = addNode('hostname', finding.host, finding)
+      const user = addNode('user', finding.user, finding)
+      const source = addNode('domain', finding.src, finding)
+      addLink(host, user, finding)
+      addLink(host, source, finding)
+      addLink(user, source, finding)
+    })
+
+    return { nodes: Array.from(nodes.values()), links: Array.from(links.values()) }
+  }, [rows])
+
+  const counts = useMemo(() => {
+    const byType = new Map<GraphNode['type'], number>()
+    graph.nodes.forEach((node) => byType.set(node.type, (byType.get(node.type) || 0) + 1))
+    return Array.from(byType.entries()).sort(([a], [b]) => a.localeCompare(b))
+  }, [graph.nodes])
+
+  if (phase === 'loading') {
+    return <div className="entity-empty"><h3>Loading entity graph…</h3></div>
+  }
+
+  if (phase === 'error') {
+    return (
+      <div className="entity-empty">
+        <h3>Entity graph unavailable</h3>
+        <p>{error || 'Could not load findings for graph analysis.'}</p>
+        <button className="btn ghost" onClick={reload}>Retry</button>
       </div>
-      <h3>Entity Graph</h3>
-      <p>Interactive host, user &amp; device relationship graph — pivot across shared entities to trace lateral movement. Coming soon.</p>
-      <button className="btn primary"><Icon name="graph" /> Preview the graph</button>
+    )
+  }
+
+  if (graph.nodes.length === 0) {
+    return (
+      <div className="entity-empty">
+        <h3>No entities found</h3>
+        <p>Load findings with host, user, or source fields to build the relationship graph.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="entity-tab">
+      <div className="entity-summary">
+        <div>
+          <h3>Entity relationships</h3>
+          <span className="muted">{graph.nodes.length} entities · {graph.links.length} relationships · {rows.length} findings</span>
+        </div>
+        <div className="entity-counts">
+          {counts.map(([type, count]) => (
+            <span key={type}>{entityTypeLabel(type)} <b>{count}</b></span>
+          ))}
+        </div>
+      </div>
+      <EntityGraph nodes={graph.nodes} links={graph.links} height="calc(100vh - 255px)" maxNodes={500} />
     </div>
   )
 }

--- a/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
+++ b/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
@@ -150,11 +150,13 @@ export default function FindingPopup({
   id,
   onClose,
   onChanged,
+  onInvestigate,
 }: {
   id: string | null
   onClose: () => void
   /** called after a status change / delete so the list can refetch */
   onChanged?: () => void
+  onInvestigate?: (finding: ReturnType<typeof mapApiFinding>) => void
 }) {
   const [raw, setRaw] = useState<RawFinding | null>(null)
   const [phase, setPhase] = useState<Phase>('loading')
@@ -355,6 +357,11 @@ export default function FindingPopup({
 
           {/* actions */}
           <div className="fp-actions">
+            {onInvestigate && (
+              <button className="btn primary" onClick={() => onInvestigate(f)} disabled={acting}>
+                <Icon name="brain" size={14} /> Investigate with agent
+              </button>
+            )}
             <button className="btn danger" onClick={() => setConfirmDel(true)} disabled={acting}>
               <Icon name="trash" size={14} /> Delete finding
             </button>

--- a/frontend/src/redesign/shared/types.ts
+++ b/frontend/src/redesign/shared/types.ts
@@ -1,8 +1,12 @@
 /* Shared contract every redesign screen component implements. */
+export interface ChatOpenOptions {
+  agentId?: string
+}
+
 export interface ScreenProps {
   /** open the Vigil chat dock; pass a prompt to auto-send it (used by
       "investigate with Vigil" affordances) */
-  openChat: (prompt?: string) => void
+  openChat: (prompt?: string, options?: ChatOpenOptions) => void
   /** tell the shell this screen wants the full-height, non-scrolling view
       (used by the cases / decisions master-detail split layouts) */
   setViewFull: (full: boolean) => void

--- a/frontend/src/redesign/shell/Chat.tsx
+++ b/frontend/src/redesign/shell/Chat.tsx
@@ -21,6 +21,7 @@ import {
   type CostEstimate,
   type ConversationDetail,
   type ImportConversationInput,
+  type AIModelInfo,
 } from '../../services/api'
 import { notificationService } from '../../services/notifications'
 import { useConversations } from './useConversations'
@@ -72,9 +73,22 @@ interface TraceDetail {
 }
 
 const MODEL = 'claude-sonnet-4-6'
-const CONTEXT_WINDOW = 200000
-// shown only until the live model list arrives from GET /claude/models
-const MODEL_FALLBACK = [{ id: MODEL, name: 'Claude Sonnet 4.6' }]
+const DEFAULT_CONTEXT_WINDOW = 200000
+interface ChatModelOption {
+  id: string
+  name: string
+  modelId: string
+  providerId?: string
+  providerType: string
+  contextWindow: number
+}
+const MODEL_FALLBACK: ChatModelOption[] = [{
+  id: MODEL,
+  name: 'Claude Sonnet 4.6',
+  modelId: MODEL,
+  providerType: 'anthropic',
+  contextWindow: DEFAULT_CONTEXT_WINDOW,
+}]
 const newSessionId = () =>
   typeof crypto !== 'undefined' && 'randomUUID' in crypto
     ? crypto.randomUUID()
@@ -221,12 +235,14 @@ export default function Chat({
   open,
   onClose,
   seed,
+  seedAgentId,
   onSeedConsumed,
 }: {
   open: boolean
   onClose: () => void
   /** when set, auto-send this prompt (e.g. "Investigate finding …") */
   seed?: string | null
+  seedAgentId?: string
   onSeedConsumed?: () => void
 }) {
   const [messages, setMessages] = useState<ChatMsg[]>([])
@@ -262,7 +278,7 @@ export default function Chat({
   const [enableThinking, setEnableThinking] = useState(savedSettings.enableThinking)
   const [thinkingBudget, setThinkingBudget] = useState(savedSettings.thinkingBudget)
   const [systemPrompt, setSystemPrompt] = useState(savedSettings.systemPrompt)
-  const [models, setModels] = useState<{ id: string; name: string }[]>([])
+  const [models, setModels] = useState<ChatModelOption[]>([])
   const [mcpStatus, setMcpStatus] = useState<{ available: number; total: number } | null>(null)
   // live pre-call estimate from the backend (exact count_tokens + USD band),
   // mirroring the classic drawer; null until the first debounced estimate lands
@@ -364,19 +380,38 @@ export default function Chat({
   useEffect(() => {
     if (!open || metaLoadedRef.current) return
     metaLoadedRef.current = true
-    claudeApi
-      .getModels()
-      .then((r) => setModels((r.data?.models || []) as { id: string; name: string }[]))
-      .catch(() => {})
-    aiConfigApi
-      .getConfig()
-      .then((r) => {
-        const configured = r.data?.assignments?.chat_default?.model_id
-        if (configured && !settingsExistedRef.current && !userPickedModelRef.current) {
-          setModel(configured)
-        }
-      })
-      .catch(() => {})
+    Promise.all([
+      aiConfigApi.listModels().catch(() => ({ data: { models: [] as AIModelInfo[] } })),
+      aiConfigApi.getConfig().catch(() => ({ data: null })),
+    ]).then(([modelsRes, configRes]) => {
+      const liveModels = (modelsRes.data?.models || []).map((m) => ({
+        id: m.provider_id ? `${m.provider_id}::${m.model_id}` : m.model_id,
+        name: `${m.display_name || m.model_id} · ${m.provider_type}`,
+        modelId: m.model_id,
+        providerId: m.provider_id,
+        providerType: m.provider_type,
+        contextWindow: m.context_window || DEFAULT_CONTEXT_WINDOW,
+      }))
+      if (liveModels.length > 0) setModels(liveModels)
+      const assignment = configRes.data?.assignments?.chat_default
+      if (assignment && !settingsExistedRef.current && !userPickedModelRef.current) {
+        setModel(`${assignment.provider_id}::${assignment.model_id}`)
+      }
+    }).catch(() => {
+      claudeApi
+        .getModels()
+        .then((r) => {
+          const fallback = ((r.data?.models || []) as { id: string; name: string }[]).map((m) => ({
+            id: m.id,
+            name: m.name,
+            modelId: m.id,
+            providerType: 'anthropic',
+            contextWindow: DEFAULT_CONTEXT_WINDOW,
+          }))
+          setModels(fallback)
+        })
+        .catch(() => {})
+    })
     mcpApi
       .getStatuses()
       .then((r) => {
@@ -421,6 +456,12 @@ export default function Chat({
   }, [menuOpen])
 
   const agentName = agents.find((a) => a.id === agentId)?.name || 'Default agent'
+  const activeModels = models.length ? models : MODEL_FALLBACK
+  const selectedModel =
+    activeModels.find((m) => m.id === model) ||
+    activeModels.find((m) => m.modelId === model) ||
+    MODEL_FALLBACK[0]
+  const contextWindow = selectedModel.contextWindow || DEFAULT_CONTEXT_WINDOW
 
   // Pre-call cost + exact-token estimate (debounced 400ms, abortable), mirroring
   // the classic drawer: the backend runs Anthropic count_tokens and prices the
@@ -444,8 +485,8 @@ export default function Chat({
       }
       analyticsApi
         .estimateCost({
-          provider_type: 'anthropic',
-          model_id: model,
+          provider_type: selectedModel.providerType,
+          model_id: selectedModel.modelId,
           messages: payloadMsgs,
           system_prompt: systemPrompt || undefined,
           max_tokens: maxTokens,
@@ -463,7 +504,7 @@ export default function Chat({
       clearTimeout(t)
       ctrl.abort()
     }
-  }, [open, messages, draft, systemPrompt, model, maxTokens])
+  }, [open, messages, draft, systemPrompt, model, maxTokens, selectedModel])
 
   // char heuristic (~chars/4), used only until the first server estimate lands
   const heuristicTokens = useMemo(() => {
@@ -473,8 +514,8 @@ export default function Chat({
     return Math.round(chars / 4)
   }, [messages, streamText, streamThinking, systemPrompt, draft])
   const estimatedTokens = exactTokens ?? heuristicTokens
-  const ctxPct = Math.min((estimatedTokens / CONTEXT_WINDOW) * 100, 100)
-  const ctxState = estimatedTokens > 150000 ? 'danger' : estimatedTokens > 100000 ? 'warn' : 'ok'
+  const ctxPct = Math.min((estimatedTokens / contextWindow) * 100, 100)
+  const ctxState = estimatedTokens > contextWindow * 0.75 ? 'danger' : estimatedTokens > contextWindow * 0.5 ? 'warn' : 'ok'
   const costTitle = costEstimate
     ? `${
         costEstimate.token_count_method === 'anthropic_count_tokens'
@@ -485,7 +526,7 @@ export default function Chat({
       } Pricing: ${costEstimate.pricing_source}.`
     : ''
 
-  const send = async (override?: string, opts?: { fresh?: boolean }) => {
+  const send = async (override?: string, opts?: { fresh?: boolean; agentId?: string }) => {
     const text = (override ?? draft).trim()
     if (!text || loading) return
     // `fresh` starts a clean thread (used when opening a new investigation) so
@@ -514,7 +555,7 @@ export default function Chat({
           enable_thinking: enableThinking,
           thinking_budget: enableThinking ? thinkingBudget : undefined,
           system_prompt: systemPrompt || undefined,
-          agent_id: agentId || undefined,
+          agent_id: (opts?.agentId ?? agentId) || undefined,
           session_id: sessionRef.current,
         }),
         signal: ac.signal,
@@ -690,22 +731,24 @@ export default function Chat({
   // (current or archived) if one exists, else archive the current and start a
   // fresh one. The seed prompt is deterministic per finding/case, so it doubles
   // as the dedup key (investigation-keyed, like the classic drawer's tabs).
-  const openInvestigation = async (prompt: string) => {
+  const openInvestigation = async (prompt: string, opts?: { agentId?: string }) => {
     if (loading) return
-    if (currentKeyRef.current === prompt && messages.length > 0) return // already here
-    const mapped = loadKeymap()[prompt]
+    const key = opts?.agentId ? `${prompt}\n\n[agent:${opts.agentId}]` : prompt
+    if (opts?.agentId) setAgentId(opts.agentId)
+    if (currentKeyRef.current === key && messages.length > 0) return // already here
+    const mapped = loadKeymap()[key]
     if (mapped) {
-      const opened = await openConversation(mapped, prompt)
+      const opened = await openConversation(mapped, key)
       if (opened) return // reopened the existing thread for this finding/case
     }
     archiveCurrent()
     sessionRef.current = newSessionId()
-    currentKeyRef.current = prompt
-    setKeymapEntry(prompt, sessionRef.current) // so re-opening this finding restores it
+    currentKeyRef.current = key
+    setKeymapEntry(key, sessionRef.current) // so re-opening this finding restores it
     setSessionSummary(null)
     setCostEstimate(null)
     setExactTokens(null)
-    send(prompt, { fresh: true })
+    send(prompt, { fresh: true, agentId: opts?.agentId })
   }
 
   // load the per-interaction reasoning trace for the current session
@@ -836,12 +879,12 @@ export default function Chat({
     // guard against StrictMode's double-invoke firing the same seed twice
     if (open && seed !== seedRef.current && !loading) {
       seedRef.current = seed
-      openInvestigation(seed)
+      openInvestigation(seed, seedAgentId ? { agentId: seedAgentId } : undefined)
       onSeedConsumed?.()
     }
     // send/loading intentionally omitted: we fire once per new seed
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, seed])
+  }, [open, seed, seedAgentId])
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
@@ -912,8 +955,8 @@ export default function Chat({
         <div className="chat-meta">
           <div className="cm-line">
             <span className={`cm-ctx ${ctxState}`} title="Estimated context usage for the next request">
-              {estimatedTokens.toLocaleString()} / {CONTEXT_WINDOW / 1000}k tokens
-              {estimatedTokens > 150000 && <span className="cm-warn"> · auto-summarizes on send</span>}
+              {estimatedTokens.toLocaleString()} / {Math.round(contextWindow / 1000)}k tokens
+              {estimatedTokens > contextWindow * 0.75 && <span className="cm-warn"> · auto-summarizes on send</span>}
             </span>
             {costEstimate && (
               <span className="cm-cost" title={costTitle}>
@@ -1101,8 +1144,8 @@ export default function Chat({
           </div>
           <div className="cs-ctx">
             <span className={`cs-ctx-label ${ctxState}`}>
-              Context {exactTokens != null ? '' : '~'}{estimatedTokens.toLocaleString()} / {CONTEXT_WINDOW.toLocaleString()} tokens
-              {estimatedTokens > 150000 && ' · auto-summarizes on next send'}
+              Context {exactTokens != null ? '' : '~'}{estimatedTokens.toLocaleString()} / {contextWindow.toLocaleString()} tokens
+              {estimatedTokens > contextWindow * 0.75 && ' · auto-summarizes on next send'}
             </span>
             <div className="cs-bar"><span className={`cs-bar-fill ${ctxState}`} style={{ width: `${ctxPct}%` }} /></div>
             <span className="cs-ctx-sub">Output max {maxTokens.toLocaleString()} tokens</span>
@@ -1126,7 +1169,7 @@ export default function Chat({
             <Select
               value={model}
               onSelect={(m) => { userPickedModelRef.current = true; setModel(m) }}
-              options={(models.length ? models : MODEL_FALLBACK).map((m) => ({ value: m.id, label: m.name }))}
+              options={activeModels.map((m) => ({ value: m.id, label: m.name }))}
             />
           </div>
           <div className="cs-field">

--- a/frontend/src/redesign/styles.css
+++ b/frontend/src/redesign/styles.css
@@ -3109,6 +3109,54 @@
       white-space: normal;
    }
 
+   .agent-pick-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+   }
+
+   .agent-pick-row {
+      width: 100%;
+      text-align: left;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 11px 12px;
+      border: 1px solid var(--line-soft);
+      border-radius: 8px;
+      background: var(--bg-2);
+      color: var(--tx-2);
+      cursor: pointer;
+   }
+
+   .agent-pick-row:hover:not(:disabled) {
+      border-color: var(--accent);
+      background: var(--hover);
+      color: var(--tx);
+   }
+
+   .agent-pick-row:disabled {
+      cursor: wait;
+      opacity: .65;
+   }
+
+   .agent-pick-row .am-name {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--tx);
+   }
+
+   .agent-pick-row .am-spec {
+      font-size: 11.5px;
+      color: var(--accent-2);
+   }
+
+   .agent-pick-row .am-desc {
+      font-size: 12px;
+      line-height: 1.4;
+      color: var(--tx-3);
+   }
+
    .agent-menu {
       max-width: 300px;
    }
@@ -4393,6 +4441,50 @@
       max-width: 440px;
       line-height: 1.55;
       margin: -4px 0 6px;
+   }
+
+   .entity-tab {
+      padding: 18px 22px 24px;
+      min-height: calc(100vh - 145px);
+      background: var(--bg);
+   }
+
+   .entity-summary {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding-bottom: 14px;
+   }
+
+   .entity-summary h3 {
+      font-size: 14.5px;
+      margin: 0 0 3px;
+   }
+
+   .entity-counts {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+   }
+
+   .entity-counts span {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 5px 8px;
+      border: 1px solid var(--line-soft);
+      border-radius: 8px;
+      background: var(--bg-2);
+      color: var(--tx-3);
+      font-size: 12px;
+   }
+
+   .entity-counts b {
+      color: var(--tx);
+      font-weight: 600;
    }
 
    /* ---------- Timeline tab ---------- */


### PR DESCRIPTION
## Summary
- add agent selection from the main Findings table and finding detail modal
- add bulk finding selection with correlated investigation prompts
- wire Findings export button to the backend export API
- make Chat honor seeded agent choices and configured AI model metadata
- replace the Entity Graph placeholder with a live graph built from findings

## Verification
- npm run build
- npx eslint src/redesign/SocConsole.tsx src/redesign/screens/dashboard/DashboardScreen.tsx src/redesign/screens/dashboard/FindingPopup.tsx src/redesign/shared/types.ts src/redesign/shell/Chat.tsx --ext ts,tsx --report-unused-disable-directives

## Notes
- Full npm run lint still fails on pre-existing unrelated lint errors outside this PR, including legacy case/detail components, VStrike iframe context, Settings, Skills, Timesketch, and CustomIntegrationBuilder.