### PR TITLE
fix(llm): use adaptive thinking for Opus 4.7/4.8 & Fable 5

### DIFF
--- a/services/claude_service.py
+++ b/services/claude_service.py
@@ -15,7 +15,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Union
 sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
 from secrets_manager import get_secret, set_secret
 
-from services.defaults import DEFAULT_MODEL
+from services.defaults import DEFAULT_MODEL, build_thinking_kwargs
 
 # GH #89 — resolve the summarization model via ai_model_configs with a safe
 # fallback to the historical hardcoded default. Defined at module scope so
@@ -2153,7 +2153,8 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                 else self.default_system_prompt
             )
 
-            # Set thinking config
+            # Set thinking config (model-aware: newer Anthropic models reject
+            # the budget_tokens shape and require adaptive thinking).
             thinking_config = None
             if use_thinking:
                 budget = (
@@ -2161,7 +2162,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                     if thinking_budget is not None
                     else self.thinking_budget
                 )
-                thinking_config = {"type": "enabled", "budget_tokens": budget}
+                thinking_config = build_thinking_kwargs(model, budget)
 
             # Sliding window + rolling summary compression (no LLM call).
             messages, _windowed_out = self._prepare_context_sync(
@@ -2181,7 +2182,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                 api_kwargs["tools"] = tools
                 logger.debug(f"🔧 MCP Tools enabled: {len(tools)} tools available")
             if thinking_config:
-                api_kwargs["thinking"] = thinking_config
+                api_kwargs.update(thinking_config)
                 logger.info(f"💭 Thinking config: {thinking_config}")
 
             # GH #84 PR-C: tag system prompt + last tool block for prompt caching.
@@ -2416,7 +2417,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                         api_kwargs["tools"] = tools
                     # IMPORTANT: Include thinking config in follow-up request too!
                     if thinking_config:
-                        api_kwargs["thinking"] = thinking_config
+                        api_kwargs.update(thinking_config)
 
                     # GH #84 PR-C: cache markers for the follow-up rounds too.
                     # System + tools are stable across rounds so the same
@@ -2777,7 +2778,8 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                 else self.default_system_prompt
             )
 
-            # Set thinking config
+            # Set thinking config (model-aware: newer Anthropic models reject
+            # the budget_tokens shape and require adaptive thinking).
             thinking_config = None
             if use_thinking:
                 budget = (
@@ -2785,7 +2787,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                     if thinking_budget is not None
                     else self.thinking_budget
                 )
