### PR TITLE
feat(#413): AnthropicTurnEngine behind the shared LoopController (PR3b)

### DIFF
--- a/frontend/src/components/claude/ClaudeDrawer.tsx
+++ b/frontend/src/components/claude/ClaudeDrawer.tsx
@@ -378,8 +378,8 @@ export default function ClaudeDrawer({ open, onClose, initialMessages, initialAg
                   if (!data) continue
                   let event: any
                   try { event = JSON.parse(data) } catch { continue }
-                  if (event.error) {
-                    throw new Error(event.error)
+                  if (event.error || event.type === 'error') {
+                    throw new Error(event.error || event.content || 'stream error')
                   } else if (event.type === 'thinking_start') {
                     setIsThinking(true)
                     currentThinking = ''
@@ -598,8 +598,8 @@ export default function ClaudeDrawer({ open, onClose, initialMessages, initialAg
                     continue
                   }
                   
-                  if (event.error) {
-                    throw new Error(event.error)
+                  if (event.error || event.type === 'error') {
+                    throw new Error(event.error || event.content || 'stream error')
                   } else if (event.type === 'context_windowed') {
                     logger.info(`Context compressed: ${event.windowed_messages} older messages condensed, ${event.remaining_messages} recent messages kept`)
                     currentText += `[Context compressed: ${event.windowed_messages} older messages were condensed to preserve context within the model's limits. Recent messages and all key details are preserved.]\n\n`

--- a/frontend/src/redesign/shell/Chat.tsx
+++ b/frontend/src/redesign/shell/Chat.tsx
@@ -622,7 +622,8 @@ export default function Chat({
             } catch {
               continue
             }
-            if (ev.error) throw new Error(ev.error)
+            if (ev.error || ev.type === 'error')
+              throw new Error(ev.error || ev.content || 'stream error')
             if (ev.type === 'thinking_start') {
               setIsThinking(true)
               curThinking = ''

--- a/services/agent_loop.py
+++ b/services/agent_loop.py
@@ -3,21 +3,22 @@
 This module houses the two halves of the multi-turn tool loop that used to live
 entirely inside ``OpenAIAgentService``:
 
-  - :class:`LoopController` — the **provider-agnostic** loop skeleton: iteration
-    and wall-clock guards, inter-iteration backoff, canonicalized loop-detection,
-    the tool-execution + human-approval flow, per-turn telemetry, and the
-    iteration-limit message. It knows nothing about any specific provider; it
-    drives a :class:`TurnEngine` for model I/O and calls back into a ``runtime``
-    handle for tool execution, approval, and logging.
+  - :class:`LoopController` — the **provider-agnostic** loop *sequencer*: only
+    the cross-cutting guards every provider shares — the iteration cap, the
+    wall-clock timeout, inter-iteration backoff, canonicalized loop-detection,
+    and the stop/limit messages. It knows nothing about any specific provider; it
+    drives a :class:`TurnEngine` and forwards its events.
   - :class:`TurnEngine` — the interface a provider adapter implements, plus the
     :class:`OpenAITurnEngine` adapter that speaks the OpenAI-compatible dialect
     (delta reassembly over ``LLMRouter.stream_openai_raw``, tool-call
-    normalization, usage accounting, and the malformed-tool-JSON heuristic).
+    normalization, per-tool gated execution, telemetry, usage accounting, and the
+    malformed-tool-JSON heuristic).
 
-Each engine owns its own message-history dialect; the controller only ever sees
-provider-agnostic :class:`TurnResult` / :class:`NormalizedToolCall` values. This
-lets a future ``AnthropicTurnEngine`` keep native Anthropic-block history without
-the controller having to convert anything.
+Each engine owns its own message-history dialect, SSE event vocabulary, tool
+execution/gating, and telemetry; the controller only ever sees provider-agnostic
+:class:`TurnResult` / :class:`ToolPhaseResult` values. This lets a future
+``AnthropicTurnEngine`` keep native Anthropic-block history, emit thinking
+events, and batch-execute tools without the controller having to know.
 
 Behaviour here is a straight lift of the previous ``OpenAIAgentService.stream``
 loop — the split is structural, not behavioural.
@@ -43,6 +44,7 @@ __all__ = [
     "PendingApprovalError",
     "NormalizedToolCall",
     "TurnResult",
+    "ToolPhaseResult",
     "TurnEngine",
     "OpenAITurnEngine",
     "LoopController",
@@ -162,12 +164,33 @@ class TurnResult:
     duration_ms: int = 0
 
 
+@dataclass
+class ToolPhaseResult:
+    """The terminal outcome of an engine's tool-execution phase.
+
+    ``halt`` tells the controller to stop the whole run immediately (e.g. an
+    approval failed closed or timed out). ``waited`` is human approval think-time
+    the controller adds back to its wall-clock baseline so operator delay isn't
+    charged against the processing-time guard.
+    """
+
+    halt: bool = False
+    waited: float = 0.0
+
+
 class TurnEngine(Protocol):
     """Provider adapter driven by :class:`LoopController`.
 
-    Implementations own their message-history dialect. ``stream_turn`` yields
-    SSE-compatible delta dicts (``text``/``thinking``/…) as they arrive and
-    terminates by yielding exactly one :class:`TurnResult`.
+    Implementations own their message-history dialect, their provider-shaped SSE
+    event vocabulary, their tool execution/gating, and their own telemetry — the
+    controller only sequences turns and enforces the cross-cutting guards. Each
+    engine is constructed per-run with its full context (session/agent, runtime).
+
+    ``stream_turn`` yields SSE-compatible delta dicts (``text``/``thinking``/…)
+    as they arrive, records its own interaction telemetry, and terminates by
+    yielding exactly one :class:`TurnResult`. ``execute_tools`` runs the tool
+    calls for a turn — yielding provider-shaped tool events, extending history,
+    and terminating with a :class:`ToolPhaseResult`.
     """
 
     #: Resolved model id (for cost lookup).
@@ -183,9 +206,9 @@ class TurnEngine(Protocol):
 
     def append_assistant(self, turn: TurnResult) -> None: ...
 
-    def append_tool_result(
-        self, tool_call_id: str, result_text: str, is_error: bool
-    ) -> None: ...
+    def execute_tools(
+        self, turn: TurnResult, *, iteration: int
+    ) -> AsyncIterator[Union[Dict[str, Any], ToolPhaseResult]]: ...
 
 
 class OpenAITurnEngine:
@@ -206,6 +229,9 @@ class OpenAITurnEngine:
         max_tokens: int,
         temperature: Optional[float],
         tools: List[Dict[str, Any]],
+        runtime: Any,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
         history_window: int = _HISTORY_WINDOW_DEFAULT,
         router: Optional[LLMRouter] = None,
     ):
@@ -215,6 +241,12 @@ class OpenAITurnEngine:
         self._max_tokens = max_tokens
         self._temperature = temperature
         self._tools = tools
+        # Tool execution, approval, and telemetry live on the runtime (the
+        # OpenAIAgentService instance) — the engine calls back into it, mirroring
+        # the PR3a arrangement now that the controller no longer owns that work.
+        self._runtime = runtime
+        self._session_id = session_id
+        self._agent_id = agent_id
         self._router = router or LLMRouter()
         # The loop appends assistant/tool turns in OpenAI shape, so normalize the
         # incoming history up front; the router re-converts idempotently.
@@ -237,7 +269,7 @@ class OpenAITurnEngine:
         if turn.assistant_message is not None:
             self._history.append(turn.assistant_message)
 
-    def append_tool_result(
+    def _append_tool_result(
         self, tool_call_id: str, result_text: str, is_error: bool
     ) -> None:
         # OpenAI tool messages carry no is_error field, so mark failures inline —
@@ -370,7 +402,7 @@ class OpenAITurnEngine:
                 "7B+ model with tool support)."
             )
 
-        yield TurnResult(
+        turn = TurnResult(
             text=text_buffer,
             finish_reason=finish_reason,
             raw_tool_call_count=len(tool_calls_buffer),
@@ -382,14 +414,117 @@ class OpenAITurnEngine:
             output_tokens=output_tokens,
             duration_ms=duration_ms,
         )
+        # Persist this iteration's interaction log (non-fatal, fire-and-forget)
+        # via the runtime, then hand the turn to the controller.
+        self._record_turn(turn, iteration)
+        yield turn
+
+    def _record_turn(self, turn: TurnResult, iteration: int) -> None:
+        """Record per-iteration cost + interaction telemetry via the runtime."""
+        cost_usd = self._runtime._compute_cost(
+            self._model,
+            self._provider.provider_type,
+            turn.input_tokens,
+            turn.output_tokens,
+        )
+        self._runtime._log_interaction(
+            session_id=self._session_id,
+            agent_id=self._agent_id,
+            model=self.model_label,
+            iteration=iteration,
+            interaction_id=turn.interaction_id,
+            duration_ms=turn.duration_ms,
+            text_content=turn.text,
+            tool_calls_count=turn.raw_tool_call_count,
+            finish_reason=turn.finish_reason,
+            input_tokens=turn.input_tokens,
+            output_tokens=turn.output_tokens,
+            cost_usd=cost_usd,
+        )
+
+    async def execute_tools(
+        self, turn: TurnResult, *, iteration: int
+    ) -> AsyncIterator[Union[Dict[str, Any], ToolPhaseResult]]:
+        """Execute a turn's tool calls, one at a time, through the runtime.
+
+        Each call passes through the runtime's tier/approval gate; a
+        ``requires_approval`` tool holds the run until an operator decides.
+        Yields ``tool_processing`` / ``tool_result`` / ``approval_required`` /
+        ``error`` events and terminates with a :class:`ToolPhaseResult`.
+        """
+        runtime = self._runtime
+        halt = False
+        total_waited = 0.0
+        for tc in turn.tool_calls:
+            tool_name = tc.name
+            tool_call_id = tc.id
+            raw_args = tc.arguments
+
+            yield {
+                "type": "tool_processing",
+                "tool_name": tool_name,
+                "tool_id": tool_call_id,
+            }
+
+            try:
+                result_text, is_error = await runtime._execute_tool(tool_name, raw_args)
+            except PendingApprovalError as exc:
+                # Hold the run here until an operator decides, so a run never
+                # completes with the action un-taken.
+                yield {
+                    "type": "approval_required",
+                    "tool_name": tool_name,
+                    "tool_id": tool_call_id,
+                    "action_id": exc.action_id,
+                    "content": str(exc),
+                }
+                yield {"type": "text", "content": f"\n\n_{exc}_\n\n"}
+                if not exc.action_id:
+                    # No action to poll — fail closed rather than hang.
+                    yield {"type": "error", "content": str(exc)}
+                    halt = True
+                    break
+                decision, detail, waited = await runtime._await_approval(exc.action_id)
+                # Human think-time isn't LLM processing time.
+                total_waited += waited
+                if decision == "approved":
+                    result_text, is_error = await runtime._execute_tool(
+                        tool_name, raw_args, approved=True
+                    )
+                    runtime._mark_action_executed(exc.action_id, result_text, is_error)
+                elif decision == "rejected":
+                    result_text, is_error = (
+                        f"Operator REJECTED this action. Reason: {detail}. "
+                        "Do not retry it; continue with another approach or "
+                        "report that the step could not be completed.",
+                        True,
+                    )
+                else:
+                    yield {"type": "error", "content": detail}
+                    halt = True
+                    break
+
+            preview = result_text[:500] + ("…" if len(result_text) > 500 else "")
+            yield {
+                "type": "tool_result",
+                "tool_name": tool_name,
+                "tool_id": tool_call_id,
+                "result": preview,
+                "is_error": is_error,
+            }
+
+            self._append_tool_result(tool_call_id, result_text, is_error)
+
+        yield ToolPhaseResult(halt=halt, waited=total_waited)
 
 
 class _ToolRuntime(Protocol):
-    """The tool-side collaborator the controller calls back into.
+    """The tool-side collaborator the OpenAI engine calls back into.
 
-    In PR3a this is the ``OpenAIAgentService`` instance (so its existing,
-    unit-tested methods — and any test doubles patched onto them — keep being
-    the code that runs). Relocating these into the controller is deferred.
+    This is the ``OpenAIAgentService`` instance (so its existing, unit-tested
+    methods — and any test doubles patched onto them — keep being the code that
+    runs). The engine owns tool execution and telemetry orchestration; the
+    controller no longer touches the runtime.
     """
 
     async def _execute_tool(
@@ -410,32 +545,28 @@ class _ToolRuntime(Protocol):
 
 
 class LoopController:
-    """Provider-agnostic multi-turn agentic tool loop.
+    """Provider-agnostic multi-turn agentic loop sequencer.
 
-    Drives a :class:`TurnEngine` for model I/O and a ``runtime`` handle for tool
-    execution / approval / telemetry. Yields SSE-compatible event dicts matching
-    the frontend protocol.
+    Owns only the cross-cutting guards shared by every provider: the iteration
+    cap, the wall-clock timeout, inter-iteration backoff, canonicalized
+    loop-detection, and the stop/limit messages. Everything provider-specific —
+    streaming, telemetry, tool execution/gating, history mutation, and the
+    provider's SSE event vocabulary — lives in the :class:`TurnEngine` it drives.
+    Yields SSE-compatible event dicts matching the frontend protocol.
     """
 
     def __init__(
         self,
         *,
         engine: TurnEngine,
-        runtime: Any,
         max_iterations: int = _MAX_TOOL_ITERATIONS,
         max_processing_time_s: float = _MAX_PROCESSING_TIME_S,
     ):
         self._engine = engine
-        self._runtime = runtime
         self._max_iterations = max_iterations
         self._max_processing_time_s = max_processing_time_s
 
-    async def run(
-        self,
-        *,
-        session_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-    ) -> AsyncIterator[Dict[str, Any]]:
+    async def run(self) -> AsyncIterator[Dict[str, Any]]:
         """Run the agentic loop, yielding SSE event dicts.
 
         Guardrails (unchanged from the pre-refactor OpenAI loop):
@@ -445,7 +576,6 @@ class LoopController:
             - infinite loop detection (3 repeated identical tool sets)
         """
         engine = self._engine
-        runtime = self._runtime
 
         start_time = asyncio.get_event_loop().time()
         tool_call_history: deque = deque(maxlen=_LOOP_DETECT_WINDOW)
@@ -467,6 +597,7 @@ class LoopController:
                 await asyncio.sleep(_inter_iteration_delay(iteration))
 
             # Stream one model turn; re-yield deltas, capture the terminal result.
+            # The engine records its own telemetry before yielding the TurnResult.
             turn: Optional[TurnResult] = None
             try:
                 async for item in engine.stream_turn(iteration=iteration):
@@ -483,27 +614,6 @@ class LoopController:
                 # A well-behaved engine always yields a terminal TurnResult; if
                 # one didn't, stop rather than spin.
                 break
-
-            cost_usd = runtime._compute_cost(
-                engine.model,
-                engine.provider_type,
-                turn.input_tokens,
-                turn.output_tokens,
-            )
-            runtime._log_interaction(
-                session_id=session_id,
-                agent_id=agent_id,
-                model=engine.model_label,
-                iteration=iteration,
-                interaction_id=turn.interaction_id,
-                duration_ms=turn.duration_ms,
-                text_content=turn.text,
-                tool_calls_count=turn.raw_tool_call_count,
-                finish_reason=turn.finish_reason,
-                input_tokens=turn.input_tokens,
-                output_tokens=turn.output_tokens,
-                cost_usd=cost_usd,
-            )
 
             # No actionable tool call → done.
             if turn.finish_reason != "tool_calls" or turn.raw_tool_call_count == 0:
@@ -537,74 +647,19 @@ class LoopController:
                 }
                 break
 
-            halt = False
-            for tc in turn.tool_calls:
-                tool_name = tc.name
-                tool_call_id = tc.id
-                raw_args = tc.arguments
-
-                yield {
-                    "type": "tool_processing",
-                    "tool_name": tool_name,
-                    "tool_id": tool_call_id,
-                }
-
-                try:
-                    result_text, is_error = await runtime._execute_tool(
-                        tool_name, raw_args
-                    )
-                except PendingApprovalError as exc:
-                    # Hold the run here until an operator decides, so a run never
-                    # completes with the action un-taken.
-                    yield {
-                        "type": "approval_required",
-                        "tool_name": tool_name,
-                        "tool_id": tool_call_id,
-                        "action_id": exc.action_id,
-                        "content": str(exc),
-                    }
-                    yield {"type": "text", "content": f"\n\n_{exc}_\n\n"}
-                    if not exc.action_id:
-                        # No action to poll — fail closed rather than hang.
-                        yield {"type": "error", "content": str(exc)}
-                        halt = True
-                        break
-                    decision, detail, waited = await runtime._await_approval(
-                        exc.action_id
-                    )
-                    # Human think-time isn't LLM processing time.
-                    start_time += waited
-                    if decision == "approved":
-                        result_text, is_error = await runtime._execute_tool(
-                            tool_name, raw_args, approved=True
-                        )
-                        runtime._mark_action_executed(
-                            exc.action_id, result_text, is_error
-                        )
-                    elif decision == "rejected":
-                        result_text, is_error = (
-                            f"Operator REJECTED this action. Reason: {detail}. "
-                            "Do not retry it; continue with another approach or "
-                            "report that the step could not be completed.",
-                            True,
-                        )
-                    else:
-                        yield {"type": "error", "content": detail}
-                        halt = True
-                        break
-
-                preview = result_text[:500] + ("…" if len(result_text) > 500 else "")
-                yield {
-                    "type": "tool_result",
-                    "tool_name": tool_name,
-                    "tool_id": tool_call_id,
-                    "result": preview,
-                    "is_error": is_error,
-                }
-
-                engine.append_tool_result(tool_call_id, result_text, is_error)
-            if halt:
-                return
+            # Hand the tool-execution phase to the engine; it yields provider-
+            # shaped tool events and reports back whether to halt and how much
+            # human approval time to exclude from the wall-clock guard.
+            phase: Optional[ToolPhaseResult] = None
+            async for tool_event in engine.execute_tools(turn, iteration=iteration):
+                if isinstance(tool_event, ToolPhaseResult):
+                    phase = tool_event
+                else:
+                    yield tool_event
+            if phase is not None:
+                start_time += phase.waited
+                if phase.halt:
+                    return
         else:
             # for/else: loop exhausted without break
             yield {

--- a/services/agent_loop.py
+++ b/services/agent_loop.py
@@ -1,0 +1,616 @@
+"""Provider-agnostic agentic tool loop.
+
+This module houses the two halves of the multi-turn tool loop that used to live
+entirely inside ``OpenAIAgentService``:
+
+  - :class:`LoopController` — the **provider-agnostic** loop skeleton: iteration
+    and wall-clock guards, inter-iteration backoff, canonicalized loop-detection,
+    the tool-execution + human-approval flow, per-turn telemetry, and the
+    iteration-limit message. It knows nothing about any specific provider; it
+    drives a :class:`TurnEngine` for model I/O and calls back into a ``runtime``
+    handle for tool execution, approval, and logging.
+  - :class:`TurnEngine` — the interface a provider adapter implements, plus the
+    :class:`OpenAITurnEngine` adapter that speaks the OpenAI-compatible dialect
+    (delta reassembly over ``LLMRouter.stream_openai_raw``, tool-call
+    normalization, usage accounting, and the malformed-tool-JSON heuristic).
+
+Each engine owns its own message-history dialect; the controller only ever sees
+provider-agnostic :class:`TurnResult` / :class:`NormalizedToolCall` values. This
+lets a future ``AnthropicTurnEngine`` keep native Anthropic-block history without
+the controller having to convert anything.
+
+Behaviour here is a straight lift of the previous ``OpenAIAgentService.stream``
+loop — the split is structural, not behavioural.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Dict, List, Optional, Protocol, Union
+
+from services.llm_format import anthropic_messages_to_openai
+from services.llm_router import LLMRouter, ProviderSpec
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "PendingApprovalError",
+    "NormalizedToolCall",
+    "TurnResult",
+    "TurnEngine",
+    "OpenAITurnEngine",
+    "LoopController",
+]
+
+_MAX_TOOL_ITERATIONS = 30
+_MAX_PROCESSING_TIME_S = 300.0
+_HISTORY_WINDOW_DEFAULT = 20
+_LOOP_DETECT_WINDOW = 5
+_LOOP_DETECT_THRESHOLD = 3
+_BASE_INTER_ITERATION_DELAY_S = 0.5
+_MAX_INTER_ITERATION_DELAY_S = 3.0
+_BACKOFF_ITERATION_THRESHOLD = 15
+
+
+class PendingApprovalError(Exception):
+    """Tool call blocked pending human approval; action_id is the queue row to
+    poll, or None when the request could not be created."""
+
+    def __init__(self, message: str, action_id: Optional[str] = None):
+        super().__init__(message)
+        self.action_id = action_id
+
+
+def _inter_iteration_delay(iteration: int) -> float:
+    """Exponential backoff matching ClaudeService: 500ms base, ramp after 15."""
+    if iteration <= _BACKOFF_ITERATION_THRESHOLD:
+        return _BASE_INTER_ITERATION_DELAY_S
+    exp = iteration - _BACKOFF_ITERATION_THRESHOLD
+    delay = _BASE_INTER_ITERATION_DELAY_S * (1.5**exp)
+    return min(delay, _MAX_INTER_ITERATION_DELAY_S)
+
+
+def _canonical_args(raw: str) -> str:
+    """Canonicalize tool-call argument JSON for stable loop detection.
+
+    Parse and re-serialize with sorted keys so cosmetic streaming
+    differences (whitespace, key ordering) don't make a repeated call look
+    distinct and defeat the infinite-loop guard. Falls back to the stripped
+    raw string when the arguments aren't valid JSON.
+    """
+    try:
+        return json.dumps(
+            json.loads(raw or "{}"), sort_keys=True, separators=(",", ":")
+        )
+    except (json.JSONDecodeError, TypeError):
+        return (raw or "").strip()
+
+
+def _detect_infinite_loop(history: deque) -> bool:
+    """Detect if the same tool call set repeats >= threshold times."""
+    if len(history) < _LOOP_DETECT_THRESHOLD:
+        return False
+    recent = list(history)[-_LOOP_DETECT_THRESHOLD:]
+    return len(set(recent)) == 1
+
+
+def _apply_history_window(
+    messages: List[Dict[str, Any]],
+    window: int = _HISTORY_WINDOW_DEFAULT,
+) -> List[Dict[str, Any]]:
+    """Enforce a sliding history window (configurable max turns).
+
+    Keeps the system message (if first) + the most recent ``window * 2``
+    messages. Matches ClaudeService._apply_history_window behavior.
+    """
+    if window <= 0:
+        return messages
+    max_msgs = window * 2
+    if len(messages) <= max_msgs:
+        return messages
+    # Preserve system message at index 0 if present
+    if messages and messages[0].get("role") == "system":
+        keep = max_msgs - 1
+        return [messages[0]] + messages[-keep:]
+    return messages[-max_msgs:]
+
+
+@dataclass
+class NormalizedToolCall:
+    """A provider-agnostic tool call the controller acts on.
+
+    ``arguments`` stays the raw JSON *string* the model emitted so it flows into
+    the tool executor unchanged and is canonicalized only for loop-detection.
+    """
+
+    id: str
+    name: str
+    arguments: str
+
+
+@dataclass
+class TurnResult:
+    """The terminal outcome of one model turn, produced by a ``TurnEngine``.
+
+    The engine has already streamed any text/thinking deltas to the caller by
+    the time it yields this; the controller uses these fields to decide whether
+    to execute tools, stop, or emit a diagnostic.
+    """
+
+    text: str
+    finish_reason: Optional[str]
+    # Number of tool-call slots the provider emitted *before* filtering (a slot
+    # that never received a name is unusable and dropped from ``tool_calls``, but
+    # still counted here so the controller's "did the model try to call a tool?"
+    # check matches the pre-refactor behaviour).
+    raw_tool_call_count: int
+    tool_calls: List[NormalizedToolCall]
+    # Provider-shape assistant message to append to history when continuing.
+    assistant_message: Optional[Dict[str, Any]]
+    # Diagnostic to surface when the model dumped raw tool-call JSON as text
+    # instead of making a structured call (populated only on the first turn).
+    malformed_help: Optional[str]
+    interaction_id: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    duration_ms: int = 0
+
+
+class TurnEngine(Protocol):
+    """Provider adapter driven by :class:`LoopController`.
+
+    Implementations own their message-history dialect. ``stream_turn`` yields
+    SSE-compatible delta dicts (``text``/``thinking``/…) as they arrive and
+    terminates by yielding exactly one :class:`TurnResult`.
+    """
+
+    #: Resolved model id (for cost lookup).
+    model: str
+    #: Provider type string, e.g. "ollama"/"openai" (for cost lookup).
+    provider_type: str
+    #: Human-readable model label for interaction logs, e.g. "ollama/llama3".
+    model_label: str
+
+    def stream_turn(
+        self, *, iteration: int
+    ) -> AsyncIterator[Union[Dict[str, Any], TurnResult]]: ...
+
+    def append_assistant(self, turn: TurnResult) -> None: ...
+
+    def append_tool_result(
+        self, tool_call_id: str, result_text: str, is_error: bool
+    ) -> None: ...
+
+
+class OpenAITurnEngine:
+    """OpenAI-compatible :class:`TurnEngine` over ``LLMRouter.stream_openai_raw``.
+
+    Owns an OpenAI chat-completion message history and reassembles streamed
+    deltas (text + tool-call fragments) into a :class:`TurnResult`. Lifted from
+    the body of the old ``OpenAIAgentService.stream``.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: ProviderSpec,
+        messages: List[Dict[str, Any]],
+        system_prompt: Optional[str],
+        model: str,
+        max_tokens: int,
+        temperature: Optional[float],
+        tools: List[Dict[str, Any]],
+        history_window: int = _HISTORY_WINDOW_DEFAULT,
+        router: Optional[LLMRouter] = None,
+    ):
+        self._provider = provider
+        self._system_prompt = system_prompt
+        self._model = model
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+        self._tools = tools
+        self._router = router or LLMRouter()
+        # The loop appends assistant/tool turns in OpenAI shape, so normalize the
+        # incoming history up front; the router re-converts idempotently.
+        history = anthropic_messages_to_openai(messages)
+        self._history = _apply_history_window(history, history_window)
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def provider_type(self) -> str:
+        return self._provider.provider_type
+
+    @property
+    def model_label(self) -> str:
+        return f"{self._provider.provider_type}/{self._model}"
+
+    def append_assistant(self, turn: TurnResult) -> None:
+        if turn.assistant_message is not None:
+            self._history.append(turn.assistant_message)
+
+    def append_tool_result(
+        self, tool_call_id: str, result_text: str, is_error: bool
+    ) -> None:
+        # OpenAI tool messages carry no is_error field, so mark failures inline —
+        # otherwise the model treats an error as a valid result.
+        self._history.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call_id,
+                "content": (f"ERROR: {result_text}" if is_error else result_text),
+            }
+        )
+
+    async def stream_turn(
+        self, *, iteration: int
+    ) -> AsyncIterator[Union[Dict[str, Any], TurnResult]]:
+        interaction_id = str(uuid.uuid4())
+        text_buffer = ""
+        tool_calls_buffer: Dict[int, Dict[str, Any]] = {}
+        finish_reason: Optional[str] = None
+        input_tokens = 0
+        output_tokens = 0
+        iter_start = time.monotonic()
+
+        async for chunk in self._router.stream_openai_raw(
+            provider=self._provider,
+            messages=self._history,
+            system_prompt=self._system_prompt,
+            model=self._model,
+            max_tokens=self._max_tokens,
+            temperature=self._temperature,
+            tools=self._tools or None,
+            interaction_id=interaction_id,
+            # Ask for a final usage-only chunk so token counts (and thus cost)
+            # are recorded — without this, streamed responses carry no usage and
+            # analytics would show $0 for OpenAI/Groq/Ollama.
+            include_usage=True,
+        ):
+            # The usage-only chunk (include_usage) arrives with an empty
+            # ``choices`` list, so read usage before skipping it.
+            usage = getattr(chunk, "usage", None)
+            if usage:
+                input_tokens = getattr(usage, "prompt_tokens", 0) or 0
+                output_tokens = getattr(usage, "completion_tokens", 0) or 0
+            if not chunk.choices:
+                continue
+            choice = chunk.choices[0]
+            delta = choice.delta
+            finish_reason = choice.finish_reason or finish_reason
+
+            if delta and delta.content:
+                text_buffer += delta.content
+                yield {"type": "text", "content": delta.content}
+
+            if delta and delta.tool_calls:
+                for tc_delta in delta.tool_calls:
+                    idx = tc_delta.index
+                    if idx not in tool_calls_buffer:
+                        tool_calls_buffer[idx] = {
+                            "id": tc_delta.id or "",
+                            "name": "",
+                            "arguments": "",
+                        }
+                    entry = tool_calls_buffer[idx]
+                    if tc_delta.id:
+                        entry["id"] = tc_delta.id
+                    if tc_delta.function:
+                        if tc_delta.function.name:
+                            entry["name"] += tc_delta.function.name
+                        if tc_delta.function.arguments:
+                            entry["arguments"] += tc_delta.function.arguments
+
+        duration_ms = int((time.monotonic() - iter_start) * 1000)
+
+        # Build the assistant message + normalized tool calls from the buffer.
+        assistant_msg: Dict[str, Any] = {"role": "assistant"}
+        if text_buffer:
+            assistant_msg["content"] = text_buffer
+        normalized: List[NormalizedToolCall] = []
+        oai_tool_calls: List[Dict[str, Any]] = []
+        for idx in sorted(tool_calls_buffer.keys()):
+            tc = tool_calls_buffer[idx]
+            name = (tc["name"] or "").strip()
+            if not name:
+                # A tool-call slot that never received a function name is unusable
+                # — skip it rather than emit a malformed call the provider rejects.
+                logger.warning(
+                    "Skipping tool call %d with empty name (id=%r)", idx, tc["id"]
+                )
+                continue
+            # Some providers omit the streamed id; synthesize a stable one so tool
+            # results can be correlated back to the call.
+            call_id = tc["id"] or f"call_{uuid.uuid4().hex[:12]}"
+            oai_tool_calls.append(
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": name, "arguments": tc["arguments"]},
+                }
+            )
+            normalized.append(
+                NormalizedToolCall(id=call_id, name=name, arguments=tc["arguments"])
+            )
+        if oai_tool_calls:
+            assistant_msg["tool_calls"] = oai_tool_calls
+
+        malformed_help = None
+        # Detect malformed tool calls dumped as text (common with smaller models
+        # that attempt tool use but fail at structured output). Only relevant on
+        # a turn with no actionable tool call — mirror the original loop's gate
+        # (``finish_reason != "tool_calls" or not tool_calls_buffer``) so a turn
+        # that *did* call a tool never triggers a spurious warning.
+        finished = finish_reason != "tool_calls" or not tool_calls_buffer
+        if (
+            finished
+            and text_buffer
+            and iteration == 0
+            and (
+                '{"type":"function"' in text_buffer
+                or ('"function"' in text_buffer and '"parameters"' in text_buffer)
+            )
+        ):
+            logger.warning(
+                "Model output contains raw tool-call JSON in text "
+                "(model may not support structured tool calling)"
+            )
+            malformed_help = (
+                "I attempted to use tools but this model doesn't reliably "
+                "support structured tool calling. Please select a more capable "
+                "model in Settings > AI Config (e.g., sec8-tools, gpt-4o, or any "
+                "7B+ model with tool support)."
+            )
+
+        yield TurnResult(
+            text=text_buffer,
+            finish_reason=finish_reason,
+            raw_tool_call_count=len(tool_calls_buffer),
+            tool_calls=normalized,
+            assistant_message=assistant_msg,
+            malformed_help=malformed_help,
+            interaction_id=interaction_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            duration_ms=duration_ms,
+        )
+
+
+class _ToolRuntime(Protocol):
+    """The tool-side collaborator the controller calls back into.
+
+    In PR3a this is the ``OpenAIAgentService`` instance (so its existing,
+    unit-tested methods — and any test doubles patched onto them — keep being
+    the code that runs). Relocating these into the controller is deferred.
+    """
+
+    async def _execute_tool(
+        self, tool_name: str, raw_arguments: str, *, approved: bool = False
+    ) -> "tuple[str, bool]": ...
+
+    async def _await_approval(self, action_id: str) -> "tuple[str, str, float]": ...
+
+    def _mark_action_executed(
+        self, action_id: Optional[str], result_text: str, is_error: bool
+    ) -> None: ...
+
+    def _compute_cost(
+        self, model: str, provider_type: str, input_tokens: int, output_tokens: int
+    ) -> float: ...
+
+    def _log_interaction(self, **kwargs: Any) -> None: ...
+
+
+class LoopController:
+    """Provider-agnostic multi-turn agentic tool loop.
+
+    Drives a :class:`TurnEngine` for model I/O and a ``runtime`` handle for tool
+    execution / approval / telemetry. Yields SSE-compatible event dicts matching
+    the frontend protocol.
+    """
+
+    def __init__(
+        self,
+        *,
+        engine: TurnEngine,
+        runtime: Any,
+        max_iterations: int = _MAX_TOOL_ITERATIONS,
+        max_processing_time_s: float = _MAX_PROCESSING_TIME_S,
+    ):
+        self._engine = engine
+        self._runtime = runtime
+        self._max_iterations = max_iterations
+        self._max_processing_time_s = max_processing_time_s
+
+    async def run(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """Run the agentic loop, yielding SSE event dicts.
+
+        Guardrails (unchanged from the pre-refactor OpenAI loop):
+            - iteration cap (default 30)
+            - wall-clock timeout (default 300s)
+            - exponential inter-iteration backoff
+            - infinite loop detection (3 repeated identical tool sets)
+        """
+        engine = self._engine
+        runtime = self._runtime
+
+        start_time = asyncio.get_event_loop().time()
+        tool_call_history: deque = deque(maxlen=_LOOP_DETECT_WINDOW)
+
+        for iteration in range(self._max_iterations):
+            elapsed = asyncio.get_event_loop().time() - start_time
+            if elapsed > self._max_processing_time_s:
+                yield {
+                    "type": "text",
+                    "content": (
+                        "\n\n[Maximum processing time "
+                        f"({self._max_processing_time_s:.0f}s) exceeded "
+                        f"after {iteration} iterations.]"
+                    ),
+                }
+                break
+
+            if iteration > 0:
+                await asyncio.sleep(_inter_iteration_delay(iteration))
+
+            # Stream one model turn; re-yield deltas, capture the terminal result.
+            turn: Optional[TurnResult] = None
+            try:
+                async for item in engine.stream_turn(iteration=iteration):
+                    if isinstance(item, TurnResult):
+                        turn = item
+                    else:
+                        yield item
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Turn stream error iteration %d: %s", iteration, exc)
+                yield {"type": "error", "content": str(exc)}
+                break
+
+            if turn is None:
+                # A well-behaved engine always yields a terminal TurnResult; if
+                # one didn't, stop rather than spin.
+                break
+
+            cost_usd = runtime._compute_cost(
+                engine.model,
+                engine.provider_type,
+                turn.input_tokens,
+                turn.output_tokens,
+            )
+            runtime._log_interaction(
+                session_id=session_id,
+                agent_id=agent_id,
+                model=engine.model_label,
+                iteration=iteration,
+                interaction_id=turn.interaction_id,
+                duration_ms=turn.duration_ms,
+                text_content=turn.text,
+                tool_calls_count=turn.raw_tool_call_count,
+                finish_reason=turn.finish_reason,
+                input_tokens=turn.input_tokens,
+                output_tokens=turn.output_tokens,
+                cost_usd=cost_usd,
+            )
+
+            # No actionable tool call → done.
+            if turn.finish_reason != "tool_calls" or turn.raw_tool_call_count == 0:
+                if turn.malformed_help:
+                    yield {"type": "text", "content": turn.malformed_help}
+                break
+
+            if not turn.tool_calls:
+                # Every tool-call slot was malformed (empty name). Surface any
+                # assistant text and stop rather than loop on an empty turn.
+                if turn.assistant_message and "content" in turn.assistant_message:
+                    engine.append_assistant(turn)
+                break
+
+            engine.append_assistant(turn)
+
+            # Infinite loop detection (canonicalized args so cosmetic streaming
+            # differences don't defeat repeat detection).
+            call_signature = frozenset(
+                "{}:{}".format(tc.name, _canonical_args(tc.arguments))
+                for tc in turn.tool_calls
+            )
+            tool_call_history.append(call_signature)
+            if _detect_infinite_loop(tool_call_history):
+                yield {
+                    "type": "text",
+                    "content": (
+                        "\n\n[Stopping: repeated identical tool calls "
+                        "detected (possible infinite loop).]"
+                    ),
+                }
+                break
+
+            halt = False
+            for tc in turn.tool_calls:
+                tool_name = tc.name
+                tool_call_id = tc.id
+                raw_args = tc.arguments
+
+                yield {
+                    "type": "tool_processing",
+                    "tool_name": tool_name,
+                    "tool_id": tool_call_id,
+                }
+
+                try:
+                    result_text, is_error = await runtime._execute_tool(
+                        tool_name, raw_args
+                    )
+                except PendingApprovalError as exc:
+                    # Hold the run here until an operator decides, so a run never
+                    # completes with the action un-taken.
+                    yield {
+                        "type": "approval_required",
+                        "tool_name": tool_name,
+                        "tool_id": tool_call_id,
+                        "action_id": exc.action_id,
+                        "content": str(exc),
+                    }
+                    yield {"type": "text", "content": f"\n\n_{exc}_\n\n"}
+                    if not exc.action_id:
+                        # No action to poll — fail closed rather than hang.
+                        yield {"type": "error", "content": str(exc)}
+                        halt = True
+                        break
+                    decision, detail, waited = await runtime._await_approval(
+                        exc.action_id
+                    )
+                    # Human think-time isn't LLM processing time.
+                    start_time += waited
+                    if decision == "approved":
+                        result_text, is_error = await runtime._execute_tool(
+                            tool_name, raw_args, approved=True
+                        )
+                        runtime._mark_action_executed(
+                            exc.action_id, result_text, is_error
+                        )
+                    elif decision == "rejected":
+                        result_text, is_error = (
+                            f"Operator REJECTED this action. Reason: {detail}. "
+                            "Do not retry it; continue with another approach or "
+                            "report that the step could not be completed.",
+                            True,
+                        )
+                    else:
+                        yield {"type": "error", "content": detail}
+                        halt = True
+                        break
+
+                preview = result_text[:500] + ("…" if len(result_text) > 500 else "")
+                yield {
+                    "type": "tool_result",
+                    "tool_name": tool_name,
+                    "tool_id": tool_call_id,
+                    "result": preview,
+                    "is_error": is_error,
+                }
+
+                engine.append_tool_result(tool_call_id, result_text, is_error)
+            if halt:
+                return
+        else:
+            # for/else: loop exhausted without break
+            yield {
+                "type": "text",
+                "content": (
+                    f"\n\n[Tool iteration limit ({self._max_iterations}) "
+                    "reached. Stopping.]"
+                ),
+            }

--- a/services/agent_loop.py
+++ b/services/agent_loop.py
@@ -47,6 +47,7 @@ __all__ = [
     "ToolPhaseResult",
     "TurnEngine",
     "OpenAITurnEngine",
+    "AnthropicTurnEngine",
     "LoopController",
 ]
 
@@ -516,6 +517,227 @@ class OpenAITurnEngine:
             self._append_tool_result(tool_call_id, result_text, is_error)
 
         yield ToolPhaseResult(halt=halt, waited=total_waited)
+
+
+class AnthropicTurnEngine:
+    """Anthropic-native :class:`TurnEngine` over ``client.messages.stream``.
+
+    Wraps a ``ClaudeService`` instance and reuses its proven helpers
+    (``async_client.messages.stream``, ``_process_mixed_tool_use``,
+    ``_clean_blocks_for_resend``, ``_persist_interaction``). Lifted from the
+    body of ``ClaudeService.chat_stream``:
+
+      - ``stream_turn`` emits ``thinking_start``/``thinking``/``thinking_end`` and
+        ``text`` deltas, reads final usage via ``get_final_message()``, and
+        persists the reasoning trace — one interaction row per iteration.
+      - ``execute_tools`` runs the turn's tool calls as a single batch through
+        ``_process_mixed_tool_use`` and appends the Anthropic-block tool results.
+
+    Canonical history is Anthropic content-block shape (native to this engine),
+    so no conversion happens at the boundary. Approval gating is intentionally
+    absent here — it matches ``chat_stream``'s current behaviour and is unified
+    across providers in a later sub-PR.
+    """
+
+    def __init__(
+        self,
+        *,
+        runtime: Any,
+        messages: List[Dict[str, Any]],
+        system_prompt: Optional[str],
+        model: str,
+        max_tokens: int,
+        tools: Optional[List[Dict[str, Any]]],
+        thinking_config: Optional[Dict[str, Any]],
+        use_thinking: bool,
+        thinking_budget: Optional[int] = None,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        investigation_id: Optional[str] = None,
+    ):
+        self._runtime = runtime
+        self._messages = messages
+        self._system_prompt = system_prompt
+        self._model = model
+        self._max_tokens = max_tokens
+        self._tools = tools
+        self._thinking_config = thinking_config
+        self._use_thinking = use_thinking
+        self._thinking_budget = thinking_budget
+        self._session_id = session_id
+        self._agent_id = agent_id
+        self._investigation_id = investigation_id
+        # Raw response blocks from the most recent turn, handed to execute_tools.
+        self._last_accumulated: List[Any] = []
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def provider_type(self) -> str:
+        return "anthropic"
+
+    @property
+    def model_label(self) -> str:
+        return f"anthropic/{self._model}"
+
+    def _build_api_kwargs(self, interaction_id: str) -> Dict[str, Any]:
+        api_kwargs: Dict[str, Any] = {
+            "model": self._model,
+            "max_tokens": self._max_tokens,
+            "messages": self._messages,
+        }
+        if self._system_prompt:
+            api_kwargs["system"] = self._system_prompt
+        if self._tools:
+            api_kwargs["tools"] = self._tools
+        if self._thinking_config:
+            api_kwargs["thinking"] = self._thinking_config
+        # #185: fresh interaction UUID per streaming iteration so each upstream
+        # Bifrost call lands its own log row correlated with the local one.
+        api_kwargs["extra_headers"] = {"x-bf-lh-vigil-interaction-id": interaction_id}
+        return api_kwargs
+
+    async def stream_turn(
+        self, *, iteration: int
+    ) -> AsyncIterator[Union[Dict[str, Any], TurnResult]]:
+        interaction_id = str(uuid.uuid4())
+        api_kwargs = self._build_api_kwargs(interaction_id)
+
+        stream_started = asyncio.get_event_loop().time()
+        accumulated_content: List[Any] = []
+        current_thinking_block: List[str] = []
+        in_thinking = False
+        final_message = None
+        stop_reason = None
+
+        async with self._runtime.async_client.messages.stream(**api_kwargs) as stream:
+            async for event in stream:
+                if not hasattr(event, "type"):
+                    continue
+                event_type = event.type
+
+                if event_type == "content_block_start":
+                    block = getattr(event, "content_block", None)
+                    if block is not None and getattr(block, "type", None) == "thinking":
+                        in_thinking = True
+                        current_thinking_block = []
+                        yield {"type": "thinking_start"}
+
+                elif event_type == "content_block_delta":
+                    delta = getattr(event, "delta", None)
+                    delta_type = getattr(delta, "type", None) if delta else None
+                    if delta_type == "thinking_delta" and hasattr(delta, "thinking"):
+                        thinking_text = getattr(delta, "thinking", "")
+                        current_thinking_block.append(thinking_text)
+                        yield {"type": "thinking", "content": thinking_text}
+                    elif delta_type == "text_delta" and hasattr(delta, "text"):
+                        if not in_thinking:
+                            text = getattr(delta, "text", "")
+                            yield {"type": "text", "content": text}
+
+                elif event_type == "content_block_stop":
+                    if in_thinking:
+                        in_thinking = False
+                        yield {"type": "thinking_end"}
+
+            final_message = await stream.get_final_message()
+            accumulated_content = final_message.content
+            stop_reason = final_message.stop_reason
+
+        duration_ms = int((asyncio.get_event_loop().time() - stream_started) * 1000)
+        usage = getattr(final_message, "usage", None)
+
+        # Persist this iteration's reasoning trace (non-fatal, fire-and-forget).
+        try:
+            await asyncio.to_thread(
+                self._runtime._persist_interaction,
+                session_id=self._session_id,
+                agent_id=self._agent_id,
+                investigation_id=self._investigation_id,
+                model=getattr(final_message, "model", self._model),
+                system_prompt=self._system_prompt,
+                request_messages=self._messages,
+                response_content=(
+                    list(accumulated_content) if accumulated_content else []
+                ),
+                thinking_enabled=self._use_thinking,
+                thinking_budget=(self._thinking_budget if self._use_thinking else None),
+                stop_reason=stop_reason,
+                input_tokens=(getattr(usage, "input_tokens", 0) if usage else 0),
+                output_tokens=(getattr(usage, "output_tokens", 0) if usage else 0),
+                cache_read_tokens=(
+                    getattr(usage, "cache_read_input_tokens", 0) if usage else 0
+                ),
+                cache_creation_tokens=(
+                    getattr(usage, "cache_creation_input_tokens", 0) if usage else 0
+                ),
+                duration_ms=duration_ms,
+                interaction_id=interaction_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Reasoning-trace persist skipped (stream): %s", exc)
+
+        # Normalize tool_use blocks so the controller can loop-detect and decide.
+        normalized: List[NormalizedToolCall] = []
+        raw_tool_call_count = 0
+        for block in accumulated_content:
+            if getattr(block, "type", None) == "tool_use":
+                raw_tool_call_count += 1
+                name = getattr(block, "name", "") or ""
+                tool_input = getattr(block, "input", {}) or {}
+                block_id = getattr(block, "id", "") or f"toolu_{uuid.uuid4().hex[:12]}"
+                try:
+                    arguments = json.dumps(tool_input, sort_keys=True, default=str)
+                except (TypeError, ValueError):
+                    arguments = str(tool_input)
+                normalized.append(
+                    NormalizedToolCall(id=block_id, name=name, arguments=arguments)
+                )
+
+        # stop_reason "tool_use" is the Anthropic signal for "run tools"; map it
+        # to the controller's provider-agnostic "tool_calls" sentinel.
+        finish_reason = "tool_calls" if stop_reason == "tool_use" else stop_reason
+        assistant_message = {
+            "role": "assistant",
+            "content": self._runtime._clean_blocks_for_resend(accumulated_content),
+        }
+        self._last_accumulated = accumulated_content
+
+        yield TurnResult(
+            text="",
+            finish_reason=finish_reason,
+            raw_tool_call_count=raw_tool_call_count,
+            tool_calls=normalized,
+            assistant_message=assistant_message,
+            malformed_help=None,
+            interaction_id=interaction_id,
+            input_tokens=(getattr(usage, "input_tokens", 0) if usage else 0),
+            output_tokens=(getattr(usage, "output_tokens", 0) if usage else 0),
+            duration_ms=duration_ms,
+        )
+
+    def append_assistant(self, turn: TurnResult) -> None:
+        if turn.assistant_message is not None:
+            self._messages.append(turn.assistant_message)
+
+    async def execute_tools(
+        self, turn: TurnResult, *, iteration: int
+    ) -> AsyncIterator[Union[Dict[str, Any], ToolPhaseResult]]:
+        """Batch-execute the turn's tool calls via the runtime.
+
+        Mirrors ``chat_stream``: one ``tool_processing`` signal, all tool_use
+        blocks routed through ``_process_mixed_tool_use``, and the results
+        appended as a single Anthropic ``user`` message. No per-tool approval
+        gate today (unified across providers in a later sub-PR).
+        """
+        yield {"type": "tool_processing"}
+        tool_results = await self._runtime._process_mixed_tool_use(
+            self._last_accumulated
+        )
+        self._messages.append({"role": "user", "content": tool_results})
+        yield ToolPhaseResult(halt=False, waited=0.0)
 
 
 class _ToolRuntime(Protocol):

--- a/services/claude_service.py
+++ b/services/claude_service.py
@@ -2798,287 +2798,33 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                     "remaining_messages": len(messages),
                 }
 
-            api_kwargs = {
-                "model": model,
-                "max_tokens": max_tokens,
-                "messages": messages,
-            }
-            if effective_system_prompt:
-                api_kwargs["system"] = effective_system_prompt
-            if tools:
-                api_kwargs["tools"] = tools
-                logger.debug(f"🔧 Stream with {len(tools)} MCP tools")
-            if thinking_config:
-                api_kwargs["thinking"] = thinking_config
-                logger.info(f"💭 Stream thinking config: {thinking_config}")
-
-            # Stream with proper tool use handling using streaming API throughout
-            max_iterations = 30  # Allow more iterations for complex workflows
-            max_processing_time = 300  # 5 minutes maximum total processing time
-            iteration = 0
-            start_time = asyncio.get_event_loop().time()
-            last_tool_calls = []  # Track recent tool calls to detect loops
-            iteration_delays = []  # Track delays for rate limiting
-
-            logger.debug(
-                f"🚀 Starting stream iterations (max: {max_iterations}, max_time: {max_processing_time}s)"
+            resolved_budget = (
+                thinking_budget if thinking_budget is not None else self.thinking_budget
             )
 
-            while iteration < max_iterations:
-                iteration += 1
-                current_time = asyncio.get_event_loop().time()
-                elapsed_time = current_time - start_time
+            # The multi-turn loop now lives behind the provider-agnostic
+            # LoopController; this service supplies the Anthropic TurnEngine plus
+            # its proven helpers (streaming, tool dispatch, persistence). Local
+            # import keeps claude_service out of any import cycle at module load.
+            from services.agent_loop import AnthropicTurnEngine, LoopController
 
-                # Check if we've exceeded maximum processing time
-                if elapsed_time > max_processing_time:
-                    logger.warning(
-                        f"⏱️ Maximum processing time ({max_processing_time}s) exceeded after {iteration} iterations"
-                    )
-                    yield {
-                        "type": "text",
-                        "content": "\n\n[Maximum processing time reached. Stopping to prevent timeout.]",
-                    }
-                    break
-
-                logger.debug(
-                    f"🔄 Stream iteration {iteration}/{max_iterations} (elapsed: {elapsed_time:.1f}s)"
-                )
-
-                # Add rate limiting delay between iterations (except first one)
-                if iteration > 1:
-                    # Start with 500ms delay, increase with exponential backoff if many iterations
-                    base_delay = 0.5  # 500ms
-                    if iteration > 15:
-                        # Increase delay for later iterations to be more conservative
-                        delay = base_delay * (1.5 ** (iteration - 15))
-                    else:
-                        delay = base_delay
-
-                    # Cap delay at 3 seconds
-                    delay = min(delay, 3.0)
-
-                    logger.debug(
-                        f"⏳ Rate limiting: waiting {delay:.2f}s before iteration {iteration}"
-                    )
-                    await asyncio.sleep(delay)
-                    iteration_delays.append(delay)
-
-                # #185: fresh interaction UUID per streaming iteration so each
-                # upstream Bifrost call (one per loop turn) lands its own log
-                # row that correlates with the local LLMInteractionLog row
-                # written below.
-                _stream_interaction_id = str(uuid.uuid4())
-                api_kwargs["extra_headers"] = {
-                    **(api_kwargs.get("extra_headers") or {}),
-                    "x-bf-lh-vigil-interaction-id": _stream_interaction_id,
-                }
-
-                # Use streaming API to avoid timeout issues with tool use
-                _stream_started = asyncio.get_event_loop().time()
-                async with self.async_client.messages.stream(**api_kwargs) as stream:
-                    accumulated_content = []
-                    current_thinking_block = []
-                    in_thinking = False
-
-                    event_count = 0
-                    thinking_event_count = 0
-                    text_event_count = 0
-
-                    # Handle different event types from the stream
-                    async for event in stream:
-                        event_count += 1
-                        # Check event type
-                        if hasattr(event, "type"):
-                            event_type = event.type
-
-                            # Handle content block start (including thinking blocks)
-                            if event_type == "content_block_start":
-                                if hasattr(event, "content_block"):
-                                    block = event.content_block
-                                    if (
-                                        hasattr(block, "type")
-                                        and block.type == "thinking"
-                                    ):
-                                        in_thinking = True
-                                        current_thinking_block = []
-                                        # Emit thinking block start marker
-                                        logger.debug("💭 Thinking block started")
-                                        yield {"type": "thinking_start"}
-
-                            # Handle content block delta (text chunks)
-                            elif event_type == "content_block_delta":
-                                if hasattr(event, "delta"):
-                                    delta = event.delta
-                                    if hasattr(delta, "type"):
-                                        if delta.type == "thinking_delta" and hasattr(
-                                            delta, "thinking"
-                                        ):
-                                            # This is thinking content
-                                            thinking_text = delta.thinking
-                                            current_thinking_block.append(thinking_text)
-                                            thinking_event_count += 1
-                                            if thinking_event_count <= 2:
-                                                logger.debug(
-                                                    f"💭 Thinking delta: {thinking_text[:50]}..."
-                                                )
-                                            # Emit thinking chunk
-                                            yield {
-                                                "type": "thinking",
-                                                "content": thinking_text,
-                                            }
-                                        elif delta.type == "text_delta" and hasattr(
-                                            delta, "text"
-                                        ):
-                                            if not in_thinking:
-                                                # Regular text content
-                                                text_event_count += 1
-                                                if text_event_count <= 2:
-                                                    logger.debug(
-                                                        f"📝 Text delta: {delta.text[:50]}..."
-                                                    )
-                                                yield {
-                                                    "type": "text",
-                                                    "content": delta.text,
-                                                }
-
-                            # Handle content block stop
-                            elif event_type == "content_block_stop":
-                                if in_thinking:
-                                    in_thinking = False
-                                    total_thinking = "".join(current_thinking_block)
-                                    logger.info(
-                                        f"💭 Thinking block ended - {len(total_thinking)} chars"
-                                    )
-                                    # Emit thinking block end marker
-                                    yield {"type": "thinking_end"}
-
-                    logger.debug(
-                        f"📊 Stream events: total={event_count}, thinking={thinking_event_count}, text={text_event_count}"
-                    )
-
-                    # Get the final message to check for tool use
-                    final_message = await stream.get_final_message()
-                    accumulated_content = final_message.content
-                    stop_reason = final_message.stop_reason
-
-                    logger.debug(f"🏁 Stream stop reason: {stop_reason}")
-
-                # Persist reasoning trace for this streaming iteration (GH #79)
-                try:
-                    _stream_duration_ms = int(
-                        (asyncio.get_event_loop().time() - _stream_started) * 1000
-                    )
-                    _fm_usage = getattr(final_message, "usage", None)
-                    await asyncio.to_thread(
-                        self._persist_interaction,
-                        session_id=session_id,
-                        agent_id=agent_id,
-                        investigation_id=investigation_id,
-                        model=getattr(final_message, "model", model),
-                        system_prompt=effective_system_prompt,
-                        request_messages=messages,
-                        response_content=(
-                            list(accumulated_content) if accumulated_content else []
-                        ),
-                        thinking_enabled=use_thinking,
-                        thinking_budget=(
-                            (
-                                thinking_budget
-                                if thinking_budget is not None
-                                else self.thinking_budget
-                            )
-                            if use_thinking
-                            else None
-                        ),
-                        stop_reason=stop_reason,
-                        input_tokens=(
-                            getattr(_fm_usage, "input_tokens", 0) if _fm_usage else 0
-                        ),
-                        output_tokens=(
-                            getattr(_fm_usage, "output_tokens", 0) if _fm_usage else 0
-                        ),
-                        cache_read_tokens=(
-                            getattr(_fm_usage, "cache_read_input_tokens", 0)
-                            if _fm_usage
-                            else 0
-                        ),
-                        cache_creation_tokens=(
-                            getattr(_fm_usage, "cache_creation_input_tokens", 0)
-                            if _fm_usage
-                            else 0
-                        ),
-                        duration_ms=_stream_duration_ms,
-                        interaction_id=_stream_interaction_id,
-                    )
-                except Exception as _pe:
-                    logger.debug(f"Reasoning-trace persist skipped (stream): {_pe}")
-
-                # Check if tool use is needed
-                if stop_reason == "tool_use" and accumulated_content:
-                    logger.info(f"🔧 Tool use in stream - processing...")
-
-                    # Check for infinite loop detection
-                    current_tool_calls = []
-                    for block in accumulated_content:
-                        if hasattr(block, "type") and block.type == "tool_use":
-                            tool_name = getattr(block, "name", "unknown")
-                            tool_input = getattr(block, "input", {})
-                            tool_signature = f"{tool_name}:{str(tool_input)}"
-                            current_tool_calls.append(tool_signature)
-
-                    # Check if we're calling the same tools repeatedly (potential infinite loop)
-                    if (
-                        current_tool_calls
-                        and current_tool_calls in last_tool_calls[-3:]
-                    ):
-                        logger.warning(
-                            f"⚠️ Infinite loop detected - same tool calls repeated"
-                        )
-                        yield {
-                            "type": "text",
-                            "content": "\n\n[Detected repeated tool calls. Stopping to prevent infinite loop.]",
-                        }
-                        break
-
-                    last_tool_calls.append(current_tool_calls)
-                    # Keep only last 5 tool call sets for comparison
-                    if len(last_tool_calls) > 5:
-                        last_tool_calls.pop(0)
-
-                    yield {"type": "tool_processing"}
-
-                    # Route each tool call to the correct processor (backend or MCP)
-                    tool_results = await self._process_mixed_tool_use(
-                        accumulated_content
-                    )
-                    logger.info(
-                        f"✅ Tool processing complete in stream - {len(tool_results)} results"
-                    )
-
-                    # Add assistant message and tool results to conversation.
-                    # Strip non-spec keys from the replayed response blocks so a
-                    # proxy-injected "caller" field doesn't fail strict request
-                    # validation on the next iteration.
-                    messages.append(
-                        {
-                            "role": "assistant",
-                            "content": self._clean_blocks_for_resend(
-                                accumulated_content
-                            ),
-                        }
-                    )
-                    messages.append({"role": "user", "content": tool_results})
-
-                    # Update api_kwargs for next iteration with tool results
-                    api_kwargs["messages"] = messages
-                else:
-                    # Done - no more tool use needed
-                    total_elapsed = asyncio.get_event_loop().time() - start_time
-                    total_delay = sum(iteration_delays)
-                    logger.info(
-                        f"✅ Stream complete after {iteration} iteration(s) in {total_elapsed:.1f}s (rate limiting: {total_delay:.1f}s)"
-                    )
-                    break
+            engine = AnthropicTurnEngine(
+                runtime=self,
+                messages=messages,
+                system_prompt=effective_system_prompt,
+                model=model,
+                max_tokens=max_tokens,
+                tools=tools,
+                thinking_config=thinking_config,
+                use_thinking=use_thinking,
+                thinking_budget=resolved_budget,
+                session_id=session_id,
+                agent_id=agent_id,
+                investigation_id=investigation_id,
+            )
+            controller = LoopController(engine=engine)
+            async for event in controller.run():
+                yield event
 
         except Exception as e:
             logger.error(f"Error in Claude chat stream: {e}")

--- a/services/openai_agent_service.py
+++ b/services/openai_agent_service.py
@@ -8,21 +8,34 @@ from collections import deque
 from typing import Any, AsyncIterator, Dict, List, Optional, Set
 
 from services import tool_manager
+
 # The provider-agnostic loop skeleton (guards, backoff, loop-detection, tool
 # exec/approval orchestration, telemetry) now lives in services.agent_loop. This
 # service supplies the OpenAI TurnEngine plus the tool-execution runtime the
 # controller calls back into. Several private names are re-exported here so
 # existing imports (and their tests) keep resolving from this module.
-from services.agent_loop import (_HISTORY_WINDOW_DEFAULT,  # noqa: F401
-                                 _LOOP_DETECT_THRESHOLD, LoopController,
-                                 OpenAITurnEngine, PendingApprovalError,
-                                 _canonical_args, _detect_infinite_loop)
+from services.agent_loop import _HISTORY_WINDOW_DEFAULT  # noqa: F401
+from services.agent_loop import (
+    _LOOP_DETECT_THRESHOLD,
+    LoopController,
+    OpenAITurnEngine,
+    PendingApprovalError,
+    _canonical_args,
+    _detect_infinite_loop,
+)
 from services.llm_format import anthropic_tools_to_openai
 from services.llm_router import ProviderSpec
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["OpenAIAgentService", "PendingApprovalError", "anthropic_tools_to_openai"]
+__all__ = [
+    "OpenAIAgentService",
+    "PendingApprovalError",
+    "anthropic_tools_to_openai",
+    # Re-exported for compatibility with existing test imports.
+    "_canonical_args",
+    "_LOOP_DETECT_THRESHOLD",
+]
 
 _TOOL_TIMEOUT_S = 30.0
 _MAX_TOOL_RESPONSE_CHARS = 50_000
@@ -159,10 +172,13 @@ class OpenAIAgentService:
             max_tokens=max_tokens,
             temperature=temperature,
             tools=tools,
+            runtime=self,
+            session_id=session_id,
+            agent_id=agent_id,
             history_window=history_window,
         )
-        controller = LoopController(engine=engine, runtime=self)
-        async for event in controller.run(session_id=session_id, agent_id=agent_id):
+        controller = LoopController(engine=engine)
+        async for event in controller.run():
             yield event
 
     async def run(
@@ -253,8 +269,7 @@ class OpenAIAgentService:
         """Queue a pending approval instead of executing the tool, returning the
         message for the model and the action id to poll (None if not created)."""
         try:
-            from services.approval_service import (ActionType,
-                                                   get_approval_service)
+            from services.approval_service import ActionType, get_approval_service
 
             service = get_approval_service()
             try:
@@ -300,8 +315,7 @@ class OpenAIAgentService:
         """Poll the approval queue until an operator decides, returning
         ``(decision, detail, waited_seconds)``. A vanished action reads as a
         rejection so an uncleared action never executes."""
-        from services.approval_service import (ActionStatus,
-                                               get_approval_service)
+        from services.approval_service import ActionStatus, get_approval_service
 
         service = get_approval_service()
         started = time.monotonic()

--- a/services/openai_agent_service.py
+++ b/services/openai_agent_service.py
@@ -4,39 +4,30 @@ import asyncio
 import json
 import logging
 import time
-import uuid
 from collections import deque
 from typing import Any, AsyncIterator, Dict, List, Optional, Set
 
 from services import tool_manager
+# The provider-agnostic loop skeleton (guards, backoff, loop-detection, tool
+# exec/approval orchestration, telemetry) now lives in services.agent_loop. This
+# service supplies the OpenAI TurnEngine plus the tool-execution runtime the
+# controller calls back into. Several private names are re-exported here so
+# existing imports (and their tests) keep resolving from this module.
+from services.agent_loop import (_HISTORY_WINDOW_DEFAULT,  # noqa: F401
+                                 _LOOP_DETECT_THRESHOLD, LoopController,
+                                 OpenAITurnEngine, PendingApprovalError,
+                                 _canonical_args, _detect_infinite_loop)
 from services.llm_format import anthropic_tools_to_openai
-from services.llm_router import LLMRouter, ProviderSpec
+from services.llm_router import ProviderSpec
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["OpenAIAgentService", "anthropic_tools_to_openai"]
+__all__ = ["OpenAIAgentService", "PendingApprovalError", "anthropic_tools_to_openai"]
 
-_MAX_TOOL_ITERATIONS = 30
-_MAX_PROCESSING_TIME_S = 300.0
 _TOOL_TIMEOUT_S = 30.0
 _MAX_TOOL_RESPONSE_CHARS = 50_000
-_HISTORY_WINDOW_DEFAULT = 20
-_LOOP_DETECT_WINDOW = 5
-_LOOP_DETECT_THRESHOLD = 3
-_BASE_INTER_ITERATION_DELAY_S = 0.5
-_MAX_INTER_ITERATION_DELAY_S = 3.0
-_BACKOFF_ITERATION_THRESHOLD = 15
 _APPROVAL_POLL_INTERVAL_S = 5.0
 _APPROVAL_WAIT_TIMEOUT_S = 600.0
-
-
-class PendingApprovalError(Exception):
-    """Tool call blocked pending human approval; action_id is the queue row to
-    poll, or None when the request could not be created."""
-
-    def __init__(self, message: str, action_id: Optional[str] = None):
-        super().__init__(message)
-        self.action_id = action_id
 
 
 def _truncate(text: str, max_chars: int = _MAX_TOOL_RESPONSE_CHARS) -> str:
@@ -44,31 +35,6 @@ def _truncate(text: str, max_chars: int = _MAX_TOOL_RESPONSE_CHARS) -> str:
         return text
     omitted = len(text) - max_chars
     return text[:max_chars] + f"\n...[truncated, {omitted} chars omitted]"
-
-
-def _inter_iteration_delay(iteration: int) -> float:
-    """Exponential backoff matching ClaudeService: 500ms base, ramp after 15."""
-    if iteration <= _BACKOFF_ITERATION_THRESHOLD:
-        return _BASE_INTER_ITERATION_DELAY_S
-    exp = iteration - _BACKOFF_ITERATION_THRESHOLD
-    delay = _BASE_INTER_ITERATION_DELAY_S * (1.5**exp)
-    return min(delay, _MAX_INTER_ITERATION_DELAY_S)
-
-
-def _canonical_args(raw: str) -> str:
-    """Canonicalize tool-call argument JSON for stable loop detection.
-
-    Parse and re-serialize with sorted keys so cosmetic streaming
-    differences (whitespace, key ordering) don't make a repeated call look
-    distinct and defeat the infinite-loop guard. Falls back to the stripped
-    raw string when the arguments aren't valid JSON.
-    """
-    try:
-        return json.dumps(
-            json.loads(raw or "{}"), sort_keys=True, separators=(",", ":")
-        )
-    except (json.JSONDecodeError, TypeError):
-        return (raw or "").strip()
 
 
 class OpenAIAgentService:
@@ -141,27 +107,6 @@ class OpenAIAgentService:
         """
         return bool(self._all_tools_openai_format())
 
-    @staticmethod
-    def _apply_history_window(
-        messages: List[Dict[str, Any]],
-        window: int = _HISTORY_WINDOW_DEFAULT,
-    ) -> List[Dict[str, Any]]:
-        """Enforce a sliding history window (configurable max turns).
-
-        Keeps the system message (if first) + the most recent `window * 2`
-        messages. Matches ClaudeService._apply_history_window behavior.
-        """
-        if window <= 0:
-            return messages
-        max_msgs = window * 2
-        if len(messages) <= max_msgs:
-            return messages
-        # Preserve system message at index 0 if present
-        if messages and messages[0].get("role") == "system":
-            keep = max_msgs - 1
-            return [messages[0]] + messages[-keep:]
-        return messages[-max_msgs:]
-
     async def stream(
         self,
         *,
@@ -193,301 +138,32 @@ class OpenAIAgentService:
             - Infinite loop detection (3 repeated identical tool sets)
         """
         # Stash attribution context for tool gating (approval requests) raised
-        # deep in the loop without threading it through every call.
+        # deep in the loop without threading it through every call. The
+        # controller drives this instance as its ``runtime`` — the approval and
+        # tool-exec callbacks below read these.
         self._session_id = session_id
         self._agent_id = agent_id
 
-        router = LLMRouter()
         model = model or provider.default_model
-
         tools = self._all_tools_openai_format() if enable_tools else []
 
-        from services.llm_format import anthropic_messages_to_openai
-
-        # The loop appends assistant/tool turns in OpenAI shape, so normalize
-        # the incoming history up front; the router re-converts idempotently.
-        oai_messages = anthropic_messages_to_openai(messages)
-        oai_messages = self._apply_history_window(oai_messages, history_window)
-
-        start_time = asyncio.get_event_loop().time()
-
-        # Infinite loop detection state
-        tool_call_history: deque = deque(maxlen=_LOOP_DETECT_WINDOW)
-
-        for iteration in range(_MAX_TOOL_ITERATIONS):
-            elapsed = asyncio.get_event_loop().time() - start_time
-            if elapsed > _MAX_PROCESSING_TIME_S:
-                yield {
-                    "type": "text",
-                    "content": (
-                        "\n\n[Maximum processing time "
-                        f"({_MAX_PROCESSING_TIME_S:.0f}s) exceeded "
-                        f"after {iteration} iterations.]"
-                    ),
-                }
-                break
-
-            if iteration > 0:
-                delay = _inter_iteration_delay(iteration)
-                await asyncio.sleep(delay)
-
-            interaction_id = str(uuid.uuid4())
-
-            # Accumulate streamed response
-            text_buffer = ""
-            tool_calls_buffer: Dict[int, Dict[str, Any]] = {}
-            finish_reason: Optional[str] = None
-            input_tokens = 0
-            output_tokens = 0
-            iter_start = time.monotonic()
-
-            try:
-                async for chunk in router.stream_openai_raw(
-                    provider=provider,
-                    messages=oai_messages,
-                    system_prompt=system_prompt,
-                    model=model,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    tools=tools or None,
-                    interaction_id=interaction_id,
-                    # Ask for a final usage-only chunk so token counts (and thus
-                    # cost) are recorded — without this, streamed responses carry
-                    # no usage and analytics would show $0 for OpenAI/Groq/Ollama.
-                    include_usage=True,
-                ):
-                    # The usage-only chunk (include_usage) arrives with an
-                    # empty ``choices`` list, so read usage before skipping it.
-                    usage = getattr(chunk, "usage", None)
-                    if usage:
-                        input_tokens = getattr(usage, "prompt_tokens", 0) or 0
-                        output_tokens = getattr(usage, "completion_tokens", 0) or 0
-                    if not chunk.choices:
-                        continue
-                    choice = chunk.choices[0]
-                    delta = choice.delta
-                    finish_reason = choice.finish_reason or finish_reason
-
-                    if delta and delta.content:
-                        text_buffer += delta.content
-                        yield {"type": "text", "content": delta.content}
-
-                    if delta and delta.tool_calls:
-                        for tc_delta in delta.tool_calls:
-                            idx = tc_delta.index
-                            if idx not in tool_calls_buffer:
-                                tool_calls_buffer[idx] = {
-                                    "id": tc_delta.id or "",
-                                    "name": "",
-                                    "arguments": "",
-                                }
-                            entry = tool_calls_buffer[idx]
-                            if tc_delta.id:
-                                entry["id"] = tc_delta.id
-                            if tc_delta.function:
-                                if tc_delta.function.name:
-                                    entry["name"] += tc_delta.function.name
-                                if tc_delta.function.arguments:
-                                    entry["arguments"] += tc_delta.function.arguments
-
-            except Exception as exc:
-                logger.error("OpenAI stream error iteration %d: %s", iteration, exc)
-                yield {"type": "error", "content": str(exc)}
-                break
-
-            iter_duration_ms = int((time.monotonic() - iter_start) * 1000)
-            cost_usd = self._compute_cost(
-                model, provider.provider_type, input_tokens, output_tokens
-            )
-
-            # Persist interaction log (non-fatal)
-            self._log_interaction(
-                session_id=session_id,
-                agent_id=agent_id,
-                model=f"{provider.provider_type}/{model}",
-                iteration=iteration,
-                interaction_id=interaction_id,
-                duration_ms=iter_duration_ms,
-                text_content=text_buffer,
-                tool_calls_count=len(tool_calls_buffer),
-                finish_reason=finish_reason,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cost_usd=cost_usd,
-            )
-
-            # No tool calls → done
-            if finish_reason != "tool_calls" or not tool_calls_buffer:
-                # Detect malformed tool calls dumped as text (common with
-                # smaller models that attempt tool use but fail at structured
-                # output). Filter it rather than passing hallucinated JSON.
-                if (
-                    text_buffer
-                    and iteration == 0
-                    and (
-                        '{"type":"function"' in text_buffer
-                        or (
-                            '"function"' in text_buffer
-                            and '"parameters"' in text_buffer
-                        )
-                    )
-                ):
-                    logger.warning(
-                        "Model output contains raw tool-call JSON in text "
-                        "(model may not support structured tool calling)"
-                    )
-                    yield {
-                        "type": "text",
-                        "content": (
-                            "I attempted to use tools but this model doesn't "
-                            "reliably support structured tool calling. Please "
-                            "select a more capable model in Settings > AI Config "
-                            "(e.g., sec8-tools, gpt-4o, or any 7B+ model with "
-                            "tool support)."
-                        ),
-                    }
-                break
-
-            # Build assistant message with tool_calls
-            assistant_msg: Dict[str, Any] = {"role": "assistant"}
-            if text_buffer:
-                assistant_msg["content"] = text_buffer
-            assistant_tool_calls = []
-            for idx in sorted(tool_calls_buffer.keys()):
-                tc = tool_calls_buffer[idx]
-                name = (tc["name"] or "").strip()
-                if not name:
-                    # A tool-call slot that never received a function name is
-                    # unusable — skip it rather than emit a malformed call the
-                    # provider will reject.
-                    logger.warning(
-                        "Skipping tool call %d with empty name (id=%r)", idx, tc["id"]
-                    )
-                    continue
-                assistant_tool_calls.append(
-                    {
-                        # Some providers omit the streamed id; synthesize a stable
-                        # one so tool results can be correlated back to the call.
-                        "id": tc["id"] or f"call_{uuid.uuid4().hex[:12]}",
-                        "type": "function",
-                        "function": {"name": name, "arguments": tc["arguments"]},
-                    }
-                )
-
-            if not assistant_tool_calls:
-                # Every tool-call slot was malformed. Surface any assistant
-                # text and stop rather than loop on an empty turn.
-                if "content" in assistant_msg:
-                    oai_messages.append(assistant_msg)
-                break
-
-            assistant_msg["tool_calls"] = assistant_tool_calls
-            oai_messages.append(assistant_msg)
-
-            # Infinite loop detection (canonicalized args so cosmetic
-            # streaming differences don't defeat repeat detection)
-            call_signature = frozenset(
-                "{}:{}".format(
-                    tc["function"]["name"],
-                    _canonical_args(tc["function"]["arguments"]),
-                )
-                for tc in assistant_tool_calls
-            )
-            tool_call_history.append(call_signature)
-            if self._detect_infinite_loop(tool_call_history):
-                yield {
-                    "type": "text",
-                    "content": (
-                        "\n\n[Stopping: repeated identical tool calls "
-                        "detected (possible infinite loop).]"
-                    ),
-                }
-                break
-
-            # Execute each tool and append results
-            halt = False
-            for tc in assistant_tool_calls:
-                tool_name = tc["function"]["name"]
-                tool_call_id = tc["id"]
-                raw_args = tc["function"]["arguments"]
-
-                yield {
-                    "type": "tool_processing",
-                    "tool_name": tool_name,
-                    "tool_id": tool_call_id,
-                }
-
-                try:
-                    result_text, is_error = await self._execute_tool(
-                        tool_name, raw_args
-                    )
-                except PendingApprovalError as exc:
-                    # Hold the run here until an operator decides, so a run
-                    # never completes with the action un-taken.
-                    yield {
-                        "type": "approval_required",
-                        "tool_name": tool_name,
-                        "tool_id": tool_call_id,
-                        "action_id": exc.action_id,
-                        "content": str(exc),
-                    }
-                    yield {"type": "text", "content": f"\n\n_{exc}_\n\n"}
-                    if not exc.action_id:
-                        # No action to poll — fail closed rather than hang.
-                        yield {"type": "error", "content": str(exc)}
-                        halt = True
-                        break
-                    decision, detail, waited = await self._await_approval(exc.action_id)
-                    # Human think-time isn't LLM processing time.
-                    start_time += waited
-                    if decision == "approved":
-                        result_text, is_error = await self._execute_tool(
-                            tool_name, raw_args, approved=True
-                        )
-                        self._mark_action_executed(exc.action_id, result_text, is_error)
-                    elif decision == "rejected":
-                        result_text, is_error = (
-                            f"Operator REJECTED this action. Reason: {detail}. "
-                            "Do not retry it; continue with another approach or "
-                            "report that the step could not be completed.",
-                            True,
-                        )
-                    else:
-                        yield {"type": "error", "content": detail}
-                        halt = True
-                        break
-
-                preview = result_text[:500] + ("…" if len(result_text) > 500 else "")
-                yield {
-                    "type": "tool_result",
-                    "tool_name": tool_name,
-                    "tool_id": tool_call_id,
-                    "result": preview,
-                    "is_error": is_error,
-                }
-
-                # OpenAI tool messages carry no is_error field, so mark failures
-                # inline — otherwise the model treats an error as a valid result.
-                oai_messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": tool_call_id,
-                        "content": (
-                            f"ERROR: {result_text}" if is_error else result_text
-                        ),
-                    }
-                )
-            if halt:
-                return
-        else:
-            # for/else: loop exhausted without break
-            yield {
-                "type": "text",
-                "content": (
-                    f"\n\n[Tool iteration limit ({_MAX_TOOL_ITERATIONS}) "
-                    "reached. Stopping.]"
-                ),
-            }
+        # Provider-specific model I/O lives in the engine; the provider-agnostic
+        # loop skeleton (guards, backoff, loop-detection, tool-exec/approval
+        # orchestration, telemetry) lives in the controller, which calls back
+        # into this service for tool execution, approval, cost, and logging.
+        engine = OpenAITurnEngine(
+            provider=provider,
+            messages=messages,
+            system_prompt=system_prompt,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tools=tools,
+            history_window=history_window,
+        )
+        controller = LoopController(engine=engine, runtime=self)
+        async for event in controller.run(session_id=session_id, agent_id=agent_id):
+            yield event
 
     async def run(
         self,
@@ -533,11 +209,12 @@ class OpenAIAgentService:
 
     @staticmethod
     def _detect_infinite_loop(history: deque) -> bool:
-        """Detect if the same tool call set repeats >= threshold times."""
-        if len(history) < _LOOP_DETECT_THRESHOLD:
-            return False
-        recent = list(history)[-_LOOP_DETECT_THRESHOLD:]
-        return len(set(recent)) == 1
+        """Detect if the same tool call set repeats >= threshold times.
+
+        Kept as a thin passthrough to the controller's implementation so
+        existing callers/tests that reach for it on this class still resolve.
+        """
+        return _detect_infinite_loop(history)
 
     async def _execute_tool(
         self, tool_name: str, raw_arguments: str, *, approved: bool = False
@@ -576,7 +253,8 @@ class OpenAIAgentService:
         """Queue a pending approval instead of executing the tool, returning the
         message for the model and the action id to poll (None if not created)."""
         try:
-            from services.approval_service import ActionType, get_approval_service
+            from services.approval_service import (ActionType,
+                                                   get_approval_service)
 
             service = get_approval_service()
             try:
@@ -622,7 +300,8 @@ class OpenAIAgentService:
         """Poll the approval queue until an operator decides, returning
         ``(decision, detail, waited_seconds)``. A vanished action reads as a
         rejection so an uncleared action never executes."""
-        from services.approval_service import ActionStatus, get_approval_service
+        from services.approval_service import (ActionStatus,
+                                               get_approval_service)
 
         service = get_approval_service()
         started = time.monotonic()

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -1,0 +1,465 @@
+"""Unit tests for the provider-agnostic agent loop (services/agent_loop.py).
+
+These exercise the two halves of the refactored OpenAI agent loop in isolation:
+
+  - ``LoopController`` — the provider-agnostic loop skeleton (iteration/wall-clock
+    guards, backoff, loop-detection, tool exec + approval flow, telemetry, the
+    iteration-limit message). Driven here against a *fake* engine and a *fake*
+    runtime so the control flow is tested without any provider or DB.
+  - ``OpenAITurnEngine`` — the OpenAI dialect (delta reassembly, tool-call
+    normalization, usage, the malformed-tool-JSON heuristic). Driven with a
+    mocked ``stream_openai_raw``.
+
+The end-to-end behaviour parity guard lives in test_openai_agent_service.py; this
+file adds focused coverage of the new seam.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from services.agent_loop import (LoopController,  # noqa: E402
+                                 NormalizedToolCall, OpenAITurnEngine,
+                                 PendingApprovalError, TurnResult,
+                                 _canonical_args, _inter_iteration_delay)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# Pure helpers
+# --------------------------------------------------------------------------
+class TestCanonicalArgs:
+    def test_key_order_and_whitespace_equivalent(self):
+        assert _canonical_args('{"b": 1, "a": 2}') == _canonical_args('{"a":2,"b":1}')
+
+    def test_invalid_json_falls_back_to_stripped_raw(self):
+        assert _canonical_args("  not json  ") == "not json"
+
+
+class TestBackoff:
+    def test_flat_before_threshold(self):
+        assert _inter_iteration_delay(1) == 0.5
+        assert _inter_iteration_delay(15) == 0.5
+
+    def test_ramps_and_caps_after_threshold(self):
+        assert _inter_iteration_delay(16) > 0.5
+        assert _inter_iteration_delay(100) == 3.0
+
+
+# --------------------------------------------------------------------------
+# LoopController — driven by a fake engine + fake runtime
+# --------------------------------------------------------------------------
+class _FakeEngine:
+    """Scripts a sequence of TurnResults; records history mutations."""
+
+    provider_type = "ollama"
+    model = "llama3.1:8b"
+    model_label = "ollama/llama3.1:8b"
+
+    def __init__(self, turns, *, deltas_per_turn=None):
+        # turns: list of TurnResult; deltas_per_turn: optional list-of-lists of
+        # SSE delta dicts the engine yields before each turn's terminal result.
+        # When omitted, a text delta is auto-emitted for each turn's text — as a
+        # real engine streams text before yielding its terminal TurnResult (the
+        # controller never re-emits turn.text itself).
+        self._turns = list(turns)
+        if deltas_per_turn is None:
+            deltas_per_turn = [
+                [{"type": "text", "content": t.text}] if t.text else [] for t in turns
+            ]
+        self._deltas = deltas_per_turn
+        self._i = 0
+        self.appended_assistant = []
+        self.appended_tool_results = []
+
+    async def stream_turn(self, *, iteration):
+        idx = min(self._i, len(self._turns) - 1)
+        for delta in self._deltas[idx] if idx < len(self._deltas) else []:
+            yield delta
+        turn = self._turns[idx]
+        self._i += 1
+        yield turn
+
+    def append_assistant(self, turn):
+        self.appended_assistant.append(turn)
+
+    def append_tool_result(self, tool_call_id, result_text, is_error):
+        self.appended_tool_results.append((tool_call_id, result_text, is_error))
+
+
+def _runtime(**overrides):
+    rt = SimpleNamespace(
+        _execute_tool=AsyncMock(return_value=("RESULT", False)),
+        _await_approval=AsyncMock(return_value=("approved", "approved", 0.0)),
+        _mark_action_executed=MagicMock(),
+        _compute_cost=MagicMock(return_value=0.0),
+        _log_interaction=MagicMock(),
+    )
+    for k, v in overrides.items():
+        setattr(rt, k, v)
+    return rt
+
+
+def _turn(*, text="", tool_calls=None, finish_reason="stop", raw_count=None):
+    tcs = tool_calls or []
+    assistant = {"role": "assistant"}
+    if text:
+        assistant["content"] = text
+    if tcs:
+        assistant["tool_calls"] = [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {"name": tc.name, "arguments": tc.arguments},
+            }
+            for tc in tcs
+        ]
+    return TurnResult(
+        text=text,
+        finish_reason=finish_reason,
+        raw_tool_call_count=raw_count if raw_count is not None else len(tcs),
+        tool_calls=tcs,
+        assistant_message=assistant,
+        malformed_help=None,
+        interaction_id="iid",
+        input_tokens=1,
+        output_tokens=2,
+        duration_ms=3,
+    )
+
+
+async def _drive(engine, runtime, **kwargs):
+    controller = LoopController(engine=engine, runtime=runtime, **kwargs)
+    return [ev async for ev in controller.run()]
+
+
+@pytest.mark.asyncio
+async def test_text_only_turn_stops_without_tools():
+    engine = _FakeEngine(
+        [_turn(text="hi", finish_reason="stop")],
+        deltas_per_turn=[[{"type": "text", "content": "hi"}]],
+    )
+    runtime = _runtime()
+    events = await _drive(engine, runtime)
+    assert [e for e in events if e["type"] == "text"] == [
+        {"type": "text", "content": "hi"}
+    ]
+    assert not any(e["type"] == "tool_processing" for e in events)
+    runtime._execute_tool.assert_not_awaited()
+    runtime._log_interaction.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_tool_call_executes_then_finishes():
+    tc = NormalizedToolCall(id="call1", name="mytool", arguments='{"q":"x"}')
+    engine = _FakeEngine(
+        [
+            _turn(tool_calls=[tc], finish_reason="tool_calls"),
+            _turn(text="done", finish_reason="stop"),
+        ]
+    )
+    runtime = _runtime()
+    events = await _drive(engine, runtime)
+    assert [
+        e["type"] for e in events if e["type"] in ("tool_processing", "tool_result")
+    ] == [
+        "tool_processing",
+        "tool_result",
+    ]
+    runtime._execute_tool.assert_awaited_once_with("mytool", '{"q":"x"}')
+    assert engine.appended_tool_results == [("call1", "RESULT", False)]
+    assert any(e.get("content") == "done" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_tool_error_flag_propagates():
+    tc = NormalizedToolCall(id="c", name="mytool", arguments="{}")
+    engine = _FakeEngine(
+        [
+            _turn(tool_calls=[tc], finish_reason="tool_calls"),
+            _turn(text="ok", finish_reason="stop"),
+        ]
+    )
+    runtime = _runtime(_execute_tool=AsyncMock(return_value=("boom", True)))
+    events = await _drive(engine, runtime)
+    res = [e for e in events if e["type"] == "tool_result"]
+    assert res and res[0]["is_error"] is True
+    assert engine.appended_tool_results == [("c", "boom", True)]
+
+
+@pytest.mark.asyncio
+async def test_loop_detection_halts_on_repeats():
+    tc = NormalizedToolCall(id="c", name="mytool", arguments='{"q":"x"}')
+    # Same tool call every turn -> should trip the infinite-loop guard.
+    engine = _FakeEngine(
+        [_turn(tool_calls=[tc], finish_reason="tool_calls") for _ in range(6)]
+    )
+    runtime = _runtime()
+    with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+        events = await _drive(engine, runtime)
+    assert any(e["type"] == "text" and "infinite loop" in e["content"] for e in events)
+
+
+@pytest.mark.asyncio
+async def test_iteration_limit_message():
+    # Distinct args each turn so loop-detection never trips; hit the cap instead.
+    turns = [
+        _turn(
+            tool_calls=[
+                NormalizedToolCall(id=f"c{i}", name="t", arguments=f'{{"i":{i}}}')
+            ],
+            finish_reason="tool_calls",
+        )
+        for i in range(10)
+    ]
+    engine = _FakeEngine(turns)
+    runtime = _runtime()
+    with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+        events = await _drive(engine, runtime, max_iterations=3)
+    assert events[-1]["type"] == "text"
+    assert "iteration limit" in events[-1]["content"].lower()
+
+
+@pytest.mark.asyncio
+async def test_wall_clock_guard_stops_immediately():
+    engine = _FakeEngine([_turn(text="never", finish_reason="stop")])
+    runtime = _runtime()
+    # Negative budget => the very first elapsed check trips.
+    events = await _drive(engine, runtime, max_processing_time_s=-1.0)
+    assert events[-1]["type"] == "text"
+    assert "maximum processing time" in events[-1]["content"].lower()
+    runtime._execute_tool.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stream_error_is_surfaced_and_stops():
+    class _BoomEngine(_FakeEngine):
+        async def stream_turn(self, *, iteration):
+            yield {"type": "text", "content": "partial"}
+            raise RuntimeError("provider exploded")
+
+    engine = _BoomEngine([_turn()])
+    runtime = _runtime()
+    events = await _drive(engine, runtime)
+    assert events[-1] == {"type": "error", "content": "provider exploded"}
+    assert {"type": "text", "content": "partial"} in events
+    runtime._log_interaction.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Approval flow through the controller
+# --------------------------------------------------------------------------
+class TestApprovalFlow:
+    def _approval_engine(self):
+        tc = NormalizedToolCall(
+            id="call1", name="isolate_host", arguments='{"host":"h1"}'
+        )
+        return _FakeEngine(
+            [
+                _turn(tool_calls=[tc], finish_reason="tool_calls"),
+                _turn(text="contained", finish_reason="stop"),
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_approved_reexecutes_and_continues(self):
+        engine = self._approval_engine()
+        runtime = _runtime(
+            _execute_tool=AsyncMock(
+                side_effect=[
+                    PendingApprovalError("needs approval", "ACT-1"),
+                    ("isolated", False),
+                ]
+            ),
+            _await_approval=AsyncMock(return_value=("approved", "approved", 0.0)),
+        )
+        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+            events = await _drive(engine, runtime)
+        assert [e["action_id"] for e in events if e["type"] == "approval_required"] == [
+            "ACT-1"
+        ]
+        assert runtime._execute_tool.await_args_list[-1].kwargs == {"approved": True}
+        runtime._mark_action_executed.assert_called_once()
+        assert any(e.get("content") == "contained" for e in events)
+
+    @pytest.mark.asyncio
+    async def test_rejected_is_reported_not_executed(self):
+        engine = self._approval_engine()
+        runtime = _runtime(
+            _execute_tool=AsyncMock(
+                side_effect=PendingApprovalError("needs approval", "ACT-1")
+            ),
+            _await_approval=AsyncMock(return_value=("rejected", "too risky", 0.0)),
+        )
+        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+            events = await _drive(engine, runtime)
+        res = [e for e in events if e["type"] == "tool_result"]
+        assert res and res[0]["is_error"] is True
+        assert "REJECTED" in res[0]["result"] and "too risky" in res[0]["result"]
+        runtime._execute_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_timeout_halts_run(self):
+        engine = self._approval_engine()
+        runtime = _runtime(
+            _execute_tool=AsyncMock(
+                side_effect=PendingApprovalError("needs approval", "ACT-1")
+            ),
+            _await_approval=AsyncMock(return_value=("timeout", "timed out", 0.0)),
+        )
+        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+            events = await _drive(engine, runtime)
+        assert events[-1] == {"type": "error", "content": "timed out"}
+        assert not any(e.get("content") == "contained" for e in events)
+
+    @pytest.mark.asyncio
+    async def test_uncreatable_approval_fails_closed(self):
+        engine = self._approval_engine()
+        await_mock = AsyncMock()
+        runtime = _runtime(
+            _execute_tool=AsyncMock(
+                side_effect=PendingApprovalError("queue down", None)
+            ),
+            _await_approval=await_mock,
+        )
+        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+            events = await _drive(engine, runtime)
+        assert events[-1]["type"] == "error"
+        await_mock.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------
+# OpenAITurnEngine — delta reassembly against a mocked stream_openai_raw
+# --------------------------------------------------------------------------
+def _usage_chunk(prompt, completion):
+    usage = SimpleNamespace(prompt_tokens=prompt, completion_tokens=completion)
+    return SimpleNamespace(choices=[], usage=usage)
+
+
+def _tc(index, tc_id=None, name=None, arguments=None):
+    return SimpleNamespace(
+        index=index, id=tc_id, function=SimpleNamespace(name=name, arguments=arguments)
+    )
+
+
+class _StreamChunk:
+    def __init__(self, content=None, tool_calls=None, finish_reason=None):
+        delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+        self.choices = [SimpleNamespace(delta=delta, finish_reason=finish_reason)]
+        self.usage = None
+
+
+def _engine(tools=None, iteration_messages=None):
+    return OpenAITurnEngine(
+        provider=SimpleNamespace(provider_type="ollama", default_model="llama3.1:8b"),
+        messages=iteration_messages or [{"role": "user", "content": "hi"}],
+        system_prompt=None,
+        model="llama3.1:8b",
+        max_tokens=256,
+        temperature=None,
+        tools=tools or [],
+        history_window=20,
+    )
+
+
+async def _run_turn(engine, chunks, iteration=0):
+    async def _fake_stream(**_kwargs):
+        for c in chunks:
+            yield c
+
+    events = []
+    result = None
+    with patch(
+        "services.agent_loop.LLMRouter.stream_openai_raw",
+        side_effect=lambda **kw: _fake_stream(**kw),
+    ):
+        async for item in engine.stream_turn(iteration=iteration):
+            if isinstance(item, TurnResult):
+                result = item
+            else:
+                events.append(item)
+    return events, result
+
+
+class TestOpenAITurnEngine:
+    @pytest.mark.asyncio
+    async def test_text_reassembly_and_deltas(self):
+        chunks = [
+            _StreamChunk(content="hel"),
+            _StreamChunk(content="lo", finish_reason="stop"),
+        ]
+        events, result = await _run_turn(_engine(), chunks)
+        assert [e["content"] for e in events if e["type"] == "text"] == ["hel", "lo"]
+        assert result.text == "hello"
+        assert result.finish_reason == "stop"
+        assert result.tool_calls == []
+        assert result.raw_tool_call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_tool_call_reassembly_across_chunks(self):
+        chunks = [
+            _StreamChunk(tool_calls=[_tc(0, "id1", "mytool", '{"q":')]),
+            _StreamChunk(
+                tool_calls=[_tc(0, None, None, '"x"}')], finish_reason="tool_calls"
+            ),
+        ]
+        _events, result = await _run_turn(_engine(), chunks)
+        assert result.finish_reason == "tool_calls"
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "mytool"
+        assert result.tool_calls[0].arguments == '{"q":"x"}'
+        assert result.tool_calls[0].id == "id1"
+        assert "tool_calls" in result.assistant_message
+
+    @pytest.mark.asyncio
+    async def test_empty_name_tool_call_is_skipped_but_counted(self):
+        chunks = [
+            _StreamChunk(
+                tool_calls=[_tc(0, "id1", None, "{}")], finish_reason="tool_calls"
+            )
+        ]
+        _events, result = await _run_turn(_engine(), chunks)
+        assert result.tool_calls == []
+        assert result.raw_tool_call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_id_is_synthesized(self):
+        chunks = [
+            _StreamChunk(
+                tool_calls=[_tc(0, None, "mytool", "{}")], finish_reason="tool_calls"
+            )
+        ]
+        _events, result = await _run_turn(_engine(), chunks)
+        assert result.tool_calls[0].id.startswith("call_")
+
+    @pytest.mark.asyncio
+    async def test_usage_is_read_from_usage_only_chunk(self):
+        chunks = [
+            _StreamChunk(content="hi", finish_reason="stop"),
+            _usage_chunk(11, 22),
+        ]
+        _events, result = await _run_turn(_engine(), chunks)
+        assert result.input_tokens == 11 and result.output_tokens == 22
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_json_help_on_first_iteration(self):
+        text = 'Sure: {"type":"function","name":"x"}'
+        chunks = [_StreamChunk(content=text, finish_reason="stop")]
+        _events, result = await _run_turn(_engine(), chunks, iteration=0)
+        assert result.malformed_help is not None
+
+    @pytest.mark.asyncio
+    async def test_no_malformed_help_after_first_iteration(self):
+        text = 'Sure: {"type":"function","name":"x"}'
+        chunks = [_StreamChunk(content=text, finish_reason="stop")]
+        _events, result = await _run_turn(_engine(), chunks, iteration=1)
+        assert result.malformed_help is None

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -26,11 +26,17 @@ import pytest
 REPO = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO))
 
-from services.agent_loop import (LoopController,  # noqa: E402
-                                 NormalizedToolCall, OpenAITurnEngine,
-                                 PendingApprovalError, ToolPhaseResult,
-                                 TurnResult, _canonical_args,
-                                 _inter_iteration_delay)
+from services.agent_loop import (  # noqa: E402
+    AnthropicTurnEngine,
+    LoopController,
+    NormalizedToolCall,
+    OpenAITurnEngine,
+    PendingApprovalError,
+    ToolPhaseResult,
+    TurnResult,
+    _canonical_args,
+    _inter_iteration_delay,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -504,3 +510,217 @@ class TestOpenAIExecuteTools:
         assert events[-1]["type"] == "error"
         assert phase.halt is True
         await_mock.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------
+# AnthropicTurnEngine — characterization tests (lifted chat_stream behaviour)
+# --------------------------------------------------------------------------
+class _FakeAnthropicStream:
+    def __init__(self, events, final_message):
+        self._events = events
+        self._final = final_message
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    def __aiter__(self):
+        async def _gen():
+            for e in self._events:
+                yield e
+
+        return _gen()
+
+    async def get_final_message(self):
+        return self._final
+
+
+def _thinking_start():
+    return SimpleNamespace(
+        type="content_block_start", content_block=SimpleNamespace(type="thinking")
+    )
+
+
+def _thinking_delta(text):
+    return SimpleNamespace(
+        type="content_block_delta",
+        delta=SimpleNamespace(type="thinking_delta", thinking=text),
+    )
+
+
+def _text_delta(text):
+    return SimpleNamespace(
+        type="content_block_delta",
+        delta=SimpleNamespace(type="text_delta", text=text),
+    )
+
+
+def _block_stop():
+    return SimpleNamespace(type="content_block_stop")
+
+
+def _final(content, stop_reason, *, model="claude-opus-4-8", usage=None):
+    return SimpleNamespace(
+        content=content,
+        stop_reason=stop_reason,
+        model=model,
+        usage=usage
+        or SimpleNamespace(
+            input_tokens=7,
+            output_tokens=9,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+        ),
+    )
+
+
+def _anthropic_runtime(events, final_message, *, process_result=None):
+    messages_ns = SimpleNamespace(
+        stream=MagicMock(return_value=_FakeAnthropicStream(events, final_message))
+    )
+    return SimpleNamespace(
+        async_client=SimpleNamespace(messages=messages_ns),
+        _process_mixed_tool_use=AsyncMock(return_value=process_result or []),
+        _clean_blocks_for_resend=MagicMock(side_effect=lambda blocks: list(blocks)),
+        _persist_interaction=MagicMock(),
+    )
+
+
+def _anthropic_engine(runtime, *, messages=None, tools=None, use_thinking=False):
+    return AnthropicTurnEngine(
+        runtime=runtime,
+        messages=(
+            messages if messages is not None else [{"role": "user", "content": "hi"}]
+        ),
+        system_prompt="sys",
+        model="claude-opus-4-8",
+        max_tokens=1024,
+        tools=tools,
+        thinking_config=(
+            {"type": "enabled", "budget_tokens": 1000} if use_thinking else None
+        ),
+        use_thinking=use_thinking,
+        thinking_budget=1000 if use_thinking else None,
+        session_id="s",
+        agent_id="a",
+        investigation_id=None,
+    )
+
+
+async def _run_anth_turn(engine):
+    events, result = [], None
+    async for item in engine.stream_turn(iteration=0):
+        if isinstance(item, TurnResult):
+            result = item
+        else:
+            events.append(item)
+    return events, result
+
+
+class TestAnthropicStreamTurn:
+    @pytest.mark.asyncio
+    async def test_thinking_and_text_deltas_in_order(self):
+        events_in = [
+            _thinking_start(),
+            _thinking_delta("pondering"),
+            _block_stop(),
+            _text_delta("answer"),
+        ]
+        rt = _anthropic_runtime(
+            events_in,
+            _final([SimpleNamespace(type="text", text="answer")], "end_turn"),
+        )
+        events, _result = await _run_anth_turn(_anthropic_engine(rt, use_thinking=True))
+        assert [e["type"] for e in events] == [
+            "thinking_start",
+            "thinking",
+            "thinking_end",
+            "text",
+        ]
+        assert events[1]["content"] == "pondering"
+        assert events[3]["content"] == "answer"
+
+    @pytest.mark.asyncio
+    async def test_done_turn_reports_stop_reason_and_no_tools(self):
+        rt = _anthropic_runtime(
+            [_text_delta("done")],
+            _final([SimpleNamespace(type="text", text="done")], "end_turn"),
+        )
+        _events, result = await _run_anth_turn(_anthropic_engine(rt))
+        assert result.finish_reason == "end_turn"
+        assert result.raw_tool_call_count == 0
+        assert result.tool_calls == []
+
+    @pytest.mark.asyncio
+    async def test_tool_use_turn_normalizes_and_maps_finish_reason(self):
+        block = SimpleNamespace(
+            type="tool_use", name="isolate_host", input={"host": "h1"}, id="toolu_1"
+        )
+        rt = _anthropic_runtime([], _final([block], "tool_use"))
+        _events, result = await _run_anth_turn(_anthropic_engine(rt))
+        # stop_reason "tool_use" maps to the controller's "tool_calls" sentinel.
+        assert result.finish_reason == "tool_calls"
+        assert result.raw_tool_call_count == 1
+        tc = result.tool_calls[0]
+        assert tc.name == "isolate_host" and tc.id == "toolu_1"
+        assert _canonical_args(tc.arguments) == '{"host":"h1"}'
+        # assistant_message content comes from _clean_blocks_for_resend.
+        rt._clean_blocks_for_resend.assert_called_once()
+        assert result.assistant_message["role"] == "assistant"
+
+    @pytest.mark.asyncio
+    async def test_persists_interaction_and_reads_usage(self):
+        rt = _anthropic_runtime(
+            [_text_delta("hi")],
+            _final(
+                [SimpleNamespace(type="text", text="hi")],
+                "end_turn",
+                usage=SimpleNamespace(
+                    input_tokens=11,
+                    output_tokens=22,
+                    cache_read_input_tokens=3,
+                    cache_creation_input_tokens=4,
+                ),
+            ),
+        )
+        _events, result = await _run_anth_turn(_anthropic_engine(rt))
+        rt._persist_interaction.assert_called_once()
+        assert result.input_tokens == 11 and result.output_tokens == 22
+
+
+class TestAnthropicExecuteTools:
+    @pytest.mark.asyncio
+    async def test_batch_executes_and_appends_user_results(self):
+        block = SimpleNamespace(
+            type="tool_use", name="list_findings", input={}, id="toolu_9"
+        )
+        tool_results = [
+            {"type": "tool_result", "tool_use_id": "toolu_9", "content": "ok"}
+        ]
+        rt = _anthropic_runtime(
+            [], _final([block], "tool_use"), process_result=tool_results
+        )
+        messages = [{"role": "user", "content": "hi"}]
+        engine = _anthropic_engine(rt, messages=messages)
+        # Populate _last_accumulated via a turn, then append assistant (as the
+        # controller would) before executing tools.
+        _events, turn = await _run_anth_turn(engine)
+        engine.append_assistant(turn)
+
+        events, phase = [], None
+        async for item in engine.execute_tools(turn, iteration=0):
+            if isinstance(item, ToolPhaseResult):
+                phase = item
+            else:
+                events.append(item)
+
+        # Single, detail-less tool_processing signal (Anthropic shape).
+        assert events == [{"type": "tool_processing"}]
+        rt._process_mixed_tool_use.assert_awaited_once()
+        # History now ends with the user tool-result message.
+        assert messages[-1] == {"role": "user", "content": tool_results}
+        assert messages[-2] == turn.assistant_message  # assistant appended first
+        # No approval gate on this path today: never halts, never waits.
+        assert phase.halt is False and phase.waited == 0.0

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -1,17 +1,17 @@
 """Unit tests for the provider-agnostic agent loop (services/agent_loop.py).
 
-These exercise the two halves of the refactored OpenAI agent loop in isolation:
+Two seams are covered in isolation:
 
-  - ``LoopController`` — the provider-agnostic loop skeleton (iteration/wall-clock
-    guards, backoff, loop-detection, tool exec + approval flow, telemetry, the
-    iteration-limit message). Driven here against a *fake* engine and a *fake*
-    runtime so the control flow is tested without any provider or DB.
-  - ``OpenAITurnEngine`` — the OpenAI dialect (delta reassembly, tool-call
-    normalization, usage, the malformed-tool-JSON heuristic). Driven with a
-    mocked ``stream_openai_raw``.
+  - ``LoopController`` — the provider-agnostic *sequencer*: iteration/wall-clock
+    guards, backoff, loop-detection, the stop/limit messages, and forwarding of
+    the engine's ``stream_turn`` deltas and ``execute_tools`` events. Driven here
+    against a *fake* engine so the control flow is tested without any provider.
+  - ``OpenAITurnEngine`` — the OpenAI dialect: delta reassembly + telemetry
+    (``stream_turn``) and the per-tool gated execution phase (``execute_tools``),
+    driven with a mocked ``stream_openai_raw`` and a fake runtime.
 
-The end-to-end behaviour parity guard lives in test_openai_agent_service.py; this
-file adds focused coverage of the new seam.
+The end-to-end behaviour parity guard lives in test_openai_agent_service.py;
+this file adds focused coverage of the controller/engine seam.
 """
 
 from __future__ import annotations
@@ -28,8 +28,9 @@ sys.path.insert(0, str(REPO))
 
 from services.agent_loop import (LoopController,  # noqa: E402
                                  NormalizedToolCall, OpenAITurnEngine,
-                                 PendingApprovalError, TurnResult,
-                                 _canonical_args, _inter_iteration_delay)
+                                 PendingApprovalError, ToolPhaseResult,
+                                 TurnResult, _canonical_args,
+                                 _inter_iteration_delay)
 
 pytestmark = pytest.mark.unit
 
@@ -56,59 +57,8 @@ class TestBackoff:
 
 
 # --------------------------------------------------------------------------
-# LoopController — driven by a fake engine + fake runtime
+# TurnResult factory
 # --------------------------------------------------------------------------
-class _FakeEngine:
-    """Scripts a sequence of TurnResults; records history mutations."""
-
-    provider_type = "ollama"
-    model = "llama3.1:8b"
-    model_label = "ollama/llama3.1:8b"
-
-    def __init__(self, turns, *, deltas_per_turn=None):
-        # turns: list of TurnResult; deltas_per_turn: optional list-of-lists of
-        # SSE delta dicts the engine yields before each turn's terminal result.
-        # When omitted, a text delta is auto-emitted for each turn's text — as a
-        # real engine streams text before yielding its terminal TurnResult (the
-        # controller never re-emits turn.text itself).
-        self._turns = list(turns)
-        if deltas_per_turn is None:
-            deltas_per_turn = [
-                [{"type": "text", "content": t.text}] if t.text else [] for t in turns
-            ]
-        self._deltas = deltas_per_turn
-        self._i = 0
-        self.appended_assistant = []
-        self.appended_tool_results = []
-
-    async def stream_turn(self, *, iteration):
-        idx = min(self._i, len(self._turns) - 1)
-        for delta in self._deltas[idx] if idx < len(self._deltas) else []:
-            yield delta
-        turn = self._turns[idx]
-        self._i += 1
-        yield turn
-
-    def append_assistant(self, turn):
-        self.appended_assistant.append(turn)
-
-    def append_tool_result(self, tool_call_id, result_text, is_error):
-        self.appended_tool_results.append((tool_call_id, result_text, is_error))
-
-
-def _runtime(**overrides):
-    rt = SimpleNamespace(
-        _execute_tool=AsyncMock(return_value=("RESULT", False)),
-        _await_approval=AsyncMock(return_value=("approved", "approved", 0.0)),
-        _mark_action_executed=MagicMock(),
-        _compute_cost=MagicMock(return_value=0.0),
-        _log_interaction=MagicMock(),
-    )
-    for k, v in overrides.items():
-        setattr(rt, k, v)
-    return rt
-
-
 def _turn(*, text="", tool_calls=None, finish_reason="stop", raw_count=None):
     tcs = tool_calls or []
     assistant = {"role": "assistant"}
@@ -137,8 +87,68 @@ def _turn(*, text="", tool_calls=None, finish_reason="stop", raw_count=None):
     )
 
 
-async def _drive(engine, runtime, **kwargs):
-    controller = LoopController(engine=engine, runtime=runtime, **kwargs)
+# --------------------------------------------------------------------------
+# LoopController — driven by a fake engine
+# --------------------------------------------------------------------------
+class _FakeEngine:
+    """Scripts a sequence of turns and their tool-phase outcomes.
+
+    The controller sequences turns; this fake supplies the two engine hooks the
+    controller drives (``stream_turn`` and ``execute_tools``) plus the telemetry
+    fields it reads. Telemetry and tool execution are the engine's job now, so
+    the fake just records that ``execute_tools`` ran.
+    """
+
+    provider_type = "ollama"
+    model = "llama3.1:8b"
+    model_label = "ollama/llama3.1:8b"
+
+    def __init__(self, turns, *, tool_phase=None, deltas_per_turn=None):
+        # tool_phase: ToolPhaseResult (or callable(turn)->ToolPhaseResult) the
+        # engine returns from execute_tools; defaults to a no-op continue.
+        self._turns = list(turns)
+        if deltas_per_turn is None:
+            deltas_per_turn = [
+                [{"type": "text", "content": t.text}] if t.text else [] for t in turns
+            ]
+        self._deltas = deltas_per_turn
+        self._tool_phase = tool_phase
+        self._i = 0
+        self.appended_assistant = []
+        self.tool_phase_turns = []
+
+    async def stream_turn(self, *, iteration):
+        idx = min(self._i, len(self._turns) - 1)
+        for delta in self._deltas[idx] if idx < len(self._deltas) else []:
+            yield delta
+        turn = self._turns[idx]
+        self._i += 1
+        yield turn
+
+    def append_assistant(self, turn):
+        self.appended_assistant.append(turn)
+
+    async def execute_tools(self, turn, *, iteration):
+        self.tool_phase_turns.append(turn)
+        # Emit the same provider-shaped events a real engine would, so callers
+        # can assert on forwarding.
+        for tc in turn.tool_calls:
+            yield {"type": "tool_processing", "tool_name": tc.name, "tool_id": tc.id}
+            yield {
+                "type": "tool_result",
+                "tool_name": tc.name,
+                "tool_id": tc.id,
+                "result": "ok",
+                "is_error": False,
+            }
+        phase = self._tool_phase
+        if callable(phase):
+            phase = phase(turn)
+        yield phase if phase is not None else ToolPhaseResult()
+
+
+async def _drive(engine, **kwargs):
+    controller = LoopController(engine=engine, **kwargs)
     return [ev async for ev in controller.run()]
 
 
@@ -148,18 +158,16 @@ async def test_text_only_turn_stops_without_tools():
         [_turn(text="hi", finish_reason="stop")],
         deltas_per_turn=[[{"type": "text", "content": "hi"}]],
     )
-    runtime = _runtime()
-    events = await _drive(engine, runtime)
+    events = await _drive(engine)
     assert [e for e in events if e["type"] == "text"] == [
         {"type": "text", "content": "hi"}
     ]
     assert not any(e["type"] == "tool_processing" for e in events)
-    runtime._execute_tool.assert_not_awaited()
-    runtime._log_interaction.assert_called_once()
+    assert engine.tool_phase_turns == []  # execute_tools never invoked
 
 
 @pytest.mark.asyncio
-async def test_tool_call_executes_then_finishes():
+async def test_tool_turn_delegates_to_engine_then_finishes():
     tc = NormalizedToolCall(id="call1", name="mytool", arguments='{"q":"x"}')
     engine = _FakeEngine(
         [
@@ -167,51 +175,42 @@ async def test_tool_call_executes_then_finishes():
             _turn(text="done", finish_reason="stop"),
         ]
     )
-    runtime = _runtime()
-    events = await _drive(engine, runtime)
+    with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+        events = await _drive(engine)
     assert [
         e["type"] for e in events if e["type"] in ("tool_processing", "tool_result")
-    ] == [
-        "tool_processing",
-        "tool_result",
-    ]
-    runtime._execute_tool.assert_awaited_once_with("mytool", '{"q":"x"}')
-    assert engine.appended_tool_results == [("call1", "RESULT", False)]
+    ] == ["tool_processing", "tool_result"]
+    assert len(engine.tool_phase_turns) == 1  # execute_tools ran once
+    assert engine.appended_assistant  # assistant appended before the tool phase
     assert any(e.get("content") == "done" for e in events)
 
 
 @pytest.mark.asyncio
-async def test_tool_error_flag_propagates():
-    tc = NormalizedToolCall(id="c", name="mytool", arguments="{}")
+async def test_halt_from_tool_phase_stops_run_before_limit_message():
+    tc = NormalizedToolCall(id="c", name="t", arguments="{}")
     engine = _FakeEngine(
-        [
-            _turn(tool_calls=[tc], finish_reason="tool_calls"),
-            _turn(text="ok", finish_reason="stop"),
-        ]
+        [_turn(tool_calls=[tc], finish_reason="tool_calls")],
+        tool_phase=ToolPhaseResult(halt=True),
     )
-    runtime = _runtime(_execute_tool=AsyncMock(return_value=("boom", True)))
-    events = await _drive(engine, runtime)
-    res = [e for e in events if e["type"] == "tool_result"]
-    assert res and res[0]["is_error"] is True
-    assert engine.appended_tool_results == [("c", "boom", True)]
+    with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
+        events = await _drive(engine)
+    # halt => return, so neither the iteration-limit nor another turn happens.
+    assert not any("iteration limit" in e.get("content", "").lower() for e in events)
 
 
 @pytest.mark.asyncio
 async def test_loop_detection_halts_on_repeats():
     tc = NormalizedToolCall(id="c", name="mytool", arguments='{"q":"x"}')
-    # Same tool call every turn -> should trip the infinite-loop guard.
     engine = _FakeEngine(
         [_turn(tool_calls=[tc], finish_reason="tool_calls") for _ in range(6)]
     )
-    runtime = _runtime()
     with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
-        events = await _drive(engine, runtime)
+        events = await _drive(engine)
     assert any(e["type"] == "text" and "infinite loop" in e["content"] for e in events)
 
 
 @pytest.mark.asyncio
 async def test_iteration_limit_message():
-    # Distinct args each turn so loop-detection never trips; hit the cap instead.
     turns = [
         _turn(
             tool_calls=[
@@ -222,9 +221,8 @@ async def test_iteration_limit_message():
         for i in range(10)
     ]
     engine = _FakeEngine(turns)
-    runtime = _runtime()
     with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
-        events = await _drive(engine, runtime, max_iterations=3)
+        events = await _drive(engine, max_iterations=3)
     assert events[-1]["type"] == "text"
     assert "iteration limit" in events[-1]["content"].lower()
 
@@ -232,12 +230,10 @@ async def test_iteration_limit_message():
 @pytest.mark.asyncio
 async def test_wall_clock_guard_stops_immediately():
     engine = _FakeEngine([_turn(text="never", finish_reason="stop")])
-    runtime = _runtime()
-    # Negative budget => the very first elapsed check trips.
-    events = await _drive(engine, runtime, max_processing_time_s=-1.0)
+    events = await _drive(engine, max_processing_time_s=-1.0)
     assert events[-1]["type"] == "text"
     assert "maximum processing time" in events[-1]["content"].lower()
-    runtime._execute_tool.assert_not_awaited()
+    assert engine.tool_phase_turns == []
 
 
 @pytest.mark.asyncio
@@ -248,98 +244,21 @@ async def test_stream_error_is_surfaced_and_stops():
             raise RuntimeError("provider exploded")
 
     engine = _BoomEngine([_turn()])
-    runtime = _runtime()
-    events = await _drive(engine, runtime)
+    events = await _drive(engine)
     assert events[-1] == {"type": "error", "content": "provider exploded"}
     assert {"type": "text", "content": "partial"} in events
-    runtime._log_interaction.assert_not_called()
 
 
 # --------------------------------------------------------------------------
-# Approval flow through the controller
+# OpenAITurnEngine — delta reassembly + telemetry (stream_turn)
 # --------------------------------------------------------------------------
-class TestApprovalFlow:
-    def _approval_engine(self):
-        tc = NormalizedToolCall(
-            id="call1", name="isolate_host", arguments='{"host":"h1"}'
-        )
-        return _FakeEngine(
-            [
-                _turn(tool_calls=[tc], finish_reason="tool_calls"),
-                _turn(text="contained", finish_reason="stop"),
-            ]
-        )
-
-    @pytest.mark.asyncio
-    async def test_approved_reexecutes_and_continues(self):
-        engine = self._approval_engine()
-        runtime = _runtime(
-            _execute_tool=AsyncMock(
-                side_effect=[
-                    PendingApprovalError("needs approval", "ACT-1"),
-                    ("isolated", False),
-                ]
-            ),
-            _await_approval=AsyncMock(return_value=("approved", "approved", 0.0)),
-        )
-        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
-            events = await _drive(engine, runtime)
-        assert [e["action_id"] for e in events if e["type"] == "approval_required"] == [
-            "ACT-1"
-        ]
-        assert runtime._execute_tool.await_args_list[-1].kwargs == {"approved": True}
-        runtime._mark_action_executed.assert_called_once()
-        assert any(e.get("content") == "contained" for e in events)
-
-    @pytest.mark.asyncio
-    async def test_rejected_is_reported_not_executed(self):
-        engine = self._approval_engine()
-        runtime = _runtime(
-            _execute_tool=AsyncMock(
-                side_effect=PendingApprovalError("needs approval", "ACT-1")
-            ),
-            _await_approval=AsyncMock(return_value=("rejected", "too risky", 0.0)),
-        )
-        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
-            events = await _drive(engine, runtime)
-        res = [e for e in events if e["type"] == "tool_result"]
-        assert res and res[0]["is_error"] is True
-        assert "REJECTED" in res[0]["result"] and "too risky" in res[0]["result"]
-        runtime._execute_tool.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_timeout_halts_run(self):
-        engine = self._approval_engine()
-        runtime = _runtime(
-            _execute_tool=AsyncMock(
-                side_effect=PendingApprovalError("needs approval", "ACT-1")
-            ),
-            _await_approval=AsyncMock(return_value=("timeout", "timed out", 0.0)),
-        )
-        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
-            events = await _drive(engine, runtime)
-        assert events[-1] == {"type": "error", "content": "timed out"}
-        assert not any(e.get("content") == "contained" for e in events)
-
-    @pytest.mark.asyncio
-    async def test_uncreatable_approval_fails_closed(self):
-        engine = self._approval_engine()
-        await_mock = AsyncMock()
-        runtime = _runtime(
-            _execute_tool=AsyncMock(
-                side_effect=PendingApprovalError("queue down", None)
-            ),
-            _await_approval=await_mock,
-        )
-        with patch("services.agent_loop.asyncio.sleep", new=AsyncMock()):
-            events = await _drive(engine, runtime)
-        assert events[-1]["type"] == "error"
-        await_mock.assert_not_awaited()
+class _StreamChunk:
+    def __init__(self, content=None, tool_calls=None, finish_reason=None):
+        delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+        self.choices = [SimpleNamespace(delta=delta, finish_reason=finish_reason)]
+        self.usage = None
 
 
-# --------------------------------------------------------------------------
-# OpenAITurnEngine — delta reassembly against a mocked stream_openai_raw
-# --------------------------------------------------------------------------
 def _usage_chunk(prompt, completion):
     usage = SimpleNamespace(prompt_tokens=prompt, completion_tokens=completion)
     return SimpleNamespace(choices=[], usage=usage)
@@ -351,23 +270,29 @@ def _tc(index, tc_id=None, name=None, arguments=None):
     )
 
 
-class _StreamChunk:
-    def __init__(self, content=None, tool_calls=None, finish_reason=None):
-        delta = SimpleNamespace(content=content, tool_calls=tool_calls)
-        self.choices = [SimpleNamespace(delta=delta, finish_reason=finish_reason)]
-        self.usage = None
+def _fake_runtime(**overrides):
+    rt = SimpleNamespace(
+        _execute_tool=AsyncMock(return_value=("RESULT", False)),
+        _await_approval=AsyncMock(return_value=("approved", "approved", 0.0)),
+        _mark_action_executed=MagicMock(),
+        _compute_cost=MagicMock(return_value=0.0),
+        _log_interaction=MagicMock(),
+    )
+    for k, v in overrides.items():
+        setattr(rt, k, v)
+    return rt
 
 
-def _engine(tools=None, iteration_messages=None):
+def _engine(runtime=None, tools=None, messages=None):
     return OpenAITurnEngine(
         provider=SimpleNamespace(provider_type="ollama", default_model="llama3.1:8b"),
-        messages=iteration_messages or [{"role": "user", "content": "hi"}],
+        messages=messages or [{"role": "user", "content": "hi"}],
         system_prompt=None,
         model="llama3.1:8b",
         max_tokens=256,
         temperature=None,
         tools=tools or [],
-        history_window=20,
+        runtime=runtime or _fake_runtime(),
     )
 
 
@@ -376,8 +301,7 @@ async def _run_turn(engine, chunks, iteration=0):
         for c in chunks:
             yield c
 
-    events = []
-    result = None
+    events, result = [], None
     with patch(
         "services.agent_loop.LLMRouter.stream_openai_raw",
         side_effect=lambda **kw: _fake_stream(**kw),
@@ -390,7 +314,7 @@ async def _run_turn(engine, chunks, iteration=0):
     return events, result
 
 
-class TestOpenAITurnEngine:
+class TestOpenAIStreamTurn:
     @pytest.mark.asyncio
     async def test_text_reassembly_and_deltas(self):
         chunks = [
@@ -463,3 +387,120 @@ class TestOpenAITurnEngine:
         chunks = [_StreamChunk(content=text, finish_reason="stop")]
         _events, result = await _run_turn(_engine(), chunks, iteration=1)
         assert result.malformed_help is None
+
+    @pytest.mark.asyncio
+    async def test_records_telemetry_via_runtime(self):
+        rt = _fake_runtime()
+        engine = _engine(runtime=rt)
+        chunks = [_StreamChunk(content="hi", finish_reason="stop")]
+        await _run_turn(engine, chunks)
+        rt._log_interaction.assert_called_once()
+        rt._compute_cost.assert_called_once()
+        assert rt._log_interaction.call_args.kwargs["model"] == "ollama/llama3.1:8b"
+
+
+# --------------------------------------------------------------------------
+# OpenAITurnEngine — tool-execution phase (execute_tools)
+# --------------------------------------------------------------------------
+async def _run_tools(engine, turn):
+    events, phase = [], None
+    async for item in engine.execute_tools(turn, iteration=0):
+        if isinstance(item, ToolPhaseResult):
+            phase = item
+        else:
+            events.append(item)
+    return events, phase
+
+
+class TestOpenAIExecuteTools:
+    @pytest.mark.asyncio
+    async def test_executes_tool_and_appends_result(self):
+        rt = _fake_runtime()
+        engine = _engine(runtime=rt)
+        tc = NormalizedToolCall(id="call1", name="mytool", arguments='{"q":"x"}')
+        events, phase = await _run_tools(engine, _turn(tool_calls=[tc]))
+        assert [e["type"] for e in events] == ["tool_processing", "tool_result"]
+        assert events[1]["is_error"] is False and events[1]["result"].startswith(
+            "RESULT"
+        )
+        rt._execute_tool.assert_awaited_once_with("mytool", '{"q":"x"}')
+        assert phase.halt is False and phase.waited == 0.0
+        # tool result appended to the engine's history
+        assert engine._history[-1]["role"] == "tool"
+
+    @pytest.mark.asyncio
+    async def test_error_flag_propagates(self):
+        rt = _fake_runtime(_execute_tool=AsyncMock(return_value=("boom", True)))
+        engine = _engine(runtime=rt)
+        tc = NormalizedToolCall(id="c", name="mytool", arguments="{}")
+        events, _phase = await _run_tools(engine, _turn(tool_calls=[tc]))
+        res = [e for e in events if e["type"] == "tool_result"]
+        assert res and res[0]["is_error"] is True
+
+    @pytest.mark.asyncio
+    async def test_approved_reexecutes_and_reports_wait(self):
+        rt = _fake_runtime(
+            _execute_tool=AsyncMock(
+                side_effect=[
+                    PendingApprovalError("needs approval", "ACT-1"),
+                    ("isolated", False),
+                ]
+            ),
+            _await_approval=AsyncMock(return_value=("approved", "approved", 4.0)),
+        )
+        engine = _engine(runtime=rt)
+        tc = NormalizedToolCall(id="c", name="isolate_host", arguments='{"host":"h1"}')
+        events, phase = await _run_tools(engine, _turn(tool_calls=[tc]))
+        assert [e["action_id"] for e in events if e["type"] == "approval_required"] == [
+            "ACT-1"
+        ]
+        assert rt._execute_tool.await_args_list[-1].kwargs == {"approved": True}
+        rt._mark_action_executed.assert_called_once()
+        assert phase.halt is False and phase.waited == 4.0
+
+    @pytest.mark.asyncio
+    async def test_rejected_is_reported_not_reexecuted(self):
+        rt = _fake_runtime(
+            _execute_tool=AsyncMock(
+                side_effect=PendingApprovalError("needs approval", "ACT-1")
+            ),
+            _await_approval=AsyncMock(return_value=("rejected", "too risky", 0.0)),
+        )
+        engine = _engine(runtime=rt)
+        tc = NormalizedToolCall(id="c", name="isolate_host", arguments='{"host":"h1"}')
+        events, phase = await _run_tools(engine, _turn(tool_calls=[tc]))
+        res = [e for e in events if e["type"] == "tool_result"]
+        assert res and res[0]["is_error"] is True
+        assert "REJECTED" in res[0]["result"] and "too risky" in res[0]["result"]
+        rt._execute_tool.assert_awaited_once()
+        assert phase.halt is False
+
+    @pytest.mark.asyncio
+    async def test_timeout_halts_phase(self):
+        rt = _fake_runtime(
+            _execute_tool=AsyncMock(
+                side_effect=PendingApprovalError("needs approval", "ACT-1")
+            ),
+            _await_approval=AsyncMock(return_value=("timeout", "timed out", 0.0)),
+        )
+        engine = _engine(runtime=rt)
+        tc = NormalizedToolCall(id="c", name="isolate_host", arguments='{"host":"h1"}')
+        events, phase = await _run_tools(engine, _turn(tool_calls=[tc]))
+        assert events[-1] == {"type": "error", "content": "timed out"}
+        assert phase.halt is True
+
+    @pytest.mark.asyncio
+    async def test_uncreatable_approval_fails_closed(self):
+        await_mock = AsyncMock()
+        rt = _fake_runtime(
+            _execute_tool=AsyncMock(
+                side_effect=PendingApprovalError("queue down", None)
+            ),
+            _await_approval=await_mock,
+        )
+        engine = _engine(runtime=rt)
+        tc = NormalizedToolCall(id="c", name="isolate_host", arguments='{"host":"h1"}')
+        events, phase = await _run_tools(engine, _turn(tool_calls=[tc]))
+        assert events[-1]["type"] == "error"
+        assert phase.halt is True
+        await_mock.assert_not_awaited()

--- a/tests/unit/test_agent_runner_preflight.py
+++ b/tests/unit/test_agent_runner_preflight.py
@@ -76,7 +76,11 @@ def _stub_estimate(high_usd: float, low_usd: float = 0.0, source: str = "exact")
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # asyncio.run() creates, drives, and closes its own event loop, so this is
+    # robust regardless of whether a prior test left a current loop set. On
+    # Python 3.13, asyncio.get_event_loop() raises when no loop is current —
+    # which happened once an async test file ran earlier in the session (#442).
+    return asyncio.run(coro)
 
 
 def test_preflight_proceeds_when_estimate_fits_budget():


### PR DESCRIPTION
## What

**PR3b** of #413. Introduces `AnthropicTurnEngine` so the Anthropic chat path runs behind the same provider-agnostic `LoopController` that PR3a established for the OpenAI path. Two structural commits + one review-driven fix:

1. **`refactor(agent-loop): thin the controller`** — moves the tool-execution phase and per-iteration telemetry *out* of `LoopController` and *into* the `TurnEngine` (`execute_tools()` + telemetry at the end of `stream_turn()`). The controller now owns only the cross-cutting guards every provider shares: iteration cap, wall-clock timeout, backoff, canonicalized loop-detection, and the stop/limit messages. It no longer holds a runtime. Behaviour-preserving for the OpenAI path — `test_openai_agent_service.py` passes **unmodified**.
2. **`feat(agent-loop): add AnthropicTurnEngine; route chat_stream through it`** — an Anthropic-native `TurnEngine` that reproduces `ClaudeService.chat_stream`'s loop body: native `messages.stream` with `thinking_start`/`thinking`/`thinking_end` + `text` events, `get_final_message()` usage, per-iteration reasoning-trace persistence, and batch tool execution via `_process_mixed_tool_use`. It wraps a `ClaudeService` and reuses its proven helpers, so canonical history stays native Anthropic blocks (no conversion at the boundary). `ClaudeService.chat_stream` keeps its setup (message/tool/thinking assembly, `_prepare_context_async` + `context_windowed`) and delegates the multi-turn loop.
3. **`fix(chat): surface {"type":"error"} stream events in the chat UIs`** — see delta #2 below.

## Why

Making `LLMRouter` the single LLM entry point (#413) requires the Anthropic loop to run behind the same controller as the OpenAI loop. Their turn bodies diverge in every particular (thinking events, `context_windowed`, batch-vs-per-tool execution, block-vs-OpenAI history, telemetry shape), so the controller had to become a thin sequencer and each engine own its own dialect. This sets up the later sub-PRs (unified persistence/budget in 3c, `run_agent_task` in 3d, caller migration + uniform gate in 3e).

## Deliberate behaviour deltas on the Anthropic chat path

All three follow from unifying the two loops behind one controller, and are intentional:

1. **Loop-detection** now uses the canonicalized `frozenset` signature (the unification chosen in review) instead of `str(input)` list-containment. It requires 3 *consecutive* identical tool-sets; the previous check tripped on 2 repeats and caught `A,B,A,B` oscillation. Bounded by the 30-iteration / 300s guards either way.
2. **Per-turn stream errors** now yield `{"type":"error"}` and stop gracefully (matching the OpenAI path) instead of raising. Both chat consumers only handled a top-level `error` key, so commit 3 adds `type === 'error'` handling to `Chat.tsx` and `ClaudeDrawer.tsx` — which also repairs the pre-existing OpenAI/Ollama path (it already emitted `{"type":"error"}` and dropped it). Setup-phase errors still raise.
3. **Assistant message** is appended just before loop-detection rather than after — unobservable (a loop-detect trip discards engine-local history).

The tier/approval gate remains **absent** on the Anthropic path (unchanged from `chat_stream`); unifying it across providers is deferred to PR3e, alongside the frontend `approval_required` handler.

## How it was tested

- `test_openai_agent_service.py` (OpenAI end-to-end parity) passes **unmodified** — the behaviour-preservation proof for commit 1.
- `test_agent_loop.py` rewritten for the thin-controller split + new `AnthropicTurnEngine` characterization tests (thinking events, tool-use normalization, `_persist_interaction` args, usage, batch tool exec).
- The existing `chat_stream` test and `test_claude_service` / `test_claude_chat_routing` suites pass.
- `black` / `flake8` / `mypy` clean on all new/changed backend files; `eslint` clean on the two frontend files.
- A fresh-eyes reviewer confirmed both commits are faithful lifts; the one HIGH finding (errors silently dropped by the UIs) is fixed in commit 3.

## Notes for reviewers

- **Stacked on #443 (PR3a).** Until #443 merges, this PR's diff includes 3a's commits plus the `test(preflight)` fix (`627ca42`, "Fixes #442"). The 3b-specific changes are the top three commits.
- `services/claude_service.py` has pre-existing `flake8`/`black` findings unrelated to this change; only the `chat_stream` region was touched.

Part of #413.
