### PR TITLE
fix(llm): omit thinking for adaptive-only models behind Bifrost

### DIFF
--- a/services/defaults.py
+++ b/services/defaults.py
@@ -46,19 +46,24 @@ def _thinking_budget_to_effort(budget: Optional[int]) -> str:
 def build_thinking_kwargs(model: str, budget: Optional[int]) -> Dict[str, Any]:
     """Build the messages.create/stream kwargs that enable extended thinking.
 
-    Newer Anthropic models (Opus 4.7/4.8, Fable 5, Mythos) reject
-    ``thinking={"type": "enabled", "budget_tokens": N}`` with a 400 and require
-    adaptive thinking plus an ``output_config.effort`` hint instead; older
-    models keep the budget-based form. ``display: "summarized"`` is set on the
-    adaptive path so thinking content is still returned (the API default is
-    ``omitted`` on these models, which would blank the UI's thinking view).
+    Two model families need different shapes, and the Bifrost gateway that all
+    Anthropic traffic routes through (``services/llm_clients.py``) constrains
+    what we can send:
 
-    Returns a dict to merge into the API kwargs — on the adaptive path it sets
-    both ``thinking`` and ``output_config``.
+    * **Adaptive-only models** (Opus 4.7/4.8, Fable 5, Mythos) reject
+      ``thinking={"type": "enabled", "budget_tokens": N}`` with a 400. They want
+      ``thinking={"type": "adaptive"}`` + ``output_config.effort`` — but the
+      pinned ``maximhq/bifrost`` image cannot convert ``thinking.type=adaptive``
+      and 500s ("failed to convert bifrost request..."). Since neither thinking
+      shape survives the round trip for these models, we omit ``thinking``
+      entirely and steer reasoning depth with ``output_config.effort`` alone
+      (Bifrost forwards it, and it is valid direct-to-Anthropic too). Thinking
+      blocks won't stream for these models until Bifrost gains adaptive support.
+    * **Older models** (Sonnet 4.x, Haiku 4.5, Opus 4.6) keep the budget-based
+      ``enabled`` shape, which both Anthropic and Bifrost accept.
+
+    Returns a dict to merge into the API kwargs.
     """
     if model_requires_adaptive_thinking(model):
-        return {
-            "thinking": {"type": "adaptive", "display": "summarized"},
-            "output_config": {"effort": _thinking_budget_to_effort(budget)},
-        }
+        return {"output_config": {"effort": _thinking_budget_to_effort(budget)}}
     return {"thinking": {"type": "enabled", "budget_tokens": budget}}


### PR DESCRIPTION
## Problem

Follow-up to #454. That PR made the chat drawer send `thinking={"type":"adaptive"}` + `output_config.effort` for the models that reject the legacy `enabled` shape (Opus 4.7/4.8, Fable 5, Mythos). That's correct against the Anthropic API — but **all Anthropic traffic routes through the Bifrost gateway** (`services/llm_clients.py`), and the pinned `maximhq/bifrost` image **cannot convert `thinking.type=adaptive`**:

```
500 api_error: "failed to convert bifrost request to the expected provider request body"
```

So these models were still unusable in the chat drawer after #454 — the failure just moved from a `400` (Anthropic rejecting `enabled`) to a `500` (Bifrost rejecting `adaptive`).

## Root cause (probed against Bifrost directly, model `claude-opus-4-8`)

| Payload | Result |
|---|---|
| no thinking | ✅ 200 |
| `thinking:{type:adaptive}` | ❌ 500 — Bifrost can't convert |
| `output_config:{effort}` alone | ✅ 200 — Bifrost forwards it |
| `thinking:{type:enabled,budget_tokens}` | ❌ 400 — Anthropic rejects for this model |

Neither thinking shape survives the round trip for adaptive-only models.

## Fix

For adaptive-only models, **omit `thinking` entirely** and steer reasoning depth with `output_config.effort` alone (Bifrost forwards it; also valid direct-to-Anthropic). Older models (Sonnet 4.x, Haiku 4.5, Opus 4.6) keep the budget-based `enabled` shape, which both Anthropic and Bifrost accept.

Trade-off: thinking blocks won't stream for Opus 4.7/4.8 & Fable 5 until Bifrost gains `adaptive` support; the chat is functional in the meantime, and Sonnet 4.6 still streams full thinking.

## Testing

- **Live backend** `POST /api/claude/chat/stream` with `enable_thinking=true` now returns **200** for `claude-opus-4-8`, `claude-fable-5`, and `claude-sonnet-4-6` (the last still streaming thinking blocks). Previously opus/fable returned the Bifrost 500.
- `tests/unit/test_llm_router.py` + `tests/unit/test_claude_service.py`: **84 passed**.

## Follow-up (not in this PR)

The real long-term fix is Bifrost gaining `thinking.type=adaptive` support (or bypassing Bifrost for Anthropic via `ANTHROPIC_BASE_URL`). When that lands, the adaptive `thinking` field can be restored for these models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)