### PR TITLE
fix(ui): restore missing icons and clip rail labels

### DIFF
--- a/frontend/src/redesign/screens/login/LoginScreen.tsx
+++ b/frontend/src/redesign/screens/login/LoginScreen.tsx
@@ -95,10 +95,10 @@ function LoginInner() {
           </div>
 
           <div className="brand-body">
-            <h1>Security operations, under one calm pane of glass.</h1>
+            <h1>Vigilant, Open, Trustworthy.</h1>
             <p>
-              Triage findings, correlate signals across your estate, and let Vigil
-              surface what actually needs an analyst — before it becomes an incident.
+              Open source and community built, Vigil stands watch beside
+              your analysts on the journey toward greater autonomy.
             </p>
           </div>
         </section>

--- a/frontend/src/redesign/screens/login/LoginScreen.tsx
+++ b/frontend/src/redesign/screens/login/LoginScreen.tsx
@@ -128,7 +128,7 @@ function LoginInner() {
                   <div className="field">
                     <label htmlFor="auth-user">Username or email</label>
                     <div className="ctrl">
-                      <Icon name="name" className="lead" />
+                      <Icon name="user" className="lead" />
                       <input
                         id="auth-user"
                         name="username"

--- a/frontend/src/redesign/shared/icons.tsx
+++ b/frontend/src/redesign/shared/icons.tsx
@@ -4,7 +4,10 @@
    ============================================================ */
 import type { CSSProperties } from 'react'
 
-export const ICON: Record<string, string> = {
+// Deliberately not annotated Record<string, string>: that widens IconName to
+// `string`, so a misspelled name type-checks and renders an empty svg instead
+// of failing the build.
+export const ICON = {
   shield: '<path d="M12 2l8 3v6c0 5-3.5 8.5-8 11-4.5-2.5-8-6-8-11V5l8-3z"/>',
   grid: '<rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/>',
   folder: '<path d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"/>',
@@ -63,6 +66,7 @@ export const ICON: Record<string, string> = {
   sun: '<circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/>',
   moon: '<path d="M21 12.8A9 9 0 1111.2 3 7 7 0 0021 12.8z"/>',
   bot: '<rect x="4" y="8" width="16" height="12" rx="2.5"/><path d="M12 4v4M9 13h.01M15 13h.01M2 14v2M22 14v2"/>',
+  user: '<path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/>',
 }
 
 export type IconName = keyof typeof ICON

--- a/frontend/src/redesign/styles.css
+++ b/frontend/src/redesign/styles.css
@@ -276,6 +276,7 @@
       font-weight: 500;
       white-space: nowrap;
       overflow: hidden;
+      text-overflow: ellipsis;
       max-width: 0;
       opacity: 0;
       transition: max-width .2s cubic-bezier(.4, 0, .2, 1), opacity .16s;


### PR DESCRIPTION
 **The login identity icon never rendered**
-> `LoginScreen` asks for `<Icon name="name" />`, but no `name` icon exists — `Icon` does `ICON[name] || ""`, so it silently rendered an empty `<svg>`. Adds a `user` icon in the set’s existing style and points the field at it.

Why the compiler did not catch it

`ICON` was annotated `Record<string, string>`, which widens `IconName = keyof typeof ICON` to plain `string` — so **any** misspelled icon name type-checks and renders nothing. Dropping the annotation makes `IconName` a literal union, and the next typo fails the build instead of vanishing.

Swept every `<Icon name=... >` in the codebase against the icon set: this was the only broken reference (`SocConsole`’s `name={icon}` is dynamic and correctly typed).

## Rail labels clipped mid-glyph

`.rail .nav-label` sets `overflow: hidden` with no `text-overflow`, so a long account name (`Dev User (Full Admin)`) was cut rather than ellipsized.

A copy commit swapping the login brand panel to lead with the project’s values. Kept separate so the fix above stands alone.
