### PR TITLE
ci: skip pipeline jobs on forks to stop failure-notification spam

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,6 +19,11 @@ jobs:
   # ============================================================================
   lint-backend:
     name: Lint Backend
+    # Canonical repo only. Forks can't run this pipeline (private submodules +
+    # missing secrets) so pushes to a fork's main/develop just email the owner
+    # a failure. For pull_request events github.repository is the BASE repo, so
+    # contributor PRs against Vigil-SOC/vigil still run CI as normal.
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -54,6 +59,7 @@ jobs:
 
   lint-frontend:
     name: Lint Frontend
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -76,6 +82,7 @@ jobs:
 
   lint-docker:
     name: Lint Dockerfiles
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -92,6 +99,7 @@ jobs:
   # ============================================================================
   test-unit-backend:
     name: Unit Tests - Backend
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -129,6 +137,7 @@ jobs:
 
   test-unit-frontend:
     name: Unit Tests - Frontend
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -154,6 +163,7 @@ jobs:
   # ============================================================================
   test-integration:
     name: Integration Tests
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -224,6 +234,7 @@ jobs:
   # ============================================================================
   test-unit-backend-db:
     name: Unit Tests - Backend (DB-backed)
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -282,6 +293,7 @@ jobs:
   # ============================================================================
   security-scan-python:
     name: Security Scan - Python
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -308,6 +320,7 @@ jobs:
 
   security-scan-npm:
     name: Security Scan - NPM
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -396,7 +409,7 @@ jobs:
     name: Build Frontend
     runs-on: ubuntu-latest
     needs: [lint-frontend]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'Vigil-SOC/vigil'
     steps:
       - uses: actions/checkout@v5
       

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,11 @@ jobs:
   # ============================================================================
   full-test-suite:
     name: Full Test Suite
+    # Canonical repo only. Scheduled workflows run on the default branch of any
+    # fork with Actions enabled, but forks lack the private submodules + secrets
+    # this suite needs, so a nightly run just emails the fork owner a failure.
+    # Skipping (not failing) keeps forks quiet.
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -64,6 +69,7 @@ jobs:
   # ============================================================================
   performance-tests:
     name: Performance Regression Tests
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -95,6 +101,7 @@ jobs:
   # ============================================================================
   security-audit:
     name: Security Audit
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -123,6 +130,7 @@ jobs:
   # ============================================================================
   migration-tests:
     name: Database Migration Tests
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -166,7 +174,7 @@ jobs:
     name: Notify Results
     runs-on: ubuntu-latest
     needs: [full-test-suite, performance-tests, security-audit]
-    if: failure()
+    if: failure() && github.repository == 'Vigil-SOC/vigil'
     steps:
       - name: Notify Slack
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,10 @@ concurrency:
 
 jobs:
   release-please:
+    # Only run on the canonical repo. Forks lack the release-please GitHub
+    # App vars/secrets below, so this job would fail on every push to their
+    # main and email the fork owner. Skipping (not failing) keeps forks quiet.
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
   # ---------------------------------------------------------------------------
   version:
     name: Resolve version
+    # Canonical repo only. This pipeline pushes to ghcr.io/vigil-soc and needs
+    # org packages permissions a fork can't use; skipping keeps forks quiet if
+    # a vX.Y.Z tag is ever pushed in one.
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.v.outputs.version }}
@@ -48,6 +52,7 @@ jobs:
   # ---------------------------------------------------------------------------
   build-backend:
     name: Build backend image
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     needs: [version]
     permissions:
@@ -114,6 +119,7 @@ jobs:
   # ---------------------------------------------------------------------------
   build-daemon:
     name: Build daemon image
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -173,6 +179,7 @@ jobs:
   # ---------------------------------------------------------------------------
   smoke-test:
     name: Smoke test images
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     needs: [version, build-backend, build-daemon]
     permissions:
@@ -214,6 +221,7 @@ jobs:
   # ---------------------------------------------------------------------------
   update-release:
     name: Annotate GitHub Release
+    if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
     needs: [version, smoke-test]
     permissions:


### PR DESCRIPTION
## Problem
Fork owners (and teammates who fork Vigil to their own accounts) get a GitHub failure email on essentially every commit and merge. The failures come from the forks, not `Vigil-SOC/vigil` itself: the pipeline needs org secrets/vars (the release-please GitHub App, `CLAUDEAPI`) and private submodules a fork can't access, so the workflows fail there and GitHub emails whoever pushed.
## Fix
Guard every fork-hostile job with `if: github.repository == 'Vigil-SOC/vigil'` so it **skips** in forks instead of failing. GitHub does not send failure notifications for skipped jobs.
- **`release-please.yml`** — the `release-please` job (fires on every push to `main`; the main "every merge" source).
- **`release.yml`** — all 5 jobs (only triggers on `vX.Y.Z` tags, but this keeps a stray fork tag from hitting GHCR).
- **`ci-cd.yml`** — all 9 active lint/test/security jobs + `build-frontend` (combined with its existing `push` condition). `build-images`/`scan-images` were already `if: false` and left untouched.
## Why it's safe
- **Upstream unaffected** — on `Vigil-SOC/vigil` the condition is always true, so the real pipeline (and any required status checks on branch protection) runs exactly as before.
- **Contributor PRs still run** — for `pull_request` events the context repo is the *base* repo, so a fork→upstream PR evaluates as `Vigil-SOC/vigil` and CI runs normally.
- **Forks go quiet** — a push to a fork evaluates as `<owner>/vigil`, so the jobs skip and no email is sent.
## Notes
- This is forward-looking: a teammate whose fork *already* has Actions enabled keeps getting runs until they pull this change (or flip Settings → Actions → "Disable actions" on their fork for immediate relief).