### PR TITLE
fix(chat): hide Ollama embedding models from the chat picker (#433)

### DIFF
--- a/backend/api/claude.py
+++ b/backend/api/claude.py
@@ -1154,9 +1154,18 @@ async def get_models():
 
     # Dedupe by bare model_id: the picker uses it as both the menu key and the
     # stored value, and two providers can advertise the same id. First wins.
+    # Embedding-only models (e.g. nomic-embed-text) are dropped here: they show
+    # up in provider discovery but can't hold a chat, so they must not appear in
+    # the chat picker. Signal is the registry's is_embedding flag (from the
+    # provider capability array), with a name heuristic as fallback for
+    # providers/paths that don't carry live capability meta.
+    from services.provider_model_discovery import is_embedding_model_id
+
     seen: set = set()
     models = []
     for m in all_models:
+        if getattr(m, "is_embedding", False) or is_embedding_model_id(m.model_id):
+            continue
         if m.model_id in seen:
             continue
         seen.add(m.model_id)

--- a/services/model_registry.py
+++ b/services/model_registry.py
@@ -360,6 +360,7 @@ def record_live_meta(provider_type: str, meta_list: List[Any]) -> None:
             "supports_tools": bool(caps.get("supports_tools", False)),
             "supports_thinking": bool(caps.get("supports_thinking", False)),
             "supports_vision": bool(caps.get("supports_vision", False)),
+            "is_embedding": bool(caps.get("is_embedding", False)),
         }
 
 
@@ -386,6 +387,7 @@ def _default_entry(provider_type: str, model_id: str) -> Dict[str, Any]:
         "supports_tools": False,
         "supports_thinking": False,
         "supports_vision": False,
+        "is_embedding": False,
         "pricing_source": "unknown",
     }
 
@@ -416,6 +418,7 @@ def _catalog_entry(provider_type: str, model_id: str) -> Dict[str, Any]:
             "supports_tools",
             "supports_thinking",
             "supports_vision",
+            "is_embedding",
         ):
             if field_name in source and source[field_name]:
                 entry[field_name] = source[field_name]
@@ -472,6 +475,10 @@ class ModelInfo:
     # but is no longer advertised by the upstream API. Kept in the UI
     # list so a user's saved selection doesn't silently disappear.
     deprecated: bool = False
+    # True for embedding-only models (e.g. nomic-embed-text). They stay in
+    # the registry (analytics / future config) but are filtered out of the
+    # chat model picker, since you can't hold a conversation with them.
+    is_embedding: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -487,6 +494,7 @@ class ModelInfo:
             "supports_vision": self.supports_vision,
             "pricing_source": self.pricing_source,
             "deprecated": self.deprecated,
+            "is_embedding": self.is_embedding,
         }
 
 
@@ -747,6 +755,7 @@ class ModelRegistry:
             supports_vision=entry["supports_vision"],
             pricing_source=entry.get("pricing_source", "exact"),
             deprecated=deprecated,
+            is_embedding=bool(entry.get("is_embedding", False)),
         )
 
     # ---- assignments -----------------------------------------------------

--- a/services/provider_model_discovery.py
+++ b/services/provider_model_discovery.py
@@ -395,6 +395,25 @@ def _name_matches_family(name_lower: str, families) -> bool:
     return any(name_lower.startswith(f) or name_lower == f for f in families)
 
 
