### PR TITLE
feat: seamless startup, live DB switching, adaptive tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,6 @@ splunk_test_data.json
 *_test.json
 enrichment_result_*.json
 claude_analysis_*.txt
+
+# Autostart list, written by Settings -> Services (see services/autostart_config.py)
+.vigil-autostart

--- a/backend/api/local_services.py
+++ b/backend/api/local_services.py
@@ -1,297 +1,230 @@
-"""Local Services API - Manage local Docker containers (Splunk, PostgreSQL, etc.)."""
+"""Local Services API — start/stop/status for Docker services and Ollama.
 
-import subprocess
+All orchestration lives in ``services/service_manager.py``; this module is the
+HTTP surface over it. Two structural rules:
+
+- Handlers are **sync** ``def``. They call blocking subprocesses, so an
+  ``async def`` would stall the event loop — and every request in the process —
+  for the duration of a compose command. FastAPI runs sync defs in a threadpool.
+- The literal ``/splunk/*`` and ``/postgres/status`` routes are registered
+  **before** the generic ``/{name}/*`` routes. FastAPI matches in registration
+  order, so the reverse would let ``/{name}/status`` swallow ``/splunk/status``.
+"""
+
 import logging
-from typing import Dict, Optional
-from fastapi import APIRouter, HTTPException
+from typing import Callable, List
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+
+from backend.middleware.auth import get_current_active_user, require_settings_admin
+from database.models import User
+from services import service_manager
+from services.autostart_config import get_autostart_services, set_autostart_services
+from services.service_manager import SERVICES, ActionResult, ServiceStatus
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
-
-class ServiceAction(BaseModel):
-    """Service action request."""
-    action: str  # start, stop, restart, status
-
-
-def run_docker_compose_command(service: str, action: str, profile: Optional[str] = None) -> Dict:
-    """
-    Run a docker-compose command for a service.
-    
-    Args:
-        service: Service name (e.g., 'splunk', 'postgres')
-        action: Action to perform ('up', 'down', 'restart', 'ps')
-        profile: Optional docker-compose profile to use
-    
-    Returns:
-        Dict with success status and output/error message
-    """
-    try:
-        import os
-        docker_dir = os.path.join(os.getcwd(), 'docker')
-        
-        if not os.path.exists(docker_dir):
-            return {
-                "success": False,
-                "message": "Docker directory not found"
-            }
-        
-        # Build command (support both v1 standalone and v2 plugin)
-        import shutil
-        if shutil.which('docker-compose'):
-            cmd = ['docker-compose']
-        else:
-            cmd = ['docker', 'compose']
-        
-        if profile:
-            cmd.extend(['--profile', profile])
-        
-        if action == 'up':
-            cmd.extend(['up', '-d', service])
-        elif action == 'down':
-            cmd.extend(['stop', service])
-        elif action == 'restart':
-            cmd.extend(['restart', service])
-        elif action == 'ps':
-            cmd.extend(['ps', '--format', 'json'])
-        else:
-            return {"success": False, "message": f"Unknown action: {action}"}
-        
-        # Run command
-        result = subprocess.run(
-            cmd,
-            cwd=docker_dir,
-            capture_output=True,
-            text=True,
-            timeout=60
-        )
-        
-        if result.returncode == 0:
-            return {
-                "success": True,
-                "message": f"Successfully {action}ed {service}",
-                "output": result.stdout
-            }
-        else:
-            return {
-                "success": False,
-                "message": f"Failed to {action} {service}",
-                "error": result.stderr
-            }
-            
-    except subprocess.TimeoutExpired:
-        return {
-            "success": False,
-            "message": f"Command timed out after 60 seconds"
-        }
-    except Exception as e:
-        logger.error(f"Error running docker-compose: {e}")
-        return {
-            "success": False,
-            "message": f"Error: {str(e)}"
-        }
+# Path params are constrained to the registry, so an argument like `-f/etc/passwd`
+# is rejected by FastAPI before any of our code runs.
+ServiceName = str
 
 
-def get_container_status(container_name: str) -> Dict:
-    """
-    Get the status of a Docker container.
-    
-    Args:
-        container_name: Name of the container
-    
-    Returns:
-        Dict with container status information
-    """
-    try:
-        # Check if container exists and is running
-        result = subprocess.run(
-            ['docker', 'ps', '--filter', f'name={container_name}', '--format', '{{.Status}}'],
-            capture_output=True,
-            text=True,
-            timeout=10
-        )
-        
-        if result.returncode == 0 and result.stdout.strip():
-            status = result.stdout.strip()
-            return {
-                "running": True,
-                "status": status,
-                "container_name": container_name
-            }
-        
-        # Check if container exists but is stopped
-        result = subprocess.run(
-            ['docker', 'ps', '-a', '--filter', f'name={container_name}', '--format', '{{.Status}}'],
-            capture_output=True,
-            text=True,
-            timeout=10
-        )
-        
-        if result.returncode == 0 and result.stdout.strip():
-            return {
-                "running": False,
-                "status": result.stdout.strip(),
-                "container_name": container_name
-            }
-        
-        return {
-            "running": False,
-            "status": "not found",
-            "container_name": container_name
-        }
-        
-    except Exception as e:
-        logger.error(f"Error getting container status: {e}")
-        return {
-            "running": False,
-            "status": "error",
-            "error": str(e)
-        }
+class AutostartRequest(BaseModel):
+    services: List[str]
+
+
+def _resolve(name: str):
+    if name not in SERVICES:
+        raise HTTPException(status_code=404, detail=f"Unknown service: {name}")
+
+
+def _status_payload(s: ServiceStatus) -> dict:
+    return {
+        "name": s.name,
+        "kind": s.kind,
+        "running": s.running,
+        "ready": s.ready,
+        "installed": s.installed,
+        "status": s.status,
+        "managed_by_vigil": s.managed_by_vigil,
+        "startable": s.startable,
+        "stoppable": s.stoppable,
+        "description": s.description,
+        "detail": s.detail,
+    }
+
+
+def _action_payload(r: ActionResult) -> dict:
+    return {
+        "success": r.success,
+        "message": r.message,
+        "already_running": r.already_running,
+        "code": r.code,
+        **r.detail,
+    }
+
+
+# --- Legacy routes (registered first; shapes frozen for the existing client) ---
 
 
 @router.get("/splunk/status")
