### PR TITLE
ci: run Build Frontend on pull requests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -409,7 +409,11 @@ jobs:
     name: Build Frontend
     runs-on: ubuntu-latest
     needs: [lint-frontend]
-    if: github.event_name == 'push' && github.repository == 'Vigil-SOC/vigil'
+    # Runs on PRs too, not just push. This is the only job that type-checks
+    # (tsc); gating it to post-merge let type errors land on main. The
+    # pull_request build compiles the PR merged into its base, so it also
+    # catches breakage that only appears after the merge.
+    if: github.repository == 'Vigil-SOC/vigil'
     steps:
       - uses: actions/checkout@v5
       
@@ -429,6 +433,7 @@ jobs:
         run: npm run build
       
       - name: Upload build artifacts
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v5
         with:
           name: frontend-build


### PR DESCRIPTION
## ci: run Build Frontend on pull requests

### Why
`Build Frontend` (`tsc && vite build`) is the only CI job that type-checks the frontend — Lint runs ESLint and Unit Tests runs Vitest, neither of which runs `tsc`. Until now this job was gated to `push` events only, so type errors were caught *after* merge, on the push to `main`, instead of on the PR. That gap let the same `SocConsole.tsx` breakage reach `main` twice (#438 → #448, fixed in #452).

### Change
Drop the `github.event_name == 'push'` guard on the `build-frontend` job so it runs on `pull_request` as well as push. Because a `pull_request` build compiles the branch *merged into its base*, it also catches breakage that only surfaces after the merge — not just errors already on the PR branch. The artifact upload step stays push-only, so PR runs build-and-check without uploading artifacts. The canonical-repo guard (`github.repository == 'Vigil-SOC/vigil'`) is unchanged, so fork PRs keep working and the build needs no secrets or private submodules.

### Follow-up (separate, after this merges)
Once `Build Frontend` reports green on a real PR, mark it a required status check on `main` (Settings → Branches → Require status checks). That's the piece that actually blocks an untype-checked change from merging. Note the `needs: [lint-frontend]` dependency when configuring required checks — a lint failure skips the build, and a skipped required check also blocks merge.