### PR TITLE
feat: add local Ollama recovery settings

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional, List
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pathlib import Path
 import json
 import logging
@@ -1140,6 +1140,9 @@ class AIOperationsSettingsConfig(BaseModel):
     history_window: int = 20
     tool_response_budget_default: int = 8000
     thinking_budget: int = 10000
+    local_ollama_recovery_enabled: bool = True
+    local_ollama_recovery_retry_limit: int = Field(default=1, ge=0, le=3)
+    local_ollama_recovery_restart_gateway: bool = True
 
 
 AI_OPERATIONS_DEFAULTS = AIOperationsSettingsConfig().model_dump()

--- a/env.example
+++ b/env.example
@@ -578,6 +578,13 @@ OLLAMA_ENABLED="false"
 OLLAMA_URL="http://localhost:11434"
 OLLAMA_DEFAULT_MODEL="llama3.1:70b"
 
+# Local-only resilience for Ollama-backed finding enrichment. The Settings UI
+# overrides these defaults at runtime when PostgreSQL is available. They are
+# ignored outside a host-run DEV_MODE server with loopback Bifrost.
+LOCAL_OLLAMA_RECOVERY_ENABLED="true"
+LOCAL_OLLAMA_RECOVERY_RETRY_LIMIT="1"
+LOCAL_OLLAMA_RECOVERY_RESTART_GATEWAY="true"
+
 # OpenAI (direct API or OpenAI-compatible endpoint)
 OPENAI_ENABLED="false"
 OPENAI_API_KEY=""

