### PR TITLE
feat(cases): create linked cases from findings

### DIFF
--- a/frontend/src/redesign/screens/cases/CaseCreateDialog.test.tsx
+++ b/frontend/src/redesign/screens/cases/CaseCreateDialog.test.tsx
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import CaseCreateDialog from './CaseCreateDialog'
+import { casesApi } from '../../../services/api'
+
+vi.mock('../../../services/api', () => ({
+  casesApi: { create: vi.fn() },
+}))
+
+const createdResponse = (caseId: string) => ({ data: { case_id: caseId } }) as never
+
+beforeEach(() => {
+  vi.mocked(casesApi.create).mockReset()
+})
+
+describe('CaseCreateDialog', () => {
+  it('creates a standalone case without linked findings', async () => {
+    vi.mocked(casesApi.create).mockResolvedValueOnce(createdResponse('case-standalone'))
+    const onCreated = vi.fn()
+    const onClose = vi.fn()
+    render(<CaseCreateDialog open onClose={onClose} onCreated={onCreated} />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Title' }), { target: { value: 'Standalone review' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create case' }))
+
+    await waitFor(() => expect(casesApi.create).toHaveBeenCalledWith({
+      title: 'Standalone review',
+      description: undefined,
+      finding_ids: [],
+      priority: 'medium',
+      status: 'open',
+    }))
+    expect(onCreated).toHaveBeenCalledWith('case-standalone')
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('deduplicates findings and defaults to the highest selected severity', async () => {
+    vi.mocked(casesApi.create).mockResolvedValueOnce(createdResponse('case-linked'))
+    render(
+      <CaseCreateDialog
+        open
+        initialFindings={[
+          { id: 'finding-1', severity: 'low' },
+          { id: 'finding-2', severity: 'critical' },
+          { id: 'finding-1', severity: 'high' },
+        ]}
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('textbox', { name: 'Title' })).toHaveValue('Investigation for 2 findings')
+    const linked = within(screen.getByLabelText('Linked findings'))
+    expect(linked.getAllByText('finding-1')).toHaveLength(1)
+    expect(linked.getAllByText('finding-2')).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create case' }))
+    await waitFor(() => expect(casesApi.create).toHaveBeenCalledWith({
+      title: 'Investigation for 2 findings',
+      description: undefined,
+      finding_ids: ['finding-1', 'finding-2'],
+      priority: 'critical',
+      status: 'open',
+    }))
+  })
+
+  it('uses the finding identifier for a single linked case', () => {
+    render(
+      <CaseCreateDialog
+        open
+        initialFindings={[{ id: 'finding-42', severity: 'high' }]}
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('textbox', { name: 'Title' })).toHaveValue('Investigation for finding-42')
+    expect(screen.getByRole('button', { name: 'Priority' })).toHaveTextContent('High')
+  })
+
+  it('cancels without submitting', () => {
+    const onClose = vi.fn()
+    render(<CaseCreateDialog open onClose={onClose} onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(casesApi.create).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the dialog open and reports backend failures', async () => {
+    vi.mocked(casesApi.create).mockRejectedValueOnce({
+      response: { data: { detail: 'One or more findings no longer exist' } },
+    })
+    const onClose = vi.fn()
+    render(
+      <CaseCreateDialog
+        open
+        initialFindings={[{ id: 'finding-1', severity: 'medium' }]}
+        onClose={onClose}
+        onCreated={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create case' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('One or more findings no longer exist')
+    expect(screen.getByRole('dialog', { name: 'Create case from findings' })).toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/redesign/screens/cases/CaseCreateDialog.tsx
+++ b/frontend/src/redesign/screens/cases/CaseCreateDialog.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from 'react'
+import { casesApi } from '../../../services/api'
+import { Popup, Select } from '../../shared/ui'
+import { inputCls } from './CaseSections'
+
+export interface InitialCaseFinding {
+  id: string
+  severity?: string
+}
+
+interface CaseCreateDialogProps {
+  open: boolean
+  initialFindings?: InitialCaseFinding[]
+  onClose: () => void
+  onCreated: (caseId: string) => void
+}
+
+const PRIORITY_RANK: Record<string, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+}
+
+function dedupeInitialFindings(findings: InitialCaseFinding[]): InitialCaseFinding[] {
+  const byId = new Map<string, InitialCaseFinding>()
+  for (const finding of findings) {
+    const id = finding.id.trim()
+    if (!id) continue
+    const severity = finding.severity?.toLowerCase()
+    const current = byId.get(id)
+    if (!current || (PRIORITY_RANK[severity || ''] ?? -1) > (PRIORITY_RANK[current.severity?.toLowerCase() || ''] ?? -1)) {
+      byId.set(id, { id, severity })
+    }
+  }
+  return [...byId.values()]
+}
+
+function caseDefaults(findings: InitialCaseFinding[]): { title: string; priority: string } {
+  if (findings.length === 0) return { title: '', priority: 'medium' }
+  const title = findings.length === 1
+    ? `Investigation for ${findings[0].id}`
+    : `Investigation for ${findings.length} findings`
+  const priorities = findings
+    .map((finding) => finding.severity?.toLowerCase() || '')
+    .filter((severity) => severity in PRIORITY_RANK)
+  const priority = priorities.length
+    ? priorities.reduce((highest, severity) => PRIORITY_RANK[severity] > PRIORITY_RANK[highest] ? severity : highest)
+    : 'medium'
+  return { title, priority }
+}
+
+function createError(error: unknown): string {
+  const detail = (error as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
+  if (typeof detail === 'string' && detail.trim()) return detail
+  return (error as { message?: string })?.message || 'Failed to create case'
+}
+
+export default function CaseCreateDialog({
+  open,
+  initialFindings = [],
+  onClose,
+  onCreated,
+}: CaseCreateDialogProps) {
+  const findings = useMemo(() => dedupeInitialFindings(initialFindings), [initialFindings])
+  const defaults = caseDefaults(findings)
+  const findingKey = findings.map((finding) => `${finding.id}:${finding.severity || ''}`).join('|')
+  const [title, setTitle] = useState('')
+  const [priority, setPriority] = useState('medium')
+  const [status, setStatus] = useState('open')
+  const [description, setDescription] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+    setTitle(defaults.title)
+    setPriority(defaults.priority)
+    setStatus('open')
+    setDescription('')
+    setBusy(false)
+    setError('')
+    // findingKey captures the normalized IDs and severities that drive defaults.
+  }, [open, findingKey, defaults.title, defaults.priority])
+
+  const close = () => {
+    if (!busy) onClose()
+  }
+
+  const submit = async () => {
+    if (!title.trim()) {
+      setError('Title is required.')
+      return
+    }
+    setBusy(true)
+    setError('')
+    try {
+      const response = await casesApi.create({
+        title: title.trim(),
+        description: description.trim() || undefined,
+        finding_ids: findings.map((finding) => finding.id),
+        priority,
+        status,
+      })
+      const caseId = response.data?.case_id
+      if (typeof caseId !== 'string' || !caseId) {
+        throw new Error('The case was created without an identifier')
+      }
+      onCreated(caseId)
+      onClose()
+    } catch (cause) {
+      setError(createError(cause))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Popup open={open} onClose={close} title={findings.length ? 'Create case from findings' : 'New case'} width={520}>
+      <div className="flex flex-col gap-3.5">
+        {findings.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-semibold uppercase tracking-wide text-tx-3">Linked findings</span>
+            <div className="fp-chips" aria-label="Linked findings">
+              {findings.map((finding) => <span className="chip mono" key={finding.id}>{finding.id}</span>)}
+            </div>
+            <span className="text-xs text-tx-3">These findings will be linked when the case is created.</span>
+          </div>
+        )}
+        <label className="flex flex-col gap-1.5 text-xs font-semibold uppercase tracking-wide text-tx-3">
+          <span>Title</span>
+          <input className={inputCls} placeholder="Case title" value={title} onChange={(event) => setTitle(event.target.value)} autoFocus />
+        </label>
+        <div className="grid grid-cols-2 gap-3">
+          <label className="flex flex-col gap-1.5 text-xs font-semibold uppercase tracking-wide text-tx-3">
+            <span>Priority</span>
+            <Select
+              value={priority}
+              onSelect={setPriority}
+              options={[
+                { value: 'critical', label: 'Critical' },
+                { value: 'high', label: 'High' },
+                { value: 'medium', label: 'Medium' },
+                { value: 'low', label: 'Low' },
+              ]}
+            />
+          </label>
+          <label className="flex flex-col gap-1.5 text-xs font-semibold uppercase tracking-wide text-tx-3">
+            <span>Status</span>
+            <Select
+              value={status}
+              onSelect={setStatus}
+              options={[
+                { value: 'open', label: 'Open' },
+                { value: 'investigating', label: 'Investigating' },
+                { value: 'closed', label: 'Closed' },
+              ]}
+            />
+          </label>
+        </div>
+        <label className="flex flex-col gap-1.5 text-xs font-semibold uppercase tracking-wide text-tx-3">
+          <span>Description</span>
+          <textarea className={inputCls} rows={4} placeholder="Optional description" value={description} onChange={(event) => setDescription(event.target.value)} style={{ resize: 'vertical' }} />
+        </label>
+        {error && <div role="alert" className="text-[13px]" style={{ color: 'var(--crit)' }}>{error}</div>}
+        <div className="flex justify-end gap-2.5">
+          <button className="btn ghost" onClick={close} disabled={busy}>Cancel</button>
+          <button className="btn primary" onClick={submit} disabled={busy}>{busy ? 'Creating…' : 'Create case'}</button>
+        </div>
+      </div>
+    </Popup>
+  )
+}

--- a/frontend/src/redesign/screens/cases/CasesScreen.tsx
+++ b/frontend/src/redesign/screens/cases/CasesScreen.tsx
@@ -15,6 +15,8 @@ import type { CaseRow } from '../../data/data'
 import type { ScreenProps } from '../../shared/types'
 import { useCases, useCaseDetail, type Phase } from './useCases'
 import { EmptyState, FilterButton, FilterGroup, Popup, Select } from '../../shared/ui'
+import { useAuth } from '../../../contexts/AuthContext'
+import CaseCreateDialog from './CaseCreateDialog'
 import {
   inputCls,
   SectionCard,
@@ -256,6 +258,8 @@ function CasesTable({
   reload: () => void
   onSelect: (id: string) => void
 }) {
+  const { hasPermission } = useAuth()
+  const canCreate = hasPermission('cases.write')
   const [query, setQuery] = useState('')
   const [statusF, setStatusF] = useState('any')
   const [prioF, setPrioF] = useState('any')
@@ -365,7 +369,9 @@ function CasesTable({
           Advanced Search
         </button>
         <button className="btn ghost icon" title="Refresh" onClick={reload}><Icon name="refresh" /></button>
-        <button className="btn primary" onClick={() => setNewOpen(true)}><Icon name="plus" /> New Case</button>
+        {canCreate && (
+          <button className="btn primary" onClick={() => setNewOpen(true)}><Icon name="plus" /> New Case</button>
+        )}
       </div>
       {showAdvanced && <AdvancedSearchPanel onResults={setResults} rows={rows} />}
       {results && (
@@ -405,7 +411,9 @@ function CasesTable({
                   icon={rows.length === 0 ? 'folder' : 'filter'}
                   title={results ? 'No cases match this search' : rows.length === 0 ? 'No cases yet' : 'No cases match these filters'}
                   body={results || rows.length > 0 ? 'Clear the search and filters to return to the full case queue.' : 'Create a case manually or link findings from the dashboard to start an investigation record.'}
-                  primary={results || rows.length > 0 ? { label: 'Clear filters', onClick: () => { setResults(null); setQuery(''); setStatusF('any'); setPrioF('any'); setAssigneeF('any') }, icon: 'close' } : { label: 'New case', onClick: () => setNewOpen(true), icon: 'plus' }}
+                  primary={results || rows.length > 0
+                    ? { label: 'Clear filters', onClick: () => { setResults(null); setQuery(''); setStatusF('any'); setPrioF('any'); setAssigneeF('any') }, icon: 'close' }
+                    : canCreate ? { label: 'New case', onClick: () => setNewOpen(true), icon: 'plus' } : undefined}
                 />
               </StateRow>
             )}
@@ -450,7 +458,11 @@ function CasesTable({
         </span>
       </div>
 
-      <NewCaseDialog open={newOpen} onClose={() => setNewOpen(false)} onCreated={reload} />
+      <CaseCreateDialog
+        open={newOpen}
+        onClose={() => setNewOpen(false)}
+        onCreated={() => reload()}
+      />
     </>
   )
 }
@@ -601,90 +613,6 @@ function AdvancedSearchPanel({ onResults, rows }: { onResults: (r: CaseRow[] | n
         <button className="btn primary" onClick={run} disabled={busy}>{busy ? 'Searching…' : 'Search'}</button>
       </div>
     </div>
-  )
-}
-
-/* ---------------- New case dialog ----------------
-   POST /cases/ with title/priority/status/description (no findings yet);
-   refreshes the list on success. */
-function NewCaseDialog({ open, onClose, onCreated }: { open: boolean; onClose: () => void; onCreated: () => void }) {
-  const [title, setTitle] = useState('')
-  const [priority, setPriority] = useState('medium')
-  const [status, setStatus] = useState('open')
-  const [description, setDescription] = useState('')
-  const [busy, setBusy] = useState(false)
-  const [err, setErr] = useState('')
-
-  const submit = async () => {
-    if (!title.trim()) {
-      setErr('Title is required.')
-      return
-    }
-    setBusy(true)
-    setErr('')
-    try {
-      await casesApi.create({
-        title: title.trim(),
-        description: description.trim() || undefined,
-        finding_ids: [],
-        priority,
-        status,
-      })
-      setTitle(''); setDescription(''); setPriority('medium'); setStatus('open')
-      onCreated()
-      onClose()
-    } catch (e) {
-      setErr((e as { message?: string })?.message || 'Failed to create case')
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  return (
-    <Popup open={open} onClose={onClose} title="New case" width={520}>
-      <div className="flex flex-col gap-3.5">
-        <label className="flex flex-col gap-1.5 text-xs font-semibold uppercase tracking-wide text-tx-3">
-          <span>Title</span>
-          <input className={inputCls} placeholder="Case title" value={title} onChange={(e) => setTitle(e.target.value)} autoFocus />
-        </label>
-        <div className="grid grid-cols-2 gap-3">
-          <label className="flex flex-col gap-1.5 text-xs font-semibold uppercase tracking-wide text-tx-3">
-            <span>Priority</span>
-            <Select
-              value={priority}
-              onSelect={setPriority}
-              options={[
-                { value: 'critical', label: 'Critical' },
-                { value: 'high', label: 'High' },
-                { value: 'medium', label: 'Medium' },
-                { value: 'low', label: 'Low' },
-              ]}
-            />
-          </label>
-          <label className="flex flex-col gap-1.5 text-xs font-semibold uppercase tracking-wide text-tx-3">
-            <span>Status</span>
-            <Select
-              value={status}
-              onSelect={setStatus}
-              options={[
-                { value: 'open', label: 'Open' },
-                { value: 'investigating', label: 'Investigating' },
-                { value: 'closed', label: 'Closed' },
-              ]}
-            />
-          </label>
-        </div>
-        <label className="flex flex-col gap-1.5 text-xs font-semibold uppercase tracking-wide text-tx-3">
-          <span>Description</span>
-          <textarea className={inputCls} rows={4} placeholder="Optional description" value={description} onChange={(e) => setDescription(e.target.value)} style={{ resize: 'vertical' }} />
-        </label>
-        {err && <div className="text-[13px]" style={{ color: 'var(--crit)' }}>{err}</div>}
-        <div className="flex justify-end gap-2.5">
-          <button className="btn ghost" onClick={onClose}>Cancel</button>
-          <button className="btn primary" onClick={submit} disabled={busy}>{busy ? 'Creating…' : 'Create case'}</button>
-        </div>
-      </div>
-    </Popup>
   )
 }
 

--- a/frontend/src/redesign/screens/dashboard/DashboardScreen.test.tsx
+++ b/frontend/src/redesign/screens/dashboard/DashboardScreen.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import DashboardScreen from './DashboardScreen'
+
+vi.mock('./FindingPopup', () => ({
+  default: ({ onCaseCreated }: { onCaseCreated?: (caseId: string) => void }) => (
+    <button onClick={() => onCaseCreated?.('case/linked')}>Complete linked case</button>
+  ),
+}))
+
+vi.mock('./useFindings', () => ({
+  useFindings: () => ({ rows: [], phase: 'ready', error: null, reload: vi.fn() }),
+  useDashboardKpis: () => ({ kpis: null, reload: vi.fn() }),
+}))
+
+describe('DashboardScreen linked-case navigation', () => {
+  it('opens the created case detail using an encoded query parameter', () => {
+    const go = vi.fn()
+    render(
+      <DashboardScreen
+        openChat={vi.fn()}
+        go={go}
+        goSettings={vi.fn()}
+        setViewFull={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Complete linked case' }))
+    expect(go).toHaveBeenCalledWith('cases', { search: '?case=case%2Flinked' })
+  })
+})

--- a/frontend/src/redesign/screens/dashboard/DashboardScreen.tsx
+++ b/frontend/src/redesign/screens/dashboard/DashboardScreen.tsx
@@ -17,8 +17,12 @@ import type { ScreenProps } from '../../shared/types'
 
 type DashTab = 'findings' | 'attack' | 'timeline' | 'entity'
 
-export default function DashboardScreen({ openChat, goSettings }: ScreenProps) {
+export default function DashboardScreen({ openChat, go, goSettings }: ScreenProps) {
   const [tab, setTab] = useState<DashTab>('findings')
+  const openCreatedCase = useCallback(
+    (caseId: string) => go('cases', { search: `?case=${encodeURIComponent(caseId)}` }),
+    [go],
+  )
   const tabs: [DashTab, string][] = [
     ['findings', 'Findings'],
     ['attack', 'ATT&CK'],
@@ -42,9 +46,9 @@ export default function DashboardScreen({ openChat, goSettings }: ScreenProps) {
           ))}
         </div>
       </div>
-      {tab === 'findings' && <FindingsTab openChat={openChat} goSettings={goSettings} />}
+      {tab === 'findings' && <FindingsTab openChat={openChat} goSettings={goSettings} onCaseCreated={openCreatedCase} />}
       {tab === 'attack' && <AttackTab />}
-      {tab === 'timeline' && <TimelineTab />}
+      {tab === 'timeline' && <TimelineTab onCaseCreated={openCreatedCase} />}
       {tab === 'entity' && <EntityStub />}
     </>
   )
@@ -104,7 +108,11 @@ function findingPrompt(f: Finding): string {
   return `Investigate finding ${f.id} — ${parts.join(', ')}. What happened and what should I do next?`
 }
 
-function FindingsTab({ openChat, goSettings }: Pick<ScreenProps, 'openChat' | 'goSettings'>) {
+function FindingsTab({
+  openChat,
+  goSettings,
+  onCaseCreated,
+}: Pick<ScreenProps, 'openChat' | 'goSettings'> & { onCaseCreated: (caseId: string) => void }) {
   const { rows, phase, error, reload } = useFindings()
   const { kpis, reload: reloadKpis } = useDashboardKpis()
   const [query, setQuery] = useState('')
@@ -309,7 +317,13 @@ function FindingsTab({ openChat, goSettings }: Pick<ScreenProps, 'openChat' | 'g
           ><Icon name="chevR" size={14} /></button>
         </span>
       </div>
-      <FindingPopup id={detailId} onClose={() => setDetailId(null)} onChanged={() => { reload(); reloadKpis() }} onConfigureAi={() => goSettings('ai-config')} />
+      <FindingPopup
+        id={detailId}
+        onClose={() => setDetailId(null)}
+        onChanged={() => { reload(); reloadKpis() }}
+        onConfigureAi={() => goSettings('ai-config')}
+        onCaseCreated={onCaseCreated}
+      />
     </>
   )
 }
@@ -530,7 +544,7 @@ function computeLayout(events: TimelineEvent[], zoom: number, containerW: number
   return { min, max, pxPerDay, innerW, plotH, bars, ticks, grids, months }
 }
 
-function TimelineTab() {
+function TimelineTab({ onCaseCreated }: { onCaseCreated: (caseId: string) => void }) {
   const [filter, setFilter] = useState<'all' | 'finding'>('all')
   const [speed, setSpeed] = useState(1)
   const [zoom, setZoom] = useState(1)
@@ -754,7 +768,7 @@ function TimelineTab() {
           <div className="tl-playhead" ref={playheadRef} style={{ display: 'none' }} />
         </div>
       </div>
-      <FindingPopup id={detailId} onClose={() => setDetailId(null)} />
+      <FindingPopup id={detailId} onClose={() => setDetailId(null)} onCaseCreated={onCaseCreated} />
     </>
   )
 }

--- a/frontend/src/redesign/screens/dashboard/FindingPopup.test.tsx
+++ b/frontend/src/redesign/screens/dashboard/FindingPopup.test.tsx
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import FindingPopup from './FindingPopup'
+import { casesApi } from '../../../services/api'
+
+const testState = vi.hoisted(() => ({ canWriteCases: true }))
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    hasPermission: (permission: string) => permission !== 'cases.write' || testState.canWriteCases,
+  }),
+}))
+
+vi.mock('../../../services/api', () => ({
+  findingsApi: {
+    getById: vi.fn(() => Promise.resolve({ data: {
+      finding_id: 'finding-42',
+      severity: 'high',
+      data_source: 'network',
+      status: 'open',
+      anomaly_score: 0.91,
+      timestamp: '2026-07-21T12:00:00Z',
+      mitre_predictions: { T1071: 0.82 },
+      entity_context: { hostnames: ['host-42'] },
+    } })),
+    getEnrichment: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  casesApi: { create: vi.fn() },
+}))
+
+beforeEach(() => {
+  testState.canWriteCases = true
+  vi.mocked(casesApi.create).mockReset()
+})
+
+describe('finding-linked case creation', () => {
+  it('hides the action without cases.write permission', async () => {
+    testState.canWriteCases = false
+    render(<FindingPopup id="finding-42" onClose={vi.fn()} onCaseCreated={vi.fn()} />)
+
+    expect(await screen.findAllByText('host-42')).toHaveLength(2)
+    expect(screen.queryByRole('button', { name: 'Create case' })).not.toBeInTheDocument()
+  })
+
+  it('creates a linked case and returns its identifier', async () => {
+    vi.mocked(casesApi.create).mockResolvedValueOnce({ data: { case_id: 'case-linked' } } as never)
+    const onClose = vi.fn()
+    const onCaseCreated = vi.fn()
+    render(<FindingPopup id="finding-42" onClose={onClose} onCaseCreated={onCaseCreated} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Create case' }))
+    expect(onClose).toHaveBeenCalledOnce()
+
+    const dialog = screen.getByRole('dialog', { name: 'Create case from findings' })
+    expect(within(dialog).getByRole('textbox', { name: 'Title' }))
+      .toHaveValue('Investigation for finding-42')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Create case' }))
+
+    await waitFor(() => expect(casesApi.create).toHaveBeenCalledWith({
+      title: 'Investigation for finding-42',
+      description: undefined,
+      finding_ids: ['finding-42'],
+      priority: 'high',
+      status: 'open',
+    }))
+    expect(onCaseCreated).toHaveBeenCalledWith('case-linked')
+  })
+})

--- a/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
+++ b/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
@@ -15,7 +15,10 @@ import { mapApiFinding, type ApiFinding } from '../../data/mappers'
 import { techniqueName } from '../../data/mitre'
 import { ConfirmDialog, EmptyState, Popup, Select } from '../../shared/ui'
 import { Icon } from '../../shared/icons'
+import type { Finding } from '../../data/data'
 import type { Phase } from '../cases/useCases'
+import CaseCreateDialog, { type InitialCaseFinding } from '../cases/CaseCreateDialog'
+import { useAuth } from '../../../contexts/AuthContext'
 
 interface RawFinding extends ApiFinding {
   description?: string
@@ -151,13 +154,17 @@ export default function FindingPopup({
   onClose,
   onChanged,
   onConfigureAi,
+  onCaseCreated,
 }: {
   id: string | null
   onClose: () => void
   /** called after a status change / delete so the list can refetch */
   onChanged?: () => void
   onConfigureAi?: () => void
+  onCaseCreated?: (caseId: string) => void
 }) {
+  const { hasPermission } = useAuth()
+  const canCreateCase = hasPermission('cases.write')
   const [raw, setRaw] = useState<RawFinding | null>(null)
   const [phase, setPhase] = useState<Phase>('loading')
   const [error, setError] = useState<string | null>(null)
@@ -171,6 +178,7 @@ export default function FindingPopup({
   const [status, setStatus] = useState('')
   const [acting, setActing] = useState(false)
   const [confirmDel, setConfirmDel] = useState(false)
+  const [caseFinding, setCaseFinding] = useState<InitialCaseFinding | null>(null)
 
   useEffect(() => {
     if (!id) return
@@ -255,8 +263,14 @@ export default function FindingPopup({
       id || 'Finding'
     )
 
+  const createCase = (finding: Finding) => {
+    setCaseFinding({ id: finding.id, severity: finding.sev })
+    onClose()
+  }
+
   return (
-    <Popup open={id !== null} onClose={onClose} title={title} width={640}>
+    <>
+      <Popup open={id !== null} onClose={onClose} title={title} width={640}>
       {phase === 'loading' && <div className="muted">Loading finding…</div>}
       {phase === 'error' && <div className="muted">Couldn’t load finding: {error}</div>}
       {phase === 'ready' && f && raw && (
@@ -367,6 +381,11 @@ export default function FindingPopup({
 
           {/* actions */}
           <div className="fp-actions">
+            {canCreateCase && onCaseCreated && (
+              <button className="btn primary" onClick={() => createCase(f)} disabled={acting}>
+                <Icon name="folder" size={14} /> Create case
+              </button>
+            )}
             <button className="btn danger" onClick={() => setConfirmDel(true)} disabled={acting}>
               <Icon name="trash" size={14} /> Delete finding
             </button>
@@ -383,6 +402,16 @@ export default function FindingPopup({
         onConfirm={doDelete}
         onClose={() => setConfirmDel(false)}
       />
-    </Popup>
+      </Popup>
+      <CaseCreateDialog
+        open={caseFinding !== null}
+        initialFindings={caseFinding ? [caseFinding] : []}
+        onClose={() => setCaseFinding(null)}
+        onCreated={(caseId) => {
+          setCaseFinding(null)
+          onCaseCreated?.(caseId)
+        }}
+      />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- extract redesign case creation into a reusable dialog that accepts initial findings
- preserve standalone Cases -> New Case creation while gating creation with cases.write
- create a linked case directly from finding detail, with read-only deduplicated finding IDs
- default the title, open status, and highest selected severity; keep failures non-destructive
- navigate directly to the created case detail

## Verification
- npm run test:run -- src/redesign/screens/cases/CaseCreateDialog.test.tsx src/redesign/screens/dashboard/FindingPopup.test.tsx src/redesign/screens/dashboard/DashboardScreen.test.tsx (8 passed)
- focused ESLint for all changed implementation and test files
- npm run build
- git diff --check

## Dependency note
PR #378 remains open and owns the finding-selection UI. This branch intentionally does not duplicate that toolbar. The reusable dialog already accepts and tests multiple findings, so selected-finding wiring should be added while rebasing this draft after #378 settles.

No backend route, demo-only review-case API, or AI field generation is included.