### PR TITLE
refactor(#413): introduce provider-agnostic LoopController + TurnEngine (PR3a)

### DIFF
--- a/services/agent_loop.py
+++ b/services/agent_loop.py
@@ -1,0 +1,616 @@
+"""Provider-agnostic agentic tool loop.
+
+This module houses the two halves of the multi-turn tool loop that used to live
+entirely inside ``OpenAIAgentService``:
+
+  - :class:`LoopController` — the **provider-agnostic** loop skeleton: iteration
+    and wall-clock guards, inter-iteration backoff, canonicalized loop-detection,
+    the tool-execution + human-approval flow, per-turn telemetry, and the
+    iteration-limit message. It knows nothing about any specific provider; it
+    drives a :class:`TurnEngine` for model I/O and calls back into a ``runtime``
+    handle for tool execution, approval, and logging.
+  - :class:`TurnEngine` — the interface a provider adapter implements, plus the
+    :class:`OpenAITurnEngine` adapter that speaks the OpenAI-compatible dialect
+    (delta reassembly over ``LLMRouter.stream_openai_raw``, tool-call
+    normalization, usage accounting, and the malformed-tool-JSON heuristic).
+
+Each engine owns its own message-history dialect; the controller only ever sees
+provider-agnostic :class:`TurnResult` / :class:`NormalizedToolCall` values. This
+lets a future ``AnthropicTurnEngine`` keep native Anthropic-block history without
+the controller having to convert anything.
+
+Behaviour here is a straight lift of the previous ``OpenAIAgentService.stream``
+loop — the split is structural, not behavioural.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Dict, List, Optional, Protocol, Union
+
+from services.llm_format import anthropic_messages_to_openai
+from services.llm_router import LLMRouter, ProviderSpec
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "PendingApprovalError",
+    "NormalizedToolCall",
+    "TurnResult",
+    "TurnEngine",
+    "OpenAITurnEngine",
+    "LoopController",
+]
+
+_MAX_TOOL_ITERATIONS = 30
+_MAX_PROCESSING_TIME_S = 300.0
+_HISTORY_WINDOW_DEFAULT = 20
+_LOOP_DETECT_WINDOW = 5
+_LOOP_DETECT_THRESHOLD = 3
+_BASE_INTER_ITERATION_DELAY_S = 0.5
+_MAX_INTER_ITERATION_DELAY_S = 3.0
+_BACKOFF_ITERATION_THRESHOLD = 15
+
+
+class PendingApprovalError(Exception):
+    """Tool call blocked pending human approval; action_id is the queue row to
+    poll, or None when the request could not be created."""
+
+    def __init__(self, message: str, action_id: Optional[str] = None):
+        super().__init__(message)
+        self.action_id = action_id
+
+
+def _inter_iteration_delay(iteration: int) -> float:
+    """Exponential backoff matching ClaudeService: 500ms base, ramp after 15."""
+    if iteration <= _BACKOFF_ITERATION_THRESHOLD:
+        return _BASE_INTER_ITERATION_DELAY_S
+    exp = iteration - _BACKOFF_ITERATION_THRESHOLD
+    delay = _BASE_INTER_ITERATION_DELAY_S * (1.5**exp)
+    return min(delay, _MAX_INTER_ITERATION_DELAY_S)
+
+
+def _canonical_args(raw: str) -> str:
+    """Canonicalize tool-call argument JSON for stable loop detection.
+
+    Parse and re-serialize with sorted keys so cosmetic streaming
+    differences (whitespace, key ordering) don't make a repeated call look
+    distinct and defeat the infinite-loop guard. Falls back to the stripped
+    raw string when the arguments aren't valid JSON.
+    """
+    try:
+        return json.dumps(
+            json.loads(raw or "{}"), sort_keys=True, separators=(",", ":")
+        )
+    except (json.JSONDecodeError, TypeError):
+        return (raw or "").strip()
+
+
+def _detect_infinite_loop(history: deque) -> bool:
+    """Detect if the same tool call set repeats >= threshold times."""
+    if len(history) < _LOOP_DETECT_THRESHOLD:
+        return False
+    recent = list(history)[-_LOOP_DETECT_THRESHOLD:]
+    return len(set(recent)) == 1
+
+
+def _apply_history_window(
+    messages: List[Dict[str, Any]],
+    window: int = _HISTORY_WINDOW_DEFAULT,
+) -> List[Dict[str, Any]]:
+    """Enforce a sliding history window (configurable max turns).
+
+    Keeps the system message (if first) + the most recent ``window * 2``
+    messages. Matches ClaudeService._apply_history_window behavior.
+    """
+    if window <= 0:
+        return messages
+    max_msgs = window * 2
+    if len(messages) <= max_msgs:
+        return messages
+    # Preserve system message at index 0 if present
+    if messages and messages[0].get("role") == "system":
+        keep = max_msgs - 1
+        return [messages[0]] + messages[-keep:]
+    return messages[-max_msgs:]
+
+
+@dataclass
+class NormalizedToolCall:
+    """A provider-agnostic tool call the controller acts on.
+
+    ``arguments`` stays the raw JSON *string* the model emitted so it flows into
+    the tool executor unchanged and is canonicalized only for loop-detection.
+    """
+
+    id: str
+    name: str
+    arguments: str
+
+
+@dataclass
+class TurnResult:
+    """The terminal outcome of one model turn, produced by a ``TurnEngine``.
+
+    The engine has already streamed any text/thinking deltas to the caller by
+    the time it yields this; the controller uses these fields to decide whether
+    to execute tools, stop, or emit a diagnostic.
+    """
+
+    text: str
+    finish_reason: Optional[str]
+    # Number of tool-call slots the provider emitted *before* filtering (a slot
+    # that never received a name is unusable and dropped from ``tool_calls``, but
+    # still counted here so the controller's "did the model try to call a tool?"
+    # check matches the pre-refactor behaviour).
+    raw_tool_call_count: int
+    tool_calls: List[NormalizedToolCall]
+    # Provider-shape assistant message to append to history when continuing.
+    assistant_message: Optional[Dict[str, Any]]
+    # Diagnostic to surface when the model dumped raw tool-call JSON as text
+    # instead of making a structured call (populated only on the first turn).
+    malformed_help: Optional[str]
+    interaction_id: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    duration_ms: int = 0
+
+
+class TurnEngine(Protocol):
+    """Provider adapter driven by :class:`LoopController`.
+
+    Implementations own their message-history dialect. ``stream_turn`` yields
+    SSE-compatible delta dicts (``text``/``thinking``/…) as they arrive and
+    terminates by yielding exactly one :class:`TurnResult`.
+    """
+
+    #: Resolved model id (for cost lookup).
+    model: str
+    #: Provider type string, e.g. "ollama"/"openai" (for cost lookup).
+    provider_type: str
+    #: Human-readable model label for interaction logs, e.g. "ollama/llama3".
+    model_label: str
+
+    def stream_turn(
+        self, *, iteration: int
+    ) -> AsyncIterator[Union[Dict[str, Any], TurnResult]]: ...
+
+    def append_assistant(self, turn: TurnResult) -> None: ...
+
+    def append_tool_result(
+        self, tool_call_id: str, result_text: str, is_error: bool
+    ) -> None: ...
+
+
+class OpenAITurnEngine:
+    """OpenAI-compatible :class:`TurnEngine` over ``LLMRouter.stream_openai_raw``.
+
+    Owns an OpenAI chat-completion message history and reassembles streamed
+    deltas (text + tool-call fragments) into a :class:`TurnResult`. Lifted from
+    the body of the old ``OpenAIAgentService.stream``.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: ProviderSpec,
+        messages: List[Dict[str, Any]],
+        system_prompt: Optional[str],
+        model: str,
+        max_tokens: int,
+        temperature: Optional[float],
+        tools: List[Dict[str, Any]],
+        history_window: int = _HISTORY_WINDOW_DEFAULT,
+        router: Optional[LLMRouter] = None,
+    ):
+        self._provider = provider
+        self._system_prompt = system_prompt
+        self._model = model
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+        self._tools = tools
+        self._router = router or LLMRouter()
+        # The loop appends assistant/tool turns in OpenAI shape, so normalize the
+        # incoming history up front; the router re-converts idempotently.
+        history = anthropic_messages_to_openai(messages)
+        self._history = _apply_history_window(history, history_window)
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def provider_type(self) -> str:
+        return self._provider.provider_type
+
+    @property
+    def model_label(self) -> str:
+        return f"{self._provider.provider_type}/{self._model}"
+
+    def append_assistant(self, turn: TurnResult) -> None:
+        if turn.assistant_message is not None:
+            self._history.append(turn.assistant_message)
+
+    def append_tool_result(
+        self, tool_call_id: str, result_text: str, is_error: bool
+    ) -> None:
+        # OpenAI tool messages carry no is_error field, so mark failures inline —
+        # otherwise the model treats an error as a valid result.
+        self._history.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call_id,
+                "content": (f"ERROR: {result_text}" if is_error else result_text),
+            }
+        )
+
+    async def stream_turn(
+        self, *, iteration: int
+    ) -> AsyncIterator[Union[Dict[str, Any], TurnResult]]:
+        interaction_id = str(uuid.uuid4())
+        text_buffer = ""
+        tool_calls_buffer: Dict[int, Dict[str, Any]] = {}
+        finish_reason: Optional[str] = None
+        input_tokens = 0
+        output_tokens = 0
+        iter_start = time.monotonic()
+
+        async for chunk in self._router.stream_openai_raw(
+            provider=self._provider,
+            messages=self._history,
+            system_prompt=self._system_prompt,
+            model=self._model,
+            max_tokens=self._max_tokens,
+            temperature=self._temperature,
+            tools=self._tools or None,
+            interaction_id=interaction_id,
+            # Ask for a final usage-only chunk so token counts (and thus cost)
+            # are recorded — without this, streamed responses carry no usage and
+            # analytics would show $0 for OpenAI/Groq/Ollama.
+            include_usage=True,
+        ):
+            # The usage-only chunk (include_usage) arrives with an empty
+            # ``choices`` list, so read usage before skipping it.
+            usage = getattr(chunk, "usage", None)
+            if usage:
+                input_tokens = getattr(usage, "prompt_tokens", 0) or 0
+                output_tokens = getattr(usage, "completion_tokens", 0) or 0
+            if not chunk.choices:
+                continue
+            choice = chunk.choices[0]
+            delta = choice.delta
+            finish_reason = choice.finish_reason or finish_reason
+
+            if delta and delta.content:
+                text_buffer += delta.content
+                yield {"type": "text", "content": delta.content}
+
+            if delta and delta.tool_calls:
+                for tc_delta in delta.tool_calls:
+                    idx = tc_delta.index
+                    if idx not in tool_calls_buffer:
+                        tool_calls_buffer[idx] = {
+                            "id": tc_delta.id or "",
+                            "name": "",
+                            "arguments": "",
+                        }
+                    entry = tool_calls_buffer[idx]
+                    if tc_delta.id:
+                        entry["id"] = tc_delta.id
+                    if tc_delta.function:
+                        if tc_delta.function.name:
+                            entry["name"] += tc_delta.function.name
+                        if tc_delta.function.arguments:
+                            entry["arguments"] += tc_delta.function.arguments
+
+        duration_ms = int((time.monotonic() - iter_start) * 1000)
+
+        # Build the assistant message + normalized tool calls from the buffer.
+        assistant_msg: Dict[str, Any] = {"role": "assistant"}
+        if text_buffer:
+            assistant_msg["content"] = text_buffer
+        normalized: List[NormalizedToolCall] = []
+        oai_tool_calls: List[Dict[str, Any]] = []
+        for idx in sorted(tool_calls_buffer.keys()):
+            tc = tool_calls_buffer[idx]
+            name = (tc["name"] or "").strip()
+            if not name:
+                # A tool-call slot that never received a function name is unusable
+                # — skip it rather than emit a malformed call the provider rejects.
+                logger.warning(
+                    "Skipping tool call %d with empty name (id=%r)", idx, tc["id"]
+                )
+                continue
+            # Some providers omit the streamed id; synthesize a stable one so tool
+            # results can be correlated back to the call.
+            call_id = tc["id"] or f"call_{uuid.uuid4().hex[:12]}"
+            oai_tool_calls.append(
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": name, "arguments": tc["arguments"]},
+                }
+            )
+            normalized.append(
+                NormalizedToolCall(id=call_id, name=name, arguments=tc["arguments"])
+            )
+        if oai_tool_calls:
+            assistant_msg["tool_calls"] = oai_tool_calls
+
+        malformed_help = None
+        # Detect malformed tool calls dumped as text (common with smaller models
+        # that attempt tool use but fail at structured output). Only relevant on
+        # a turn with no actionable tool call — mirror the original loop's gate
+        # (``finish_reason != "tool_calls" or not tool_calls_buffer``) so a turn
+        # that *did* call a tool never triggers a spurious warning.
+        finished = finish_reason != "tool_calls" or not tool_calls_buffer
+        if (
+            finished
+            and text_buffer
+            and iteration == 0
+            and (
+                '{"type":"function"' in text_buffer
+                or ('"function"' in text_buffer and '"parameters"' in text_buffer)
+            )
+        ):
+            logger.warning(
+                "Model output contains raw tool-call JSON in text "
+                "(model may not support structured tool calling)"
+            )
+            malformed_help = (
+                "I attempted to use tools but this model doesn't reliably "
+                "support structured tool calling. Please select a more capable "
+                "model in Settings > AI Config (e.g., sec8-tools, gpt-4o, or any "
+                "7B+ model with tool support)."
+            )
+
+        yield TurnResult(
+            text=text_buffer,
+            finish_reason=finish_reason,
+            raw_tool_call_count=len(tool_calls_buffer),
+            tool_calls=normalized,
+            assistant_message=assistant_msg,
+            malformed_help=malformed_help,
+            interaction_id=interaction_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            duration_ms=duration_ms,
+        )
+
+
+class _ToolRuntime(Protocol):
+    """The tool-side collaborator the controller calls back into.
+
+    In PR3a this is the ``OpenAIAgentService`` instance (so its existing,
+    unit-tested methods — and any test doubles patched onto them — keep being
+    the code that runs). Relocating these into the controller is deferred.
+    """
+
+    async def _execute_tool(
+        self, tool_name: str, raw_arguments: str, *, approved: bool = False
+    ) -> "tuple[str, bool]": ...
+
+    async def _await_approval(self, action_id: str) -> "tuple[str, str, float]": ...
+
+    def _mark_action_executed(
+        self, action_id: Optional[str], result_text: str, is_error: bool
+    ) -> None: ...
+
+    def _compute_cost(
+        self, model: str, provider_type: str, input_tokens: int, output_tokens: int
+    ) -> float: ...
+
+    def _log_interaction(self, **kwargs: Any) -> None: ...
+
+
+class LoopController:
+    """Provider-agnostic multi-turn agentic tool loop.
+
+    Drives a :class:`TurnEngine` for model I/O and a ``runtime`` handle for tool
+    execution / approval / telemetry. Yields SSE-compatible event dicts matching
+    the frontend protocol.
+    """
+
+    def __init__(
+        self,
+        *,
+        engine: TurnEngine,
+        runtime: Any,
+        max_iterations: int = _MAX_TOOL_ITERATIONS,
+        max_processing_time_s: float = _MAX_PROCESSING_TIME_S,
+    ):
+        self._engine = engine
+        self._runtime = runtime
+        self._max_iterations = max_iterations
+        self._max_processing_time_s = max_processing_time_s
+
+    async def run(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """Run the agentic loop, yielding SSE event dicts.
+
+        Guardrails (unchanged from the pre-refactor OpenAI loop):
+            - iteration cap (default 30)
+            - wall-clock timeout (default 300s)
+            - exponential inter-iteration backoff
+            - infinite loop detection (3 repeated identical tool sets)
+        """
+        engine = self._engine
+        runtime = self._runtime
+
+        start_time = asyncio.get_event_loop().time()
+        tool_call_history: deque = deque(maxlen=_LOOP_DETECT_WINDOW)
+
+        for iteration in range(self._max_iterations):
+            elapsed = asyncio.get_event_loop().time() - start_time
+            if elapsed > self._max_processing_time_s:
+                yield {
+                    "type": "text",
+                    "content": (
+                        "\n\n[Maximum processing time "
+                        f"({self._max_processing_time_s:.0f}s) exceeded "
+                        f"after {iteration} iterations.]"
+                    ),
+                }
+                break
+
+            if iteration > 0:
+                await asyncio.sleep(_inter_iteration_delay(iteration))
+
+            # Stream one model turn; re-yield deltas, capture the terminal result.
+            turn: Optional[TurnResult] = None
+            try:
+                async for item in engine.stream_turn(iteration=iteration):
+                    if isinstance(item, TurnResult):
+                        turn = item
+                    else:
+                        yield item
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Turn stream error iteration %d: %s", iteration, exc)
+                yield {"type": "error", "content": str(exc)}
+                break
+
+            if turn is None:
+                # A well-behaved engine always yields a terminal TurnResult; if
+                # one didn't, stop rather than spin.
+                break
+
+            cost_usd = runtime._compute_cost(
+                engine.model,
+                engine.provider_type,
+                turn.input_tokens,
+                turn.output_tokens,
+            )
+            runtime._log_interaction(
+                session_id=session_id,
+                agent_id=agent_id,
+                model=engine.model_label,
+                iteration=iteration,
+                interaction_id=turn.interaction_id,
+                duration_ms=turn.duration_ms,
+                text_content=turn.text,
+                tool_calls_count=turn.raw_tool_call_count,
+                finish_reason=turn.finish_reason,
+                input_tokens=turn.input_tokens,
+                output_tokens=turn.output_tokens,
+                cost_usd=cost_usd,
+            )
+
+            # No actionable tool call → done.
+            if turn.finish_reason != "tool_calls" or turn.raw_tool_call_count == 0:
+                if turn.malformed_help:
+                    yield {"type": "text", "content": turn.malformed_help}
+                break
+
+            if not turn.tool_calls:
+                # Every tool-call slot was malformed (empty name). Surface any
+                # assistant text and stop rather than loop on an empty turn.
+                if turn.assistant_message and "content" in turn.assistant_message:
+                    engine.append_assistant(turn)
+                break
+
+            engine.append_assistant(turn)
+
+            # Infinite loop detection (canonicalized args so cosmetic streaming
+            # differences don't defeat repeat detection).
+            call_signature = frozenset(
+                "{}:{}".format(tc.name, _canonical_args(tc.arguments))
+                for tc in turn.tool_calls
+            )
+            tool_call_history.append(call_signature)
+            if _detect_infinite_loop(tool_call_history):
+                yield {
+                    "type": "text",
+                    "content": (
+                        "\n\n[Stopping: repeated identical tool calls "
+                        "detected (possible infinite loop).]"
+                    ),
+                }
+                break
+
+            halt = False
+            for tc in turn.tool_calls:
+                tool_name = tc.name
+                tool_call_id = tc.id
+                raw_args = tc.arguments
+
+                yield {
+                    "type": "tool_processing",
+                    "tool_name": tool_name,
+                    "tool_id": tool_call_id,
+                }
+
+                try:
+                    result_text, is_error = await runtime._execute_tool(
+                        tool_name, raw_args
+                    )
+                except PendingApprovalError as exc:
+                    # Hold the run here until an operator decides, so a run never
+                    # completes with the action un-taken.
+                    yield {
+                        "type": "approval_required",
+                        "tool_name": tool_name,
+                        "tool_id": tool_call_id,
+                        "action_id": exc.action_id,
+                        "content": str(exc),
+                    }
+                    yield {"type": "text", "content": f"\n\n_{exc}_\n\n"}
+                    if not exc.action_id:
+                        # No action to poll — fail closed rather than hang.
+                        yield {"type": "error", "content": str(exc)}
+                        halt = True
+                        break
+                    decision, detail, waited = await runtime._await_approval(
+                        exc.action_id
+                    )
+                    # Human think-time isn't LLM processing time.
+                    start_time += waited
+                    if decision == "approved":
+                        result_text, is_error = await runtime._execute_tool(
+                            tool_name, raw_args, approved=True
+                        )
+                        runtime._mark_action_executed(
+                            exc.action_id, result_text, is_error
+                        )
+                    elif decision == "rejected":
+                        result_text, is_error = (
+                            f"Operator REJECTED this action. Reason: {detail}. "
+                            "Do not retry it; continue with another approach or "
+                            "report that the step could not be completed.",
+                            True,
+                        )
+                    else:
+                        yield {"type": "error", "content": detail}
+                        halt = True
+                        break
+
+                preview = result_text[:500] + ("…" if len(result_text) > 500 else "")
+                yield {
+                    "type": "tool_result",
+                    "tool_name": tool_name,
+                    "tool_id": tool_call_id,
+                    "result": preview,
+                    "is_error": is_error,
+                }
+
+                engine.append_tool_result(tool_call_id, result_text, is_error)
+            if halt:
+                return
+        else:
+            # for/else: loop exhausted without break
+            yield {
+                "type": "text",
+                "content": (
+                    f"\n\n[Tool iteration limit ({self._max_iterations}) "
+                    "reached. Stopping.]"
+                ),
+            }

--- a/services/openai_agent_service.py
+++ b/services/openai_agent_service.py
@@ -4,39 +4,30 @@ import asyncio
 import json
 import logging
 import time
-import uuid
 from collections import deque
 from typing import Any, AsyncIterator, Dict, List, Optional, Set
 
 from services import tool_manager
+# The provider-agnostic loop skeleton (guards, backoff, loop-detection, tool
+# exec/approval orchestration, telemetry) now lives in services.agent_loop. This
+# service supplies the OpenAI TurnEngine plus the tool-execution runtime the
+# controller calls back into. Several private names are re-exported here so
+# existing imports (and their tests) keep resolving from this module.
+from services.agent_loop import (_HISTORY_WINDOW_DEFAULT,  # noqa: F401
+                                 _LOOP_DETECT_THRESHOLD, LoopController,
+                                 OpenAITurnEngine, PendingApprovalError,
+                                 _canonical_args, _detect_infinite_loop)
 from services.llm_format import anthropic_tools_to_openai
-from services.llm_router import LLMRouter, ProviderSpec
+from services.llm_router import ProviderSpec
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["OpenAIAgentService", "anthropic_tools_to_openai"]
+__all__ = ["OpenAIAgentService", "PendingApprovalError", "anthropic_tools_to_openai"]
 
-_MAX_TOOL_ITERATIONS = 30
-_MAX_PROCESSING_TIME_S = 300.0
 _TOOL_TIMEOUT_S = 30.0
 _MAX_TOOL_RESPONSE_CHARS = 50_000
-_HISTORY_WINDOW_DEFAULT = 20
-_LOOP_DETECT_WINDOW = 5
-_LOOP_DETECT_THRESHOLD = 3
-_BASE_INTER_ITERATION_DELAY_S = 0.5
-_MAX_INTER_ITERATION_DELAY_S = 3.0
-_BACKOFF_ITERATION_THRESHOLD = 15
 _APPROVAL_POLL_INTERVAL_S = 5.0
 _APPROVAL_WAIT_TIMEOUT_S = 600.0
-
-
-class PendingApprovalError(Exception):
-    """Tool call blocked pending human approval; action_id is the queue row to
-    poll, or None when the request could not be created."""
-
-    def __init__(self, message: str, action_id: Optional[str] = None):
-        super().__init__(message)
-        self.action_id = action_id
 
 
 def _truncate(text: str, max_chars: int = _MAX_TOOL_RESPONSE_CHARS) -> str:
@@ -44,31 +35,6 @@ def _truncate(text: str, max_chars: int = _MAX_TOOL_RESPONSE_CHARS) -> str:
         return text
     omitted = len(text) - max_chars
     return text[:max_chars] + f"\n...[truncated, {omitted} chars omitted]"
-
-
-def _inter_iteration_delay(iteration: int) -> float:
-    """Exponential backoff matching ClaudeService: 500ms base, ramp after 15."""
-    if iteration <= _BACKOFF_ITERATION_THRESHOLD:
-        return _BASE_INTER_ITERATION_DELAY_S
-    exp = iteration - _BACKOFF_ITERATION_THRESHOLD
-    delay = _BASE_INTER_ITERATION_DELAY_S * (1.5**exp)
-    return min(delay, _MAX_INTER_ITERATION_DELAY_S)
-
-
-def _canonical_args(raw: str) -> str:
-    """Canonicalize tool-call argument JSON for stable loop detection.
-
-    Parse and re-serialize with sorted keys so cosmetic streaming
-    differences (whitespace, key ordering) don't make a repeated call look
-    distinct and defeat the infinite-loop guard. Falls back to the stripped
-    raw string when the arguments aren't valid JSON.
-    """
-    try:
-        return json.dumps(
-            json.loads(raw or "{}"), sort_keys=True, separators=(",", ":")
-        )
-    except (json.JSONDecodeError, TypeError):
-        return (raw or "").strip()
 
 
 class OpenAIAgentService:
@@ -141,27 +107,6 @@ class OpenAIAgentService:
         """
         return bool(self._all_tools_openai_format())
 
-    @staticmethod
-    def _apply_history_window(
-        messages: List[Dict[str, Any]],
-        window: int = _HISTORY_WINDOW_DEFAULT,
-    ) -> List[Dict[str, Any]]:
-        """Enforce a sliding history window (configurable max turns).
-
-        Keeps the system message (if first) + the most recent `window * 2`
-        messages. Matches ClaudeService._apply_history_window behavior.
-        """
-        if window <= 0:
-            return messages
-        max_msgs = window * 2
-        if len(messages) <= max_msgs:
-            return messages
-        # Preserve system message at index 0 if present
-        if messages and messages[0].get("role") == "system":
-            keep = max_msgs - 1
-            return [messages[0]] + messages[-keep:]
-        return messages[-max_msgs:]
-
     async def stream(
         self,
         *,
@@ -193,301 +138,32 @@ class OpenAIAgentService:
             - Infinite loop detection (3 repeated identical tool sets)
         """
         # Stash attribution context for tool gating (approval requests) raised
-        # deep in the loop without threading it through every call.
+        # deep in the loop without threading it through every call. The
+        # controller drives this instance as its ``runtime`` — the approval and
+        # tool-exec callbacks below read these.
         self._session_id = session_id
         self._agent_id = agent_id
 
-        router = LLMRouter()
         model = model or provider.default_model
-
         tools = self._all_tools_openai_format() if enable_tools else []
 
-        from services.llm_format import anthropic_messages_to_openai
-
-        # The loop appends assistant/tool turns in OpenAI shape, so normalize
-        # the incoming history up front; the router re-converts idempotently.
-        oai_messages = anthropic_messages_to_openai(messages)
-        oai_messages = self._apply_history_window(oai_messages, history_window)
-
-        start_time = asyncio.get_event_loop().time()
-
-        # Infinite loop detection state
-        tool_call_history: deque = deque(maxlen=_LOOP_DETECT_WINDOW)
-
-        for iteration in range(_MAX_TOOL_ITERATIONS):
-            elapsed = asyncio.get_event_loop().time() - start_time
-            if elapsed > _MAX_PROCESSING_TIME_S:
-                yield {
-                    "type": "text",
-                    "content": (
-                        "\n\n[Maximum processing time "
-                        f"({_MAX_PROCESSING_TIME_S:.0f}s) exceeded "
-                        f"after {iteration} iterations.]"
-                    ),
-                }
-                break
-
-            if iteration > 0:
-                delay = _inter_iteration_delay(iteration)
-                await asyncio.sleep(delay)
-
-            interaction_id = str(uuid.uuid4())
-
-            # Accumulate streamed response
-            text_buffer = ""
-            tool_calls_buffer: Dict[int, Dict[str, Any]] = {}
-            finish_reason: Optional[str] = None
-            input_tokens = 0
-            output_tokens = 0
-            iter_start = time.monotonic()
-
-            try:
-                async for chunk in router.stream_openai_raw(
-                    provider=provider,
-                    messages=oai_messages,
-                    system_prompt=system_prompt,
-                    model=model,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    tools=tools or None,
-                    interaction_id=interaction_id,
-                    # Ask for a final usage-only chunk so token counts (and thus
-                    # cost) are recorded — without this, streamed responses carry
-                    # no usage and analytics would show $0 for OpenAI/Groq/Ollama.
-                    include_usage=True,
-                ):
-                    # The usage-only chunk (include_usage) arrives with an
-                    # empty ``choices`` list, so read usage before skipping it.
-                    usage = getattr(chunk, "usage", None)
-                    if usage:
-                        input_tokens = getattr(usage, "prompt_tokens", 0) or 0
-                        output_tokens = getattr(usage, "completion_tokens", 0) or 0
-                    if not chunk.choices:
-                        continue
-                    choice = chunk.choices[0]
-                    delta = choice.delta
-                    finish_reason = choice.finish_reason or finish_reason
-
-                    if delta and delta.content:
-                        text_buffer += delta.content
-                        yield {"type": "text", "content": delta.content}
-
-                    if delta and delta.tool_calls:
-                        for tc_delta in delta.tool_calls:
-                            idx = tc_delta.index
-                            if idx not in tool_calls_buffer:
-                                tool_calls_buffer[idx] = {
-                                    "id": tc_delta.id or "",
-                                    "name": "",
-                                    "arguments": "",
-                                }
-                            entry = tool_calls_buffer[idx]
-                            if tc_delta.id:
-                                entry["id"] = tc_delta.id
-                            if tc_delta.function:
-                                if tc_delta.function.name:
-                                    entry["name"] += tc_delta.function.name
-                                if tc_delta.function.arguments:
-                                    entry["arguments"] += tc_delta.function.arguments
-
-            except Exception as exc:
-                logger.error("OpenAI stream error iteration %d: %s", iteration, exc)
-                yield {"type": "error", "content": str(exc)}
-                break
-
-            iter_duration_ms = int((time.monotonic() - iter_start) * 1000)
-            cost_usd = self._compute_cost(
-                model, provider.provider_type, input_tokens, output_tokens
-            )
-
-            # Persist interaction log (non-fatal)
-            self._log_interaction(
-                session_id=session_id,
-                agent_id=agent_id,
-                model=f"{provider.provider_type}/{model}",
-                iteration=iteration,
-                interaction_id=interaction_id,
-                duration_ms=iter_duration_ms,
-                text_content=text_buffer,
-                tool_calls_count=len(tool_calls_buffer),
-                finish_reason=finish_reason,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cost_usd=cost_usd,
-            )
-
-            # No tool calls → done
-            if finish_reason != "tool_calls" or not tool_calls_buffer:
-                # Detect malformed tool calls dumped as text (common with
-                # smaller models that attempt tool use but fail at structured
-                # output). Filter it rather than passing hallucinated JSON.
-                if (
-                    text_buffer
-                    and iteration == 0
-                    and (
-                        '{"type":"function"' in text_buffer
-                        or (
-                            '"function"' in text_buffer
-                            and '"parameters"' in text_buffer
-                        )
-                    )
-                ):
-                    logger.warning(
-                        "Model output contains raw tool-call JSON in text "
-                        "(model may not support structured tool calling)"
-                    )
-                    yield {
-                        "type": "text",
-                        "content": (
-                            "I attempted to use tools but this model doesn't "
-                            "reliably support structured tool calling. Please "
-                            "select a more capable model in Settings > AI Config "
-                            "(e.g., sec8-tools, gpt-4o, or any 7B+ model with "
-                            "tool support)."
-                        ),
-                    }
-                break
-
-            # Build assistant message with tool_calls
-            assistant_msg: Dict[str, Any] = {"role": "assistant"}
-            if text_buffer:
-                assistant_msg["content"] = text_buffer
-            assistant_tool_calls = []
-            for idx in sorted(tool_calls_buffer.keys()):
-                tc = tool_calls_buffer[idx]
-                name = (tc["name"] or "").strip()
-                if not name:
-                    # A tool-call slot that never received a function name is
-                    # unusable — skip it rather than emit a malformed call the
-                    # provider will reject.
-                    logger.warning(
-                        "Skipping tool call %d with empty name (id=%r)", idx, tc["id"]
-                    )
-                    continue
-                assistant_tool_calls.append(
-                    {
-                        # Some providers omit the streamed id; synthesize a stable
-                        # one so tool results can be correlated back to the call.
-                        "id": tc["id"] or f"call_{uuid.uuid4().hex[:12]}",
-                        "type": "function",
-                        "function": {"name": name, "arguments": tc["arguments"]},
-                    }
-                )
-
-            if not assistant_tool_calls:
-                # Every tool-call slot was malformed. Surface any assistant
-                # text and stop rather than loop on an empty turn.
-                if "content" in assistant_msg:
-                    oai_messages.append(assistant_msg)
-                break
-
-            assistant_msg["tool_calls"] = assistant_tool_calls
-            oai_messages.append(assistant_msg)
-
-            # Infinite loop detection (canonicalized args so cosmetic
-            # streaming differences don't defeat repeat detection)
-            call_signature = frozenset(
-                "{}:{}".format(
-                    tc["function"]["name"],
-                    _canonical_args(tc["function"]["arguments"]),
-                )
-                for tc in assistant_tool_calls
-            )
-            tool_call_history.append(call_signature)
-            if self._detect_infinite_loop(tool_call_history):
-                yield {
-                    "type": "text",
-                    "content": (
-                        "\n\n[Stopping: repeated identical tool calls "
-                        "detected (possible infinite loop).]"
-                    ),
-                }
-                break
-
-            # Execute each tool and append results
-            halt = False
-            for tc in assistant_tool_calls:
-                tool_name = tc["function"]["name"]
-                tool_call_id = tc["id"]
-                raw_args = tc["function"]["arguments"]
-
-                yield {
-                    "type": "tool_processing",
-                    "tool_name": tool_name,
-                    "tool_id": tool_call_id,
-                }
-
-                try:
-                    result_text, is_error = await self._execute_tool(
-                        tool_name, raw_args
-                    )
-                except PendingApprovalError as exc:
-                    # Hold the run here until an operator decides, so a run
-                    # never completes with the action un-taken.
-                    yield {
-                        "type": "approval_required",
-                        "tool_name": tool_name,
-                        "tool_id": tool_call_id,
-                        "action_id": exc.action_id,
-                        "content": str(exc),
-                    }
-                    yield {"type": "text", "content": f"\n\n_{exc}_\n\n"}
-                    if not exc.action_id:
-                        # No action to poll — fail closed rather than hang.
-                        yield {"type": "error", "content": str(exc)}
-                        halt = True
-                        break
-                    decision, detail, waited = await self._await_approval(exc.action_id)
-                    # Human think-time isn't LLM processing time.
-                    start_time += waited
-                    if decision == "approved":
-                        result_text, is_error = await self._execute_tool(
-                            tool_name, raw_args, approved=True
-                        )
-                        self._mark_action_executed(exc.action_id, result_text, is_error)
-                    elif decision == "rejected":
-                        result_text, is_error = (
-                            f"Operator REJECTED this action. Reason: {detail}. "
-                            "Do not retry it; continue with another approach or "
-                            "report that the step could not be completed.",
-                            True,
-                        )
-                    else:
-                        yield {"type": "error", "content": detail}
-                        halt = True
-                        break
-
-                preview = result_text[:500] + ("…" if len(result_text) > 500 else "")
-                yield {
-                    "type": "tool_result",
-                    "tool_name": tool_name,
-                    "tool_id": tool_call_id,
-                    "result": preview,
-                    "is_error": is_error,
-                }
-
-                # OpenAI tool messages carry no is_error field, so mark failures
-                # inline — otherwise the model treats an error as a valid result.
-                oai_messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": tool_call_id,
-                        "content": (
-                            f"ERROR: {result_text}" if is_error else result_text
-                        ),
-                    }
-                )
-            if halt:
-                return
-        else:
-            # for/else: loop exhausted without break
-            yield {
-                "type": "text",
-                "content": (
-                    f"\n\n[Tool iteration limit ({_MAX_TOOL_ITERATIONS}) "
-                    "reached. Stopping.]"
-                ),
-            }
+        # Provider-specific model I/O lives in the engine; the provider-agnostic
+        # loop skeleton (guards, backoff, loop-detection, tool-exec/approval
+        # orchestration, telemetry) lives in the controller, which calls back
+        # into this service for tool execution, approval, cost, and logging.
+        engine = OpenAITurnEngine(
+            provider=provider,
+            messages=messages,
+            system_prompt=system_prompt,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tools=tools,
+            history_window=history_window,
+        )
+        controller = LoopController(engine=engine, runtime=self)
+        async for event in controller.run(session_id=session_id, agent_id=agent_id):
+            yield event
 
     async def run(
         self,
@@ -533,11 +209,12 @@ class OpenAIAgentService:
 
     @staticmethod
     def _detect_infinite_loop(history: deque) -> bool:
-        """Detect if the same tool call set repeats >= threshold times."""
-        if len(history) < _LOOP_DETECT_THRESHOLD:
-            return False
-        recent = list(history)[-_LOOP_DETECT_THRESHOLD:]
-        return len(set(recent)) == 1
+        """Detect if the same tool call set repeats >= threshold times.
+
+        Kept as a thin passthrough to the controller's implementation so
+        existing callers/tests that reach for it on this class still resolve.
+        """
+        return _detect_infinite_loop(history)
 
     async def _execute_tool(
         self, tool_name: str, raw_arguments: str, *, approved: bool = False
@@ -576,7 +253,8 @@ class OpenAIAgentService:
         """Queue a pending approval instead of executing the tool, returning the
         message for the model and the action id to poll (None if not created)."""
         try:
-            from services.approval_service import ActionType, get_approval_service
+            from services.approval_service import (ActionType,
+                                                   get_approval_service)
 
             service = get_approval_service()
             try:
@@ -622,7 +300,8 @@ class OpenAIAgentService:
         """Poll the approval queue until an operator decides, returning
         ``(decision, detail, waited_seconds)``. A vanished action reads as a
         rejection so an uncleared action never executes."""
-        from services.approval_service import ActionStatus, get_approval_service
+        from services.approval_service import (ActionStatus,
+                                               get_approval_service)
 
         service = get_approval_service()
         started = time.monotonic()

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -1,0 +1,465 @@
+"""Unit tests for the provider-agnostic agent loop (services/agent_loop.py).
+
+These exercise the two halves of the refactored OpenAI agent loop in isolation:
+
+  - ``LoopController`` — the provider-agnostic loop skeleton (iteration/wall-clock
+    guards, backoff, loop-detection, tool exec + approval flow, telemetry, the
+    iteration-limit message). Driven here against a *fake* engine and a *fake*
+    runtime so the control flow is tested without any provider or DB.
+  - ``OpenAITurnEngine`` — the OpenAI dialect (delta reassembly, tool-call
+    normalization, usage, the malformed-tool-JSON heuristic). Driven with a
+    mocked ``stream_openai_raw``.
+
+The end-to-end behaviour parity guard lives in test_openai_agent_service.py; this
+file adds focused coverage of the new seam.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from services.agent_loop import (LoopController,  # noqa: E402
+                                 NormalizedToolCall, OpenAITurnEngine,
+                                 PendingApprovalError, TurnResult,
+                                 _canonical_args, _inter_iteration_delay)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# Pure helpers
+# --------------------------------------------------------------------------
+class TestCanonicalArgs:
+    def test_key_order_and_whitespace_equivalent(self):
+        assert _canonical_args('{"b": 1, "a": 2}') == _canonical_args('{"a":2,"b":1}')
+
+    def test_invalid_json_falls_back_to_stripped_raw(self):
+        assert _canonical_args("  not json  ") == "not json"
+
+
+class TestBackoff:
+    def test_flat_before_threshold(self):
+        assert _inter_iteration_delay(1) == 0.5
+        assert _inter_iteration_delay(15) == 0.5
+
+    def test_ramps_and_caps_after_threshold(self):
+        assert _inter_iteration_delay(16) > 0.5
+        assert _inter_iteration_delay(100) == 3.0
+
+
+# --------------------------------------------------------------------------
+# LoopController — driven by a fake engine + fake runtime
+# --------------------------------------------------------------------------
+class _FakeEngine:
+    """Scripts a sequence of TurnResults; records history mutations."""
+
+    provider_type = "ollama"
+    model = "llama3.1:8b"
+    model_label = "ollama/llama3.1:8b"
+
+    def __init__(self, turns, *, deltas_per_turn=None):
+        # turns: list of TurnResult; deltas_per_turn: optional list-of-lists of
+        # SSE delta dicts the engine yields before each turn's terminal result.
+        # When omitted, a text delta is auto-emitted for each turn's text — as a
+        # real engine streams text before yielding its terminal TurnResult (the
+        # controller never re-emits turn.text itself).
+        self._turns = list(turns)
+        if deltas_per_turn is None:
+            deltas_per_turn = [
+                [{"type": "text", "content": t.text}] if t.text else [] for t in turns
+            ]
+        self._deltas = deltas_per_turn
+        self._i = 0
+        self.appended_assistant = []
+        self.appended_tool_results = []
+
+    async def stream_turn(self, *, iteration):
+        idx = min(self._i, len(self._turns) - 1)
+        for delta in self._deltas[idx] if idx < len(self._deltas) else []:
+            yield delta
+        turn = self._turns[idx]
+        self._i += 1
+        yield turn
+
+    def append_assistant(self, turn):
+        self.appended_assistant.append(turn)
+
+    def append_tool_result(self, tool_call_id, result_text, is_error):
+        self.appended_tool_results.append((tool_call_id, result_text, is_error))
+
+
+def _runtime(**overrides):
+    rt = SimpleNamespace(
+        _execute_tool=AsyncMock(return_value=("RESULT", False)),
+        _await_approval=AsyncMock(return_value=("approved", "approved", 0.0)),
+        _mark_action_executed=MagicMock(),
+        _compute_cost=MagicMock(return_value=0.0),
+        _log_interaction=MagicMock(),
+    )
+    for k, v in overrides.items():
+        setattr(rt, k, v)
+    return rt
+
+
+def _turn(*, text="", tool_calls=None, finish_reason="stop", raw_count=None):
+    tcs = tool_calls or []
+    assistant = {"role": "assistant"}
+    if text:
+        assistant["content"] = text
+    if tcs:
+        assistant["tool_calls"] = [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {"name": tc.name, "arguments": tc.arguments},
+            }
+            for tc in tcs
+        ]
+    return TurnResult(
+        text=text,
+        finish_reason=finish_reason,
+        raw_tool_call_count=raw_count if raw_count is not None else len(tcs),
+        tool_calls=tcs,
+        assistant_message=assistant,
+        malformed_help=None,
+        interaction_id="iid",
+        input_tokens=1,
+        output_tokens=2,
+        duration_ms=3,
+    )
+
+
+async def _drive(engine, runtime, **kwargs):
+    controller = LoopController(engine=engine, runtime=runtime, **kwargs)
+    return [ev async for ev in controller.run()]
+
+
+@pytest.mark.asyncio
+async def test_text_only_turn_stops_without_tools():
+    engine = _FakeEngine(
+        [_turn(text="hi", finish_reason="stop")],
+        deltas_per_turn=[[{"type": "text", "content": "hi"}]],
+    )
+    runtime = _runtime()
+    events = await _drive(engine, runtime)
+    assert [e for e in events if e["type"] == "text"] == [
+        {"type": "text", "content": "hi"}
+    ]
+    assert not any(e["type"] == "tool_processing" for e in events)
+    runtime._execute_tool.assert_not_awaited()
+    runtime._log_interaction.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_tool_call_executes_then_finishes():
+    tc = NormalizedToolCall(id="call1", name="mytool", arguments='{"q":"x"}')
+    engine = _FakeEngine(
+        [
+            _turn(tool_calls=[tc], finish_reason="tool_calls"),
+            _turn(text="done", finish_reason="stop"),
+        ]
+    )
+    runtime = _runtime()
+    events = await _drive(engine, runtime)
+    assert [
+        e["type"] for e in events if e["type"] in ("tool_processing", "tool_result")
+    ] == [
+        "tool_processing",
+        "tool_result",
+    ]
+    runtime._execute_tool.assert_awaited_once_with("mytool", '{"q":"x"}')
+    assert engine.appended_tool_results == [("call1", "RESULT", False)]
+    assert any(e.get("content") == "done" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_tool_error_flag_propagates():
+    tc = NormalizedToolCall(id="c", name="mytool", arguments="{}")
+    engine = _FakeEngine(
+        [
+            _turn(tool_calls=[tc], finish_reason="tool_calls"),
+            _turn(text="ok", finish_reason="stop"),
+        ]
+    )
+    runtime = _runtime(_execute_tool=AsyncMock(return_value=("boom", True)))
+    events = await _drive(engine, runtime)
+    res = [e for e in events if e["type"] == "tool_result"]
+    assert res and res[0]["is_error"] is True
+    assert engine.appended_tool_results == [("c", "boom", True)]
+
+
+@pytest.mark.asyncio
+async def test_loop_detection_halts_on_repeats():
+    tc = NormalizedToolCall(id="c", name="mytool", arguments='{"q":"x"}')
+    # Same tool call every turn -> should trip the infinite-loop guard.
+    engine = _FakeEngine(
+        [_turn(tool_calls=[tc], finish_reason="tool_calls") for _ in range(6)]
+    )
+    runtime = _runtime()
+    with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+        events = await _drive(engine, runtime)
+    assert any(e["type"] == "text" and "infinite loop" in e["content"] for e in events)
+
+
+@pytest.mark.asyncio
+async def test_iteration_limit_message():
+    # Distinct args each turn so loop-detection never trips; hit the cap instead.
+    turns = [
+        _turn(
+            tool_calls=[
+                NormalizedToolCall(id=f"c{i}", name="t", arguments=f'{{"i":{i}}}')
+            ],
+            finish_reason="tool_calls",
+        )
+        for i in range(10)
+    ]
+    engine = _FakeEngine(turns)
+    runtime = _runtime()
+    with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+        events = await _drive(engine, runtime, max_iterations=3)
+    assert events[-1]["type"] == "text"
+    assert "iteration limit" in events[-1]["content"].lower()
+
+
+@pytest.mark.asyncio
+async def test_wall_clock_guard_stops_immediately():
+    engine = _FakeEngine([_turn(text="never", finish_reason="stop")])
+    runtime = _runtime()
+    # Negative budget => the very first elapsed check trips.
+    events = await _drive(engine, runtime, max_processing_time_s=-1.0)
+    assert events[-1]["type"] == "text"
+    assert "maximum processing time" in events[-1]["content"].lower()
+    runtime._execute_tool.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stream_error_is_surfaced_and_stops():
+    class _BoomEngine(_FakeEngine):
+        async def stream_turn(self, *, iteration):
+            yield {"type": "text", "content": "partial"}
+            raise RuntimeError("provider exploded")
+
+    engine = _BoomEngine([_turn()])
+    runtime = _runtime()
+    events = await _drive(engine, runtime)
+    assert events[-1] == {"type": "error", "content": "provider exploded"}
+    assert {"type": "text", "content": "partial"} in events
+    runtime._log_interaction.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Approval flow through the controller
+# --------------------------------------------------------------------------
+class TestApprovalFlow:
+    def _approval_engine(self):
+        tc = NormalizedToolCall(
+            id="call1", name="isolate_host", arguments='{"host":"h1"}'
+        )
+        return _FakeEngine(
+            [
+                _turn(tool_calls=[tc], finish_reason="tool_calls"),
+                _turn(text="contained", finish_reason="stop"),
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_approved_reexecutes_and_continues(self):
+        engine = self._approval_engine()
+        runtime = _runtime(
+            _execute_tool=AsyncMock(
+                side_effect=[
+                    PendingApprovalError("needs approval", "ACT-1"),
+                    ("isolated", False),
+                ]
+            ),
+            _await_approval=AsyncMock(return_value=("approved", "approved", 0.0)),
+        )
+        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+            events = await _drive(engine, runtime)
+        assert [e["action_id"] for e in events if e["type"] == "approval_required"] == [
+            "ACT-1"
+        ]
+        assert runtime._execute_tool.await_args_list[-1].kwargs == {"approved": True}
+        runtime._mark_action_executed.assert_called_once()
+        assert any(e.get("content") == "contained" for e in events)
+
+    @pytest.mark.asyncio
+    async def test_rejected_is_reported_not_executed(self):
+        engine = self._approval_engine()
+        runtime = _runtime(
+            _execute_tool=AsyncMock(
+                side_effect=PendingApprovalError("needs approval", "ACT-1")
+            ),
+            _await_approval=AsyncMock(return_value=("rejected", "too risky", 0.0)),
+        )
+        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+            events = await _drive(engine, runtime)
+        res = [e for e in events if e["type"] == "tool_result"]
+        assert res and res[0]["is_error"] is True
+        assert "REJECTED" in res[0]["result"] and "too risky" in res[0]["result"]
+        runtime._execute_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_timeout_halts_run(self):
+        engine = self._approval_engine()
+        runtime = _runtime(
+            _execute_tool=AsyncMock(
+                side_effect=PendingApprovalError("needs approval", "ACT-1")
+            ),
+            _await_approval=AsyncMock(return_value=("timeout", "timed out", 0.0)),
+        )
+        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+            events = await _drive(engine, runtime)
+        assert events[-1] == {"type": "error", "content": "timed out"}
+        assert not any(e.get("content") == "contained" for e in events)
+
+    @pytest.mark.asyncio
+    async def test_uncreatable_approval_fails_closed(self):
+        engine = self._approval_engine()
+        await_mock = AsyncMock()
+        runtime = _runtime(
+            _execute_tool=AsyncMock(
+                side_effect=PendingApprovalError("queue down", None)
+            ),
+            _await_approval=await_mock,
+        )
+        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+            events = await _drive(engine, runtime)
+        assert events[-1]["type"] == "error"
+        await_mock.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------
+# OpenAITurnEngine — delta reassembly against a mocked stream_openai_raw
+# --------------------------------------------------------------------------
+def _usage_chunk(prompt, completion):
+    usage = SimpleNamespace(prompt_tokens=prompt, completion_tokens=completion)
+    return SimpleNamespace(choices=[], usage=usage)
+
+
+def _tc(index, tc_id=None, name=None, arguments=None):
+    return SimpleNamespace(
+        index=index, id=tc_id, function=SimpleNamespace(name=name, arguments=arguments)
+    )
+
+
+class _StreamChunk:
+    def __init__(self, content=None, tool_calls=None, finish_reason=None):
+        delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+        self.choices = [SimpleNamespace(delta=delta, finish_reason=finish_reason)]
+        self.usage = None
+
+
+def _engine(tools=None, iteration_messages=None):
+    return OpenAITurnEngine(
+        provider=SimpleNamespace(provider_type="ollama", default_model="llama3.1:8b"),
+        messages=iteration_messages or [{"role": "user", "content": "hi"}],
+        system_prompt=None,
+        model="llama3.1:8b",
+        max_tokens=256,
+        temperature=None,
+        tools=tools or [],
+        history_window=20,
+    )
+
+
+async def _run_turn(engine, chunks, iteration=0):
+    async def _fake_stream(**_kwargs):
+        for c in chunks:
+            yield c
+
+    events = []
+    result = None
+    with patch(
+        "services.agent_loop.LLMRouter.stream_openai_raw",
+        side_effect=lambda **kw: _fake_stream(**kw),
+    ):
+        async for item in engine.stream_turn(iteration=iteration):
+            if isinstance(item, TurnResult):
+                result = item
+            else:
+                events.append(item)
+    return events, result
+
+
+class TestOpenAITurnEngine:
+    @pytest.mark.asyncio
+    async def test_text_reassembly_and_deltas(self):
+        chunks = [
+            _StreamChunk(content="hel"),
+            _StreamChunk(content="lo", finish_reason="stop"),
+        ]
+        events, result = await _run_turn(_engine(), chunks)
+        assert [e["content"] for e in events if e["type"] == "text"] == ["hel", "lo"]
+        assert result.text == "hello"
+        assert result.finish_reason == "stop"
+        assert result.tool_calls == []
+        assert result.raw_tool_call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_tool_call_reassembly_across_chunks(self):
+        chunks = [
+            _StreamChunk(tool_calls=[_tc(0, "id1", "mytool", '{"q":')]),
+            _StreamChunk(
+                tool_calls=[_tc(0, None, None, '"x"}')], finish_reason="tool_calls"
+            ),
+        ]
+        _events, result = await _run_turn(_engine(), chunks)
+        assert result.finish_reason == "tool_calls"
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "mytool"
+        assert result.tool_calls[0].arguments == '{"q":"x"}'
+        assert result.tool_calls[0].id == "id1"
+        assert "tool_calls" in result.assistant_message
+
+    @pytest.mark.asyncio
+    async def test_empty_name_tool_call_is_skipped_but_counted(self):
+        chunks = [
+            _StreamChunk(
+                tool_calls=[_tc(0, "id1", None, "{}")], finish_reason="tool_calls"
+            )
+        ]
+        _events, result = await _run_turn(_engine(), chunks)
+        assert result.tool_calls == []
+        assert result.raw_tool_call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_id_is_synthesized(self):
+        chunks = [
+            _StreamChunk(
+                tool_calls=[_tc(0, None, "mytool", "{}")], finish_reason="tool_calls"
+            )
+        ]
+        _events, result = await _run_turn(_engine(), chunks)
+        assert result.tool_calls[0].id.startswith("call_")
+
+    @pytest.mark.asyncio
+    async def test_usage_is_read_from_usage_only_chunk(self):
+        chunks = [
+            _StreamChunk(content="hi", finish_reason="stop"),
+            _usage_chunk(11, 22),
+        ]
+        _events, result = await _run_turn(_engine(), chunks)
+        assert result.input_tokens == 11 and result.output_tokens == 22
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_json_help_on_first_iteration(self):
+        text = 'Sure: {"type":"function","name":"x"}'
+        chunks = [_StreamChunk(content=text, finish_reason="stop")]
+        _events, result = await _run_turn(_engine(), chunks, iteration=0)
+        assert result.malformed_help is not None
+
+    @pytest.mark.asyncio
+    async def test_no_malformed_help_after_first_iteration(self):
+        text = 'Sure: {"type":"function","name":"x"}'
+        chunks = [_StreamChunk(content=text, finish_reason="stop")]
+        _events, result = await _run_turn(_engine(), chunks, iteration=1)
+        assert result.malformed_help is None

--- a/tests/unit/test_agent_runner_preflight.py
+++ b/tests/unit/test_agent_runner_preflight.py
@@ -76,7 +76,11 @@ def _stub_estimate(high_usd: float, low_usd: float = 0.0, source: str = "exact")
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # asyncio.run() creates, drives, and closes its own event loop, so this is
+    # robust regardless of whether a prior test left a current loop set. On
+    # Python 3.13, asyncio.get_event_loop() raises when no loop is current —
+    # which happened once an async test file ran earlier in the session (#442).
+    return asyncio.run(coro)
 
 
 def test_preflight_proceeds_when_estimate_fits_budget():


### PR DESCRIPTION
## What

Behaviour-preserving refactor that extracts the multi-turn agentic tool loop out of `OpenAIAgentService.stream` into a new, provider-agnostic seam in `services/agent_loop.py`:

- **`LoopController`** — the provider-agnostic loop skeleton: iteration/wall-clock guards, inter-iteration backoff, canonicalized loop-detection, the tool-execution + human-approval flow, per-turn telemetry, and the iteration-limit message.
- **`TurnEngine`** — the interface a provider adapter implements, plus **`OpenAITurnEngine`**, which speaks the OpenAI-compatible dialect (delta reassembly over `LLMRouter.stream_openai_raw`, tool-call normalization, usage accounting, malformed-tool-JSON heuristic).
- `OpenAIAgentService.stream()` now builds an engine + controller and delegates, passing itself as the controller's tool-exec/approval/telemetry **runtime**. Net **−321 lines** in that file.

Each engine owns its own message-history dialect, so the controller only ever handles provider-agnostic `TurnResult` / `NormalizedToolCall` values. A future `AnthropicTurnEngine` can keep native Anthropic-block history with no conversion at the boundary.

## Why

This is **PR3a** of the phased work to make `LLMRouter` the single LLM entry point (#413). It establishes the provider-agnostic loop seam that later sub-PRs build on (Anthropic engine, unified persistence/budget, `run_agent_task` passthrough) without landing one giant diff. This PR is purely structural — **no behaviour change**.

## How it was tested

- **Parity guard, unmodified:** the existing `tests/unit/test_openai_agent_service.py` (27 tests) passes **without edits** — it exercises the real controller + engine after the refactor and is the behaviour-preservation proof.
- **New focused unit tests:** `tests/unit/test_agent_loop.py` (22 tests) cover the controller against a fake engine/runtime (tool loop, loop-detection, wall-clock guard, iteration limit, streaming-error path, full approval flow) and the `OpenAITurnEngine` delta reassembly (text, tool-call fragments across chunks, empty-name skip, id synthesis, usage, malformed heuristic).
- **49/49 pass.** `black` / `isort` / `flake8` clean; `mypy` clean on `services/agent_loop.py`.
- A fresh-eyes reviewer did a line-by-line diff against the pre-refactor loop and confirmed identical yield ordering/payloads, `for/else` semantics, approval `start_time` adjustment, telemetry arguments, empty-name counting, the no-log-on-stream-error path, and that the re-exported `PendingApprovalError` is the same class the controller catches.

## Notes for reviewers

- Tool execution, approval gating, and interaction logging deliberately **stay** on `OpenAIAgentService` in this PR (the controller calls back into them). That keeps the parity suite green unmodified; relocating them into the controller is left for a later sub-PR alongside the Anthropic engine.
- Moved private names (`_canonical_args`, `_detect_infinite_loop`, `_LOOP_DETECT_THRESHOLD`, `PendingApprovalError`) are re-exported from `services/openai_agent_service.py` for compatibility.

Part of #413.

cc @johnvanlowe
