### PR TITLE
fix(setup): correct wizard readiness and model assignment

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -1223,9 +1223,8 @@ async def set_ai_operations_config(config: AIOperationsSettingsConfig):
 class OrchestratorSettingsConfig(BaseModel):
     """Orchestrator configuration for autonomous investigations."""
 
-    # Autonomous mode is opt-in. This default also feeds ORCHESTRATOR_DEFAULTS,
-    # so GET /config/orchestrator reports disabled until the user turns it on —
-    # matching GET /api/orchestrator/status, which already defaults False.
+    # Opt-in; also feeds ORCHESTRATOR_DEFAULTS. Matches GET /api/orchestrator/status,
+    # which already defaults False.
     enabled: bool = False
     dry_run: bool = False
     auto_assign_findings: bool = True

--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -1223,7 +1223,10 @@ async def set_ai_operations_config(config: AIOperationsSettingsConfig):
 class OrchestratorSettingsConfig(BaseModel):
     """Orchestrator configuration for autonomous investigations."""
 
-    enabled: bool = True
+    # Autonomous mode is opt-in. This default also feeds ORCHESTRATOR_DEFAULTS,
+    # so GET /config/orchestrator reports disabled until the user turns it on —
+    # matching GET /api/orchestrator/status, which already defaults False.
+    enabled: bool = False
     dry_run: bool = False
     auto_assign_findings: bool = True
     auto_assign_severities: List[str] = ["critical", "high"]

--- a/frontend/src/config/aiComponents.ts
+++ b/frontend/src/config/aiComponents.ts
@@ -1,0 +1,37 @@
+// frontend/src/config/aiComponents.ts
+//
+// Display labels for the backend's assignable AI components (the ids come from
+// services/model_registry.py COMPONENTS). Shared by the AI Config settings panel
+// and the setup wizard's model-assignment step so the two can't drift.
+export const CHAT_DEFAULT_KEY = 'chat_default'
+
+export const COMPONENT_LABELS: Record<string, { label: string; description: string }> = {
+  chat_default: {
+    label: 'Chat (Default)',
+    description: 'Fallback for interactive chat and every component below when unset.',
+  },
+  triage: {
+    label: 'Triage Agent',
+    description: 'Automated alert triage — cheaper/faster models work well here.',
+  },
+  investigation: {
+    label: 'Investigation Agents',
+    description: 'Investigator, Threat Hunter, Correlator, etc. — the heavy lifters.',
+  },
+  orchestrator_plan: {
+    label: 'Orchestrator — Planning',
+    description: 'Generates the investigation plan from the initial finding.',
+  },
+  orchestrator_review: {
+    label: 'Orchestrator — Review',
+    description: 'Reviews and approves sub-agent output at the end of an investigation.',
+  },
+  summarization: {
+    label: 'Context Summarization',
+    description: 'Compresses long conversations — a cheap model is usually fine.',
+  },
+  reporting: {
+    label: 'Report Generation',
+    description: 'Reporter agent output — clarity and structure matter more than depth.',
+  },
+}

--- a/frontend/src/config/aiComponents.ts
+++ b/frontend/src/config/aiComponents.ts
@@ -1,8 +1,7 @@
 // frontend/src/config/aiComponents.ts
 //