+# Name prefixes for embedding families whose id doesn't contain "embed"
+# (e.g. BAAI general embedding, GTE, MiniLM, OpenAI text-embedding-*).
+_EMBEDDING_NAME_PREFIXES = ("bge-", "gte-", "all-minilm", "text-embedding")
+
+
+def is_embedding_model_id(model_id: str) -> bool:
+    """Best-effort name check for embedding-only models.
+
+    Used as a fallback signal when a provider doesn't report a machine
+    capability (older Ollama, or a bootstrap/fallback id with no live meta).
+    The authoritative signal is the provider capability array; this only
+    fills the gap.
+    """
+    name = (model_id or "").lower().split(":")[0]
+    if "embed" in name:
+        return True
+    return name.startswith(_EMBEDDING_NAME_PREFIXES)
+
+
 def _ollama_capabilities_from_show(
     model_name: str,
     show_payload: Dict[str, Any],
@@ -451,11 +470,26 @@ def _ollama_capabilities_from_show(
         name_lower, _OLLAMA_VISION_CAPABLE_FAMILIES
     )
 
+    # Embedding vs chat: Ollama's capability array is authoritative. An
+    # embedding-only model reports ["embedding"] and no "completion"; chat
+    # models report "completion" (plus optionally tools/vision/thinking).
+    # Consult both the /api/tags caps (live_caps) and the /api/show top-level
+    # capabilities; fall back to a name heuristic when neither is reported.
+    all_caps = {c.lower() for c in live_caps}
+    all_caps |= {c.lower() for c in (show_payload.get("capabilities") or [])}
+    if "embedding" in all_caps:
+        is_embedding = "completion" not in all_caps
+    elif all_caps:
+        is_embedding = False
+    else:
+        is_embedding = is_embedding_model_id(name_lower)
+
     # Ollama models don't have native extended thinking in the Anthropic sense
     return {
         "supports_tools": supports_tools,
         "supports_thinking": False,
         "supports_vision": supports_vision,
+        "is_embedding": is_embedding,
     }
 
 

--- a/tests/unit/test_chat_picker_embedding_filter.py
+++ b/tests/unit/test_chat_picker_embedding_filter.py
@@ -1,0 +1,80 @@
+"""Unit tests for embedding-model filtering in the chat picker (issue #433).
+
+`GET /claude/models` must not offer embedding-only models (e.g.
+nomic-embed-text) in the chat picker: they show up in provider discovery
+but can't hold a conversation. Filtering uses the registry's `is_embedding`
+flag, with a name heuristic as a fallback for ids that carry no live meta.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+# backend/ must be on sys.path too: importing backend.api.claude cascades into
+# backend/api/__init__.py which does bare `from api.findings import ...`.
+sys.path.insert(0, str(REPO / "backend"))
+
+from backend.api import claude as claude_api  # noqa: E402
+from services.model_registry import ModelInfo  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _model(model_id, *, is_embedding=False, provider_type="ollama"):
+    return ModelInfo(
+        model_id=model_id,
+        provider_id=f"{provider_type}-default",
+        provider_type=provider_type,
+        display_name=model_id,
+        context_window=2048,
+        input_cost_per_1k=0.0,
+        output_cost_per_1k=0.0,
+        supports_tools=False,
+        supports_thinking=False,
+        supports_vision=False,
+        is_embedding=is_embedding,
+    )
+
+
+class _FakeRegistry:
+    def __init__(self, models):
+        self._models = models
+
+    async def list_available_models(self):
+        return list(self._models)
+
+
+async def test_get_models_excludes_embedding_by_flag(monkeypatch):
+    reg = _FakeRegistry(
+        [_model("llama3.1:8b"), _model("nomic-embed-text:latest", is_embedding=True)]
+    )
+    monkeypatch.setattr(claude_api, "get_registry", lambda: reg)
+    out = await claude_api.get_models()
+    ids = [m["id"] for m in out["models"]]
+    assert ids == ["llama3.1:8b"]
+
+
+async def test_get_models_excludes_embedding_by_name_when_flag_absent(monkeypatch):
+    # No live meta → is_embedding flag is False; the name heuristic must still
+    # keep nomic-embed-text out of the chat picker.
+    reg = _FakeRegistry(
+        [_model("qwen2.5:14b"), _model("nomic-embed-text:latest", is_embedding=False)]
+    )
+    monkeypatch.setattr(claude_api, "get_registry", lambda: reg)
+    out = await claude_api.get_models()
+    ids = [m["id"] for m in out["models"]]
+    assert "qwen2.5:14b" in ids
+    assert "nomic-embed-text:latest" not in ids
+
+
+async def test_get_models_keeps_chat_models(monkeypatch):
+    reg = _FakeRegistry([_model("qwen2.5:14b"), _model("llama3.1:8b")])
+    monkeypatch.setattr(claude_api, "get_registry", lambda: reg)
+    out = await claude_api.get_models()
+    ids = {m["id"] for m in out["models"]}
+    assert ids == {"qwen2.5:14b", "llama3.1:8b"}

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -328,3 +328,44 @@ def test_agent_override_pins_model_but_uses_default_provider():
     )
     assert provider == "anthropic-default"
     assert model == "claude-opus-4-20250514"
+
+
+# ---------------------------------------------------------------------------
+# Embedding flag plumbing (issue #433)
+# ---------------------------------------------------------------------------
+
+
+def test_get_model_info_surfaces_is_embedding_from_live_meta():
+    from services import model_registry
+
+    class _M:
+        id = "nomic-embed-text:latest"
+        display_name = "nomic-embed-text"
+        context_window = 2048
+        capabilities = {
+            "supports_tools": False,
+            "supports_thinking": False,
+            "supports_vision": False,
+            "is_embedding": True,
+        }
+
+    try:
+        model_registry.record_live_meta("ollama", [_M()])
+        info = ModelRegistry.get_model_info(
+            provider_id="ollama-local",
+            provider_type="ollama",
+            model_id="nomic-embed-text:latest",
+        )
+        assert info.is_embedding is True
+        assert info.to_dict()["is_embedding"] is True
+    finally:
+        model_registry.clear_live_meta("ollama")
+
+
+def test_get_model_info_is_embedding_defaults_false():
+    info = ModelRegistry.get_model_info(
+        provider_id="ollama-local",
+        provider_type="ollama",
+        model_id="llama3.1:8b",
+    )
+    assert info.is_embedding is False

--- a/tests/unit/test_provider_model_discovery.py
+++ b/tests/unit/test_provider_model_discovery.py
@@ -381,3 +381,51 @@ def test_fetch_provider_models_hard_fallback_when_sync_fails(monkeypatch):
     # Bootstrap list is preserved.
     assert "claude-opus-4-7" in result
     _reset_registry_state()
+
+
+# ---------------------------------------------------------------------------
+# Embedding-model detection (issue #433 — keep embedders out of chat picker)
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_caps_flag_embedding_only_from_capability_array():
+    caps = discovery._ollama_capabilities_from_show(
+        "nomic-embed-text:latest",
+        {"capabilities": ["embedding"]},
+        live_caps=["embedding"],
+    )
+    assert caps["is_embedding"] is True
+
+
+def test_ollama_caps_completion_model_is_not_embedding():
+    caps = discovery._ollama_capabilities_from_show(
+        "llama3.1:8b",
+        {"capabilities": ["completion", "tools"]},
+        live_caps=["completion", "tools"],
+    )
+    assert caps["is_embedding"] is False
+
+
+def test_ollama_caps_name_fallback_when_no_capability_array():
+    # Older Ollama reports no capabilities → fall back to the name heuristic.
+    embed = discovery._ollama_capabilities_from_show(
+        "nomic-embed-text:latest", {}, live_caps=[]
+    )
+    chat = discovery._ollama_capabilities_from_show("llama3.1:8b", {}, live_caps=[])
+    assert embed["is_embedding"] is True
+    assert chat["is_embedding"] is False
+
+
+def test_is_embedding_model_id_heuristic():
+    for embed in (
+        "nomic-embed-text:latest",
+        "mxbai-embed-large",
+        "snowflake-arctic-embed",
+        "bge-m3",
+        "all-minilm",
+        "gte-small",
+        "text-embedding-3-small",
+    ):
+        assert discovery.is_embedding_model_id(embed) is True, embed
+    for chat in ("llama3.1:8b", "qwen2.5:14b", "claude-sonnet-4-6", "gpt-4o"):
+        assert discovery.is_embedding_model_id(chat) is False, chat


### PR DESCRIPTION
## What

The chat model picker (`GET /api/claude/models`) listed Ollama **embedding-only** models such as `nomic-embed-text` alongside chat models. You can't hold a conversation with an embedder, so selecting one breaks chat. Closes #433.

## Root cause

Ollama's discovery (`/api/tags` + `/api/show`) already reports a `capabilities` array that distinguishes embedders (`["embedding"]`) from chat models (`["completion", ...]`), and Vigil was already fetching it — but `_ollama_capabilities_from_show` only read it for `tools`/`vision` and discarded the embedding/completion signal. So every discovered model reached the picker.

## Changes

- **`services/provider_model_discovery.py`** — derive an `is_embedding` flag from the capability array (`"embedding"` present and `"completion"` absent), with a name heuristic fallback for older Ollama that doesn't report capabilities. New shared `is_embedding_model_id()` helper.
- **`services/model_registry.py`** — plumb `is_embedding` through `ModelMeta → _LIVE_META → _catalog_entry → ModelInfo` (and `to_dict`).
- **`backend/api/claude.py`** — `get_models()` drops embedding-only models from the chat picker (flag first, name heuristic as fallback). The registry keeps them, so `/api/ai/models`, cost analytics, and any future embedding-model config are unaffected.

## Why this is safe

No code path in `services/`, `backend/`, or `database/` fetches an Ollama embedding model by name at runtime — pgvector similarity uses pre-computed 768-dim vectors from LogLM ingestion, not live Ollama embedding. Filtering `nomic-embed-text` from the **chat** picker does not touch the embedding pipeline.

## Testing

- **9 new unit tests** (all green): capability-array detection (embedding vs completion), name-heuristic fallback, `is_embedding` flag plumbing through `get_model_info`, and the `get_models()` endpoint filter (by flag and by name when no live meta).
- **Live verification** on a local Ollama-via-Bifrost instance: `GET /api/claude/models` returned `['qwen2.5:14b', 'llama3.1:8b']` — `nomic-embed-text` no longer appears.

## Notes

- Independent of #432 (the #409 fix); both touch `get_models()` but in different regions, so they merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
