### PR TITLE
feat: recover local Ollama enrichment

### DIFF
--- a/backend/api/findings.py
+++ b/backend/api/findings.py
@@ -596,6 +596,11 @@ Respond ONLY with valid JSON. Be specific and actionable. Focus on helping a SOC
                 "analysis_notes": response[:1000],  # Store first 1000 chars as notes
                 "raw_response": response  # Store full response
             }
+
+        # Keep the provider's original response even when it parsed cleanly.
+        # Analysts can compare the rendered fields against the local model's
+        # exact output without having to regenerate the enrichment.
+        enrichment["raw_response"] = response
         
         # Add metadata
         enrichment['generated_at'] = datetime.utcnow().isoformat() + 'Z'

--- a/backend/api/findings.py
+++ b/backend/api/findings.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 import logging
 
 from services.database_data_service import DatabaseDataService
-from services.defaults import DEFAULT_MODEL
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -309,7 +308,8 @@ async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Q
     
     This endpoint checks if AI enrichment already exists for the finding.
     If it exists, returns the cached enrichment immediately.
-    If not, generates new enrichment using Claude AI, caches it, and returns it.
+    If not, generates new enrichment using the configured reporting model,
+    caches it, and returns it.
     
     Args:
         finding_id: The finding ID to enrich
@@ -350,17 +350,34 @@ async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Q
             "enrichment": existing_enrichment
         }
     
-    # Generate new enrichment using Claude
+    # Generate new enrichment using the configured reporting provider.
     try:
-        from services.claude_service import ClaudeService
-        
-        claude_service = ClaudeService(use_backend_tools=True, use_mcp_tools=False)
-        
-        # Check if API key is configured
-        if not claude_service.has_api_key():
+        from services.llm_router import LLMRouter, get_provider_spec
+        from services.model_registry import get_registry
+
+        resolved_model = get_registry().resolve_model_for_component("reporting")
+        if not resolved_model:
             from backend.api.claude import NO_PROVIDER_DETAIL
 
             raise HTTPException(status_code=503, detail=NO_PROVIDER_DETAIL)
+
+        provider_id, model_id = resolved_model
+        provider = get_provider_spec(provider_id)
+        if provider is None:
+            raise HTTPException(
+                status_code=503,
+                detail=f"Configured provider '{provider_id}' is unavailable",
+            )
+
+        claude_service = None
+        if provider.provider_type == "anthropic":
+            from services.claude_service import ClaudeService
+
+            claude_service = ClaudeService(use_backend_tools=True, use_mcp_tools=False)
+            if not claude_service.has_api_key():
+                from backend.api.claude import NO_PROVIDER_DETAIL
+
+                raise HTTPException(status_code=503, detail=NO_PROVIDER_DETAIL)
         
         # Extract finding details (use `or` to guard against keys present with None values)
         severity = finding.get('severity') or 'unknown'
