### PR TITLE
docs(#413): ADR + glossary for the LLM provider boundary (PR1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,71 @@
+# Vigil SOC
+
+Vigil is an AI-native Security Operations Center: specialized AI agents perform
+triage, investigation, threat hunting, and response across many security
+integrations. This glossary fixes the language used across the codebase and
+docs. It is a glossary, not a spec — it defines what terms *mean*, not how any
+component is built.
+
+## Language — LLM plumbing
+
+**Provider**:
+An LLM backend Vigil can send a call to — currently Anthropic, OpenAI, or a
+local Ollama instance. A provider has a type and one or more usable models.
+_Avoid_: vendor, backend, engine (see "Engine").
+
+**Active provider**:
+The provider a given call actually runs on — the configured default of any type,
+not necessarily Anthropic. Distinct from "the Anthropic provider," which is one
+specific provider that may or may not be active.
+_Avoid_: current provider, selected provider.
+
+**Model**:
+A specific named LLM offered by a provider (e.g. `claude-sonnet-4-6`,
+`qwen2.5:14b`). A model belongs to exactly one provider type; a Claude model
+must never be routed to a non-Anthropic provider.
+
+**LLM entry point**:
+The single seam every LLM call passes through. All model calls go through it so
+provider selection, tool execution, streaming, and persistence live in one place.
+_Avoid_: LLM client, chat service (those name implementations, not the role).
+
+**Agentic tool loop**:
+The multi-turn cycle in which a model requests a tool, Vigil executes the tool,
+feeds the result back, and repeats until the model produces a final answer.
+Owned by the LLM entry point, not by individual callers.
+_Avoid_: agent loop, tool loop (acceptable shorthands), ReAct loop.
+
+**Transport**:
+The mechanism that carries one request to one provider and returns its response.
+A single turn within the agentic tool loop. Provider-specific.
+_Avoid_: dispatch call (reserve "dispatch" for the act, not the mechanism).
+
+**Engine**:
+A provider-specific implementation of a turn — e.g. the Anthropic path or the
+OpenAI-compatible path. Engines are internal to the LLM entry point; callers
+never talk to an engine directly.
+
+**Gateway**:
+The queue front for LLM work: it accepts a request, enqueues it for a background
+worker, and is how asynchronous/long-running calls are submitted. Distinct from
+the entry point, which performs the call.
+_Avoid_: queue service, job service.
+
+## Flagged ambiguities
+
+**"Claude"** is overloaded: it names the vendor (Anthropic), the SDK, and — in
+older code — the LLM entry point itself (`ClaudeService`). Use **Anthropic** for
+the provider, **Claude Agent SDK** for Anthropic's agent framework, and reserve
+**LLM entry point** for the routing seam regardless of provider.
+
+## Example dialogue
+
+> **PM:** If someone's on Ollama with no Anthropic key, does chat still work?
+> **Dev:** Yes. The active provider is Ollama, so the entry point picks the
+> Ollama engine as transport. It never touches the Anthropic engine.
+> **PM:** And if a stale request asks for a Claude model?
+> **Dev:** The entry point sees a Claude model on a non-Anthropic active
+> provider and swaps it for that provider's own model before dispatch.
+> **PM:** Where does the agentic tool loop run?
+> **Dev:** In the entry point. The caller just asks for a chat; the loop,
+> tool execution, and persistence all happen behind that one seam.

--- a/docs/adr/0001-llmrouter-sole-llm-entry-point.md
+++ b/docs/adr/0001-llmrouter-sole-llm-entry-point.md
@@ -1,0 +1,49 @@
+# LLMRouter is the sole entry point for LLM calls
+
+- **Status:** accepted
+- **Date:** 2026-07-23
+- **Issue:** [#413](https://github.com/Vigil-SOC/vigil/issues/413)
+
+## Context
+
+Vigil must run its agents on any configured provider (Anthropic, OpenAI, or a
+local Ollama model), not just Anthropic. Today fourteen non-test modules import
+`services.claude_service.ClaudeService` directly, and most call
+`ClaudeService.chat(use_backend_tools=True)` — a single call that couples LLM
+dispatch with the multi-turn agentic tool loop and MCP tool loading. Because
+`ClaudeService` is the Anthropic SDK path, every one of those call sites is
+implicitly Anthropic-only, which is what blocks non-Anthropic providers. There
+is no enforced boundary, so new code keeps reaching for `ClaudeService`.
+
+## Decision
+
+`LLMRouter` (`services/llm_router.py`) becomes the **single entry point for all
+LLM calls**. It absorbs the multi-turn agentic tool loop, streaming, interaction
+persistence, and a passthrough for the Anthropic-only Claude Agent SDK
+(`run_agent_task`). `ClaudeService` and `OpenAIAgentService` become internal
+engines that only `LLMRouter` may import. The boundary is enforced by an
+import-linter contract in CI that forbids `from services.claude_service import`
+anywhere except `LLMRouter` and tests.
+
+## Considered options
+
+- **A — A higher-level facade seam** (extend `LLMGateway` or a new `services/llm.py`)
+  as the entry point, with `LLMRouter` kept as a pure transport. Rejected: does
+  not match the issue's framing and would leave two "front doors" (gateway +
+  router).
+- **B — `LLMRouter` literally becomes the entry point (chosen).** Matches the
+  issue's wording and gives one class to reason about.
+- **C — Keep `ClaudeService` intact but hide it behind `LLMRouter`.** Rejected:
+  the dispatch/tool-loop coupling inside `ClaudeService` would remain — the
+  contract would pass without the underlying cleanup.
+
+## Consequences
+
+- `LLMRouter` grows to own two loops (its provider-agnostic tool loop plus the
+  Anthropic Agent SDK passthrough). This concentrates responsibility and carries
+  a "god-object" risk; PR3 (the loop relocation) warrants a dedicated
+  fresh-eyes engineering review.
+- All LLM-dispatch callers must be redirected off `ClaudeService`; the daemon's
+  tool execution and the worker's persistence move behind the router.
+- Once enforced, any new module that imports `ClaudeService` fails CI, keeping
+  the boundary from eroding.


### PR DESCRIPTION
## What & why

First slice of **#413 (Complete the LLM provider boundary and enforce it with an import contract)** — the low-risk, docs-only groundwork. No production code.

Records the architectural decision that `LLMRouter` becomes the **sole entry point for all LLM calls**, so Vigil agents can run on any configured provider (Anthropic / OpenAI / Ollama), and fixes the vocabulary the rest of the work will use.

## Changes

- **`docs/adr/0001-llmrouter-sole-llm-entry-point.md`** — the boundary decision, the alternatives weighed (facade seam / hide-behind-router), and consequences (LLMRouter grows to own the agentic loop + Anthropic Agent SDK passthrough → PR3 warrants a dedicated review).
- **`CONTEXT.md`** (new) — root glossary fixing LLM-plumbing terms: *provider*, *active provider*, *model*, *LLM entry point*, *agentic tool loop*, *transport*, *engine*, *gateway*, plus the overloaded-"Claude" ambiguity.

## Tracker reconciliation (context, not code)

Investigation found most of #413's children already landed on `main` under unrelated PRs that never referenced them:

| Issue | State | Fixed by |
|---|---|---|
| #324 | done | #348 |
| #326 | done + tests | #341/#348 |
| #327 | functionally done | #341/#348/#357 |
| #328 | done + tests | #341/#348 |
| #325 | canonical helpers still to add | (this effort, PR3) |
| #393 | outstanding | (this effort, PR2) |

Comments posted on #324/#326/#327/#328 for a maintainer to close.

## Remaining PRs in #413

- **PR2** — #393: collapse to one backend-tool dispatch table (`tool_manager.execute_backend_tool`).
- **PR3** — `LLMRouter` absorbs the agentic tool loop + unified streaming + `get_active_provider_spec` (=#325) + `run_agent_task` passthrough. *(highest-risk; dedicated review)*
- **PR4** — redirect all 12 `ClaudeService` callers.
- **PR5** — import-linter contract (new blocking CI job + pre-commit) + `docs/AGENTS.md`.

## How tested

Docs only — no tests. Content verified against the current code paths in `backend/api/claude.py`, `services/llm_router.py`, `services/llm_gateway.py`, and `services/tool_manager.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)