### PR TITLE
fix: replace hardcoded palace path with get_palace_path()

### DIFF
--- a/daemon/shared_intel.py
+++ b/daemon/shared_intel.py
@@ -20,11 +20,9 @@ def _get_mempalace_searcher():
     try:
         from mempalace.searcher import search_memories
 
-        data_dir = Path(
-            os.environ.get(
-                "MEMPALACE_PALACE_PATH", str(Path.home() / ".mempalace" / "palace")
-            )
-        )
+        from services.mempalace_paths import get_palace_path
+
+        data_dir = get_palace_path()
         return (search_memories, data_dir)
     except Exception as e:
         logger.debug(f"MemPalace searcher unavailable in daemon: {e}")

--- a/daemon/shared_intel.py
+++ b/daemon/shared_intel.py
@@ -7,7 +7,6 @@ overlapping investigations and link related cases.
 import logging
 import os
 from collections import defaultdict
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

This PR resolves #456 by replacing the hardcoded  path with a call to the shared  helper.

## Changes

- Replaced hardcoded path in  with 
- Ensures consistency with the rest of the application

## Verification

- [x] Hardcoded path replaced with get_palace_path()
- [x] No other modules hardcode a .mempalace path