### PR TITLE
fix(chat): show non-Anthropic models in the chat model picker (#409)

### DIFF
--- a/backend/api/claude.py
+++ b/backend/api/claude.py
@@ -1130,8 +1130,18 @@ async def get_models():
         all_models = []
 
     if not all_models:
-        # Fallback — ensures the Chat UI still has something to render if the
-        # provider registry isn't reachable (e.g. fresh install, no DB).
+        # Live discovery returned nothing. Before rendering anything, reflect
+        # the providers the instance actually has configured — an Ollama-only
+        # deployment must not be shown Claude models it can't call (#409).
+        try:
+            all_models = await registry.fallback_models()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("get_models: provider fallback failed: %s", exc)
+            all_models = []
+
+    if not all_models:
+        # Genuinely nothing configured (fresh install / no DB). Last-resort
+        # default so the Chat UI still renders a picker.
         return {
             "models": [
                 {

--- a/frontend/src/redesign/shell/Chat.tsx
+++ b/frontend/src/redesign/shell/Chat.tsx
@@ -364,15 +364,23 @@ export default function Chat({
       .catch(() => {})
   }, [])
 
-  // model list + MCP tool status — fetched once, the first time the dock opens
-  const metaLoadedRef = useRef(false)
+  // model list — refetched every time the dock opens so providers added or
+  // activated after the first open (e.g. Ollama) show up without a full page
+  // reload (#409). The classic ClaudeDrawer already refetches on each open.
   useEffect(() => {
-    if (!open || metaLoadedRef.current) return
-    metaLoadedRef.current = true
+    if (!open) return
     claudeApi
       .getModels()
       .then((r) => setModels((r.data?.models || []) as { id: string; name: string }[]))
       .catch(() => {})
+  }, [open])
+
+  // MCP tool status + configured default — fetched once, the first time the
+  // dock opens.
+  const metaLoadedRef = useRef(false)
+  useEffect(() => {
+    if (!open || metaLoadedRef.current) return
+    metaLoadedRef.current = true
     aiConfigApi
       .getConfig()
       .then((r) => {

--- a/services/model_registry.py
+++ b/services/model_registry.py
@@ -860,6 +860,30 @@ class ModelRegistry:
         finally:
             session.close()
 
+    def _active_providers(self) -> List:
+        """Return active ``LLMProviderConfig`` rows.
+
+        Isolated (and overridable) so the aggregation logic in
+        ``list_available_models`` / ``fallback_models`` can be unit-tested
+        without a live Postgres.
+        """
+        try:
+            from database.connection import get_db_session
+            from database.models import LLMProviderConfig
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("_active_providers: DB unreachable: %s", exc)
+            return []
+
+        session = get_db_session()
+        try:
+            return (
+                session.query(LLMProviderConfig)
+                .filter(LLMProviderConfig.is_active.is_(True))
+                .all()
+            )
+        finally:
+            session.close()
+
     async def list_available_models(self) -> List[ModelInfo]:
         """Aggregate live model lists across all active providers.
 
@@ -869,22 +893,7 @@ class ModelRegistry:
         still returned with ``deprecated=True`` so users don't see their
         saved selection silently disappear.
         """
-        try:
-            from database.connection import get_db_session
-            from database.models import LLMProviderConfig
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("list_available_models: DB unreachable: %s", exc)
-            return []
-
-        session = get_db_session()
-        try:
-            providers = (
-                session.query(LLMProviderConfig)
-                .filter(LLMProviderConfig.is_active.is_(True))
-                .all()
-            )
-        finally:
-            session.close()
+        providers = self._active_providers()
 
         # Collect pinned (provider_id, model_id) pairs so we can keep
         # orphaned selections visible.
@@ -910,6 +919,22 @@ class ModelRegistry:
                     exc,
                 )
                 model_ids = [p.default_model] if p.default_model else []
+
+            # An active provider that discovers no models (e.g. an Ollama
+            # endpoint unreachable at sync time — its bootstrap list is
+            # empty) would otherwise contribute nothing, collapsing the
+            # aggregate to whatever other providers return (often just
+            # Anthropic). Floor it to the configured default_model so the
+            # provider is always represented in the picker (#409).
+            if not model_ids and getattr(p, "default_model", None):
+                logger.info(
+                    "Provider %s (%s) discovered no models — flooring to "
+                    "default_model %s so it still appears in the picker",
+                    p.provider_id,
+                    p.provider_type,
+                    p.default_model,
+                )
+                model_ids = [p.default_model]
 
             provider_live: set = set()
             for mid in model_ids:
@@ -958,6 +983,41 @@ class ModelRegistry:
                     )
                 )
 
+        return out
+
+    async def fallback_models(self) -> List[ModelInfo]:
+        """Provider-aware bootstrap list for the picker.
+
+        Used when live discovery yields nothing at all. Reflects the
+        *configured* providers (their bootstrap lists, extras and
+        ``default_model``) instead of hardcoding Claude, so an Ollama-only
+        instance never shows Anthropic models it can't call (#409). Returns
+        ``[]`` when no provider is configured — the caller then applies its
+        own last-resort default.
+        """
+        out: List[ModelInfo] = []
+        seen: set = set()
+        for p in self._active_providers():
+            ids = list(_FALLBACK_MODELS_BY_PROVIDER.get(p.provider_type, ()))
+            for mid in get_extra_model_ids(p.provider_type):
+                if mid not in ids:
+                    ids.append(mid)
+            default_model = getattr(p, "default_model", None)
+            if default_model and default_model not in ids:
+                ids.insert(0, default_model)
+            for mid in ids:
+                key = (p.provider_id, mid)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(
+                    self.get_model_info(
+                        provider_id=p.provider_id,
+                        provider_type=p.provider_type,
+                        model_id=mid,
+                        deprecated=is_extra_model(p.provider_type, mid),
+                    )
+                )
         return out
 
 

--- a/tests/unit/test_chat_models_endpoint.py
+++ b/tests/unit/test_chat_models_endpoint.py
@@ -1,0 +1,77 @@
+"""Unit tests for the chat model picker endpoint `GET /claude/models` (GH #409).
+
+The bug: the dropdown only listed Anthropic models on instances that run
+other providers (e.g. Ollama via Bifrost). These tests pin the endpoint's
+provider-aware behaviour: live models pass through, an empty live list falls
+back to the *configured* providers (not hardcoded Claude), and the hardcoded
+Claude bootstrap only appears when nothing is configured at all.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from backend.api import claude as claude_api  # noqa: E402
+from services.model_registry import ModelRegistry  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _mi(provider_type, model_id, provider_id=None):
+    return ModelRegistry.get_model_info(
+        provider_id=provider_id or f"{provider_type}-default",
+        provider_type=provider_type,
+        model_id=model_id,
+    )
+
+
+class _FakeRegistry:
+    def __init__(self, live=None, fallback=None):
+        self._live = live or []
+        self._fallback = fallback or []
+
+    async def list_available_models(self):
+        return list(self._live)
+
+    async def fallback_models(self):
+        return list(self._fallback)
+
+
+async def test_get_models_returns_live_non_anthropic(monkeypatch):
+    reg = _FakeRegistry(
+        live=[_mi("ollama", "llama3.1:8b"), _mi("ollama", "mistral:7b")]
+    )
+    monkeypatch.setattr(claude_api, "get_registry", lambda: reg)
+    out = await claude_api.get_models()
+    ids = [m["id"] for m in out["models"]]
+    assert ids == ["llama3.1:8b", "mistral:7b"]
+    assert not any(i.startswith("claude") for i in ids)
+
+
+async def test_get_models_uses_provider_fallback_not_claude(monkeypatch):
+    # Live discovery empty, but an Ollama provider IS configured → the picker
+    # must reflect Ollama, not the hardcoded Claude bootstrap (#409).
+    reg = _FakeRegistry(live=[], fallback=[_mi("ollama", "llama3.1:8b")])
+    monkeypatch.setattr(claude_api, "get_registry", lambda: reg)
+    out = await claude_api.get_models()
+    ids = [m["id"] for m in out["models"]]
+    assert ids == ["llama3.1:8b"]
+    assert not any(i.startswith("claude") for i in ids)
+
+
+async def test_get_models_hardcoded_claude_only_when_nothing_configured(monkeypatch):
+    # No live models AND no configured providers → last-resort Claude bootstrap
+    # so a truly fresh install still renders a picker.
+    reg = _FakeRegistry(live=[], fallback=[])
+    monkeypatch.setattr(claude_api, "get_registry", lambda: reg)
+    out = await claude_api.get_models()
+    ids = [m["id"] for m in out["models"]]
+    assert ids  # non-empty
+    assert all(i.startswith("claude") for i in ids)
+    assert "claude-sonnet-4-6" in ids

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -239,6 +239,15 @@ def test_is_extra_model_flips_after_registration():
 # ---------------------------------------------------------------------------
 
 
+class _Prov:
+    """Minimal stand-in for an LLMProviderConfig row."""
+
+    def __init__(self, provider_id, provider_type, default_model=None):
+        self.provider_id = provider_id
+        self.provider_type = provider_type
+        self.default_model = default_model
+
+
 class _StubRegistry(ModelRegistry):
     """ModelRegistry that returns canned DB responses without touching a DB."""
 
@@ -247,10 +256,12 @@ class _StubRegistry(ModelRegistry):
         *,
         assignments: Optional[Dict[str, ComponentAssignment]] = None,
         default_anthropic: Optional[Dict[str, str]] = None,
+        active_providers=None,
     ):
         super().__init__()
         self._assignments = assignments or {}
         self._default_anthropic = default_anthropic
+        self._active = active_providers or []
 
     def get_all_assignments(  # type: ignore[override]
         self,
@@ -259,6 +270,9 @@ class _StubRegistry(ModelRegistry):
 
     def _default_anthropic_provider(self):  # type: ignore[override]
         return self._default_anthropic
+
+    def _active_providers(self):  # type: ignore[override]
+        return self._active
 
 
 def test_resolve_uses_explicit_component_assignment():
@@ -328,3 +342,62 @@ def test_agent_override_pins_model_but_uses_default_provider():
     )
     assert provider == "anthropic-default"
     assert model == "claude-opus-4-20250514"
+
+
+# ---------------------------------------------------------------------------
+# Non-Anthropic models in the picker (GH #409)
+# ---------------------------------------------------------------------------
+
+
+async def test_list_available_models_floors_empty_provider_to_default(monkeypatch):
+    """An active Ollama provider whose discovery returns nothing (empty
+    bootstrap) must still surface its configured default_model, not vanish
+    and let the aggregate collapse to Anthropic (#409)."""
+    from services import model_registry
+
+    async def _no_models(_row):
+        return []
+
+    monkeypatch.setattr(model_registry, "fetch_provider_models", _no_models)
+    reg = _StubRegistry(
+        active_providers=[_Prov("ollama-local", "ollama", default_model="llama3.1:8b")]
+    )
+    models = await reg.list_available_models()
+    assert [m.model_id for m in models] == ["llama3.1:8b"]
+    assert all(m.provider_type == "ollama" for m in models)
+
+
+async def test_list_available_models_uses_live_ids_when_present(monkeypatch):
+    """When discovery returns real ids the default_model floor is not used."""
+    from services import model_registry
+
+    async def _live(_row):
+        return ["llama3.1:8b", "mistral:7b"]
+
+    monkeypatch.setattr(model_registry, "fetch_provider_models", _live)
+    reg = _StubRegistry(
+        active_providers=[_Prov("ollama-local", "ollama", default_model="qwen:0.5b")]
+    )
+    ids = [m.model_id for m in await reg.list_available_models()]
+    assert ids == ["llama3.1:8b", "mistral:7b"]
+    assert "qwen:0.5b" not in ids
+
+
+async def test_fallback_models_reflects_ollama_not_anthropic():
+    """fallback_models() must return the configured provider's models
+    (Ollama here), never a hardcoded Anthropic set (#409)."""
+    reg = _StubRegistry(
+        active_providers=[_Prov("ollama-local", "ollama", default_model="llama3.1:8b")]
+    )
+    models = await reg.fallback_models()
+    ids = [m.model_id for m in models]
+    assert "llama3.1:8b" in ids
+    assert all(m.provider_type == "ollama" for m in models)
+    assert not any(mid.startswith("claude") for mid in ids)
+
+
+async def test_fallback_models_empty_when_no_providers():
+    """No configured providers → empty, so the caller can apply its own
+    last-resort default (the fresh-install Claude bootstrap in the API)."""
+    reg = _StubRegistry(active_providers=[])
+    assert await reg.fallback_models() == []


### PR DESCRIPTION
## What

Fixes the chat model picker still collapsing to **Anthropic-only** on instances that run other providers (e.g. Ollama via Bifrost). Closes #409.

Even after #412 removed the `/claude/models` anthropic filter, three residual paths still produced Anthropic-only results:

1. **Empty-provider collapse** — an active provider whose live discovery returned nothing contributed zero models (Ollama's bootstrap list is `()`), so the aggregate could fall to empty.
2. **Hardcoded Claude fallback** — when the aggregate was empty, `get_models()` returned three hardcoded Claude models regardless of what was configured.
3. **Once-per-session dock fetch** — the redesign chat dock (`Chat.tsx`) fetched the model list only the first time it opened, so a provider added/activated later never appeared until a full reload.

## Changes

- **`services/model_registry.py`**
  - `list_available_models`: floor an active provider that discovers no models to its configured `default_model`, so it is always represented.
  - New `fallback_models()`: provider-aware bootstrap list (reflects configured providers, not hardcoded Claude).
  - Extracted `_active_providers()` so the aggregation is unit-testable without Postgres.
- **`backend/api/claude.py`** — `get_models()` falls back to the configured providers before the hardcoded Claude bootstrap; Claude is now the last resort only on a genuinely empty install (no DB / no providers).
- **`frontend/src/redesign/shell/Chat.tsx`** — the dock refetches models on every open (matching the classic `ClaudeDrawer`); MCP status + config stay one-shot.

## Testing

- **Backend unit tests** (7 new, all green): `pytest tests/unit/test_model_registry.py tests/unit/test_chat_models_endpoint.py` — covers the default_model floor, live-ids-win, `fallback_models()` returning Ollama (not Claude), empty→[] , and the endpoint's three branches (live / provider-fallback / hardcoded-Claude-only-when-empty).
- **Live verification** on a local Ollama-via-Bifrost instance: `GET /api/claude/models` returns the Ollama models (`qwen2.5:14b`, `llama3.1:8b`, …) with no phantom Claude entries; frontend serves the updated dock.

## Notes / follow-ups

- The picker currently also lists Ollama **embedding** models (e.g. `nomic-embed-text`) since discovery returns every Ollama model. Filtering embedders out of the chat picker is intentionally left as a separate follow-up.
- Backend lint (`black`/`flake8`) shows pre-existing violations in these files unrelated to this change; the CI lint steps are `continue-on-error`. No new violations were introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