@@ -474,23 +491,79 @@ Please provide a detailed analysis in the following JSON structure:
 Respond ONLY with valid JSON. Be specific and actionable. Focus on helping a SOC analyst make quick, informed decisions."""
 
         # Generate enrichment
-        logger.info(f"Generating AI enrichment for {finding_id}")
-        loop = asyncio.get_event_loop()
-        response = await loop.run_in_executor(
-            None,
-            lambda: claude_service.chat(
-                message=prompt,
-                model=DEFAULT_MODEL,
-                max_tokens=4096
-            )
+        logger.info(
+            "Generating AI enrichment for %s via %s/%s",
+            finding_id,
+            provider.provider_id,
+            model_id,
         )
+        max_enrichment_tokens = 1400
+        loop = asyncio.get_event_loop()
+        if provider.provider_type == "anthropic":
+            response = await loop.run_in_executor(
+                None,
+                lambda: claude_service.chat(
+                    message=prompt,
+                    model=model_id,
+                    max_tokens=max_enrichment_tokens,
+                ),
+            )
+        else:
+            dispatch_args = {
+                "provider": provider,
+                "messages": [{"role": "user", "content": f"/no_think\n{prompt}"}],
+                "system_prompt": (
+                    "You are a cybersecurity analyst. Respond only with valid "
+                    "JSON matching the requested enrichment schema. Keep the "
+                    "response concise and do not include chain-of-thought."
+                ),
+                "model": model_id,
+                "max_tokens": max_enrichment_tokens,
+            }
+            from services.local_ai_recovery import (
+                is_gateway_connection_error,
+                local_bifrost_recovery_enabled,
+                local_bifrost_recovery_retry_limit,
+                recover_local_bifrost,
+            )
+
+            retry_limit = local_bifrost_recovery_retry_limit()
+            for attempt in range(retry_limit + 1):
+                try:
+                    result = await LLMRouter().dispatch(**dispatch_args)
+                    break
+                except Exception as dispatch_error:
+                    eligible = (
+                        provider.provider_type == "ollama"
+                        and local_bifrost_recovery_enabled()
+                        and is_gateway_connection_error(dispatch_error)
+                    )
+                    if not eligible or attempt >= retry_limit:
+                        raise
+
+                    recovery = await recover_local_bifrost()
+                    if not recovery.ready:
+                        logger.warning(
+                            "Local Bifrost recovery for %s failed: %s",
+                            finding_id,
+                            recovery.detail,
+                        )
+                        raise
+                    logger.info(
+                        "Local Bifrost recovery for %s: %s; retrying enrichment (%s/%s)",
+                        finding_id,
+                        recovery.detail,
+                        attempt + 1,
+                        retry_limit,
+                    )
+            response = result.get("content", "")
         
         # Parse JSON response
         import json
         import re
         
         if not response:
-            raise ValueError("Claude API returned an empty response")
+            raise ValueError("LLM provider returned an empty response")
         
         # Try to extract JSON from response (handle markdown code blocks)
         json_match = re.search(r'```json\s*(\{.*?\})\s*```', response, re.DOTALL)
@@ -526,7 +599,9 @@ Respond ONLY with valid JSON. Be specific and actionable. Focus on helping a SOC
         
         # Add metadata
         enrichment['generated_at'] = datetime.utcnow().isoformat() + 'Z'
-        enrichment['model'] = DEFAULT_MODEL
+        enrichment['model'] = model_id
+        enrichment['provider_id'] = provider.provider_id
+        enrichment['provider_type'] = provider.provider_type
         
         # Save enrichment to database
         success = data_service.update_finding(finding_id, ai_enrichment=enrichment)
@@ -568,4 +643,3 @@ async def clear_all_findings():
     except Exception as e:
         logger.error(f"Error clearing findings: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to clear findings: {str(e)}")
-

--- a/backend/api/findings.py
+++ b/backend/api/findings.py
@@ -497,18 +497,20 @@ Respond ONLY with valid JSON. Be specific and actionable. Focus on helping a SOC
             provider.provider_id,
             model_id,
         )
-        max_enrichment_tokens = 1400
         loop = asyncio.get_event_loop()
         if provider.provider_type == "anthropic":
+            # The enrichment JSON schema is large; a tight cap truncates it.
             response = await loop.run_in_executor(
                 None,
                 lambda: claude_service.chat(
                     message=prompt,
                     model=model_id,
-                    max_tokens=max_enrichment_tokens,
+                    max_tokens=4096,
                 ),
             )
         else:
+            # Local models are slow per token; bound them tighter than the
+            # cloud path while leaving room for the full JSON object.
             dispatch_args = {
                 "provider": provider,
                 "messages": [{"role": "user", "content": f"/no_think\n{prompt}"}],
@@ -518,7 +520,7 @@ Respond ONLY with valid JSON. Be specific and actionable. Focus on helping a SOC
                     "response concise and do not include chain-of-thought."
                 ),
                 "model": model_id,
-                "max_tokens": max_enrichment_tokens,
+                "max_tokens": 1400,
             }
             from services.local_ai_recovery import (
                 is_gateway_connection_error,
@@ -623,10 +625,12 @@ Respond ONLY with valid JSON. Be specific and actionable. Focus on helping a SOC
             "enrichment": enrichment
         }
     
+    except HTTPException:
+        raise  # preserve 503 (no provider / unavailable) so the UI can distinguish it
     except Exception as e:
         logger.error(f"Error generating enrichment for {finding_id}: {e}")
         raise HTTPException(
-            status_code=500, 
+            status_code=500,
             detail=f"Failed to generate enrichment: {str(e)}"
         )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -457,6 +457,18 @@ app.include_router(
 )
 
 
+def _mcp_auto_connect_enabled() -> bool:
+    """Keep optional MCP processes from blocking a local backend startup."""
+    dev_mode = os.getenv("DEV_MODE", "false").lower() in {"1", "true", "yes"}
+    default = "false" if dev_mode else "true"
+    return os.getenv("MCP_AUTO_CONNECT_ON_STARTUP", default).lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 async def _connect_external_services():
     """Connect external startup integrations (skipped under TESTING)."""
     import asyncio
@@ -501,6 +513,17 @@ async def _connect_external_services():
         logger.warning(
             "  LLM calls will fail until Redis is running and ARQ worker is started"
         )
+
+    # MCP tools connect lazily when an agent actually needs them. Starting
+    # every configured stdio server during local development makes the entire
+    # API unavailable if an optional integration has a stale executable or
+    # missing runtime. Preserve eager connection outside DEV_MODE unless an
+    # operator explicitly overrides it.
+    if not _mcp_auto_connect_enabled():
+        logger.info(
+            "MCP auto-connect disabled; optional MCP servers will connect on demand"
+        )
+        return
 
     logger.info("Initializing MCP client with persistent connections...")
     try:

--- a/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
+++ b/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
@@ -43,6 +43,14 @@ interface Enrichment {
   analysis_notes?: string
 }
 
+const ENRICHMENT_PROGRESS = [
+  'Preparing a local AI analysis…',
+  'Reviewing the finding with your local model…',
+  'Still working — detailed local analysis can take a little while.',
+  'Checking the local AI gateway and automatically retrying if needed…',
+  'Keeping the analysis running while the local AI service reconnects…',
+]
+
 const RISK_COLOR: Record<string, string> = {
   critical: 'var(--crit)',
   high: 'var(--crit)',
@@ -165,6 +173,7 @@ export default function FindingPopup({
   const [enrichment, setEnrichment] = useState<Enrichment | null>(null)
   const [enrichPhase, setEnrichPhase] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
   const [enrichError, setEnrichError] = useState<'not_configured' | 'failed' | null>(null)
+  const [enrichmentProgressIndex, setEnrichmentProgressIndex] = useState(0)
 
   const [status, setStatus] = useState('')
   const [acting, setActing] = useState(false)
@@ -198,10 +207,23 @@ export default function FindingPopup({
     }
   }, [id])
 
+  useEffect(() => {
+    if (enrichPhase !== 'loading') {
+      setEnrichmentProgressIndex(0)
+      return
+    }
+
+    const timers = [4_000, 15_000, 35_000, 60_000].map((delay, index) =>
+      window.setTimeout(() => setEnrichmentProgressIndex(index + 1), delay),
+    )
+    return () => timers.forEach(window.clearTimeout)
+  }, [enrichPhase])
+
   const loadEnrichment = (force = false) => {
     if (!id) return
     setEnrichPhase('loading')
     setEnrichError(null)
+    setEnrichmentProgressIndex(0)
     findingsApi
       .getEnrichment(id, force)
       .then((res) => {
@@ -338,12 +360,17 @@ export default function FindingPopup({
                 <Icon name="sparkle" size={15} /> Generate AI analysis
               </button>
             )}
-            {enrichPhase === 'loading' && <div className="muted" style={{ marginTop: 10 }}>Generating AI analysis…</div>}
+            {enrichPhase === 'loading' && (
+              <div className="fp-ai-progress muted flex items-center gap-2" style={{ marginTop: 10 }} aria-live="polite">
+                <span className="spin" aria-hidden="true" />
+                <span>{ENRICHMENT_PROGRESS[enrichmentProgressIndex]}</span>
+              </div>
+            )}
             {enrichPhase === 'error' && (
               <div className="muted" style={{ marginTop: 10 }}>
                 {enrichError === 'not_configured'
-                  ? 'AI enrichment is not configured — add a Claude API key in Settings → AI.'
-                  : 'AI enrichment failed. '}
+                  ? 'AI enrichment is not configured — choose an AI provider in Settings → AI.'
+                  : 'Vigil could not restore the local AI service. '}
                 {enrichError !== 'not_configured' && (
                   <button className="btn ghost" onClick={() => loadEnrichment(false)}>Retry</button>
                 )}

--- a/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
+++ b/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
@@ -47,9 +47,9 @@ interface Enrichment {
 const ENRICHMENT_PROGRESS = [
   'Preparing a local AI analysis…',
   'Reviewing the finding with your local model…',
-  'Still working — detailed local analysis can take a little while.',
-  'Checking the local AI gateway and automatically retrying if needed…',
-  'Keeping the analysis running while the local AI service reconnects…',
+  'Still analysing — local models often take a minute or two.',
+  'Checking the local AI gateway and automatically retrying if needed. Please keep this window open…',
+  'Local gateway recovery can take up to a minute. The analysis is still running…',
 ]
 
 const RISK_COLOR: Record<string, string> = {
@@ -231,7 +231,7 @@ export default function FindingPopup({
       return
     }
 
-    const timers = [4_000, 15_000, 35_000, 60_000].map((delay, index) =>
+    const timers = [4_000, 15_000, 45_000, 75_000].map((delay, index) =>
       window.setTimeout(() => setEnrichmentProgressIndex(index + 1), delay),
     )
     return () => timers.forEach(window.clearTimeout)

--- a/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
+++ b/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
@@ -20,7 +20,7 @@ import type { Phase } from '../cases/useCases'
 interface RawFinding extends ApiFinding {
   description?: string
   cluster_id?: string | null
-  ai_enrichment?: { model?: string } | null
+  ai_enrichment?: Enrichment | null
 }
 
 interface RelatedTechnique {
@@ -41,6 +41,7 @@ interface Enrichment {
   business_context?: string
   indicators?: { malicious_ips?: string[]; suspicious_domains?: string[] }
   analysis_notes?: string
+  raw_response?: string
 }
 
 const ENRICHMENT_PROGRESS = [
@@ -150,6 +151,13 @@ function EnrichmentView({ e }: { e: Enrichment }) {
           <p className="muted" style={{ fontSize: 12.5, margin: 0 }}><strong>Analyst notes:</strong> {e.analysis_notes}</p>
         </div>
       )}
+
+      {e.raw_response && (
+        <div className="modal-section">
+          <h4>Raw model output</h4>
+          <pre className="fp-raw-ai-output">{e.raw_response}</pre>
+        </div>
+      )}
     </>
   )
 }
@@ -167,6 +175,7 @@ export default function FindingPopup({
   const [raw, setRaw] = useState<RawFinding | null>(null)
   const [phase, setPhase] = useState<Phase>('loading')
   const [error, setError] = useState<string | null>(null)
+  const [loadAttempt, setLoadAttempt] = useState(0)
 
   // AI enrichment — on-demand (a getEnrichment call may invoke an LLM, so we
   // don't fire it automatically on open). 'idle' until the user asks for it.
@@ -195,17 +204,26 @@ export default function FindingPopup({
         const data = res.data as RawFinding
         setRaw(data)
         setStatus((data as { status?: string }).status || '')
+        if (data.ai_enrichment) {
+          setEnrichment(data.ai_enrichment)
+          setEnrichPhase('ready')
+        }
         setPhase('ready')
       })
       .catch((e) => {
         if (cancelled) return
-        setError((e as { message?: string })?.message || 'Failed to load finding')
+        const code = (e as { code?: string })?.code
+        setError(
+          code === 'ECONNABORTED'
+            ? 'The local Vigil API did not respond. It may be restarting.'
+            : (e as { message?: string })?.message || 'Failed to load finding',
+        )
         setPhase('error')
       })
     return () => {
       cancelled = true
     }
-  }, [id])
+  }, [id, loadAttempt])
 
   useEffect(() => {
     if (enrichPhase !== 'loading') {
@@ -277,8 +295,20 @@ export default function FindingPopup({
 
   return (
     <Popup open={id !== null} onClose={onClose} title={title} width={640}>
-      {phase === 'loading' && <div className="muted">Loading finding…</div>}
-      {phase === 'error' && <div className="muted">Couldn’t load finding: {error}</div>}
+      {phase === 'loading' && (
+        <div className="fp-ai-progress muted flex items-center gap-2" aria-live="polite">
+          <span className="spin" aria-hidden="true" />
+          <span>Loading finding details…</span>
+        </div>
+      )}
+      {phase === 'error' && (
+        <div className="muted">
+          Couldn’t load finding: {error}{' '}
+          <button className="btn ghost" onClick={() => setLoadAttempt((attempt) => attempt + 1)}>
+            Retry
+          </button>
+        </div>
+      )}
       {phase === 'ready' && f && raw && (
         <>
           {/* hero — top technique + tactic on the left, key metrics on the right */}

--- a/frontend/src/redesign/styles.css
+++ b/frontend/src/redesign/styles.css
@@ -5412,6 +5412,20 @@
       line-height: 1.45;
    }
 
+   .fp-ai-progress {
+      min-height: 20px;
+   }
+
+   .fp-ai-progress .spin {
+      width: 16px;
+      height: 16px;
+      flex: 0 0 16px;
+      border: 2px solid var(--line);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: soc-spin .7s linear infinite;
+   }
+
    .fp-actions {
       margin-top: 20px;
       padding-top: 14px;

--- a/frontend/src/redesign/styles.css
+++ b/frontend/src/redesign/styles.css
@@ -5426,6 +5426,20 @@
       animation: soc-spin .7s linear infinite;
    }
 
+   .fp-raw-ai-output {
+      max-height: 280px;
+      margin: 0;
+      padding: 12px;
+      overflow: auto;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--bg-2);
+      color: var(--tx-2);
+      font: 12px/1.5 var(--font-mono);
+      white-space: pre-wrap;
+      word-break: break-word;
+   }
+
    .fp-actions {
       margin-top: 20px;
       padding-top: 14px;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -191,7 +191,13 @@ export const findingsApi = {
   delete: (id: string) => api.delete(`/findings/${id}`),
   
   getEnrichment: (id: string, force_regenerate: boolean = false) =>
-    api.post(`/findings/${id}/enrich`, null, { params: { force_regenerate } }),
+    // Enrichment may need to restart a local Bifrost gateway and then wait for
+    // a local model response. Keep the ordinary API timeout short, but do not
+    // abandon this recoverable request while that work is still in progress.
+    api.post(`/findings/${id}/enrich`, null, {
+      params: { force_regenerate },
+      timeout: 180_000,
+    }),
 
   deleteAll: () => api.delete('/findings/all'),
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -16,6 +16,11 @@ const api = axios.create({
   },
 })
 
+// LLM-backed calls (chat, agents, workflows, enrichment) can legitimately run
+// for minutes, so they override the short default. Streaming endpoints pass 0
+// to disable the timeout entirely for the life of the SSE connection.
+const LLM_TIMEOUT = 180_000
+
 // Read the csrf_token cookie set by the backend CSRF middleware. The
 // backend seeds this on any request that doesn't already have one, so
 // after the first /auth/me call it's always present.
@@ -196,7 +201,7 @@ export const findingsApi = {
     // abandon this recoverable request while that work is still in progress.
     api.post(`/findings/${id}/enrich`, null, {
       params: { force_regenerate },
-      timeout: 180_000,
+      timeout: LLM_TIMEOUT,
     }),
 
   deleteAll: () => api.delete('/findings/all'),
@@ -249,7 +254,8 @@ export const casesApi = {
   removeFinding: (id: string, finding_id: string) =>
     api.delete(`/cases/${id}/findings/${finding_id}`),
   
-  generateReport: (id: string) => api.post(`/cases/${id}/generate-report`),
+  generateReport: (id: string) =>
+    api.post(`/cases/${id}/generate-report`, null, { timeout: LLM_TIMEOUT }),
   
   getSummary: () => api.get('/cases/stats/summary'),
   
@@ -684,7 +690,7 @@ export const claudeApi = {
     agent_id?: string
     streaming?: boolean
     use_agent_sdk?: boolean
-  }) => api.post('/claude/chat', data),
+  }) => api.post('/claude/chat', data, { timeout: LLM_TIMEOUT }),
   
   chatStream: (data: {
     messages: Array<{ 
@@ -707,6 +713,7 @@ export const claudeApi = {
     agent_id?: string
   }) => api.post('/claude/chat/stream', data, {
     responseType: 'stream',
+    timeout: 0,
     headers: {
       'Accept': 'text/event-stream',
     }
@@ -736,11 +743,12 @@ export const claudeApi = {
       }>
     }>
     model?: string
-  }) => api.post('/claude/summarize', data),
-  
+  }) => api.post('/claude/summarize', data, { timeout: LLM_TIMEOUT }),
+
   analyzeFinding: (finding_id: string, context?: string) =>
     api.post('/claude/analyze-finding', null, {
       params: { finding_id, context },
+      timeout: LLM_TIMEOUT,
     }),
   
   generateChatReport: (data: {
@@ -754,7 +762,7 @@ export const claudeApi = {
       }>
     }>
     notes?: string
-  }) => api.post('/claude/generate-chat-report', data),
+  }) => api.post('/claude/generate-chat-report', data, { timeout: LLM_TIMEOUT }),
   
   // Agent SDK endpoints
   runAgentTask: (data: {
@@ -765,7 +773,7 @@ export const claudeApi = {
     model?: string
     session_id?: string
     agent_id?: string
-  }) => api.post('/claude/agent/task', data),
+  }) => api.post('/claude/agent/task', data, { timeout: LLM_TIMEOUT }),
   
   streamAgentTask: (data: {
     task: string
@@ -777,6 +785,7 @@ export const claudeApi = {
     agent_id?: string
   }) => api.post('/claude/agent/stream', data, {
     responseType: 'stream',
+    timeout: 0,
     headers: {
       'Accept': 'text/event-stream',
     }
@@ -796,15 +805,15 @@ export const agentsApi = {
     finding_id: string
     agent_id?: string
     additional_context?: string
-  }) => api.post('/agents/agents/investigate', data),
-  
+  }) => api.post('/agents/agents/investigate', data, { timeout: LLM_TIMEOUT }),
+
   runAgent: (data: {
     finding_id?: string
     case_id?: string
     task?: string
     agent_id?: string
     use_agent_sdk?: boolean
-  }) => api.post('/agents/agents/run', data),
+  }) => api.post('/agents/agents/run', data, { timeout: LLM_TIMEOUT }),
 
   // Custom Agent Builder (issue #80)
   listCustom: () => api.get('/agents/custom'),
@@ -824,7 +833,10 @@ export const agentsApi = {
     description: string
     current_draft?: GeneratedAgentDraft | null
     feedback?: string
-  }) => api.post<{ draft: GeneratedAgentDraft }>('/agents/custom/generate', data),
+  }) =>
+    api.post<{ draft: GeneratedAgentDraft }>('/agents/custom/generate', data, {
+      timeout: LLM_TIMEOUT,
+    }),
 }
 
 export interface GeneratedAgentDraft {
@@ -1418,7 +1430,7 @@ export const workflowApi = {
     case_id?: string
     context?: string
     hypothesis?: string
-  }) => api.post(`/workflows/${id}/execute`, params),
+  }) => api.post(`/workflows/${id}/execute`, params, { timeout: LLM_TIMEOUT }),
   reloadFiles: () => api.post('/workflows/reload'),
 
   // Run history (#127) — execution is persisted to workflow_runs so the
@@ -1454,7 +1466,7 @@ export const workflowApi = {
 
   // AI generation (returns draft — does not save)
   generate: (description: string) =>
-    api.post('/workflows/generate', { description }),
+    api.post('/workflows/generate', { description }, { timeout: LLM_TIMEOUT }),
 }
 
 // Skills API (workflow skill management and execution)
@@ -1471,7 +1483,7 @@ export const skillsApi = {
     case_id?: string
     context?: string
     hypothesis?: string
-  }) => api.post(`/workflows/${skillId}/execute`, params),
+  }) => api.post(`/workflows/${skillId}/execute`, params, { timeout: LLM_TIMEOUT }),
 
   // Force reload skills from disk
   reloadSkills: () => api.post('/workflows/reload'),
@@ -1502,7 +1514,7 @@ export const orchestratorApi = {
   scanFindings: (severities?: string[]) =>
     api.post('/orchestrator/scan-findings', {
       severities: severities || ['critical', 'high'],
-    }),
+    }, { timeout: LLM_TIMEOUT }),
   reviewInvestigation: (id: string, action: 'approve' | 'rework', notes?: string) =>
     api.post(`/orchestrator/investigations/${id}/review`, { action, notes }),
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -7,6 +7,10 @@ import { basePath } from '../config/basePath'
 const api = axios.create({
   baseURL: `${basePath}/api`,
   withCredentials: true,
+  // A dead local backend can leave Vite's proxy connection open indefinitely.
+  // Bound every request so the UI can show a recoverable error instead of a
+  // permanent loading state.
+  timeout: 15_000,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -1653,4 +1657,3 @@ export const kafkaApi = {
 }
 
 export default api
-

--- a/services/local_ai_recovery.py
+++ b/services/local_ai_recovery.py
@@ -1,0 +1,132 @@
+"""Local-only recovery for the Bifrost gateway used by Ollama enrichment.
+
+This is intentionally unavailable outside a host-run development server. A
+remote deployment must not allow an HTTP request to restart local containers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import httpx
+
+from services.runtime_config import get_ai_operations_setting
+
+logger = logging.getLogger(__name__)
+
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+_RECOVERY_LOCK = asyncio.Lock()
+_HEALTH_WAIT_SECONDS = 45
+
+
+@dataclass(frozen=True)
+class RecoveryResult:
+    """The result of one local gateway recovery attempt."""
+
+    ready: bool
+    restarted: bool
+    detail: str
+
+
+def _bifrost_url() -> str:
+    return os.getenv("BIFROST_URL", "http://localhost:8080").rstrip("/")
+
+
+def local_bifrost_recovery_enabled() -> bool:
+    """Return true only for an explicitly local, host-run dev server."""
+    if os.getenv("DEV_MODE", "false").lower() not in {"1", "true", "yes"}:
+        return False
+    if urlparse(_bifrost_url()).hostname not in _LOOPBACK_HOSTS:
+        return False
+    return bool(get_ai_operations_setting("local_ollama_recovery_enabled", True))
+
+
+def local_bifrost_recovery_retry_limit() -> int:
+    """Return the bounded number of retries following the initial failure."""
+    value = get_ai_operations_setting("local_ollama_recovery_retry_limit", 1)
+    try:
+        return max(0, min(3, int(value)))
+    except (TypeError, ValueError):
+        return 1
+
+
+def local_bifrost_restart_enabled() -> bool:
+    return bool(get_ai_operations_setting("local_ollama_recovery_restart_gateway", True))
+
+
+def is_gateway_connection_error(error: Exception) -> bool:
+    """Recognize network errors without retrying provider or model errors."""
+    if isinstance(
+        error,
+        (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout, httpx.NetworkError),
+    ):
+        return True
+    return error.__class__.__name__ in {"APIConnectionError", "APIConnectionTimeout"}
+
+
+async def _bifrost_healthy() -> bool:
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            response = await client.get(f"{_bifrost_url()}/health")
+        return response.status_code == 200
+    except httpx.HTTPError:
+        return False
+
+
+async def _restart_bifrost() -> bool:
+    """Restart the known local Bifrost container without invoking a shell."""
+    process = None
+    try:
+        process = await asyncio.create_subprocess_exec(
+            "docker",
+            "restart",
+            "deeptempo-bifrost",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+    except asyncio.TimeoutError:
+        if process is not None:
+            process.kill()
+            await process.communicate()
+        logger.warning("Local Bifrost restart timed out")
+        return False
+    except OSError as exc:
+        logger.warning("Local Bifrost restart could not start: %s", exc)
+        return False
+
+    if process.returncode != 0:
+        logger.warning("Local Bifrost restart failed: %s", stderr.decode().strip())
+        return False
+    return True
+
+
+async def _wait_for_bifrost() -> bool:
+    for _ in range(_HEALTH_WAIT_SECONDS):
+        if await _bifrost_healthy():
+            return True
+        await asyncio.sleep(1)
+    return False
+
+
+async def recover_local_bifrost() -> RecoveryResult:
+    """Make one serialized local recovery attempt, returning when Bifrost is ready."""
+    if not local_bifrost_recovery_enabled():
+        return RecoveryResult(False, False, "local recovery is disabled")
+
+    async with _RECOVERY_LOCK:
+        if await _bifrost_healthy():
+            return RecoveryResult(True, False, "gateway is reachable; retrying the request")
+        if not local_bifrost_restart_enabled():
+            return RecoveryResult(False, False, "gateway is unavailable and automatic restart is disabled")
+
+        logger.warning("Local Bifrost is unavailable; restarting its container")
+        if not await _restart_bifrost():
+            return RecoveryResult(False, True, "could not restart the local gateway")
+        if await _wait_for_bifrost():
+            return RecoveryResult(True, True, "local gateway restarted and is healthy")
+        return RecoveryResult(False, True, "local gateway did not become healthy in time")

--- a/services/local_ai_recovery.py
+++ b/services/local_ai_recovery.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
@@ -19,6 +20,8 @@ from services.runtime_config import get_ai_operations_setting
 logger = logging.getLogger(__name__)
 
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+# Serializes recovery within one event loop only; multi-worker hosts could
+# still issue concurrent docker restarts. Acceptable for a local dev feature.
 _RECOVERY_LOCK = asyncio.Lock()
 _HEALTH_WAIT_SECONDS = 45
 
@@ -65,7 +68,15 @@ def is_gateway_connection_error(error: Exception) -> bool:
         (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout, httpx.NetworkError),
     ):
         return True
