### PR TITLE
fix(daemon): use get_palace_path() in shared_intel.py

### DIFF
--- a/daemon/shared_intel.py
+++ b/daemon/shared_intel.py
@@ -20,11 +20,9 @@ def _get_mempalace_searcher():
     try:
         from mempalace.searcher import search_memories
 
-        data_dir = Path(
-            os.environ.get(
-                "MEMPALACE_PALACE_PATH", str(Path.home() / ".mempalace" / "palace")
-            )
-        )
+        from services.mempalace_paths import get_palace_path
+
+        data_dir = get_palace_path()
         return (search_memories, data_dir)
     except Exception as e:
         logger.debug(f"MemPalace searcher unavailable in daemon: {e}")


### PR DESCRIPTION
## Problem
`daemon/shared_intel.py`'s `_get_mempalace_searcher()` hardcoded `~/.mempalace/palace` via an ad-hoc `MEMPALACE_PALACE_PATH` env lookup instead of the central `get_palace_path()` helper in `services/mempalace_paths.py`. Any deployment with a non-default palace location (custom home dir, container volume, test fixture) had shared intel silently reading/writing the wrong directory — the split-brain class documented in `mempalace_paths.py`'s own docstring and already fixed once in `daemon/orchestrator.py` (#129).

## Fix
Import and call `get_palace_path()`, matching the exact pattern used in `daemon/orchestrator.py:853`.

## Verification
- `py_compile` + `ast.parse` clean.
- Repo-wide `grep -rn '"\.mempalace"' --include=*.py .` (excluding `mempalace_paths.py` itself) returns nothing — no stragglers, satisfying the issue's second acceptance criterion.
- No existing test file targets `shared_intel.py`; the change is a one-line call-site swap to an already-used, already-tested helper.

Fixes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)