-async def get_splunk_status():
-    """
-    Get Splunk Docker container status.
-    
-    Returns:
-        Splunk container status and connection info
-    """
-    try:
-        status = get_container_status("deeptempo-splunk")
-        
-        return {
-            "installed": True,  # Docker compose file exists
-            "running": status["running"],
-            "status": status["status"],
-            "container_name": "deeptempo-splunk",
-            "web_url": "http://localhost:6990" if status["running"] else None,
-            "hec_url": "http://localhost:8088" if status["running"] else None,
-            "username": "admin",
-            "note": "Default password: changeme123"
-        }
-    except Exception as e:
-        logger.error(f"Error getting Splunk status: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+def get_splunk_status():
+    s = service_manager.status("splunk")
+    return {
+        "installed": True,
+        "running": s.running,
+        "status": s.status,
+        "container_name": "deeptempo-splunk",
+        "web_url": "http://localhost:6990" if s.running else None,
+        "hec_url": "http://localhost:8088" if s.running else None,
+        "username": "admin",
+        "note": "Default password: changeme123",
+    }
 
 
 @router.post("/splunk/start")
-async def start_splunk():
-    """
-    Start the local Splunk Docker container.
-    
-    Returns:
-        Success status and message
-    """
-    try:
-        # Check if already running
-        status = get_container_status("deeptempo-splunk")
-        if status["running"]:
-            return {
-                "success": True,
-                "message": "Splunk is already running",
-                "web_url": "http://localhost:6990",
-                "already_running": True
-            }
-        
-        # Start Splunk with profile
-        result = run_docker_compose_command("splunk", "up", profile="splunk")
-        
-        if result["success"]:
-            return {
-                "success": True,
-                "message": "Splunk is starting. It may take 2-3 minutes to be fully ready.",
-                "web_url": "http://localhost:6990",
-                "hec_url": "http://localhost:8088",
-                "username": "admin",
-                "password": "changeme123",
-                "note": "First startup may take several minutes. Check status endpoint for ready state."
-            }
-        else:
-            raise HTTPException(status_code=500, detail=result.get("message", "Failed to start Splunk"))
-            
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error starting Splunk: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+def start_splunk(current_user: User = Depends(get_current_active_user)):
+    require_settings_admin(current_user)
+    r = service_manager.start("splunk")
+    if not r.success:
+        raise HTTPException(status_code=500, detail=r.message)
+    if r.already_running:
+        return {
+            "success": True,
+            "message": "Splunk is already running",
+            "web_url": "http://localhost:6990",
+            "already_running": True,
+        }
+    return {
+        "success": True,
+        "message": "Splunk is starting. It may take 2-3 minutes to be fully ready.",
+        "web_url": "http://localhost:6990",
+        "hec_url": "http://localhost:8088",
+        "username": "admin",
+        "password": "changeme123",
+        "note": "First startup may take several minutes. "
+        "Check status endpoint for ready state.",
+    }
 
 
 @router.post("/splunk/stop")
-async def stop_splunk():
-    """
-    Stop the local Splunk Docker container.
-    
-    Returns:
-        Success status and message
-    """
-    try:
-        result = run_docker_compose_command("splunk", "down", profile="splunk")
-        
-        if result["success"]:
-            return {
-                "success": True,
-                "message": "Splunk stopped successfully"
-            }
-        else:
-            raise HTTPException(status_code=500, detail=result.get("message", "Failed to stop Splunk"))
-            
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error stopping Splunk: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+def stop_splunk(current_user: User = Depends(get_current_active_user)):
+    require_settings_admin(current_user)
+    r = service_manager.stop("splunk")
+    if not r.success:
+        raise HTTPException(status_code=500, detail=r.message)
+    return {"success": True, "message": "Splunk stopped successfully"}
 
 
 @router.post("/splunk/restart")
-async def restart_splunk():
-    """
-    Restart the local Splunk Docker container.
-    
-    Returns:
-        Success status and message
-    """
-    try:
-        result = run_docker_compose_command("splunk", "restart", profile="splunk")
-        
-        if result["success"]:
-            return {
-                "success": True,
-                "message": "Splunk restarted successfully",
-                "web_url": "http://localhost:6990"
-            }
-        else:
-            raise HTTPException(status_code=500, detail=result.get("message", "Failed to restart Splunk"))
-            
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error restarting Splunk: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+def restart_splunk(current_user: User = Depends(get_current_active_user)):
+    require_settings_admin(current_user)
+    r = service_manager.restart("splunk")
+    if not r.success:
+        raise HTTPException(status_code=500, detail=r.message)
+    return {
+        "success": True,
+        "message": "Splunk restarted successfully",
+        "web_url": "http://localhost:6990",
+    }
 
 
 @router.get("/postgres/status")
-async def get_postgres_status():
-    """
-    Get PostgreSQL Docker container status.
-    
-    Returns:
-        PostgreSQL container status and connection info
-    """
-    try:
-        status = get_container_status("deeptempo-postgres")
-        
-        return {
-            "installed": True,
-            "running": status["running"],
-            "status": status["status"],
-            "container_name": "deeptempo-postgres",
-            "host": "localhost",
-            "port": 5432,
-            "database": "deeptempo_soc"
-        }
-    except Exception as e:
-        logger.error(f"Error getting PostgreSQL status: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+def get_postgres_status():
+    s = service_manager.status("postgres")
+    return {
+        "installed": True,
+        "running": s.running,
+        "status": s.status,
+        "container_name": "deeptempo-postgres",
+        "host": "localhost",
+        "port": 5432,
+        "database": "deeptempo_soc",
+    }
 
+
+# --- Autostart (literal path; must precede /{name}) ---
+
+
+@router.get("/autostart")
+def read_autostart():
+    return {"services": get_autostart_services(), "available": list(SERVICES)}
+
+
+@router.put("/autostart")
+def write_autostart(
+    body: AutostartRequest, current_user: User = Depends(get_current_active_user)
+):
+    require_settings_admin(current_user)
+    try:
+        return {"services": set_autostart_services(body.services)}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except OSError as e:
+        raise HTTPException(
+            status_code=500, detail=f"Could not persist autostart list: {e}"
+        )
+
+
+# --- Generic routes ---
+
+
+@router.get("")
+@router.get("/")
+def list_services():
+    ok, detail = service_manager.docker_available()
+    return {
+        "docker_available": ok,
+        "docker_detail": detail,
+        "autostart": get_autostart_services(),
+        "services": [_status_payload(s) for s in service_manager.list_services()],
+    }
+
+
+@router.get("/{name}/status")
+def service_status(name: ServiceName):
+    _resolve(name)
+    return _status_payload(service_manager.status(name))
+
+
+@router.post("/{name}/start")
+def service_start(
+    name: ServiceName,
+    wait: bool = Query(False),
+    current_user: User = Depends(get_current_active_user),
+):
+    require_settings_admin(current_user)
+    _resolve(name)
+    r = service_manager.start(name, wait=wait)
+    if not r.success:
+        code = 409 if r.code in ("not_startable", "not_installed") else 500
+        raise HTTPException(status_code=code, detail=r.message)
+    return _action_payload(r)
+
+
+def _lifecycle(name: str, current_user: User, action: Callable[[str], ActionResult]):
+    """Shared body for the stop/restart routes: gate, resolve, act, translate."""
+    require_settings_admin(current_user)
+    _resolve(name)
+    r = action(name)
+    if not r.success:
+        raise HTTPException(
+            status_code=409 if r.code == "not_stoppable" else 500, detail=r.message
+        )
+    return _action_payload(r)
+
+
+@router.post("/{name}/stop")
+def service_stop(
+    name: ServiceName, current_user: User = Depends(get_current_active_user)
+):
+    return _lifecycle(name, current_user, service_manager.stop)
+
+
+@router.post("/{name}/restart")
+def service_restart(
+    name: ServiceName, current_user: User = Depends(get_current_active_user)
+):
+    return _lifecycle(name, current_user, service_manager.restart)

--- a/backend/api/storage_status.py
+++ b/backend/api/storage_status.py
@@ -5,84 +5,96 @@ Provides information about the current data storage backend (PostgreSQL or JSON)
 """
 
 import logging
-from fastapi import APIRouter
+import threading
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.middleware.auth import get_current_active_user, require_settings_admin
+from database.models import User
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Serializes engine swaps; two concurrent retargets would race on the manager.
+_RETARGET_LOCK = threading.Lock()
 
 
 @router.get("/status")
 async def get_storage_status():
     """
     Get information about the current storage backend.
-    
+
     Returns:
         Dictionary with storage backend information
     """
     try:
         from services.database_data_service import DatabaseDataService
         from core.config import is_demo_mode
-        
+
         test_service = DatabaseDataService()
         backend_info = test_service.get_backend_info()
         demo_mode = is_demo_mode()
-        
+
         return {
-            'backend': backend_info['backend'],
-            'database_available': backend_info.get('database_available', False),
-            'demo_mode': demo_mode,
-            'description': _get_backend_description(backend_info['backend'], demo_mode),
-            'recommendations': _get_recommendations(backend_info)
+            "backend": backend_info["backend"],
+            "database_available": backend_info.get("database_available", False),
+            "demo_mode": demo_mode,
+            "description": _get_backend_description(backend_info["backend"], demo_mode),
+            "recommendations": _get_recommendations(backend_info),
         }
-    
+
     except Exception as e:
         logger.error(f"Error getting storage status: {e}")
         return {
-            'backend': 'unknown',
-            'database_available': False,
-            'demo_mode': False,
-            'json_available': True,
-            'error': str(e),
-            'description': 'Unable to determine storage backend'
+            "backend": "unknown",
+            "database_available": False,
+            "demo_mode": False,
+            "json_available": True,
+            "error": str(e),
+            "description": "Unable to determine storage backend",
         }
 
 
 def _get_backend_description(backend: str, demo_mode: bool = False) -> str:
     """Get human-readable description of the backend."""
-    if demo_mode or backend == 'demo':
-        return 'Demo mode: Using generated sample data for demonstration'
+    if demo_mode or backend == "demo":
+        return "Demo mode: Using generated sample data for demonstration"
     descriptions = {
-        'postgresql': 'Using PostgreSQL database for production-grade data storage',
-        'json': 'Using JSON file storage (development/fallback mode)',
-        'unknown': 'Storage backend status unknown'
+        "postgresql": "Using PostgreSQL database for production-grade data storage",
+        "json": "Using JSON file storage (development/fallback mode)",
+        "unknown": "Storage backend status unknown",
     }
-    return descriptions.get(backend, 'Unknown storage backend')
+    return descriptions.get(backend, "Unknown storage backend")
 
 
 def _get_recommendations(backend_info: dict) -> list:
     """Get recommendations based on current backend status."""
     recommendations = []
-    
-    backend = backend_info.get('backend')
-    database_available = backend_info.get('database_available', False)
-    
-    if backend == 'json' and not database_available:
-        recommendations.append({
-            'title': 'Enable PostgreSQL for Production',
-            'description': 'Currently using JSON file storage. For better performance and reliability, enable PostgreSQL.',
-            'action': 'Start database with: cd docker && docker compose up -d postgres',
-            'priority': 'medium'
-        })
-    
-    if backend == 'postgresql':
-        recommendations.append({
-            'title': 'Database Running',
-            'description': 'PostgreSQL is active and ready for production use.',
-            'action': 'Set up automated backups for data protection',
-            'priority': 'low'
-        })
-    
+
+    backend = backend_info.get("backend")
+    database_available = backend_info.get("database_available", False)
+
+    if backend == "json" and not database_available:
+        recommendations.append(
+            {
+                "title": "Enable PostgreSQL for Production",
+                "description": "Currently using JSON file storage. For better performance and reliability, enable PostgreSQL.",
+                "action": "Start database with: cd docker && docker compose up -d postgres",
+                "priority": "medium",
+            }
+        )
+
+    if backend == "postgresql":
+        recommendations.append(
+            {
+                "title": "Database Running",
+                "description": "PostgreSQL is active and ready for production use.",
+                "action": "Set up automated backups for data protection",
+                "priority": "low",
+            }
+        )
+
     return recommendations
 
 
@@ -90,178 +102,274 @@ def _get_recommendations(backend_info: dict) -> list:
 async def check_storage_health():
     """
     Perform health check on the storage backend.
-    
+
     Returns:
         Health status of the storage backend
     """
     try:
         from services.database_data_service import DatabaseDataService
         from core.config import is_demo_mode
-        
+
         service = DatabaseDataService()
         is_healthy = True
         demo_mode = is_demo_mode()
-        
+
         # Test basic operations
         try:
             findings = service.get_findings()
             cases = service.get_cases()
-            
+
             if demo_mode:
-                backend = 'demo'
+                backend = "demo"
             elif service.is_using_database():
-                backend = 'postgresql'
+                backend = "postgresql"
             else:
-                backend = 'json'
-            
+                backend = "json"
+
             return {
-                'healthy': is_healthy,
-                'backend': backend,
-                'demo_mode': demo_mode,
-                'findings_count': len(findings),
-                'cases_count': len(cases),
-                'message': 'Demo mode active with sample data' if demo_mode else 'Storage backend is functioning normally'
+                "healthy": is_healthy,
+                "backend": backend,
+                "demo_mode": demo_mode,
+                "findings_count": len(findings),
+                "cases_count": len(cases),
+                "message": "Demo mode active with sample data"
+                if demo_mode
+                else "Storage backend is functioning normally",
             }
-        
+
         except Exception as e:
             return {
-                'healthy': False,
-                'backend': 'unknown',
-                'demo_mode': demo_mode,
-                'error': str(e),
-                'message': 'Storage backend health check failed'
+                "healthy": False,
+                "backend": "unknown",
+                "demo_mode": demo_mode,
+                "error": str(e),
+                "message": "Storage backend health check failed",
             }
-    
+
     except Exception as e:
         logger.error(f"Health check error: {e}")
         return {
-            'healthy': False,
-            'backend': 'unknown',
-            'demo_mode': False,
-            'error': str(e),
-            'message': 'Unable to perform health check'
+            "healthy": False,
+            "backend": "unknown",
+            "demo_mode": False,
+            "error": str(e),
+            "message": "Unable to perform health check",
         }
 
 
 @router.post("/reconnect")
-async def reconnect_database():
+def reconnect_database(current_user: User = Depends(get_current_active_user)):
     """
-    Attempt to reconnect to PostgreSQL database without restarting the application.
-    
-    This is useful when:
-    - PostgreSQL was started after the application
-    - Database configuration was changed
-    - Connection was lost and needs to be re-established
-    
-    Returns:
-        Status of the reconnection attempt
+    Re-read the database configuration and swap onto it, without a restart.
+
+    Handles both "PostgreSQL came up after the app did" and "the admin changed
+    the connection string in Settings" — the config is re-read every call.
+
+    The new engine is built and probed *before* the old one is discarded, so a
+    bad target leaves the working connection serving. Sync def on purpose: it
+    blocks on I/O, so FastAPI runs it in a threadpool instead of stalling the
+    event loop.
     """
-    try:
-        from database.connection import get_db_manager
-        
-        logger.info("Attempting to reconnect to PostgreSQL database...")
-        
-        # Get the database manager
+    require_settings_admin(current_user)
+
+    from database.connection import get_db_manager
+
+    with _RETARGET_LOCK:
         db_manager = get_db_manager()
-        
-        # Close existing connections
-        db_manager.close()
-        
-        # Reinitialize the database connection
-        db_manager.initialize(echo=False)
-        db_manager.create_tables()
-        
-        # Test the connection
-        if db_manager.health_check():
-            logger.info("✓ Successfully reconnected to PostgreSQL")
-            
+        previous = getattr(db_manager, "config", None)
+        try:
+            result = db_manager.retarget(validate=True)
+        except Exception as e:
+            logger.error("Database retarget rejected: %s", e)
             return {
-                'success': True,
-                'backend': 'postgresql',
-                'message': 'Successfully reconnected to PostgreSQL database',
-                'database_available': True,
-                'connection_info': {
-                    'host': db_manager.config.host,
-                    'port': db_manager.config.port,
-                    'database': db_manager.config.database
-                }
+                "success": False,
+                "changed": False,
+                "backend": "postgresql" if db_manager.health_check() else "json",
+                "message": f"New target rejected; the existing connection is intact: {e}",
+                "database_available": db_manager.health_check(),
+                "recommendation": "Check the connection string, and that the database is reachable.",
             }
-        else:
-            logger.warning("Database health check failed after reconnection attempt")
-            return {
-                'success': False,
-                'backend': 'json',
-                'message': 'Database reconnection failed. Health check did not pass.',
-                'database_available': False,
-                'recommendation': 'Ensure PostgreSQL is running: cd docker && docker compose up -d postgres'
-            }
-    
-    except Exception as e:
-        logger.error(f"Error reconnecting to database: {e}")
+
+        cfg = result.config
+        schema = db_manager.schema_report()
+        _audit_retarget(previous, cfg, current_user)
+        logger.info(
+            "Reconnected to %s:%s/%s (schema=%s)",
+            cfg.host,
+            cfg.port,
+            cfg.database,
+            schema["state"],
+        )
+        if schema["state"] == "drifted":
+            logger.warning(
+                "Target schema is out of date: missing tables=%s columns=%s",
+                schema["missing_tables"],
+                schema["missing_columns"],
+            )
         return {
-            'success': False,
-            'backend': 'json',
-            'message': f'Failed to reconnect: {str(e)}',
-            'database_available': False,
-            'recommendation': 'Check PostgreSQL logs and ensure it is running'
+            "success": True,
+            "changed": True,
+            "backend": "postgresql",
+            "message": _schema_message(schema),
+            "database_available": True,
+            "connection_info": {
+                "host": cfg.host,
+                "port": cfg.port,
+                "database": cfg.database,
+                "source": cfg.source,
+            },
+            # Connections checked out at swap time finish against the previous
+            # database — surface that rather than let it look atomic.
+            "in_flight_connections_at_swap": result.in_flight_at_swap,
+            "schema_state": schema["state"],
+            "missing_tables": schema["missing_tables"],
+            "missing_columns": schema["missing_columns"],
+            "requires_schema_init": schema["state"] == "empty",
+            "requires_migration": schema["state"] == "drifted",
+            # The worker and daemon are separate processes with their own
+            # engines; they converge on their next config check.
+            "other_processes_stale": True,
         }
+
+
+def _schema_message(schema: dict) -> str:
+    state = schema["state"]
+    if state == "empty":
+        return "Connected. The database has no Vigil tables yet - initialize the schema to use it."
+    if state == "drifted":
+        return (
+            "Connected, but the database schema is out of date and the app will "
+            "misbehave against it. Run scripts/migrate_schema.py to bring it up to date."
+        )
+    if state == "unknown":
+        return "Connected, but the schema could not be inspected."
+    return "Connected to PostgreSQL database"
+
+
+def _audit_retarget(previous, current, user: User) -> None:
+    """Record the target change. Best-effort: never fails the swap."""
+    try:
+        from database.connection import get_db_session
+        from database.models import ConfigAuditLog
+
+        before = (
+            f"{previous.host}:{previous.port}/{previous.database}"
+            if previous
+            else "(none)"
+        )
+        with get_db_session() as session:
+            session.add(
+                ConfigAuditLog(
+                    config_key="DATABASE_TARGET",
+                    action="update",
+                    old_value=before,
+                    new_value=f"{current.host}:{current.port}/{current.database}",
+                    changed_by=str(user.user_id),
+                )
+            )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Could not write retarget audit log: %s", e)
+
+
+@router.post("/init-schema")
+def init_schema(current_user: User = Depends(get_current_active_user)):
+    """
+    Provision Vigil's tables into an **empty** target database.
+
+    Split out of /reconnect, and deliberately narrow. ``create_all`` is
+    ``checkfirst=True``: it creates what's missing and silently skips tables
+    that already exist, whatever shape they're in. That makes it correct for an
+    empty database and useless — actively misleading — for a drifted one.
+
+    So this refuses anything but ``state == "empty"``:
+      - ``drifted`` -> scripts/migrate_schema.py owns that (it has the real
+        ALTER TABLE migrations); create_all here would report success and
+        change nothing.
+      - ``ok`` -> nothing to do.
+
+    Refusing on non-empty also means a mistyped host can't scatter ~50 tables
+    through an unrelated production database.
+    """
+    require_settings_admin(current_user)
+
+    from database.connection import get_db_manager
+
+    db_manager = get_db_manager()
+    before = db_manager.schema_report()
+    if before["state"] == "drifted":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Database has an out-of-date Vigil schema. create_all cannot alter "
+                "existing tables - run scripts/migrate_schema.py against it instead. "
+                f"Missing columns: {before['missing_columns']}"
+            ),
+        )
+    if before["state"] == "ok":
+        return {"success": True, "message": "Schema already up to date", **before}
+    if before["state"] == "unknown":
+        raise HTTPException(status_code=409, detail="Cannot inspect the target schema.")
+
+    try:
+        db_manager.create_tables()
+    except Exception as e:
+        logger.error("Schema init failed: %s", e)
+        raise HTTPException(status_code=500, detail=f"Schema init failed: {e}")
+    logger.info("Provisioned Vigil schema into empty database")
+    return {"success": True, "message": "Schema created", **db_manager.schema_report()}
 
 
 @router.post("/switch-backend")
 async def switch_backend(backend: str):
     """
     Attempt to switch storage backend (requires restart).
-    
+
     Args:
         backend: Target backend ('database' or 'json')
-    
+
     Returns:
         Status of the switch request
     """
-    if backend not in ['database', 'json']:
+    if backend not in ["database", "json"]:
         return {
-            'success': False,
-            'message': 'Invalid backend. Must be "database" or "json"'
+            "success": False,
+            "message": 'Invalid backend. Must be "database" or "json"',
         }
-    
+
     import os
     from pathlib import Path
-    
+
     try:
         # Update .env file
-        env_file = Path('.env')
-        
+        env_file = Path(".env")
+
         if env_file.exists():
-            with open(env_file, 'r') as f:
+            with open(env_file, "r") as f:
                 lines = f.readlines()
-            
+
             updated = False
-            with open(env_file, 'w') as f:
+            with open(env_file, "w") as f:
                 for line in lines:
-                    if line.startswith('DATA_BACKEND='):
-                        f.write(f'DATA_BACKEND={backend}\n')
+                    if line.startswith("DATA_BACKEND="):
+                        f.write(f"DATA_BACKEND={backend}\n")
                         updated = True
                     else:
                         f.write(line)
-                
+
                 if not updated:
-                    f.write(f'\n# Data storage backend\nDATA_BACKEND={backend}\n')
-            
+                    f.write(f"\n# Data storage backend\nDATA_BACKEND={backend}\n")
+
             return {
-                'success': True,
-                'message': f'Backend set to {backend}. Please restart the application for changes to take effect.',
-                'requires_restart': True
+                "success": True,
+                "message": f"Backend set to {backend}. Please restart the application for changes to take effect.",
+                "requires_restart": True,
             }
         else:
             return {
-                'success': False,
-                'message': '.env file not found. Please create one from env.example'
+                "success": False,
+                "message": ".env file not found. Please create one from env.example",
             }
-    
+
     except Exception as e:
         logger.error(f"Error switching backend: {e}")
-        return {
-            'success': False,
-            'message': f'Failed to switch backend: {str(e)}'
-        }
-
+        return {"success": False, "message": f"Failed to switch backend: {str(e)}"}

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -34,27 +34,27 @@ _dev_user = None
 def _get_dev_user(session: Session) -> User:
     """
     Get or create a mock dev user for development mode.
-    
+
     Args:
         session: Database session
-    
+
     Returns:
         Mock dev user with admin permissions
     """
     global _dev_user
-    
+
     if _dev_user is None:
         # Try to get existing admin user
         _dev_user = session.query(User).filter(User.username == "admin").first()
-        
+
         # If no admin, create a mock user object (won't be persisted)
         if _dev_user is None:
             from database.models import Role
             import uuid
-            
+
             # Try to get admin role
             admin_role = session.query(Role).filter(Role.name == "admin").first()
-            
+
             # Create mock user
             _dev_user = User(
                 user_id=str(uuid.uuid4()),
@@ -63,17 +63,17 @@ def _get_dev_user(session: Session) -> User:
                 password_hash="",  # Not used in dev mode
                 role_id=admin_role.role_id if admin_role else str(uuid.uuid4()),
                 is_active=True,
-                mfa_enabled=False
+                mfa_enabled=False,
             )
             logger.info("Created mock dev user (not persisted to DB)")
-    
+
     return _dev_user
 
 
 async def get_current_user(
     request: Request,
     authorization: Optional[str] = Header(None),
-    session: Session = Depends(get_db)
+    session: Session = Depends(get_db),
 ) -> User:
     """
     Resolve the authenticated user from either the access_token HttpOnly
@@ -120,7 +120,7 @@ async def get_current_user(
             detail="Not authenticated",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    
+
     # Verify JWT token
     payload = AuthService.verify_jwt_token(token)
     if not payload:
@@ -156,160 +156,194 @@ async def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found",
         )
-    
+
     if not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="User account is inactive",
         )
-    
+
     return user
 
 
 async def get_current_active_user(
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user),
 ) -> User:
     """
     Dependency to get current active user.
-    
+
     Args:
         current_user: Current user from get_current_user
-    
+
     Returns:
         Current active User object
     """
     if not current_user.is_active:
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="User account is inactive"
+            status_code=status.HTTP_403_FORBIDDEN, detail="User account is inactive"
         )
     return current_user
+
+
+def require_settings_admin(current_user: User) -> None:
+    """Raise 403 unless the user may change system settings.
+
+    A plain call, not a decorator: the callers are sync route handlers, which
+    ``require_permission`` below cannot wrap (it awaits the endpoint).
+    """
+    if not AuthService.check_permission(current_user.user_id, "settings.write"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permission denied: settings.write required",
+        )
 
 
 def require_permission(permission: str):
     """
     Decorator to require a specific permission for an endpoint.
-    
+
     Usage:
         @router.get("/cases")
         @require_permission("cases.read")
         async def get_cases(current_user: User = Depends(get_current_user)):
             ...
-    
+
     Args:
         permission: Permission string (e.g., "cases.write")
-    
+
     Returns:
         Decorated function
     """
+
     def decorator(func: Callable):
         @wraps(func)
-        async def wrapper(*args, current_user: User = Depends(get_current_user), **kwargs):
+        async def wrapper(
+            *args, current_user: User = Depends(get_current_user), **kwargs
+        ):
             # Check if user has permission
             has_permission = AuthService.check_permission(
-                current_user.user_id,
-                permission
+                current_user.user_id, permission
             )
-            
+
             if not has_permission:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
-                    detail=f"Permission denied: {permission} required"
+                    detail=f"Permission denied: {permission} required",
                 )
-            
+
             return await func(*args, current_user=current_user, **kwargs)
