### PR TITLE
fix(db): enable pgvector extension before create_all()

### DIFF
--- a/database/connection.py
+++ b/database/connection.py
@@ -621,6 +621,16 @@ class DatabaseManager:
             raise RuntimeError("Database not initialized. Call initialize() first.")
 
         try:
+            # Enable pgvector before create_all(); the findings table uses
+            # VECTOR(768) which requires the extension to exist first.
+            with self._engine.connect() as conn:
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+                conn.commit()
+        except Exception as e:
+            # Non-fatal: pgvector may be unavailable in non-embedding deployments.
+            logger.warning(f"Could not enable pgvector extension: {e}")
+
+        try:
             Base.metadata.create_all(self._engine)
             logger.info("Database tables created successfully")
         except Exception as e:


### PR DESCRIPTION
## Summary

- `database/connection.py`'s `create_tables()` now runs `CREATE EXTENSION IF NOT EXISTS vector` before calling `Base.metadata.create_all()`
- Fixes startup failure introduced by #398 (loglm pgvector embeddings), which added a `VECTOR(768)` column to the `Finding` ORM model but didn't update `create_tables()` to ensure the extension exists first
- The Docker init path (`17_loglm_setup.sql`) already enabled the extension for fresh container starts, leaving existing volumes and non-Docker setups broken on every launch

## Root cause

`Finding.__tablename__ = "findings"` has `embedding = Column(Vector(768), nullable=False)`. SQLAlchemy's `create_all()` emits `CREATE TABLE findings (... embedding VECTOR(768) ...)` before any extension setup, causing:

```
psycopg2.errors.UndefinedObject: type "vector" does not exist
```

This aborted the entire `create_all()` after the first few tables (those with no FK dependencies on `findings`), leaving the DB with only 4 of 43 expected tables and making `llm_provider_configs` missing — the symptom reported in #406.

## Test plan

- [ ] Fresh checkout with existing Postgres volume: `./start.sh` completes without the `UndefinedObject` error
- [ ] `python3 scripts/init_schema.py` exits 0 and logs "Database schema ready"
- [ ] `SELECT count(*) FROM information_schema.tables WHERE table_schema='public'` returns 45 (all ORM tables present)
- [ ] Re-running `init_schema.py` is idempotent (`IF NOT EXISTS` on both the extension and all tables)
- [ ] Deployments without pgvector log a warning and continue (non-fatal path)

Fixes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)