### PR TITLE
fix(redesign): scope Escape to the topmost dialog layer

### DIFF
--- a/frontend/src/redesign/shared/ui.test.tsx
+++ b/frontend/src/redesign/shared/ui.test.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Popup, Select } from './ui'
+
+function NestedLayers({ onParentClose }: { onParentClose: () => void }) {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <Popup
+      open={open}
+      title={<span>Review finding</span>}
+      onClose={() => {
+        setOpen(false)
+        onParentClose()
+      }}
+    >
+      <Select
+        value=""
+        placeholder="Choose status"
+        options={[{ value: 'open', label: 'Open' }]}
+        onSelect={() => undefined}
+      />
+    </Popup>
+  )
+}
+
+describe('redesign shared UI', () => {
+  it('names dialogs from the visible heading and labels the close action', () => {
+    render(<Popup open title={<span>Case confirmation</span>} onClose={() => undefined}>Body</Popup>)
+
+    expect(screen.getByRole('dialog', { name: 'Case confirmation' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+  })
+
+  it('dismisses only the topmost Select before its parent Popup', () => {
+    const onParentClose = vi.fn()
+    render(<NestedLayers onParentClose={onParentClose} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose status' }))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: 'Review finding' })).toBeInTheDocument()
+    expect(onParentClose).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onParentClose).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('dialog', { name: 'Review finding' })).not.toBeInTheDocument()
+  })
+
+  it('restores focus to the element that opened the Popup', () => {
+    function FocusExample() {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open review</button>
+          <Popup open={open} title="Review" onClose={() => setOpen(false)}>Body</Popup>
+        </>
+      )
+    }
+
+    render(<FocusExample />)
+    const opener = screen.getByRole('button', { name: 'Open review' })
+    opener.focus()
+    fireEvent.click(opener)
+    expect(screen.getByRole('dialog', { name: 'Review' })).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(opener).toHaveFocus()
+  })
+
+  it('preserves outside-click dismissal', () => {
+    const onClose = vi.fn()
+    render(<Popup open title="Review" onClose={onClose}>Body</Popup>)
+
+    fireEvent.click(screen.getByRole('dialog', { name: 'Review' }))
+    expect(onClose).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('dialog', { name: 'Review' }).parentElement as HTMLElement)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/redesign/shared/ui.tsx
+++ b/frontend/src/redesign/shared/ui.tsx
@@ -8,6 +8,7 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
   type InputHTMLAttributes,
@@ -16,6 +17,23 @@ import {
 } from 'react'
 import { createPortal } from 'react-dom'
 import { Icon, type IconName } from './icons'
+
+// Popup and portal-backed Select can be nested. Keep Escape scoped to the
+// most recently opened interactive layer so one keypress cannot dismiss both.
+const escapeLayers: symbol[] = []
+
+function addEscapeLayer(layer: symbol) {
+  escapeLayers.push(layer)
+}
+
+function removeEscapeLayer(layer: symbol) {
+  const index = escapeLayers.lastIndexOf(layer)
+  if (index >= 0) escapeLayers.splice(index, 1)
+}
+
+function isTopEscapeLayer(layer: symbol) {
+  return escapeLayers[escapeLayers.length - 1] === layer
+}
 
 /** Enter/Space → activate. For non-button elements given `role="button"` or
  *  `role="switch"` so they stay keyboard-operable (REDESIGN_GAPS.md §10). */
@@ -98,6 +116,8 @@ export function Popup({
   width?: number
 }) {
   const panelRef = useRef<HTMLDivElement>(null)
+  const escapeLayerRef = useRef(Symbol('popup'))
+  const titleId = useId()
   // Keep the latest onClose in a ref so the focus effect can depend on `open`
   // alone. Depending on `onClose` (usually a fresh inline arrow each render)
   // would re-run the effect on every keystroke and steal focus back to the
@@ -107,14 +127,21 @@ export function Popup({
 
   useEffect(() => {
     if (!open) return
+    const escapeLayer = escapeLayerRef.current
+    addEscapeLayer(escapeLayer)
     const opener = document.activeElement as HTMLElement | null
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCloseRef.current()
+      if (e.key === 'Escape' && isTopEscapeLayer(escapeLayer)) {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        onCloseRef.current()
+      }
     }
     document.addEventListener('keydown', onKey)
     panelRef.current?.focus()
     return () => {
       document.removeEventListener('keydown', onKey)
+      removeEscapeLayer(escapeLayer)
       opener?.focus?.()
     }
   }, [open])
@@ -127,14 +154,14 @@ export function Popup({
         className="modal"
         role="dialog"
         aria-modal="true"
-        aria-label={typeof title === 'string' ? title : 'Dialog'}
+        aria-labelledby={titleId}
         tabIndex={-1}
         style={{ width }}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="modal-head">
-          <h3>{title}</h3>
-          <button className="modal-x" title="Close" onClick={onClose}><Icon name="close" size={16} /></button>
+          <h3 id={titleId}>{title}</h3>
+          <button className="modal-x" title="Close" aria-label="Close" onClick={onClose}><Icon name="close" size={16} /></button>
         </div>
         <div className="modal-body">{children}</div>
       </div>
@@ -252,6 +279,7 @@ export function Select({
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+  const escapeLayerRef = useRef(Symbol('select'))
   // Menu is rendered in a fixed-position portal so it escapes any overflow
   // clipping (cards, .table-wrap, the scrolling settings pane). We anchor it
   // to the trigger's bounding rect and reposition on scroll/resize.
@@ -267,6 +295,8 @@ export function Select({
 
   useEffect(() => {
     if (!open) return
+    const escapeLayer = escapeLayerRef.current
+    addEscapeLayer(escapeLayer)
     place()
     const onDoc = (e: MouseEvent) => {
       const t = e.target as Node
@@ -274,7 +304,11 @@ export function Select({
       setOpen(false)
     }
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
+      if (e.key === 'Escape' && isTopEscapeLayer(escapeLayer)) {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        setOpen(false)
+      }
     }
     document.addEventListener('mousedown', onDoc)
     document.addEventListener('keydown', onKey)
@@ -283,6 +317,7 @@ export function Select({
     return () => {
       document.removeEventListener('mousedown', onDoc)
       document.removeEventListener('keydown', onKey)
+      removeEscapeLayer(escapeLayer)
       window.removeEventListener('resize', place)
       window.removeEventListener('scroll', place, true)
     }


### PR DESCRIPTION
## Summary

- keep Escape scoped to the most recently opened redesign Popup or portal-backed Select
- connect dialogs to their visible headings with `aria-labelledby`
- give dialog close controls an explicit accessible name
- preserve outside-click dismissal and focus restoration

## Why

A Select can be open inside a Popup or confirmation dialog. Both layers previously listened for Escape independently, so one keypress could dismiss more than the analyst intended. This change gives nested layers a deterministic dismissal order without changing the public component API.

## Verification

- `npm run test:run -- src/redesign/shared/ui.test.tsx` — 4 passed
- focused ESLint — 0 errors; one pre-existing Fast Refresh warning in `ui.tsx`
- `npm run build` — passed
- `git diff --check` — passed
