### PR TITLE
fix(logs): don't crash backend when logs dir isn't writable (#376)

### DIFF
--- a/backend/api/logs.py
+++ b/backend/api/logs.py
@@ -1,10 +1,11 @@
 """Frontend logging endpoint."""
 
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
-from typing import Optional, Any, Dict
-from datetime import datetime
 import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
 
 router = APIRouter()
 
@@ -12,28 +13,36 @@ router = APIRouter()
 frontend_logger = logging.getLogger('frontend')
 frontend_logger.setLevel(logging.DEBUG)
 
-# Create file handler if not already configured
+# Resolve the frontend log file path.
+log_file = Path("logs") / "frontend-app.log"
+
+# Configure a handler if not already configured. This runs at import time,
+# so it must never raise: a non-writable working directory (e.g. a
+# read-only or non-root container filesystem) previously crashed the whole
+# backend on startup with PermissionError (issue #376). Fall back to a
+# console handler if the log file cannot be created.
 if not frontend_logger.handlers:
-    from pathlib import Path
-    
-    # Ensure logs directory exists
-    log_dir = Path("logs")
-    log_dir.mkdir(exist_ok=True)
-    
-    # Create file handler
-    file_handler = logging.FileHandler(log_dir / "frontend-app.log")
-    file_handler.setLevel(logging.DEBUG)
-    
-    # Create formatter
     formatter = logging.Formatter(
         '%(asctime)s - %(levelname)s - %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S'
     )
-    file_handler.setFormatter(formatter)
-    
-    # Add handler to logger
-    frontend_logger.addHandler(file_handler)
-    
+
+    try:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        handler: logging.Handler = logging.FileHandler(log_file)
+    except OSError as exc:
+        # Directory not writable (or similar) — degrade gracefully to
+        # the console instead of taking down the process on import.
+        logging.getLogger(__name__).warning(
+            "Frontend file logging disabled, falling back to console: %s",
+            exc,
+        )
+        handler = logging.StreamHandler()
+
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(formatter)
+    frontend_logger.addHandler(handler)
+
     # Don't propagate to root logger (avoid duplicate logs)
     frontend_logger.propagate = False
 
@@ -92,10 +101,6 @@ async def log_frontend(entry: FrontendLogEntry):
 @router.get("/frontend/status")
 async def get_frontend_log_status():
     """Check if frontend logging is working."""
-    from pathlib import Path
-    
-    log_file = Path("logs/frontend-app.log")
-    
     return {
         "enabled": True,
         "log_file": str(log_file),


### PR DESCRIPTION
## Problem

Fixes #376.

After upgrading to `0.3.0`, `vigil-backend` pods crash-loop on startup with:

```
File "/app/backend/api/logs.py", line 21, in <module>
    log_dir.mkdir(exist_ok=True)
PermissionError: [Errno 13] Permission denied: 'logs'
```

`backend/api/logs.py` created a relative `logs/` directory and a
`FileHandler` **at import time**. On a non-root / read-only container
filesystem the working directory isn't writable, so `mkdir` raised
`PermissionError`. Because this happens during module import, it
propagates through `backend/api/__init__.py` and takes down the entire
backend — nothing after the import ever runs.

(The `gin_trgm_ops` / `custom_agents` messages earlier in the issue log
are pre-existing, non-fatal noise; the `PermissionError` is what
actually kills the process.)

## Fix

Scoped to the single file that causes the crash:

- Wrap the handler setup so it **never raises** at import time. If the
  log directory/file can't be created, fall back to a console
  `StreamHandler` and emit a warning instead of crashing. In a container
  this means frontend logs simply go to stdout, which is the desired
  behavior there anyway.

No new config, no schema/Helm changes — just the import-time crash.

## Testing

Imported the module with the working directory set to a read-only
(`0555`) directory to simulate the failing container scenario:

- **Non-writable cwd** → imports cleanly, logs a warning, attaches a
  `StreamHandler` (no crash).
- **Writable cwd** → imports cleanly, creates `logs/`, attaches a
  `FileHandler` (unchanged dev behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)