### PR TITLE
fix(redesign): define missing chat-dock resize helpers (#401 regression)

### DIFF
--- a/frontend/src/redesign/SocConsole.tsx
+++ b/frontend/src/redesign/SocConsole.tsx
@@ -3,7 +3,7 @@
    dock, floating "Ask Vigil" FAB, and the theme tweaks panel.
    Ported from the design's index HTML + main.js.
    ============================================================ */
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import './styles.css'
 import { useAuth } from '../contexts/AuthContext'
@@ -50,6 +50,44 @@ const SCREEN_PERMS: Partial<Record<ScreenKey, string>> = {
   cases: 'cases.read',
   decisions: 'ai_decisions.approve',
   settings: 'settings.read',
+}
+
+/* ---------- resizable chat dock (#401) ----------
+ * The dock width is an operator preference persisted in localStorage and
+ * clamped to a sensible band; on narrow viewports the dock goes full-width and
+ * resizing is disabled. These module-level helpers back that behaviour. */
+const CHAT_MIN_WIDTH = 360
+const CHAT_MAX_WIDTH = 720
+const CHAT_DEFAULT_WIDTH = 420
+const CHAT_WIDTH_STORAGE_KEY = 'soc.chat.width.v1'
+
+/** Clamp a requested dock width to the [min, max] band (rounded to a whole px). */
+function clampChatPreference(width: number): number {
+  return Math.min(CHAT_MAX_WIDTH, Math.max(CHAT_MIN_WIDTH, Math.round(width)))
+}
+
+/** Largest dock width allowed for a viewport — never more than half the screen
+ *  (so the main canvas stays usable) and never beyond the hard max. */
+function chatMaxForViewport(viewportWidth: number): number {
+  return Math.min(
+    CHAT_MAX_WIDTH,
+    Math.max(CHAT_MIN_WIDTH, Math.floor(viewportWidth * 0.5)),
+  )
+}
+
+/** Restore the persisted dock-width preference, clamped; default when unset or
+ *  when localStorage is unavailable. */
+function readChatWidth(): number {
+  try {
+    const raw = localStorage.getItem(CHAT_WIDTH_STORAGE_KEY)
+    if (raw) {
+      const parsed = Number.parseInt(raw, 10)
+      if (Number.isFinite(parsed)) return clampChatPreference(parsed)
+    }
+  } catch {
+    /* localStorage unavailable — fall through to the default */
+  }
+  return CHAT_DEFAULT_WIDTH
 }
 
 export default function SocConsole() {
@@ -231,6 +269,7 @@ function SocConsoleInner() {
   const resizeMinWidth = viewportWidth <= 600 ? effectiveChatWidth : CHAT_MIN_WIDTH
   const resizeMaxWidth = viewportWidth <= 600 ? effectiveChatWidth : chatViewportMax
   const consoleStyle = {
+    ...bgVars(bg.base),
     ...accentVars(accent.a, accent.b),
     '--chat-w': `${effectiveChatWidth}px`,
   } as CSSProperties
@@ -239,7 +278,7 @@ function SocConsoleInner() {
     <div
       className={wrapperClass}
       data-theme={isDarkBase(bg.base) ? 'dark' : 'light'}
-      style={{ ...bgVars(bg.base), ...accentVars(accent.a, accent.b) }}
+      style={consoleStyle}
     >
       <ToastProvider>
       <div className="shell">


### PR DESCRIPTION
## What

Restores the redesign SOC console, which white-screens on `main`. `SocConsole.tsx` (from #401) referenced five module helpers — `readChatWidth`, `clampChatPreference`, `CHAT_WIDTH_STORAGE_KEY`, `chatMaxForViewport`, `CHAT_MIN_WIDTH` — that were never defined or imported, so `useState(readChatWidth)` throws `ReferenceError` in `SocConsoleInner` and the whole console renders blank.

## Why

#401 ("make assistant dock resizable") appears to have lost these helper definitions (and the `consoleStyle`/`--chat-w` wiring) when it merged. All 15 `SocConsole.test.tsx` cases fail on `main` as a result.

## Changes

- Define the five helpers at module scope in `SocConsole.tsx`: width band **[360, 720]**, default **420**, localStorage key **`soc.chat.width.v1`** (the key the tests already assert), `clampChatPreference` + a per-viewport max (never more than half the screen), and `readChatWidth` restoring the persisted preference with a safe default.
- Wire the dropped `consoleStyle` onto the root element (folding in `bgVars`) so the `--chat-w` dock-width CSS variable is actually applied — it was computed but never used — and import the `CSSProperties` type it needs.

## How tested

- `npx vitest run src/redesign/SocConsole.test.tsx`: **0/15 → 13/15**.
- Loaded the app in a headless browser: the console mounts, nav + dashboard render, and the resizable chat dock opens at its 420px default with **0 render errors**.
- `eslint` + `tsc` clean on `SocConsole.tsx`.

## Out of scope (noted)

The 2 still-failing `SocConsole.test.tsx` cases are a **separate, pre-existing** test-mock gap — the shared-api mock lacks `caseMetricsApi` and a `default` export that the Metrics/Analytics screens now require. Unrelated to the resize dock (it was masked by this crash) and left for a follow-up.

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)