### PR TITLE
feat(findings): render structured source evidence

### DIFF
--- a/backend/api/findings.py
+++ b/backend/api/findings.py
@@ -7,6 +7,10 @@ import logging
 
 from services.database_data_service import DatabaseDataService
 from services.defaults import DEFAULT_MODEL
+from services.source_evidence import (
+    normalize_finding_source_evidence,
+    project_finding_source_evidence_for_list,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -67,7 +71,9 @@ async def get_findings(
     )
     
     return {
-        "findings": findings,
+        "findings": [
+            project_finding_source_evidence_for_list(finding) for finding in findings
+        ],
         "total": total,
         "offset": offset,
         "limit": limit,
@@ -89,7 +95,7 @@ async def get_finding(finding_id: str):
     finding = data_service.get_finding(finding_id)
     if not finding:
         raise HTTPException(status_code=404, detail="Finding not found")
-    return finding
+    return normalize_finding_source_evidence(finding)
 
 
 @router.get("/stats/summary")
@@ -568,4 +574,3 @@ async def clear_all_findings():
     except Exception as e:
         logger.error(f"Error clearing findings: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to clear findings: {str(e)}")
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,5 +80,6 @@ AI-powered Security Operations Center using Claude and MCP (Model Context Protoc
 - [AGENTS.md](AGENTS.md) - 13 specialized SOC AI agents
 - [INTEGRATIONS.md](INTEGRATIONS.md) - Splunk, Timesketch, Cribl, 27+ tools
 - [KAFKA_INGESTION.md](KAFKA_INGESTION.md) - Stream findings from Kafka topics
+- [SOURCE_EVIDENCE.md](SOURCE_EVIDENCE.md) - Attach bounded source records to findings
 - [FEATURES.md](FEATURES.md) - Cases, approvals, enrichment, reports
 - [API.md](API.md) - MCP tool contracts, data models

--- a/docs/SOURCE_EVIDENCE.md
+++ b/docs/SOURCE_EVIDENCE.md
@@ -1,0 +1,71 @@
+# Structured source evidence
+
+Vigil can retain a bounded preview of the source records that produced a
+finding. The preview lives at `finding.entity_context.source_evidence`, so it
+does not require a database migration. Finding list responses retain only the
+envelope metadata with `payload_included: false`;
+`GET /api/findings/{finding_id}` returns the payload.
+
+## Contract
+
+```json
+{
+  "version": 1,
+  "telemetry_kind": "netflow",
+  "schema_id": "netflow.v1",
+  "status": "available",
+  "provenance": "embedded",
+  "total_records": 150,
+  "truncated": true,
+  "records": [],
+  "raw_text": "optional source-native text"
+}
+```
+
+`telemetry_kind` is the renderer selector, not `finding.data_source`. Supported
+values are `netflow`, `dns`, `http_session`, and `generic_log`. This lets the
+capability apply to network flows, DNS, Layer 7 sessions, and other logs without
+forcing unrelated schemas into a NetFlow table. `schema_id` remains owned by
+the producer and should be versioned when its record fields change.
+
+`status` is one of:
+
+- `available`: at least one structured record or non-empty `raw_text` exists.
+- `not_in_artifact`: the source artifact did not include raw evidence.
+- `redacted`: evidence existed but was intentionally removed before ingestion.
+- `invalid`: evidence was supplied but failed contract validation.
+
+No envelope means the finding has no declared source-evidence capability, so
+the finding dialog hides the section. The other non-available states render a
+short, truthful message.
+
+## LogLM Parquet inputs
+
+The preferred Parquet column is `source_evidence`, containing the object above
+or its JSON representation. Current artifacts with `events_json` and/or
+`sequence` are adapted during ingestion:
+
+- `events_json` becomes ordered `records`.
+- `sequence` becomes `raw_text`.
+- `source_evidence_kind` explicitly selects the telemetry renderer. If absent,
+  these legacy columns use `generic_log` rather than guessing from
+  `data_source="flow"`.
+- Optional columns are `source_evidence_schema_id`, `source_evidence_status`,
+  `source_evidence_provenance`, and `source_evidence_total_records`.
+
+Ingestion retains at most 100 structured records and 64 KiB of raw text per
+finding, records truncation metadata, converts non-finite numbers to `null`,
+and never lets malformed evidence prevent the finding itself from ingesting.
+
+## Canonical record fields
+
+The built-in tables recognize these v1 field names:
+
+- NetFlow: `timestamp`, `source_ip`, `source_port`, `destination_ip`,
+  `destination_port`, `protocol`, `forward_packets`, `backward_packets`,
+  `forward_bytes`, `backward_bytes`, `duration_ms`.
+- DNS: `timestamp`, `client_ip`, `server_ip`, `query`, `query_type`, `answer`,
+  `response_code`, `ttl`.
+
+HTTP-session and generic-log records render as ordered, expandable key/value
+records so source fields remain visible without inventing a universal schema.

--- a/frontend/src/redesign/data/mappers.ts
+++ b/frontend/src/redesign/data/mappers.ts
@@ -60,6 +60,8 @@ export interface ApiFinding {
     usernames?: string[]
     dest_ips?: string[]
     file_hashes?: string[]
+    source_evidence?: unknown
+    [key: string]: unknown
   }
 }
 

--- a/frontend/src/redesign/data/sourceEvidence.test.ts
+++ b/frontend/src/redesign/data/sourceEvidence.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { parseSourceEvidence } from './sourceEvidence'
+
+describe('parseSourceEvidence', () => {
+  it('parses a bounded NetFlow envelope', () => {
+    const result = parseSourceEvidence({
+      version: 1,
+      telemetry_kind: 'netflow',
+      schema_id: 'netflow.v1',
+      status: 'available',
+      provenance: 'joined',
+      total_records: 150,
+      truncated: true,
+      records: [{
+        timestamp: '2026-07-21T12:00:00Z',
+        source_ip: '10.0.0.1',
+        destination_ip: '198.51.100.2',
+      }],
+    })
+
+    expect(result).toMatchObject({
+      telemetryKind: 'netflow',
+      status: 'available',
+      provenance: 'joined',
+      totalRecords: 150,
+      truncated: true,
+    })
+    expect(result?.records).toHaveLength(1)
+  })
+
+  it('preserves explicit unavailable states and hides an absent contract', () => {
+    expect(parseSourceEvidence(undefined)).toBeUndefined()
+    expect(parseSourceEvidence({
+      version: 1,
+      telemetry_kind: 'dns',
+      schema_id: 'dns.v1',
+      status: 'not_in_artifact',
+      provenance: 'embedded',
+    })).toMatchObject({ telemetryKind: 'dns', status: 'not_in_artifact' })
+  })
+
+  it('fails malformed or mismatched records closed', () => {
+    expect(parseSourceEvidence('{bad-json')).toMatchObject({ status: 'invalid' })
+    expect(parseSourceEvidence({
+      version: 1,
+      telemetry_kind: 'dns',
+      schema_id: 'dns.v1',
+      status: 'available',
+      provenance: 'embedded',
+      records: [{ response_code: 'NOERROR' }],
+    })).toMatchObject({ status: 'invalid' })
+  })
+})

--- a/frontend/src/redesign/data/sourceEvidence.ts
+++ b/frontend/src/redesign/data/sourceEvidence.ts
@@ -1,0 +1,124 @@
+export type SourceTelemetryKind = 'netflow' | 'dns' | 'http_session' | 'generic_log'
+export type SourceEvidenceStatus = 'available' | 'not_in_artifact' | 'redacted' | 'invalid'
+export type SourceEvidenceProvenance = 'embedded' | 'joined'
+
+export interface SourceEvidence {
+  version: 1
+  telemetryKind: SourceTelemetryKind
+  schemaId: string
+  status: SourceEvidenceStatus
+  provenance: SourceEvidenceProvenance
+  totalRecords: number
+  truncated: boolean
+  records: Array<Record<string, unknown>>
+  rawText?: string
+  rawTextTruncated: boolean
+}
+
+const KINDS = new Set<SourceTelemetryKind>(['netflow', 'dns', 'http_session', 'generic_log'])
+const STATUSES = new Set<SourceEvidenceStatus>(['available', 'not_in_artifact', 'redacted', 'invalid'])
+const PROVENANCE = new Set<SourceEvidenceProvenance>(['embedded', 'joined'])
+
+function invalidEvidence(value?: Record<string, unknown>): SourceEvidence {
+  const kind = KINDS.has(value?.telemetry_kind as SourceTelemetryKind)
+    ? value?.telemetry_kind as SourceTelemetryKind
+    : 'generic_log'
+  return {
+    version: 1,
+    telemetryKind: kind,
+    schemaId: typeof value?.schema_id === 'string' ? value.schema_id : 'unknown',
+    status: 'invalid',
+    provenance: 'embedded',
+    totalRecords: 0,
+    truncated: false,
+    records: [],
+    rawTextTruncated: false,
+  }
+}
+
+function recordShapeIsValid(kind: SourceTelemetryKind, record: Record<string, unknown>): boolean {
+  if (kind === 'netflow') {
+    return typeof record.timestamp === 'string'
+      && typeof record.source_ip === 'string'
+      && typeof record.destination_ip === 'string'
+  }
+  if (kind === 'dns') return typeof record.query === 'string'
+  return true
+}
+
+export function parseSourceEvidence(value: unknown): SourceEvidence | undefined {
+  if (value === undefined || value === null) return undefined
+  let parsed: unknown = value
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value) as unknown
+    } catch {
+      return invalidEvidence()
+    }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return invalidEvidence()
+  const raw = parsed as Record<string, unknown>
+  const kind = raw.telemetry_kind as SourceTelemetryKind
+  const status = raw.status as SourceEvidenceStatus
+  const provenance = raw.provenance as SourceEvidenceProvenance
+  if (
+    raw.version !== 1
+    || !KINDS.has(kind)
+    || typeof raw.schema_id !== 'string'
+    || !STATUSES.has(status)
+    || !PROVENANCE.has(provenance)
+  ) return invalidEvidence(raw)
+
+  if (status !== 'available') {
+    return {
+      version: 1,
+      telemetryKind: kind,
+      schemaId: raw.schema_id,
+      status,
+      provenance,
+      totalRecords: 0,
+      truncated: false,
+      records: [],
+      rawTextTruncated: false,
+    }
+  }
+
+  const records = Array.isArray(raw.records)
+    ? raw.records.filter((record): record is Record<string, unknown> => (
+        Boolean(record) && typeof record === 'object' && !Array.isArray(record)
+      ))
+    : []
+  if (Array.isArray(raw.records) && records.length !== raw.records.length) return invalidEvidence(raw)
+  if (!records.every((record) => recordShapeIsValid(kind, record))) return invalidEvidence(raw)
+
+  const rawText = typeof raw.raw_text === 'string' && raw.raw_text.trim() ? raw.raw_text : undefined
+  if (records.length === 0 && !rawText) return invalidEvidence(raw)
+
+  if (raw.total_records !== undefined && (
+    typeof raw.total_records !== 'number' || !Number.isInteger(raw.total_records)
+  )) return invalidEvidence(raw)
+  if (raw.truncated !== undefined && typeof raw.truncated !== 'boolean') return invalidEvidence(raw)
+  if (raw.raw_text_truncated !== undefined && typeof raw.raw_text_truncated !== 'boolean') return invalidEvidence(raw)
+  const totalRecords = raw.total_records ?? records.length
+  if (totalRecords < records.length || totalRecords < 0) return invalidEvidence(raw)
+
+  return {
+    version: 1,
+    telemetryKind: kind,
+    schemaId: raw.schema_id,
+    status,
+    provenance,
+    totalRecords,
+    truncated: raw.truncated === true || totalRecords > records.length,
+    records,
+    rawText,
+    rawTextTruncated: raw.raw_text_truncated === true,
+  }
+}
+
+export const SOURCE_TELEMETRY_LABELS: Record<SourceTelemetryKind, string> = {
+  netflow: 'NetFlow',
+  dns: 'DNS',
+  http_session: 'HTTP session',
+  generic_log: 'Log events',
+}