-        
+
         return wrapper
+
     return decorator
 
 
 def require_any_permission(*permissions: str):
     """
     Decorator to require any of the specified permissions.
-    
+
     Args:
         permissions: Permission strings
-    
+
     Returns:
         Decorated function
     """
+
     def decorator(func: Callable):
         @wraps(func)
-        async def wrapper(*args, current_user: User = Depends(get_current_user), **kwargs):
+        async def wrapper(
+            *args, current_user: User = Depends(get_current_user), **kwargs
+        ):
             # Check if user has any of the permissions
             user_permissions = AuthService.get_user_permissions(current_user.user_id)
-            
+
             has_any = any(user_permissions.get(perm, False) for perm in permissions)
-            
+
             if not has_any:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
-                    detail=f"Permission denied: One of {permissions} required"
+                    detail=f"Permission denied: One of {permissions} required",
                 )
-            
+
             return await func(*args, current_user=current_user, **kwargs)
-        
+
         return wrapper
+
     return decorator
 
 
 def require_all_permissions(*permissions: str):
     """
     Decorator to require all of the specified permissions.
-    
+
     Args:
         permissions: Permission strings
-    
+
     Returns:
         Decorated function
     """
+
     def decorator(func: Callable):
         @wraps(func)
-        async def wrapper(*args, current_user: User = Depends(get_current_user), **kwargs):
+        async def wrapper(
+            *args, current_user: User = Depends(get_current_user), **kwargs
+        ):
             # Check if user has all permissions
             user_permissions = AuthService.get_user_permissions(current_user.user_id)
-            
+
             has_all = all(user_permissions.get(perm, False) for perm in permissions)
-            
+
             if not has_all:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
-                    detail=f"Permission denied: All of {permissions} required"
+                    detail=f"Permission denied: All of {permissions} required",
                 )
-            
+
             return await func(*args, current_user=current_user, **kwargs)
-        
+
         return wrapper
+
     return decorator
 
 
 def require_role(role_name: str):
     """
     Decorator to require a specific role.
-    
+
     Args:
         role_name: Role name (e.g., "Admin")
-    
+
     Returns:
         Decorated function
     """
+
     def decorator(func: Callable):
         @wraps(func)
-        async def wrapper(*args, current_user: User = Depends(get_current_user), session: Session = Depends(get_db), **kwargs):
+        async def wrapper(
+            *args,
+            current_user: User = Depends(get_current_user),
+            session: Session = Depends(get_db),
+            **kwargs,
+        ):
             from database.models import Role
-            
+
             # Get user's role
-            role = session.query(Role).filter(Role.role_id == current_user.role_id).first()
-            
+            role = (
+                session.query(Role).filter(Role.role_id == current_user.role_id).first()
+            )
+
             if not role or role.name != role_name:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
-                    detail=f"Role '{role_name}' required"
+                    detail=f"Role '{role_name}' required",
                 )
-            
-            return await func(*args, current_user=current_user, session=session, **kwargs)
-        
+
+            return await func(
+                *args, current_user=current_user, session=session, **kwargs
+            )
+
         return wrapper
+
     return decorator
 
 
@@ -317,7 +351,7 @@ def require_role(role_name: str):
 async def get_optional_user(
     request: Request,
     authorization: Optional[str] = Header(None),
-    session: Session = Depends(get_db)
+    session: Session = Depends(get_db),
 ) -> Optional[User]:
     """
     Dependency to optionally get the current user.
@@ -341,4 +375,3 @@ async def get_optional_user(
         return await get_current_user(request, authorization, session)
     except HTTPException:
         return None
-

--- a/core/config.py
+++ b/core/config.py
@@ -62,14 +62,3 @@ def get_enabled_integrations() -> list[str]:
 def get_general_config(key: str, default: Any = None) -> Any:
     data = _load_json_config(GENERAL_CONFIG_FILE)
     return data.get(key, default)
-
-
-def get_database_url() -> str:
-    from backend.secrets_manager import get_secret
-    url = get_secret("POSTGRESQL_CONNECTION_STRING")
-    if url:
-        return url
-    return os.getenv(
-        "DATABASE_URL",
-        "postgresql://deeptempo:deeptempo@localhost:5432/deeptempo_soc"
-    )

--- a/database/connection.py
+++ b/database/connection.py
@@ -6,10 +6,12 @@ Handles database connections, session management, and connection pooling.
 
 import os
 import logging
-from typing import Optional, Generator, TYPE_CHECKING
-from urllib.parse import quote
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Generator, TYPE_CHECKING
+from urllib.parse import parse_qsl, quote, unquote, urlsplit
 from contextlib import contextmanager
-from sqlalchemy import create_engine, event, pool, text
+from sqlalchemy import create_engine, inspect, pool, text
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.engine import Engine
 
@@ -88,17 +90,17 @@ def _load_platform_db_proxy() -> "ProxyConfig":
         from services.db_proxy import ProxyConfig
         from backend.secrets_manager import get_secret
     except ImportError:
-        # If the secrets manager isn't importable yet (e.g. during a
-        # pre-install sanity check), skip proxy support gracefully.
+        # If the secrets manager isn't importable yet skip proxy support gracefully.
         from services.db_proxy import ProxyConfig
 
         return ProxyConfig()
 
     raw: dict[str, object] = {}
-    for field, secret_key in _PLATFORM_DB_PROXY_KEYS.items():
+    # `attr`, not `field`: dataclasses.field is imported at module scope.
+    for attr, secret_key in _PLATFORM_DB_PROXY_KEYS.items():
         value = get_secret(secret_key)
         if value is not None and value != "":
-            raw[field] = value
+            raw[attr] = value
     if not raw or (raw.get("proxy_type") or "none").lower() in ("", "none"):
         return ProxyConfig()
     raw.setdefault("verify_proxy_tls", True)
@@ -114,11 +116,139 @@ def _load_platform_db_proxy() -> "ProxyConfig":
     return ProxyConfig.from_dict(raw)
 
 
-class DatabaseConfig:
-    """Database configuration management."""
+# libpq parameters we accept from a user-supplied DSN. Everything else is
+# rejected: sslcert/sslkey/sslrootcert/passfile/service take *local file paths*,
+# so honouring them would hand an authenticated admin a file-read/probe
+# primitive against the backend host. Allowlist, not blocklist.
+_ALLOWED_DSN_PARAMS = frozenset(
+    {"sslmode", "connect_timeout", "application_name", "target_session_attrs"}
+)
+_ALLOWED_DSN_SCHEMES = frozenset({"postgresql", "postgres", "postgresql+psycopg2"})
 
-    def __init__(self):
-        """Initialize database configuration from environment variables."""
+
+@dataclass(frozen=True)
+class ParsedDsn:
+    """A validated PostgreSQL connection string."""
+
+    host: str
+    port: int
+    database: str
+    user: str
+    password: str
+    query: Dict[str, str] = field(default_factory=dict)
+
+
+def parse_connection_string(dsn: str) -> ParsedDsn:
+    dsn = (dsn or "").strip()
+    if not dsn:
+        raise ValueError("empty connection string")
+
+    parts = urlsplit(dsn)
+    if parts.scheme not in _ALLOWED_DSN_SCHEMES:
+        raise ValueError(f"unsupported scheme: {parts.scheme or '(none)'}")
+
+    try:
+        port = parts.port or 5432
+    except ValueError:
+        raise ValueError("port must be numeric") from None
+
+    # Decode before validating: urlsplit leaves the host percent-encoded, so a
+    # raw startswith("/") check misses "%2Fvar%2Frun" — which SQLAlchemy would
+    # decode straight back into a unix socket path.
+    host = unquote(parts.hostname or "")
+    if not host:
+        raise ValueError("missing host")
+    if host.startswith("/"):
+        raise ValueError("unix socket paths are not supported")
+    if any(c.isspace() or ord(c) < 32 for c in host):
+        raise ValueError("host contains invalid characters")
+    database = unquote(parts.path.lstrip("/"))
+    if not database:
+        raise ValueError("missing database name")
+
+    query = {k.lower(): v for k, v in parse_qsl(parts.query, keep_blank_values=False)}
+    rejected = set(query) - _ALLOWED_DSN_PARAMS
+    if rejected:
+        raise ValueError(
+            f"unsupported connection parameter(s): {', '.join(sorted(rejected))}"
+        )
+
+    return ParsedDsn(
+        host=host,
+        port=port,
+        database=database,
+        user=unquote(parts.username or ""),
+        password=unquote(parts.password or ""),
+        query=query,
+    )
+
+
+def _load_connection_string_secret() -> Optional[str]:
+    """Read POSTGRESQL_CONNECTION_STRING from the **encrypted store only**.
+
+    Deliberately not ``get_secret()``: that falls back to the environment, and
+    ``backend/main.py`` stuffs a hardcoded default connection string into
+    ``os.environ`` for the MCP servers whenever the secret is unset. Reading
+    through the fallback chain would let that default outrank an operator's
+    POSTGRES_* variables — silently pinning them to localhost. The encrypted
+    store is where Settings -> PostgreSQL writes, so it alone expresses intent.
+
+    Local import for the same reason as :func:`_load_platform_db_proxy` —
+    ``database/`` must not hard-depend on the secrets manager at import time.
+    """
+    try:
+        from backend.secrets_manager import get_secrets_manager
+    except ImportError:
+        return None
+    try:
+        backend = get_secrets_manager().encrypted_backend
+        return (
+            backend.get("POSTGRESQL_CONNECTION_STRING")
+            if backend.is_available()
+            else None
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Could not read POSTGRESQL_CONNECTION_STRING: %s", e)
+        return None
+
+
+class DatabaseConfig:
+    def __init__(self, *, connection_string: Optional[str] = None):
+        """Initialize from the connection-string secret, else the environment."""
+        dsn = (
+            connection_string
+            if connection_string is not None
+            else _load_connection_string_secret()
+        )
+        self.source = "env"
+        if dsn:
+            try:
+                self._from_dsn(parse_connection_string(dsn))
+                self.source = "connection_string"
+            except ValueError as e:
+                logger.error(
+                    "Invalid POSTGRESQL_CONNECTION_STRING (%s); using POSTGRES_* env",
+                    e,
+                )
+                self._from_env()
+        else:
+            self._from_env()
+
+        # Connection pool settings
+        self.pool_size = int(os.getenv("DB_POOL_SIZE", "10"))
+        self.max_overflow = int(os.getenv("DB_MAX_OVERFLOW", "20"))
+        self.pool_timeout = int(os.getenv("DB_POOL_TIMEOUT", "30"))
+        self.pool_recycle = int(os.getenv("DB_POOL_RECYCLE", "3600"))
+        try:
+            self.proxy = _load_platform_db_proxy()
+        except Exception as e:  # noqa: BLE001
+            # A malformed proxy secret must not make retarget unrecoverable.
+            from services.db_proxy import ProxyConfig
+
+            logger.error("Ignoring invalid platform DB proxy config: %s", e)
+            self.proxy = ProxyConfig()
+
+    def _from_env(self) -> None:
         self.host = os.getenv("POSTGRES_HOST", "localhost")
         self.port = int(os.getenv("POSTGRES_PORT", "5432"))
         self.database = os.getenv("POSTGRES_DB", "deeptempo_soc")
@@ -126,20 +256,19 @@ class DatabaseConfig:
         self.password = os.getenv(
             "POSTGRES_PASSWORD", "deeptempo_secure_password_change_me"
         )
-
-        # Connection pool settings
-        self.pool_size = int(os.getenv("DB_POOL_SIZE", "10"))
-        self.max_overflow = int(os.getenv("DB_MAX_OVERFLOW", "20"))
-        self.pool_timeout = int(os.getenv("DB_POOL_TIMEOUT", "30"))
-        self.pool_recycle = int(os.getenv("DB_POOL_RECYCLE", "3600"))
-
-        # SSL settings
         self.ssl_mode = os.getenv("POSTGRES_SSL_MODE", "prefer")
+        self.extra_query: Dict[str, str] = {}
 
-        # Optional proxy in front of the DB (PgBouncer or SSH tunnel).
-        # Loaded lazily so unrelated tests that import DatabaseConfig
-        # don't need a live secrets manager.
-        self.proxy = _load_platform_db_proxy()
+    def _from_dsn(self, parsed: ParsedDsn) -> None:
+        self.host = parsed.host
+        self.port = parsed.port
+        self.database = parsed.database
+        self.user = parsed.user
+        self.password = parsed.password
+        self.ssl_mode = parsed.query.get("sslmode") or os.getenv(
+            "POSTGRES_SSL_MODE", "prefer"
+        )
+        self.extra_query = {k: v for k, v in parsed.query.items() if k != "sslmode"}
 
     def get_database_url(
         self,
@@ -148,17 +277,6 @@ class DatabaseConfig:
         host: Optional[str] = None,
         port: Optional[int] = None,
     ) -> str:
-        """
-        Get the database connection URL.
-
-        Args:
-            async_driver: If True, use async driver (asyncpg), otherwise use psycopg2
-            host: Override host (used after a proxy rewrites the endpoint).
-            port: Override port (used after a proxy rewrites the endpoint).
-
-        Returns:
-            Database connection URL
-        """
         driver = "postgresql+asyncpg" if async_driver else "postgresql+psycopg2"
         effective_host = host or self.host
         effective_port = port or self.port
@@ -169,10 +287,50 @@ class DatabaseConfig:
             f"@{effective_host}:{effective_port}/{self.database}"
         )
 
+        params = dict(getattr(self, "extra_query", {}) or {})
         if self.ssl_mode != "prefer":
-            url += f"?sslmode={self.ssl_mode}"
+            params["sslmode"] = self.ssl_mode
+        if params:
+            url += "?" + "&".join(
+                f"{k}={quote(v, safe='')}" for k, v in sorted(params.items())
+            )
 
         return url
+
+
+@dataclass(frozen=True)
+class RetargetResult:
+    """Outcome of a successful :meth:`DatabaseManager.retarget`."""
+
+    config: "DatabaseConfig"
+    in_flight_at_swap: int = 0
+
+
+# Backend, LLM worker and daemon are separate processes with independent
+# DatabaseManager singletons, so an API-driven retarget only moves one of them.
+# Left alone, the daemon would keep ingesting into the old database while the
+# backend wrote to the new one — silent divergence, the worst failure mode for
+# a SOC tool. The DSN lives in the secrets file, which is file-backed and
+# DB-independent (you cannot read the new database's address from the old
+# database), so its mtime is the cross-process change signal.
+_CONFIG_CHECK_INTERVAL = float(os.getenv("DB_CONFIG_CHECK_INTERVAL", "5"))
+
+
+def db_config_generation() -> float:
+    """Change-stamp for the DB config: the secrets file's mtime, else 0.0.
+
+    Returns 0.0 when the encrypted backend isn't in use — the dotenv backend
+    has no mtime tracking, so propagation is unavailable there.
+    """
+    try:
+        from backend.secrets_manager import get_secrets_manager
+
+        backend = get_secrets_manager().encrypted_backend
+        if not backend.is_available():
+            return 0.0
+        return backend._current_mtime()
+    except Exception:  # noqa: BLE001
+        return 0.0
 
 
 class DatabaseManager:
@@ -192,78 +350,207 @@ class DatabaseManager:
         """Initialize the database manager."""
         if not hasattr(self, "_initialized"):
             self.config = DatabaseConfig()
-            # Holds an SSH tunnel (or other proxy artifact) for the
-            # process lifetime when the platform DB is fronted by a
-            # tunneling proxy. Closed in :meth:`close`.
             self._proxy_handle = None
             self._initialized = True
 
-    def initialize(self, echo: bool = False):
+    def _build(self, config: DatabaseConfig, echo: bool) -> tuple[Engine, Any]:
+        """Resolve the proxy and create an engine. Touches no instance state.
+
+        Keeping this side-effect free is what lets :meth:`retarget` validate a
+        candidate before disturbing the live engine.
+        """
+        host, port, proxy = config.host, config.port, None
+        if config.proxy.enabled:
+            from services.db_proxy import apply as apply_proxy
+
+            proxy = apply_proxy(host, port, config.proxy)
+            host, port = proxy.host, proxy.port
+            logger.info(
+                "Platform DB proxy active: type=%s effective endpoint %s:%s",
+                config.proxy.proxy_type,
+                host,
+                port,
+            )
+
+        engine = create_engine(
+            config.get_database_url(host=host, port=port),
+            echo=echo,
+            pool_size=config.pool_size,
+            max_overflow=config.max_overflow,
+            pool_timeout=config.pool_timeout,
+            pool_recycle=config.pool_recycle,
+            pool_pre_ping=True,  # Verify connections before using them
+            # Bounded so validating an unreachable host fails in seconds rather
+            # than hanging a worker thread for the OS TCP timeout (~75s).
+            connect_args={"connect_timeout": 5},
+        )
+
+        return engine, proxy
+
+    def retarget(
+        self,
+        config: Optional[DatabaseConfig] = None,
+        *,
+        echo: bool = False,
+        validate: bool = True,
+    ):
+        new_config = config or DatabaseConfig()
+        engine, proxy = self._build(new_config, echo)
+
+        if validate:
+            try:
+                with engine.connect() as conn:
+                    conn.execute(text("SELECT 1"))
+            except Exception:
+                engine.dispose()
+                if proxy is not None:
+                    proxy.close()
+                raise  # live engine/proxy untouched
+
+        old_engine, old_proxy = self._engine, self._proxy_handle
+        # Checked-out connections survive dispose() and finish against the OLD
+        # database, so report how many were in flight rather than pretend not.
+        in_flight = old_engine.pool.checkedout() if old_engine is not None else 0
+
+        self.config = new_config
+        self._engine = engine
+        self._proxy_handle = proxy
+        self._session_factory = sessionmaker(
+            bind=engine,
+            expire_on_commit=False,
+            autoflush=True,
+            autocommit=False,
+        )
+
+        if old_engine is not None:
+            old_engine.dispose()
+        if old_proxy is not None and old_proxy is not proxy:
+            try:
+                old_proxy.close()
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Could not close previous DB proxy: %s", e)
+
+        self._config_generation = db_config_generation()
+        self._generation_checked_at = time.monotonic()
+
+        logger.info(
+            "Database target: %s:%s/%s (source=%s)",
+            new_config.host,
+            new_config.port,
+            new_config.database,
+            new_config.source,
+        )
+        return RetargetResult(config=new_config, in_flight_at_swap=in_flight)
+
+    def refresh_if_stale(self) -> bool:
+        """Adopt a DB config another process wrote. Returns True if we swapped.
+
+        Rate-limited to one stat() per ``_CONFIG_CHECK_INTERVAL`` so it can sit
+        on a hot path. Failures are swallowed: a process that cannot reach the
+        new target must keep serving the old one rather than fall over.
+        """
+        if self._engine is None:
+            return False
+        now = time.monotonic()
+        if now - getattr(self, "_generation_checked_at", 0.0) < _CONFIG_CHECK_INTERVAL:
+            return False
+        self._generation_checked_at = now
+
+        generation = db_config_generation()
+        if generation == 0.0 or generation == getattr(self, "_config_generation", 0.0):
+            return False
+
+        old = (self.config.host, self.config.port, self.config.database)
+        try:
+            new_config = DatabaseConfig()
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Could not re-read DB config: %s", e)
+            self._config_generation = generation
+            return False
+        if (new_config.host, new_config.port, new_config.database) == old:
+            self._config_generation = generation  # secrets changed, but not ours
+            return False
+
+        try:
+            self.retarget(new_config, validate=True)
+        except Exception as e:  # noqa: BLE001
+            logger.error(
+                "DB config changed to %s:%s/%s but it is unreachable; "
+                "staying on %s:%s/%s (%s)",
+                new_config.host,
+                new_config.port,
+                new_config.database,
+                *old,
+                e,
+            )
+            self._config_generation = generation  # don't retry every interval
+            return False
+        logger.info("Adopted database config change from another process")
+        return True
+
+    def initialize(self, echo: bool = False, *, force: bool = False):
         """
         Initialize the database engine and session factory.
 
         Args:
             echo: If True, log all SQL statements
