### PR TITLE
[codex] add redesign empty states and settings deep links

### DIFF
--- a/frontend/src/redesign/SocConsole.test.tsx
+++ b/frontend/src/redesign/SocConsole.test.tsx
@@ -247,9 +247,9 @@ describe('SocConsole redesign', () => {
     // Timeline (exercises ResizeObserver + layout math); count resolves async
     fireEvent.click(screen.getByRole('tab', { name: 'Timeline' }))
     expect(await screen.findByText(/events$/)).toBeInTheDocument()
-    // Entity Graph stub
+    // Entity Graph empty state
     fireEvent.click(screen.getByRole('tab', { name: 'Entity Graph' }))
-    expect(screen.getByText('Coming soon.', { exact: false })).toBeInTheDocument()
+    expect(screen.getByText('No entity graph yet')).toBeInTheDocument()
   })
 
   it('opens the Cases master-detail and returns to the table', async () => {

--- a/frontend/src/redesign/SocConsole.tsx
+++ b/frontend/src/redesign/SocConsole.tsx
@@ -17,7 +17,7 @@ import ErrorBoundary from './shell/ErrorBoundary'
 import { ToastProvider } from './shell/toast'
 import { useDesktopNotifications } from './shell/useDesktopNotifications'
 import { RedesignThemeProvider, useSocTheme } from './shell/theme'
-import type { ScreenProps } from './shared/types'
+import type { ScreenGoOptions, ScreenProps, SettingsSectionKey } from './shared/types'
 import DashboardScreen from './screens/dashboard/DashboardScreen'
 import CasesScreen from './screens/cases/CasesScreen'
 import MetricsScreen from './screens/metrics/MetricsScreen'
@@ -120,11 +120,18 @@ function SocConsoleInner() {
   const closeChat = useCallback(() => setChatOpen(false), [])
 
   const go = useCallback(
-    (next: ScreenKey) => {
-      if (valid && next === current) return
-      navigate(`/${next}`)
+    (next: ScreenKey, options?: ScreenGoOptions) => {
+      const search = options?.search || ''
+      if (valid && next === current && !search) return
+      navigate({ pathname: `/${next}`, search }, { replace: options?.replace })
     },
     [valid, current, navigate],
+  )
+  const goSettings = useCallback(
+    (section: SettingsSectionKey) => {
+      navigate({ pathname: '/settings', search: `?section=${section}` })
+    },
+    [navigate],
   )
 
   // leaving a screen drops any full-bleed detail it had open; screens that
@@ -224,7 +231,7 @@ function SocConsoleInner() {
                     <button className="btn primary" onClick={() => go('dashboard')}>Back to Dashboard</button>
                   </div>
                 ) : (
-                  <Screen openChat={openChat} setViewFull={setViewFull} />
+                  <Screen openChat={openChat} go={go} goSettings={goSettings} setViewFull={setViewFull} />
                 )}
               </ErrorBoundary>
             </div>

--- a/frontend/src/redesign/screens/analytics/AnalyticsScreen.tsx
+++ b/frontend/src/redesign/screens/analytics/AnalyticsScreen.tsx
@@ -348,7 +348,7 @@ function AnalyticsBody({ data }: { data: AnalyticsData }) {
 }
 
 function InsightsRail({ timeRange, onClose }: { timeRange: TimeRange; onClose: () => void }) {
-  const { insights, generatedAt, isStale, generating, phase } = useAnalyticsInsights(timeRange)
+  const { insights, generatedAt, isStale, generating, phase, reload } = useAnalyticsInsights(timeRange)
   return (
     <aside className="insights-rail">
       <div className="ir-head">
@@ -364,8 +364,8 @@ function InsightsRail({ timeRange, onClose }: { timeRange: TimeRange; onClose: (
         </button>
       </div>
       <div className="ir-body">
-        {phase === 'loading' && <EmptyState compact icon="brain" title="Loading insights…" />}
-        {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load insights" />}
+        {phase === 'loading' && <EmptyState loading compact icon="brain" title="Loading insights…" />}
+        {phase === 'error' && <EmptyState error compact icon="alert" title="Couldn’t load insights" primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
         {phase === 'ready' && insights.length === 0 && (
           <EmptyState
             compact
@@ -440,8 +440,8 @@ export default function AnalyticsScreen() {
           </button>
         </div>
 
-        {phase === 'loading' && <EmptyState icon="chart" title="Loading analytics…" />}
-        {phase === 'error' && <EmptyState icon="alert" title="Couldn’t load analytics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
+        {phase === 'loading' && <EmptyState loading icon="chart" title="Loading analytics…" />}
+        {phase === 'error' && <EmptyState error icon="alert" title="Couldn’t load analytics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
         {phase === 'ready' && data && (hasActivity ? (
           <AnalyticsBody data={data} />
         ) : (

--- a/frontend/src/redesign/screens/analytics/AnalyticsScreen.tsx
+++ b/frontend/src/redesign/screens/analytics/AnalyticsScreen.tsx
@@ -6,6 +6,7 @@
 import { useMemo, useRef, useState } from 'react'
 import { format } from 'date-fns'
 import { Icon } from '../../shared/icons'
+import { EmptyState } from '../../shared/ui'
 import { Pie, Hbars, Trend } from '../../shared/charts'
 import {
   useAnalytics,
@@ -363,12 +364,15 @@ function InsightsRail({ timeRange, onClose }: { timeRange: TimeRange; onClose: (
         </button>
       </div>
       <div className="ir-body">
-        {phase === 'loading' && <div className="text-sm text-tx-3">Loading insights…</div>}
-        {phase === 'error' && <div className="text-sm text-tx-3">Couldn’t load insights.</div>}
+        {phase === 'loading' && <EmptyState compact icon="brain" title="Loading insights…" />}
+        {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load insights" />}
         {phase === 'ready' && insights.length === 0 && (
-          <div className="text-sm text-tx-3">
-            {generating ? 'Generating insights — this can take up to a minute.' : 'No insights yet.'}
-          </div>
+          <EmptyState
+            compact
+            icon="brain"
+            title={generating ? 'Generating insights' : 'No insights yet'}
+            body={generating ? 'This can take up to a minute.' : 'AI insights will appear after enough analytics data is available.'}
+          />
         )}
         {insights.map((i) => {
           const when = (() => {
@@ -402,6 +406,11 @@ export default function AnalyticsScreen() {
   ]
   const [showInsights, setShowInsights] = useState(true)
   const { data, phase, error, reload } = useAnalytics(range)
+  const hasActivity = data
+    ? data.metrics.totalFindings > 0 ||
+      data.metrics.totalCases > 0 ||
+      data.timeSeriesData.some((p) => p.findings > 0 || p.cases > 0 || p.alerts > 0)
+    : false
 
   return (
     <div className="flex items-start min-h-full">
@@ -431,18 +440,18 @@ export default function AnalyticsScreen() {
           </button>
         </div>
 
-        {phase === 'loading' && (
-          <div className="text-sm text-tx-3 py-20 text-center">Loading analytics…</div>
-        )}
-        {phase === 'error' && (
-          <div className="py-20 text-center">
-            <div className="flex flex-col items-center gap-2.5">
-              <span className="text-sm text-tx-3">Couldn’t load analytics: {error}</span>
-              <button className="btn ghost" onClick={reload}>Retry</button>
-            </div>
-          </div>
-        )}
-        {phase === 'ready' && data && <AnalyticsBody data={data} />}
+        {phase === 'loading' && <EmptyState icon="chart" title="Loading analytics…" />}
+        {phase === 'error' && <EmptyState icon="alert" title="Couldn’t load analytics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
+        {phase === 'ready' && data && (hasActivity ? (
+          <AnalyticsBody data={data} />
+        ) : (
+          <EmptyState
+            icon="chart"
+            title="No analytics data in this range"
+            body="Ingest findings, create cases, or select a broader time range to populate this report."
+            primary={range !== 'all' ? { label: 'Show all time', onClick: () => setRange('all'), icon: 'clock' } : undefined}
+          />
+        ))}
       </div>
 
       {showInsights && <InsightsRail timeRange={range} onClose={() => setShowInsights(false)} />}

--- a/frontend/src/redesign/screens/autoops/AutoOpsScreen.tsx
+++ b/frontend/src/redesign/screens/autoops/AutoOpsScreen.tsx
@@ -9,7 +9,7 @@
    ============================================================ */
 import { useEffect, useState, type ReactNode } from 'react'
 import { Icon } from '../../shared/icons'
-import { Toggle, NumberInput } from '../../shared/ui'
+import { EmptyState, Toggle, NumberInput } from '../../shared/ui'
 import type { ScreenProps } from '../../shared/types'
 import { useAutoOps, type Investigation, type OrchestratorStatus } from './useAutoOps'
 import { StatusBadge } from './statusBadge'
@@ -33,7 +33,7 @@ const KPIS: KpiDef[] = [
   { key: 'failed', label: 'Failed', statuses: ['failed'], value: (s) => s.failed, color: 'var(--crit)', note: 'errored out' },
 ]
 
-export default function AutoOpsScreen({ openChat, setViewFull }: ScreenProps) {
+export default function AutoOpsScreen({ openChat, go, goSettings, setViewFull }: ScreenProps) {
   const {
     status, investigations, phase, error, notice, busy,
     reload, clearError, clearNotice,
@@ -64,17 +64,10 @@ export default function AutoOpsScreen({ openChat, setViewFull }: ScreenProps) {
   }
 
   if (!status && phase === 'loading') {
-    return <div className="text-sm text-tx-3 py-20 text-center">Loading autonomous operations…</div>
+    return <EmptyState icon="bot" title="Loading autonomous operations…" />
   }
   if (!status && phase === 'error') {
-    return (
-      <div className="py-20 text-center">
-        <div className="flex flex-col items-center gap-2.5">
-          <span className="text-sm text-tx-3">Couldn’t load autonomous operations: {error}</span>
-          <button className="btn ghost" onClick={reload}>Retry</button>
-        </div>
-      </div>
-    )
+    return <EmptyState icon="alert" title="Couldn’t load autonomous operations" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
   }
   if (!status) return <></>
 
@@ -141,6 +134,18 @@ export default function AutoOpsScreen({ openChat, setViewFull }: ScreenProps) {
 
       {error && <Banner tone="error" onClose={clearError}>{error}</Banner>}
       {notice && <Banner tone="ok" onClose={clearNotice}>{notice}</Banner>}
+      {!status.enabled && (
+        <div className="px-[22px] pt-4">
+          <EmptyState
+            compact
+            icon="bot"
+            title="Auto Ops is disabled"
+            body="You can queue investigations from findings, but agents will not run until autonomous investigation is enabled."
+            primary={{ label: 'Open Auto Investigate settings', onClick: () => goSettings('autoinvestigate'), icon: 'gear' }}
+            secondary={{ label: 'Enable now', onClick: toggleEnabled, icon: 'bolt' }}
+          />
+        </div>
+      )}
 
       {/* ---------- KPI strip ---------- */}
       <div className="kpi-strip" style={{ gridTemplateColumns: 'repeat(6, 1fr)' }}>
@@ -195,8 +200,15 @@ export default function AutoOpsScreen({ openChat, setViewFull }: ScreenProps) {
               <tbody>
                 {filtered.length === 0 ? (
                   <tr>
-                    <td colSpan={9} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
-                      {statusFilter ? 'No investigations match this filter.' : 'No investigations yet.'}
+                    <td colSpan={9}>
+                      <EmptyState
+                        table
+                        icon={statusFilter ? 'filter' : 'bot'}
+                        title={statusFilter ? 'No investigations match this filter' : 'No investigations queued'}
+                        body={statusFilter ? 'Clear the status filter to return to the full investigation queue.' : 'Scan existing findings to queue investigations, or open Findings to select a specific alert.'}
+                        primary={statusFilter ? { label: 'Clear filter', onClick: () => setStatusFilter(null), icon: 'close' } : { label: 'Scan findings', onClick: scanFindings, icon: 'search' }}
+                        secondary={statusFilter ? undefined : { label: 'Open Findings', onClick: () => go('dashboard'), icon: 'grid' }}
+                      />
                     </td>
                   </tr>
                 ) : (

--- a/frontend/src/redesign/screens/autoops/AutoOpsScreen.tsx
+++ b/frontend/src/redesign/screens/autoops/AutoOpsScreen.tsx
@@ -64,10 +64,10 @@ export default function AutoOpsScreen({ openChat, go, goSettings, setViewFull }:
   }
 
   if (!status && phase === 'loading') {
-    return <EmptyState icon="bot" title="Loading autonomous operations…" />
+    return <EmptyState loading icon="bot" title="Loading autonomous operations…" />
   }
   if (!status && phase === 'error') {
-    return <EmptyState icon="alert" title="Couldn’t load autonomous operations" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
+    return <EmptyState error icon="alert" title="Couldn’t load autonomous operations" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
   }
   if (!status) return <></>
 

--- a/frontend/src/redesign/screens/cases/CaseSections.tsx
+++ b/frontend/src/redesign/screens/cases/CaseSections.tsx
@@ -106,12 +106,12 @@ export function SectionCard({
   )
 }
 
-function Note({ children }: { children: ReactNode }) {
-  return <div className="muted text-center py-6 text-[13px] px-[18px]">{children}</div>
-}
-
 function MiniEmpty({ title, body, icon = 'info' }: { title: string; body?: string; icon?: Parameters<typeof EmptyState>[0]['icon'] }) {
   return <EmptyState compact icon={icon} title={title} body={body} />
+}
+
+function MiniLoading({ title, icon = 'info', table = false }: { title: string; icon?: Parameters<typeof EmptyState>[0]['icon']; table?: boolean }) {
+  return <EmptyState loading compact table={table} icon={icon} title={title} />
 }
 
 function AddBtn({ on, onClick }: { on: boolean; onClick: () => void }) {
@@ -181,7 +181,7 @@ export function EvidenceCard({ caseId }: { caseId: string }) {
         <table className="tbl">
           <thead><tr><th>Type</th><th>Name</th><th>Description</th><th>Collected</th><th>By</th><th>Hash</th></tr></thead>
           <tbody>
-            {phase === 'loading' && <tr><td colSpan={6}><Note>Loading…</Note></td></tr>}
+            {phase === 'loading' && <tr><td colSpan={6}><MiniLoading table icon="doc" title="Loading evidence…" /></td></tr>}
             {phase === 'ready' && items.length === 0 && <tr><td colSpan={6}><MiniEmpty icon="doc" title="No evidence attached" body="Add screenshots, URLs, logs, or files that support this case." /></td></tr>}
             {items.map((e) => (
               <tr key={e.id}>
@@ -302,7 +302,7 @@ export function TasksCard({ caseId }: { caseId: string }) {
         </div>
       )}
       <div className="p-[18px] pt-3 flex flex-col gap-2.5">
-        {phase === 'loading' && <Note>Loading…</Note>}
+        {phase === 'loading' && <MiniLoading icon="note" title="Loading tasks…" />}
         {phase === 'ready' && tasks.length === 0 && <MiniEmpty icon="note" title="No tasks yet" body="Add tasks to assign containment, validation, or follow-up work." />}
         {tasks.map((t) => {
           const overdue = t.due_date && t.status !== 'completed' && new Date(t.due_date).getTime() < Date.now()
@@ -392,7 +392,7 @@ export function SLACard({ caseId }: { caseId: string }) {
   return (
     <SectionCard title="SLA">
       <div className="p-[18px]">
-        {phase === 'loading' && <Note>Loading…</Note>}
+        {phase === 'loading' && <MiniLoading icon="clock" title="Loading SLA…" />}
         {phase === 'ready' && !data && <MiniEmpty icon="clock" title="No SLA policy attached" body="Apply an SLA policy to track response and resolution timing." />}
         {data && (
           <>
@@ -520,7 +520,7 @@ export function CommentsCard({ caseId }: { caseId: string }) {
   return (
     <SectionCard title="Comments" count={`${total}`} wide>
       <div className="p-[18px] flex flex-col gap-4">
-        {phase === 'loading' && <Note>Loading…</Note>}
+        {phase === 'loading' && <MiniLoading icon="note" title="Loading comments…" />}
         {phase === 'ready' && total === 0 && <MiniEmpty icon="note" title="No comments yet" body="Use comments to capture analyst notes, handoffs, and review decisions." />}
         {visible.map((c) => <CommentNode key={c.id} c={c} onReply={setReplyTo} />)}
         {tree.length > 1 && (
@@ -594,7 +594,7 @@ export function WatchersCard({ caseId }: { caseId: string }) {
         </div>
       )}
       <div className="p-[18px] flex flex-col gap-2.5">
-        {phase === 'loading' && <Note>Loading…</Note>}
+        {phase === 'loading' && <MiniLoading icon="eye" title="Loading watchers…" />}
         {phase === 'ready' && watchers.length === 0 && <MiniEmpty icon="eye" title="No watchers yet" body="Add analysts who should receive updates for this case." />}
         {watchers.map((w) => (
           <div key={w.user_id} className="flex items-center gap-2.5">
@@ -670,7 +670,7 @@ export function IOCsCard({ caseId }: { caseId: string }) {
         <table className="tbl">
           <thead><tr><th>Type</th><th>Value</th><th>Description</th><th>Source</th><th>Threat</th><th>First seen</th></tr></thead>
           <tbody>
-            {phase === 'loading' && <tr><td colSpan={6}><Note>Loading…</Note></td></tr>}
+            {phase === 'loading' && <tr><td colSpan={6}><MiniLoading table icon="alert" title="Loading IOCs…" /></td></tr>}
             {phase === 'ready' && iocs.length === 0 && <tr><td colSpan={6}><MiniEmpty icon="alert" title="No IOCs recorded" body="Add IPs, domains, hashes, URLs, or emails observed during investigation." /></td></tr>}
             {iocs.map((i) => {
               const tl = threatLevel(i)
@@ -747,7 +747,7 @@ export function RelatedCasesCard({ caseId, rows, onSelect }: { caseId: string; r
         </div>
       )}
       <div className="p-[18px] flex flex-col gap-2.5">
-        {phase === 'loading' && <Note>Loading…</Note>}
+        {phase === 'loading' && <MiniLoading icon="link" title="Loading related cases…" />}
         {phase === 'ready' && linked.length === 0 && <MiniEmpty icon="link" title="No related cases" body="Link duplicate, blocking, or related cases when investigations overlap." />}
         {linked.map((l) => (
           <div key={l.link_id} className="flex items-center gap-2.5 clickable" onClick={() => onSelect(l.related_case_id)}>
@@ -788,7 +788,7 @@ export function AuditLogCard({ caseId }: { caseId: string }) {
   return (
     <SectionCard title="Audit log" count={`${entries.length}`} wide>
       <div className="p-[18px] flex flex-col gap-2.5">
-        {phase === 'loading' && <Note>Loading…</Note>}
+        {phase === 'loading' && <MiniLoading icon="clock" title="Loading audit log…" />}
         {phase === 'ready' && entries.length === 0 && <MiniEmpty icon="clock" title="No audit entries yet" body="Status, assignment, and field changes will be recorded here." />}
         {entries.map((a) => (
           <div key={a.id} className="flex gap-2.5 text-[13px]">

--- a/frontend/src/redesign/screens/cases/CaseSections.tsx
+++ b/frontend/src/redesign/screens/cases/CaseSections.tsx
@@ -17,6 +17,7 @@ import {
 import { format } from 'date-fns'
 import { casesApi } from '../../../services/api'
 import { Icon } from '../../shared/icons'
+import { EmptyState } from '../../shared/ui'
 import type { CaseRow } from '../../data/data'
 
 /** the old CaseComments default — the redesign has no auth context */
@@ -109,6 +110,10 @@ function Note({ children }: { children: ReactNode }) {
   return <div className="muted text-center py-6 text-[13px] px-[18px]">{children}</div>
 }
 
+function MiniEmpty({ title, body, icon = 'info' }: { title: string; body?: string; icon?: Parameters<typeof EmptyState>[0]['icon'] }) {
+  return <EmptyState compact icon={icon} title={title} body={body} />
+}
+
 function AddBtn({ on, onClick }: { on: boolean; onClick: () => void }) {
   return (
     <button className="btn ghost icon" title={on ? 'Cancel' : 'Add'} onClick={onClick}>
@@ -177,7 +182,7 @@ export function EvidenceCard({ caseId }: { caseId: string }) {
           <thead><tr><th>Type</th><th>Name</th><th>Description</th><th>Collected</th><th>By</th><th>Hash</th></tr></thead>
           <tbody>
             {phase === 'loading' && <tr><td colSpan={6}><Note>Loading…</Note></td></tr>}
-            {phase === 'ready' && items.length === 0 && <tr><td colSpan={6}><Note>No data here.</Note></td></tr>}
+            {phase === 'ready' && items.length === 0 && <tr><td colSpan={6}><MiniEmpty icon="doc" title="No evidence attached" body="Add screenshots, URLs, logs, or files that support this case." /></td></tr>}
             {items.map((e) => (
               <tr key={e.id}>
                 <td><span className="tag">{e.evidence_type}</span></td>
@@ -207,7 +212,7 @@ export function ResolutionStepsCard({ steps }: { steps: ResolutionStep[] }) {
   return (
     <SectionCard title="Resolution steps" count={`${steps.length}`}>
       <div className="p-[18px] flex flex-col gap-3">
-        {steps.length === 0 && <Note>No data here.</Note>}
+        {steps.length === 0 && <MiniEmpty icon="check2" title="No resolution steps yet" body="Document actions taken and outcomes as this case moves toward closure." />}
         {steps.map((s, i) => (
           <div key={i} className="flex gap-2.5">
             <span className="text-ok mt-[1px]">✓</span>
@@ -298,7 +303,7 @@ export function TasksCard({ caseId }: { caseId: string }) {
       )}
       <div className="p-[18px] pt-3 flex flex-col gap-2.5">
         {phase === 'loading' && <Note>Loading…</Note>}
-        {phase === 'ready' && tasks.length === 0 && <Note>No data here.</Note>}
+        {phase === 'ready' && tasks.length === 0 && <MiniEmpty icon="note" title="No tasks yet" body="Add tasks to assign containment, validation, or follow-up work." />}
         {tasks.map((t) => {
           const overdue = t.due_date && t.status !== 'completed' && new Date(t.due_date).getTime() < Date.now()
           return (
@@ -388,7 +393,7 @@ export function SLACard({ caseId }: { caseId: string }) {
     <SectionCard title="SLA">
       <div className="p-[18px]">
         {phase === 'loading' && <Note>Loading…</Note>}
-        {phase === 'ready' && !data && <Note>No data here.</Note>}
+        {phase === 'ready' && !data && <MiniEmpty icon="clock" title="No SLA policy attached" body="Apply an SLA policy to track response and resolution timing." />}
         {data && (
           <>
             <div className="flex items-center gap-2 mb-3">
@@ -516,7 +521,7 @@ export function CommentsCard({ caseId }: { caseId: string }) {
     <SectionCard title="Comments" count={`${total}`} wide>
       <div className="p-[18px] flex flex-col gap-4">
         {phase === 'loading' && <Note>Loading…</Note>}
-        {phase === 'ready' && total === 0 && <Note>No data here.</Note>}
+        {phase === 'ready' && total === 0 && <MiniEmpty icon="note" title="No comments yet" body="Use comments to capture analyst notes, handoffs, and review decisions." />}
         {visible.map((c) => <CommentNode key={c.id} c={c} onReply={setReplyTo} />)}
         {tree.length > 1 && (
           <button
@@ -590,7 +595,7 @@ export function WatchersCard({ caseId }: { caseId: string }) {
       )}
       <div className="p-[18px] flex flex-col gap-2.5">
         {phase === 'loading' && <Note>Loading…</Note>}
-        {phase === 'ready' && watchers.length === 0 && <Note>No data here.</Note>}
+        {phase === 'ready' && watchers.length === 0 && <MiniEmpty icon="eye" title="No watchers yet" body="Add analysts who should receive updates for this case." />}
         {watchers.map((w) => (
           <div key={w.user_id} className="flex items-center gap-2.5">
             <span className="avatar">{initials(w.user_id)}</span>
@@ -666,7 +671,7 @@ export function IOCsCard({ caseId }: { caseId: string }) {
           <thead><tr><th>Type</th><th>Value</th><th>Description</th><th>Source</th><th>Threat</th><th>First seen</th></tr></thead>
           <tbody>
             {phase === 'loading' && <tr><td colSpan={6}><Note>Loading…</Note></td></tr>}
-            {phase === 'ready' && iocs.length === 0 && <tr><td colSpan={6}><Note>No data here.</Note></td></tr>}
+            {phase === 'ready' && iocs.length === 0 && <tr><td colSpan={6}><MiniEmpty icon="alert" title="No IOCs recorded" body="Add IPs, domains, hashes, URLs, or emails observed during investigation." /></td></tr>}
             {iocs.map((i) => {
               const tl = threatLevel(i)
               return (
@@ -743,7 +748,7 @@ export function RelatedCasesCard({ caseId, rows, onSelect }: { caseId: string; r
       )}
       <div className="p-[18px] flex flex-col gap-2.5">
         {phase === 'loading' && <Note>Loading…</Note>}
-        {phase === 'ready' && linked.length === 0 && <Note>No data here.</Note>}
+        {phase === 'ready' && linked.length === 0 && <MiniEmpty icon="link" title="No related cases" body="Link duplicate, blocking, or related cases when investigations overlap." />}
         {linked.map((l) => (
           <div key={l.link_id} className="flex items-center gap-2.5 clickable" onClick={() => onSelect(l.related_case_id)}>
             <span className="tag">{REL_LABEL[l.relationship_type || ''] || l.relationship_type || '—'}</span>
@@ -784,7 +789,7 @@ export function AuditLogCard({ caseId }: { caseId: string }) {
     <SectionCard title="Audit log" count={`${entries.length}`} wide>
       <div className="p-[18px] flex flex-col gap-2.5">
         {phase === 'loading' && <Note>Loading…</Note>}
-        {phase === 'ready' && entries.length === 0 && <Note>No data here.</Note>}
+        {phase === 'ready' && entries.length === 0 && <MiniEmpty icon="clock" title="No audit entries yet" body="Status, assignment, and field changes will be recorded here." />}
         {entries.map((a) => (
           <div key={a.id} className="flex gap-2.5 text-[13px]">
             <span className="avatar">{initials(a.user)}</span>
@@ -817,7 +822,7 @@ export function ActivityCard({ activities }: { activities: Activity[] }) {
   return (
     <SectionCard title="Recent activity" count={`${activities.length}`}>
       <div className="p-[18px] flex flex-col gap-3">
-        {activities.length === 0 && <Note>No data here.</Note>}
+        {activities.length === 0 && <MiniEmpty icon="clock" title="No recent activity" body="Case updates, comments, workflow events, and finding changes will appear here." />}
         {activities.slice(0, 12).map((a, i) => (
           <div key={i} className="text-[13px]">
             <div className="text-tx-2">{a.description || '—'}</div>

--- a/frontend/src/redesign/screens/cases/CasesScreen.tsx
+++ b/frontend/src/redesign/screens/cases/CasesScreen.tsx
@@ -14,7 +14,7 @@ import { mapApiCase } from '../../data/mappers'
 import type { CaseRow } from '../../data/data'
 import type { ScreenProps } from '../../shared/types'
 import { useCases, useCaseDetail, type Phase } from './useCases'
-import { FilterButton, FilterGroup, Popup, Select } from '../../shared/ui'
+import { EmptyState, FilterButton, FilterGroup, Popup, Select } from '../../shared/ui'
 import {
   inputCls,
   SectionCard,
@@ -126,10 +126,10 @@ function FindingsCard({ total, linked, phase }: { total: number; linked: DetailD
           <thead><tr><th>Finding ID</th><th>Severity</th><th>Technique</th><th>Time</th></tr></thead>
           <tbody>
             {phase === 'loading' && (
-              <tr><td colSpan={4} className="muted" style={{ textAlign: 'center', padding: '24px 0' }}>Loading findings…</td></tr>
+              <tr><td colSpan={4}><EmptyState table compact icon="search" title="Loading findings…" /></td></tr>
             )}
             {phase === 'ready' && linked.length === 0 && (
-              <tr><td colSpan={4} className="muted" style={{ textAlign: 'center', padding: '24px 0' }}>No data here.</td></tr>
+              <tr><td colSpan={4}><EmptyState table compact icon="shield" title="No findings linked" body="Attach findings to this case to keep investigation evidence in one place." /></td></tr>
             )}
             {linked.map((f) => (
               <tr key={f.id}>
@@ -179,9 +179,9 @@ function TimelineCard({ caseId }: { caseId: string }) {
   return (
     <SectionCard title="Timeline" count={phase === 'ready' ? `${events.length} events` : undefined}>
       <div className="p-[18px]">
-        {phase === 'loading' && <div className="muted">Loading timeline…</div>}
-        {phase === 'error' && <div className="muted">Couldn’t load the timeline.</div>}
-        {phase === 'ready' && events.length === 0 && <div className="muted">No timeline events.</div>}
+        {phase === 'loading' && <EmptyState compact icon="clock" title="Loading timeline…" />}
+        {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load the timeline" />}
+        {phase === 'ready' && events.length === 0 && <EmptyState compact icon="clock" title="No timeline events" body="Case activity, findings, comments, and workflow events will appear here." />}
         {phase === 'ready' && events.length > 0 && (
           <div className="timeline">
             {events.map((e, i) => (
@@ -197,7 +197,7 @@ function TimelineCard({ caseId }: { caseId: string }) {
   )
 }
 
-export default function CasesScreen({ openChat, setViewFull }: ScreenProps) {
+export default function CasesScreen({ openChat, goSettings, setViewFull }: ScreenProps) {
   // the open case lives in a ?case=<id> query param so it's shareable /
   // deep-linkable; no ?case ⇒ show the full-width table.
   const [searchParams, setSearchParams] = useSearchParams()
@@ -221,6 +221,7 @@ export default function CasesScreen({ openChat, setViewFull }: ScreenProps) {
       onSelect={selectCase}
       onBack={backToList}
       openChat={openChat}
+      goSettings={goSettings}
       reloadList={reload}
     />
   ) : (
@@ -232,7 +233,7 @@ export default function CasesScreen({ openChat, setViewFull }: ScreenProps) {
 function StateRow({ children }: { children: ReactNode }) {
   return (
     <tr>
-      <td colSpan={11} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
+      <td colSpan={11}>
         {children}
       </td>
     </tr>
@@ -389,22 +390,21 @@ function CasesTable({
             </tr>
           </thead>
           <tbody>
-            {phase === 'loading' && <StateRow>Loading cases…</StateRow>}
+            {phase === 'loading' && <StateRow><EmptyState table compact icon="folder" title="Loading cases…" /></StateRow>}
             {phase === 'error' && (
               <StateRow>
-                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
-                  <span>Couldn’t load cases: {error}</span>
-                  <button className="btn ghost" onClick={reload}>Retry</button>
-                </div>
+                <EmptyState table icon="alert" title="Couldn’t load cases" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
               </StateRow>
             )}
             {phase === 'ready' && sorted.length === 0 && (
               <StateRow>
-                {results
-                  ? 'No cases match your search.'
-                  : rows.length === 0
-                    ? 'No cases found.'
-                    : 'No cases match your filters.'}
+                <EmptyState
+                  table
+                  icon={rows.length === 0 ? 'folder' : 'filter'}
+                  title={results ? 'No cases match this search' : rows.length === 0 ? 'No cases yet' : 'No cases match these filters'}
+                  body={results || rows.length > 0 ? 'Clear the search and filters to return to the full case queue.' : 'Create a case manually or link findings from the dashboard to start an investigation record.'}
+                  primary={results || rows.length > 0 ? { label: 'Clear filters', onClick: () => { setResults(null); setQuery(''); setStatusF('any'); setPrioF('any'); setAssigneeF('any') }, icon: 'close' } : { label: 'New case', onClick: () => setNewOpen(true), icon: 'plus' }}
+                />
               </StateRow>
             )}
             {phase === 'ready' &&
@@ -825,7 +825,7 @@ function MergeCaseDialog({ open, c, rows, onClose, onMerged }: { open: boolean; 
 /* ---------------- Export to Timesketch dialog ----------------
    POST /timesketch/export. Requires the Timesketch integration to be
    configured; surfaces the backend error otherwise. */
-function ExportTimesketchDialog({ open, c, onClose }: { open: boolean; c: CaseRow | null; onClose: () => void }) {
+function ExportTimesketchDialog({ open, c, onClose, onConfigure }: { open: boolean; c: CaseRow | null; onClose: () => void; onConfigure: () => void }) {
   const [timeline, setTimeline] = useState('')
   const [sketch, setSketch] = useState('')
   const [busy, setBusy] = useState(false)
@@ -878,7 +878,16 @@ function ExportTimesketchDialog({ open, c, onClose }: { open: boolean; c: CaseRo
             <span>Sketch name <span className="normal-case font-normal text-tx-faint">(new sketch if it doesn't exist)</span></span>
             <input className={inputCls} value={sketch} onChange={(e) => setSketch(e.target.value)} />
           </label>
-          {err && <div className="text-[13px]" style={{ color: 'var(--crit)' }}>{err}</div>}
+          {err && (
+            <EmptyState
+              compact
+              icon="alert"
+              title="Timesketch export failed"
+              body={err}
+              primary={{ label: 'Configure integrations', onClick: onConfigure, icon: 'link' }}
+              secondary={{ label: 'Retry', onClick: submit, icon: 'refresh' }}
+            />
+          )}
           <div className="flex justify-end gap-2.5">
             <button className="btn ghost" onClick={onClose}>Cancel</button>
             <button className="btn primary" onClick={submit} disabled={busy}>{busy ? 'Exporting…' : 'Export'}</button>
@@ -896,6 +905,7 @@ function CasesDetail({
   onSelect,
   onBack,
   openChat,
+  goSettings,
   reloadList,
 }: {
   id: string
@@ -903,6 +913,7 @@ function CasesDetail({
   onSelect: (id: string) => void
   onBack: () => void
   openChat: (prompt?: string) => void
+  goSettings: ScreenProps['goSettings']
   reloadList: () => void
 }) {
   const { row, created, linked, sev, activities, resolutionSteps, phase, error, reload: reloadDetail } =
@@ -1065,6 +1076,7 @@ function CasesDetail({
         open={action === 'export'}
         c={c}
         onClose={() => setAction(null)}
+        onConfigure={() => goSettings('integrations')}
       />
     </div>
   )

--- a/frontend/src/redesign/screens/cases/CasesScreen.tsx
+++ b/frontend/src/redesign/screens/cases/CasesScreen.tsx
@@ -126,7 +126,7 @@ function FindingsCard({ total, linked, phase }: { total: number; linked: DetailD
           <thead><tr><th>Finding ID</th><th>Severity</th><th>Technique</th><th>Time</th></tr></thead>
           <tbody>
             {phase === 'loading' && (
-              <tr><td colSpan={4}><EmptyState table compact icon="search" title="Loading findings…" /></td></tr>
+              <tr><td colSpan={4}><EmptyState loading table compact icon="search" title="Loading findings…" /></td></tr>
             )}
             {phase === 'ready' && linked.length === 0 && (
               <tr><td colSpan={4}><EmptyState table compact icon="shield" title="No findings linked" body="Attach findings to this case to keep investigation evidence in one place." /></td></tr>
@@ -154,7 +154,7 @@ function TimelineCard({ caseId }: { caseId: string }) {
   const [events, setEvents] = useState<TlEvent[]>([])
   const [phase, setPhase] = useState<Phase>('loading')
 
-  useEffect(() => {
+  const load = useCallback(() => {
     let cancelled = false
     setPhase('loading')
     timelineApi
@@ -171,6 +171,8 @@ function TimelineCard({ caseId }: { caseId: string }) {
     }
   }, [caseId])
 
+  useEffect(() => load(), [load])
+
   const fmt = (s: string) => {
     const d = new Date(s)
     return Number.isNaN(d.getTime()) ? '—' : format(d, 'MMM d · HH:mm')
@@ -179,8 +181,8 @@ function TimelineCard({ caseId }: { caseId: string }) {
   return (
     <SectionCard title="Timeline" count={phase === 'ready' ? `${events.length} events` : undefined}>
       <div className="p-[18px]">
-        {phase === 'loading' && <EmptyState compact icon="clock" title="Loading timeline…" />}
-        {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load the timeline" />}
+        {phase === 'loading' && <EmptyState loading compact icon="clock" title="Loading timeline…" />}
+        {phase === 'error' && <EmptyState error compact icon="alert" title="Couldn’t load the timeline" primary={{ label: 'Retry', onClick: load, icon: 'refresh' }} />}
         {phase === 'ready' && events.length === 0 && <EmptyState compact icon="clock" title="No timeline events" body="Case activity, findings, comments, and workflow events will appear here." />}
         {phase === 'ready' && events.length > 0 && (
           <div className="timeline">
@@ -390,10 +392,10 @@ function CasesTable({
             </tr>
           </thead>
           <tbody>
-            {phase === 'loading' && <StateRow><EmptyState table compact icon="folder" title="Loading cases…" /></StateRow>}
+            {phase === 'loading' && <StateRow><EmptyState loading table compact icon="folder" title="Loading cases…" /></StateRow>}
             {phase === 'error' && (
               <StateRow>
-                <EmptyState table icon="alert" title="Couldn’t load cases" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
+                <EmptyState error table icon="alert" title="Couldn’t load cases" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
               </StateRow>
             )}
             {phase === 'ready' && sorted.length === 0 && (
@@ -880,6 +882,7 @@ function ExportTimesketchDialog({ open, c, onClose, onConfigure }: { open: boole
           </label>
           {err && (
             <EmptyState
+              error
               compact
               icon="alert"
               title="Timesketch export failed"

--- a/frontend/src/redesign/screens/dashboard/DashboardScreen.tsx
+++ b/frontend/src/redesign/screens/dashboard/DashboardScreen.tsx
@@ -237,10 +237,10 @@ function FindingsTab({ openChat, goSettings }: Pick<ScreenProps, 'openChat' | 'g
           </thead>
           <tbody>
             {phase === 'loading' && (
-              <tr><td colSpan={11}><EmptyState table compact icon="search" title="Loading findings…" /></td></tr>
+              <tr><td colSpan={11}><EmptyState loading table compact icon="search" title="Loading findings…" /></td></tr>
             )}
             {phase === 'error' && (
-              <tr><td colSpan={11}><EmptyState table icon="alert" title="Couldn’t load findings" body={error} primary={{ label: 'Retry', onClick: refresh, icon: 'refresh' }} /></td></tr>
+              <tr><td colSpan={11}><EmptyState error table icon="alert" title="Couldn’t load findings" body={error} primary={{ label: 'Retry', onClick: refresh, icon: 'refresh' }} /></td></tr>
             )}
             {phase === 'ready' && filtered.length === 0 && (
               <tr><td colSpan={11}>
@@ -398,10 +398,10 @@ function AttackTab() {
               </thead>
               <tbody>
                 {phase === 'loading' && (
-                  <tr><td colSpan={9}><EmptyState table compact icon="graph" title="Loading techniques…" /></td></tr>
+                  <tr><td colSpan={9}><EmptyState loading table compact icon="graph" title="Loading techniques…" /></td></tr>
                 )}
                 {phase === 'error' && (
-                  <tr><td colSpan={9}><EmptyState table icon="alert" title="Couldn’t load ATT&CK data" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></td></tr>
+                  <tr><td colSpan={9}><EmptyState error table icon="alert" title="Couldn’t load ATT&CK data" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></td></tr>
                 )}
                 {phase === 'ready' && techniques.length === 0 && (
                   <tr><td colSpan={9}><EmptyState table icon="filter" title="No techniques at this confidence threshold" body="Lower the confidence threshold or load findings with ATT&CK mappings." /></td></tr>

--- a/frontend/src/redesign/screens/dashboard/DashboardScreen.tsx
+++ b/frontend/src/redesign/screens/dashboard/DashboardScreen.tsx
@@ -9,7 +9,7 @@ import { useFindings, useDashboardKpis } from './useFindings'
 import type { Finding } from '../../data/data'
 import { useAttack } from './useAttack'
 import { useTimeline } from './useTimeline'
-import { FilterButton, FilterGroup } from '../../shared/ui'
+import { EmptyState, FilterButton, FilterGroup } from '../../shared/ui'
 import FindingPopup from './FindingPopup'
 import AttackTechniqueFindings from './AttackTechniqueFindings'
 import { SEV_COLOR, TL_MONTHS, type TimelineEvent } from './attackData'
@@ -17,7 +17,7 @@ import type { ScreenProps } from '../../shared/types'
 
 type DashTab = 'findings' | 'attack' | 'timeline' | 'entity'
 
-export default function DashboardScreen({ openChat }: ScreenProps) {
+export default function DashboardScreen({ openChat, goSettings }: ScreenProps) {
   const [tab, setTab] = useState<DashTab>('findings')
   const tabs: [DashTab, string][] = [
     ['findings', 'Findings'],
@@ -42,7 +42,7 @@ export default function DashboardScreen({ openChat }: ScreenProps) {
           ))}
         </div>
       </div>
-      {tab === 'findings' && <FindingsTab openChat={openChat} />}
+      {tab === 'findings' && <FindingsTab openChat={openChat} goSettings={goSettings} />}
       {tab === 'attack' && <AttackTab />}
       {tab === 'timeline' && <TimelineTab />}
       {tab === 'entity' && <EntityStub />}
@@ -104,7 +104,7 @@ function findingPrompt(f: Finding): string {
   return `Investigate finding ${f.id} — ${parts.join(', ')}. What happened and what should I do next?`
 }
 
-function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
+function FindingsTab({ openChat, goSettings }: Pick<ScreenProps, 'openChat' | 'goSettings'>) {
   const { rows, phase, error, reload } = useFindings()
   const { kpis, reload: reloadKpis } = useDashboardKpis()
   const [query, setQuery] = useState('')
@@ -237,19 +237,20 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
           </thead>
           <tbody>
             {phase === 'loading' && (
-              <tr><td colSpan={11} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>Loading findings…</td></tr>
+              <tr><td colSpan={11}><EmptyState table compact icon="search" title="Loading findings…" /></td></tr>
             )}
             {phase === 'error' && (
-              <tr><td colSpan={11} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
-                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
-                  <span>Couldn’t load findings: {error}</span>
-                  <button className="btn ghost" onClick={refresh}>Retry</button>
-                </div>
-              </td></tr>
+              <tr><td colSpan={11}><EmptyState table icon="alert" title="Couldn’t load findings" body={error} primary={{ label: 'Retry', onClick: refresh, icon: 'refresh' }} /></td></tr>
             )}
             {phase === 'ready' && filtered.length === 0 && (
-              <tr><td colSpan={11} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
-                {rows.length === 0 ? 'No findings found.' : 'No findings match your filters.'}
+              <tr><td colSpan={11}>
+                <EmptyState
+                  table
+                  icon={rows.length === 0 ? 'shield' : 'filter'}
+                  title={rows.length === 0 ? 'No findings yet' : 'No findings match this view'}
+                  body={rows.length === 0 ? 'Ingest alerts or run a workflow to populate the findings queue.' : 'Clear search and filters to return to the full findings queue.'}
+                  primary={rows.length === 0 ? { label: 'Configure integrations', onClick: () => goSettings('integrations'), icon: 'link' } : { label: 'Clear filters', onClick: () => { setQuery(''); setSev('any'); setSrc('any') }, icon: 'close' }}
+                />
               </td></tr>
             )}
             {phase === 'ready' && paged.map((f) => (
@@ -308,7 +309,7 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
           ><Icon name="chevR" size={14} /></button>
         </span>
       </div>
-      <FindingPopup id={detailId} onClose={() => setDetailId(null)} onChanged={() => { reload(); reloadKpis() }} />
+      <FindingPopup id={detailId} onClose={() => setDetailId(null)} onChanged={() => { reload(); reloadKpis() }} onConfigureAi={() => goSettings('ai-config')} />
     </>
   )
 }
@@ -397,18 +398,13 @@ function AttackTab() {
               </thead>
               <tbody>
                 {phase === 'loading' && (
-                  <tr><td colSpan={9} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>Loading techniques…</td></tr>
+                  <tr><td colSpan={9}><EmptyState table compact icon="graph" title="Loading techniques…" /></td></tr>
                 )}
                 {phase === 'error' && (
-                  <tr><td colSpan={9} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
-                    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
-                      <span>Couldn’t load ATT&CK data: {error}</span>
-                      <button className="btn ghost" onClick={reload}>Retry</button>
-                    </div>
-                  </td></tr>
+                  <tr><td colSpan={9}><EmptyState table icon="alert" title="Couldn’t load ATT&CK data" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></td></tr>
                 )}
                 {phase === 'ready' && techniques.length === 0 && (
-                  <tr><td colSpan={9} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>No techniques at this confidence threshold.</td></tr>
+                  <tr><td colSpan={9}><EmptyState table icon="filter" title="No techniques at this confidence threshold" body="Lower the confidence threshold or load findings with ATT&CK mappings." /></td></tr>
                 )}
                 {phase === 'ready' && techniques.map((t) => (
                   <Fragment key={t.id}>
@@ -444,19 +440,11 @@ function AttackTab() {
 function EntityStub() {
   return (
     <div className="entity-empty">
-      <div className="ee-graphic">
-        <svg viewBox="0 0 220 150" fill="none">
-          <line x1="110" y1="75" x2="40" y2="36" /><line x1="110" y1="75" x2="186" y2="42" />
-          <line x1="110" y1="75" x2="52" y2="120" /><line x1="110" y1="75" x2="172" y2="116" />
-          <line x1="40" y1="36" x2="186" y2="42" /><line x1="52" y1="120" x2="172" y2="116" />
-          <circle cx="110" cy="75" r="13" className="n-core" />
-          <circle cx="40" cy="36" r="8" /><circle cx="186" cy="42" r="8" />
-          <circle cx="52" cy="120" r="8" /><circle cx="172" cy="116" r="8" />
-        </svg>
-      </div>
-      <h3>Entity Graph</h3>
-      <p>Interactive host, user &amp; device relationship graph — pivot across shared entities to trace lateral movement. Coming soon.</p>
-      <button className="btn primary"><Icon name="graph" /> Preview the graph</button>
+      <EmptyState
+        icon="graph"
+        title="No entity graph yet"
+        body="Host, user, and source relationships appear here once findings include entity fields."
+      />
     </div>
   )
 }
@@ -714,6 +702,14 @@ function TimelineTab() {
         <button className="tl-iconbtn" title="Export visible events (CSV)" onClick={exportCsv}><Icon name="download" /></button>
       </div>
       <div className="tl-hint">Drag anywhere to scrub · click a bar to investigate · scroll to pan</div>
+      {tlPhase === 'ready' && events.length === 0 && (
+        <EmptyState
+          icon="clock"
+          title={filter === 'finding' ? 'No finding events in this window' : 'No timeline events yet'}
+          body={filter === 'finding' ? 'Switch to All events or load findings with timestamps.' : 'Create cases or ingest findings to build an investigation timeline.'}
+          primary={filter === 'finding' ? { label: 'Show all events', onClick: () => changeFilter('all'), icon: 'filter' } : undefined}
+        />
+      )}
       <div className="tl-scroll" ref={scrollRef}>
         <div
           className="tl-inner"

--- a/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
+++ b/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
@@ -13,7 +13,7 @@ import { useEffect, useState } from 'react'
 import { findingsApi } from '../../../services/api'
 import { mapApiFinding, type ApiFinding } from '../../data/mappers'
 import { techniqueName } from '../../data/mitre'
-import { ConfirmDialog, Popup, Select } from '../../shared/ui'
+import { ConfirmDialog, EmptyState, Popup, Select } from '../../shared/ui'
 import { Icon } from '../../shared/icons'
 import type { Phase } from '../cases/useCases'
 
@@ -150,11 +150,13 @@ export default function FindingPopup({
   id,
   onClose,
   onChanged,
+  onConfigureAi,
 }: {
   id: string | null
   onClose: () => void
   /** called after a status change / delete so the list can refetch */
   onChanged?: () => void
+  onConfigureAi?: () => void
 }) {
   const [raw, setRaw] = useState<RawFinding | null>(null)
   const [phase, setPhase] = useState<Phase>('loading')
@@ -340,14 +342,23 @@ export default function FindingPopup({
             )}
             {enrichPhase === 'loading' && <div className="muted" style={{ marginTop: 10 }}>Generating AI analysis…</div>}
             {enrichPhase === 'error' && (
-              <div className="muted" style={{ marginTop: 10 }}>
-                {enrichError === 'not_configured'
-                  ? 'AI enrichment is not configured — add a Claude API key in Settings → AI.'
-                  : 'AI enrichment failed. '}
-                {enrichError !== 'not_configured' && (
-                  <button className="btn ghost" onClick={() => loadEnrichment(false)}>Retry</button>
-                )}
-              </div>
+              enrichError === 'not_configured' ? (
+                <EmptyState
+                  compact
+                  icon="sparkle"
+                  title="AI enrichment is not configured"
+                  body="Add an AI provider and assign a chat/enrichment model before generating finding analysis."
+                  primary={onConfigureAi ? { label: 'Open AI Config', onClick: onConfigureAi, icon: 'gear' } : undefined}
+                />
+              ) : (
+                <EmptyState
+                  compact
+                  icon="alert"
+                  title="AI enrichment failed"
+                  body="The analysis request did not complete."
+                  primary={{ label: 'Retry', onClick: () => loadEnrichment(false), icon: 'refresh' }}
+                />
+              )
             )}
             {enrichPhase === 'ready' && enrichment && <div style={{ marginTop: 10 }}><EnrichmentView e={enrichment} /></div>}
             {enrichPhase === 'ready' && !enrichment && <div className="muted" style={{ marginTop: 10 }}>No enrichment returned for this finding.</div>}

--- a/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
+++ b/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
@@ -352,6 +352,7 @@ export default function FindingPopup({
                 />
               ) : (
                 <EmptyState
+                  error
                   compact
                   icon="alert"
                   title="AI enrichment failed"

--- a/frontend/src/redesign/screens/decisions/DecisionsScreen.tsx
+++ b/frontend/src/redesign/screens/decisions/DecisionsScreen.tsx
@@ -103,7 +103,7 @@ function StateRow({ cols, children }: { cols: number; children: ReactNode }) {
 }
 
 function RetryState({ msg, reload }: { msg: string | null; reload: () => void }) {
-  return <EmptyState table icon="alert" title="Couldn’t load data" body={msg} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
+  return <EmptyState error table icon="alert" title="Couldn’t load data" body={msg} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
 }
 
 /* ---------------- KPI strip ---------------- */
@@ -174,7 +174,7 @@ function DecisionRows({
           </tr>
         </thead>
         <tbody>
-          {phase === 'loading' && <StateRow cols={9}><EmptyState table compact icon="brain" title="Loading decisions…" /></StateRow>}
+          {phase === 'loading' && <StateRow cols={9}><EmptyState loading table compact icon="brain" title="Loading decisions…" /></StateRow>}
           {phase === 'error' && <StateRow cols={9}><RetryState msg={error} reload={reload} /></StateRow>}
           {phase === 'ready' && rows.length === 0 && (
             <StateRow cols={9}>
@@ -224,9 +224,9 @@ function DecisionRows({
 
 /* ---------------- Analytics tab ---------------- */
 function AnalyticsTab({ s, phase, error, reload }: { s: DecisionStats | null; phase: Phase; error: string | null; reload: () => void }) {
-  if (phase === 'loading') return <EmptyState icon="bars" title="Loading analytics…" />
+  if (phase === 'loading') return <EmptyState loading icon="bars" title="Loading analytics…" />
   if (phase === 'error') {
-    return <EmptyState icon="alert" title="Couldn’t load analytics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
+    return <EmptyState error icon="alert" title="Couldn’t load analytics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
   }
   if (!s) return <EmptyState icon="bars" title="No decision analytics yet" body="Review AI decisions to populate accuracy, outcome, and time-saved analytics." />
 
@@ -294,7 +294,7 @@ function ApprovalsTab({
             </tr>
           </thead>
           <tbody>
-            {phase === 'loading' && <StateRow cols={6}><EmptyState table compact icon="check2" title="Loading approvals…" /></StateRow>}
+            {phase === 'loading' && <StateRow cols={6}><EmptyState loading table compact icon="check2" title="Loading approvals…" /></StateRow>}
             {phase === 'error' && <StateRow cols={6}><RetryState msg={error} reload={reload} /></StateRow>}
             {phase === 'ready' && actions.length === 0 && (
               <StateRow cols={6}>

--- a/frontend/src/redesign/screens/decisions/DecisionsScreen.tsx
+++ b/frontend/src/redesign/screens/decisions/DecisionsScreen.tsx
@@ -23,7 +23,7 @@ import {
   type ApprovalAction,
 } from './useDecisions'
 import { aiDecisionsApi, approvalsApi } from '../../../services/api'
-import { Popup, Field, TextInput, Select, Rating, Slider, Dropdown, activateOnKey } from '../../shared/ui'
+import { EmptyState, Popup, Field, TextInput, Select, Rating, Slider, Dropdown, activateOnKey } from '../../shared/ui'
 
 type DecTab = 'pending' | 'all' | 'analytics' | 'approvals'
 type Assessment = 'agree' | 'partial' | 'disagree'
@@ -95,7 +95,7 @@ function outcomeChip(o: Outcome) {
 function StateRow({ cols, children }: { cols: number; children: ReactNode }) {
   return (
     <tr>
-      <td colSpan={cols} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
+      <td colSpan={cols}>
         {children}
       </td>
     </tr>
@@ -103,12 +103,7 @@ function StateRow({ cols, children }: { cols: number; children: ReactNode }) {
 }
 
 function RetryState({ msg, reload }: { msg: string | null; reload: () => void }) {
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
-      <span>{msg}</span>
-      <button className="btn ghost" onClick={reload}>Retry</button>
-    </div>
-  )
+  return <EmptyState table icon="alert" title="Couldn’t load data" body={msg} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
 }
 
 /* ---------------- KPI strip ---------------- */
@@ -179,9 +174,18 @@ function DecisionRows({
           </tr>
         </thead>
         <tbody>
-          {phase === 'loading' && <StateRow cols={9}>Loading decisions…</StateRow>}
+          {phase === 'loading' && <StateRow cols={9}><EmptyState table compact icon="brain" title="Loading decisions…" /></StateRow>}
           {phase === 'error' && <StateRow cols={9}><RetryState msg={error} reload={reload} /></StateRow>}
-          {phase === 'ready' && rows.length === 0 && <StateRow cols={9}>{empty}</StateRow>}
+          {phase === 'ready' && rows.length === 0 && (
+            <StateRow cols={9}>
+              <EmptyState
+                table
+                icon="brain"
+                title={empty.includes('filters') ? 'No decisions match these filters' : 'No AI decisions yet'}
+                body={empty.includes('filters') ? 'Clear the selected filters to return to the full decision history.' : 'Agent decisions will appear here after workflows or autonomous investigations run.'}
+              />
+            </StateRow>
+          )}
           {phase === 'ready' &&
             shown.map((d) => (
               <tr key={d.id} className="clickable decisions-tbl-row" onClick={() => onSelect(d.id)}>
@@ -220,15 +224,11 @@ function DecisionRows({
 
 /* ---------------- Analytics tab ---------------- */
 function AnalyticsTab({ s, phase, error, reload }: { s: DecisionStats | null; phase: Phase; error: string | null; reload: () => void }) {
-  if (phase === 'loading') return <div className="muted" style={{ padding: '40px 22px', textAlign: 'center' }}>Loading analytics…</div>
+  if (phase === 'loading') return <EmptyState icon="bars" title="Loading analytics…" />
   if (phase === 'error') {
-    return (
-      <div style={{ padding: '40px 22px', textAlign: 'center' }} className="muted">
-        <RetryState msg={`Couldn’t load analytics: ${error}`} reload={reload} />
-      </div>
-    )
+    return <EmptyState icon="alert" title="Couldn’t load analytics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
   }
-  if (!s) return <div className="muted" style={{ padding: '40px 22px', textAlign: 'center' }}>No analytics available.</div>
+  if (!s) return <EmptyState icon="bars" title="No decision analytics yet" body="Review AI decisions to populate accuracy, outcome, and time-saved analytics." />
 
   const total = s.total_with_feedback || 0
   const items: HbarItem[] = Object.entries(s.outcomes || {}).map(([k, v]) => ({
@@ -245,7 +245,7 @@ function AnalyticsTab({ s, phase, error, reload }: { s: DecisionStats | null; ph
     <div style={{ padding: 22 }} className="grid grid-cols-2 gap-4">
       <section className="bg-panel border border-line rounded-lg shadow-panel overflow-hidden">
         <div className="flex items-center gap-2.5 px-[18px] py-[15px] border-b border-line-soft"><h3 className="text-[14.5px]">Outcome distribution</h3></div>
-        <div className="p-[18px]">{items.length > 0 ? <Hbars items={items} /> : <div className="muted">No outcome data yet.</div>}</div>
+        <div className="p-[18px]">{items.length > 0 ? <Hbars items={items} /> : <EmptyState compact icon="bars" title="No outcome data yet" body="Decision feedback outcomes will populate this chart." />}</div>
       </section>
       <section className="bg-panel border border-line rounded-lg shadow-panel overflow-hidden">
         <div className="flex items-center gap-2.5 px-[18px] py-[15px] border-b border-line-soft"><h3 className="text-[14.5px]">Performance metrics</h3></div>
@@ -294,10 +294,17 @@ function ApprovalsTab({
             </tr>
           </thead>
           <tbody>
-            {phase === 'loading' && <StateRow cols={6}>Loading approvals…</StateRow>}
+            {phase === 'loading' && <StateRow cols={6}><EmptyState table compact icon="check2" title="Loading approvals…" /></StateRow>}
             {phase === 'error' && <StateRow cols={6}><RetryState msg={error} reload={reload} /></StateRow>}
             {phase === 'ready' && actions.length === 0 && (
-              <StateRow cols={6}>No pending approvals. Workflow phases that require approval will appear here.</StateRow>
+              <StateRow cols={6}>
+                <EmptyState
+                  table
+                  icon="check2"
+                  title="No pending approvals"
+                  body="Workflow phases that require human approval will appear here when agents submit actions for review."
+                />
+              </StateRow>
             )}
             {phase === 'ready' &&
               actions.map((a) => (

--- a/frontend/src/redesign/screens/metrics/MetricsScreen.tsx
+++ b/frontend/src/redesign/screens/metrics/MetricsScreen.tsx
@@ -6,6 +6,7 @@
    ============================================================ */
 import { useState } from 'react'
 import { Icon } from '../../shared/icons'
+import { EmptyState } from '../../shared/ui'
 import { Pie, GroupedBars, Trend } from '../../shared/charts'
 import { useCaseMetrics, type CaseMetricsData } from './useCaseMetrics'
 
@@ -47,6 +48,7 @@ function successRate(resolved: number, assigned: number): number {
 export default function MetricsScreen() {
   const [days, setDays] = useState(30)
   const { data, phase, error, reload } = useCaseMetrics(days)
+  const hasCases = data ? data.totalCases > 0 || data.byPriority.some((p) => p.count > 0) || data.byStatus.some((s) => s.count > 0) : false
 
   return (
     <>
@@ -64,16 +66,17 @@ export default function MetricsScreen() {
         <button className="btn primary"><Icon name="download" /> Export report</button>
       </div>
 
-      {phase === 'loading' && <div className="text-sm text-tx-3 py-20 text-center">Loading case metrics…</div>}
-      {phase === 'error' && (
-        <div className="py-20 text-center">
-          <div className="flex flex-col items-center gap-2.5">
-            <span className="text-sm text-tx-3">Couldn’t load case metrics: {error}</span>
-            <button className="btn ghost" onClick={reload}>Retry</button>
-          </div>
-        </div>
-      )}
-      {phase === 'ready' && data && <MetricsBody data={data} />}
+      {phase === 'loading' && <EmptyState icon="bars" title="Loading case metrics…" />}
+      {phase === 'error' && <EmptyState icon="alert" title="Couldn’t load case metrics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
+      {phase === 'ready' && data && (hasCases ? (
+        <MetricsBody data={data} />
+      ) : (
+        <EmptyState
+          icon="bars"
+          title="No case metrics yet"
+          body="Create or import cases to populate priority, status, response time, and analyst performance metrics."
+        />
+      ))}
     </>
   )
 }
@@ -201,7 +204,7 @@ function MetricsBody({ data }: { data: CaseMetricsData }) {
               </thead>
               <tbody>
                 {analysts.length === 0 && (
-                  <tr><td colSpan={5} className="muted" style={{ textAlign: 'center', padding: '32px 0' }}>No analyst activity in range.</td></tr>
+                  <tr><td colSpan={5}><EmptyState table compact icon="lock" title="No analyst activity in range" body="Assigned and closed cases will populate this table." /></td></tr>
                 )}
                 {analysts.map((a) => {
                   const rate = successRate(a.cases_resolved, a.cases_assigned)

--- a/frontend/src/redesign/screens/metrics/MetricsScreen.tsx
+++ b/frontend/src/redesign/screens/metrics/MetricsScreen.tsx
@@ -66,8 +66,8 @@ export default function MetricsScreen() {
         <button className="btn primary"><Icon name="download" /> Export report</button>
       </div>
 
-      {phase === 'loading' && <EmptyState icon="bars" title="Loading case metrics…" />}
-      {phase === 'error' && <EmptyState icon="alert" title="Couldn’t load case metrics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
+      {phase === 'loading' && <EmptyState loading icon="bars" title="Loading case metrics…" />}
+      {phase === 'error' && <EmptyState error icon="alert" title="Couldn’t load case metrics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
       {phase === 'ready' && data && (hasCases ? (
         <MetricsBody data={data} />
       ) : (

--- a/frontend/src/redesign/screens/settings/AiConfigSection.tsx
+++ b/frontend/src/redesign/screens/settings/AiConfigSection.tsx
@@ -150,8 +150,8 @@ function ProvidersPanel({ notify }: SectionProps) {
         </button>
       }
     >
-      {phase === 'loading' && <EmptyState compact icon="sparkle" title="Loading providers…" />}
-      {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load providers" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
+      {phase === 'loading' && <EmptyState loading compact icon="sparkle" title="Loading providers…" />}
+      {phase === 'error' && <EmptyState error compact icon="alert" title="Couldn’t load providers" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
       {phase === 'ready' && (
         <div className="table-wrap">
           <table className="tbl">
@@ -297,8 +297,8 @@ function ModelAssignmentPanel({ notify }: SectionProps) {
       title="Model Assignment"
       desc="Pick a provider + model for each system component. Unassigned rows fall back to the chat_default assignment. The model list is live-queried from each provider."
     >
-      {phase === 'loading' && <EmptyState compact icon="sparkle" title="Loading AI config…" />}
-      {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load AI config" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
+      {phase === 'loading' && <EmptyState loading compact icon="sparkle" title="Loading AI config…" />}
+      {phase === 'error' && <EmptyState error compact icon="alert" title="Couldn’t load AI config" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
       {phase === 'ready' && (
         <>
           {providerIds.length === 0 && (

--- a/frontend/src/redesign/screens/settings/AiConfigSection.tsx
+++ b/frontend/src/redesign/screens/settings/AiConfigSection.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { Icon } from '../../shared/icons'
 import {
   ConfirmDialog,
+  EmptyState,
   Field,
   NumberInput,
   Select,
@@ -149,13 +150,8 @@ function ProvidersPanel({ notify }: SectionProps) {
         </button>
       }
     >
-      {phase === 'loading' && <div className="text-sm text-tx-3 py-8 text-center">Loading providers…</div>}
-      {phase === 'error' && (
-        <div className="py-8 text-center flex flex-col items-center gap-2.5">
-          <span className="text-sm text-tx-3">Couldn’t load providers: {error}</span>
-          <button className="btn ghost" onClick={reload}>Retry</button>
-        </div>
-      )}
+      {phase === 'loading' && <EmptyState compact icon="sparkle" title="Loading providers…" />}
+      {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load providers" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
       {phase === 'ready' && (
         <div className="table-wrap">
           <table className="tbl">
@@ -167,7 +163,7 @@ function ProvidersPanel({ notify }: SectionProps) {
             </thead>
             <tbody>
               {providers.length === 0 && (
-                <tr><td colSpan={6} className="muted" style={{ textAlign: 'center', padding: '24px 0' }}>No providers configured.</td></tr>
+                <tr><td colSpan={6}><EmptyState table compact icon="sparkle" title="No AI providers configured" body="Add Ollama, Anthropic, or OpenAI-compatible providers before using AI analysis, workflow generation, or agent chat." primary={{ label: 'Add provider', onClick: () => { setEditing(null); setDialogOpen(true) }, icon: 'plus' }} /></td></tr>
               )}
               {providers.map((p) => (
                 <tr key={p.provider_id}>
@@ -301,20 +297,12 @@ function ModelAssignmentPanel({ notify }: SectionProps) {
       title="Model Assignment"
       desc="Pick a provider + model for each system component. Unassigned rows fall back to the chat_default assignment. The model list is live-queried from each provider."
     >
-      {phase === 'loading' && <div className="text-sm text-tx-3 py-8 text-center">Loading AI config…</div>}
-      {phase === 'error' && (
-        <div className="py-8 text-center flex flex-col items-center gap-2.5">
-          <span className="text-sm text-tx-3">Couldn’t load AI config: {error}</span>
-          <button className="btn ghost" onClick={reload}>Retry</button>
-        </div>
-      )}
+      {phase === 'loading' && <EmptyState compact icon="sparkle" title="Loading AI config…" />}
+      {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load AI config" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
       {phase === 'ready' && (
         <>
           {providerIds.length === 0 && (
-            <div className="settings-banner info mb-3">
-              <Icon name="info" size={14} />
-              <span>No models discovered — add at least one active provider under Providers first.</span>
-            </div>
+            <EmptyState compact icon="sparkle" title="No assignable models discovered" body="Add and test at least one active provider before assigning models to Vigil components." />
           )}
           <div className="table-wrap">
             <table className="tbl">

--- a/frontend/src/redesign/screens/settings/CostAnalyticsCard.tsx
+++ b/frontend/src/redesign/screens/settings/CostAnalyticsCard.tsx
@@ -48,8 +48,8 @@ export default function CostAnalyticsCard() {
         </>
       }
     >
-      {phase === 'loading' && <EmptyState compact icon="bars" title="Loading cost analytics…" />}
-      {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load cost analytics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
+      {phase === 'loading' && <EmptyState loading compact icon="bars" title="Loading cost analytics…" />}
+      {phase === 'error' && <EmptyState error compact icon="alert" title="Couldn’t load cost analytics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
       {phase === 'ready' && data && (
         <>
           <div className="grid grid-cols-4 gap-3 mb-4">

--- a/frontend/src/redesign/screens/settings/CostAnalyticsCard.tsx
+++ b/frontend/src/redesign/screens/settings/CostAnalyticsCard.tsx
@@ -5,7 +5,7 @@
    ============================================================ */
 import { useState } from 'react'
 import { Icon } from '../../shared/icons'
-import { SettingsCard } from '../../shared/ui'
+import { EmptyState, SettingsCard } from '../../shared/ui'
 import { useCostAnalytics, type CostModelRow, type CostTimeRange } from './useSettings'
 
 const RANGES: [CostTimeRange, string][] = [
@@ -48,13 +48,8 @@ export default function CostAnalyticsCard() {
         </>
       }
     >
-      {phase === 'loading' && <div className="text-sm text-tx-3 py-8 text-center">Loading cost analytics…</div>}
-      {phase === 'error' && (
-        <div className="py-8 text-center flex flex-col items-center gap-2.5">
-          <span className="text-sm text-tx-3">Couldn’t load cost analytics: {error}</span>
-          <button className="btn ghost" onClick={reload}>Retry</button>
-        </div>
-      )}
+      {phase === 'loading' && <EmptyState compact icon="bars" title="Loading cost analytics…" />}
+      {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load cost analytics" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
       {phase === 'ready' && data && (
         <>
           <div className="grid grid-cols-4 gap-3 mb-4">
@@ -74,7 +69,7 @@ export default function CostAnalyticsCard() {
               </thead>
               <tbody>
                 {data.by_model.length === 0 && (
-                  <tr><td colSpan={8} className="muted" style={{ textAlign: 'center', padding: '24px 0' }}>No usage in this window.</td></tr>
+                  <tr><td colSpan={8}><EmptyState table compact icon="bars" title="No usage in this window" body="LLM calls will appear here after chat, enrichment, workflows, or autonomous investigations use a configured provider." /></td></tr>
                 )}
                 {data.by_model.map((m) => {
                   const pricing = PRICING_LABEL[m.pricing_source] || PRICING_LABEL.unknown

--- a/frontend/src/redesign/screens/settings/DetectionRulesPanel.tsx
+++ b/frontend/src/redesign/screens/settings/DetectionRulesPanel.tsx
@@ -50,9 +50,9 @@ export default function DetectionRulesPanel({ notify }: SectionProps) {
   const [saving, setSaving] = useState(false)
   const [confirmDel, setConfirmDel] = useState<DetectionSource | null>(null)
 
-  if (phase === 'loading') return <EmptyState icon="shield" title="Loading detection rules…" />
+  if (phase === 'loading') return <EmptyState loading icon="shield" title="Loading detection rules…" />
   if (phase === 'error') {
-    return <EmptyState icon="alert" title="Couldn’t load detection rules" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
+    return <EmptyState error icon="alert" title="Couldn’t load detection rules" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
   }
 
   const onUpdateSource = async (id: string) => {

--- a/frontend/src/redesign/screens/settings/DetectionRulesPanel.tsx
+++ b/frontend/src/redesign/screens/settings/DetectionRulesPanel.tsx
@@ -5,7 +5,7 @@
    ============================================================ */
 import { useState } from 'react'
 import { Icon } from '../../shared/icons'
-import { Field, Popup, Select, TextInput } from '../../shared/ui'
+import { EmptyState, Field, Popup, Select, TextInput } from '../../shared/ui'
 import { useDetectionRules, type AddSourcePayload, type DetectionSource } from './useSettings'
 import type { SectionProps } from './types'
 
@@ -50,14 +50,9 @@ export default function DetectionRulesPanel({ notify }: SectionProps) {
   const [saving, setSaving] = useState(false)
   const [confirmDel, setConfirmDel] = useState<DetectionSource | null>(null)
 
-  if (phase === 'loading') return <div className="text-sm text-tx-3 py-16 text-center">Loading detection rules…</div>
+  if (phase === 'loading') return <EmptyState icon="shield" title="Loading detection rules…" />
   if (phase === 'error') {
-    return (
-      <div className="py-16 text-center flex flex-col items-center gap-2.5">
-        <span className="text-sm text-tx-3">Couldn’t load detection rules: {error}</span>
-        <button className="btn ghost" onClick={reload}>Retry</button>
-      </div>
-    )
+    return <EmptyState icon="alert" title="Couldn’t load detection rules" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />
   }
 
   const onUpdateSource = async (id: string) => {
@@ -148,10 +143,14 @@ export default function DetectionRulesPanel({ notify }: SectionProps) {
       </div>
 
       {sources.length === 0 ? (
-        <div className="settings-banner info">
-          <Icon name="info" size={14} />
-          <span>No detection rule sources configured. Click “Add Source”, or the service seeds defaults on first load.</span>
-        </div>
+        <EmptyState
+          compact
+          icon="shield"
+          title="No detection rule sources configured"
+          body="Add a Git repository or local directory, or let the service seed defaults on first load."
+          primary={{ label: 'Add source', onClick: () => setAddOpen(true), icon: 'plus' }}
+          secondary={{ label: 'Refresh', onClick: reload, icon: 'refresh' }}
+        />
       ) : (
         <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
           {sources.map((s) => (

--- a/frontend/src/redesign/screens/settings/FederationSection.tsx
+++ b/frontend/src/redesign/screens/settings/FederationSection.tsx
@@ -4,7 +4,7 @@
    FederationTab.tsx. Auto-refreshes every 10s via useFederation.
    ============================================================ */
 import { Icon } from '../../shared/icons'
-import { Select, SettingsCard, TextInput, Toggle } from '../../shared/ui'
+import { EmptyState, Select, SettingsCard, TextInput, Toggle } from '../../shared/ui'
 import { useFederation } from './useSettings'
 import type { SectionProps } from './types'
 
@@ -135,9 +135,14 @@ export default function FederationSection({ notify }: SectionProps) {
           <tbody>
             {sources.length === 0 && (
               <tr>
-                <td colSpan={7} className="muted" style={{ textAlign: 'center', padding: '28px 0' }}>
-                  No federation sources available. Configure an integration (Splunk, CrowdStrike,
-                  Sentinel, etc.) under Integrations first — adapters auto-seed when the daemon starts.
+                <td colSpan={7}>
+                  <EmptyState
+                    table
+                    compact
+                    icon="graph"
+                    title="No federation sources available"
+                    body="Configure an integration such as Splunk, CrowdStrike, or Sentinel first. Federation adapters auto-seed when the daemon starts."
+                  />
                 </td>
               </tr>
             )}

--- a/frontend/src/redesign/screens/settings/IntegrationsSection.tsx
+++ b/frontend/src/redesign/screens/settings/IntegrationsSection.tsx
@@ -8,7 +8,7 @@
    ============================================================ */
 import { useMemo, useState } from 'react'
 import { Icon } from '../../shared/icons'
-import { TextInput } from '../../shared/ui'
+import { EmptyState, TextInput } from '../../shared/ui'
 import { useMcpServers, useIntegrationsConfig } from './useSettings'
 import {
   getIntegrationForServer,
@@ -114,16 +114,17 @@ function ServersPanel({ notify }: SectionProps) {
       </div>
 
 
-      {phase === 'loading' && <div className="text-sm text-tx-3 py-16 text-center">Loading integrations…</div>}
-      {phase === 'error' && (
-        <div className="py-16 text-center flex flex-col items-center gap-2.5">
-          <span className="text-sm text-tx-3">Couldn’t load MCP servers: {error}</span>
-          <button className="btn ghost" onClick={reload}>Retry</button>
-        </div>
-      )}
+      {phase === 'loading' && <EmptyState icon="link" title="Loading integrations…" />}
+      {phase === 'error' && <EmptyState icon="alert" title="Couldn’t load MCP servers" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
 
       {phase === 'ready' && grouped.length === 0 && (
-        <div className="text-sm text-tx-3 py-10 text-center">No integrations match “{search}”.</div>
+        <EmptyState
+          compact
+          icon="filter"
+          title="No integrations match this search"
+          body={`No MCP servers match “${search}”.`}
+          primary={{ label: 'Clear search', onClick: () => setSearch(''), icon: 'close' }}
+        />
       )}
 
       {phase === 'ready' &&

--- a/frontend/src/redesign/screens/settings/IntegrationsSection.tsx
+++ b/frontend/src/redesign/screens/settings/IntegrationsSection.tsx
@@ -114,8 +114,8 @@ function ServersPanel({ notify }: SectionProps) {
       </div>
 
 
-      {phase === 'loading' && <EmptyState icon="link" title="Loading integrations…" />}
-      {phase === 'error' && <EmptyState icon="alert" title="Couldn’t load MCP servers" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
+      {phase === 'loading' && <EmptyState loading icon="link" title="Loading integrations…" />}
+      {phase === 'error' && <EmptyState error icon="alert" title="Couldn’t load MCP servers" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} />}
 
       {phase === 'ready' && grouped.length === 0 && (
         <EmptyState

--- a/frontend/src/redesign/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/redesign/screens/settings/SettingsScreen.tsx
@@ -5,9 +5,10 @@
    tab set (AI Config / Integrations / Users / Auto Investigate /
    Federation / System / General / Developer).
    ============================================================ */
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { Icon, type IconName } from '../../shared/icons'
-import type { ScreenProps } from '../../shared/types'
+import type { ScreenProps, SettingsSectionKey } from '../../shared/types'
 import { useToast } from '../../shell/toast'
 import AppearanceSection from './AppearanceSection'
 import GeneralSection from './GeneralSection'
@@ -23,20 +24,8 @@ import type { SectionProps } from './types'
 
 const IS_DEV_MODE = import.meta.env.VITE_DEV_MODE === 'true'
 
-type SectionKey =
-  | 'appearance'
-  | 'ai-config'
-  | 'integrations'
-  | 'users'
-  | 'sla'
-  | 'autoinvestigate'
-  | 'federation'
-  | 'system'
-  | 'general'
-  | 'dev'
-
 interface SectionDef {
-  key: SectionKey
+  key: SettingsSectionKey
   label: string
   icon: IconName
   devOnly?: boolean
@@ -57,9 +46,17 @@ const SECTIONS: SectionDef[] = [
 ]
 
 export default function SettingsScreen({ setViewFull }: ScreenProps) {
-  const sections = SECTIONS.filter((s) => !s.devOnly || IS_DEV_MODE)
+  const sections = useMemo(() => SECTIONS.filter((s) => !s.devOnly || IS_DEV_MODE), [])
+  const [searchParams, setSearchParams] = useSearchParams()
+  const sectionParam = searchParams.get('section')
+  const sectionKeys = useMemo(() => new Set(sections.map((s) => s.key)), [sections])
+  const getSection = useCallback(
+    (value: string | null): SettingsSectionKey =>
+      value && sectionKeys.has(value as SettingsSectionKey) ? (value as SettingsSectionKey) : 'appearance',
+    [sectionKeys],
+  )
   // open on the first section (Appearance)
-  const [active, setActive] = useState<SectionKey>('appearance')
+  const [active, setActive] = useState<SettingsSectionKey>(() => getSection(sectionParam))
   // section save/test results surface through the shell-wide toast (§10) rather
   // than a settings-local banner, so feedback is consistent across the console
   const { notify } = useToast()
@@ -68,6 +65,10 @@ export default function SettingsScreen({ setViewFull }: ScreenProps) {
     setViewFull(true)
     return () => setViewFull(false)
   }, [setViewFull])
+
+  useEffect(() => {
+    setActive(getSection(sectionParam))
+  }, [getSection, sectionParam])
 
   const current = sections.find((s) => s.key === active) ?? sections[0]
   const Section = current.Component
@@ -79,7 +80,7 @@ export default function SettingsScreen({ setViewFull }: ScreenProps) {
           <button
             key={s.key}
             className={`settings-nav-item${s.key === active ? ' active' : ''}`}
-            onClick={() => setActive(s.key)}
+            onClick={() => setSearchParams({ section: s.key })}
           >
             <Icon name={s.icon} size={16} />
             <span>{s.label}</span>

--- a/frontend/src/redesign/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/redesign/screens/settings/SettingsScreen.tsx
@@ -5,7 +5,7 @@
    tab set (AI Config / Integrations / Users / Auto Investigate /
    Federation / System / General / Developer).
    ============================================================ */
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { Icon, type IconName } from '../../shared/icons'
 import type { ScreenProps, SettingsSectionKey } from '../../shared/types'
@@ -50,13 +50,12 @@ export default function SettingsScreen({ setViewFull }: ScreenProps) {
   const [searchParams, setSearchParams] = useSearchParams()
   const sectionParam = searchParams.get('section')
   const sectionKeys = useMemo(() => new Set(sections.map((s) => s.key)), [sections])
-  const getSection = useCallback(
-    (value: string | null): SettingsSectionKey =>
-      value && sectionKeys.has(value as SettingsSectionKey) ? (value as SettingsSectionKey) : 'appearance',
-    [sectionKeys],
-  )
-  // open on the first section (Appearance)
-  const [active, setActive] = useState<SettingsSectionKey>(() => getSection(sectionParam))
+  // the active section is derived straight from the URL (?section=), falling
+  // back to Appearance for a missing / unknown / dev-gated key
+  const active: SettingsSectionKey =
+    sectionParam && sectionKeys.has(sectionParam as SettingsSectionKey)
+      ? (sectionParam as SettingsSectionKey)
+      : 'appearance'
   // section save/test results surface through the shell-wide toast (§10) rather
   // than a settings-local banner, so feedback is consistent across the console
   const { notify } = useToast()
@@ -65,10 +64,6 @@ export default function SettingsScreen({ setViewFull }: ScreenProps) {
     setViewFull(true)
     return () => setViewFull(false)
   }, [setViewFull])
-
-  useEffect(() => {
-    setActive(getSection(sectionParam))
-  }, [getSection, sectionParam])
 
   const current = sections.find((s) => s.key === active) ?? sections[0]
   const Section = current.Component
@@ -80,7 +75,7 @@ export default function SettingsScreen({ setViewFull }: ScreenProps) {
           <button
             key={s.key}
             className={`settings-nav-item${s.key === active ? ' active' : ''}`}
-            onClick={() => setSearchParams({ section: s.key })}
+            onClick={() => setSearchParams({ section: s.key }, { replace: true })}
           >
             <Icon name={s.icon} size={16} />
             <span>{s.label}</span>

--- a/frontend/src/redesign/screens/workflows/WorkflowsScreen.tsx
+++ b/frontend/src/redesign/screens/workflows/WorkflowsScreen.tsx
@@ -6,7 +6,7 @@
    ============================================================ */
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { Icon } from '../../shared/icons'
-import { Popup, activateOnKey } from '../../shared/ui'
+import { EmptyState, Popup, activateOnKey } from '../../shared/ui'
 import { Markdown } from '../../shared/Markdown'
 import { AGENT_META, prettyHandle, type Workflow, type AgentTemplate } from '../../data/appData'
 import { useWorkflows, useAgents, useSkills } from './useWorkflowsData'
@@ -18,7 +18,7 @@ import type { ScreenProps } from '../../shared/types'
 
 type WfTab = 'workflows' | 'agents' | 'skills'
 
-export default function WorkflowsScreen({ openChat }: ScreenProps) {
+export default function WorkflowsScreen({ openChat, goSettings }: ScreenProps) {
   const [tab, setTab] = useState<WfTab>('workflows')
   const tabs: [WfTab, string][] = [
     ['workflows', 'Workflows'],
@@ -42,7 +42,7 @@ export default function WorkflowsScreen({ openChat }: ScreenProps) {
           ))}
         </div>
       </div>
-      {tab === 'workflows' && <WorkflowCatalog openChat={openChat} />}
+      {tab === 'workflows' && <WorkflowCatalog openChat={openChat} goSettings={goSettings} />}
       {tab === 'agents' && <AgentsTab />}
       {tab === 'skills' && <SkillsTab />}
     </>
@@ -52,7 +52,7 @@ export default function WorkflowsScreen({ openChat }: ScreenProps) {
 /* ---- shared empty/loading/error row ---- */
 function StateMsg({ children }: { children: React.ReactNode }) {
   return (
-    <div className="muted" style={{ padding: '40px 22px', textAlign: 'center' }}>
+    <div style={{ padding: '10px 22px 22px' }}>
       {children}
     </div>
   )
@@ -83,7 +83,7 @@ function AgentSequence({ agents }: { agents: string[] }) {
 /* ---------------- Workflows catalog ---------------- */
 type WfModal = { kind: 'run' | 'history' | 'edit' | 'delete' | 'details'; wf: Workflow }
 
-function WorkflowCatalog({ openChat }: { openChat: (prompt?: string) => void }) {
+function WorkflowCatalog({ openChat, goSettings }: { openChat: (prompt?: string) => void; goSettings: ScreenProps['goSettings'] }) {
   const { rows, phase, error, reload } = useWorkflows()
   const [q, setQ] = useState('')
   const [modal, setModal] = useState<WfModal | null>(null)
@@ -104,10 +104,18 @@ function WorkflowCatalog({ openChat }: { openChat: (prompt?: string) => void }) 
         <button className="btn ghost" onClick={() => setCreating('ai')}><Icon name="sparkle" /> Generate with AI</button>
         <button className="btn primary" onClick={() => setCreating('blank')}><Icon name="plus" /> New workflow</button>
       </div>
-      {phase === 'loading' && <StateMsg>Loading workflows…</StateMsg>}
-      {phase === 'error' && <StateMsg>Couldn’t load workflows: {error}</StateMsg>}
+      {phase === 'loading' && <StateMsg><EmptyState compact icon="flow" title="Loading workflows…" /></StateMsg>}
+      {phase === 'error' && <StateMsg><EmptyState icon="alert" title="Couldn’t load workflows" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></StateMsg>}
       {phase === 'ready' && list.length === 0 && (
-        <StateMsg>{q ? 'No workflows match your search.' : 'No workflows available.'}</StateMsg>
+        <StateMsg>
+          <EmptyState
+            icon={q ? 'filter' : 'flow'}
+            title={q ? 'No workflows match this search' : 'No workflows yet'}
+            body={q ? 'Clear the search to return to the workflow catalog.' : 'Create a workflow manually or generate one with AI from a plain-language investigation goal.'}
+            primary={q ? { label: 'Clear search', onClick: () => setQ(''), icon: 'close' } : { label: 'New workflow', onClick: () => setCreating('blank'), icon: 'plus' }}
+            secondary={q ? undefined : { label: 'Generate with AI', onClick: () => setCreating('ai'), icon: 'sparkle' }}
+          />
+        </StateMsg>
       )}
       {phase === 'ready' && list.length > 0 && (
         <div className="grid gap-4 px-[22px] py-5 [grid-template-columns:repeat(auto-fill,minmax(390px,1fr))]">
@@ -158,6 +166,11 @@ function WorkflowCatalog({ openChat }: { openChat: (prompt?: string) => void }) 
       {modal?.kind === 'edit' && <EditModal wf={modal.wf} onClose={close} onSaved={() => { close(); reload() }} />}
       {modal?.kind === 'delete' && <DeleteModal wf={modal.wf} onClose={close} onDeleted={() => { close(); reload() }} />}
       {creating && <WorkflowBuilder autoGenerate={creating === 'ai'} onClose={() => setCreating(null)} onSaved={() => { setCreating(null); reload() }} />}
+      {phase === 'ready' && rows.length === 0 && (
+        <div className="px-[22px] pb-5">
+          <button className="btn ghost" onClick={() => goSettings('ai-config')}><Icon name="gear" /> Configure AI models</button>
+        </div>
+      )}
     </>
   )
 }
@@ -442,9 +455,9 @@ function HistoryModal({ wf, onClose }: { wf: Workflow; onClose: () => void }) {
 
   return (
     <Popup open onClose={onClose} title={`History · ${wf.name}`} width={720}>
-      {phase === 'loading' && <div className="muted" style={{ padding: '24px 0', textAlign: 'center' }}>Loading run history…</div>}
-      {phase === 'error' && <div className="muted" style={{ padding: '24px 0', textAlign: 'center' }}>Couldn’t load history: {error}</div>}
-      {phase === 'ready' && runs.length === 0 && <div className="muted" style={{ padding: '24px 0', textAlign: 'center' }}>No runs yet for this workflow.</div>}
+      {phase === 'loading' && <EmptyState compact icon="clock" title="Loading run history…" />}
+      {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load history" body={error} />}
+      {phase === 'ready' && runs.length === 0 && <EmptyState compact icon="clock" title="No runs yet" body="Run this workflow to capture execution history, duration, trigger, and cost." />}
       {phase === 'ready' && runs.length > 0 && (
         <div className="table-wrap">
           <table className="tbl">
@@ -670,9 +683,9 @@ function AgentsTab() {
         </div>
       </div>
 
-      {phase === 'loading' && <StateMsg>Loading agents…</StateMsg>}
-      {phase === 'error' && <StateMsg>Couldn’t load agents: {error}</StateMsg>}
-      {phase === 'ready' && rows.length === 0 && <StateMsg>No agents available.</StateMsg>}
+      {phase === 'loading' && <StateMsg><EmptyState compact icon="brain" title="Loading agents…" /></StateMsg>}
+      {phase === 'error' && <StateMsg><EmptyState icon="alert" title="Couldn’t load agents" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></StateMsg>}
+      {phase === 'ready' && rows.length === 0 && <StateMsg><EmptyState icon="brain" title="No agents yet" body="Create a custom SOC agent or refresh to load built-in templates." primary={{ label: 'New agent', onClick: () => setCreating(true), icon: 'plus' }} secondary={{ label: 'Refresh', onClick: reload, icon: 'refresh' }} /></StateMsg>}
 
       {phase === 'ready' && rows.length > 0 && (
         // Two-up (Custom | Built-in) when forked copies exist; otherwise the
@@ -1101,9 +1114,9 @@ function SkillsTab() {
         </div>
       </div>
       {importErr && <div className="px-[22px] text-[12.5px]" style={{ color: 'var(--crit)' }}>Import failed: {importErr}</div>}
-      {phase === 'loading' && <StateMsg>Loading skills…</StateMsg>}
-      {phase === 'error' && <StateMsg>Couldn’t load skills: {error}</StateMsg>}
-      {phase === 'ready' && rows.length === 0 && <StateMsg>No skills available.</StateMsg>}
+      {phase === 'loading' && <StateMsg><EmptyState compact icon="sparkle" title="Loading skills…" /></StateMsg>}
+      {phase === 'error' && <StateMsg><EmptyState icon="alert" title="Couldn’t load skills" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></StateMsg>}
+      {phase === 'ready' && rows.length === 0 && <StateMsg><EmptyState icon="sparkle" title="No skills yet" body="Build or import reusable capabilities that agents and workflows can invoke." primary={{ label: 'Build skill', onClick: () => setBuilding(true), icon: 'sparkle' }} secondary={{ label: 'Import Zip', onClick: () => fileRef.current?.click(), icon: 'upload' }} /></StateMsg>}
       {phase === 'ready' && rows.length > 0 && (
         <div className="grid gap-4 px-[22px] pt-[14px] pb-6 [grid-template-columns:repeat(auto-fill,minmax(360px,1fr))]">
           {rows.map((s) => (

--- a/frontend/src/redesign/screens/workflows/WorkflowsScreen.tsx
+++ b/frontend/src/redesign/screens/workflows/WorkflowsScreen.tsx
@@ -4,7 +4,7 @@
    via useWorkflows / useAgents / useSkills, with loading / empty /
    error states. See REDESIGN_GAPS.md §9.
    ============================================================ */
-import { Fragment, useEffect, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { Icon } from '../../shared/icons'
 import { EmptyState, Popup, activateOnKey } from '../../shared/ui'
 import { Markdown } from '../../shared/Markdown'
@@ -104,8 +104,8 @@ function WorkflowCatalog({ openChat, goSettings }: { openChat: (prompt?: string)
         <button className="btn ghost" onClick={() => setCreating('ai')}><Icon name="sparkle" /> Generate with AI</button>
         <button className="btn primary" onClick={() => setCreating('blank')}><Icon name="plus" /> New workflow</button>
       </div>
-      {phase === 'loading' && <StateMsg><EmptyState compact icon="flow" title="Loading workflows…" /></StateMsg>}
-      {phase === 'error' && <StateMsg><EmptyState icon="alert" title="Couldn’t load workflows" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></StateMsg>}
+      {phase === 'loading' && <StateMsg><EmptyState loading compact icon="flow" title="Loading workflows…" /></StateMsg>}
+      {phase === 'error' && <StateMsg><EmptyState error icon="alert" title="Couldn’t load workflows" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></StateMsg>}
       {phase === 'ready' && list.length === 0 && (
         <StateMsg>
           <EmptyState
@@ -436,8 +436,10 @@ function HistoryModal({ wf, onClose }: { wf: Workflow; onClose: () => void }) {
   const [phase, setPhase] = useState<'loading' | 'ready' | 'error'>('loading')
   const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
+  const load = useCallback(() => {
     let cancelled = false
+    setPhase('loading')
+    setError(null)
     workflowApi
       .listRuns(wf.id, { limit: 50 })
       .then((res) => {
@@ -453,10 +455,12 @@ function HistoryModal({ wf, onClose }: { wf: Workflow; onClose: () => void }) {
     return () => { cancelled = true }
   }, [wf.id])
 
+  useEffect(() => load(), [load])
+
   return (
     <Popup open onClose={onClose} title={`History · ${wf.name}`} width={720}>
-      {phase === 'loading' && <EmptyState compact icon="clock" title="Loading run history…" />}
-      {phase === 'error' && <EmptyState compact icon="alert" title="Couldn’t load history" body={error} />}
+      {phase === 'loading' && <EmptyState loading compact icon="clock" title="Loading run history…" />}
+      {phase === 'error' && <EmptyState error compact icon="alert" title="Couldn’t load history" body={error} primary={{ label: 'Retry', onClick: load, icon: 'refresh' }} />}
       {phase === 'ready' && runs.length === 0 && <EmptyState compact icon="clock" title="No runs yet" body="Run this workflow to capture execution history, duration, trigger, and cost." />}
       {phase === 'ready' && runs.length > 0 && (
         <div className="table-wrap">
@@ -683,8 +687,8 @@ function AgentsTab() {
         </div>
       </div>
 
-      {phase === 'loading' && <StateMsg><EmptyState compact icon="brain" title="Loading agents…" /></StateMsg>}
-      {phase === 'error' && <StateMsg><EmptyState icon="alert" title="Couldn’t load agents" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></StateMsg>}
+      {phase === 'loading' && <StateMsg><EmptyState loading compact icon="brain" title="Loading agents…" /></StateMsg>}
+      {phase === 'error' && <StateMsg><EmptyState error icon="alert" title="Couldn’t load agents" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></StateMsg>}
       {phase === 'ready' && rows.length === 0 && <StateMsg><EmptyState icon="brain" title="No agents yet" body="Create a custom SOC agent or refresh to load built-in templates." primary={{ label: 'New agent', onClick: () => setCreating(true), icon: 'plus' }} secondary={{ label: 'Refresh', onClick: reload, icon: 'refresh' }} /></StateMsg>}
 
       {phase === 'ready' && rows.length > 0 && (
@@ -1114,8 +1118,8 @@ function SkillsTab() {
         </div>
       </div>
       {importErr && <div className="px-[22px] text-[12.5px]" style={{ color: 'var(--crit)' }}>Import failed: {importErr}</div>}
-      {phase === 'loading' && <StateMsg><EmptyState compact icon="sparkle" title="Loading skills…" /></StateMsg>}
-      {phase === 'error' && <StateMsg><EmptyState icon="alert" title="Couldn’t load skills" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></StateMsg>}
+      {phase === 'loading' && <StateMsg><EmptyState loading compact icon="sparkle" title="Loading skills…" /></StateMsg>}
+      {phase === 'error' && <StateMsg><EmptyState error icon="alert" title="Couldn’t load skills" body={error} primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }} /></StateMsg>}
       {phase === 'ready' && rows.length === 0 && <StateMsg><EmptyState icon="sparkle" title="No skills yet" body="Build or import reusable capabilities that agents and workflows can invoke." primary={{ label: 'Build skill', onClick: () => setBuilding(true), icon: 'sparkle' }} secondary={{ label: 'Import Zip', onClick: () => fileRef.current?.click(), icon: 'upload' }} /></StateMsg>}
       {phase === 'ready' && rows.length > 0 && (
         <div className="grid gap-4 px-[22px] pt-[14px] pb-6 [grid-template-columns:repeat(auto-fill,minmax(360px,1fr))]">

--- a/frontend/src/redesign/shared/types.ts
+++ b/frontend/src/redesign/shared/types.ts
@@ -1,8 +1,31 @@
 /* Shared contract every redesign screen component implements. */
+import type { ScreenKey } from '../data/data'
+
+export type SettingsSectionKey =
+  | 'appearance'
+  | 'ai-config'
+  | 'integrations'
+  | 'users'
+  | 'sla'
+  | 'autoinvestigate'
+  | 'federation'
+  | 'system'
+  | 'general'
+  | 'dev'
+
+export interface ScreenGoOptions {
+  search?: string
+  replace?: boolean
+}
+
 export interface ScreenProps {
   /** open the Vigil chat dock; pass a prompt to auto-send it (used by
       "investigate with Vigil" affordances) */
   openChat: (prompt?: string) => void
+  /** navigate within the redesign shell */
+  go: (screen: ScreenKey, options?: ScreenGoOptions) => void
+  /** navigate to a concrete Settings section */
+  goSettings: (section: SettingsSectionKey) => void
   /** tell the shell this screen wants the full-height, non-scrolling view
       (used by the cases / decisions master-detail split layouts) */
   setViewFull: (full: boolean) => void

--- a/frontend/src/redesign/shared/ui.tsx
+++ b/frontend/src/redesign/shared/ui.tsx
@@ -36,6 +36,8 @@ export function EmptyState({
   secondary,
   compact = false,
   table = false,
+  loading = false,
+  error = false,
 }: {
   icon?: IconName
   title: ReactNode
@@ -44,9 +46,17 @@ export function EmptyState({
   secondary?: { label: ReactNode; onClick: () => void; icon?: IconName }
   compact?: boolean
   table?: boolean
+  /** announce as a live region so screen readers hear the transition
+   *  (REDESIGN_GAPS.md §10): `loading` → polite status, `error` → assertive alert */
+  loading?: boolean
+  error?: boolean
 }) {
   const content = (
-    <div className={`empty-state${compact ? ' compact' : ''}`}>
+    <div
+      className={`empty-state${compact ? ' compact' : ''}`}
+      role={loading ? 'status' : error ? 'alert' : undefined}
+      aria-live={loading ? 'polite' : error ? 'assertive' : undefined}
+    >
       <div className="empty-state-icon"><Icon name={icon} size={compact ? 18 : 24} /></div>
       <div className="empty-state-copy">
         <h3>{title}</h3>
@@ -56,19 +66,21 @@ export function EmptyState({
         <div className="empty-state-actions">
           {secondary && (
             <button className="btn ghost" onClick={secondary.onClick}>
-              {secondary.icon && <Icon name={secondary.icon} />} {secondary.label}
+              {secondary.icon && <Icon name={secondary.icon} />}
+              {secondary.label}
             </button>
           )}
           {primary && (
             <button className="btn primary" onClick={primary.onClick}>
-              {primary.icon && <Icon name={primary.icon} />} {primary.label}
+              {primary.icon && <Icon name={primary.icon} />}
+              {primary.label}
             </button>
           )}
         </div>
       )}
     </div>
   )
-  return table ? <div className="empty-state-table">{content}</div> : content
+  return table ? <div className={`empty-state-table${compact ? ' compact' : ''}`}>{content}</div> : content
 }
 
 /* ---------------- Popup (modal dialog) ---------------- */

--- a/frontend/src/redesign/shared/ui.tsx
+++ b/frontend/src/redesign/shared/ui.tsx
@@ -15,7 +15,7 @@ import {
   type ReactNode,
 } from 'react'
 import { createPortal } from 'react-dom'
-import { Icon } from './icons'
+import { Icon, type IconName } from './icons'
 
 /** Enter/Space → activate. For non-button elements given `role="button"` or
  *  `role="switch"` so they stay keyboard-operable (REDESIGN_GAPS.md §10). */
@@ -26,6 +26,49 @@ export function activateOnKey(fn: () => void) {
       fn()
     }
   }
+}
+
+export function EmptyState({
+  icon = 'info',
+  title,
+  body,
+  primary,
+  secondary,
+  compact = false,
+  table = false,
+}: {
+  icon?: IconName
+  title: ReactNode
+  body?: ReactNode
+  primary?: { label: ReactNode; onClick: () => void; icon?: IconName }
+  secondary?: { label: ReactNode; onClick: () => void; icon?: IconName }
+  compact?: boolean
+  table?: boolean
+}) {
+  const content = (
+    <div className={`empty-state${compact ? ' compact' : ''}`}>
+      <div className="empty-state-icon"><Icon name={icon} size={compact ? 18 : 24} /></div>
+      <div className="empty-state-copy">
+        <h3>{title}</h3>
+        {body && <p>{body}</p>}
+      </div>
+      {(primary || secondary) && (
+        <div className="empty-state-actions">
+          {secondary && (
+            <button className="btn ghost" onClick={secondary.onClick}>
+              {secondary.icon && <Icon name={secondary.icon} />} {secondary.label}
+            </button>
+          )}
+          {primary && (
+            <button className="btn primary" onClick={primary.onClick}>
+              {primary.icon && <Icon name={primary.icon} />} {primary.label}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+  return table ? <div className="empty-state-table">{content}</div> : content
 }
 
 /* ---------------- Popup (modal dialog) ---------------- */

--- a/frontend/src/redesign/styles.css
+++ b/frontend/src/redesign/styles.css
@@ -1240,6 +1240,76 @@
       color: var(--tx-3);
    }
 
+   .empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      min-height: 190px;
+      padding: 28px 24px;
+      text-align: center;
+      color: var(--tx-2);
+   }
+
+   .empty-state.compact {
+      min-height: 96px;
+      padding: 18px 16px;
+      gap: 9px;
+   }
+
+   .empty-state-table {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 160px;
+   }
+
+   .empty-state-icon {
+      display: grid;
+      place-items: center;
+      width: 46px;
+      height: 46px;
+      border: 1px solid var(--line-soft);
+      border-radius: 10px;
+      background: var(--bg-2);
+      color: var(--accent-2);
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,.02);
+   }
+
+   .empty-state.compact .empty-state-icon {
+      width: 34px;
+      height: 34px;
+      border-radius: 8px;
+   }
+
+   .empty-state-copy {
+      max-width: 520px;
+   }
+
+   .empty-state-copy h3 {
+      margin: 0;
+      font-size: 14.5px;
+      font-weight: 650;
+      color: var(--tx);
+   }
+
+   .empty-state-copy p {
+      margin: 5px 0 0;
+      font-size: 13px;
+      line-height: 1.5;
+      color: var(--tx-3);
+   }
+
+   .empty-state-actions {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 9px;
+      flex-wrap: wrap;
+      margin-top: 2px;
+   }
+
    /* ---------- charts ---------- */
    .chart-grid {
       display: grid;

--- a/frontend/src/redesign/styles.css
+++ b/frontend/src/redesign/styles.css
@@ -1265,6 +1265,12 @@
       min-height: 160px;
    }
 
+   /* compact in-table rows (loading / linked-list empties) size to their
+      content instead of the full 160px block */
+   .empty-state-table.compact {
+      min-height: 0;
+   }
+
    .empty-state-icon {
       display: grid;
       place-items: center;
@@ -4420,49 +4426,14 @@
       gap: 18px;
    }
 
+   /* full-height wrapper so the Entity Graph tab centres its EmptyState;
+      the EmptyState primitive owns the icon/copy styling */
    .entity-empty {
       display: flex;
-      flex-direction: column;
       align-items: center;
       justify-content: center;
-      gap: 16px;
-      text-align: center;
       min-height: calc(100vh - 180px);
       padding: 40px;
-   }
-
-   .entity-empty .ee-graphic svg {
-      width: 220px;
-      height: 150px;
-   }
-
-   .entity-empty .ee-graphic line {
-      stroke: var(--line);
-      stroke-width: 1.5;
-   }
-
-   .entity-empty .ee-graphic circle {
-      fill: var(--bg-2);
-      stroke: var(--tx-faint);
-      stroke-width: 1.5;
-   }
-
-   .entity-empty .ee-graphic circle.n-core {
-      fill: var(--accent-dim);
-      stroke: var(--accent);
-      stroke-width: 2;
-   }
-
-   .entity-empty h3 {
-      font-size: 19px;
-   }
-
-   .entity-empty p {
-      font-size: 13.5px;
-      color: var(--tx-3);
-      max-width: 440px;
-      line-height: 1.55;
-      margin: -4px 0 6px;
    }
 
    /* ---------- Timeline tab ---------- */


### PR DESCRIPTION
## Summary
- add a shared redesign EmptyState primitive with compact/table variants and action buttons
- make redesign settings URL-addressable with section= deep links and shared navigation helpers
- replace blank/error/no-results states across Dashboard, Cases, Workflows, Auto Ops, Analytics, Metrics, Decisions, and key Settings sections

## Verification
- npm run build passes
- targeted ESLint on touched redesign files passes with one pre-existing fast-refresh warning in shared/ui.tsx
- git diff --check passes
- npm run lint still fails on pre-existing repo-wide lint errors outside this PR, including legacy unused variables and unused eslint-disable directives