### PR TITLE
fix(agents): approval-gate vendor MCP action tools

### DIFF
--- a/daemon/agent_runner.py
+++ b/daemon/agent_runner.py
@@ -1249,6 +1249,25 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
         if tier == "requires_approval":
             return await self._request_tool_approval(inv_id, tool_name, tool_input)
 
+        # Fail-open tripwire: unknown-tier tools execute with no approval gate.
+        # Log each one so a state-changing tool the verb-floor missed is visible
+        # rather than silent — the signal for whether the daemon needs to fail
+        # closed by default. See services.tool_manager.get_tool_tier.
+        if tier == "unknown":
+            logger.warning(
+                f"{inv_id}: Executing unclassified tool '{tool_name}' "
+                "(tier=unknown; no approval gate). If it changes state, add it "
+                "to TOOL_TIERS or _ACTION_VERB_TOKENS in services.tool_manager."
+            )
+            self.workdir.append_log(
+                inv_id,
+                {
+                    "event": "unknown_tier_execute",
+                    "tool": tool_name,
+                    "tier": "unknown",
+                },
+            )
+
         if self._claude_service and hasattr(
             self._claude_service, "_execute_backend_tool"
         ):

--- a/daemon/agent_runner.py
+++ b/daemon/agent_runner.py
@@ -42,6 +42,12 @@ from daemon.workdir import WorkdirManager
 
 logger = logging.getLogger(__name__)
 
+# Tool names already flagged as executing at the unknown (ungated) tier. The
+# fail-open tripwire logs each unclassified tool once per process rather than on
+# every routine vendor read call, so a genuinely novel tool stays visible
+# instead of drowning in per-call noise. See _execute_external_tool.
+_SEEN_UNKNOWN_TIER_TOOLS: set = set()
+
 try:
     from opentelemetry.trace import SpanKind
 
@@ -1250,22 +1256,16 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
             return await self._request_tool_approval(inv_id, tool_name, tool_input)
 
         # Fail-open tripwire: unknown-tier tools execute with no approval gate.
-        # Log each one so a state-changing tool the verb-floor missed is visible
-        # rather than silent — the signal for whether the daemon needs to fail
+        # Most are benign vendor reads, so log each distinct tool once (INFO)
+        # rather than warning on every call — enough to spot a state-changing
+        # tool the verb-floor missed and decide whether the daemon should fail
         # closed by default. See services.tool_manager.get_tool_tier.