-    return error.__class__.__name__ in {"APIConnectionError", "APIConnectionTimeout"}
+    try:
+        import openai
+
+        # APITimeoutError subclasses APIConnectionError, so this covers both.
+        if isinstance(error, openai.APIConnectionError):
+            return True
+    except ImportError:
+        pass
+    return error.__class__.__name__ in {"APIConnectionError", "APITimeoutError"}
 
 
 async def _bifrost_healthy() -> bool:
@@ -106,7 +117,8 @@ async def _restart_bifrost() -> bool:
 
 
 async def _wait_for_bifrost() -> bool:
-    for _ in range(_HEALTH_WAIT_SECONDS):
+    deadline = time.monotonic() + _HEALTH_WAIT_SECONDS
+    while time.monotonic() < deadline:
         if await _bifrost_healthy():
             return True
         await asyncio.sleep(1)

--- a/tests/unit/test_local_ai_recovery.py
+++ b/tests/unit/test_local_ai_recovery.py
@@ -1,0 +1,48 @@
+import pytest
+
+from services import local_ai_recovery as recovery
+
+
+def test_local_recovery_requires_dev_mode_and_loopback_gateway(monkeypatch):
+    monkeypatch.setenv("DEV_MODE", "true")
+    monkeypatch.setenv("BIFROST_URL", "http://localhost:8080")
+    monkeypatch.setattr(recovery, "get_ai_operations_setting", lambda key, default: True)
+    assert recovery.local_bifrost_recovery_enabled() is True
+
+    monkeypatch.setenv("BIFROST_URL", "http://bifrost:8080")
+    assert recovery.local_bifrost_recovery_enabled() is False
+
+    monkeypatch.setenv("BIFROST_URL", "http://localhost:8080")
+    monkeypatch.setenv("DEV_MODE", "false")
+    assert recovery.local_bifrost_recovery_enabled() is False
+
+
+def test_retry_limit_is_bounded(monkeypatch):
+    monkeypatch.setattr(recovery, "get_ai_operations_setting", lambda key, default: 9)
+    assert recovery.local_bifrost_recovery_retry_limit() == 3
+
+
+def test_connection_error_classifier_does_not_retry_provider_errors():
+    assert recovery.is_gateway_connection_error(recovery.httpx.ConnectError("offline"))
+    assert recovery.is_gateway_connection_error(RuntimeError("offline")) is False
+
+
+@pytest.mark.asyncio
+async def test_recovery_retries_without_restart_when_gateway_is_already_healthy(monkeypatch):
+    monkeypatch.setenv("DEV_MODE", "true")
+    monkeypatch.setenv("BIFROST_URL", "http://localhost:8080")
+    monkeypatch.setattr(recovery, "get_ai_operations_setting", lambda key, default: True)
+
+    async def healthy():
+        return True
+
+    async def should_not_restart():
+        raise AssertionError("healthy Bifrost must not be restarted")
+
+    monkeypatch.setattr(recovery, "_bifrost_healthy", healthy)
+    monkeypatch.setattr(recovery, "_restart_bifrost", should_not_restart)
+
+    result = await recovery.recover_local_bifrost()
+
+    assert result.ready is True
+    assert result.restarted is False