+            force: Rebuild against freshly-read config even if already initialized
         """
-        if self._engine is not None:
+        if self._engine is not None and not force:
             logger.warning("Database already initialized")
             return
-
         try:
-            host = self.config.host
-            port = self.config.port
-            if self.config.proxy.enabled:
-                from services.db_proxy import apply as apply_proxy
-
-                applied = apply_proxy(host, port, self.config.proxy)
-                self._proxy_handle = applied
-                host = applied.host
-                port = applied.port
-                logger.info(
-                    "Platform DB proxy active: type=%s effective endpoint %s:%s",
-                    self.config.proxy.proxy_type,
-                    host,
-                    port,
-                )
-
-            database_url = self.config.get_database_url(host=host, port=port)
-
-            self._engine = create_engine(
-                database_url,
-                echo=echo,
-                pool_size=self.config.pool_size,
-                max_overflow=self.config.max_overflow,
-                pool_timeout=self.config.pool_timeout,
-                pool_recycle=self.config.pool_recycle,
-                pool_pre_ping=True,  # Verify connections before using them
-            )
-
-            # Set up event listeners
-            @event.listens_for(self._engine, "connect")
-            def receive_connect(dbapi_conn, connection_record):
-                """Called when a new connection is created."""
-                logger.debug("New database connection established")
-
-            @event.listens_for(self._engine, "close")
-            def receive_close(dbapi_conn, connection_record):
-                """Called when a connection is closed."""
-                logger.debug("Database connection closed")
-
-            # Create session factory
-            self._session_factory = sessionmaker(
-                bind=self._engine,
-                expire_on_commit=False,
-                autoflush=True,
-                autocommit=False,
-            )
-
-            logger.info(
-                f"Database initialized: {self.config.host}:{self.config.port}/{self.config.database}"
-            )
-
+            # validate=False: create_engine is lazy today, so cold boot has
+            # always succeeded with postgres down (scripts/init_schema.py and
+            # database_data_service rely on it). Only retarget() validates.
+            self.retarget(None if force else self.config, echo=echo, validate=False)
         except Exception as e:
             logger.error(f"Failed to initialize database: {e}")
             raise
+
+    def schema_report(self) -> Dict[str, Any]:
+        """Classify the current target against the ORM models.
+
+        Compares **columns**, not just table names: a name-only check calls an
+        outdated schema healthy — every table exists — right until the app hits
+        a column that isn't there and it surfaces as a mystery application bug.
+
+        ``empty`` no Vigil tables (safe to provision) / ``ok`` / ``drifted``
+        (tables exist, columns missing — needs scripts/migrate_schema.py, since
+        create_all is checkfirst=True and won't alter them) / ``unknown``.
+        """
+        if self._engine is None:
+            raise RuntimeError("Database not initialized. Call initialize() first.")
+        try:
+            inspector = inspect(self._engine)
+            present = set(inspector.get_table_names())
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Could not inspect target schema: %s", e)
+            return {"state": "unknown", "missing_tables": [], "missing_columns": {}}
+
+        expected = set(Base.metadata.tables)
+        missing_tables = sorted(expected - present)
+        missing_columns: Dict[str, list] = {}
+        for name in sorted(expected & present):
+            try:
+                actual = {c["name"] for c in inspector.get_columns(name)}
+            except Exception:  # noqa: BLE001
+                continue
+            gap = sorted({c.name for c in Base.metadata.tables[name].columns} - actual)
+            if gap:
+                missing_columns[name] = gap
+
+        if not (expected & present):
+            state = "empty"
+        elif missing_columns or missing_tables:
+            state = "drifted"
+        else:
+            state = "ok"
+        return {
+            "state": state,
+            "missing_tables": missing_tables,
+            "missing_columns": missing_columns,
+        }
 
     def create_tables(self):
         """Create all database tables."""
@@ -386,6 +673,9 @@ def get_db_session() -> Session:
         SQLAlchemy session
     """
     db_manager = get_db_manager()
+    # The session entry point every process shares, so this is where the LLM
+    # worker and daemon notice a retarget the backend performed. Rate-limited.
+    db_manager.refresh_if_stale()
     return db_manager.get_session()
 
 
@@ -397,7 +687,9 @@ def get_db() -> Generator[Session, None, None]:
     generator dependencies, so ``Depends(get_db_session)`` leaks a connection
     on every request.
     """
-    session = get_db_manager().get_session()
+    manager = get_db_manager()
+    manager.refresh_if_stale()  # rate-limited; adopts another process's retarget
+    session = manager.get_session()
     try:
         yield session
     finally:

--- a/env.example
+++ b/env.example
@@ -572,11 +572,13 @@ TOOL_RESPONSE_BUDGET_DEFAULT="8000"
 # back to this process-wide default.
 CLAUDE_THINKING_BUDGET="10000"
 
-# Ollama (local or remote). base_url and per-provider config are also stored
-# per-row in llm_provider_configs; these are defaults for first-boot seeding.
-OLLAMA_ENABLED="false"
+# Ollama. Vigil runs Ollama natively rather than in a container (Docker on
+# macOS has no Metal passthrough, so a containerized Ollama is CPU-only) and
+# can start it for you — Settings -> Services, or automatically via
+# .vigil-autostart. This is the HOST-side URL; the rewrite to
+# host.docker.internal for containers happens at the compose boundary.
+# Per-provider base_url is also stored per-row in llm_provider_configs.
 OLLAMA_URL="http://localhost:11434"
-OLLAMA_DEFAULT_MODEL="llama3.1:70b"
 
 # OpenAI (direct API or OpenAI-compatible endpoint)
 OPENAI_ENABLED="false"

--- a/frontend/src/redesign/data/data.ts
+++ b/frontend/src/redesign/data/data.ts
@@ -57,6 +57,11 @@ export interface Finding {
   ts?: number
   score: number
   status: 'open' | 'investigating' | 'closed'
+  /** entity_context keys the fixed fields above don't cover. Sources disagree
+   *  about these — CrowdStrike sends device_id and no dest_ips, Splunk the
+   *  reverse — so they're carried through rather than dropped, and rendered as
+   *  optional columns derived from whatever the loaded rows actually contain. */
+  extra?: Record<string, string>
 }
 
 export interface CaseRow {

--- a/frontend/src/redesign/data/mappers.ts
+++ b/frontend/src/redesign/data/mappers.ts
@@ -54,12 +54,16 @@ export interface ApiFinding {
   description?: string
   mitre_predictions?: Record<string, number>
   status?: string
-  /** host / user / IP entities extracted by the backend */
+  /** host / user / IP entities extracted by the backend.
+   *  Open-ended on purpose: the set of keys varies by data source (CrowdStrike
+   *  emits device_id and no dest_ips; Splunk emits dest_ips), so anything
+   *  beyond the known names is carried through to `Finding.extra`. */
   entity_context?: {
     hostnames?: string[]
     usernames?: string[]
     dest_ips?: string[]
     file_hashes?: string[]
+    [key: string]: string[] | string | number | null | undefined
   }
 }
 
@@ -166,6 +170,21 @@ function topTechnique(preds?: Record<string, number>): { tech: string; conf: num
   return best ? { tech: best, conf: Math.round(bestConf * 100) } : { tech: DASH, conf: 0 }
 }
 
+/** entity_context keys already surfaced as fixed columns; the rest become `extra`. */
+const MAPPED_ENTITY_KEYS = new Set(['hostnames', 'usernames'])
+
+/** Flatten leftover entity_context entries to display strings. */
+function extraEntities(ec: ApiFinding['entity_context']): Record<string, string> | undefined {
+  if (!ec) return undefined
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(ec)) {
+    if (MAPPED_ENTITY_KEYS.has(k) || v == null) continue
+    const text = Array.isArray(v) ? v.filter(Boolean).join(', ') : String(v)
+    if (text) out[k] = text
+  }
+  return Object.keys(out).length ? out : undefined
+}
+
 export function mapApiFinding(f: ApiFinding): Finding {
   const { tech, conf } = topTechnique(f.mitre_predictions)
   const ec = f.entity_context
@@ -182,6 +201,7 @@ export function mapApiFinding(f: ApiFinding): Finding {
     ts: epochMs(f.timestamp),
     score: typeof f.anomaly_score === 'number' ? f.anomaly_score : 0,
     status: findingStatus(f.status),
+    extra: extraEntities(ec),
   }
 }
 

--- a/frontend/src/redesign/screens/dashboard/DashboardScreen.tsx
+++ b/frontend/src/redesign/screens/dashboard/DashboardScreen.tsx
@@ -10,6 +10,8 @@ import type { Finding } from '../../data/data'
 import { useAttack } from './useAttack'
 import { useTimeline } from './useTimeline'
 import { FilterButton, FilterGroup } from '../../shared/ui'
+import { ColumnPicker, DataTable, searchRows, sortRows, useTableSort } from '../../shared/DataTable'
+import { baseFindingColumns, extraFindingColumns } from './findingsColumns'
 import FindingPopup from './FindingPopup'
 import AttackTechniqueFindings from './AttackTechniqueFindings'
 import { SEV_COLOR, TL_MONTHS, type TimelineEvent } from './attackData'
@@ -53,48 +55,6 @@ export default function DashboardScreen({ openChat }: ScreenProps) {
 /* ---------------- Findings ---------------- */
 const NDASH = '—'
 
-/* Sorting — only columns with a meaningful order are sortable. */
-type SortKey = 'sev' | 'time' | 'score' | 'status'
-type SortState = { key: SortKey; dir: 'asc' | 'desc' }
-const SEV_RANK: Record<Finding['sev'], number> = { Critical: 4, High: 3, Medium: 2, Low: 1 }
-const STATUS_RANK: Record<Finding['status'], number> = { open: 0, investigating: 1, closed: 2 }
-// status reads best low→high (open first); the rest read best high→low
-const DEFAULT_DIR: Record<SortKey, 'asc' | 'desc'> = { sev: 'desc', time: 'desc', score: 'desc', status: 'asc' }
-
-/** comparable time key: findings normally carry epoch-ms `ts`; when it's
- *  missing, fall back to the YYYYMMDD in the id plus HH:MM from the display string */
-function timeKey(f: Finding): number {
-  if (typeof f.ts === 'number') return f.ts
-  const d = /(\d{8})/.exec(f.id)?.[1]
-  if (!d) return 0
-  const t = /(\d{1,2}):(\d{2})/.exec(f.time)
-  return Number(d) * 10000 + (t ? Number(t[1]) * 100 + Number(t[2]) : 0)
-}
-
-function sortVal(f: Finding, key: SortKey): number {
-  switch (key) {
-    case 'sev': return SEV_RANK[f.sev]
-    case 'score': return f.score
-    case 'time': return timeKey(f)
-    case 'status': return STATUS_RANK[f.status]
-  }
-}
-
-function SortHeader(
-  { label, col, sort, onSort }:
-  { label: string; col: SortKey; sort: SortState; onSort: (k: SortKey) => void },
-) {
-  const active = sort.key === col
-  return (
-    <th className={`sortable${active ? ' sorted' : ''}`} onClick={() => onSort(col)}>
-      {label}
-      {active && (
-        <span className="arr"><Icon name={sort.dir === 'asc' ? 'arrowUp' : 'arrowDn'} size={12} /></span>
-      )}
-    </th>
-  )
-}
-
 /** build the "Investigate with Vigil" auto-message for a finding */
 function findingPrompt(f: Finding): string {
   const parts = [`${f.sev} severity`, `MITRE ${f.tech}${f.tactic !== NDASH ? ` (${f.tactic})` : ''}`, `source ${f.src}`]
@@ -113,11 +73,34 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
   const [detailId, setDetailId] = useState<string | null>(null)
   const [pageSize, setPageSize] = useState(10)
   const [page, setPage] = useState(1)
-  const [sort, setSort] = useState<SortState>({ key: 'time', dir: 'desc' })
-  const toggleSort = (key: SortKey) =>
-    setSort((s) => (s.key === key
-      ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
-      : { key, dir: DEFAULT_DIR[key] }))
+  // null = untouched, so use each column's default visibility. An empty Set is
+  // meaningfully different: the user unhid everything.
+  const [hiddenCols, setHiddenCols] = useState<Set<string> | null>(null)
+
+  // Base columns are fixed; the rest are derived from whatever entity keys the
+  // loaded rows actually carry, so a new source needs no code change here.
+  const allColumns = useMemo(() => {
+    const base = baseFindingColumns(
+      (f) => setDetailId(f.id),
+      (f) => openChat(findingPrompt(f)),
+    )
+    const extra = extraFindingColumns(rows)
+    // actions stay last
+    return [...base.slice(0, -1), ...extra, base[base.length - 1]]
+  }, [rows, openChat])
+
+  // Columns marked visible:false start hidden but stay toggleable.
+  const defaultHidden = useMemo(
+    () => new Set(allColumns.filter((c) => c.visible === false).map((c) => c.key)),
+    [allColumns],
+  )
+  const effectiveHidden = hiddenCols ?? defaultHidden
+  const columns = useMemo(
+    () => allColumns.filter((c) => !effectiveHidden.has(c.key)),
+    [allColumns, effectiveHidden],
+  )
+
+  const { sort, toggle: toggleSort } = useTableSort(allColumns, { key: 'time', dir: 'desc' })
 
   // source options derive from the data
   const srcOptions = useMemo(() => {
@@ -126,28 +109,15 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
   }, [rows])
 
   const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase()
-    return rows.filter((f) => {
+    const byFacet = rows.filter((f) => {
       if (sev !== 'any' && f.sev.toLowerCase() !== sev) return false
       if (src !== 'any' && f.src !== src) return false
-      if (!q) return true
-      return (
-        f.id.toLowerCase().includes(q) ||
-        f.tech.toLowerCase().includes(q) ||
-        f.host.toLowerCase().includes(q) ||
-        f.user.toLowerCase().includes(q) ||
-        f.src.toLowerCase().includes(q)
-      )
+      return true
     })
-  }, [rows, query, sev, src])
+    return searchRows(byFacet, columns, query)
+  }, [rows, query, sev, src, columns])
 
-  const sorted = useMemo(() => {
-    const { key, dir } = sort
-    return [...filtered].sort((a, b) => {
-      const d = sortVal(a, key) - sortVal(b, key)
-      return dir === 'asc' ? d : -d
-    })
-  }, [filtered, sort])
+  const sorted = useMemo(() => sortRows(filtered, columns, sort), [filtered, columns, sort])
 
   // reset to the first page whenever the filtered set changes shape
   // (re-sorting keeps the same rows, so it doesn't reset the page)
@@ -200,7 +170,7 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
         </div>
         <FilterButton
           activeCount={(sev !== 'any' ? 1 : 0) + (src !== 'any' ? 1 : 0)}
-          onClearAll={() => { setSev('any'); setSrc('any') }}
+          onClearAll={() => { setSev('any'); setSrc('any'); setHiddenCols(null) }}
         >
           <FilterGroup
             label="Severity"
@@ -215,6 +185,16 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
             ]}
           />
           <FilterGroup label="Source" value={src} onSelect={setSrc} options={srcOptions} />
+          <ColumnPicker
+            columns={allColumns}
+            hidden={effectiveHidden}
+            onToggle={(key) => setHiddenCols((h) => {
+              const next = new Set(h ?? defaultHidden)
+              if (next.has(key)) next.delete(key)
+              else next.add(key)
+              return next
+            })}
+          />
         </FilterButton>
         <div className="flex-1" />
         <button className="btn ghost icon" title="Refresh" onClick={refresh}><Icon name="refresh" /></button>
@@ -222,63 +202,20 @@ function FindingsTab({ openChat }: { openChat: (prompt?: string) => void }) {
       </div>
 
       <div className="table-wrap list-scroll list-scroll-kpi">
-        <table className="tbl findings-tbl">
-          <thead>
-            <tr>
-              <th>Finding ID</th>
-              <SortHeader label="Severity" col="sev" sort={sort} onSort={toggleSort} />
-              <th>MITRE Technique</th><th>Tactic</th>
-              <th>Source</th><th>Host</th><th>User</th>
-              <SortHeader label="Time" col="time" sort={sort} onSort={toggleSort} />
-              <SortHeader label="Score" col="score" sort={sort} onSort={toggleSort} />
-              <SortHeader label="Status" col="status" sort={sort} onSort={toggleSort} />
-              <th />
-            </tr>
-          </thead>
-          <tbody>
-            {phase === 'loading' && (
-              <tr><td colSpan={11} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>Loading findings…</td></tr>
-            )}
-            {phase === 'error' && (
-              <tr><td colSpan={11} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
-                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
-                  <span>Couldn’t load findings: {error}</span>
-                  <button className="btn ghost" onClick={refresh}>Retry</button>
-                </div>
-              </td></tr>
-            )}
-            {phase === 'ready' && filtered.length === 0 && (
-              <tr><td colSpan={11} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
-                {rows.length === 0 ? 'No findings found.' : 'No findings match your filters.'}
-              </td></tr>
-            )}
-            {phase === 'ready' && paged.map((f) => (
-              <tr key={f.id} className="clickable" onClick={() => setDetailId(f.id)}>
-                <td><span className="id-cell">{f.id}</span></td>
-                <td><span className={`sev ${f.sev.toLowerCase()}`}><span className="dot" />{f.sev}</span></td>
-                <td><span className="tag">{f.tech}</span> <span className="muted">{f.conf}%</span></td>
-                <td>{f.tactic}</td>
-                <td className="muted">{f.src}</td>
-                <td><span className="mono">{f.host}</span></td>
-                <td><span className="mono muted">{f.user}</span></td>
-                <td className="muted">{f.time}</td>
-                <td>
-                  <span className="scorebar">
-                    <span className="track"><i className={f.score >= 0.8 ? 'hot' : ''} style={{ width: `${f.score * 100}%` }} /></span>
-                    <span className="num">{f.score.toFixed(2)}</span>
-                  </span>
-                </td>
-                <td><span className={`status ${f.status}`}>{f.status}</span></td>
-                <td>
-                  <span className="row-act">
-                    <button title="View" onClick={(e) => { e.stopPropagation(); setDetailId(f.id) }}><Icon name="eye" /></button>
-                    <button title="Investigate with Vigil" onClick={(e) => { e.stopPropagation(); openChat(findingPrompt(f)) }}><Icon name="brain" /></button>
-                  </span>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <DataTable
+          className="tbl findings-tbl"
+          columns={columns}
+          rows={paged}
+          rowKey={(f) => f.id}
+          phase={phase}
+          error={`Couldn’t load findings: ${error}`}
+          sort={sort}
+          onSort={toggleSort}
+          onRowClick={(f) => setDetailId(f.id)}
+          onRetry={refresh}
+          loadingMessage="Loading findings…"
+          emptyMessage={rows.length === 0 ? 'No findings found.' : 'No findings match your filters.'}
+        />
       </div>
       <div className="pager">
         <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>

--- a/frontend/src/redesign/screens/dashboard/findingsColumns.test.ts
+++ b/frontend/src/redesign/screens/dashboard/findingsColumns.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { mapApiFinding } from '../../data/mappers'
+import { extraFindingColumns, baseFindingColumns } from './findingsColumns'
+
+// CrowdStrike emits device_id and no dest_ips; Splunk emits dest_ips. The
+// dashboard must surface both without knowing either in advance.
+const crowdstrike = mapApiFinding({
+  finding_id: 'CS-1', severity: 'high', data_source: 'crowdstrike',
+  entity_context: { hostnames: ['h1'], usernames: ['u1'], src_ips: ['1.1.1.1'], device_id: 'abc123' },
+} as never)
+const splunk = mapApiFinding({
+  finding_id: 'SP-1', severity: 'low', data_source: 'splunk',
+  entity_context: { hostnames: ['h2'], usernames: ['u2'], dest_ips: ['2.2.2.2', '3.3.3.3'] },
+} as never)
+
+describe('adaptive findings columns', () => {
+  it('keeps source-specific entity keys instead of dropping them', () => {
+    expect(crowdstrike.extra).toEqual({ src_ips: '1.1.1.1', device_id: 'abc123' })
+    expect(splunk.extra).toEqual({ dest_ips: '2.2.2.2, 3.3.3.3' })
+  })
+
+  it('does not duplicate keys already shown as fixed columns', () => {
+    expect(crowdstrike.extra).not.toHaveProperty('hostnames')
+    expect(crowdstrike.extra).not.toHaveProperty('usernames')
+  })
+
+  it('derives a column per distinct extra key across the union of rows', () => {
+    const cols = extraFindingColumns([crowdstrike, splunk])
+    expect(cols.map((c) => c.key)).toEqual(['extra:dest_ips', 'extra:device_id', 'extra:src_ips'])
+    expect(cols.map((c) => c.label)).toEqual(['Dest Ips', 'Device Id', 'Src Ips'])
+    expect(cols.every((c) => c.visible === false)).toBe(true)
+  })
+
+  it('renders an em-dash, not undefined, when a row lacks the key', () => {
+    const cols = extraFindingColumns([crowdstrike, splunk])
+    const deviceCol = cols.find((c) => c.key === 'extra:device_id')!
+    expect(deviceCol.render(splunk)).toMatchObject({ props: { children: '—' } })
+  })
+
+  it('preserves the default 11-column view', () => {
+    const base = baseFindingColumns(() => {}, () => {})
+    expect(base).toHaveLength(11)
+    expect(base.filter((c) => c.sortVal).map((c) => c.key)).toEqual(['sev', 'time', 'score', 'status'])
+    // same five fields the old hardcoded search covered, in column order
+    expect(base.filter((c) => c.searchVal).map((c) => c.key)).toEqual(['id', 'tech', 'src', 'host', 'user'])
+  })
+})

--- a/frontend/src/redesign/screens/dashboard/findingsColumns.tsx
+++ b/frontend/src/redesign/screens/dashboard/findingsColumns.tsx
@@ -1,0 +1,114 @@
+import { Icon } from '../../shared/icons'
+import type { ColumnDef } from '../../shared/DataTable'
+import type { Finding } from '../../data/data'
+
+const NDASH = '—'
+
+const SEV_RANK: Record<Finding['sev'], number> = { Critical: 4, High: 3, Medium: 2, Low: 1 }
+const STATUS_RANK: Record<Finding['status'], number> = { open: 0, investigating: 1, closed: 2 }
+
+/** comparable time key: findings normally carry epoch-ms `ts`; when it's
+ *  missing, fall back to the YYYYMMDD in the id plus HH:MM from the display string */
+function timeKey(f: Finding): number {
+  if (typeof f.ts === 'number') return f.ts
+  const d = /(\d{8})/.exec(f.id)?.[1]
+  if (!d) return 0
+  const t = /(\d{1,2}):(\d{2})/.exec(f.time)
+  return Number(d) * 10000 + (t ? Number(t[1]) * 100 + Number(t[2]) : 0)
+}
+
+/** Turn an entity_context key into a column label: dest_ips -> "Dest Ips". */
+function labelFor(key: string): string {
+  return key.replace(/[._-]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+/** The columns every finding has, whatever produced it. */
+export function baseFindingColumns(
+  onView: (f: Finding) => void,
+  onInvestigate: (f: Finding) => void,
+): ColumnDef<Finding>[] {
+  return [
+    {
+      key: 'id', label: 'Finding ID',
+      render: (f) => <span className="id-cell">{f.id}</span>,
+      searchVal: (f) => f.id,
+    },
+    {
+      key: 'sev', label: 'Severity',
+      render: (f) => <span className={`sev ${f.sev.toLowerCase()}`}><span className="dot" />{f.sev}</span>,
+      sortVal: (f) => SEV_RANK[f.sev], defaultDir: 'desc',
+    },
+    {
+      key: 'tech', label: 'MITRE Technique',
+      render: (f) => <><span className="tag">{f.tech}</span> <span className="muted">{f.conf}%</span></>,
+      searchVal: (f) => f.tech,
+    },
+    { key: 'tactic', label: 'Tactic', render: (f) => f.tactic },
+    {
+      key: 'src', label: 'Source',
+      render: (f) => <span className="muted">{f.src}</span>,
+      searchVal: (f) => f.src,
+    },
+    {
+      key: 'host', label: 'Host',
+      render: (f) => <span className="mono">{f.host}</span>,
+      searchVal: (f) => f.host,
+    },
+    {
+      key: 'user', label: 'User',
+      render: (f) => <span className="mono muted">{f.user}</span>,
+      searchVal: (f) => f.user,
+    },
+    {
+      key: 'time', label: 'Time',
+      render: (f) => <span className="muted">{f.time}</span>,
+      sortVal: timeKey, defaultDir: 'desc',
+    },
+    {
+      key: 'score', label: 'Score',
+      render: (f) => (
+        <span className="scorebar">
+          <span className="track"><i className={f.score >= 0.8 ? 'hot' : ''} style={{ width: `${f.score * 100}%` }} /></span>
+          <span className="num">{f.score.toFixed(2)}</span>
+        </span>
+      ),
+      sortVal: (f) => f.score, defaultDir: 'desc',
+    },
+    {
+      key: 'status', label: 'Status',
+      render: (f) => <span className={`status ${f.status}`}>{f.status}</span>,
+      // status reads best low->high (open first); the rest read best high->low
+      sortVal: (f) => STATUS_RANK[f.status], defaultDir: 'asc',
+    },
+    {
+      key: 'actions', label: 'Actions', headless: true,
+      render: (f) => (
+        <span className="row-act">
+          <button title="View" onClick={(e) => { e.stopPropagation(); onView(f) }}><Icon name="eye" /></button>
+          <button title="Investigate with Vigil" onClick={(e) => { e.stopPropagation(); onInvestigate(f) }}><Icon name="brain" /></button>
+        </span>
+      ),
+    },
+  ]
+}
+
+/**
+ * Columns for whatever source-specific entity keys the loaded rows carry.
+ *
+ * Derived from the data rather than declared, so a source that sends a field no
+ * other source does (CrowdStrike's device_id) shows up without a code change.
+ * Hidden by default — they're additive detail, not part of the default view.
+ */
+export function extraFindingColumns(rows: Finding[]): ColumnDef<Finding>[] {
+  const keys = new Set<string>()
+  for (const r of rows) {
+    if (r.extra) for (const k of Object.keys(r.extra)) keys.add(k)
+  }
+  return [...keys].sort().map((key) => ({
+    key: `extra:${key}`,
+    label: labelFor(key),
+    visible: false,
+    render: (f: Finding) => <span className="mono muted">{f.extra?.[key] || NDASH}</span>,
+    searchVal: (f: Finding) => f.extra?.[key] || '',
+  }))
+}

--- a/frontend/src/redesign/screens/settings/ServicesSection.tsx
+++ b/frontend/src/redesign/screens/settings/ServicesSection.tsx
@@ -1,0 +1,165 @@
+/* ============================================================
+   Settings · Services — start local services on demand and pick
+   which ones ./start.sh brings up automatically.
+
+   Ollama is a host process, not a container: Docker on macOS has
+   no Metal GPU passthrough, so a containerized Ollama would be
+   CPU-only. It's therefore started but never stopped from here —
+   the running instance is often the user's own (brew services /
+   Ollama.app), and killing that would destroy unrelated state.
+   ============================================================ */
+import { useCallback, useEffect, useState } from 'react'
+import { Icon } from '../../shared/icons'
+import { SettingsCard, ToggleRow } from '../../shared/ui'
+import { localServicesApi } from '../../../services/api'
+import type { SectionProps } from './types'
+
+interface ServiceRow {
+  name: string
+  kind: 'docker' | 'host'
+  running: boolean
+  ready: boolean
+  installed: boolean
+  status: string
+  managed_by_vigil: boolean
+  startable: boolean
+  stoppable: boolean
+  description: string
+  detail?: string | null
+}
+
+function StatusPill({ s }: { s: ServiceRow }) {
+  const tone = s.running ? 'ok' : s.installed ? 'idle' : 'warn'
+  return <span className={`status ${tone === 'ok' ? 'open' : 'closed'}`}>{s.status}</span>
+}
+
+export default function ServicesSection({ notify }: SectionProps) {
+  const [rows, setRows] = useState<ServiceRow[]>([])
+  const [autostart, setAutostart] = useState<string[]>([])
+  const [dockerOk, setDockerOk] = useState(true)
+  const [dockerDetail, setDockerDetail] = useState('')
+  const [busy, setBusy] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    try {
+      const { data } = await localServicesApi.list()
+      setRows(data.services || [])
+      setAutostart(data.autostart || [])
+      setDockerOk(!!data.docker_available)
+      setDockerDetail(data.docker_detail || '')
+    } catch (e) {
+      notify('err', `Couldn't load services: ${e instanceof Error ? e.message : String(e)}`)
+    } finally {
+      setLoading(false)
+    }
+  }, [notify])
+
+  useEffect(() => { void load() }, [load])
+
+  const act = async (name: string, action: 'start' | 'stop' | 'restart') => {
+    setBusy(name)
+    try {
+      const { data } = await localServicesApi[action](name)
+      notify(data.already_running ? 'info' : 'ok', data.message || `${name} ${action}ed`)
+      // Ollama only becomes usable once Bifrost knows about it.
+      if (data.bifrost_synced === false && data.bifrost_sync_error) {
+        notify('info', `${name} is up, but the model catalog didn't sync: ${data.bifrost_sync_error}`)
+      }
+      await load()
+    } catch (e) {
+      const msg = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+      notify('err', msg || `Couldn't ${action} ${name}`)
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const toggleAutostart = async (name: string, on: boolean) => {
+    const next = on ? [...autostart, name] : autostart.filter((n) => n !== name)
+    const previous = autostart
+    setAutostart(next)  // optimistic
+    try {
+      const { data } = await localServicesApi.setAutostart(next)
+      setAutostart(data.services)
+    } catch (e) {
+      setAutostart(previous)
+      const msg = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+      notify('err', msg || "Couldn't save the autostart list")
+    }
+  }
+
+  return (
+    <>
+      {!dockerOk && (
+        <SettingsCard
+          title="Docker isn't running"
+          desc={dockerDetail || 'Container services can’t start until the Docker daemon is reachable. ./start.sh launches Docker Desktop for you.'}
+        >
+          <span />
+        </SettingsCard>
+      )}
+
+      <SettingsCard
+        title="Services"
+        desc="Start local services on demand. Vigil starts Ollama natively rather than in Docker so it keeps GPU acceleration."
+        actions={<button className="btn ghost icon" title="Refresh" onClick={() => void load()}><Icon name="refresh" /></button>}
+        wide
+      >
+        {loading ? (
+          <p className="muted">Loading services…</p>
+        ) : (
+          <div className="svc-list">
+            {rows.map((s) => (
+              <div key={s.name} className="svc-row" style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 0' }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <strong>{s.name}</strong>
+                    <StatusPill s={s} />
+                    {s.kind === 'host' && <span className="tag">host</span>}
+                    {s.running && !s.managed_by_vigil && s.kind === 'host' && (
+                      <span className="muted" style={{ fontSize: 12 }}>started outside Vigil</span>
+                    )}
+                  </div>
+                  <span className="muted" style={{ fontSize: 12 }}>
+                    {s.detail || s.description}
+                  </span>
+                </div>
+                <button
+                  className="btn primary"
+                  disabled={busy === s.name || s.running || !s.startable || !s.installed}
+                  onClick={() => void act(s.name, 'start')}
+                >
+                  {busy === s.name ? 'Starting…' : s.running ? 'Running' : 'Start'}
+                </button>
+                {s.stoppable && (
+                  <button
+                    className="btn ghost"
+                    disabled={busy === s.name || !s.running}
+                    onClick={() => void act(s.name, 'stop')}
+                  >Stop</button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </SettingsCard>
+
+      <SettingsCard
+        title="Start automatically"
+        desc="Services ./start.sh brings up on boot. Heavy ones (Splunk, Kafka, observability) are off by default so startup stays fast."
+        wide
+      >
+        {rows.map((s) => (
+          <ToggleRow
+            key={s.name}
+            label={s.name}
+            hint={s.description}
+            checked={autostart.includes(s.name)}
+            onChange={(v) => void toggleAutostart(s.name, v)}
+          />
+        ))}
+      </SettingsCard>
+    </>
+  )
+}

--- a/frontend/src/redesign/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/redesign/screens/settings/SettingsScreen.tsx
@@ -17,6 +17,7 @@ import UsersSection from './UsersSection'
 import AutoInvestigateSection from './AutoInvestigateSection'
 import DeveloperSection from './DeveloperSection'
 import AiConfigSection from './AiConfigSection'
+import ServicesSection from './ServicesSection'
 import IntegrationsSection from './IntegrationsSection'
 import SlaPoliciesSection from './SlaPoliciesSection'
 import type { SectionProps } from './types'
@@ -26,6 +27,7 @@ const IS_DEV_MODE = import.meta.env.VITE_DEV_MODE === 'true'
 type SectionKey =
   | 'appearance'
   | 'ai-config'
+  | 'services'
   | 'integrations'
   | 'users'
   | 'sla'
@@ -46,6 +48,7 @@ interface SectionDef {
 const SECTIONS: SectionDef[] = [
   { key: 'appearance', label: 'Appearance', icon: 'palette', Component: AppearanceSection },
   { key: 'ai-config', label: 'AI Config', icon: 'sparkle', Component: AiConfigSection },
+  { key: 'services', label: 'Services', icon: 'play', Component: ServicesSection },
   { key: 'integrations', label: 'Integrations', icon: 'link', Component: IntegrationsSection },
   { key: 'users', label: 'Users', icon: 'lock', Component: UsersSection },
   { key: 'sla', label: 'SLA Policies', icon: 'clock', Component: SlaPoliciesSection },

--- a/frontend/src/redesign/shared/DataTable.tsx
+++ b/frontend/src/redesign/shared/DataTable.tsx
@@ -1,0 +1,157 @@
+import { useMemo, useState, type ReactNode } from 'react'
+import { Icon } from './icons'
+
+/**
+ * Column-driven table.
+ *
+ * Hand-written <thead>/<td> pairs couple three things that then have to be kept
+ * in sync by hand: the header cells, the body cells, and the colSpan on the
+ * loading/empty/error rows. Sorting and searching add a fourth and fifth, as
+ * parallel unions of field names. A ColumnDef collapses all of them — a column
+ * is sortable because it has `sortVal`, searchable because it has `searchVal`.
+ *
+ * That also lets columns be built at runtime, which is what makes a table
+ * adaptable to rows whose fields differ by source.
+ */
+export interface ColumnDef<T> {
+  key: string
+  label: string
+  render: (row: T) => ReactNode
+  /** presence makes the column sortable */
+  sortVal?: (row: T) => number | string
+  /** presence makes the column searchable */
+  searchVal?: (row: T) => string
+  defaultDir?: 'asc' | 'desc'
+  /** false hides the column by default (still toggleable) */
+  visible?: boolean
+  /** header content when `label` should not be rendered as text (e.g. an actions column) */
+  headless?: boolean
+}
+
+export type SortState = { key: string; dir: 'asc' | 'desc' }
+
+export type TablePhase = 'loading' | 'error' | 'ready'
+
+/** Rows matching `query` across every column that declares `searchVal`. */
+export function searchRows<T>(rows: T[], columns: ColumnDef<T>[], query: string): T[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return rows
+  const searchable = columns.filter((c) => c.searchVal)
+  return rows.filter((r) => searchable.some((c) => c.searchVal!(r).toLowerCase().includes(q)))
+}
+
+/** Rows ordered by the column named in `sort`; unsortable/unknown keys pass through. */
+export function sortRows<T>(rows: T[], columns: ColumnDef<T>[], sort: SortState): T[] {
+  const col = columns.find((c) => c.key === sort.key && c.sortVal)
+  if (!col) return rows
+  const val = col.sortVal!
+  return [...rows].sort((a, b) => {
+    const x = val(a)
+    const y = val(b)
+    const d = typeof x === 'number' && typeof y === 'number' ? x - y : String(x).localeCompare(String(y))
+    return sort.dir === 'asc' ? d : -d
+  })
+}
+
+function SortHeader<T>(
+  { col, sort, onSort }: { col: ColumnDef<T>; sort: SortState; onSort: (k: string) => void },
+) {
+  if (!col.sortVal) return <th>{col.headless ? null : col.label}</th>
+  const active = sort.key === col.key
+  return (
+    <th className={`sortable${active ? ' sorted' : ''}`} onClick={() => onSort(col.key)}>
+      {col.label}
+      {active && (
+        <span className="arr"><Icon name={sort.dir === 'asc' ? 'arrowUp' : 'arrowDn'} size={12} /></span>
+      )}
+    </th>
+  )
+}
+
+export interface DataTableProps<T> {
+  columns: ColumnDef<T>[]
+  rows: T[]
+  rowKey: (row: T) => string
+  phase?: TablePhase
+  error?: string | null
+  sort: SortState
+  onSort: (key: string) => void
+  onRowClick?: (row: T) => void
+  className?: string
+  emptyMessage?: ReactNode
+  loadingMessage?: ReactNode
+  onRetry?: () => void
+}
+
+export function DataTable<T>({
+  columns, rows, rowKey, phase = 'ready', error, sort, onSort,
+  onRowClick, className = 'tbl', emptyMessage = 'No rows found.',
+  loadingMessage = 'Loading…', onRetry,
+}: DataTableProps<T>) {
+  // Derived, so a column added or hidden can never desync the placeholder rows.
+  const span = columns.length
+
+  return (
+    <table className={className}>
+      <thead>
+        <tr>
+          {columns.map((c) => <SortHeader key={c.key} col={c} sort={sort} onSort={onSort} />)}
+        </tr>
+      </thead>
+      <tbody>
+        {phase === 'loading' && (
+          <tr><td colSpan={span} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>{loadingMessage}</td></tr>
+        )}
+        {phase === 'error' && (
+          <tr><td colSpan={span} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+              <span>{error}</span>
+              {onRetry && <button className="btn ghost" onClick={onRetry}>Retry</button>}
+            </div>
+          </td></tr>
+        )}
+        {phase === 'ready' && rows.length === 0 && (
+          <tr><td colSpan={span} className="muted" style={{ textAlign: 'center', padding: '40px 0' }}>{emptyMessage}</td></tr>
+        )}
+        {phase === 'ready' && rows.map((r) => (
+          <tr
+            key={rowKey(r)}
+            className={onRowClick ? 'clickable' : undefined}
+            onClick={onRowClick ? () => onRowClick(r) : undefined}
+          >
+            {columns.map((c) => <td key={c.key}>{c.render(r)}</td>)}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+/** Checklist of toggleable columns, for use inside a FilterButton/popup. */
+export function ColumnPicker<T>(
+  { columns, hidden, onToggle }:
+  { columns: ColumnDef<T>[]; hidden: Set<string>; onToggle: (key: string) => void },
+) {
+  const toggleable = useMemo(() => columns.filter((c) => !c.headless), [columns])
+  return (
+    <div className="filter-group">
+      <div className="filter-group-label">Columns</div>
+      {toggleable.map((c) => (
+        <label key={c.key} className="filter-opt" style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <input type="checkbox" checked={!hidden.has(c.key)} onChange={() => onToggle(c.key)} />
+          <span>{c.label}</span>
+        </label>
+      ))}
+    </div>
+  )
+}
+
+/** Sort state + toggle, honouring each column's preferred initial direction. */
+export function useTableSort<T>(columns: ColumnDef<T>[], initial: SortState) {
+  const [sort, setSort] = useState<SortState>(initial)
+  const toggle = (key: string) =>
+    setSort((s) => (s.key === key
+      ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
+      : { key, dir: columns.find((c) => c.key === key)?.defaultDir ?? 'desc' }))
+  return { sort, setSort, toggle }
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1355,16 +1355,27 @@ export const detectionRulesApi = {
   reload: () => api.post('/detection-rules/reload'),
 }
 
-// Local Services API (Docker containers management)
+// Local Services API (Docker containers + the host-native Ollama process)
 export const localServicesApi = {
   // Splunk management
   getSplunkStatus: () => api.get('/services/splunk/status'),
   startSplunk: () => api.post('/services/splunk/start'),
   stopSplunk: () => api.post('/services/splunk/stop'),
   restartSplunk: () => api.post('/services/splunk/restart'),
-  
+
   // PostgreSQL management
   getPostgresStatus: () => api.get('/services/postgres/status'),
+
+  // Generic management — service names are allowlisted server-side
+  list: () => api.get('/services'),
+  getStatus: (name: string) => api.get(`/services/${name}/status`),
+  start: (name: string) => api.post(`/services/${name}/start`),
+  stop: (name: string) => api.post(`/services/${name}/stop`),
+  restart: (name: string) => api.post(`/services/${name}/restart`),
+
+  // Which services ./start.sh brings up automatically
+  getAutostart: () => api.get('/services/autostart'),
+  setAutostart: (services: string[]) => api.put('/services/autostart', { services }),
 }
 
 // Workflow Builder phase (used inline in the builder UI)

--- a/helm/vigil/values.yaml
+++ b/helm/vigil/values.yaml
@@ -605,9 +605,7 @@ config:
   # per-row in llm_provider_configs after first boot).
   BIFROST_ENABLED: "false"
   BIFROST_URL: "http://bifrost:8080"
-  OLLAMA_ENABLED: "false"
   OLLAMA_URL: "http://ollama:11434"
-  OLLAMA_DEFAULT_MODEL: "llama3.1:70b"
   OPENAI_ENABLED: "false"
   OPENAI_BASE_URL: "https://api.openai.com/v1"
   OPENAI_ORGANIZATION: ""

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -14,7 +14,82 @@ elif command -v docker-compose &>/dev/null; then
 else
     _DC_CMD=(docker compose)  # last resort; surfaces a clear error on use
 fi
-dc() { "${_DC_CMD[@]}" -f "$REPO_ROOT/docker/docker-compose.yml" "$@"; }
+# Containers reach the host-native Ollama via host.docker.internal, but
+# load_env exports the host-side OLLAMA_URL and shell env beats the compose
+# default - so rewrite it here, at the single container boundary.
+_container_ollama_url() {
+    echo "${OLLAMA_URL:-http://localhost:11434}" \
+        | sed -e 's|//localhost:|//host.docker.internal:|' \
+              -e 's|//127\.0\.0\.1:|//host.docker.internal:|' \
+              -e 's|//0\.0\.0\.0:|//host.docker.internal:|'
+}
+dc() {
+    OLLAMA_URL="$(_container_ollama_url)" \
+        "${_DC_CMD[@]}" -f "$REPO_ROOT/docker/docker-compose.yml" "$@"
+}
+
+# --- Ensure the Docker daemon is reachable, launching Docker Desktop if not ---
+# `command -v docker` only proves the CLI exists; every compose call still fails
+# if the daemon is down. Checks the daemon, starts it, and waits.
+docker_daemon_ready() { docker info &>/dev/null; }
+
+ensure_docker() {
+    command -v docker &>/dev/null || { echo "Docker is required but not installed." >&2; return 1; }
+    docker_daemon_ready && return 0
+    echo "Docker daemon not reachable - starting Docker..."
+    case "$(uname -s)" in
+        Darwin) open -a Docker &>/dev/null || open -a "Docker Desktop" &>/dev/null || true ;;
+        Linux)  (systemctl start docker || sudo systemctl start docker) &>/dev/null || true ;;
+    esac
+    local i=0
+    while [ $i -lt 90 ]; do
+        docker_daemon_ready && { echo "Docker daemon ready."; return 0; }
+        sleep 2; i=$((i + 1))
+    done
+    echo "Docker daemon did not become ready after 180s. Start Docker and retry." >&2
+    return 1
+}
+
+# --- Resolve the autostart service list (mirrors services/autostart_config.py) ---
+read_autostart() {
+    if [ -f "$REPO_ROOT/.vigil-autostart" ]; then
+        grep -vE '^\s*(#|$)' "$REPO_ROOT/.vigil-autostart" | tr -d '\r' | tr '\n' ' '
+    elif [ -n "${AUTOSTART_SERVICES:-}" ]; then
+        echo "${AUTOSTART_SERVICES//,/ }"
+    else
+        echo "postgres redis bifrost ollama"
+    fi
+}
+
+# --- Compose service + profile for an autostart name ---
+# Mirrors the SERVICES registry; `ollama` is host-native and handled separately.
+service_profile() {
+    case "$1" in
+        pgadmin) echo "dev" ;;
+        splunk)  echo "splunk" ;;
+        kafka)   echo "kafka" ;;
+        jaeger|prometheus|grafana|otel-collector) echo "observability" ;;
+        *)       echo "" ;;
+    esac
+}
+
+service_container() {
+    case "$1" in
+        otel-collector) echo "deeptempo-otel-collector" ;;
+        *) echo "deeptempo-$1" ;;
+    esac
+}
+
+# --- Start the host-native Ollama (never containerized: no Metal in Docker) ---
+# Delegates to services/ollama_process.py rather than reimplementing the spawn:
+# macOS has no `setsid`, and a bare `nohup ... &` leaves Ollama in this script's
+# process group, where Ctrl+C would kill it. Never fatal - Ollama is optional.
+ensure_ollama() {
+    PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}" \
+        python3 -m services.ollama_process || \
+        echo "Warning: Ollama not started; see logs/ollama.log" >&2
+    return 0
+}
 
 # --- Find Python 3.10+ ---
 # Vigil requires Python 3.13+ (claude-agent-sdk). Some integration packages
@@ -91,14 +166,35 @@ wait_for_url() {
 }
 
 # --- Ensure a docker service is running ---
+# Profiled services (splunk, kafka, observability...) need COMPOSE_PROFILES set
+# or `up` silently no-ops on them.
 ensure_container() {
-    local name="$1" service="$2"
+    local name="$1" service="$2" profile="${3:-}"
     # Anchored exact-name match so e.g. deeptempo-postgres-test doesn't
     # mask a missing deeptempo-postgres.
     if [ -n "$(docker ps -q -f "name=^${name}$")" ]; then
         return 0
     fi
-    dc up -d "$service"
+    if [ -n "$profile" ]; then
+        COMPOSE_PROFILES="$profile" dc up -d "$service"
+    else
+        dc up -d "$service"
+    fi
+}
+
+# --- Start every service in the resolved autostart list ---
+start_autostart_services() {
+    local svc profile container
+    for svc in $(read_autostart); do
+        if [ "$svc" = "ollama" ]; then
+            ensure_ollama
+            continue
+        fi
+        profile="$(service_profile "$svc")"
+        container="$(service_container "$svc")"
+        ensure_container "$container" "$svc" "$profile"
+        [ "$svc" = "postgres" ] && wait_for_postgres || true
+    done
 }
 
 # --- Wait for postgres readiness ---

--- a/services/autostart_config.py
+++ b/services/autostart_config.py
@@ -1,0 +1,95 @@
+"""Which services ``./start.sh`` brings up without being asked.
+
+Stored as a plain text file at the repo root — one service name per line, ``#``
+comments ignored. Resolution order mirrors ``services/runtime_config.py``'s
+DB -> env -> default layering: **file -> AUTOSTART_SERVICES -> DEFAULT**, with
+the file as the UI-writable live source of truth and the env var as the
+operator pin for CI/hardened deploys.
+
+The storage choice is forced by bootstrapping, not taste:
+
+- **Not the database.** ``postgres`` is itself on the list, so a list living in
+  postgres cannot be read before postgres is up. Circular.
+- **Not the secrets store.** It is Fernet over ``~/.vigil/secrets.enc`` —
+  unreadable from bash, and an autostart list is not a secret.
+- **Not ``.env``.** Bash gets it free, but the backend would have to rewrite the
+  file that holds every credential in the system from a request handler, with
+  no locking and no atomic replace.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import List
+
+from services.service_manager import SERVICES
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AUTOSTART_FILE = REPO_ROOT / ".vigil-autostart"
+
+DEFAULT: tuple[str, ...] = ("postgres", "redis", "bifrost", "ollama")
+
+_HEADER = """\
+# Services Vigil starts automatically (./start.sh). One name per line.
+# Managed by Settings -> Services; hand-edits are preserved.
+# Valid names: {valid}
+"""
+
+
+def _known(names: List[str], source: str) -> List[str]:
+    out = []
+    for n in names:
+        if n in SERVICES:
+            out.append(n)
+        else:
+            logger.warning("Ignoring unknown service %r in %s", n, source)
+    return out
+
+
+def _read_file() -> List[str] | None:
+    try:
+        raw = AUTOSTART_FILE.read_text()
+    except OSError:
+        return None
+    names = [
+        line.strip()
+        for line in raw.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    return _known(names, str(AUTOSTART_FILE))
+
+
+def get_autostart_services() -> List[str]:
+    from_file = _read_file()
+    if from_file is not None:
+        return from_file
+    env = os.getenv("AUTOSTART_SERVICES")
+    if env:
+        return _known(
+            [n.strip() for n in env.replace(",", " ").split()], "AUTOSTART_SERVICES"
+        )
+    return list(DEFAULT)
+
+
+def set_autostart_services(names: List[str]) -> List[str]:
+    """Persist the list. Raises ValueError on an unknown service name."""
+    unknown = [n for n in names if n not in SERVICES]
+    if unknown:
+        raise ValueError(f"Unknown service(s): {', '.join(unknown)}")
+    deduped = list(dict.fromkeys(names))
+    body = _HEADER.format(valid=", ".join(SERVICES)) + "\n".join(deduped) + "\n"
+    # Atomic replace: a torn write here would silently change what boots.
+    fd, tmp = tempfile.mkstemp(dir=str(REPO_ROOT), prefix=".vigil-autostart.")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(body)
+        os.replace(tmp, AUTOSTART_FILE)
+    except OSError:
+        os.path.exists(tmp) and os.unlink(tmp)
+        raise
+    return deduped

--- a/services/ollama_process.py
+++ b/services/ollama_process.py
@@ -1,0 +1,255 @@
+"""Host-native Ollama supervisor.
+
+Ollama runs as a host process, not a container: Docker on macOS has no Metal
+passthrough, so a containerized Ollama would be CPU-only.
+
+Three constraints shape every function here:
+
+- **Liveness is always an HTTP probe, never a held handle.** uvicorn ``--reload``
+  respawns the server process on any edit under ``backend/``/``services/``/
+  ``database/``, destroying in-memory state. A ``Popen`` handle as source of
+  truth would report Ollama down seconds after starting it, because someone
+  saved a file. Probing also makes spawn idempotent across reloads.
+- **The running Ollama is often not ours** — ``brew services`` (launchd) and
+  Ollama.app both bind 11434. So Vigil never stops it, and never pattern-kills:
+  that would take down a user's own instance and lose a race with launchd.
+- **The spawned process must outlive its parent's process group.**
+  ``start_new_session=True`` keeps Ctrl+C on ``./start.sh`` from killing it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from services.provider_model_discovery import ollama_ping
+
+if TYPE_CHECKING:
+    from services.service_manager import ActionResult, ServiceSpec, ServiceStatus
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PIDFILE = REPO_ROOT / "logs" / "ollama.pid"
+LOGFILE = REPO_ROOT / "logs" / "ollama.log"
+
+_FALLBACK_PATHS = ("/opt/homebrew/bin/ollama", "/usr/local/bin/ollama")
+_SPAWN_LOCK = threading.Lock()
+
+
+def base_url() -> str:
+    """Host-side Ollama URL — what the backend/worker/daemon should call.
+
+    ``OLLAMA_URL`` holds the host-side value (``.env`` ships localhost:11434).
+    See :func:`container_base_url` for the container-side form.
+    """
+    return (os.getenv("OLLAMA_URL") or "http://localhost:11434").strip().rstrip("/")
+
+
+def container_base_url() -> str:
+    """``base_url`` as a *container* must address it.
+
+    Ollama runs on the host, so a container reaching it needs
+    ``host.docker.internal``. Compose already defaults to that — but
+    ``scripts/lib.sh::load_env`` exports the root ``.env`` OLLAMA_URL into the
+    shell, and shell env beats a compose default, so containers would otherwise
+    inherit a ``localhost`` that resolves to themselves (Bifrost then can't
+    reach Ollama at all).
+
+    Applied at the two places that shell out to compose — the ``_compose`` env
+    in ``services/service_manager.py`` and ``dc()`` in ``scripts/lib.sh`` — so
+    there is one variable and one rewrite rule, not two configs to keep in sync.
+    """
+    url = base_url()
+    for host in ("localhost", "127.0.0.1", "0.0.0.0"):
+        url = url.replace(f"//{host}:", "//host.docker.internal:")
+    return url
+
+
+def binary_path() -> Optional[str]:
+    found = shutil.which("ollama")
+    if found:
+        return found
+    return next((p for p in _FALLBACK_PATHS if os.path.exists(p)), None)
+
+
+def _read_pid() -> Optional[int]:
+    try:
+        return int(PIDFILE.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _pid_is_ollama(pid: int) -> bool:
+    """Guard against a stale pidfile pointing at a recycled PID."""
+    try:
+        r = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "comm="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return r.returncode == 0 and "ollama" in r.stdout.strip().lower()
+
+
+def _managed_by_vigil() -> bool:
+    pid = _read_pid()
+    return pid is not None and _pid_is_ollama(pid)
+
+
+def status(spec: "ServiceSpec") -> "ServiceStatus":
+    from services.service_manager import ServiceStatus
+
+    installed = binary_path() is not None
+    running = ollama_ping(base_url())
+    if running:
+        state = (
+            "running (started by Vigil)"
+            if _managed_by_vigil()
+            else "running (external)"
+        )
+    elif installed:
+        state = "stopped"
+    else:
+        state = "not installed"
+    return ServiceStatus(
+        name=spec.name,
+        kind="host",
+        running=running,
+        ready=running,
+        status=state,
+        installed=installed,
+        managed_by_vigil=running and _managed_by_vigil(),
+        startable=spec.startable,
+        stoppable=spec.stoppable,
+        description=spec.description,
+        detail=None if installed else "Install with: brew install ollama",
+    )
+
+
+def start(spec: "ServiceSpec", *, timeout: int = 30) -> "ActionResult":
+    from services.service_manager import ActionResult
+
+    url = base_url()
+    if ollama_ping(url):
+        return ActionResult(
+            True, "Ollama already running", already_running=True, detail=_sync_bifrost()
+        )
+
+    exe = binary_path()
+    if exe is None:
+        return ActionResult(
+            False,
+            "Ollama binary not found. Install it with `brew install ollama` — "
+            "Vigil runs Ollama natively (a container would be CPU-only on macOS) "
+            "and will not fall back to Docker.",
+            code="not_installed",
+        )
+
+    with _SPAWN_LOCK:
+        if ollama_ping(url):  # won the race while waiting on the lock
+            return ActionResult(
+                True,
+                "Ollama already running",
+                already_running=True,
+                detail=_sync_bifrost(),
+            )
+        try:
+            LOGFILE.parent.mkdir(parents=True, exist_ok=True)
+            # A file handle, never PIPE: nothing drains a pipe here, so ollama
+            # would block once the ~64KB buffer filled.
+            log_fh = open(LOGFILE, "ab")
+            proc = subprocess.Popen(
+                [exe, "serve"],
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+                cwd=str(REPO_ROOT),
+            )
+        except OSError as e:
+            return ActionResult(
+                False, f"Failed to spawn ollama: {e}", code="spawn_error"
+            )
+        try:
+            PIDFILE.write_text(str(proc.pid))
+        except OSError as e:
+            logger.warning("Could not write %s: %s", PIDFILE, e)
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if ollama_ping(url):
+            return ActionResult(True, "Ollama started", detail=_sync_bifrost())
+        if proc.poll() is not None:
+            return ActionResult(
+                False,
+                f"ollama serve exited with code {proc.returncode}. " f"See {LOGFILE}.",
+                code="exited",
+            )
+        time.sleep(0.25)
+    return ActionResult(
+        False,
+        f"Ollama did not become ready within {timeout}s. See {LOGFILE}.",
+        code="timeout",
+    )
+
+
+def _sync_bifrost() -> dict:
+    """Push the freshly-reachable Ollama catalog into Bifrost's live config.
+
+    Starting Ollama alone accomplishes nothing user-visible: LLM traffic is
+    dispatched through Bifrost, and ``docker/bifrost/config.json`` is only a
+    first-boot seed (live config lives in Bifrost's SQLite). Without this the
+    button "succeeds" and no Ollama model is selectable.
+
+    Mirrors ``backend/api/llm_providers.py::_schedule_catalog_resync`` (cache
+    invalidate + sync), but awaits the sync rather than firing it off, so the
+    caller can report ``bifrost_synced`` truthfully. Callers run in a threadpool
+    thread with no running loop; if a loop *is* running we fall back to
+    scheduling, since ``asyncio.run`` would raise. Best-effort throughout — a
+    Bifrost that is still booting must not fail the start call.
+    """
+    import asyncio
+
+    try:
+        from services.bifrost_admin import sync_all_provider_models
+        from services.model_registry import invalidate_model_cache
+
+        invalidate_model_cache()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(sync_all_provider_models())
+            return {"bifrost_synced": True}
+        loop.create_task(sync_all_provider_models())
+        return {"bifrost_synced": False, "bifrost_sync_scheduled": True}
+    except Exception as e:  # noqa: BLE001
+        logger.info("Bifrost model sync after Ollama start did not complete: %s", e)
+        return {"bifrost_synced": False, "bifrost_sync_error": str(e)}
+
+
+def main() -> int:
+    """CLI entry so ``scripts/lib.sh`` reuses this spawn rather than copying it.
+
+    macOS ships no ``setsid``, and a bare ``nohup ... &`` would leave Ollama in
+    start.sh's process group where Ctrl+C kills it. Shelling back into this
+    module keeps one implementation of the probe/pidfile/session semantics.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    from services.service_manager import SERVICES
+
+    result = start(SERVICES["ollama"])
+    print(result.message)
+    return 0 if result.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/provider_model_discovery.py
+++ b/services/provider_model_discovery.py
@@ -411,3 +411,22 @@ async def fetch_ollama_models(
 
     _META_CACHE.set(cache_key, list(models))
     return list(models)
+
+
+def ollama_ping(base_url: Optional[str] = None, timeout: float = 2.0) -> bool:
+    """Cheap liveness probe: is an Ollama serving ``/api/tags`` at ``base_url``?
+
+    Deliberately sync and uncached — it is polled every ~250ms while waiting
+    for a spawned ``ollama serve`` to come up, which rules out
+    :func:`fetch_ollama_models` (async, plus an ``/api/show`` per model).
+    """
+    base = (
+        (base_url or os.getenv("OLLAMA_URL") or "http://localhost:11434")
+        .strip()
+        .rstrip("/")
+    )
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=False) as client:
+            return client.get(f"{base}/api/tags").status_code == 200
+    except Exception:  # noqa: BLE001 — any failure means "not serving"
+        return False

--- a/services/service_manager.py
+++ b/services/service_manager.py
@@ -1,0 +1,351 @@
+"""Local service orchestration — the sanctioned channel for start/stop/status.
+
+Covers docker-compose services and the host-native Ollama process behind one
+API. The ``SERVICES`` registry is the allowlist: a name that isn't a key here
+can never reach a subprocess, which is what keeps the ``{name}`` path param on
+``backend/api/local_services.py`` safe.
+
+Compose invariants worth preserving:
+
+- Profiles are selected with ``COMPOSE_PROFILES``, not ``--profile``. It works
+  on both compose v1 (>=1.28) and v2 and needs no global-flag ordering, so
+  ``scripts/lib.sh`` can use the identical mechanism.
+- No ``-p``/``--project-directory``. Compose derives the project name from the
+  compose file's parent directory; passing one would orphan every container
+  ``start.sh`` created via ``scripts/lib.sh::dc``.
+- ``cwd`` is the repo root and the compose file is passed by absolute path, so
+  behaviour doesn't depend on where the backend was launched from.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_FILE = REPO_ROOT / "docker" / "docker-compose.yml"
+
+
+@dataclass(frozen=True)
+class ServiceSpec:
+    """A managed service. ``container is None`` means host-native."""
+
+    name: str
+    container: Optional[str]
+    compose_service: Optional[str]
+    profile: Optional[str] = None
+    startable: bool = True
+    stoppable: bool = True
+    description: str = ""
+
+
+# postgres/redis/bifrost are stoppable=False on purpose: a UI stop button on
+# them takes the running application down with it.
+SERVICES: Dict[str, ServiceSpec] = {
+    "postgres": ServiceSpec(
+        "postgres",
+        "deeptempo-postgres",
+        "postgres",
+        stoppable=False,
+        description="Local PostgreSQL container",
+    ),
+    "redis": ServiceSpec(
+        "redis",
+        "deeptempo-redis",
+        "redis",
+        stoppable=False,
+        description="Redis (ARQ job queue)",
+    ),
+    "bifrost": ServiceSpec(
+        "bifrost",
+        "deeptempo-bifrost",
+        "bifrost",
+        stoppable=False,
+        description="LLM gateway",
+    ),
+    "pgadmin": ServiceSpec(
+        "pgadmin", "deeptempo-pgadmin", "pgadmin", "dev", description="pgAdmin"
+    ),
+    "splunk": ServiceSpec(
+        "splunk", "deeptempo-splunk", "splunk", "splunk", description="Splunk"
+    ),
+    "kafka": ServiceSpec(
+        "kafka", "deeptempo-kafka", "kafka", "kafka", description="Kafka ingestion"
+    ),
+    "jaeger": ServiceSpec(
+        "jaeger",
+        "deeptempo-jaeger",
+        "jaeger",
+        "observability",
+        description="Jaeger tracing",
+    ),
+    "prometheus": ServiceSpec(
+        "prometheus",
+        "deeptempo-prometheus",
+        "prometheus",
+        "observability",
+        description="Prometheus",
+    ),
+    "grafana": ServiceSpec(
+        "grafana",
+        "deeptempo-grafana",
+        "grafana",
+        "observability",
+        description="Grafana",
+    ),
+    "otel-collector": ServiceSpec(
+        "otel-collector",
+        "deeptempo-otel-collector",
+        "otel-collector",
+        "observability",
+        description="OpenTelemetry collector",
+    ),
+    # Host-native (Docker on macOS has no Metal passthrough, so a container
+    # would be CPU-only). Never stopped: see services/ollama_process.py.
+    "ollama": ServiceSpec(
+        "ollama",
+        None,
+        None,
+        stoppable=False,
+        description="Ollama (host-native LLM runtime)",
+    ),
+}
+
+
+@dataclass
+class ServiceStatus:
+    name: str
+    kind: str
+    running: bool
+    status: str
+    installed: bool = True
+    ready: bool = False
+    managed_by_vigil: bool = False
+    startable: bool = True
+    stoppable: bool = True
+    description: str = ""
+    detail: Optional[str] = None
+
+
+@dataclass
+class ActionResult:
+    success: bool
+    message: str = ""
+    already_running: bool = False
+    code: Optional[str] = None
+    detail: Dict[str, object] = field(default_factory=dict)
+
+
+class UnknownServiceError(KeyError):
+    """Raised when a name isn't in the SERVICES allowlist."""
+
+
+def _spec(name: str) -> ServiceSpec:
+    try:
+        return SERVICES[name]
+    except KeyError:
+        raise UnknownServiceError(name) from None
+
+
+def _dc_cmd() -> List[str]:
+    return (
+        ["docker-compose"] if shutil.which("docker-compose") else ["docker", "compose"]
+    )
+
+
+def docker_available() -> tuple[bool, str]:
+    """Whether the Docker *daemon* is reachable — not merely installed."""
+    if not shutil.which("docker"):
+        return False, "docker CLI not found on PATH"
+    try:
+        r = subprocess.run(
+            ["docker", "info", "--format", "{{.ServerVersion}}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "docker info timed out"
+    except OSError as e:
+        return False, str(e)
+    if r.returncode != 0:
+        return (
+            False,
+            (r.stderr.strip().splitlines() or ["docker daemon not reachable"])[0],
+        )
+    return True, r.stdout.strip()
+
+
+def _compose(
+    args: List[str], profile: Optional[str], timeout: int
+) -> subprocess.CompletedProcess:
+    from services.ollama_process import container_base_url
+
+    env = os.environ.copy()
+    if profile:
+        env["COMPOSE_PROFILES"] = profile
+    # Containers reach the host-native Ollama via host.docker.internal; the
+    # ambient OLLAMA_URL is the host-side value. See ollama_process.
+    env["OLLAMA_URL"] = container_base_url()
+    return subprocess.run(
+        [*_dc_cmd(), "-f", str(COMPOSE_FILE), *args],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _container_state(container: str) -> tuple[bool, str]:
+    """(running, status). Anchored name match so `-test` suffixes don't alias."""
+    try:
+        r = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "--filter",
+                f"name=^{container}$",
+                "--format",
+                "{{.Status}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            return True, r.stdout.strip()
+        r = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-a",
+                "--filter",
+                f"name=^{container}$",
+                "--format",
+                "{{.Status}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            return False, r.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return False, f"error: {e}"
+    return False, "not found"
+
+
+def status(name: str) -> ServiceStatus:
+    spec = _spec(name)
+    if spec.container is None:
+        from services import ollama_process
+
+        return ollama_process.status(spec)
+
+    ok, detail = docker_available()
+    if not ok:
+        return ServiceStatus(
+            name=spec.name,
+            kind="docker",
+            running=False,
+            status="docker unavailable",
+            startable=spec.startable,
+            stoppable=spec.stoppable,
+            description=spec.description,
+            detail=detail,
+        )
+    running, state = _container_state(spec.container)
+    return ServiceStatus(
+        name=spec.name,
+        kind="docker",
+        running=running,
+        ready=running,
+        status=state,
+        managed_by_vigil=running,
+        startable=spec.startable,
+        stoppable=spec.stoppable,
+        description=spec.description,
+    )
+
+
+def start(name: str, *, wait: bool = False, timeout: int = 120) -> ActionResult:
+    spec = _spec(name)
+    if not spec.startable:
+        return ActionResult(
+            False, f"{name} cannot be started by Vigil", code="not_startable"
+        )
+    if spec.container is None:
+        from services import ollama_process
+
+        return ollama_process.start(spec, timeout=min(timeout, 60))
+
+    ok, detail = docker_available()
+    if not ok:
+        return ActionResult(
+            False, f"Docker daemon not reachable: {detail}", code="docker_unavailable"
+        )
+    if _container_state(spec.container)[0]:
+        return ActionResult(True, f"{name} already running", already_running=True)
+    return _compose_action(spec, ["up", "-d", spec.compose_service], "start", timeout)
+
+
+def stop(name: str) -> ActionResult:
+    spec = _spec(name)
+    if not spec.stoppable:
+        return ActionResult(
+            False, f"{name} cannot be stopped by Vigil", code="not_stoppable"
+        )
+    if spec.container is None:
+        return ActionResult(
+            False, f"{name} is not managed by Vigil", code="not_stoppable"
+        )
+    return _compose_action(spec, ["stop", spec.compose_service], "stop", 60)
+
+
+def restart(name: str) -> ActionResult:
+    spec = _spec(name)
+    if not spec.stoppable:
+        return ActionResult(
+            False, f"{name} cannot be restarted by Vigil", code="not_stoppable"
+        )
+    if spec.container is None:
+        return ActionResult(
+            False, f"{name} is not managed by Vigil", code="not_stoppable"
+        )
+    return _compose_action(spec, ["restart", spec.compose_service], "restart", 120)
+
+
+def _compose_action(
+    spec: ServiceSpec, args: List[str], verb: str, timeout: int
+) -> ActionResult:
+    try:
+        r = _compose(args, spec.profile, timeout)
+    except subprocess.TimeoutExpired:
+        return ActionResult(
+            False, f"docker compose {verb} timed out after {timeout}s", code="timeout"
+        )
+    except OSError as e:
+        return ActionResult(False, str(e), code="exec_error")
+    if r.returncode != 0:
+        logger.error("compose %s %s failed: %s", verb, spec.name, r.stderr.strip())
+        return ActionResult(
+            False,
+            f"Failed to {verb} {spec.name}",
+            code="compose_error",
+            detail={"stderr": r.stderr.strip()},
+        )
+    return ActionResult(
+        True, f"Successfully {verb}ed {spec.name}", detail={"output": r.stdout.strip()}
+    )
+
+
+def list_services() -> List[ServiceStatus]:
+    return [status(name) for name in SERVICES]

--- a/shutdown_all.sh
+++ b/shutdown_all.sh
@@ -19,7 +19,10 @@ for pidfile in logs/backend.pid logs/daemon.pid logs/frontend.pid logs/llm_worke
     [ -f "$pidfile" ] && kill "$(cat "$pidfile")" 2>/dev/null && rm -f "$pidfile"
 done
 
-# Kill by process pattern
+# Kill by process pattern.
+# Deliberately no `pkill -f ollama`: the running Ollama is often the user's own
+# (brew services / Ollama.app), so killing it destroys unrelated state and
+# launchd just restarts it. Vigil starts Ollama but never stops it.
 pkill -f "uvicorn backend.main:app" 2>/dev/null || true
 pkill -f "daemon/main.py" 2>/dev/null || true
 pkill -f "daemon.main" 2>/dev/null || true

--- a/start.sh
+++ b/start.sh
@@ -1,22 +1,45 @@
 #!/bin/bash
 # Start Vigil SOC
-# Usage: ./start.sh [-d|--daemon]
+# Usage: ./start.sh [-d|--daemon] [--with <profile>] [--all]
 source "$(dirname "$0")/scripts/lib.sh"
 
 # Version shown in the startup banner, read from the repo VERSION file.
 VERSION="$(cat "$(dirname "$0")/VERSION" 2>/dev/null || echo "dev")"
 
+usage() {
+    cat <<EOF
+Usage: $0 [--daemon|-d] [--with <profile>] [--all]
+
+  -d, --daemon      Run in the background (logs/ + pidfiles)
+      --with NAME   Also start a profiled service (splunk, kafka, pgadmin,
+                    jaeger, prometheus, grafana, otel-collector). Repeatable.
+      --all         Also start every profiled service
+
+Core services come from .vigil-autostart (or \$AUTOSTART_SERVICES, else
+postgres redis bifrost ollama). --with/--all are additive to that list.
+EOF
+}
+
 DAEMON=0
-for arg in "$@"; do
-    case "$arg" in
+EXTRA_SERVICES=""
+ALL_PROFILES=0
+while [ $# -gt 0 ]; do
+    case "$1" in
         -d|--daemon) DAEMON=1 ;;
-        *) echo "Usage: $0 [--daemon|-d]"; exit 1 ;;
+        --all) ALL_PROFILES=1 ;;
+        --with)
+            [ -n "${2:-}" ] || { echo "--with requires a service name" >&2; exit 1; }
+            EXTRA_SERVICES="$EXTRA_SERVICES $2"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) usage >&2; exit 1 ;;
     esac
+    shift
 done
+[ "$ALL_PROFILES" -eq 1 ] && EXTRA_SERVICES="$EXTRA_SERVICES pgadmin splunk kafka jaeger prometheus grafana otel-collector"
 
 # --- Prerequisites ---
 PYTHON=$(find_python)
-command -v docker &>/dev/null || { echo "Docker required."; exit 1; }
+ensure_docker || exit 1
 
 SKIP_FRONTEND=0
 if ! command -v node &>/dev/null; then
@@ -42,15 +65,18 @@ load_env
 [ -n "$_CALLER_BIND_HOST" ] && BIND_HOST="$_CALLER_BIND_HOST"
 export BIND_HOST="${BIND_HOST:-127.0.0.1}"
 
-# --- Docker services ---
-ensure_container deeptempo-postgres postgres
-wait_for_postgres || true
-ensure_container deeptempo-redis redis
-ensure_container deeptempo-bifrost bifrost
-
+# `bifrost` only resolves inside the compose network. Rewrite before starting
+# services: bringing Ollama up syncs its catalog into Bifrost, and that runs
+# here on the host.
 if [ -z "${BIFROST_URL+x}" ] || [ "${BIFROST_URL}" = "http://bifrost:8080" ]; then
     export BIFROST_URL="http://localhost:8080"
 fi
+
+# --- Services (autostart list + any --with/--all extras) ---
+start_autostart_services
+for svc in $EXTRA_SERVICES; do
+    ensure_container "$(service_container "$svc")" "$svc" "$(service_profile "$svc")"
+done
 
 # --- Database init ---
 python3 scripts/init_schema.py || { echo "Schema init failed."; exit 1; }

--- a/tests/integration/test_bifrost_integration.py
+++ b/tests/integration/test_bifrost_integration.py
@@ -47,9 +47,8 @@ async def test_bifrost_health_endpoint():
 async def test_bifrost_chat_completion_via_ollama():
     """A chat completion routed to Ollama through Bifrost should return content.
 
-    Requires a running Ollama with the model named in OLLAMA_DEFAULT_MODEL
-    (defaults to llama3.1:8b for the smoke test — smaller than the
-    env.example production default).
+    Requires a running Ollama with the model named in OLLAMA_SMOKE_MODEL
+    (defaults to llama3.1:8b — kept small so the smoke test stays quick).
     """
     from services.llm_router import LLMRouter, ProviderSpec
 

--- a/tests/unit/test_dsn_parsing.py
+++ b/tests/unit/test_dsn_parsing.py
@@ -1,0 +1,138 @@
+"""Unit tests for parse_connection_string / DatabaseConfig DSN resolution."""
+
+import pytest
+
+from database.connection import DatabaseConfig, parse_connection_string
+
+pytestmark = [pytest.mark.unit, pytest.mark.database]
+
+
+def test_parses_all_parts():
+    p = parse_connection_string("postgresql://user:pw@db.example:6000/vigil")
+    assert (p.host, p.port, p.database, p.user, p.password) == (
+        "db.example",
+        6000,
+        "vigil",
+        "user",
+        "pw",
+    )
+
+
+def test_postgres_scheme_alias_and_default_port():
+    p = parse_connection_string("postgres://u:p@h/db")
+    assert p.port == 5432
+
+
+def test_percent_encoded_credentials_are_decoded():
+    """urlsplit does not decode; get_database_url re-quotes. Skip the unquote
+    here and every password containing @ or / authenticates wrong."""
+    p = parse_connection_string("postgresql://u%40corp:p%40ss%2Fword@h/db")
+    assert p.user == "u@corp"
+    assert p.password == "p@ss/word"
+
+
+def test_encoded_password_round_trips_through_url():
+    cfg = DatabaseConfig(connection_string="postgresql://me:p%40ss@h/db")
+    assert cfg.password == "p@ss"
+    assert "p%40ss" in cfg.get_database_url()
+
+
+def test_allowed_query_params_are_kept():
+    p = parse_connection_string(
+        "postgresql://u:p@h/db?sslmode=require&connect_timeout=3"
+    )
+    assert p.query == {"sslmode": "require", "connect_timeout": "3"}
+
+
+def test_sslmode_reaches_the_url_and_extras_are_serialized():
+    cfg = DatabaseConfig(
+        connection_string="postgresql://u:p@h/db?sslmode=require&application_name=vigil"
+    )
+    url = cfg.get_database_url()
+    assert "sslmode=require" in url
+    assert "application_name=vigil" in url
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "",
+        "   ",
+        "mysql://u:p@h/db",
+        "postgresql+asyncpg://u:p@h/db",  # no async engine exists in this repo
+        "postgresql://u:p@h:notaport/db",
+        "postgresql://u:p@h/",  # no database
+        "postgresql://u:p@/db",  # no host
+    ],
+)
+def test_rejects_malformed(dsn):
+    with pytest.raises(ValueError):
+        parse_connection_string(dsn)
+
+
+@pytest.mark.parametrize(
+    "param",
+    [
+        "sslcert=/etc/passwd",
+        "sslkey=/k.pem",
+        "sslrootcert=/ca.pem",
+        "passfile=/etc/shadow",
+        "service=prod",
+        "sslpassword=hunter2",
+    ],
+)
+def test_rejects_local_file_params(param):
+    """These libpq params take local file paths: honouring one from a
+    user-supplied DSN would be a file-read/probe primitive on the backend."""
+    with pytest.raises(ValueError):
+        parse_connection_string(f"postgresql://u:p@h/db?{param}")
+
+
+def test_rejects_unknown_param_not_on_allowlist():
+    with pytest.raises(ValueError):
+        parse_connection_string("postgresql://u:p@h/db?some_new_thing=1")
+
+
+def test_rejects_unix_socket_host():
+    with pytest.raises(ValueError):
+        parse_connection_string("postgresql://u:p@%2Fvar%2Frun/db")
+
+
+def test_config_falls_back_to_env_on_bad_dsn(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "envhost")
+    monkeypatch.setenv("POSTGRES_DB", "envdb")
+    cfg = DatabaseConfig(connection_string="postgresql://u:p@h/db?sslcert=/etc/passwd")
+    assert cfg.source == "env"
+    assert cfg.host == "envhost"
+    assert cfg.database == "envdb"
+
+
+def test_config_prefers_dsn_over_env(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "envhost")
+    cfg = DatabaseConfig(connection_string="postgresql://u:p@dsnhost/db")
+    assert cfg.source == "connection_string"
+    assert cfg.host == "dsnhost"
+
+
+def test_config_uses_env_when_no_dsn(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "envhost")
+    cfg = DatabaseConfig(connection_string="")
+    assert cfg.source == "env"
+    assert cfg.host == "envhost"
+
+
+def test_env_connection_string_does_not_outrank_postgres_vars(monkeypatch):
+    """backend/main.py exports a hardcoded default POSTGRESQL_CONNECTION_STRING
+    for the MCP servers whenever the secret is unset. Resolving the DSN through
+    the secrets manager's env fallback would let that default silently pin an
+    operator's POSTGRES_* config to localhost."""
+    monkeypatch.setenv(
+        "POSTGRESQL_CONNECTION_STRING",
+        "postgresql://deeptempo:pw@localhost:5432/deeptempo_soc",
+    )
+    monkeypatch.setenv("POSTGRES_HOST", "db.prod.internal")
+    monkeypatch.setenv("POSTGRES_DB", "prod_db")
+    cfg = DatabaseConfig()
+    assert cfg.source == "env"
+    assert cfg.host == "db.prod.internal"
+    assert cfg.database == "prod_db"


### PR DESCRIPTION
Prerequisite for the desktop app (#TBD), but standalone-useful on its own.

Brings the stack up without manually starting each service: `ensure_docker` starts Docker Desktop / the engine and waits for it, and `start_autostart_services` brings up the services marked autostart, so `./start.sh` works from cold rather than needing each piece up first.

Also: switch databases without taking the UI down, and render dashboard tables against schemas that do not match the expected shape.

Cherry-picked onto `main` directly — it has no dependency on the `ollama-agent` line it was originally written above.