--- a/frontend/src/redesign/screens/settings/AiConfigSection.tsx
+++ b/frontend/src/redesign/screens/settings/AiConfigSection.tsx
@@ -410,8 +410,8 @@ function OperationsPanel({ notify }: SectionProps) {
 
   return (
     <SettingsCard
-      title="AI Operations (Cost & Performance)"
-      desc="Runtime toggles for Anthropic prompt caching, conversation history windowing, tool-response truncation, and the daemon's default thinking budget. Persist in the DB and take effect across backend / daemon / llm-worker within ~60s."
+      title="AI Operations (Cost, Performance & Local Recovery)"
+      desc="Runtime controls for model performance and for self-healing local Ollama enrichment. These settings persist in the DB and take effect without a service restart."
       actions={
         <button className="btn ghost" onClick={() => { setSettings(AI_OPS_DEFAULTS); persist(AI_OPS_DEFAULTS) }}>
           <Icon name="refresh" /> Reset to defaults
@@ -428,6 +428,25 @@ function OperationsPanel({ notify }: SectionProps) {
         {numField('history_window', 'History window (turns)', '20 turns ≈ 40 messages. 0 disables.', 0, 200)}
         {numField('tool_response_budget_default', 'Tool-result budget (tokens)', 'Default truncation budget for tool results.', 500, 60000)}
         {numField('thinking_budget', 'Daemon thinking budget (tokens)', 'Default extended-thinking budget for the daemon.', 500, 32000)}
+      </div>
+      <div className="mt-5" style={{ paddingTop: 16, borderTop: '1px solid var(--line)' }}>
+        <h4 style={{ margin: '0 0 10px', fontSize: 12, letterSpacing: '0.04em' }}>Local Ollama enrichment recovery</h4>
+        <ToggleRow
+          label="Automatically retry local AI enrichment"
+          hint="When a local Ollama enrichment request loses the Bifrost connection, retry it in the background. This only applies to local Ollama; cloud providers are never retried here."
+          checked={settings.local_ollama_recovery_enabled}
+          onChange={(v) => { const next = { ...settings, local_ollama_recovery_enabled: v }; setSettings(next); persist(next) }}
+        />
+        <ToggleRow
+          label="Restart the local AI gateway when unavailable"
+          hint="If Bifrost is unhealthy, restart the local gateway before retrying. Disable this to retry only when the gateway is already healthy."
+          checked={settings.local_ollama_recovery_restart_gateway}
+          disabled={!settings.local_ollama_recovery_enabled}
+          onChange={(v) => { const next = { ...settings, local_ollama_recovery_restart_gateway: v }; setSettings(next); persist(next) }}
+        />
+        <div className="settings-grid-2 mt-4" style={{ gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 2fr)' }}>
+          {numField('local_ollama_recovery_retry_limit', 'Retry attempts', 'Retries after the first failed request. 0 disables retries.', 0, 3)}
+        </div>
       </div>
     </SettingsCard>
   )

--- a/frontend/src/redesign/screens/settings/useSettings.ts
+++ b/frontend/src/redesign/screens/settings/useSettings.ts
@@ -606,6 +606,9 @@ export interface AIOperationsSettings {
   history_window: number
   tool_response_budget_default: number
   thinking_budget: number
+  local_ollama_recovery_enabled: boolean
+  local_ollama_recovery_retry_limit: number
+  local_ollama_recovery_restart_gateway: boolean
 }
 
 export const AI_OPS_DEFAULTS: AIOperationsSettings = {
@@ -613,6 +616,9 @@ export const AI_OPS_DEFAULTS: AIOperationsSettings = {
   history_window: 20,
   tool_response_budget_default: 8000,
   thinking_budget: 10000,
+  local_ollama_recovery_enabled: true,
+  local_ollama_recovery_retry_limit: 1,
+  local_ollama_recovery_restart_gateway: true,
 }
 
 export function useAiOperations() {

--- a/services/runtime_config.py
+++ b/services/runtime_config.py
@@ -1,13 +1,13 @@
 """Runtime-editable AI operations settings (GH #84 PR-F).
 
-The four cost/perf toggles introduced across PR-C and PR-D —
-``prompt_cache_enabled``, ``history_window``, ``tool_response_budget_default``,
-``thinking_budget`` — need to be adjustable from the Settings UI at runtime
-without restarting the backend, daemon, or LLM worker. Persisting them as
-env vars in ``.env`` means a restart round-trip per change; persisting
-them in ``system_config`` lets us flip values live across all three
-processes while still letting operators pin values via env vars in
-hardened production deployments.
+The cost/perf and local-Ollama resilience toggles — ``prompt_cache_enabled``,
+``history_window``, ``tool_response_budget_default``, ``thinking_budget``, and
+the ``local_ollama_recovery_*`` controls — need to be adjustable from the
+Settings UI at runtime without restarting the backend, daemon, or LLM worker.
+Persisting them as env vars in ``.env`` means a restart round-trip per change;
+persisting them in ``system_config`` lets us flip values live across all three
+processes while still letting operators pin values via env vars in hardened
+production deployments.
 
 Resolution order for ``get_ai_operations_setting(key, default)``:
   1. In-process cache (short TTL, default 60s) — avoids per-call DB hits
@@ -43,6 +43,9 @@ ENV_FALLBACKS = {
     "history_window": "CLAUDE_HISTORY_WINDOW",
     "tool_response_budget_default": "TOOL_RESPONSE_BUDGET_DEFAULT",
     "thinking_budget": "CLAUDE_THINKING_BUDGET",
+    "local_ollama_recovery_enabled": "LOCAL_OLLAMA_RECOVERY_ENABLED",
+    "local_ollama_recovery_retry_limit": "LOCAL_OLLAMA_RECOVERY_RETRY_LIMIT",
+    "local_ollama_recovery_restart_gateway": "LOCAL_OLLAMA_RECOVERY_RESTART_GATEWAY",
 }
 
 _cache_lock = threading.Lock()

--- a/tests/unit/test_runtime_config.py
+++ b/tests/unit/test_runtime_config.py
@@ -128,6 +128,52 @@ class TestTypeCoercion:
                 == 2
             )
 
+    def test_local_recovery_enabled_bool_env_fallback(self, monkeypatch):
+        from services import runtime_config
+
+        monkeypatch.setenv("LOCAL_OLLAMA_RECOVERY_ENABLED", "false")
+        with patch.object(runtime_config, "_fetch_db_config", return_value={}):
+            assert (
+                runtime_config.get_ai_operations_setting(
+                    "local_ollama_recovery_enabled", True
+                )
+                is False
+            )
+
+    def test_local_recovery_restart_bool_env_fallback(self, monkeypatch):
+        from services import runtime_config
+
+        monkeypatch.setenv("LOCAL_OLLAMA_RECOVERY_RESTART_GATEWAY", "false")
+        with patch.object(runtime_config, "_fetch_db_config", return_value={}):
+            assert (
+                runtime_config.get_ai_operations_setting(
+                    "local_ollama_recovery_restart_gateway", True
+                )
+                is False
+            )
+
+
+class TestAIOperationsSettingsModel:
+    """The Settings-UI config model must expose the local-recovery toggles
+    with safe defaults and clamp the retry limit to the documented range."""
+
+    def test_defaults_include_local_recovery_toggles(self):
+        from backend.api.config import AI_OPERATIONS_DEFAULTS
+
+        assert AI_OPERATIONS_DEFAULTS["local_ollama_recovery_enabled"] is True
+        assert AI_OPERATIONS_DEFAULTS["local_ollama_recovery_retry_limit"] == 1
+        assert AI_OPERATIONS_DEFAULTS["local_ollama_recovery_restart_gateway"] is True
+
+    def test_retry_limit_rejects_out_of_range(self):
+        from pydantic import ValidationError
+
+        from backend.api.config import AIOperationsSettingsConfig
+
+        with pytest.raises(ValidationError):
+            AIOperationsSettingsConfig(local_ollama_recovery_retry_limit=5)
+        with pytest.raises(ValidationError):
+            AIOperationsSettingsConfig(local_ollama_recovery_retry_limit=-1)
+
 
 class TestCacheBehavior:
     def test_cache_avoids_repeated_db_fetch(self):

--- a/tests/unit/test_runtime_config.py
+++ b/tests/unit/test_runtime_config.py
@@ -116,6 +116,18 @@ class TestTypeCoercion:
                 == 10000
             )
 
+    def test_local_recovery_uses_its_own_env_fallback(self, monkeypatch):
+        from services import runtime_config
+
+        monkeypatch.setenv("LOCAL_OLLAMA_RECOVERY_RETRY_LIMIT", "2")
+        with patch.object(runtime_config, "_fetch_db_config", return_value={}):
+            assert (
+                runtime_config.get_ai_operations_setting(
+                    "local_ollama_recovery_retry_limit", 1
+                )
+                == 2
+            )
+
 
 class TestCacheBehavior:
     def test_cache_avoids_repeated_db_fetch(self):


### PR DESCRIPTION
## Summary

- add persisted AI Operations settings for host-run local Ollama recovery
- expose enable/disable, retry limit (0-3), and Bifrost restart controls in Settings > AI
- document matching environment fallbacks for unattended local development

## Safety boundary

These settings only configure the feature. The recovery implementation separately refuses to run unless `DEV_MODE=true` and `BIFROST_URL` resolves to a loopback host.

## Validation

- `/Users/alexmargaris/vigil/venv/bin/python3.12 -m pytest tests/unit/test_runtime_config.py -q`
- `git diff --check`