-        if tier == "unknown":
-            logger.warning(
-                f"{inv_id}: Executing unclassified tool '{tool_name}' "
-                "(tier=unknown; no approval gate). If it changes state, add it "
-                "to TOOL_TIERS or _ACTION_VERB_TOKENS in services.tool_manager."
-            )
-            self.workdir.append_log(
-                inv_id,
-                {
-                    "event": "unknown_tier_execute",
-                    "tool": tool_name,
-                    "tier": "unknown",
-                },
+        if tier == "unknown" and tool_name not in _SEEN_UNKNOWN_TIER_TOOLS:
+            _SEEN_UNKNOWN_TIER_TOOLS.add(tool_name)
+            logger.info(
+                f"Unclassified tool '{tool_name}' executing with no approval "
+                f"gate (tier=unknown, first seen {inv_id}). Classify it in "
+                "services.tool_manager if it changes state; not logged again."
             )
 
         if self._claude_service and hasattr(

--- a/services/tool_manager.py
+++ b/services/tool_manager.py
@@ -140,16 +140,67 @@ for _tier, _tier_tools in TOOL_TIERS.items():
         _TOOL_TIER_LOOKUP[_tier_tool] = _tier
 
 
-def get_tool_tier(tool_name: str) -> str:
-    """Return the safety tier for ``tool_name`` (strips MCP server prefixes).
+# Destructive/containment action verbs. A tool with one of these as a whole
+# token requires approval even when its exact name isn't in TOOL_TIERS: vendor
+# MCP tools are double-prefixed (crowdstrike_cs_isolate_host) so neither the
+# exact nor the suffix lookup below reaches the generic tier names
+# (isolate_host) — without this floor every vendor containment tool resolves to
+# "unknown" and executes with no approval. Whole-token match (not substring) so
+# "skill_*" doesn't trip "kill" and "get_container_*" doesn't trip "contain".
+_ACTION_VERB_TOKENS = frozenset(
+    {
+        # endpoint/network containment (+ reversals — still state-changing)
+        "isolate",
+        "unisolate",
+        "block",
+        "unblock",
+        "quarantine",
+        "contain",
+        # account/session state
+        "disable",
+        "deactivate",
+        "suspend",
+        "revoke",
+        "reset",
+        "deprovision",
+        # process/host lifecycle
+        "terminate",
+        "kill",
+        "shutdown",
+        "reboot",
+        "restart",
+        # data destruction
+        "purge",
+        "wipe",
+        "delete",
+    }
+)
 
-    Returns ``"unknown"`` for tools not in any tier — callers treat unknown as
-    executable-but-uncategorized (the historical daemon behavior).
+
+def _has_action_verb(tool_name: str) -> bool:
+    """True if any ``_``/``-`` delimited token is a destructive action verb."""
+    tokens = tool_name.replace("-", "_").lower().split("_")
+    return any(tok in _ACTION_VERB_TOKENS for tok in tokens)
+
+
+def get_tool_tier(tool_name: str) -> str:
+    """Return the safety tier for ``tool_name``.
+
+    Resolution order: exact name, then the post-first-underscore suffix (drops
+    the MCP ``{server}_`` prefix), then a destructive-verb floor that lifts
+    otherwise-``unknown`` action tools to ``requires_approval`` (see
+    ``_ACTION_VERB_TOKENS``). Returns ``"unknown"`` for tools in no tier —
+    callers treat unknown as executable-but-uncategorized (historical daemon
+    behavior).
     """
     if tool_name in _TOOL_TIER_LOOKUP:
         return _TOOL_TIER_LOOKUP[tool_name]
     short = tool_name.split("_", 1)[-1] if "_" in tool_name else tool_name
-    return _TOOL_TIER_LOOKUP.get(short, "unknown")
+    if short in _TOOL_TIER_LOOKUP:
+        return _TOOL_TIER_LOOKUP[short]
+    if _has_action_verb(tool_name):
+        return "requires_approval"
+    return "unknown"
 
 
 # --- Backend tool dispatch ------------------------------------------------

--- a/services/tool_manager.py
+++ b/services/tool_manager.py
@@ -14,6 +14,7 @@ skills DB never breaks a chat request.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -177,10 +178,21 @@ _ACTION_VERB_TOKENS = frozenset(
 )
 
 
+# Insert a boundary before each interior capital so camelCase vendor names
+# tokenize too: a JS/TS MCP server exposing ``suspendUser`` would otherwise
+# collapse to one unmatched token and slip the floor. See _has_action_verb.
+_CAMEL_BOUNDARY = re.compile(r"(?<!^)(?=[A-Z])")
+
+
 def _has_action_verb(tool_name: str) -> bool:
-    """True if any ``_``/``-`` delimited token is a destructive action verb."""
-    tokens = tool_name.replace("-", "_").lower().split("_")
-    return any(tok in _ACTION_VERB_TOKENS for tok in tokens)
+    """True if any token is a destructive action verb.
+
+    Splits on ``_``/``-`` and camelCase boundaries before whole-token matching,
+    so ``suspendUser`` tokenizes to ``suspend``/``user`` instead of the single
+    unmatched token ``suspenduser``.
+    """
+    normalized = _CAMEL_BOUNDARY.sub("_", tool_name).replace("-", "_").lower()
+    return any(tok in _ACTION_VERB_TOKENS for tok in normalized.split("_"))
 
 
 def get_tool_tier(tool_name: str) -> str:

--- a/services/tool_manager.py
+++ b/services/tool_manager.py
@@ -178,10 +178,11 @@ _ACTION_VERB_TOKENS = frozenset(
 )
 
 
-# Insert a boundary before each interior capital so camelCase vendor names
-# tokenize too: a JS/TS MCP server exposing ``suspendUser`` would otherwise
-# collapse to one unmatched token and slip the floor. See _has_action_verb.
-_CAMEL_BOUNDARY = re.compile(r"(?<!^)(?=[A-Z])")
+# Split only at a lowercase->uppercase boundary so camelCase vendor names
+# tokenize (``suspendUser`` -> ``suspend``/``user``) without shredding an
+# all-caps run: ``ISOLATE_HOST`` and acronyms like ``blockIP`` stay whole.
+# See _has_action_verb.
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z])(?=[A-Z])")
 
 
 def _has_action_verb(tool_name: str) -> bool:
@@ -195,14 +196,23 @@ def _has_action_verb(tool_name: str) -> bool:
     return any(tok in _ACTION_VERB_TOKENS for tok in normalized.split("_"))
 
 
+# First-party tool namespaces whose destructive-looking verbs are benign
+# internal housekeeping, not security actions — exempt from the verb floor so
+# they don't stall investigations on human approval. mempalace_delete_drawer
+# (routine memory-entry cleanup, injected into every agent's memory protocol)
+# is the motivating case; a future mempalace_purge_*/reset_* would trip too.
+_VERB_FLOOR_EXEMPT_PREFIXES = ("mempalace_",)
+
+
 def get_tool_tier(tool_name: str) -> str:
     """Return the safety tier for ``tool_name``.
 
     Resolution order: exact name, then the post-first-underscore suffix (drops
     the MCP ``{server}_`` prefix), then a destructive-verb floor that lifts
     otherwise-``unknown`` action tools to ``requires_approval`` (see
-    ``_ACTION_VERB_TOKENS``). Returns ``"unknown"`` for tools in no tier —
-    callers treat unknown as executable-but-uncategorized (historical daemon
+    ``_ACTION_VERB_TOKENS``) — skipping the floor for first-party namespaces in
+    ``_VERB_FLOOR_EXEMPT_PREFIXES``. Returns ``"unknown"`` for tools in no tier
+    — callers treat unknown as executable-but-uncategorized (historical daemon
     behavior).
     """
     if tool_name in _TOOL_TIER_LOOKUP:
@@ -210,6 +220,8 @@ def get_tool_tier(tool_name: str) -> str:
     short = tool_name.split("_", 1)[-1] if "_" in tool_name else tool_name
     if short in _TOOL_TIER_LOOKUP:
         return _TOOL_TIER_LOOKUP[short]
+    if tool_name.startswith(_VERB_FLOOR_EXEMPT_PREFIXES):
+        return "unknown"
     if _has_action_verb(tool_name):
         return "requires_approval"
     return "unknown"

--- a/services/tool_manager.py
+++ b/services/tool_manager.py
@@ -196,36 +196,37 @@ def _has_action_verb(tool_name: str) -> bool:
     return any(tok in _ACTION_VERB_TOKENS for tok in normalized.split("_"))
 
 
-# First-party tool namespaces exempt from the destructive-verb floor, so a
-# verb in their name doesn't stall investigations on human approval:
+# First-party tool namespaces that are always executable and must never be
+# gated — checked before any tier lookup so neither the suffix match nor the
+# destructive-verb floor can stall a benign call on human approval:
 #   mempalace_  — internal memory housekeeping, not a security action
-#                 (mempalace_delete_drawer is routine memory-entry cleanup;
-#                  a future mempalace_purge_*/reset_* would trip too).
+#                 (mempalace_delete_drawer is routine memory-entry cleanup).
 #   skill_      — a DB-backed Skill only renders a prompt template and returns
 #                 text (no state change); its slug comes from a user-authored
-#                 name, so "Isolate Host Playbook" -> skill_isolate_host_playbook
-#                 would otherwise gate. Any real action stays separately gated.
-_VERB_FLOOR_EXEMPT_PREFIXES = ("mempalace_", "skill_")
+#                 name, so a skill called "Isolate Host" / "Delete Case" would
+#                 otherwise match an action tier by suffix and gate (or, for the
+#                 forbidden tier, never run). Real actions stay separately gated.
+_UNGATED_PREFIXES = ("mempalace_", "skill_")
 
 
 def get_tool_tier(tool_name: str) -> str:
     """Return the safety tier for ``tool_name``.
 
-    Resolution order: exact name, then the post-first-underscore suffix (drops
-    the MCP ``{server}_`` prefix), then a destructive-verb floor that lifts
-    otherwise-``unknown`` action tools to ``requires_approval`` (see
-    ``_ACTION_VERB_TOKENS``) — skipping the floor for first-party namespaces in
-    ``_VERB_FLOOR_EXEMPT_PREFIXES``. Returns ``"unknown"`` for tools in no tier
-    — callers treat unknown as executable-but-uncategorized (historical daemon
-    behavior).
+    First-party namespaces in ``_UNGATED_PREFIXES`` short-circuit to
+    ``"unknown"`` (always executable). Otherwise: exact name, then the
+    post-first-underscore suffix (drops the MCP ``{server}_`` prefix), then a
+    destructive-verb floor that lifts otherwise-``unknown`` action tools to
+    ``requires_approval`` (see ``_ACTION_VERB_TOKENS``). Returns ``"unknown"``
+    for tools in no tier — callers treat unknown as executable-but-
+    uncategorized (historical daemon behavior).
     """
+    if tool_name.startswith(_UNGATED_PREFIXES):
+        return "unknown"
     if tool_name in _TOOL_TIER_LOOKUP:
         return _TOOL_TIER_LOOKUP[tool_name]
     short = tool_name.split("_", 1)[-1] if "_" in tool_name else tool_name
     if short in _TOOL_TIER_LOOKUP:
         return _TOOL_TIER_LOOKUP[short]
-    if tool_name.startswith(_VERB_FLOOR_EXEMPT_PREFIXES):
-        return "unknown"
     if _has_action_verb(tool_name):
         return "requires_approval"
     return "unknown"

--- a/services/tool_manager.py
+++ b/services/tool_manager.py
@@ -196,12 +196,16 @@ def _has_action_verb(tool_name: str) -> bool:
     return any(tok in _ACTION_VERB_TOKENS for tok in normalized.split("_"))
 
 
-# First-party tool namespaces whose destructive-looking verbs are benign
-# internal housekeeping, not security actions — exempt from the verb floor so
-# they don't stall investigations on human approval. mempalace_delete_drawer
-# (routine memory-entry cleanup, injected into every agent's memory protocol)
-# is the motivating case; a future mempalace_purge_*/reset_* would trip too.
-_VERB_FLOOR_EXEMPT_PREFIXES = ("mempalace_",)
+# First-party tool namespaces exempt from the destructive-verb floor, so a
+# verb in their name doesn't stall investigations on human approval:
+#   mempalace_  — internal memory housekeeping, not a security action
+#                 (mempalace_delete_drawer is routine memory-entry cleanup;
+#                  a future mempalace_purge_*/reset_* would trip too).
+#   skill_      — a DB-backed Skill only renders a prompt template and returns
+#                 text (no state change); its slug comes from a user-authored
+#                 name, so "Isolate Host Playbook" -> skill_isolate_host_playbook
+#                 would otherwise gate. Any real action stays separately gated.
+_VERB_FLOOR_EXEMPT_PREFIXES = ("mempalace_", "skill_")
 
 
 def get_tool_tier(tool_name: str) -> str:


### PR DESCRIPTION
## Summary

`get_tool_tier` classifies each agent tool call into a safety tier (`safe` / `managed` / `requires_approval` / `forbidden`) that the daemon and OpenAI-format agent loops gate on. It resolved a tool by exact name, then by stripping the MCP `{server}_` prefix. But vendor MCP tools reach the model **double-prefixed** — `{server}_{vendor}_{action}`, e.g. `crowdstrike_cs_isolate_host`, `azure-ad_aad_disable_user`, `palo-alto_pan_block_ip` — because each integration names its own tools with a vendor prefix (`cs_`, `aad_`, `pan_`) on top of the server prefix `mcp_client` adds. Stripping only the server prefix left `cs_isolate_host`, which isn't a tier key, so **every vendor containment/identity tool resolved to `unknown` and executed with no approval** on both the daemon and the interactive OpenAI path.

## Fix

Add a destructive-verb floor to `get_tool_tier`: after the exact- and suffix-name lookups miss, any tool whose `_`/`-`-delimited tokens include a containment/lifecycle/destruction verb (`isolate`, `block`, `quarantine`, `disable`, `kill`, `terminate`, `wipe`, `delete`, …) is lifted to `requires_approval` instead of `unknown`. Whole-token matching (not substring) avoids false positives like `get_container_status` → `contain` or `skill_*` → `kill`. Builtin tiers still win via exact/suffix match, so nothing is downgraded, and false positives fail toward *extra* approval — the safe direction.