### PR TITLE
Improve manual upload settings UX

### DIFF
--- a/backend/api/ingestion.py
+++ b/backend/api/ingestion.py
@@ -5,7 +5,7 @@ Handles uploading and ingesting findings/cases from various file formats:
 - JSON files
 - CSV files
 - JSONL (JSON Lines) files
-- Parquet files (DeepTempo LogLM embeddings)
+- Parquet files
 - S3 sync
 """
 
@@ -296,7 +296,7 @@ async def get_supported_formats():
             "parquet": {
                 "name": "Parquet",
                 "extensions": [".parquet"],
-                "description": "DeepTempo LogLM embedding parquet files. Columns are auto-mapped to findings.",
+                "description": "Supported parquet files. Columns are auto-mapped to findings when the schema is recognized.",
                 "expected_columns": [
                     "sequence_id (-> finding_id)",
                     "embedding (variable-dimension float vector)",
@@ -399,7 +399,7 @@ async def sync_s3_folder(prefix: Optional[str] = Query(None)):
 
     Scans the given prefix (or the configured parquet_prefix) and auto-detects
     file types by extension:
-      .parquet -> DeepTempo LogLM parquet ingestion
+      .parquet -> supported parquet ingestion
       .csv     -> CSV finding ingestion
       .json    -> JSON finding/case ingestion
       .jsonl / .ndjson -> JSON-Lines finding ingestion
@@ -706,4 +706,3 @@ async def get_s3_status():
             "connected": False,
             "error": str(e)
         }
-

--- a/frontend/src/redesign/screens/settings/DataIngestion.tsx
+++ b/frontend/src/redesign/screens/settings/DataIngestion.tsx
@@ -1,6 +1,6 @@
 /* ============================================================
-   Settings · Integrations · Data Ingestion — first-party ingest
-   sources: S3 (config + browse/ingest + local upload), Kafka
+   Settings · Integrations · Manual Upload — first-party ingest
+   sources: local upload, S3 (config + browse/ingest), Kafka
    (consumer config + live stats), Darktrace (webhook receiver).
    Mirrors the S3 dialog, KafkaTab, and Darktrace dialog from the
    legacy Integrations tab.
@@ -36,10 +36,57 @@ function formatFileSize(bytes: number): string {
 export default function DataIngestionPanel({ notify }: SectionProps) {
   return (
     <div className="flex flex-col gap-4" style={{ maxWidth: 920 }}>
+      <ManualUploadPanel notify={notify} />
       <S3Panel notify={notify} />
       <KafkaPanel notify={notify} />
       <DarktracePanel notify={notify} />
     </div>
+  )
+}
+
+/* ---------------- Manual upload ---------------- */
+function ManualUploadPanel({ notify }: SectionProps) {
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [upload, setUpload] = useState<File | null>(null)
+  const [uploading, setUploading] = useState(false)
+
+  const doUpload = async () => {
+    if (!upload) return
+    setUploading(true)
+    try {
+      const res = await ingestionApi.uploadFile(upload)
+      notify(res.data.success ? 'ok' : 'err', res.data.message || 'Upload complete.')
+      if (res.data.success) setUpload(null)
+    } catch (e) {
+      notify('err', (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail || 'Upload failed.')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <SettingsCard
+      title="Manual Upload"
+      desc="Upload a local file directly into Vigil."
+    >
+      <div className="flex items-center gap-2.5 flex-wrap">
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".parquet,.csv,.json,.jsonl,.ndjson"
+          className="hidden"
+          onChange={(e) => setUpload(e.target.files?.[0] || null)}
+        />
+        <button className="btn ghost" onClick={() => fileRef.current?.click()}>
+          <Icon name="paperclip" /> {upload ? upload.name : 'Choose File'}
+        </button>
+        {upload && <span className="text-xs text-tx-3">{formatFileSize(upload.size)}</span>}
+        <button className="btn primary" disabled={!upload || uploading} onClick={doUpload}>
+          <Icon name="upload" /> {uploading ? 'Uploading...' : 'Upload'}
+        </button>
+      </div>
+      <p className="text-xs text-tx-3 mt-1.5">Allowed file types: .parquet, .csv, .json, .jsonl, .ndjson.</p>
+    </SettingsCard>
   )
 }
 
@@ -63,11 +110,6 @@ function S3Panel({ notify }: SectionProps) {
   const [ingesting, setIngesting] = useState(false)
   const [progress, setProgress] = useState({ done: 0, total: 0 })
   const [results, setResults] = useState<{ key: string; success: boolean; message: string }[]>([])
-
-  // upload
-  const fileRef = useRef<HTMLInputElement>(null)
-  const [upload, setUpload] = useState<File | null>(null)
-  const [uploading, setUploading] = useState(false)
 
   if (phase === 'loading') return <SettingsCard title="S3 Storage" desc=""><div className="text-sm text-tx-3 py-6 text-center">Loading…</div></SettingsCard>
   if (phase === 'error') {
@@ -145,24 +187,10 @@ function S3Panel({ notify }: SectionProps) {
     notify(ok === keys.length ? 'ok' : 'err', `Ingested ${ok}/${keys.length} file(s).`)
   }
 
-  const doUpload = async () => {
-    if (!upload) return
-    setUploading(true)
-    try {
-      const res = await ingestionApi.uploadFile(upload)
-      notify(res.data.success ? 'ok' : 'err', res.data.message || 'Upload complete.')
-      if (res.data.success) setUpload(null)
-    } catch (e) {
-      notify('err', (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail || 'Upload failed.')
-    } finally {
-      setUploading(false)
-    }
-  }
-
   return (
     <SettingsCard
       title="S3 Storage"
-      desc="AWS S3 bucket for parquet ingest, browsing, and local file uploads."
+      desc="AWS S3 bucket for browsing and ingesting supported files."
       actions={
         <button className="btn primary" onClick={onSave} disabled={saving}>
           <Icon name="check2" /> {saving ? 'Saving…' : 'Save'}
@@ -275,28 +303,6 @@ function S3Panel({ notify }: SectionProps) {
             )}
           </div>
         )}
-      </div>
-
-      {/* Upload local file */}
-      <div className="mt-5 pt-5 border-t border-line-soft">
-        <h4 className="text-[11px] font-semibold tracking-[0.06em] uppercase text-tx-3 mb-2.5">Upload Local File</h4>
-        <div className="flex items-center gap-2.5 flex-wrap">
-          <input
-            ref={fileRef}
-            type="file"
-            accept=".csv,.parquet,.json,.jsonl"
-            className="hidden"
-            onChange={(e) => setUpload(e.target.files?.[0] || null)}
-          />
-          <button className="btn ghost" onClick={() => fileRef.current?.click()}>
-            <Icon name="paperclip" /> {upload ? upload.name : 'Choose File'}
-          </button>
-          {upload && <span className="text-xs text-tx-3">{formatFileSize(upload.size)}</span>}
-          <button className="btn primary" disabled={!upload || uploading} onClick={doUpload}>
-            <Icon name="upload" /> {uploading ? 'Uploading…' : 'Upload'}
-          </button>
-        </div>
-        <p className="text-xs text-tx-3 mt-1.5">Accepts CSV, Parquet, JSON, or JSONL finding exports.</p>
       </div>
 
       <ConfirmDialog

--- a/frontend/src/redesign/screens/settings/IntegrationsSection.tsx
+++ b/frontend/src/redesign/screens/settings/IntegrationsSection.tsx
@@ -3,7 +3,7 @@
    with search, summary chips, status indicators, and enable/disable
    toggles (with revert-on-failed-connect), per-server credential
    wizard + "Not Configured" state, docs links, the custom-integration
-   builder, plus Data Ingestion and Detection Rules sub-tabs. Full
+   builder, plus Manual Upload and Detection Rules sub-tabs. Full
    parity with the legacy Integrations tab.
    ============================================================ */
 import { useMemo, useState } from 'react'
@@ -28,7 +28,7 @@ import type { SectionProps } from './types'
 type IntegrationsTab = 'servers' | 'ingestion' | 'detection'
 const TABS: [IntegrationsTab, string][] = [
   ['servers', 'MCP Servers'],
-  ['ingestion', 'Data Ingestion'],
+  ['ingestion', 'Manual Upload'],
   ['detection', 'Detection Rules'],
 ]
 

--- a/frontend/src/redesign/screens/settings/IntegrationsSection.tsx
+++ b/frontend/src/redesign/screens/settings/IntegrationsSection.tsx
@@ -30,7 +30,7 @@ import type { SectionProps } from './types'
 type IntegrationsTab = 'servers' | 'ingestion' | 'detection'
 const TABS: [IntegrationsTab, string][] = [
   ['servers', 'Connectors'],
-  ['ingestion', 'Data Ingestion'],
+  ['ingestion', 'Manual Upload'],
   ['detection', 'Detection Rules'],
 ]
 


### PR DESCRIPTION
## Summary
- rename the redesigned Settings ingestion tab to Manual Upload
- move local uploads into a first-class Manual Upload card above S3
- show supported local upload extensions and neutralize parquet ingestion copy

## Validation
- python3 -m py_compile backend/api/ingestion.py
- git diff --check
- npm run build