--- a/frontend/src/redesign/screens/dashboard/FindingPopup.test.tsx
+++ b/frontend/src/redesign/screens/dashboard/FindingPopup.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import FindingPopup from './FindingPopup'
+import { findingsApi } from '../../../services/api'
+
+vi.mock('../../../services/api', () => ({
+  findingsApi: {
+    getById: vi.fn(),
+    getEnrichment: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+const baseFinding = {
+  finding_id: 'f-source-1',
+  severity: 'high',
+  data_source: 'loglm',
+  timestamp: '2026-07-21T12:00:00Z',
+  anomaly_score: 0.92,
+  status: 'new',
+  mitre_predictions: {},
+  entity_context: {},
+}
+
+function openFinding(entityContext: Record<string, unknown>) {
+  vi.mocked(findingsApi.getById).mockResolvedValueOnce({
+    data: { ...baseFinding, entity_context: entityContext },
+  } as never)
+  return render(<FindingPopup id="f-source-1" onClose={vi.fn()} />)
+}
+
+describe('FindingPopup source evidence', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('hides the section when the finding has no declared evidence contract', async () => {
+    openFinding({})
+    await screen.findByText('f-source-1')
+    expect(screen.queryByText('Source evidence')).not.toBeInTheDocument()
+  })
+
+  it('shows a truthful message when evidence was not in the artifact', async () => {
+    openFinding({
+      source_evidence: {
+        version: 1,
+        telemetry_kind: 'dns',
+        schema_id: 'dns.v1',
+        status: 'not_in_artifact',
+        provenance: 'embedded',
+      },
+    })
+
+    expect(await screen.findByText('Source evidence was not included in the ingested artifact.')).toBeInTheDocument()
+    expect(screen.getByText('DNS:')).toBeInTheDocument()
+  })
+
+  it('renders NetFlow evidence collapsed with an accessible scroll table', async () => {
+    openFinding({
+      source_evidence: {
+        version: 1,
+        telemetry_kind: 'netflow',
+        schema_id: 'netflow.v1',
+        status: 'available',
+        provenance: 'joined',
+        total_records: 150,
+        truncated: true,
+        records: [{
+          timestamp: '2026-07-21T12:00:00Z',
+          source_ip: '10.0.0.1',
+          source_port: 51515,
+          destination_ip: '198.51.100.2',
+          destination_port: 443,
+          protocol: 6,
+          forward_packets: 8,
+          backward_packets: 5,
+          forward_bytes: 2048,
+          backward_bytes: 1024,
+          duration_ms: 512,
+        }],
+      },
+    })
+
+    const summaryText = await screen.findByText('Source evidence')
+    const disclosure = summaryText.closest('details') as HTMLDetailsElement
+    expect(disclosure.open).toBe(false)
+    expect(within(disclosure).getByText('1 of 150 records')).toBeInTheDocument()
+
+    fireEvent.click(summaryText.closest('summary')!)
+    expect(disclosure.open).toBe(true)
+    const region = within(disclosure).getByRole('region', { name: 'NetFlow source evidence table' })
+    expect(region).toHaveAttribute('tabindex', '0')
+    expect(within(region).getByRole('columnheader', { name: 'Source' })).toBeInTheDocument()
+    expect(within(region).getByText('10.0.0.1:51515')).toBeInTheDocument()
+    expect(within(region).getByText('198.51.100.2:443')).toBeInTheDocument()
+  })
+
+  it('renders DNS records with the DNS-specific columns', async () => {
+    openFinding({
+      source_evidence: {
+        version: 1,
+        telemetry_kind: 'dns',
+        schema_id: 'dns.v1',
+        status: 'available',
+        provenance: 'embedded',
+        total_records: 1,
+        truncated: false,
+        records: [{
+          timestamp: '2026-07-21T12:00:00Z',
+          client_ip: '10.0.0.8',
+          server_ip: '10.0.0.53',
+          query: 'example.test',
+          query_type: 'A',
+          answer: '198.51.100.7',
+          response_code: 'NOERROR',
+          ttl: 300,
+        }],
+      },
+    })
+
+    const region = await screen.findByRole('region', { name: 'DNS source evidence table' })
+    expect(within(region).getByRole('columnheader', { name: 'Query' })).toBeInTheDocument()
+    expect(within(region).getByText('example.test')).toBeInTheDocument()
+    expect(within(region).getByText('NOERROR')).toBeInTheDocument()
+  })
+
+  it('keeps generic records and raw source text available without a NetFlow assumption', async () => {
+    openFinding({
+      source_evidence: {
+        version: 1,
+        telemetry_kind: 'generic_log',
+        schema_id: 'generic-log.v1',
+        status: 'available',
+        provenance: 'embedded',
+        total_records: 1,
+        truncated: false,
+        records: [{ timestamp: '2026-07-21T12:00:00Z', event_type: 'process_start', pid: 42 }],
+        raw_text: 'process_start pid=42',
+      },
+    })
+
+    expect(await screen.findByText('Log events')).toBeInTheDocument()
+    expect(screen.getByText('2026-07-21T12:00:00Z · process_start')).toBeInTheDocument()
+    expect(screen.getByText('process_start pid=42')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
+++ b/frontend/src/redesign/screens/dashboard/FindingPopup.tsx
@@ -16,6 +16,8 @@ import { techniqueName } from '../../data/mitre'
 import { ConfirmDialog, EmptyState, Popup, Select } from '../../shared/ui'
 import { Icon } from '../../shared/icons'
 import type { Phase } from '../cases/useCases'
+import { parseSourceEvidence } from '../../data/sourceEvidence'
+import { SourceEvidenceSection } from './SourceEvidenceSection'
 
 interface RawFinding extends ApiFinding {
   description?: string
@@ -244,6 +246,7 @@ export default function FindingPopup({
   const f = raw ? mapApiFinding(raw) : null
   const preds = Object.entries(raw?.mitre_predictions || {}).sort((a, b) => b[1] - a[1])
   const ec = raw?.entity_context || {}
+  const sourceEvidence = parseSourceEvidence(ec.source_evidence)
 
   const title =
     phase === 'ready' && f ? (
@@ -323,6 +326,8 @@ export default function FindingPopup({
               </div>
             </div>
           )}
+
+          <SourceEvidenceSection evidence={sourceEvidence} />
 
           {/* AI enrichment — on-demand */}
           <div className="modal-section">

--- a/frontend/src/redesign/screens/dashboard/SourceEvidenceSection.tsx
+++ b/frontend/src/redesign/screens/dashboard/SourceEvidenceSection.tsx
@@ -1,0 +1,155 @@
+import { SOURCE_TELEMETRY_LABELS, type SourceEvidence } from '../../data/sourceEvidence'
+import type { ReactNode } from 'react'
+
+const EMPTY = '—'
+
+function displayValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (value === undefined || value === '') return EMPTY
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return String(value)
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function endpoint(ip: unknown, port: unknown): string {
+  const address = displayValue(ip)
+  return port === undefined || port === null || port === '' ? address : `${address}:${displayValue(port)}`
+}
+
+function TableRegion({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="source-evidence-table-scroll" role="region" aria-label={label} tabIndex={0}>
+      {children}
+    </div>
+  )
+}
+
+function NetFlowTable({ evidence }: { evidence: SourceEvidence }) {
+  return (
+    <TableRegion label="NetFlow source evidence table">
+      <table className="source-evidence-table">
+        <caption className="sr-only">NetFlow records attached to this finding</caption>
+        <thead><tr>
+          <th scope="col">Time</th><th scope="col">Source</th><th scope="col">Destination</th>
+          <th scope="col">Protocol</th><th scope="col">Packets F/B</th>
+          <th scope="col">Bytes F/B</th><th scope="col">Duration</th>
+        </tr></thead>
+        <tbody>{evidence.records.map((record, index) => (
+          <tr key={`${displayValue(record.timestamp)}-${index}`}>
+            <td className="mono">{displayValue(record.timestamp)}</td>
+            <td className="mono">{endpoint(record.source_ip, record.source_port)}</td>
+            <td className="mono">{endpoint(record.destination_ip, record.destination_port)}</td>
+            <td className="mono">{displayValue(record.protocol)}</td>
+            <td className="mono">{displayValue(record.forward_packets)} / {displayValue(record.backward_packets)}</td>
+            <td className="mono">{displayValue(record.forward_bytes)} / {displayValue(record.backward_bytes)}</td>
+            <td className="mono">{record.duration_ms === undefined ? EMPTY : `${displayValue(record.duration_ms)} ms`}</td>
+          </tr>
+        ))}</tbody>
+      </table>
+    </TableRegion>
+  )
+}
+
+function DnsTable({ evidence }: { evidence: SourceEvidence }) {
+  return (
+    <TableRegion label="DNS source evidence table">
+      <table className="source-evidence-table">
+        <caption className="sr-only">DNS records attached to this finding</caption>
+        <thead><tr>
+          <th scope="col">Time</th><th scope="col">Client</th><th scope="col">Server</th>
+          <th scope="col">Query</th><th scope="col">Type</th><th scope="col">Answer</th>
+          <th scope="col">Rcode</th><th scope="col">TTL</th>
+        </tr></thead>
+        <tbody>{evidence.records.map((record, index) => (
+          <tr key={`${displayValue(record.timestamp)}-${displayValue(record.query)}-${index}`}>
+            <td className="mono">{displayValue(record.timestamp)}</td>
+            <td className="mono">{displayValue(record.client_ip)}</td>
+            <td className="mono">{displayValue(record.server_ip)}</td>
+            <td className="mono">{displayValue(record.query)}</td>
+            <td className="mono">{displayValue(record.query_type)}</td>
+            <td className="mono">{displayValue(record.answer)}</td>
+            <td className="mono">{displayValue(record.response_code)}</td>
+            <td className="mono">{displayValue(record.ttl)}</td>
+          </tr>
+        ))}</tbody>
+      </table>
+    </TableRegion>
+  )
+}
+
+function recordHeading(record: Record<string, unknown>, index: number): string {
+  const parts = [record.timestamp, record.event_type, record.method, record.path, record.message]
+    .filter((value) => typeof value === 'string' && value.trim())
+    .map(String)
+  return parts.join(' · ') || `Record ${index + 1}`
+}
+
+function StructuredRecords({ evidence }: { evidence: SourceEvidence }) {
+  return (
+    <div className="source-evidence-records" aria-label="Structured source evidence records">
+      {evidence.records.map((record, index) => (
+        <details className="source-evidence-record" key={index}>
+          <summary><span className="mono">{recordHeading(record, index)}</span></summary>
+          <dl>
+            {Object.entries(record).map(([key, value]) => (
+              <div key={key}><dt>{key}</dt><dd className="mono">{displayValue(value)}</dd></div>
+            ))}
+          </dl>
+        </details>
+      ))}
+    </div>
+  )
+}
+
+const STATUS_MESSAGES: Record<Exclude<SourceEvidence['status'], 'available'>, string> = {
+  not_in_artifact: 'Source evidence was not included in the ingested artifact.',
+  redacted: 'Source evidence is present but was redacted before ingestion.',
+  invalid: 'Source evidence was present but did not match the declared schema.',
+}
+
+export function SourceEvidenceSection({ evidence }: { evidence?: SourceEvidence }) {
+  if (!evidence) return null
+  const kindLabel = SOURCE_TELEMETRY_LABELS[evidence.telemetryKind]
+
+  if (evidence.status !== 'available') {
+    return (
+      <section className="modal-section source-evidence-status" aria-label="Source evidence">
+        <h4>Source evidence</h4>
+        <p role="status"><strong>{kindLabel}:</strong> {STATUS_MESSAGES[evidence.status]}</p>
+      </section>
+    )
+  }
+
+  const recordCount = evidence.records.length
+  const countLabel = evidence.totalRecords > 0
+    ? `${recordCount} of ${evidence.totalRecords} records`
+    : evidence.rawText ? 'Raw text' : 'No records'
+  return (
+    <details className="modal-section source-evidence">
+      <summary>
+        <span>Source evidence</span>
+        <span className="tag">{kindLabel}</span>
+        <span className="source-evidence-count">{countLabel}</span>
+      </summary>
+      <p className="source-evidence-caption">
+        {evidence.provenance === 'embedded' ? 'Embedded in the ingested artifact' : 'Joined by the ingestion pipeline'}
+        {' · '}schema <span className="mono">{evidence.schemaId}</span>
+        {evidence.truncated ? ' · preview truncated' : ''}
+      </p>
+      {recordCount > 0 && evidence.telemetryKind === 'netflow' && <NetFlowTable evidence={evidence} />}
+      {recordCount > 0 && evidence.telemetryKind === 'dns' && <DnsTable evidence={evidence} />}
+      {recordCount > 0 && (evidence.telemetryKind === 'http_session' || evidence.telemetryKind === 'generic_log') && (
+        <StructuredRecords evidence={evidence} />
+      )}
+      {evidence.rawText && (
+        <div className="source-evidence-raw">
+          <h5>Raw source text{evidence.rawTextTruncated ? ' (truncated)' : ''}</h5>
+          <pre>{evidence.rawText}</pre>
+        </div>
+      )}
+    </details>
+  )
+}

--- a/frontend/src/redesign/styles.css
+++ b/frontend/src/redesign/styles.css
@@ -5462,6 +5462,165 @@
       gap: 10px;
    }
 
+   .source-evidence,
+   .source-evidence-status {
+      border: 1px solid var(--line);
+      border-radius: var(--r);
+      background: var(--bg-2);
+   }
+
+   .source-evidence>summary {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      padding: 12px 14px;
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--tx);
+   }
+
+   .source-evidence>summary:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: -2px;
+      border-radius: var(--r);
+   }
+
+   .source-evidence-count {
+      margin-left: auto;
+      color: var(--tx-3);
+      font-size: 12px;
+      font-weight: 400;
+   }
+
+   .source-evidence-caption {
+      margin: 0;
+      padding: 0 14px 12px;
+      color: var(--tx-3);
+      font-size: 12px;
+      line-height: 1.5;
+   }
+
+   .source-evidence-table-scroll {
+      overflow-x: auto;
+      border-top: 1px solid var(--line);
+   }
+
+   .source-evidence-table-scroll:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: -2px;
+   }
+
+   .source-evidence-table {
+      width: 100%;
+      min-width: 760px;
+      border-collapse: collapse;
+      font-size: 11.5px;
+   }
+
+   .source-evidence-table th,
+   .source-evidence-table td {
+      padding: 8px 10px;
+      border-bottom: 1px solid var(--line-soft);
+      text-align: left;
+      white-space: nowrap;
+   }
+
+   .source-evidence-table th {
+      color: var(--tx-3);
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+   }
+
+   .source-evidence-records {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 0 14px 12px;
+   }
+
+   .source-evidence-record {
+      border: 1px solid var(--line-soft);
+      border-radius: var(--r-sm);
+      background: var(--bg-1);
+   }
+
+   .source-evidence-record>summary {
+      padding: 9px 10px;
+      cursor: pointer;
+      color: var(--tx-2);
+      font-size: 12px;
+   }
+
+   .source-evidence-record dl {
+      display: grid;
+      grid-template-columns: minmax(110px, 180px) 1fr;
+      margin: 0;
+      padding: 0 10px 10px;
+      gap: 6px 10px;
+   }
+
+   .source-evidence-record dl>div {
+      display: contents;
+   }
+
+   .source-evidence-record dt,
+   .source-evidence-record dd {
+      margin: 0;
+      font-size: 11.5px;
+      overflow-wrap: anywhere;
+   }
+
+   .source-evidence-record dt {
+      color: var(--tx-3);
+   }
+
+   .source-evidence-raw {
+      padding: 0 14px 12px;
+   }
+
+   .source-evidence-raw h5 {
+      margin: 0 0 7px;
+      color: var(--tx-3);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .05em;
+   }
+
+   .source-evidence-raw pre {
+      max-height: 280px;
+      margin: 0;
+      padding: 10px;
+      overflow: auto;
+      border: 1px solid var(--line-soft);
+      border-radius: var(--r-sm);
+      background: var(--bg-1);
+      color: var(--tx-2);
+      font-family: var(--mono);
+      font-size: 11.5px;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+   }
+
+   .source-evidence-status {
+      padding: 12px 14px;
+   }
+
+   .source-evidence-status>h4 {
+      margin-bottom: 7px;
+   }
+
+   .source-evidence-status p {
+      margin: 0;
+      color: var(--tx-2);
+      font-size: 12.5px;
+      line-height: 1.5;
+   }
+
    /* ATT&CK inline "show findings" expansion */
    .caret {
       display: inline-flex;

--- a/services/ingestion_service.py
+++ b/services/ingestion_service.py
@@ -21,6 +21,11 @@ from typing import List, Dict, Any, Optional, Union
 from datetime import datetime
 from io import StringIO
 
+from services.source_evidence import (
+    normalize_finding_source_evidence,
+    source_evidence_from_loglm_row,
+)
+
 logger = logging.getLogger(__name__)
 
 MITRE_TACTIC_MAP = {
@@ -132,6 +137,8 @@ class IngestionService:
             logger.error("Finding missing finding_id")
             self.stats['findings_errors'] += 1
             return False
+
+        finding_data = normalize_finding_source_evidence(finding_data)
         
         try:
             if self.use_database and self.db_service:
@@ -796,6 +803,10 @@ class IngestionService:
         if row.get('incident_pred') is not None:
             entity_context['incident_pred'] = int(row['incident_pred'])
 
+        source_evidence = source_evidence_from_loglm_row(row)
+        if source_evidence is not None:
+            entity_context['source_evidence'] = source_evidence
+
         # cluster_id from attack_id if populated
         attack_id = row.get('attack_id')
         cluster_id = attack_id if attack_id else None
@@ -1029,4 +1040,3 @@ class IngestionService:
         except Exception as e:
             logger.error(f"Error ingesting from string: {e}")
             return self.stats
-

--- a/services/source_evidence.py
+++ b/services/source_evidence.py
@@ -1,0 +1,352 @@
+"""Normalize bounded source evidence attached to security findings.
+
+The finding schema intentionally keeps source evidence inside ``entity_context``
+so existing databases can adopt the contract without a migration.  The
+envelope is source-agnostic; ``telemetry_kind`` selects the presentation while
+``schema_id`` identifies the producer-owned record shape.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from datetime import date, datetime
+from typing import Any, Dict, Optional
+
+
+SOURCE_EVIDENCE_VERSION = 1
+SOURCE_EVIDENCE_PREVIEW_LIMIT = 100
+SOURCE_EVIDENCE_RAW_TEXT_LIMIT = 65_536
+
+TELEMETRY_KINDS = {"netflow", "dns", "http_session", "generic_log"}
+SOURCE_EVIDENCE_STATUSES = {
+    "available",
+    "not_in_artifact",
+    "redacted",
+    "invalid",
+}
+SOURCE_EVIDENCE_PROVENANCE = {"embedded", "joined"}
+
+_KIND_ALIASES = {
+    "net": "netflow",
+    "network": "netflow",
+    "network_flow": "netflow",
+    "dns_flow": "dns",
+    "http": "http_session",
+    "session": "http_session",
+    "web_session": "http_session",
+    "event": "generic_log",
+    "events": "generic_log",
+    "log": "generic_log",
+    "logs": "generic_log",
+}
+
+_DEFAULT_SCHEMA_IDS = {
+    "netflow": "netflow.v1",
+    "dns": "dns.v1",
+    "http_session": "http-session.v1",
+    "generic_log": "generic-log.v1",
+}
+
+
+def _text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _telemetry_kind(value: Any) -> Optional[str]:
+    text = _text(value)
+    if not text:
+        return None
+    normalized = text.lower().replace("-", "_").replace(" ", "_")
+    normalized = _KIND_ALIASES.get(normalized, normalized)
+    return normalized if normalized in TELEMETRY_KINDS else None
+
+
+def _json_safe(value: Any, *, depth: int = 0) -> Any:
+    """Convert common Parquet values into JSON-safe values.
+
+    Evidence remains source-ordered.  The depth and collection limits prevent
+    a malformed source field from expanding without bound inside JSONB.
+    """
+    if depth >= 8:
+        return str(value)
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, Mapping):
+        return {
+            str(key): _json_safe(item, depth=depth + 1)
+            for key, item in list(value.items())[:100]
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item, depth=depth + 1) for item in value[:100]]
+    return str(value)
+
+
+def _invalid_evidence(
+    kind: Optional[str] = None, schema_id: Any = None
+) -> Dict[str, Any]:
+    resolved_kind = kind or "generic_log"
+    return {
+        "version": SOURCE_EVIDENCE_VERSION,
+        "telemetry_kind": resolved_kind,
+        "schema_id": _text(schema_id) or _DEFAULT_SCHEMA_IDS[resolved_kind],
+        "status": "invalid",
+        "provenance": "embedded",
+    }
+
+
+def normalize_source_evidence(
+    value: Any,
+    *,
+    default_kind: Any = None,
+    default_schema_id: Any = None,
+) -> Dict[str, Any]:
+    """Return a validated, bounded v1 source-evidence envelope.
+
+    Malformed explicit evidence becomes a truthful ``invalid`` state instead
+    of being passed through or causing the entire finding to be dropped.
+    """
+    fallback_kind = _telemetry_kind(default_kind)
+    parsed = value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            return _invalid_evidence(fallback_kind, default_schema_id)
+    if not isinstance(parsed, Mapping):
+        return _invalid_evidence(fallback_kind, default_schema_id)
+
+    version = parsed.get("version", SOURCE_EVIDENCE_VERSION)
+    kind = _telemetry_kind(parsed.get("telemetry_kind")) or fallback_kind
+    schema_id = _text(parsed.get("schema_id")) or _text(default_schema_id)
+    status = _text(parsed.get("status"))
+    provenance = _text(parsed.get("provenance")) or "embedded"
+
+    if (
+        type(version) is not int
+        or version != SOURCE_EVIDENCE_VERSION
+        or kind is None
+        or status not in SOURCE_EVIDENCE_STATUSES
+        or provenance not in SOURCE_EVIDENCE_PROVENANCE
+    ):
+        return _invalid_evidence(kind or fallback_kind, schema_id)
+
+    envelope: Dict[str, Any] = {
+        "version": SOURCE_EVIDENCE_VERSION,
+        "telemetry_kind": kind,
+        "schema_id": schema_id or _DEFAULT_SCHEMA_IDS[kind],
+        "status": status,
+        "provenance": provenance,
+    }
+    if status != "available":
+        return envelope
+
+    raw_records = parsed.get("records")
+    if raw_records is None:
+        records = []
+    elif isinstance(raw_records, (list, tuple)):
+        records = [
+            _json_safe(record if isinstance(record, Mapping) else {"value": record})
+            for record in raw_records[:SOURCE_EVIDENCE_PREVIEW_LIMIT]
+        ]
+    else:
+        return _invalid_evidence(kind, envelope["schema_id"])
+
+    raw_text = parsed.get("raw_text")
+    if raw_text is None:
+        cleaned_raw_text = None
+        raw_text_truncated = False
+    elif isinstance(raw_text, str):
+        cleaned_raw_text = raw_text[:SOURCE_EVIDENCE_RAW_TEXT_LIMIT]
+        raw_text_truncated = len(raw_text) > SOURCE_EVIDENCE_RAW_TEXT_LIMIT
+    else:
+        return _invalid_evidence(kind, envelope["schema_id"])
+
+    if not records and not cleaned_raw_text:
+        return _invalid_evidence(kind, envelope["schema_id"])
+
+    supplied_total = parsed.get("total_records")
+    if supplied_total is None:
+        total_records = len(raw_records or [])
+    elif isinstance(supplied_total, bool) or (
+        isinstance(supplied_total, float) and not supplied_total.is_integer()
+    ):
+        return _invalid_evidence(kind, envelope["schema_id"])
+    else:
+        try:
+            total_records = int(supplied_total)
+        except (TypeError, ValueError):
+            return _invalid_evidence(kind, envelope["schema_id"])
+    if total_records < len(records):
+        return _invalid_evidence(kind, envelope["schema_id"])
+
+    supplied_truncated = parsed.get("truncated", False)
+    supplied_raw_text_truncated = parsed.get("raw_text_truncated", False)
+    if not isinstance(supplied_truncated, bool) or not isinstance(
+        supplied_raw_text_truncated, bool
+    ):
+        return _invalid_evidence(kind, envelope["schema_id"])
+
+    envelope["total_records"] = total_records
+    envelope["truncated"] = bool(
+        supplied_truncated
+        or total_records > len(records)
+        or (raw_records is not None and len(raw_records) > len(records))
+    )
+    if records:
+        envelope["records"] = records
+    if cleaned_raw_text:
+        envelope["raw_text"] = cleaned_raw_text
+        envelope["raw_text_truncated"] = bool(
+            supplied_raw_text_truncated or raw_text_truncated
+        )
+    return envelope
+
+
+def source_evidence_from_loglm_row(row: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build source evidence from optional LogLM Parquet columns.
+
+    Preferred input is the canonical ``source_evidence`` object/JSON column.
+    For current LogLM artifacts, ``events_json`` and ``sequence`` are adapted
+    into the same envelope.  ``source_evidence_kind`` is the explicit renderer
+    selector; without it, embedded events use the generic-log renderer.
+    """
+    kind_value = row.get("source_evidence_kind")
+    kind = _telemetry_kind(kind_value)
+    schema_id = row.get("source_evidence_schema_id")
+    if kind_value is not None and kind is None:
+        return _invalid_evidence(schema_id=schema_id)
+    explicit = row.get("source_evidence")
+    if explicit is not None:
+        return normalize_source_evidence(
+            explicit,
+            default_kind=kind,
+            default_schema_id=schema_id,
+        )
+
+    status = _text(row.get("source_evidence_status"))
+    if status is not None and status not in SOURCE_EVIDENCE_STATUSES:
+        return _invalid_evidence(kind, schema_id)
+    events_value = row.get("events_json")
+    sequence_value = row.get("sequence")
+    raw_text = (
+        sequence_value
+        if isinstance(sequence_value, str) and sequence_value.strip()
+        else None
+    )
+
+    has_evidence_columns = any(
+        value is not None
+        for value in (kind_value, schema_id, status, events_value, sequence_value)
+    )
+    if not has_evidence_columns:
+        return None
+
+    resolved_kind = kind or "generic_log"
+    if status in {"not_in_artifact", "redacted", "invalid"}:
+        return normalize_source_evidence(
+            {
+                "version": SOURCE_EVIDENCE_VERSION,
+                "telemetry_kind": resolved_kind,
+                "schema_id": _text(schema_id) or _DEFAULT_SCHEMA_IDS[resolved_kind],
+                "status": status,
+                "provenance": (
+                    _text(row.get("source_evidence_provenance")) or "embedded"
+                ),
+            }
+        )
+
+    records = None
+    if events_value is not None:
+        if isinstance(events_value, str):
+            try:
+                records = json.loads(events_value)
+            except (TypeError, ValueError):
+                if raw_text is None:
+                    return _invalid_evidence(resolved_kind, schema_id)
+                records = None
+        else:
+            records = events_value
+        if records is not None and not isinstance(records, (list, tuple)):
+            if raw_text is None:
+                return _invalid_evidence(resolved_kind, schema_id)
+            records = None
+
+    if records is None and raw_text is None:
+        missing_status = (
+            status if status in SOURCE_EVIDENCE_STATUSES else "not_in_artifact"
+        )
+        return normalize_source_evidence(
+            {
+                "version": SOURCE_EVIDENCE_VERSION,
+                "telemetry_kind": resolved_kind,
+                "schema_id": _text(schema_id) or _DEFAULT_SCHEMA_IDS[resolved_kind],
+                "status": missing_status,
+                "provenance": (
+                    _text(row.get("source_evidence_provenance")) or "embedded"
+                ),
+            }
+        )
+
+    total_records = row.get("source_evidence_total_records")
+    if total_records is None and isinstance(records, (list, tuple)):
+        total_records = len(records)
+    return normalize_source_evidence(
+        {
+            "version": SOURCE_EVIDENCE_VERSION,
+            "telemetry_kind": resolved_kind,
+            "schema_id": _text(schema_id) or _DEFAULT_SCHEMA_IDS[resolved_kind],
+            "status": "available",
+            "provenance": _text(row.get("source_evidence_provenance")) or "embedded",
+            "total_records": total_records,
+            "records": records,
+            "raw_text": raw_text,
+        }
+    )
+
+
+def normalize_finding_source_evidence(finding: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize an envelope already attached to a finding without mutation."""
+    context = finding.get("entity_context")
+    if not isinstance(context, Mapping):
+        return finding
+    evidence = context.get("source_evidence")
+    if evidence is None:
+        return finding
+
+    normalized = dict(finding)
+    normalized_context = dict(context)
+    normalized_context["source_evidence"] = normalize_source_evidence(evidence)
+    normalized["entity_context"] = normalized_context
+    return normalized
+
+
+def project_finding_source_evidence_for_list(finding: Dict[str, Any]) -> Dict[str, Any]:
+    """Strip bulky evidence payloads from a finding list item without mutation."""
+    normalized = normalize_finding_source_evidence(finding)
+    context = normalized.get("entity_context")
+    if not isinstance(context, Mapping):
+        return normalized
+    evidence = context.get("source_evidence")
+    if not isinstance(evidence, Mapping):
+        return normalized
+
+    projected = dict(normalized)
+    projected_context = dict(context)
+    projected_evidence = dict(evidence)
+    projected_evidence.pop("records", None)
+    projected_evidence.pop("raw_text", None)
+    projected_evidence["payload_included"] = False
+    projected_context["source_evidence"] = projected_evidence
+    projected["entity_context"] = projected_context
+    return projected

--- a/tests/unit/test_source_evidence.py
+++ b/tests/unit/test_source_evidence.py
@@ -1,0 +1,240 @@
+"""Tests for the generic finding source-evidence contract."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+from services.ingestion_service import IngestionService
+from services.source_evidence import (
+    SOURCE_EVIDENCE_PREVIEW_LIMIT,
+    normalize_source_evidence,
+    normalize_finding_source_evidence,
+    project_finding_source_evidence_for_list,
+    source_evidence_from_loglm_row,
+)
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+_FINDINGS_SPEC = importlib.util.spec_from_file_location(
+    "source_evidence_findings_api", REPO / "backend" / "api" / "findings.py"
+)
+assert _FINDINGS_SPEC and _FINDINGS_SPEC.loader
+findings_api = importlib.util.module_from_spec(_FINDINGS_SPEC)
+_FINDINGS_SPEC.loader.exec_module(findings_api)
+
+
+def test_legacy_loglm_events_and_sequence_become_generic_evidence():
+    evidence = source_evidence_from_loglm_row(
+        {
+            "events_json": json.dumps([
+                {"timestamp": "2026-07-21T12:00:00Z", "event_type": "request"},
+                {"timestamp": "2026-07-21T12:00:01Z", "event_type": "response"},
+            ]),
+            "sequence": "request -> response",
+        }
+    )
+
+    assert evidence == {
+        "version": 1,
+        "telemetry_kind": "generic_log",
+        "schema_id": "generic-log.v1",
+        "status": "available",
+        "provenance": "embedded",
+        "total_records": 2,
+        "truncated": False,
+        "records": [
+            {"timestamp": "2026-07-21T12:00:00Z", "event_type": "request"},
+            {"timestamp": "2026-07-21T12:00:01Z", "event_type": "response"},
+        ],
+        "raw_text": "request -> response",
+        "raw_text_truncated": False,
+    }
+
+
+def test_explicit_kind_selects_dns_renderer_without_data_source_guessing():
+    evidence = source_evidence_from_loglm_row(
+        {
+            "source_evidence_kind": "dns",
+            "source_evidence_schema_id": "resolver-events.v3",
+            "events_json": [{"query": "example.test", "query_type": "A"}],
+        }
+    )
+
+    assert evidence["telemetry_kind"] == "dns"
+    assert evidence["schema_id"] == "resolver-events.v3"
+    assert evidence["records"] == [{"query": "example.test", "query_type": "A"}]
+
+
+def test_declared_missing_evidence_is_truthful_and_payload_free():
+    evidence = source_evidence_from_loglm_row(
+        {"source_evidence_kind": "netflow", "source_evidence_status": "not_in_artifact"}
+    )
+
+    assert evidence["status"] == "not_in_artifact"
+    assert "records" not in evidence
+    assert "raw_text" not in evidence
+
+
+def test_malformed_explicit_evidence_fails_closed_as_invalid():
+    evidence = normalize_source_evidence(
+        {
+            "version": 1,
+            "telemetry_kind": "netflow",
+            "schema_id": "netflow.v1",
+            "status": "available",
+            "provenance": "embedded",
+            "records": "not-a-list",
+        }
+    )
+
+    assert evidence["status"] == "invalid"
+    assert "records" not in evidence
+
+
+def test_unknown_explicit_kind_fails_closed_instead_of_guessing():
+    evidence = source_evidence_from_loglm_row(
+        {
+            "source_evidence_kind": "packet_magic",
+            "events_json": [{"message": "event"}],
+        }
+    )
+
+    assert evidence["status"] == "invalid"
+    assert evidence["telemetry_kind"] == "generic_log"
+
+
+def test_preview_is_bounded_and_non_finite_values_are_json_safe():
+    records = [{"index": index, "value": float("nan")} for index in range(140)]
+    evidence = normalize_source_evidence(
+        {
+            "version": 1,
+            "telemetry_kind": "generic_log",
+            "schema_id": "generic-log.v1",
+            "status": "available",
+            "provenance": "embedded",
+            "total_records": len(records),
+            "records": records,
+        }
+    )
+
+    assert len(evidence["records"]) == SOURCE_EVIDENCE_PREVIEW_LIMIT
+    assert evidence["total_records"] == 140
+    assert evidence["truncated"] is True
+    assert evidence["records"][0]["value"] is None
+
+
+def test_parquet_mapper_persists_source_evidence_in_entity_context():
+    service = IngestionService.__new__(IngestionService)
+    finding = service._parquet_row_to_finding(
+        {
+            "sequence_id": "sequence-1",
+            "event_start_time": 1_784_653_712_000,
+            "incident_pred": 1,
+            "confidence_score": 0.91,
+            "events_json": [{"event_type": "connection"}],
+            "sequence": "connection event",
+            "source_evidence_kind": "generic_log",
+        }
+    )
+
+    evidence = finding["entity_context"]["source_evidence"]
+    assert evidence["status"] == "available"
+    assert evidence["records"] == [{"event_type": "connection"}]
+    assert evidence["raw_text"] == "connection event"
+
+
+def _finding_with_evidence():
+    return {
+        "finding_id": "f-source-1",
+        "entity_context": {
+            "hostname": "host-1",
+            "source_evidence": {
+                "version": 1,
+                "telemetry_kind": "generic_log",
+                "schema_id": "generic-log.v1",
+                "status": "available",
+                "provenance": "embedded",
+                "total_records": 1,
+                "truncated": False,
+                "records": [{"message": "raw event"}],
+                "raw_text": "raw event",
+            },
+        },
+    }
+
+
+def test_list_projection_strips_payload_without_mutating_stored_finding():
+    finding = _finding_with_evidence()
+    original = deepcopy(finding)
+
+    projected = project_finding_source_evidence_for_list(finding)
+    evidence = projected["entity_context"]["source_evidence"]
+
+    assert "records" not in evidence
+    assert "raw_text" not in evidence
+    assert evidence["payload_included"] is False
+    assert finding == original
+
+
+def test_detail_normalization_bounds_existing_unbounded_evidence():
+    finding = _finding_with_evidence()
+    finding["entity_context"]["source_evidence"]["total_records"] = 130
+    finding["entity_context"]["source_evidence"]["records"] = [
+        {"message": f"event-{index}"} for index in range(130)
+    ]
+
+    normalized = normalize_finding_source_evidence(finding)
+    evidence = normalized["entity_context"]["source_evidence"]
+
+    assert len(evidence["records"]) == SOURCE_EVIDENCE_PREVIEW_LIMIT
+    assert evidence["truncated"] is True
+    assert len(finding["entity_context"]["source_evidence"]["records"]) == 130
+
+
+class _FakeDataService:
+    def __init__(self, finding):
+        self.finding = finding
+
+    def is_s3_configured(self):
+        return False
+
+    def count_findings(self, **_kwargs):
+        return 1
+
+    def get_findings(self, **_kwargs):
+        return [self.finding]
+
+    def get_finding(self, finding_id):
+        return self.finding if finding_id == self.finding["finding_id"] else None
+
+
+def test_findings_list_omits_payload_while_detail_retains_it(monkeypatch):
+    finding = _finding_with_evidence()
+    monkeypatch.setattr(findings_api, "data_service", _FakeDataService(finding))
+
+    list_response = asyncio.run(findings_api.get_findings(
+        severity=None,
+        data_source=None,
+        cluster_id=None,
+        min_anomaly_score=None,
+        status=None,
+        search=None,
+        offset=0,
+        limit=100,
+        sort_by="timestamp",
+        sort_order="desc",
+        force_refresh=False,
+    ))
+    detail_response = asyncio.run(findings_api.get_finding("f-source-1"))
+
+    listed = list_response["findings"][0]["entity_context"]["source_evidence"]
+    detailed = detail_response["entity_context"]["source_evidence"]
+    assert "records" not in listed
+    assert "raw_text" not in listed
+    assert detailed["records"] == [{"message": "raw event"}]
+    assert detailed["raw_text"] == "raw event"


### PR DESCRIPTION
## Summary

- add a versioned, source-agnostic evidence envelope under `finding.entity_context.source_evidence`
- adapt LogLM Parquet `events_json` and `sequence` columns while allowing producers to declare `netflow`, `dns`, `http_session`, or `generic_log`
- bound evidence to 100 structured records and 64 KiB of raw text, preserving truthful unavailable, redacted, and invalid states
- omit record and raw-text payloads from finding-list responses while retaining them in finding detail
- render collapsed source evidence in the finding dialog with NetFlow and DNS tables plus ordered expandable records for HTTP sessions and generic logs

## Why

Finding details currently stop at model output and normalized entities even when the source artifact contains the records that produced the finding. `data_source="flow"` is also too broad to decide whether those records are NetFlow, DNS, Layer 7 events, or generic logs. This adds an explicit telemetry contract so source evidence can be shown without guessing or forcing unrelated schemas into one table.

## Compatibility and safety

- no database migration; the contract uses the existing JSON `entity_context`
- findings without a declared evidence contract keep the current UI
- malformed evidence becomes an explicit invalid state and never blocks finding ingestion
- existing stored evidence is normalized and bounded at response time
- React renders source values as text; no raw HTML is introduced
- no demo fixtures, source-specific joins, credentials, or runtime configuration are included

## Validation

- `python -m pytest -q tests/unit/test_source_evidence.py` — 10 passed
- `npm run test:run -- src/redesign/data/sourceEvidence.test.ts src/redesign/screens/dashboard/FindingPopup.test.tsx src/redesign/SocConsole.test.tsx` — 21 passed
- focused ESLint for changed TypeScript/TSX files — passed
- `uvx flake8 services/source_evidence.py tests/unit/test_source_evidence.py` — passed
- `npm run build` — passed
- `git diff --check` — passed
