### PR TITLE
fix(scripts): correct daemon frontend.pid path

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -142,8 +142,13 @@ else
     echo $! > logs/daemon.pid
 
     if [ "$SKIP_FRONTEND" -eq 0 ] && [ -d "frontend/node_modules" ]; then
-        (cd frontend && nohup npm run dev > ../logs/frontend.log 2>&1 &
-         echo $! > ../logs/frontend.pid)
+        # Absolute log dir: the `cd frontend` only applies inside the
+        # backgrounded (&) job, not the subsequent `echo`, which still runs
+        # from the repo root — so a relative ../logs there pointed above the
+        # repo and failed. Anchor both writes to the repo-root logs dir.
+        logs_dir="${PWD}/logs"
+        (cd frontend && nohup npm run dev > "${logs_dir}/frontend.log" 2>&1 &
+         echo $! > "${logs_dir}/frontend.pid")
     fi
 
     print_ready


### PR DESCRIPTION
## Summary

`./start.sh --daemon` failed with `../logs/frontend.pid: No such file or directory`, aborting the frontend launch. The backend and daemon still came up (they're `nohup`'d), so the failure was easy to miss.

## Root cause

In the daemon branch, the frontend launcher backgrounds the entire `cd frontend && nohup npm run dev …` list with `&`, so the `cd` only takes effect inside that background subshell. The subsequent `echo $! > ../logs/frontend.pid` runs from the repo root, where `../logs` resolves *above* the repo and does not exist. Introduced by #362 ("slim start scripts"), which switched the launcher from `npm --prefix frontend run dev` (cwd-agnostic) to the `cd frontend` form.

## Fix

Anchor both the log and PID writes to an absolute repo-root `logs/` directory, so they no longer depend on the current working directory.

## Scope

Only the `--daemon` path was affected — the foreground path (`start_frontend()`) keeps the PID in a shell variable and never writes `../logs/…`.

## Testing

- `bash -n start.sh` passes.
- Reproduced under `bash` (matching the `#!/bin/bash` shebang): the old relative-path construct fails with the exact error above; the fixed absolute-path construct writes `logs/frontend.pid` correctly.