-// Display labels for the backend's assignable AI components (the ids come from
-// services/model_registry.py COMPONENTS). Shared by the AI Config settings panel
-// and the setup wizard's model-assignment step so the two can't drift.
+// Display labels for the backend AI components (ids: services/model_registry.py
+// COMPONENTS). Shared by AI Config settings + the setup wizard so they can't drift.
 export const CHAT_DEFAULT_KEY = 'chat_default'
 
 export const COMPONENT_LABELS: Record<string, { label: string; description: string }> = {

--- a/frontend/src/hooks/useSetupChecklist.ts
+++ b/frontend/src/hooks/useSetupChecklist.ts
@@ -5,13 +5,12 @@
 // SetupGate. `requiredReady` / `incompleteCount` are scaffolding for a planned
 // dashboard nudge, currently exercised only by tests.
 import { useCallback, useEffect, useState } from 'react'
-import { llmProviderApi, mcpApi, aiConfigApi, budgetsApi, configApi } from '../services/api'
+import { llmProviderApi, aiConfigApi, budgetsApi, configApi } from '../services/api'
 import {
   SETUP_STEPS,
   emptySetupState,
   type SetupState,
   type SetupStep,
-  type McpConnection,
 } from '../setup/setupSteps'
 
 export interface ChecklistStep extends SetupStep {
@@ -30,20 +29,17 @@ export interface SetupChecklist {
 // flaky endpoint can't crash the page. Advisory — not a security control.
 const fetchSetupState = async (): Promise<SetupState> => {
   const base = emptySetupState()
-  const [providers, connections, aiConfig, budget, orchestrator] = await Promise.allSettled([
+  const [providers, integrations, aiConfig, budget, orchestrator] = await Promise.allSettled([
     llmProviderApi.list(),
-    mcpApi.getConnections(),
+    configApi.getIntegrations(),
     aiConfigApi.getConfig(),
     budgetsApi.get(),
     configApi.getOrchestrator(),
   ])
 
   if (providers.status === 'fulfilled') base.providers = providers.value.data || []
-  if (connections.status === 'fulfilled')
-    base.connections = (connections.value.data?.connections ?? []).map((c: McpConnection) => ({
-      name: c.name,
-      connected: !!c.connected,
-    }))
+  if (integrations.status === 'fulfilled')
+    base.enabledIntegrations = integrations.value.data?.enabled_integrations ?? []
   if (aiConfig.status === 'fulfilled') base.assignments = aiConfig.value.data?.assignments ?? {}
   if (budget.status === 'fulfilled') base.budget = budget.value.data ?? null
   if (orchestrator.status === 'fulfilled')

--- a/frontend/src/hooks/useSetupChecklist.ts
+++ b/frontend/src/hooks/useSetupChecklist.ts
@@ -1,9 +1,8 @@
 // frontend/src/hooks/useSetupChecklist.ts
 //
-// Soft-checklist state: fetches every domain the setup steps read and runs each
-// readiness predicate. Purely additive — the hard gate lives in useSetupStatus /
-// SetupGate. `requiredReady` / `incompleteCount` are scaffolding for a planned
-// dashboard nudge, currently exercised only by tests.
+// Soft-checklist state: runs each step's readiness predicate over fetched state.
+// Purely additive — the hard gate lives in useSetupStatus / SetupGate.
+// `requiredReady` / `incompleteCount` feed a planned dashboard nudge (tests only).
 import { useCallback, useEffect, useState } from 'react'
 import { llmProviderApi, aiConfigApi, budgetsApi, configApi } from '../services/api'
 import {

--- a/frontend/src/redesign/screens/settings/AiConfigSection.tsx
+++ b/frontend/src/redesign/screens/settings/AiConfigSection.tsx
@@ -30,6 +30,7 @@ import {
 } from './useSettings'
 import type { LLMProvider, AIModelInfo } from '../../../services/api'
 import type { SectionProps } from './types'
+import { COMPONENT_LABELS, CHAT_DEFAULT_KEY } from '../../../config/aiComponents'
 
 type AiTab = 'providers' | 'models' | 'operations' | 'budgets'
 const TABS: [AiTab, string][] = [
@@ -227,17 +228,6 @@ function ProvidersPanel({ notify }: SectionProps) {
 }
 
 /* ---------------- Model assignment ---------------- */
-const COMPONENT_LABELS: Record<string, { label: string; description: string }> = {
-  chat_default: { label: 'Chat (Default)', description: 'Fallback for interactive chat and every component below when unset.' },
-  triage: { label: 'Triage Agent', description: 'Automated alert triage — cheaper/faster models work well here.' },
-  investigation: { label: 'Investigation Agents', description: 'Investigator, Threat Hunter, Correlator, etc. — the heavy lifters.' },
-  orchestrator_plan: { label: 'Orchestrator — Planning', description: 'Generates the investigation plan from the initial finding.' },
-  orchestrator_review: { label: 'Orchestrator — Review', description: 'Reviews and approves sub-agent output at the end of an investigation.' },
-  summarization: { label: 'Context Summarization', description: 'Compresses long conversations — a cheap model is usually fine.' },
-  reporting: { label: 'Report Generation', description: 'Reporter agent output — clarity and structure matter more than depth.' },
-}
-const CHAT_DEFAULT_KEY = 'chat_default'
-
 interface RowState { inherit: boolean; providerId: string; modelId: string }
 
 function ModelAssignmentPanel({ notify }: SectionProps) {

--- a/frontend/src/redesign/screens/setup/DataSourceDialog.tsx
+++ b/frontend/src/redesign/screens/setup/DataSourceDialog.tsx
@@ -1,7 +1,6 @@
 // frontend/src/redesign/screens/setup/DataSourceDialog.tsx
 //
-// Setup step panel — pick a telemetry source, enter credentials, connect. Picking
-// one opens IntegrationWizard; save persists creds then enables the MCP server.
+// Setup step panel — pick a telemetry source, enter credentials, connect.
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import IntegrationWizard from '../settings/IntegrationWizard'
 import type { IntegrationMetadata } from '../../../components/settings/IntegrationWizard'
@@ -88,7 +87,6 @@ const DataSourceDialog = ({ onSaved }: Props) => {
     )
   }, [dataSources, query])
 
-  // Persist creds, then connect. Throwing surfaces in the wizard's error banner.
   const handleSave = async (id: string, config: Record<string, unknown>) => {
     const cur = cfg.current
     const integrations = { ...cur.integrations, [id]: config }

--- a/frontend/src/redesign/screens/setup/DataSourceDialog.tsx
+++ b/frontend/src/redesign/screens/setup/DataSourceDialog.tsx
@@ -14,9 +14,9 @@ interface Props {
   onSaved: () => void
 }
 
-// Catalog id → MCP server name for the data-source ids that differ from their
-// server (the drift in setupSteps' MCP_ONLY_DATA_SOURCE_IDS). Shared by the
-// picker filter and the connect-on-save so the two can't diverge.
+// Catalog id → MCP server name for the few data-source ids whose mcp-config.json
+// server key differs from their catalog id. Shared by the picker filter and the
+// connect-on-save so the two can't diverge.
 const CATALOG_TO_SERVER: Record<string, string> = {
   'aws-security-hub': 'aws-security',
   'gcp-security': 'gcp-scc',
@@ -92,7 +92,8 @@ const DataSourceDialog = ({ onSaved }: Props) => {
   const handleSave = async (id: string, config: Record<string, unknown>) => {
     const cur = cfg.current
     const integrations = { ...cur.integrations, [id]: config }
-    const enabled = cur.enabled_integrations.includes(id)
+    const alreadyEnabled = cur.enabled_integrations.includes(id)
+    const enabled = alreadyEnabled
       ? cur.enabled_integrations
       : [...cur.enabled_integrations, id]
     await configApi.setIntegrations({ enabled_integrations: enabled, integrations })
@@ -105,6 +106,14 @@ const DataSourceDialog = ({ onSaved }: Props) => {
     // subsystem down, not a cred failure — let it through.
     if (data?.connected === false) {
       mcpApi.setServerEnabled(serverName, false).catch(() => {})
+      // Roll back the enabled bit too (keeping the creds), so the setup
+      // checklist's data-source step — which keys off enabled_integrations —
+      // doesn't count a source that never connected. Only if we just added it,
+      // so re-editing an already-connected source stays enabled.
+      if (!alreadyEnabled)
+        configApi
+          .setIntegrations({ enabled_integrations: cur.enabled_integrations, integrations })
+          .catch(() => {})
       const missing = data.missing_credentials?.length
         ? `Missing required credentials: ${data.missing_credentials.join(', ')}.`
         : null

--- a/frontend/src/redesign/screens/setup/ModelAssignmentDialog.tsx
+++ b/frontend/src/redesign/screens/setup/ModelAssignmentDialog.tsx
@@ -1,11 +1,13 @@
 // frontend/src/redesign/screens/setup/ModelAssignmentDialog.tsx
 //
-// Setup step panel — assigns the default chat model (chat_default), which every
-// unset component inherits. Satisfies the model-assignment step (≥1 assignment).
+// Setup step panel — assigns models per component, mirroring Settings → AI Config.
+// chat_default is the required base every unset component inherits; the rest are
+// optional overrides. Any assignment satisfies the model-assignment step.
 import { useEffect, useState } from 'react'
 import { Field, Select } from '../../shared/ui'
 import { Banner, StepFooter, useSaveAction } from '../../shared/formKit'
 import { aiConfigApi, type AIModelInfo } from '../../../services/api'
+import { COMPONENT_LABELS, CHAT_DEFAULT_KEY } from '../../../config/aiComponents'
 
 interface Props {
   onClose: () => void
@@ -15,72 +17,135 @@ interface Props {
 // provider_id + model_id, joined for the Select value. Ollama model ids contain
 // single colons (llama3.1:8b), so we split on the first "::" only.
 const SEP = '::'
+// Sentinel for "no override, inherit chat_default". Real values contain "::".
+const INHERIT = 'inherit'
 
 const ModelAssignmentDialog = ({ onClose, onSaved }: Props) => {
   const [models, setModels] = useState<AIModelInfo[]>([])
+  const [components, setComponents] = useState<string[]>([])
+  // component id -> selected value ("provider::model" or INHERIT). `initial` is the
+  // loaded snapshot so save only writes the rows the user actually changed.
+  const [rows, setRows] = useState<Record<string, string>>({})
+  const [initial, setInitial] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(true)
-  const [selected, setSelected] = useState('')
   const [selectError, setSelectError] = useState<string | null>(null)
   const { saving, error, run } = useSaveAction({ onSaved })
 
   useEffect(() => {
     let alive = true
-    aiConfigApi
-      .listModels()
-      .then(({ data }) => alive && setModels(data.models || []))
-      .catch(() => alive && setModels([]))
-      .finally(() => {
-        if (alive) setLoading(false)
-      })
+    // Fail-open (allSettled): a flaky /ai/config still lets the user set the default.
+    Promise.allSettled([aiConfigApi.listModels(), aiConfigApi.getConfig()]).then(
+      ([modelsRes, cfgRes]) => {
+        if (!alive) return
+        setModels(modelsRes.status === 'fulfilled' ? modelsRes.value.data.models || [] : [])
+        const cfg = cfgRes.status === 'fulfilled' ? cfgRes.value.data : null
+        const raw = cfg?.components?.length ? cfg.components : Object.keys(COMPONENT_LABELS)
+        // chat_default is rendered and validated unconditionally, so keep it in
+        // the list the save loop iterates — else a backend list missing it would
+        // validate but never persist the required default.
+        const comps = raw.includes(CHAT_DEFAULT_KEY) ? raw : [CHAT_DEFAULT_KEY, ...raw]
+        setComponents(comps)
+        const next: Record<string, string> = {}
+        for (const c of comps) {
+          const a = cfg?.assignments?.[c]
+          next[c] = a
+            ? `${a.provider_id}${SEP}${a.model_id}`
+            : c === CHAT_DEFAULT_KEY
+              ? ''
+              : INHERIT
+        }
+        setRows(next)
+        setInitial(next)
+      },
+    ).finally(() => {
+      if (alive) setLoading(false)
+    })
     return () => {
       alive = false
     }
   }, [])
 
-  const save = () => {
-    // Validate on click instead of disabling Save with no explanation.
-    if (!selected) {
-      setSelectError('Pick a model to assign.')
-      return
-    }
-    const i = selected.indexOf(SEP)
-    if (i < 0) return
-    run(async () => {
-      await aiConfigApi.setComponent('chat_default', {
-        provider_id: selected.slice(0, i),
-        model_id: selected.slice(i + SEP.length),
-      })
-    }, 'Failed to assign model')
-  }
-
-  const options = models.map((m) => ({
+  const modelOptions = models.map((m) => ({
     value: `${m.provider_id}${SEP}${m.model_id}`,
     label: `${m.display_name || m.model_id} · ${m.provider_type}`,
   }))
+  const optionsFor = (component: string) =>
+    component === CHAT_DEFAULT_KEY
+      ? modelOptions
+      : [{ value: INHERIT, label: 'Inherit default' }, ...modelOptions]
+
+  const setRow = (component: string, value: string) => {
+    setRows((prev) => ({ ...prev, [component]: value }))
+    if (component === CHAT_DEFAULT_KEY && selectError) setSelectError(null)
+  }
+
+  const parse = (value: string) => {
+    const i = value.indexOf(SEP)
+    return { provider_id: value.slice(0, i), model_id: value.slice(i + SEP.length) }
+  }
+
+  const save = () => {
+    // Validate on click instead of disabling Save with no explanation. chat_default
+    // is required — it's the base every unset component falls back to.
+    if (!(rows[CHAT_DEFAULT_KEY] || '').includes(SEP)) {
+      setSelectError(
+        models.length === 0 ? 'Connect an AI provider first.' : 'Pick a default model.',
+      )
+      return
+    }
+    run(async () => {
+      const ops: Promise<unknown>[] = []
+      for (const c of components) {
+        const desired = rows[c] ?? (c === CHAT_DEFAULT_KEY ? '' : INHERIT)
+        const was = initial[c] ?? (c === CHAT_DEFAULT_KEY ? '' : INHERIT)
+        if (desired === was) continue
+        if (desired === INHERIT) {
+          // switched back to inherit — clear only if a stored assignment existed
+          if (was !== INHERIT) ops.push(aiConfigApi.clearComponent(c))
+        } else {
+          ops.push(aiConfigApi.setComponent(c, parse(desired)))
+        }
+      }
+      await Promise.all(ops)
+    }, 'Failed to save model assignments')
+  }
+
+  const renderRow = (component: string, required: boolean) => {
+    const meta = COMPONENT_LABELS[component] ?? { label: component, description: '' }
+    return (
+      <Field
+        key={component}
+        label={meta.label}
+        hint={required && loading ? 'Loading available models…' : meta.description}
+        error={required ? selectError : null}
+      >
+        <Select
+          value={rows[component] ?? (required ? '' : INHERIT)}
+          placeholder={loading ? 'Loading…' : required ? 'Select a model' : 'Inherit default'}
+          options={optionsFor(component)}
+          onSelect={(v) => setRow(component, v)}
+        />
+      </Field>
+    )
+  }
 
   return (
     <div className="flex flex-col gap-3.5">
       {error && <Banner kind="err">{error}</Banner>}
       <p className="text-sm text-tx-2">
-        Pick the default model for chat and any agent without its own assignment. You can set
-        per-agent models — cheap for triage, strong for investigation — later in Settings → AI
-        Config.
+        Pick the default model for chat and any agent without its own assignment, then
+        optionally override it per agent — cheap for triage, strong for investigation.
       </p>
-      <Field
-        label="Default model"
-        hint={loading ? 'Loading available models…' : `${models.length} model(s) available.`}
-        error={selectError}
-      >
-        <Select
-          value={selected}
-          placeholder={loading ? 'Loading…' : 'Select a model'}
-          options={options}
-          onSelect={(v) => {
-            setSelected(v)
-            if (selectError) setSelectError(null)
-          }}
-        />
-      </Field>
+      {!loading && models.length === 0 && (
+        <p className="text-sm text-tx-3">
+          No models available yet — finish connecting an AI provider first.
+        </p>
+      )}
+      {renderRow(CHAT_DEFAULT_KEY, true)}
+      <div className="text-tx-3 text-xs font-medium uppercase tracking-wide mt-1">
+        Per-agent overrides (optional)
+      </div>
+      {components.filter((c) => c !== CHAT_DEFAULT_KEY).map((c) => renderRow(c, false))}
       <StepFooter
         onCancel={onClose}
         saving={saving}

--- a/frontend/src/redesign/screens/setup/ModelAssignmentDialog.tsx
+++ b/frontend/src/redesign/screens/setup/ModelAssignmentDialog.tsx
@@ -1,8 +1,8 @@
 // frontend/src/redesign/screens/setup/ModelAssignmentDialog.tsx
 //
-// Setup step panel — assigns models per component, mirroring Settings → AI Config.
+// Setup step panel — assign models per component (mirrors Settings → AI Config).
 // chat_default is the required base every unset component inherits; the rest are
-// optional overrides. Any assignment satisfies the model-assignment step.
+// optional overrides.
 import { useEffect, useState } from 'react'
 import { Field, Select } from '../../shared/ui'
 import { Banner, StepFooter, useSaveAction } from '../../shared/formKit'
@@ -40,9 +40,8 @@ const ModelAssignmentDialog = ({ onClose, onSaved }: Props) => {
         setModels(modelsRes.status === 'fulfilled' ? modelsRes.value.data.models || [] : [])
         const cfg = cfgRes.status === 'fulfilled' ? cfgRes.value.data : null
         const raw = cfg?.components?.length ? cfg.components : Object.keys(COMPONENT_LABELS)
-        // chat_default is rendered and validated unconditionally, so keep it in
-        // the list the save loop iterates — else a backend list missing it would
-        // validate but never persist the required default.
+        // Keep chat_default in the saved list even if the backend omits it —
+        // it's rendered and validated unconditionally, so it must persist.
         const comps = raw.includes(CHAT_DEFAULT_KEY) ? raw : [CHAT_DEFAULT_KEY, ...raw]
         setComponents(comps)
         const next: Record<string, string> = {}
@@ -85,8 +84,7 @@ const ModelAssignmentDialog = ({ onClose, onSaved }: Props) => {
   }
 
   const save = () => {
-    // Validate on click instead of disabling Save with no explanation. chat_default
-    // is required — it's the base every unset component falls back to.
+    // Validate on click rather than disabling Save with no explanation.
     if (!(rows[CHAT_DEFAULT_KEY] || '').includes(SEP)) {
       setSelectError(
         models.length === 0 ? 'Connect an AI provider first.' : 'Pick a default model.',
@@ -100,7 +98,6 @@ const ModelAssignmentDialog = ({ onClose, onSaved }: Props) => {
         const was = initial[c] ?? (c === CHAT_DEFAULT_KEY ? '' : INHERIT)
         if (desired === was) continue
         if (desired === INHERIT) {
-          // switched back to inherit — clear only if a stored assignment existed
           if (was !== INHERIT) ops.push(aiConfigApi.clearComponent(c))
         } else {
           ops.push(aiConfigApi.setComponent(c, parse(desired)))

--- a/frontend/src/redesign/screens/setup/ModelAssignmentDialog.tsx
+++ b/frontend/src/redesign/screens/setup/ModelAssignmentDialog.tsx
@@ -72,6 +72,7 @@ const ModelAssignmentDialog = ({ onClose, onSaved }: Props) => {
     component === CHAT_DEFAULT_KEY
       ? modelOptions
       : [{ value: INHERIT, label: 'Inherit default' }, ...modelOptions]
+  const overrides = components.filter((c) => c !== CHAT_DEFAULT_KEY)
 
   const setRow = (component: string, value: string) => {
     setRows((prev) => ({ ...prev, [component]: value }))
@@ -107,22 +108,47 @@ const ModelAssignmentDialog = ({ onClose, onSaved }: Props) => {
     }, 'Failed to save model assignments')
   }
 
-  const renderRow = (component: string, required: boolean) => {
-    const meta = COMPONENT_LABELS[component] ?? { label: component, description: '' }
+  // The required default keeps the full Field treatment (label + hint + error).
+  const renderDefaultRow = () => {
+    const meta = COMPONENT_LABELS[CHAT_DEFAULT_KEY]
     return (
       <Field
-        key={component}
         label={meta.label}
-        hint={required && loading ? 'Loading available models…' : meta.description}
-        error={required ? selectError : null}
+        hint={loading ? 'Loading available models…' : meta.description}
+        error={selectError}
       >
         <Select
-          value={rows[component] ?? (required ? '' : INHERIT)}
-          placeholder={loading ? 'Loading…' : required ? 'Select a model' : 'Inherit default'}
-          options={optionsFor(component)}
-          onSelect={(v) => setRow(component, v)}
+          value={rows[CHAT_DEFAULT_KEY] ?? ''}
+          placeholder={loading ? 'Loading…' : 'Select a model'}
+          options={optionsFor(CHAT_DEFAULT_KEY)}
+          onSelect={(v) => setRow(CHAT_DEFAULT_KEY, v)}
         />
       </Field>
+    )
+  }
+
+  // Overrides are dense single-line rows: label + hint left, picker right, so
+  // all six stay visible without growing the page into a scroll.
+  const renderOverrideRow = (component: string) => {
+    const meta = COMPONENT_LABELS[component] ?? { label: component, description: '' }
+    return (
+      <div
+        key={component}
+        className="flex items-center gap-3.5 py-2.5 border-b border-line-soft last:border-b-0"
+      >
+        <div className="flex-1 min-w-0">
+          <div className="text-[13px] text-tx">{meta.label}</div>
+          <div className="text-[11.5px] text-tx-3 leading-snug">{meta.description}</div>
+        </div>
+        <div className="flex-none w-52">
+          <Select
+            value={rows[component] ?? INHERIT}
+            placeholder={loading ? 'Loading…' : 'Inherit default'}
+            options={optionsFor(component)}
+            onSelect={(v) => setRow(component, v)}
+          />
+        </div>
+      </div>
     )
   }
 
@@ -138,11 +164,16 @@ const ModelAssignmentDialog = ({ onClose, onSaved }: Props) => {
           No models available yet — finish connecting an AI provider first.
         </p>
       )}
-      {renderRow(CHAT_DEFAULT_KEY, true)}
-      <div className="text-tx-3 text-xs font-medium uppercase tracking-wide mt-1">
-        Per-agent overrides (optional)
-      </div>
-      {components.filter((c) => c !== CHAT_DEFAULT_KEY).map((c) => renderRow(c, false))}
+      {renderDefaultRow()}
+      {overrides.length > 0 && (
+        <div className="mt-1">
+          <div className="pb-2 border-b border-line-soft text-xs font-semibold uppercase tracking-wide text-tx-3">
+            Per-agent overrides{' '}
+            <span className="font-normal normal-case tracking-normal text-tx-faint">· optional</span>
+          </div>
+          {overrides.map(renderOverrideRow)}
+        </div>
+      )}
       <StepFooter
         onCancel={onClose}
         saving={saving}

--- a/frontend/src/redesign/screens/setup/SetupScreen.tsx
+++ b/frontend/src/redesign/screens/setup/SetupScreen.tsx
@@ -100,9 +100,8 @@ const StepRow = ({
         <div className="text-tx text-sm font-medium">{step.label}</div>
         <div className="text-tx-3 text-xs mt-0.5">{step.description}</div>
       </div>
-      {/* The action stays interactive even once the step is satisfied, so a
-          completed step can be reopened and changed. Ready + collapsed shows the
-          done tag next to a "Change" button; the ✓ ring is the standing cue. */}
+      {/* Stays interactive when satisfied, so a done step can be reopened.
+          Ready + collapsed shows the done tag beside a "Change" button. */}
       <div className="shrink-0 flex items-center gap-2">
         {step.ready && !expanded && (
           <span className="whitespace-nowrap text-ok text-xs font-medium">{step.doneLabel}</span>

--- a/frontend/src/redesign/screens/setup/SetupScreen.tsx
+++ b/frontend/src/redesign/screens/setup/SetupScreen.tsx
@@ -100,36 +100,21 @@ const StepRow = ({
         <div className="text-tx text-sm font-medium">{step.label}</div>
         <div className="text-tx-3 text-xs mt-0.5">{step.description}</div>
       </div>
-      {/* Button and the "done" tag share this slot (tag overlaid) and crossfade —
-          no layout shift. When ready the button is inert + hidden from a11y. */}
-      <div className="shrink-0 relative">
-        <div
-          className={`transition-opacity duration-200 motion-reduce:transition-none ${
-            step.ready ? 'opacity-0 pointer-events-none' : 'opacity-100'
-          }`}
-          aria-hidden={step.ready}
-        >
-          <button
-            className={`btn ${required ? 'primary' : 'ghost'}`}
-            onClick={onAction}
-            tabIndex={step.ready ? -1 : undefined}
-          >
-            {expanded ? 'Close' : required ? 'Connect' : 'Configure'}
-            <Icon
-              name="chevD"
-              size={14}
-              className={`transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
-            />
-          </button>
-        </div>
-        <span
-          className={`absolute inset-0 flex items-center justify-end whitespace-nowrap pointer-events-none text-ok text-xs font-medium transition-opacity duration-200 motion-reduce:transition-none ${
-            step.ready ? 'opacity-100' : 'opacity-0'
-          }`}
-          aria-hidden={!step.ready}
-        >
-          {step.doneLabel}
-        </span>
+      {/* The action stays interactive even once the step is satisfied, so a
+          completed step can be reopened and changed. Ready + collapsed shows the
+          done tag next to a "Change" button; the ✓ ring is the standing cue. */}
+      <div className="shrink-0 flex items-center gap-2">
+        {step.ready && !expanded && (
+          <span className="whitespace-nowrap text-ok text-xs font-medium">{step.doneLabel}</span>
+        )}
+        <button className={`btn ${required && !step.ready ? 'primary' : 'ghost'}`} onClick={onAction}>
+          {expanded ? 'Close' : step.ready ? 'Change' : required ? 'Connect' : 'Configure'}
+          <Icon
+            name="chevD"
+            size={14}
+            className={`transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+          />
+        </button>
       </div>
     </div>
   )

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -482,12 +482,6 @@ export const mcpApi = {
 
   getServerStatus: (name: string) => api.get(`/mcp/servers/${name}/status`),
 
-  // Persistent connection status for all MCP servers — includes
-  // `connected: boolean` and (when not connected) `missing_credentials`
-  // and/or `error`. Used to detect whether an integration like VStrike is
-  // configured and ready.
-  getConnections: () => api.get('/mcp/connections/status'),
-
   // NOTE: startServer / stopServer / startAll / stopAll were removed —
   // every server in mcp-config.json is stdio-based, and the old endpoints
   // explicitly refused stdio. Runtime start/stop now lives on the enable

--- a/frontend/src/setup/__tests__/setupSteps.test.ts
+++ b/frontend/src/setup/__tests__/setupSteps.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   SETUP_STEPS,
-  DATA_SOURCE_SERVER_IDS,
+  DATA_SOURCE_CATALOG_IDS,
   emptySetupState,
   type SetupState,
   type SetupStepId,
@@ -23,24 +23,21 @@ const budget = (vk: string) => ({
   enforcement_mode: 'warning' as const,
 })
 
-describe('DATA_SOURCE_SERVER_IDS', () => {
-  it('includes catalog sources + mcp-only drift aliases, excludes non-sources', () => {
-    // real MCP data-source servers + the drift aliases that would otherwise be
-    // false negatives (connection name differs from the catalog id)
+describe('DATA_SOURCE_CATALOG_IDS', () => {
+  it('includes catalog data sources, excludes enrichment / identity / internal', () => {
     for (const id of [
       'splunk',
       'crowdstrike',
       'sentinelone',
       'azure-sentinel',
-      'elastic',
-      'splunk-selfhosted',
-      'aws-security',
-      'gcp-scc',
+      'elastic-siem',
+      'aws-security-hub',
+      'gcp-security',
     ])
-      expect(DATA_SOURCE_SERVER_IDS.has(id)).toBe(true)
-    // enrichment / output / internal servers must not count as a data source
-    for (const id of ['virustotal', 'slack', 'jira', 'approval', 'deeptempo-findings'])
-      expect(DATA_SOURCE_SERVER_IDS.has(id)).toBe(false)
+      expect(DATA_SOURCE_CATALOG_IDS.has(id)).toBe(true)
+    // enrichment / identity / reference integrations must not count as a data source
+    for (const id of ['virustotal', 'okta', 'github', 'shodan'])
+      expect(DATA_SOURCE_CATALOG_IDS.has(id)).toBe(false)
   })
 })
 
@@ -51,21 +48,11 @@ describe('step readiness predicates', () => {
     expect(ready('llm-provider', emptySetupState())).toBe(false)
   })
 
-  it('data-source: ready for a connected source (incl. drift alias), not for non-sources or disconnected', () => {
-    expect(ready('data-source', state({ connections: [{ name: 'splunk', connected: true }] }))).toBe(true)
-    expect(ready('data-source', state({ connections: [{ name: 'elastic', connected: true }] }))).toBe(true)
-    expect(ready('data-source', state({ connections: [{ name: 'splunk', connected: false }] }))).toBe(false)
-    expect(
-      ready(
-        'data-source',
-        state({
-          connections: [
-            { name: 'approval', connected: true },
-            { name: 'virustotal', connected: true },
-          ],
-        }),
-      ),
-    ).toBe(false)
+  it('data-source: ready once a data-source integration is enabled, not for non-sources', () => {
+    expect(ready('data-source', state({ enabledIntegrations: ['splunk'] }))).toBe(true)
+    expect(ready('data-source', state({ enabledIntegrations: ['elastic-siem'] }))).toBe(true)
+    expect(ready('data-source', state({ enabledIntegrations: [] }))).toBe(false)
+    expect(ready('data-source', state({ enabledIntegrations: ['virustotal', 'okta'] }))).toBe(false)
   })
 
   it('model-assignment: ready once any component is assigned', () => {

--- a/frontend/src/setup/setupSteps.ts
+++ b/frontend/src/setup/setupSteps.ts
@@ -1,7 +1,6 @@
 // frontend/src/setup/setupSteps.ts
 //
-// The setup-checklist registry: pure data + readiness predicates, no JSX.
-// useSetupChecklist feeds these predicates live backend state.
+// The setup-checklist registry: step data + readiness predicates (no JSX).
 import { INTEGRATIONS } from '../config/integrations'
 import type { LLMProvider, AIConfigResponse, BudgetSettings } from '../services/api'
 
@@ -28,7 +27,6 @@ export const DATA_SOURCE_CATALOG_IDS = new Set<string>(
 
 // --- Normalized backend state the predicates read -------------------------
 
-// One snapshot of everything the checklist derives from (each source fail-open).
 export interface SetupState {
   providers: LLMProvider[]
   enabledIntegrations: string[]
@@ -54,18 +52,15 @@ export type SetupStepId =
   | 'cost-guardrails'
   | 'autonomy'
 
-// Gating tier: 'required' drives the hard gate (today: only the LLM provider);
-// 'recommended' is strongly nudged but skippable; 'optional' is nice-to-have.
+// 'required' drives the hard gate; 'recommended' is nudged but skippable.
 export type SetupTier = 'required' | 'recommended' | 'optional'
 
-// Shell-agnostic Settings section key — each shell builds its own navigation to it.
 export type SettingsSection = 'ai-config' | 'integrations' | 'autoinvestigate'
 
 export interface SetupStep {
   id: SetupStepId
   label: string
   description: string
-  // Status word shown as a tag once the step is satisfied (replaces the button).
   doneLabel: string
   tier: SetupTier
   settingsSection: SettingsSection

--- a/frontend/src/setup/setupSteps.ts
+++ b/frontend/src/setup/setupSteps.ts
@@ -7,7 +7,7 @@ import type { LLMProvider, AIConfigResponse, BudgetSettings } from '../services/
 
 // --- Data-source identification -------------------------------------------
 
-// Categories whose connected integrations mean Vigil is actually being fed
+// Categories whose configured integrations mean Vigil is actually being fed
 // telemetry. Enrichment / output / identity / sandbox / forensics are excluded.
 export const DATA_SOURCE_CATEGORIES = new Set<string>([
   'SIEM',
@@ -17,32 +17,21 @@ export const DATA_SOURCE_CATEGORIES = new Set<string>([
   'Data Pipeline',
 ])
 
-// MCP connection names are mcp-config.json keys, which drift from catalog ids
-// for a few real data-source servers. Keep in sync when mcp-config.json gains a
-// data-source server whose key differs from its catalog id. (Verified 2026-06-18.)
-export const MCP_ONLY_DATA_SOURCE_IDS = [
-  'elastic', // catalog id: elastic-siem (SIEM)
-  'splunk-selfhosted', // SIEM, no catalog entry
-  'aws-security', // catalog id: aws-security-hub (Cloud Security)
-  'gcp-scc', // catalog id: gcp-security (Cloud Security)
-] as const
-
-export const DATA_SOURCE_SERVER_IDS = new Set<string>([
-  ...INTEGRATIONS.filter((i) => DATA_SOURCE_CATEGORIES.has(i.category)).map((i) => i.id),
-  ...MCP_ONLY_DATA_SOURCE_IDS,
-])
+// Catalog ids of every data-source integration. Readiness keys off the user's
+// enabled_integrations (catalog ids) — NOT live MCP connectivity: several
+// data-source servers are keyless stdio processes that boot (and so report
+// "connected") with no credentials, which would flip this step to done before
+// the user connected anything.
+export const DATA_SOURCE_CATALOG_IDS = new Set<string>(
+  INTEGRATIONS.filter((i) => DATA_SOURCE_CATEGORIES.has(i.category)).map((i) => i.id),
+)
 
 // --- Normalized backend state the predicates read -------------------------
-
-export interface McpConnection {
-  name: string
-  connected: boolean
-}
 
 // One snapshot of everything the checklist derives from (each source fail-open).
 export interface SetupState {
   providers: LLMProvider[]
-  connections: McpConnection[]
+  enabledIntegrations: string[]
   assignments: AIConfigResponse['assignments']
   budget: BudgetSettings | null
   orchestratorEnabled: boolean
@@ -50,7 +39,7 @@ export interface SetupState {
 
 export const emptySetupState = (): SetupState => ({
   providers: [],
-  connections: [],
+  enabledIntegrations: [],
   assignments: {},
   budget: null,
   orchestratorEnabled: false,
@@ -102,8 +91,7 @@ export const SETUP_STEPS: SetupStep[] = [
     doneLabel: 'Connected',
     tier: 'recommended',
     settingsSection: 'integrations',
-    selectReady: (s) =>
-      s.connections.some((c) => c.connected && DATA_SOURCE_SERVER_IDS.has(c.name)),
+    selectReady: (s) => s.enabledIntegrations.some((id) => DATA_SOURCE_CATALOG_IDS.has(id)),
   },
   {
     id: 'model-assignment',


### PR DESCRIPTION
## Summary

Fixes several correctness and UX issues in the setup wizard.

- **Data-source readiness** now keys off the user's `enabled_integrations` rather than live MCP connectivity. Keyless stdio servers boot and report `connected` with no credentials, which previously flipped the "Connect a data source" step to done before anything was actually configured. On a failed connect the enabled bit is now rolled back (credentials kept) so a source that never came online isn't counted as ready.
- **Model-assignment dialog** now mirrors Settings → AI Config: a required `chat_default` plus optional per-agent overrides with an inherit option, persisting only the rows the user changed. `COMPONENT_LABELS` / `CHAT_DEFAULT_KEY` moved into a shared config module so the wizard and settings panel can't drift.
- **Setup steps are reopenable** — a satisfied step shows a "Change" button instead of going inert, so a completed step can be revisited.
- **Orchestrator `enabled` defaults to `False`**, matching `GET /api/orchestrator/status` (previously the config endpoint reported it enabled when no row existed).

## Testing

- `tsc --noEmit` clean for all changed files.

Fixes #408