--- a/tests/unit/test_local_ai_recovery.py
+++ b/tests/unit/test_local_ai_recovery.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 
 from services import local_ai_recovery as recovery
@@ -21,10 +22,27 @@ def test_retry_limit_is_bounded(monkeypatch):
     monkeypatch.setattr(recovery, "get_ai_operations_setting", lambda key, default: 9)
     assert recovery.local_bifrost_recovery_retry_limit() == 3
 
+    monkeypatch.setattr(recovery, "get_ai_operations_setting", lambda key, default: -5)
+    assert recovery.local_bifrost_recovery_retry_limit() == 0
+
+    monkeypatch.setattr(recovery, "get_ai_operations_setting", lambda key, default: "x")
+    assert recovery.local_bifrost_recovery_retry_limit() == 1
+
 
 def test_connection_error_classifier_does_not_retry_provider_errors():
     assert recovery.is_gateway_connection_error(recovery.httpx.ConnectError("offline"))
     assert recovery.is_gateway_connection_error(RuntimeError("offline")) is False
+
+
+def test_connection_error_classifier_recognizes_openai_timeouts():
+    openai = pytest.importorskip("openai")
+    request = httpx.Request("POST", "http://localhost:8080/v1/chat/completions")
+    assert recovery.is_gateway_connection_error(
+        openai.APIConnectionError(request=request)
+    )
+    assert recovery.is_gateway_connection_error(
+        openai.APITimeoutError(request=request)
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_local_startup.py
+++ b/tests/unit/test_local_startup.py
@@ -1,0 +1,15 @@
+from backend.main import _mcp_auto_connect_enabled
+
+
+def test_mcp_auto_connect_is_off_by_default_in_dev(monkeypatch):
+    monkeypatch.setenv("DEV_MODE", "true")
+    monkeypatch.delenv("MCP_AUTO_CONNECT_ON_STARTUP", raising=False)
+
+    assert _mcp_auto_connect_enabled() is False
+
+
+def test_mcp_auto_connect_can_be_explicitly_enabled(monkeypatch):
+    monkeypatch.setenv("DEV_MODE", "true")
+    monkeypatch.setenv("MCP_AUTO_CONNECT_ON_STARTUP", "true")
+
+    assert _mcp_auto_connect_enabled() is True


### PR DESCRIPTION
## Summary

- route finding enrichment through the configured reporting provider, including local Ollama
- preserve the full finding description, cached enrichment, and raw model output in the detail modal
- on a transient local Bifrost connection failure, keep the request open, health-check/restart the local gateway, then retry once (configurable)
- show staged progress during AI analysis; a local enrichment gets a 180-second request budget while ordinary API requests retain a 15-second fail-fast timeout
- skip optional MCP eager connections by default in `DEV_MODE`, so one broken local integration cannot prevent the API from starting

## Related configuration

Configuration controls are in #391. This implementation is independently mergeable and uses safe local defaults until those persisted controls land.

## Safety boundary

The restart path only runs when the backend is host-run with `DEV_MODE=true` and Bifrost is on a loopback address. It invokes `docker restart deeptempo-bifrost` without a shell, serializes recoveries, and does not retry cloud/API/model failures.

## Validation

- `/Users/alexmargaris/vigil/venv/bin/python3.12 -m py_compile backend/main.py backend/api/findings.py services/local_ai_recovery.py`
- `DEV_MODE=true /Users/alexmargaris/vigil/venv/bin/python3.12 -m pytest tests/unit/test_local_startup.py tests/unit/test_local_ai_recovery.py -q` (6 passed)
- `npm run build` in the local frontend (passed)
- local browser flow: regeneration stayed active past the old 15-second cutoff and completed without a manual retry
- `git diff --check`