-                thinking_config = {"type": "enabled", "budget_tokens": budget}
+                thinking_config = build_thinking_kwargs(model, budget)
 
             # Sliding window + rolling summary compression (no LLM call).
             messages, windowed_out = await self._prepare_context_async(
@@ -2809,7 +2811,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                 api_kwargs["tools"] = tools
                 logger.debug(f"🔧 Stream with {len(tools)} MCP tools")
             if thinking_config:
-                api_kwargs["thinking"] = thinking_config
+                api_kwargs.update(thinking_config)
                 logger.info(f"💭 Stream thinking config: {thinking_config}")
 
             # Stream with proper tool use handling using streaming API throughout

--- a/services/defaults.py
+++ b/services/defaults.py
@@ -6,9 +6,59 @@ can change them without code changes.
 """
 
 import os
+from typing import Any, Dict, Optional
 
 # Fallback model ID used when no provider-specific model can be resolved
 # (e.g. fresh install, DB unavailable, no ai_model_configs row).
 # Operators on Ollama-only deployments should set this to their local model
 # (e.g. "llama3.2:1b") so the failsafe never tries to call an Anthropic model.
 DEFAULT_MODEL: str = os.getenv("DEFAULT_MODEL", "claude-sonnet-4-6")
+
+# Anthropic models that reject the legacy extended-thinking shape
+# thinking={"type": "enabled", "budget_tokens": N} with a 400 and instead
+# require adaptive thinking + output_config.effort (Opus 4.7/4.8, Fable 5,
+# Mythos). Matched as substrings so provider prefixes ("anthropic.") and any
+# date/speed suffixes still hit.
+_ADAPTIVE_THINKING_MODELS = (
+    "opus-4-7",
+    "opus-4-8",
+    "fable-5",
+    "mythos-5",
+    "mythos-preview",
+)
+
+
+def model_requires_adaptive_thinking(model: str) -> bool:
+    """True if ``model`` rejects budget_tokens thinking and needs adaptive."""
+    m = (model or "").lower()
+    return any(tag in m for tag in _ADAPTIVE_THINKING_MODELS)
+
+
+def _thinking_budget_to_effort(budget: Optional[int]) -> str:
+    """Map a legacy token budget onto an adaptive-thinking effort level."""
+    if not budget or budget <= 4096:
+        return "low"
+    if budget <= 12000:
+        return "medium"
+    return "high"
+
+
+def build_thinking_kwargs(model: str, budget: Optional[int]) -> Dict[str, Any]:
+    """Build the messages.create/stream kwargs that enable extended thinking.
+
+    Newer Anthropic models (Opus 4.7/4.8, Fable 5, Mythos) reject
+    ``thinking={"type": "enabled", "budget_tokens": N}`` with a 400 and require
+    adaptive thinking plus an ``output_config.effort`` hint instead; older
+    models keep the budget-based form. ``display: "summarized"`` is set on the
+    adaptive path so thinking content is still returned (the API default is
+    ``omitted`` on these models, which would blank the UI's thinking view).
+
+    Returns a dict to merge into the API kwargs — on the adaptive path it sets
+    both ``thinking`` and ``output_config``.
+    """
+    if model_requires_adaptive_thinking(model):
+        return {
+            "thinking": {"type": "adaptive", "display": "summarized"},
+            "output_config": {"effort": _thinking_budget_to_effort(budget)},
+        }
+    return {"thinking": {"type": "enabled", "budget_tokens": budget}}

--- a/services/llm_router.py
+++ b/services/llm_router.py
@@ -533,6 +533,7 @@ class LLMRouter:
         extra_headers: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         from services.llm_clients import create_async_anthropic_client
+        from services.defaults import build_thinking_kwargs
 
         api_key: Optional[str] = None
         if provider.api_key_ref and get_secret is not None:
@@ -559,7 +560,9 @@ class LLMRouter:
         if tools:
             kwargs["tools"] = tools
         if enable_thinking:
-            kwargs["thinking"] = {"type": "enabled", "budget_tokens": thinking_budget}
+            # Model-aware: newer Anthropic models reject the budget_tokens
+            # shape and require adaptive thinking + output_config.effort.
+            kwargs.update(build_thinking_kwargs(model, thinking_budget))
         if extra_headers:
             kwargs["extra_headers"] = extra_headers
 

--- a/services/llm_worker.py
+++ b/services/llm_worker.py
@@ -480,6 +480,11 @@ def _sync_claude_raw(
     """Make a direct client.messages.create() call for multi-turn tool loops."""
     import time as _time
 
+    from services.defaults import (
+        build_thinking_kwargs,
+        model_requires_adaptive_thinking,
+    )
+
     kwargs: Dict[str, Any] = {
         "model": model,
         "max_tokens": max_tokens,
@@ -487,13 +492,13 @@ def _sync_claude_raw(
     }
     if tools:
         kwargs["tools"] = tools
-    if temperature is not None:
+    # Newer Anthropic models (Opus 4.7/4.8, Fable 5, Mythos) reject sampling
+    # params like temperature with a 400, so only send it to older models.
+    if temperature is not None and not model_requires_adaptive_thinking(model):
         kwargs["temperature"] = temperature
     if enable_thinking and thinking_budget:
-        kwargs["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": thinking_budget,
-        }
+        # Model-aware: adaptive thinking for models that reject budget_tokens.
+        kwargs.update(build_thinking_kwargs(model, thinking_budget))
 
     # #185: tag the upstream Bifrost call with a Vigil interaction UUID
     # so the LogEntry on Bifrost's side can be correlated with the local


### PR DESCRIPTION
## Problem

Testing a chat in the **Vigil Assistant** drawer fails with a 400 for *any* message when thinking is enabled and the operator has selected a newer Anthropic model:

```
Could not reach Vigil: Error code: 400 - {'type': 'error', 'error': {'type':
'invalid_request_error', 'message': '"thinking.type.enabled" is not supported
for this model. Use "thinking.type.adaptive" and "output_config.effort" to
control thinking behavior.'}}. Is the backend running?
```

Newer Anthropic models — **Opus 4.7/4.8, Fable 5, Mythos** — reject the legacy extended-thinking shape `thinking={"type": "enabled", "budget_tokens": N}` and require **adaptive thinking** plus an `output_config.effort` hint. Older models (Sonnet 4.x, Haiku 4.5, Opus 4.6) still accept the budget form. The chat drawer (`POST /claude/chat/stream` → `claude_service.chat_stream`) forwards `enable_thinking`, so it hits the 400 whenever a newer model is selected. (The frontend wraps the 400 in the misleading "Is the backend running?" message.)

## Fix

Added a model-aware helper `build_thinking_kwargs(model, budget)` in `services/defaults.py`:

- **Adaptive-only models** → `thinking={"type": "adaptive", "display": "summarized"}` + `output_config={"effort": ...}`. The operator's thinking budget is mapped onto an effort level (`≤4096→low`, `≤12000→medium`, else `high`); `display:"summarized"` keeps thinking content flowing to the UI (the API default is `omitted`/empty on these models).
- **Legacy models** → unchanged `thinking={"type": "enabled", "budget_tokens": N}`.
- Model matching is substring-based, so provider prefixes (`anthropic.`) and date/speed suffixes still resolve.

Applied at every site that hand-built the thinking config:

- `services/claude_service.py` — `chat` (sync + tool-loop follow-up) and `chat_stream`
- `services/llm_router.py` — `_dispatch_anthropic`
- `services/llm_worker.py` — `_sync_claude_raw`, which additionally now skips `temperature` for adaptive-only models (sampling params also 400 on those models)

## Testing

- `tests/unit/test_llm_router.py` + `tests/unit/test_claude_service.py`: **84 passed**
- Verified helper output across `claude-opus-4-8/4-7`, `claude-fable-5`, `anthropic.`-prefixed, `claude-sonnet-4-6/4-5`, `claude-haiku-4-5`, `claude-opus-4-6`, plus the budget→effort mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)