### PR TITLE
fix(redesign): define missing chat-dock width helpers (repairs broken main)

### DIFF
--- a/frontend/src/redesign/SocConsole.tsx
+++ b/frontend/src/redesign/SocConsole.tsx
@@ -3,7 +3,7 @@
    dock, floating "Ask Vigil" FAB, and the theme tweaks panel.
    Ported from the design's index HTML + main.js.
    ============================================================ */
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import './styles.css'
 import { useAuth } from '../contexts/AuthContext'
@@ -68,6 +68,30 @@ export default function SocConsole() {
 /** Like data.ts `NAV`, but the key is a plain string so extension screens
  *  (keys outside the built-in `ScreenKey` union) can join the rail. */
 type NavItem = [IconName, string, string | null, NavGate?]
+
+// Resizable Vigil Assistant dock. The desktop width is user-preferred and
+// persisted; the effective width is always clamped to the viewport.
+const CHAT_MIN_WIDTH = 360
+const CHAT_MAX_WIDTH = 720
+const CHAT_DEFAULT_WIDTH = 420
+const CHAT_WIDTH_STORAGE_KEY = 'soc.chat.width.v1'
+
+const clampChatPreference = (width: number) =>
+  Math.min(CHAT_MAX_WIDTH, Math.max(CHAT_MIN_WIDTH, Math.round(width)))
+
+const chatMaxForViewport = (viewport: number) =>
+  Math.max(CHAT_MIN_WIDTH, Math.min(CHAT_MAX_WIDTH, viewport))
+
+function readChatWidth(): number {
+  if (typeof window === 'undefined') return CHAT_DEFAULT_WIDTH
+  try {
+    const stored = Number(window.localStorage.getItem(CHAT_WIDTH_STORAGE_KEY))
+    if (!Number.isFinite(stored) || stored <= 0) return CHAT_DEFAULT_WIDTH
+    return clampChatPreference(stored)
+  } catch {
+    return CHAT_DEFAULT_WIDTH
+  }
+}
 
 function SocConsoleInner() {
   // the active screen comes from the URL (/<screen>); the cases screen
@@ -231,6 +255,7 @@ function SocConsoleInner() {
   const resizeMinWidth = viewportWidth <= 600 ? effectiveChatWidth : CHAT_MIN_WIDTH
   const resizeMaxWidth = viewportWidth <= 600 ? effectiveChatWidth : chatViewportMax
   const consoleStyle = {
+    ...bgVars(bg.base),
     ...accentVars(accent.a, accent.b),
     '--chat-w': `${effectiveChatWidth}px`,
   } as CSSProperties
@@ -239,7 +264,7 @@ function SocConsoleInner() {
     <div
       className={wrapperClass}
       data-theme={isDarkBase(bg.base) ? 'dark' : 'light'}
-      style={{ ...bgVars(bg.base), ...accentVars(accent.a, accent.b) }}
+      style={consoleStyle}
     >
       <ToastProvider>
       <div className="shell">

--- a/frontend/src/redesign/shell/Chat.tsx
+++ b/frontend/src/redesign/shell/Chat.tsx
@@ -957,6 +957,7 @@ export default function Chat({
     onWidthCommit?.(drag.lastWidth)
   }
   const onResizeKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (maxWidth <= minWidth) return
     const step = event.shiftKey ? 48 : 16
     let next: number | null = null
     if (event.key === 'ArrowLeft') next = width + step


### PR DESCRIPTION
## Hotfix: define the chat-dock width helpers merged undefined in #401

`main` does not compile and the SOC console crashes at render. #401 (`e555120`) merged `SocConsole.tsx` code that references `readChatWidth`, `clampChatPreference`, `chatMaxForViewport`, `CHAT_MIN_WIDTH`, `CHAT_MAX_WIDTH`, `CHAT_WIDTH_STORAGE_KEY` and uses the `CSSProperties` type without defining or importing any of them. `tsc --noEmit` reports 7 errors; at runtime `<SocConsoleInner>` throws `ReferenceError: readChatWidth is not defined`.

It slipped through because the `Build Frontend` CI job is SKIPPED for these PRs and the vite/esbuild build does not fail on undefined identifiers or type errors (only `tsc` does, and nothing gates on it).

### Fix
- Define the module-level constants (`CHAT_MIN_WIDTH=360`, `CHAT_MAX_WIDTH=720`, `CHAT_DEFAULT_WIDTH=420`, `CHAT_WIDTH_STORAGE_KEY='soc.chat.width.v1'`) and helpers (`clampChatPreference`, `chatMaxForViewport`, `readChatWidth`) matching #401's documented 360–720px range, 420px default, and `soc.chat.width.v1` persistence key. `readChatWidth` handles a missing key, non-numeric/empty values, and out-of-range widths.
- Import `CSSProperties` from react.
- Apply `consoleStyle` (which carries `--chat-w`) to the console wrapper — it was defined but never wired, so the dock never received its width and resizing had no visual effect.
- Add the `maxWidth <= minWidth` guard to `onResizeKeyDown` in `Chat.tsx` for parity with the pointer handler.

### Validation
- `tsc --noEmit`: clean (was 7 errors)
- `vitest` SocConsole + Chat: 16/17 pass. The one failure — the pre-existing "renders the 404 screen" test — is unrelated: it renders the extension-loading branch because `useExtensions()` reports `loading: true` in the test env, so `NotFoundScreen` never mounts. That is orthogonal to this compile fix and left untouched.
- `npm run build`: passes.

### Follow-up (not in this PR)
- Add a `tsc --noEmit` gate to CI frontend lint, or stop skipping `Build Frontend`, so an undefined-identifier regression like this cannot merge again.
