### PR TITLE
fix(redesign): remove duplicate chat-dock helpers

### DIFF
--- a/frontend/src/redesign/SocConsole.tsx
+++ b/frontend/src/redesign/SocConsole.tsx
@@ -107,30 +107,6 @@ export default function SocConsole() {
  *  (keys outside the built-in `ScreenKey` union) can join the rail. */
 type NavItem = [IconName, string, string | null, NavGate?]
 
-// Resizable Vigil Assistant dock. The desktop width is user-preferred and
-// persisted; the effective width is always clamped to the viewport.
-const CHAT_MIN_WIDTH = 360
-const CHAT_MAX_WIDTH = 720
-const CHAT_DEFAULT_WIDTH = 420
-const CHAT_WIDTH_STORAGE_KEY = 'soc.chat.width.v1'
-
-const clampChatPreference = (width: number) =>
-  Math.min(CHAT_MAX_WIDTH, Math.max(CHAT_MIN_WIDTH, Math.round(width)))
-
-const chatMaxForViewport = (viewport: number) =>
-  Math.max(CHAT_MIN_WIDTH, Math.min(CHAT_MAX_WIDTH, viewport))
-
-function readChatWidth(): number {
-  if (typeof window === 'undefined') return CHAT_DEFAULT_WIDTH
-  try {
-    const stored = Number(window.localStorage.getItem(CHAT_WIDTH_STORAGE_KEY))
-    if (!Number.isFinite(stored) || stored <= 0) return CHAT_DEFAULT_WIDTH
-    return clampChatPreference(stored)
-  } catch {
-    return CHAT_DEFAULT_WIDTH
-  }
-}
-
 function SocConsoleInner() {
   // the active screen comes from the URL (/<screen>); the cases screen
   // additionally carries its open case in a ?case=<id> query param.


### PR DESCRIPTION
A merge of the chat-dock resize PRs (#401, #438, #448) left two copies of the CHAT_* constants and helpers in SocConsole.tsx, causing Vite to fail with "Identifier 'CHAT_MIN_WIDTH' has already been declared" and preventing the web UI from starting.

Keep the documented #401 block, whose chatMaxForViewport caps the dock at half the viewport, and drop the duplicate.