### PR TITLE
fix(ingest): background upload jobs, stop dropping rows as dupes, generic parquet schema support

### DIFF
--- a/backend/api/ingestion.py
+++ b/backend/api/ingestion.py
@@ -162,57 +162,19 @@ async def ingest_from_string(
     format: str = Form("json"),
     data_type: str = Form("finding")
 ):
-    """
-    Ingest data from a string.
-    
-    Args:
-        data: Data as string
-        format: Format ('json', 'csv', 'jsonl')
-        data_type: Type of data ('finding' or 'case')
-    
-    Returns:
-        Ingestion statistics
-    """
+    """Ingest data from a string; format is 'json', 'csv', or 'jsonl'."""
     if data_type not in ['finding', 'case']:
         raise HTTPException(status_code=400, detail="data_type must be 'finding' or 'case'")
-    
+
     if format not in ['json', 'csv', 'jsonl']:
         raise HTTPException(status_code=400, detail="format must be 'json', 'csv', or 'jsonl'")
-    
+
     try:
         ingestion_service = IngestionService()
         stats = ingestion_service.ingest_from_string(data, format=format, data_type=data_type)
-        
-        # Determine success
-        success = (
-            stats['findings_errors'] == 0 and
-            stats['cases_errors'] == 0 and
-            (stats['findings_imported'] > 0 or stats['cases_imported'] > 0)
-        )
-        
-        # Build message
-        messages = []
-        if stats['findings_imported'] > 0:
-            messages.append(f"Imported {stats['findings_imported']} findings")
-        if stats['findings_skipped'] > 0:
-            messages.append(f"Skipped {stats['findings_skipped']} duplicate findings")
-        if stats['cases_imported'] > 0:
-            messages.append(f"Imported {stats['cases_imported']} cases")
-        if stats['cases_skipped'] > 0:
-            messages.append(f"Skipped {stats['cases_skipped']} duplicate cases")
-        if stats['findings_errors'] > 0:
-            messages.append(f"⚠ {stats['findings_errors']} finding errors")
-        if stats['cases_errors'] > 0:
-            messages.append(f"⚠ {stats['cases_errors']} case errors")
-        
-        message = ". ".join(messages) if messages else "No data imported"
-        
-        return IngestionStats(
-            **stats,
-            success=success,
-            message=message
-        )
-    
+        success, message = summarize_stats(stats)
+        return IngestionStats(**stats, success=success, message=message)
+
     except Exception as e:
         logger.error(f"Error ingesting string data: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Ingestion failed: {str(e)}")

--- a/backend/api/ingestion.py
+++ b/backend/api/ingestion.py
@@ -9,15 +9,25 @@ Handles uploading and ingesting findings/cases from various file formats:
 - S3 sync
 """
 
+import asyncio
 import logging
 import os
-from typing import Optional, List
+from datetime import datetime
+from typing import Dict, Optional, List
 from fastapi import APIRouter, UploadFile, File, Form, HTTPException, Query
 from pydantic import BaseModel
 from pathlib import Path
+from starlette.concurrency import run_in_threadpool
 import tempfile
 
 from services.ingestion_service import IngestionService
+from services.ingestion_jobs import (
+    IngestionJob,
+    IngestionJobConflict,
+    get_job_registry,
+    run_job,
+    summarize_stats,
+)
 from services.database_data_service import DatabaseDataService
 
 logger = logging.getLogger(__name__)
@@ -25,6 +35,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 MAX_UPLOAD_SIZE_BYTES = int(os.environ.get("MAX_UPLOAD_SIZE_MB", "500")) * 1024 * 1024
+
+EXTENSION_FORMATS = {
+    '.json': 'json',
+    '.csv': 'csv',
+    '.jsonl': 'jsonl',
+    '.ndjson': 'jsonl',
+    '.parquet': 'parquet',
+}
+
+_running_tasks: set = set()  # asyncio only weak-refs tasks; unheld ones get GC'd
 
 
 class IngestionStats(BaseModel):
@@ -41,123 +61,99 @@ class IngestionStats(BaseModel):
     message: str
 
 
-@router.post("/upload", response_model=IngestionStats)
+class IngestionJobStatus(BaseModel):
+    """Snapshot of a background ingestion job."""
+    job_id: str
+    filename: str
+    format: str
+    data_type: str
+    status: str
+    determinate: bool
+    processed: int
+    total: int
+    created_at: datetime
+    finished_at: Optional[datetime]
+    message: str
+    error: Optional[str]
+    stats: Dict[str, int]
+
+
+async def _spool_upload(file: UploadFile, suffix: str) -> Path:
+    """Stream an upload to a temp file, enforcing the size cap as it goes."""
+
+    with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix=suffix) as temp_file:
+        temp_path = Path(temp_file.name)
+        total_size = 0
+        while True:
+            chunk = await file.read(1024 * 1024)
+            if not chunk:
+                break
+            total_size += len(chunk)
+            if total_size > MAX_UPLOAD_SIZE_BYTES:
+                temp_file.close()
+                temp_path.unlink(missing_ok=True)
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"File too large. Maximum upload size is {MAX_UPLOAD_SIZE_BYTES // (1024*1024)}MB."
+                )
+            temp_file.write(chunk)
+    return temp_path
+
+
+@router.post("/upload", response_model=IngestionJobStatus, status_code=202)
 async def upload_and_ingest_file(
     file: UploadFile = File(...),
     data_type: str = Form("finding"),
     format: Optional[str] = Form(None)
 ):
-    """
-    Upload and ingest a file containing findings or cases.
-    
-    Args:
-        file: The file to upload (JSON, CSV, JSONL, or Parquet)
-        data_type: Type of data ('finding' or 'case')
-        format: File format ('json', 'csv', 'jsonl', 'parquet'). Auto-detected if not provided.
-    
-    Returns:
-        Ingestion statistics
-    """
+    """Accept a file and ingest it as a background job; poll /ingest/jobs/{id}."""
     if data_type not in ['finding', 'case']:
         raise HTTPException(status_code=400, detail="data_type must be 'finding' or 'case'")
-    
-    # Auto-detect format from filename if not provided
+
+    filename = file.filename or 'upload'
     if not format:
-        filename = file.filename.lower()
-        if filename.endswith('.json'):
-            format = 'json'
-        elif filename.endswith('.csv'):
-            format = 'csv'
-        elif filename.endswith('.jsonl') or filename.endswith('.ndjson'):
-            format = 'jsonl'
-        elif filename.endswith('.parquet'):
-            format = 'parquet'
-        else:
+        format = EXTENSION_FORMATS.get(Path(filename).suffix.lower())
+        if format is None:
             raise HTTPException(
                 status_code=400,
                 detail="Unable to detect file format. Please specify format parameter or use .json, .csv, .jsonl, or .parquet extension"
             )
-    
+
     if format not in ['json', 'csv', 'jsonl', 'parquet']:
         raise HTTPException(status_code=400, detail="format must be 'json', 'csv', 'jsonl', or 'parquet'")
-    
+
+    temp_path = await _spool_upload(file, f'.{format}')
+
+    job = IngestionJob(filename=filename, fmt=format, data_type=data_type)
     try:
-        suffix = '.parquet' if format == 'parquet' else f'.{format}'
-        with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix=suffix) as temp_file:
-            total_size = 0
-            chunk_size = 1024 * 1024
-            while True:
-                chunk = await file.read(chunk_size)
-                if not chunk:
-                    break
-                total_size += len(chunk)
-                if total_size > MAX_UPLOAD_SIZE_BYTES:
-                    temp_file.close()
-                    Path(temp_file.name).unlink(missing_ok=True)
-                    raise HTTPException(
-                        status_code=413,
-                        detail=f"File too large. Maximum upload size is {MAX_UPLOAD_SIZE_BYTES // (1024*1024)}MB."
-                    )
-                temp_file.write(chunk)
-            temp_path = Path(temp_file.name)
-        
-        try:
-            # Ingest the file
-            ingestion_service = IngestionService()
-            
-            if format == 'json':
-                stats = ingestion_service.ingest_json_file(temp_path)
-            elif format == 'csv':
-                stats = ingestion_service.ingest_csv_file(temp_path, data_type=data_type)
-            elif format == 'jsonl':
-                stats = ingestion_service.ingest_jsonl_file(temp_path, data_type=data_type)
-            elif format == 'parquet':
-                stats = ingestion_service.ingest_parquet_file(temp_path)
-            
-            # Clean up temp file
-            temp_path.unlink()
-            
-            # Determine success
-            success = (
-                stats['findings_errors'] == 0 and
-                stats['cases_errors'] == 0 and
-                (stats['findings_imported'] > 0 or stats['cases_imported'] > 0 or
-                 stats['findings_skipped'] > 0 or stats['cases_skipped'] > 0)
-            )
-            
-            # Build message
-            messages = []
-            if stats['findings_imported'] > 0:
-                messages.append(f"Imported {stats['findings_imported']} findings")
-            if stats['findings_skipped'] > 0:
-                messages.append(f"Skipped {stats['findings_skipped']} duplicate findings")
-            if stats['cases_imported'] > 0:
-                messages.append(f"Imported {stats['cases_imported']} cases")
-            if stats['cases_skipped'] > 0:
-                messages.append(f"Skipped {stats['cases_skipped']} duplicate cases")
-            if stats['findings_errors'] > 0:
-                messages.append(f"⚠ {stats['findings_errors']} finding errors")
-            if stats['cases_errors'] > 0:
-                messages.append(f"⚠ {stats['cases_errors']} case errors")
-            
-            message = ". ".join(messages) if messages else "No data imported"
-            
-            return IngestionStats(
-                **stats,
-                success=success,
-                message=message
-            )
-        
-        finally:
-            # Ensure temp file is deleted
-            if temp_path.exists():
-                temp_path.unlink()
-    
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error ingesting file: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Ingestion failed: {str(e)}")
+        get_job_registry().start(job)
+    except IngestionJobConflict as conflict:
+        temp_path.unlink(missing_ok=True)
+        raise HTTPException(
+            status_code=409,
+            detail=f"Already ingesting '{conflict.active.filename}'. Wait for it to finish."
+        )
+
+    task = asyncio.create_task(run_in_threadpool(run_job, job, temp_path))
+    _running_tasks.add(task)
+    task.add_done_callback(_running_tasks.discard)
+
+    return IngestionJobStatus(**job.snapshot())
+
+
+@router.get("/jobs", response_model=List[IngestionJobStatus])
+async def list_ingestion_jobs():
+    """List recent jobs newest first, so the UI can re-attach to a running one."""
+    return [IngestionJobStatus(**job.snapshot()) for job in get_job_registry().recent()]
+
+
+@router.get("/jobs/{job_id}", response_model=IngestionJobStatus)
+async def get_ingestion_job(job_id: str):
+    """Get one job's status, progress, and final statistics."""
+    job = get_job_registry().get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"Unknown ingestion job '{job_id}'")
+    return IngestionJobStatus(**job.snapshot())
 
 
 @router.post("/ingest-string", response_model=IngestionStats)
@@ -436,36 +432,20 @@ async def sync_s3_folder(prefix: Optional[str] = Query(None)):
             prefix=prefix
         )
 
-        success = (
-            stats.get('findings_errors', 0) == 0
-            and stats.get('cases_errors', 0) == 0
-            and (
-                stats.get('findings_imported', 0) > 0
-                or stats.get('cases_imported', 0) > 0
-                or stats.get('findings_skipped', 0) > 0
-                or stats.get('cases_skipped', 0) > 0
-            )
-        )
+        success, summary = summarize_stats(stats)
 
-        messages = []
+        prefix = []
         fp = stats.get('files_processed', 0)
         fs = stats.get('files_skipped', 0)
         if fp > 0:
-            messages.append(f"Processed {fp} file(s)")
+            prefix.append(f"Processed {fp} file(s)")
         if fs > 0:
-            messages.append(f"Skipped {fs} unsupported file(s)")
-        if stats.get('findings_imported', 0) > 0:
-            messages.append(f"Imported {stats['findings_imported']} findings")
-        if stats.get('findings_skipped', 0) > 0:
-            messages.append(f"Skipped {stats['findings_skipped']} duplicate findings")
-        if stats.get('cases_imported', 0) > 0:
-            messages.append(f"Imported {stats['cases_imported']} cases")
-        if stats.get('findings_errors', 0) > 0:
-            messages.append(f"{stats['findings_errors']} finding errors")
-        if stats.get('cases_errors', 0) > 0:
-            messages.append(f"{stats['cases_errors']} case errors")
+            prefix.append(f"Skipped {fs} unsupported file(s)")
 
-        message = ". ".join(messages) if messages else "No supported files found or no data imported"
+        if not prefix and summary == "No data imported":
+            message = "No supported files found or no data imported"
+        else:
+            message = ". ".join(prefix + [summary])
 
         return IngestionStats(
             findings_total=stats.get('findings_total', 0),
@@ -585,18 +565,11 @@ async def ingest_s3_file(request: S3FileIngestRequest):
     """
     key = request.key
     ext = Path(key).suffix.lower()
-    FORMAT_MAP = {
-        '.parquet': 'parquet',
-        '.csv': 'csv',
-        '.json': 'json',
-        '.jsonl': 'jsonl',
-        '.ndjson': 'jsonl',
-    }
-    fmt = FORMAT_MAP.get(ext)
+    fmt = EXTENSION_FORMATS.get(ext)
     if fmt is None:
         raise HTTPException(
             status_code=400,
-            detail=f"Unsupported file extension '{ext}'. Supported: {', '.join(FORMAT_MAP.keys())}"
+            detail=f"Unsupported file extension '{ext}'. Supported: {', '.join(EXTENSION_FORMATS.keys())}"
         )
 
     try:
@@ -623,32 +596,7 @@ async def ingest_s3_file(request: S3FileIngestRequest):
             if tmp_path and tmp_path.exists():
                 tmp_path.unlink()
 
-        success = (
-            stats.get('findings_errors', 0) == 0
-            and stats.get('cases_errors', 0) == 0
-            and (
-                stats.get('findings_imported', 0) > 0
-                or stats.get('cases_imported', 0) > 0
-                or stats.get('findings_skipped', 0) > 0
-                or stats.get('cases_skipped', 0) > 0
-            )
-        )
-
-        messages = []
-        if stats.get('findings_imported', 0) > 0:
-            messages.append(f"Imported {stats['findings_imported']} findings")
-        if stats.get('findings_skipped', 0) > 0:
-            messages.append(f"Skipped {stats['findings_skipped']} duplicate findings")
-        if stats.get('cases_imported', 0) > 0:
-            messages.append(f"Imported {stats['cases_imported']} cases")
-        if stats.get('cases_skipped', 0) > 0:
-            messages.append(f"Skipped {stats['cases_skipped']} duplicate cases")
-        if stats.get('findings_errors', 0) > 0:
-            messages.append(f"{stats['findings_errors']} finding errors")
-        if stats.get('cases_errors', 0) > 0:
-            messages.append(f"{stats['cases_errors']} case errors")
-
-        message = ". ".join(messages) if messages else "No data imported"
+        success, message = summarize_stats(stats)
 
         return IngestionStats(
             findings_total=stats.get('findings_total', 0),

--- a/database/service.py
+++ b/database/service.py
@@ -96,7 +96,60 @@ class DatabaseService:
         except Exception as e:
             logger.error(f"Error creating finding {finding_id}: {e}")
             return None
-    
+
+    def bulk_create_findings(self, rows: List[Dict[str, Any]]) -> Dict[str, int]:
+        """
+        Dedup and insert many findings in one transaction.
+
+        create_finding/get_finding each open their own session_scope(); calling
+        them per row doesn't scale to the hundred-thousand-row parquet files
+        real LogLM/netflow exports can be. Rows sharing a finding_id within the
+        batch keep only their last occurrence (matches the create-then-skip
+        semantics of ingesting the same row twice).
+
+        Args:
+            rows: finding dicts shaped like create_finding's kwargs, plus
+                  finding_id; timestamp must already be a datetime.
+
+        Returns:
+            {'imported': N, 'skipped': N}
+        """
+        if not rows:
+            return {'imported': 0, 'skipped': 0}
+
+        by_id = {r['finding_id']: r for r in rows}
+        ids = list(by_id.keys())
+        try:
+            with self.db_manager.session_scope() as session:
+                existing = {
+                    row_id for (row_id,) in session.execute(
+                        select(Finding.finding_id).where(Finding.finding_id.in_(ids))
+                    )
+                }
+                new_ids = [i for i in ids if i not in existing]
+                for finding_id in new_ids:
+                    r = by_id[finding_id]
+                    session.add(Finding(
+                        finding_id=finding_id,
+                        embedding=_normalize_embedding(r.get('embedding')),
+                        mitre_predictions=r.get('mitre_predictions') or {},
+                        anomaly_score=r.get('anomaly_score', 0.0),
+                        timestamp=r['timestamp'],
+                        data_source=r.get('data_source', 'imported'),
+                        external_id=r.get('external_id'),
+                        description=r.get('description'),
+                        entity_context=r.get('entity_context'),
+                        evidence_links=r.get('evidence_links'),
+                        cluster_id=r.get('cluster_id'),
+                        severity=r.get('severity'),
+                        status=r.get('status', 'new'),
+                    ))
+                session.flush()
+                return {'imported': len(new_ids), 'skipped': len(rows) - len(new_ids)}
+        except Exception as e:
+            logger.error(f"Error bulk-creating findings: {e}")
+            return {'imported': 0, 'skipped': 0, 'errors': len(rows)}
+
     def get_finding(self, finding_id: str) -> Optional[Finding]:
         """
         Get a finding by ID.

--- a/database/service.py
+++ b/database/service.py
@@ -98,22 +98,8 @@ class DatabaseService:
             return None
 
     def bulk_create_findings(self, rows: List[Dict[str, Any]]) -> Dict[str, int]:
-        """
-        Dedup and insert many findings in one transaction.
-
-        create_finding/get_finding each open their own session_scope(); calling
-        them per row doesn't scale to the hundred-thousand-row parquet files
-        real LogLM/netflow exports can be. Rows sharing a finding_id within the
-        batch keep only their last occurrence (matches the create-then-skip
-        semantics of ingesting the same row twice).
-
-        Args:
-            rows: finding dicts shaped like create_finding's kwargs, plus
-                  finding_id; timestamp must already be a datetime.
-
-        Returns:
-            {'imported': N, 'skipped': N}
-        """
+        """Dedup + insert many findings in one transaction; per-row create_finding
+        doesn't scale to hundred-thousand-row parquet files."""
         if not rows:
             return {'imported': 0, 'skipped': 0}
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -451,18 +451,24 @@ export default function Settings() {
     setUploadResult(null)
   }
 
+  // Ingestion is a background job now, so poll it to completion.
   const handleUploadFile = async () => {
     if (!uploadFile) return
     setUploading(true)
     setUploadResult(null)
     try {
       const response = await ingestionApi.uploadFile(uploadFile)
-      setUploadResult({ success: response.data.success, message: response.data.message })
-      if (response.data.success) {
-        setMessage({ type: 'success', text: response.data.message })
-      } else {
-        setMessage({ type: 'error', text: response.data.message || 'Upload completed with issues' })
+      let job = response.data
+      while (job.status === 'running') {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        job = (await ingestionApi.getJob(job.job_id)).data
       }
+      const success = job.status === 'succeeded'
+      setUploadResult({ success, message: job.message })
+      setMessage({
+        type: success ? 'success' : 'error',
+        text: job.message || 'Upload completed with issues',
+      })
     } catch (error: any) {
       const msg = error.response?.data?.detail || 'Upload failed'
       setUploadResult({ success: false, message: msg })

--- a/frontend/src/redesign/screens/settings/DataIngestion.test.tsx
+++ b/frontend/src/redesign/screens/settings/DataIngestion.test.tsx
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import DataIngestionPanel from './DataIngestion'
+import { configApi, ingestionApi } from '../../../services/api'
+
+vi.mock('../../../services/api', () => ({
+  configApi: {
+    getS3: vi.fn(),
+    setS3: vi.fn(),
+    getDarktrace: vi.fn(() => Promise.resolve({ data: {} })),
+    setDarktrace: vi.fn(),
+  },
+  kafkaApi: {
+    getConfig: vi.fn(() => Promise.resolve({ data: {} })),
+    getStatus: vi.fn(() => Promise.resolve({ data: {} })),
+    setConfig: vi.fn(),
+  },
+  ingestionApi: {
+    listS3Files: vi.fn(),
+    ingestS3File: vi.fn(),
+    uploadFile: vi.fn(),
+    listJobs: vi.fn(() => Promise.resolve({ data: [] })),
+    getJob: vi.fn(),
+  },
+}))
+
+const runningJob = {
+  job_id: 'ing-abc123',
+  filename: 'flows.parquet',
+  format: 'parquet',
+  data_type: 'finding',
+  status: 'running' as const,
+  determinate: true,
+  processed: 40,
+  total: 200,
+  created_at: '2026-07-24T10:00:00Z',
+  finished_at: null,
+  message: '',
+  error: null,
+  stats: {},
+}
+
+function renderPanel() {
+  return render(<DataIngestionPanel notify={vi.fn()} />)
+}
+
+function chooseFile(name = 'flows.parquet') {
+  const input = screen.getByTestId('manual-upload-input') as HTMLInputElement
+  fireEvent.change(input, {
+    target: { files: [new File(['x'], name, { type: 'application/octet-stream' })] },
+  })
+}
+
+describe('manual upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(configApi.getS3).mockResolvedValue({ data: { configured: false } } as never)
+    vi.mocked(configApi.getDarktrace).mockResolvedValue({ data: {} } as never)
+    vi.mocked(ingestionApi.listJobs).mockResolvedValue({ data: [] } as never)
+  })
+
+  // Regression: this section used to live inside the S3 card.
+  it('stays available when the S3 config fails to load', async () => {
+    vi.mocked(configApi.getS3).mockRejectedValue(new Error('backend unreachable'))
+    renderPanel()
+
+    expect(await screen.findByText('Manual Upload')).toBeInTheDocument()
+    expect(await screen.findByText(/Couldn’t load S3 config/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Choose File/ })).toBeEnabled()
+  })
+
+  it('hands the chosen file to the background ingest endpoint', async () => {
+    vi.mocked(ingestionApi.uploadFile).mockResolvedValue({ data: runningJob } as never)
+    renderPanel()
+    await screen.findByText('Manual Upload')
+
+    chooseFile()
+    fireEvent.click(screen.getByRole('button', { name: /Upload/ }))
+
+    await waitFor(() => expect(ingestionApi.uploadFile).toHaveBeenCalledOnce())
+    expect(vi.mocked(ingestionApi.uploadFile).mock.calls[0][0].name).toBe('flows.parquet')
+  })
+
+  it('re-attaches to a job still running from a previous visit', async () => {
+    vi.mocked(ingestionApi.listJobs).mockResolvedValue({ data: [runningJob] } as never)
+    renderPanel()
+
+    expect(await screen.findByText(/40 of 200 rows \(20%\)/)).toBeInTheDocument()
+    expect(screen.getByText('flows.parquet')).toBeInTheDocument()
+  })
+
+  it('blocks a second upload while one is still running', async () => {
+    vi.mocked(ingestionApi.listJobs).mockResolvedValue({ data: [runningJob] } as never)
+    renderPanel()
+    await screen.findByText(/40 of 200 rows/)
+
+    expect(screen.getByRole('button', { name: /Choose File/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Upload/ })).toBeDisabled()
+  })
+
+  it('reports a row count without a percentage for row-counting formats', async () => {
+    vi.mocked(ingestionApi.listJobs).mockResolvedValue({
+      data: [{ ...runningJob, filename: 'export.csv', format: 'csv', determinate: false, total: 0 }],
+    } as never)
+    renderPanel()
+
+    expect(await screen.findByText(/40 rows so far/)).toBeInTheDocument()
+  })
+
+  it('surfaces the outcome of a finished job', async () => {
+    vi.mocked(ingestionApi.listJobs).mockResolvedValue({
+      data: [{ ...runningJob, status: 'failed', message: 'Ingestion failed: bad parquet' }],
+    } as never)
+    renderPanel()
+
+    expect(await screen.findByText(/Ingestion failed: bad parquet/)).toBeInTheDocument()
+  })
+
+  it('clears the file input so the same file can be retried', async () => {
+    renderPanel()
+    await screen.findByText('Manual Upload')
+    const input = screen.getByTestId('manual-upload-input') as HTMLInputElement
+
+    chooseFile()
+    fireEvent.click(input)
+
+    expect(input.value).toBe('')
+  })
+})

--- a/frontend/src/redesign/screens/settings/DataIngestion.tsx
+++ b/frontend/src/redesign/screens/settings/DataIngestion.tsx
@@ -17,9 +17,10 @@ import {
   TextInput,
   ToggleRow,
 } from '../../shared/ui'
-import { ingestionApi } from '../../../services/api'
+import { ingestionApi, type IngestionJob } from '../../../services/api'
 import {
   useDarktrace,
+  useIngestionJob,
   useKafka,
   useS3,
   type KafkaConfig,
@@ -45,48 +46,81 @@ export default function DataIngestionPanel({ notify }: SectionProps) {
 }
 
 /* ---------------- Manual upload ---------------- */
+const ACCEPTED_UPLOAD_TYPES = '.parquet,.csv,.json,.jsonl,.ndjson'
+
+/** Independent of S3/Kafka/Darktrace so their failures can't hide it. */
 function ManualUploadPanel({ notify }: SectionProps) {
+  const { job, attaching, upload } = useIngestionJob()
   const fileRef = useRef<HTMLInputElement>(null)
-  const [upload, setUpload] = useState<File | null>(null)
-  const [uploading, setUploading] = useState(false)
+  const [file, setFile] = useState<File | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const running = job?.status === 'running'
 
   const doUpload = async () => {
-    if (!upload) return
-    setUploading(true)
+    if (!file) return
+    setSubmitting(true)
     try {
-      const res = await ingestionApi.uploadFile(upload)
-      notify(res.data.success ? 'ok' : 'err', res.data.message || 'Upload complete.')
-      if (res.data.success) setUpload(null)
+      await upload(file)
+      setFile(null)
+      notify('ok', `Ingesting ${file.name} in the background.`)
     } catch (e) {
       notify('err', (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail || 'Upload failed.')
     } finally {
-      setUploading(false)
+      setSubmitting(false)
     }
   }
 
   return (
     <SettingsCard
       title="Manual Upload"
-      desc="Upload a local file directly into Vigil."
+      desc="Upload a local file directly into Vigil. Large files keep ingesting in the background — you can leave this page."
     >
       <div className="flex items-center gap-2.5 flex-wrap">
         <input
           ref={fileRef}
           type="file"
-          accept=".parquet,.csv,.json,.jsonl,.ndjson"
+          accept={ACCEPTED_UPLOAD_TYPES}
           className="hidden"
-          onChange={(e) => setUpload(e.target.files?.[0] || null)}
+          data-testid="manual-upload-input"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+          onClick={(e) => { (e.target as HTMLInputElement).value = '' }} // lets the same file be retried
         />
-        <button className="btn ghost" onClick={() => fileRef.current?.click()}>
-          <Icon name="paperclip" /> {upload ? upload.name : 'Choose File'}
+        <button className="btn ghost" onClick={() => fileRef.current?.click()} disabled={running}>
+          <Icon name="paperclip" /> {file ? file.name : 'Choose File'}
         </button>
-        {upload && <span className="text-xs text-tx-3">{formatFileSize(upload.size)}</span>}
-        <button className="btn primary" disabled={!upload || uploading} onClick={doUpload}>
-          <Icon name="upload" /> {uploading ? 'Uploading...' : 'Upload'}
+        {file && <span className="text-xs text-tx-3">{formatFileSize(file.size)}</span>}
+        <button className="btn primary" disabled={!file || submitting || running || attaching} onClick={doUpload}>
+          <Icon name="upload" /> {submitting ? 'Uploading…' : 'Upload'}
         </button>
       </div>
       <p className="text-xs text-tx-3 mt-1.5">Allowed file types: .parquet, .csv, .json, .jsonl, .ndjson.</p>
+
+      {job && <IngestionJobStatus job={job} />}
     </SettingsCard>
+  )
+}
+
+function IngestionJobStatus({ job }: { job: IngestionJob }) {
+  if (job.status === 'running') {
+    const pct = job.determinate && job.total > 0
+      ? Math.min(100, Math.round((job.processed / job.total) * 100))
+      : null
+    return (
+      <div className="settings-banner info mt-3" role="status" aria-live="polite">
+        <span className="spin" aria-hidden="true" />
+        <span className="text-xs">
+          Ingesting <span className="font-mono">{job.filename}</span> —{' '}
+          {pct !== null ? `${job.processed} of ${job.total} rows (${pct}%)` : `${job.processed} rows so far`}
+        </span>
+      </div>
+    )
+  }
+  const ok = job.status === 'succeeded'
+  return (
+    <div className={`settings-banner ${ok ? 'ok' : 'err'} mt-3`}>
+      <Icon name={ok ? 'check2' : 'alert'} size={13} />
+      <span className="text-xs"><span className="font-mono">{job.filename}</span> — {job.message}</span>
+    </div>
   )
 }
 

--- a/frontend/src/redesign/screens/settings/useSettings.ts
+++ b/frontend/src/redesign/screens/settings/useSettings.ts
@@ -11,6 +11,7 @@ import api, {
   configApi,
   detectionRulesApi,
   federationApi,
+  ingestionApi,
   kafkaApi,
   llmProviderApi,
   localServicesApi,
@@ -23,6 +24,7 @@ import api, {
   type BudgetSettings,
   type ComponentAssignment,
   type FederationSourceView,
+  type IngestionJob,
   type LLMProvider,
   type MempalaceHealth,
   type PlatformDatabaseProxyConfig,
@@ -1283,4 +1285,55 @@ export function useDetectionRules() {
   )
 
   return { sources, stats, phase, error, reload, addSource, removeSource, updateSource, updateAll }
+}
+
+/* ---------------- Integrations · Local file ingestion ---------------- */
+const JOB_POLL_MS = 1000
+
+/** Tracks one background ingestion job, re-attaching to whatever already runs. */
+export function useIngestionJob() {
+  const [job, setJob] = useState<IngestionJob | null>(null)
+  const [attaching, setAttaching] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    ingestionApi
+      .listJobs()
+      .then((res) => {
+        if (cancelled) return
+        const jobs = res.data || []
+        setJob(jobs.find((j) => j.status === 'running') || jobs[0] || null)
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (!cancelled) setAttaching(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (job?.status !== 'running') return
+    let cancelled = false
+    const timer = setInterval(() => {
+      ingestionApi
+        .getJob(job.job_id)
+        .then((res) => {
+          if (!cancelled) setJob(res.data)
+        })
+        .catch(() => undefined)
+    }, JOB_POLL_MS)
+    return () => {
+      cancelled = true
+      clearInterval(timer)
+    }
+  }, [job?.job_id, job?.status])
+
+  const upload = useCallback(
+    (file: File) => ingestionApi.uploadFile(file).then((res) => setJob(res.data)),
+    [],
+  )
+
+  return { job, attaching, upload }
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1145,19 +1145,39 @@ export const aiConfigApi = {
 }
 
 // Ingestion API
+export interface IngestionJob {
+  job_id: string
+  filename: string
+  format: string
+  data_type: string
+  status: 'running' | 'succeeded' | 'failed'
+  determinate: boolean // false for CSV/JSONL — row count unknown until read ends
+  processed: number
+  total: number
+  created_at: string
+  finished_at: string | null
+  message: string
+  error: string | null
+  stats: Record<string, number>
+}
+
 export const ingestionApi = {
   listS3Files: (prefix?: string) =>
     api.get('/ingest/s3-files', { params: { prefix: prefix ?? '' } }),
   ingestS3File: (key: string) =>
     api.post('/ingest/s3-file', { key }),
+  // Returns once the body is spooled; the ingest runs as a background job.
   uploadFile: (file: File, dataType: string = 'finding') => {
     const formData = new FormData()
     formData.append('file', file)
     formData.append('data_type', dataType)
-    return api.post('/ingest/upload', formData, {
+    return api.post<IngestionJob>('/ingest/upload', formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
+      timeout: 0,
     })
   },
+  listJobs: () => api.get<IngestionJob[]>('/ingest/jobs'),
+  getJob: (jobId: string) => api.get<IngestionJob>(`/ingest/jobs/${jobId}`),
 }
 
 // Analytics API (#184 Phase 2)

--- a/services/ingestion_jobs.py
+++ b/services/ingestion_jobs.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+MAX_TRACKED_JOBS = 20
+
+DETERMINATE_FORMATS = frozenset({"parquet", "json"})  # row count known upfront
+
+RUNNING = "running"
+SUCCEEDED = "succeeded"
+FAILED = "failed"
+
+_PROGRESS_KEYS = tuple(
+    f"{kind}_{outcome}"
+    for kind in ("findings", "cases")
+    for outcome in ("imported", "skipped", "errors")
+)
+
+
+class IngestionJobConflict(RuntimeError):
+    def __init__(self, active: "IngestionJob"):
+        super().__init__(f"Ingestion job {active.job_id} is already running")
+        self.active = active
+
+
+class IngestionJob:
+    def __init__(self, filename: str, fmt: str, data_type: str):
+        self.job_id = f"ing-{uuid.uuid4().hex[:12]}"
+        self.filename = filename
+        self.format = fmt
+        self.data_type = data_type
+        self.status = RUNNING
+        self.created_at = datetime.now(timezone.utc)
+        self.finished_at: Optional[datetime] = None
+        self.message = ""
+        self.error: Optional[str] = None
+        self._stats: Dict[str, int] = {}
+
+    def track(self, stats: Dict[str, int]) -> None:
+        """Adopt the service's stats dict as this job's live progress source."""
+        self._stats = stats
+
+    def finish(self, message: str) -> None:
+        self.status = SUCCEEDED
+        self.message = message
+        self.finished_at = datetime.now(timezone.utc)
+
+    def fail(self, error: str) -> None:
+        self.status = FAILED
+        self.error = error
+        self.message = error
+        self.finished_at = datetime.now(timezone.utc)
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Readable while the job runs; counts are ints written by one thread."""
+        stats = dict(self._stats)
+        processed = sum(stats.get(key, 0) for key in _PROGRESS_KEYS)
+        total = stats.get("findings_total", 0) + stats.get("cases_total", 0)
+        return {
+            "job_id": self.job_id,
+            "filename": self.filename,
+            "format": self.format,
+            "data_type": self.data_type,
+            "status": self.status,
+            "determinate": self.format in DETERMINATE_FORMATS,
+            "processed": processed,
+            "total": total,
+            "created_at": self.created_at,
+            "finished_at": self.finished_at,
+            "message": self.message,
+            "error": self.error,
+            "stats": stats,
+        }
+
+
+class IngestionJobRegistry:
+    """Bounded, in-memory job store admitting one running ingest at a time."""
+
+    def __init__(self, max_tracked: int = MAX_TRACKED_JOBS):
+        self._lock = threading.Lock()
+        self._jobs: Dict[str, IngestionJob] = {}
+        self._max_tracked = max_tracked
+
+    def start(self, job: IngestionJob) -> None:
+        """Admit a job, or raise IngestionJobConflict if one is still running."""
+        with self._lock:
+            active = self._active_locked()
+            if active is not None:
+                raise IngestionJobConflict(active)
+            self._jobs[job.job_id] = job
+            self._prune_locked()
+
+    def active(self) -> Optional[IngestionJob]:
+        with self._lock:
+            return self._active_locked()
+
+    def get(self, job_id: str) -> Optional[IngestionJob]:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def recent(self) -> List[IngestionJob]:
+        """Tracked jobs, newest first."""
+        with self._lock:
+            return list(reversed(self._jobs.values()))
+
+    def _active_locked(self) -> Optional[IngestionJob]:
+        for job in reversed(self._jobs.values()):
+            if job.status == RUNNING:
+                return job
+        return None
+
+    def _prune_locked(self) -> None:
+        while len(self._jobs) > self._max_tracked:
+            oldest = next(iter(self._jobs))
+            if self._jobs[oldest].status == RUNNING:
+                break
+            del self._jobs[oldest]
+
+
+_registry = IngestionJobRegistry()
+
+
+def get_job_registry() -> IngestionJobRegistry:
+    return _registry
+
+
+def summarize_stats(stats: Dict[str, int]) -> tuple:
+    """Reduce ingestion stats to a (success, human message) pair."""
+    imported = stats.get("findings_imported", 0) + stats.get("cases_imported", 0)
+    skipped = stats.get("findings_skipped", 0) + stats.get("cases_skipped", 0)
+    errors = stats.get("findings_errors", 0) + stats.get("cases_errors", 0)
+    success = errors == 0 and (imported > 0 or skipped > 0)
+
+    messages = []
+    if stats.get("findings_imported", 0) > 0:
+        messages.append(f"Imported {stats['findings_imported']} findings")
+    if stats.get("findings_skipped", 0) > 0:
+        messages.append(f"Skipped {stats['findings_skipped']} duplicate findings")
+    if stats.get("cases_imported", 0) > 0:
+        messages.append(f"Imported {stats['cases_imported']} cases")
+    if stats.get("cases_skipped", 0) > 0:
+        messages.append(f"Skipped {stats['cases_skipped']} duplicate cases")
+    if stats.get("findings_errors", 0) > 0:
+        messages.append(f"{stats['findings_errors']} finding errors")
+    if stats.get("cases_errors", 0) > 0:
+        messages.append(f"{stats['cases_errors']} case errors")
+
+    return success, ". ".join(messages) if messages else "No data imported"
+
+
+def run_job(job: IngestionJob, source_path: Path) -> None:
+    """Ingest source_path on a worker thread, then delete it. Never raises."""
+    from services.ingestion_service import IngestionService
+
+    try:
+        service = IngestionService()
+        job.track(service.stats)
+        stats = service._ingest_file_by_format(
+            source_path, job.format, data_type=job.data_type
+        )
+        success, message = summarize_stats(stats or {})
+        if success:
+            job.finish(message)
+        else:
+            job.fail(message)
+    except Exception as e:
+        logger.error(f"Ingestion job {job.job_id} failed: {e}", exc_info=True)
+        job.fail(f"Ingestion failed: {e}")
+    finally:
+        source_path.unlink(missing_ok=True)

--- a/services/ingestion_service.py
+++ b/services/ingestion_service.py
@@ -48,10 +48,8 @@ TEMPO_CSV_IDENTITY_COLUMNS = (
     'event_start', 'event_end', 'IP1', 'IP2', 'mitre_tactic', 'created_at',
 )
 
-# Best-effort column-name aliases for populating entity_context on parquet
-# schemas ingestion doesn't recognize (see _generic_row_to_finding). First
-# alias present in the row wins; if none match the field is just left blank
-# -- the full row is always kept as raw_features too, so nothing is lost.
+# Column-name aliases for entity_context on schemas ingest doesn't recognize.
+# First match wins; raw row is always kept in raw_features regardless.
 ENTITY_FIELD_ALIASES = {
     'src_ip': ('src_ip', 'source_ip', 'srcip', 'ip1', 'saddr'),
     'dst_ip': ('dest_ip', 'dst_ip', 'destination_ip', 'dstip', 'ip2', 'daddr'),
@@ -71,11 +69,7 @@ def _first_present(row: Dict[str, Any], aliases: tuple) -> Any:
 
 
 def row_identity_key(row: Dict[str, Any], columns: tuple) -> str:
-    """Digest a row's identifying columns, for sources with no id column.
-
-    Content-derived so re-ingesting the same file still dedupes, while rows
-    that differ in any identifying column stay distinct.
-    """
+    """Content-derived id key for rows with no id column: re-ingest still dedupes."""
     parts = []
     for column in columns:
         value = row.get(column)
@@ -271,15 +265,7 @@ class IngestionService:
             return False
 
     def _ingest_finding_batch(self, finding_dicts: List[Dict[str, Any]]) -> None:
-        """
-        Bulk-dedup and insert a batch of findings in one DB round trip.
-
-        ingest_finding does a SELECT + INSERT per call, each in its own
-        session_scope() -- fine one at a time, but a parquet file can be
-        hundreds of thousands of rows and that per-row cost dominates
-        wall-clock time. Used by ingest_parquet_file, which already has a
-        natural batch boundary from iter_batches.
-        """
+        """Bulk-dedup and insert a batch in one DB round trip, vs. per-row ingest_finding."""
         if not finding_dicts:
             return
 
@@ -294,9 +280,14 @@ class IngestionService:
                 logger.error("Finding missing finding_id")
                 self.stats['findings_errors'] += 1
                 continue
-            finding_data = normalize_finding_source_evidence(finding_data)
-            finding_data['timestamp'] = self.parse_timestamp(finding_data.get('timestamp'))
-            finding_data['anomaly_score'] = float(finding_data.get('anomaly_score', 0.0))
+            try:
+                finding_data = normalize_finding_source_evidence(finding_data)
+                finding_data['timestamp'] = self.parse_timestamp(finding_data.get('timestamp'))
+                finding_data['anomaly_score'] = float(finding_data.get('anomaly_score', 0.0))
+            except Exception as e:
+                logger.error(f"Error preparing finding {finding_data.get('finding_id')}: {e}")
+                self.stats['findings_errors'] += 1
+                continue
             valid.append(finding_data)
 
         if not valid:
@@ -310,6 +301,17 @@ class IngestionService:
         except Exception as e:
             logger.error(f"Error bulk ingesting findings: {e}")
             self.stats['findings_errors'] += len(valid)
+
+    def _ingest_findings_batched(self, findings, batch_size: int = 1000) -> None:
+        """Feed an iterable of finding dicts through _ingest_finding_batch in chunks."""
+        batch = []
+        for finding in findings:
+            batch.append(finding)
+            if len(batch) >= batch_size:
+                self._ingest_finding_batch(batch)
+                batch = []
+        if batch:
+            self._ingest_finding_batch(batch)
 
     def ingest_case(self, case_data: Dict[str, Any]) -> bool:
         """
@@ -386,17 +388,8 @@ class IngestionService:
             return False
     
     def ingest_json_file(self, file_path: Union[str, Path]) -> Dict[str, Any]:
-        """
-        Ingest data from a JSON file using streaming for large files.
-        
-        Supports:
-        - {"findings": [...], "cases": [...]}  (dict with findings/cases keys)
-        - [{"finding_id": ...}, ...]  (top-level array of findings)
-        - [{"case_id": ...}, ...]  (top-level array of cases)
-        
-        Uses ijson for streaming when available, falls back to json.load for
-        small files or unsupported structures.
-        """
+        """Ingest a JSON file: {findings, cases} dict or a top-level findings/cases array.
+        Streams via ijson when available, else falls back to json.load."""
         self.reset_stats()
         file_path = Path(file_path)
         
@@ -427,33 +420,41 @@ class IngestionService:
             f.seek(0)
             
             if peek == b'{':
-                for item in ijson.items(f, 'findings.item'):
-                    self.stats['findings_total'] += 1
-                    self.ingest_finding(item)
+                def _findings():
+                    for item in ijson.items(f, 'findings.item'):
+                        self.stats['findings_total'] += 1
+                        yield item
+                self._ingest_findings_batched(_findings())
                 f.seek(0)
                 for item in ijson.items(f, 'cases.item'):
                     self.stats['cases_total'] += 1
                     self.ingest_case(item)
             elif peek == b'[':
                 first_key = None
+                finding_batch = []
                 for item in ijson.items(f, 'item'):
                     if first_key is None:
                         first_key = 'finding' if 'finding_id' in item else 'case' if 'case_id' in item else 'finding'
                     if first_key == 'finding':
                         self.stats['findings_total'] += 1
-                        self.ingest_finding(item)
+                        finding_batch.append(item)
+                        if len(finding_batch) >= 1000:
+                            self._ingest_finding_batch(finding_batch)
+                            finding_batch = []
                     else:
                         self.stats['cases_total'] += 1
                         self.ingest_case(item)
+                if finding_batch:
+                    self._ingest_finding_batch(finding_batch)
 
     def _ingest_json_full(self, file_path: Path) -> None:
         """Fallback: load entire JSON file into memory."""
         with open(file_path, 'r') as f:
             data = json.load(f)
-        
+
         findings = []
         cases = []
-        
+
         if isinstance(data, dict):
             findings = data.get('findings', [])
             cases = data.get('cases', [])
@@ -462,57 +463,53 @@ class IngestionService:
                 findings = data
             elif data and 'case_id' in data[0]:
                 cases = data
-        
+
         self.stats['findings_total'] = len(findings)
         self.stats['cases_total'] = len(cases)
-        
-        for finding in findings:
-            self.ingest_finding(finding)
+
+        self._ingest_findings_batched(findings)
         for case in cases:
             self.ingest_case(case)
     
     def ingest_jsonl_file(self, file_path: Union[str, Path], data_type: str = 'finding') -> Dict[str, Any]:
-        """
-        Ingest data from a JSONL (JSON Lines) file.
-        
-        Args:
-            file_path: Path to JSONL file
-            data_type: Type of data ('finding' or 'case')
-        
-        Returns:
-            Dictionary with statistics
-        """
+        """Ingest a JSON Lines file, one finding or case per line."""
         self.reset_stats()
         file_path = Path(file_path)
-        
+
         if not file_path.exists():
             logger.error(f"File not found: {file_path}")
             return self.stats
-        
+
         try:
+            finding_batch = []
             with open(file_path, 'r') as f:
                 for line_num, line in enumerate(f, 1):
                     line = line.strip()
                     if not line:
                         continue
-                    
+
                     try:
                         data = json.loads(line)
-                        
+
                         if data_type == 'finding':
                             self.stats['findings_total'] += 1
-                            self.ingest_finding(data)
+                            finding_batch.append(data)
+                            if len(finding_batch) >= 1000:
+                                self._ingest_finding_batch(finding_batch)
+                                finding_batch = []
                         elif data_type == 'case':
                             self.stats['cases_total'] += 1
                             self.ingest_case(data)
-                    
+
                     except json.JSONDecodeError as e:
                         logger.error(f"Invalid JSON on line {line_num}: {e}")
                         if data_type == 'finding':
                             self.stats['findings_errors'] += 1
                         else:
                             self.stats['cases_errors'] += 1
-            
+            if finding_batch:
+                self._ingest_finding_batch(finding_batch)
+
             logger.info(f"JSONL ingestion complete: {self.stats}")
             return self.stats
         
@@ -521,45 +518,41 @@ class IngestionService:
             return self.stats
     
     def ingest_csv_file(self, file_path: Union[str, Path], data_type: str = 'finding') -> Dict[str, Any]:
-        """
-        Ingest data from a CSV file.
-        
-        Args:
-            file_path: Path to CSV file
-            data_type: Type of data ('finding' or 'case')
-        
-        Returns:
-            Dictionary with statistics
-        """
+        """Ingest a CSV file: generic finding/case rows, or the Tempo alert format."""
         self.reset_stats()
         file_path = Path(file_path)
-        
+
         if not file_path.exists():
             logger.error(f"File not found: {file_path}")
             return self.stats
-        
+
         try:
+            finding_batch = []
             with open(file_path, 'r', encoding='utf-8') as f:
                 reader = csv.DictReader(f)
-                
+
                 for row_num, row in enumerate(reader, 1):
                     try:
                         if data_type == 'finding':
                             self.stats['findings_total'] += 1
-                            finding_data = self._csv_row_to_finding(row)
-                            self.ingest_finding(finding_data)
+                            finding_batch.append(self._csv_row_to_finding(row))
+                            if len(finding_batch) >= 1000:
+                                self._ingest_finding_batch(finding_batch)
+                                finding_batch = []
                         elif data_type == 'case':
                             self.stats['cases_total'] += 1
                             case_data = self._csv_row_to_case(row)
                             self.ingest_case(case_data)
-                    
+
                     except Exception as e:
                         logger.error(f"Error processing CSV row {row_num}: {e}")
                         if data_type == 'finding':
                             self.stats['findings_errors'] += 1
                         else:
                             self.stats['cases_errors'] += 1
-            
+            if finding_batch:
+                self._ingest_finding_batch(finding_batch)
+
             logger.info(f"CSV ingestion complete: {self.stats}")
             return self.stats
         
@@ -763,32 +756,8 @@ class IngestionService:
         file_path: Union[str, Path],
         data_source: str = 'flow'
     ) -> Dict[str, Any]:
-        """
-        Ingest findings from a parquet file.
-
-        DeepTempo LogLM embedding exports (detected by a `sequence_id` or
-        `embedding` column) get bespoke handling -- see
-        _parquet_row_to_finding:
-          sequence_id   -> finding_id (hashed to f-YYYYMMDD-xxxxxxxx)
-          embedding     -> embedding (variable dimension, stored as-is)
-          mitre_pred    -> mitre_predictions (integer label stored as key)
-          incident_pred -> severity (1=attack, 0=benign)
-          confidence_score -> anomaly_score
-          focal_ip      -> entity_context.src_ip
-          engaged_ip    -> entity_context.dst_ip
-          event_start/end_time -> timestamp + entity_context
-
-        Any other schema (raw netflow captures, vendor exports, ...) is
-        ingested generically as unscored evidence -- see
-        _generic_row_to_finding.
-
-        Args:
-            file_path: Path to parquet file
-            data_source: Data source label (default 'flow')
-
-        Returns:
-            Dictionary with ingestion statistics
-        """
+        """LogLM embedding exports route through _parquet_row_to_finding; anything
+        else ingests generically via _generic_row_to_finding."""
         self.reset_stats()
         file_path = Path(file_path)
 
@@ -955,10 +924,7 @@ class IngestionService:
         }
 
     def _detect_parquet_schema(self, col_names: set) -> str:
-        """Classify a parquet file's schema so it's routed to the right row
-        mapper. LogLM embeddings need bespoke handling (embedding vectors,
-        MITRE logits, a real confidence score); anything else is ingested
-        generically as unscored evidence via _generic_row_to_finding."""
+        """'loglm' for DeepTempo embedding exports, else 'generic'."""
         if 'embedding' in col_names or 'sequence_id' in col_names:
             return 'loglm'
         return 'generic'
@@ -968,26 +934,7 @@ class IngestionService:
         row: Dict[str, Any],
         data_source: str = 'flow'
     ) -> Dict[str, Any]:
-        """
-        Map a row from an unrecognized tabular schema (parquet columns that
-        don't match the LogLM embeddings shape) to an unscored finding shell.
-
-        No column layout is assumed: the identity key hashes every column in
-        the row (stable across re-ingestion, distinct rows stay distinct), a
-        small alias table best-effort-populates entity_context for common
-        IP/port/proto/timestamp names, and the full row is always kept as
-        raw_features so nothing is lost when no alias matches. Never assigns
-        a severity or confidence score -- an unrecognized schema carries no
-        known detection verdict; status='unscored' marks it as awaiting
-        triage rather than an actual low-confidence finding.
-
-        Args:
-            row: Dictionary of column values for one row
-            data_source: Data source label
-
-        Returns:
-            Finding dictionary ready for ingest_finding()
-        """
+        """Unscored finding shell for a schema with no known column layout."""
         timestamp = _first_present(row, ENTITY_FIELD_ALIASES['timestamp'])
         event_ts = self.parse_timestamp(timestamp) if timestamp is not None else datetime.utcnow()
 
@@ -1033,25 +980,7 @@ class IngestionService:
         prefix: str = "",
         data_source: str = 'flow'
     ) -> Dict[str, Any]:
-        """
-        Discover and ingest all supported files from an S3 prefix.
-
-        Lists files under the prefix and auto-routes each by extension:
-          .parquet          -> ingest_parquet_file
-          .csv              -> ingest_csv_file
-          .json             -> ingest_json_file
-          .jsonl / .ndjson  -> ingest_jsonl_file
-        Unsupported extensions are skipped with a warning.
-
-        Args:
-            s3_service: An initialised S3Service instance
-            prefix: S3 key prefix (folder path), e.g. "embeddings/"
-            data_source: Data source label for parquet files
-
-        Returns:
-            Dictionary with aggregated ingestion statistics plus
-            files_processed and files_skipped counts.
-        """
+        """Discover and ingest all supported files from an S3 prefix, routed by extension."""
         self.reset_stats()
         files_processed = 0
         files_skipped = 0
@@ -1087,14 +1016,8 @@ class IngestionService:
 
                 file_stats = self._ingest_file_by_format(tmp_path, fmt, data_source)
 
-                self.stats['findings_total'] += file_stats.get('findings_total', 0)
-                self.stats['findings_imported'] += file_stats.get('findings_imported', 0)
-                self.stats['findings_skipped'] += file_stats.get('findings_skipped', 0)
-                self.stats['findings_errors'] += file_stats.get('findings_errors', 0)
-                self.stats['cases_total'] += file_stats.get('cases_total', 0)
-                self.stats['cases_imported'] += file_stats.get('cases_imported', 0)
-                self.stats['cases_skipped'] += file_stats.get('cases_skipped', 0)
-                self.stats['cases_errors'] += file_stats.get('cases_errors', 0)
+                for key in self.stats:
+                    self.stats[key] += file_stats.get(key, 0)
                 files_processed += 1
 
             except Exception as e:
@@ -1155,17 +1078,7 @@ class IngestionService:
         format: str = 'json',
         data_type: str = 'finding'
     ) -> Dict[str, Any]:
-        """
-        Ingest data from a string.
-        
-        Args:
-            data_string: Data as string
-            format: Format ('json', 'jsonl', 'csv')
-            data_type: Type of data ('finding' or 'case')
-        
-        Returns:
-            Dictionary with statistics
-        """
+        """Ingest data from a string; format is 'json', 'jsonl', or 'csv'."""
         self.reset_stats()
         
         try:
@@ -1193,40 +1106,41 @@ class IngestionService:
                 
                 self.stats['findings_total'] = len(findings)
                 self.stats['cases_total'] = len(cases)
-                
-                for finding in findings:
-                    self.ingest_finding(finding)
-                
+
+                self._ingest_findings_batched(findings)
                 for case in cases:
                     self.ingest_case(case)
-            
+
             elif format == 'jsonl':
+                finding_batch = []
                 for line in data_string.strip().split('\n'):
                     line = line.strip()
                     if not line:
                         continue
-                    
+
                     data = json.loads(line)
-                    
+
                     if data_type == 'finding':
                         self.stats['findings_total'] += 1
-                        self.ingest_finding(data)
+                        finding_batch.append(data)
                     elif data_type == 'case':
                         self.stats['cases_total'] += 1
                         self.ingest_case(data)
-            
+                self._ingest_findings_batched(finding_batch)
+
             elif format == 'csv':
                 reader = csv.DictReader(StringIO(data_string))
-                
+
+                finding_batch = []
                 for row in reader:
                     if data_type == 'finding':
                         self.stats['findings_total'] += 1
-                        finding_data = self._csv_row_to_finding(row)
-                        self.ingest_finding(finding_data)
+                        finding_batch.append(self._csv_row_to_finding(row))
                     elif data_type == 'case':
                         self.stats['cases_total'] += 1
                         case_data = self._csv_row_to_case(row)
                         self.ingest_case(case_data)
+                self._ingest_findings_batched(finding_batch)
             
             logger.info(f"String ingestion complete: {self.stats}")
             return self.stats

--- a/services/ingestion_service.py
+++ b/services/ingestion_service.py
@@ -48,6 +48,27 @@ TEMPO_CSV_IDENTITY_COLUMNS = (
     'event_start', 'event_end', 'IP1', 'IP2', 'mitre_tactic', 'created_at',
 )
 
+# Best-effort column-name aliases for populating entity_context on parquet
+# schemas ingestion doesn't recognize (see _generic_row_to_finding). First
+# alias present in the row wins; if none match the field is just left blank
+# -- the full row is always kept as raw_features too, so nothing is lost.
+ENTITY_FIELD_ALIASES = {
+    'src_ip': ('src_ip', 'source_ip', 'srcip', 'ip1', 'saddr'),
+    'dst_ip': ('dest_ip', 'dst_ip', 'destination_ip', 'dstip', 'ip2', 'daddr'),
+    'src_port': ('src_port', 'source_port', 'sport', 'srcport'),
+    'dst_port': ('dest_port', 'dst_port', 'destination_port', 'dport', 'dstport'),
+    'proto': ('proto', 'protocol', 'ip_proto'),
+    'timestamp': ('timestamp', 'ts', 'event_time', 'time', 'created_at'),
+}
+
+
+def _first_present(row: Dict[str, Any], aliases: tuple) -> Any:
+    """First non-null value among a row's aliases for one logical field."""
+    for alias in aliases:
+        if row.get(alias) is not None:
+            return row[alias]
+    return None
+
 
 def row_identity_key(row: Dict[str, Any], columns: tuple) -> str:
     """Digest a row's identifying columns, for sources with no id column.
@@ -248,7 +269,48 @@ class IngestionService:
             self.stats['findings_errors'] += 1
             logger.error(f"Error ingesting finding {finding_id}: {e}")
             return False
-    
+
+    def _ingest_finding_batch(self, finding_dicts: List[Dict[str, Any]]) -> None:
+        """
+        Bulk-dedup and insert a batch of findings in one DB round trip.
+
+        ingest_finding does a SELECT + INSERT per call, each in its own
+        session_scope() -- fine one at a time, but a parquet file can be
+        hundreds of thousands of rows and that per-row cost dominates
+        wall-clock time. Used by ingest_parquet_file, which already has a
+        natural batch boundary from iter_batches.
+        """
+        if not finding_dicts:
+            return
+
+        if not self.use_database or not self.db_service:
+            for finding_data in finding_dicts:
+                self.ingest_finding(finding_data)
+            return
+
+        valid = []
+        for finding_data in finding_dicts:
+            if not finding_data.get('finding_id'):
+                logger.error("Finding missing finding_id")
+                self.stats['findings_errors'] += 1
+                continue
+            finding_data = normalize_finding_source_evidence(finding_data)
+            finding_data['timestamp'] = self.parse_timestamp(finding_data.get('timestamp'))
+            finding_data['anomaly_score'] = float(finding_data.get('anomaly_score', 0.0))
+            valid.append(finding_data)
+
+        if not valid:
+            return
+
+        try:
+            result = self.db_service.bulk_create_findings(valid)
+            self.stats['findings_imported'] += result['imported']
+            self.stats['findings_skipped'] += result['skipped']
+            self.stats['findings_errors'] += result.get('errors', 0)
+        except Exception as e:
+            logger.error(f"Error bulk ingesting findings: {e}")
+            self.stats['findings_errors'] += len(valid)
+
     def ingest_case(self, case_data: Dict[str, Any]) -> bool:
         """
         Ingest a single case into the database.
@@ -702,10 +764,11 @@ class IngestionService:
         data_source: str = 'flow'
     ) -> Dict[str, Any]:
         """
-        Ingest findings from a DeepTempo LogLM parquet file.
+        Ingest findings from a parquet file.
 
-        Parquet files contain embedding vectors and metadata from the LogLM
-        model. Columns are mapped to the findings schema as follows:
+        DeepTempo LogLM embedding exports (detected by a `sequence_id` or
+        `embedding` column) get bespoke handling -- see
+        _parquet_row_to_finding:
           sequence_id   -> finding_id (hashed to f-YYYYMMDD-xxxxxxxx)
           embedding     -> embedding (variable dimension, stored as-is)
           mitre_pred    -> mitre_predictions (integer label stored as key)
@@ -714,6 +777,10 @@ class IngestionService:
           focal_ip      -> entity_context.src_ip
           engaged_ip    -> entity_context.dst_ip
           event_start/end_time -> timestamp + entity_context
+
+        Any other schema (raw netflow captures, vendor exports, ...) is
+        ingested generically as unscored evidence -- see
+        _generic_row_to_finding.
 
         Args:
             file_path: Path to parquet file
@@ -739,11 +806,15 @@ class IngestionService:
             logger.info(f"Parquet columns: {sorted(col_names)}")
             self.stats['findings_total'] = parquet_file.metadata.num_rows
 
+            schema_kind = self._detect_parquet_schema(col_names)
+            logger.info(f"Detected parquet schema: {schema_kind}")
+
             sampled_first_row = False
             batch_size = 1000
             for batch in parquet_file.iter_batches(batch_size=batch_size):
                 batch_dict = batch.to_pydict()
                 batch_len = len(next(iter(batch_dict.values()))) if batch_dict else 0
+                finding_batch = []
                 for i in range(batch_len):
                     try:
                         row = {col: batch_dict[col][i] for col in col_names if col in batch_dict}
@@ -751,11 +822,14 @@ class IngestionService:
                             sample = {k: (type(v).__name__, v) for k, v in row.items() if k != 'embedding'}
                             logger.info(f"Parquet sample row (types+values): {sample}")
                             sampled_first_row = True
-                        finding_data = self._parquet_row_to_finding(row, data_source)
-                        self.ingest_finding(finding_data)
+                        if schema_kind == 'loglm':
+                            finding_batch.append(self._parquet_row_to_finding(row, data_source))
+                        else:
+                            finding_batch.append(self._generic_row_to_finding(row, data_source))
                     except Exception as e:
                         logger.error(f"Error processing parquet row: {e}")
                         self.stats['findings_errors'] += 1
+                self._ingest_finding_batch(finding_batch)
 
             logger.info(f"Parquet ingestion complete: {self.stats}")
             return self.stats
@@ -878,6 +952,70 @@ class IngestionService:
             'cluster_id': cluster_id,
             'severity': severity,
             'status': 'new',
+        }
+
+    def _detect_parquet_schema(self, col_names: set) -> str:
+        """Classify a parquet file's schema so it's routed to the right row
+        mapper. LogLM embeddings need bespoke handling (embedding vectors,
+        MITRE logits, a real confidence score); anything else is ingested
+        generically as unscored evidence via _generic_row_to_finding."""
+        if 'embedding' in col_names or 'sequence_id' in col_names:
+            return 'loglm'
+        return 'generic'
+
+    def _generic_row_to_finding(
+        self,
+        row: Dict[str, Any],
+        data_source: str = 'flow'
+    ) -> Dict[str, Any]:
+        """
+        Map a row from an unrecognized tabular schema (parquet columns that
+        don't match the LogLM embeddings shape) to an unscored finding shell.
+
+        No column layout is assumed: the identity key hashes every column in
+        the row (stable across re-ingestion, distinct rows stay distinct), a
+        small alias table best-effort-populates entity_context for common
+        IP/port/proto/timestamp names, and the full row is always kept as
+        raw_features so nothing is lost when no alias matches. Never assigns
+        a severity or confidence score -- an unrecognized schema carries no
+        known detection verdict; status='unscored' marks it as awaiting
+        triage rather than an actual low-confidence finding.
+
+        Args:
+            row: Dictionary of column values for one row
+            data_source: Data source label
+
+        Returns:
+            Finding dictionary ready for ingest_finding()
+        """
+        timestamp = _first_present(row, ENTITY_FIELD_ALIASES['timestamp'])
+        event_ts = self.parse_timestamp(timestamp) if timestamp is not None else datetime.utcnow()
+
+        unique_key = row_identity_key(row, tuple(sorted(row.keys())))
+        id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:ID_HASH_WIDTH]
+        finding_id = f"f-{event_ts.strftime('%Y%m%d')}-{id_hash}"
+
+        entity_context = {
+            'src_ip': _first_present(row, ENTITY_FIELD_ALIASES['src_ip']),
+            'dst_ip': _first_present(row, ENTITY_FIELD_ALIASES['dst_ip']),
+            'src_port': _first_present(row, ENTITY_FIELD_ALIASES['src_port']),
+            'dst_port': _first_present(row, ENTITY_FIELD_ALIASES['dst_port']),
+            'proto': _first_present(row, ENTITY_FIELD_ALIASES['proto']),
+            'raw_features': row,
+        }
+
+        return {
+            'finding_id': finding_id,
+            'embedding': [0.0] * 768,
+            'mitre_predictions': {},
+            'anomaly_score': 0.0,
+            'timestamp': event_ts.isoformat(),
+            'data_source': data_source,
+            'entity_context': entity_context,
+            'evidence_links': None,
+            'cluster_id': None,
+            'severity': None,
+            'status': 'unscored',
         }
 
     # Extension -> (ingestion method name, temp file suffix, file mode for write)

--- a/services/ingestion_service.py
+++ b/services/ingestion_service.py
@@ -35,6 +35,36 @@ MITRE_TACTIC_MAP = {
     11: 'Privilege Escalation', 12: 'Exfiltration',
 }
 
+# 64 bits. The old 8 chars gave 32, where a 200k-row file is near-certain to
+# collide and every collision is silently reported as a duplicate.
+ID_HASH_WIDTH = 16
+
+# Columns identifying a row when the source carries no id of its own, ordered
+# most to least selective.
+PARQUET_IDENTITY_COLUMNS = (
+    'embedding', 'event_start_time', 'event_end_time', 'focal_ip', 'engaged_ip',
+)
+TEMPO_CSV_IDENTITY_COLUMNS = (
+    'event_start', 'event_end', 'IP1', 'IP2', 'mitre_tactic', 'created_at',
+)
+
+
+def row_identity_key(row: Dict[str, Any], columns: tuple) -> str:
+    """Digest a row's identifying columns, for sources with no id column.
+
+    Content-derived so re-ingesting the same file still dedupes, while rows
+    that differ in any identifying column stay distinct.
+    """
+    parts = []
+    for column in columns:
+        value = row.get(column)
+        if isinstance(value, (list, tuple)):
+            value = hashlib.sha256(
+                ','.join(repr(v) for v in value).encode()
+            ).hexdigest()
+        parts.append(f"{column}={value!r}")
+    return '|'.join(parts)
+
 
 class IngestionService:
     """Service for ingesting data from various formats into the database."""
@@ -71,7 +101,25 @@ class IngestionService:
             'cases_skipped': 0,
             'cases_errors': 0,
         }
-    
+        self._identity_warned: set = set()
+
+    def _identity_fallback(
+        self,
+        row: Dict[str, Any],
+        columns: tuple,
+        missing_column: str
+    ) -> str:
+        """Content-derived id key for a row whose id column is absent."""
+        if missing_column not in self._identity_warned:
+            self._identity_warned.add(missing_column)
+            logger.warning(
+                "No '%s' column in this source; deriving finding ids from row "
+                "content (%s). Rows identical across those columns will dedupe.",
+                missing_column,
+                ', '.join(columns),
+            )
+        return row_identity_key(row, columns)
+
     def reset_stats(self):
         """Reset ingestion statistics."""
         for key in self.stats:
@@ -538,17 +586,22 @@ class IngestionService:
             sequence_id, attack_id, IP1, IP2, mitre_tactic,
             incident_confidence, event_start, event_end, created_at, user_feedback
         """
-        sequence_id = str(row.get('sequence_id', ''))
+        sequence_id = str(row.get('sequence_id') or '').strip()
 
         # Parse event_start as timestamp
         event_start_str = row.get('event_start', '')
         event_ts = self.parse_timestamp(event_start_str) if event_start_str else datetime.utcnow()
 
-        # Generate finding_id from sequence_id + attack_id to ensure uniqueness
-        # when the same sequence appears with different attack clusters
-        attack_id = row.get('attack_id', '').strip()
-        unique_key = f"{sequence_id}_{attack_id}" if attack_id else sequence_id
-        id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:8]
+        # sequence_id + attack_id keeps the same sequence distinct across
+        # attack clusters; content identity covers rows carrying neither.
+        attack_id = (row.get('attack_id') or '').strip()
+        if sequence_id:
+            unique_key = f"{sequence_id}_{attack_id}" if attack_id else sequence_id
+        else:
+            unique_key = self._identity_fallback(
+                row, TEMPO_CSV_IDENTITY_COLUMNS, 'sequence_id'
+            )
+        id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:ID_HASH_WIDTH]
         finding_id = f"f-{event_ts.strftime('%Y%m%d')}-{id_hash}"
 
         # MITRE tactic comes as a name (e.g. "Command and Control")
@@ -729,7 +782,7 @@ class IngestionService:
         Returns:
             Finding dictionary ready for ingest_finding()
         """
-        sequence_id = str(row.get('sequence_id', ''))
+        sequence_id = str(row.get('sequence_id') or '')
 
         # Derive event timestamp from event_start_time (epoch milliseconds)
         event_start_ms = row.get('event_start_time')
@@ -738,8 +791,10 @@ class IngestionService:
         else:
             event_ts = datetime.utcnow()
 
-        # Generate finding_id: f-{YYYYMMDD}-{8-char hash of sequence_id}
-        id_hash = hashlib.sha256(sequence_id.encode()).hexdigest()[:8]
+        unique_key = sequence_id or self._identity_fallback(
+            row, PARQUET_IDENTITY_COLUMNS, 'sequence_id'
+        )
+        id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:ID_HASH_WIDTH]
         finding_id = f"f-{event_ts.strftime('%Y%m%d')}-{id_hash}"
 
         # Embedding: stored as-is regardless of dimension

--- a/services/ingestion_service.py
+++ b/services/ingestion_service.py
@@ -940,17 +940,18 @@ class IngestionService:
         self,
         file_path: Path,
         fmt: str,
-        data_source: str = 'flow'
+        data_source: str = 'flow',
+        data_type: str = 'finding'
     ) -> Dict[str, Any]:
         """Dispatch a local file to the appropriate ingestion method."""
         if fmt == 'parquet':
             return self.ingest_parquet_file(file_path, data_source=data_source)
         elif fmt == 'csv':
-            return self.ingest_csv_file(file_path, data_type='finding')
+            return self.ingest_csv_file(file_path, data_type=data_type)
         elif fmt == 'json':
             return self.ingest_json_file(file_path)
         elif fmt == 'jsonl':
-            return self.ingest_jsonl_file(file_path, data_type='finding')
+            return self.ingest_jsonl_file(file_path, data_type=data_type)
         else:
             logger.warning(f"No handler for format '{fmt}', skipping {file_path}")
             return {}

--- a/tests/unit/test_ingestion_finding_ids.py
+++ b/tests/unit/test_ingestion_finding_ids.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from services.ingestion_service import (  # noqa: E402
+    ID_HASH_WIDTH,
+    IngestionService,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def service():
+    return IngestionService()
+
+
+def _parquet_row(**overrides):
+    row = {
+        "event_start_time": 1753000000000,
+        "event_end_time": 1753000060000,
+        "focal_ip": "10.0.0.1",
+        "engaged_ip": "10.0.0.2",
+        "embedding": [0.1, 0.2, 0.3],
+    }
+    row.update(overrides)
+    return row
+
+
+def _csv_row(**overrides):
+    row = {
+        "event_start": "2026-07-21T12:00:00Z",
+        "event_end": "2026-07-21T12:01:00Z",
+        "IP1": "10.0.0.1",
+        "IP2": "10.0.0.2",
+        "mitre_tactic": "Command and Control",
+        "created_at": "2026-07-21T12:02:00Z",
+    }
+    row.update(overrides)
+    return row
+
+
+def _id(service, row):
+    return service._parquet_row_to_finding(row)["finding_id"]
+
+
+# --- the reported bug -----------------------------------------------------
+
+
+def test_parquet_rows_without_sequence_id_stay_distinct(service):
+    """L7-style parquet with no sequence_id column used to collapse every row
+    onto sha256('') and report the rest as duplicates."""
+    rows = [
+        _parquet_row(focal_ip=f"10.0.0.{i}", embedding=[float(i)]) for i in range(200)
+    ]
+
+    ids = [_id(service, row) for row in rows]
+
+    assert len(set(ids)) == 200
+
+
+def test_the_empty_string_hash_is_no_longer_produced(service):
+    import hashlib
+
+    empty = hashlib.sha256(b"").hexdigest()[:ID_HASH_WIDTH]
+
+    assert empty not in _id(service, _parquet_row())
+
+
+def test_tempo_csv_rows_without_sequence_id_stay_distinct(service):
+    rows = [_csv_row(IP1=f"10.0.0.{i}") for i in range(50)]
+
+    ids = [service._tempo_csv_row_to_finding(row)["finding_id"] for row in rows]
+
+    assert len(set(ids)) == 50
+
+
+# --- identity is content-stable so re-ingest still dedupes ----------------
+
+
+def test_the_same_row_yields_the_same_id(service):
+    assert _id(service, _parquet_row()) == _id(service, _parquet_row())
+
+
+def test_a_fresh_service_yields_the_same_id():
+    """Re-uploading a file must dedupe, so ids cannot depend on run state."""
+    assert _id(IngestionService(), _parquet_row()) == _id(
+        IngestionService(), _parquet_row()
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("focal_ip", "10.9.9.9"),
+        ("engaged_ip", "10.9.9.9"),
+        ("embedding", [9.9]),
+        ("event_end_time", 1753000999000),
+    ],
+)
+def test_differing_in_any_identity_column_changes_the_id(service, field, value):
+    assert _id(service, _parquet_row()) != _id(service, _parquet_row(**{field: value}))
+
+
+# --- sequence_id still wins when present ---------------------------------
+
+
+def test_sequence_id_drives_the_id_when_present(service):
+    a = _id(service, _parquet_row(sequence_id="seq-1"))
+    b = _id(service, _parquet_row(sequence_id="seq-2"))
+    assert a != b
+
+    # Same sequence_id, different content -> same id, since the source
+    # declared the identity itself.
+    c = _id(service, _parquet_row(sequence_id="seq-1", focal_ip="10.9.9.9"))
+    assert a == c
+
+
+def test_a_blank_sequence_id_falls_back_instead_of_colliding(service):
+    """An empty or null cell is not an identity."""
+    blank = _id(service, _parquet_row(sequence_id=""))
+    null = _id(service, _parquet_row(sequence_id=None, focal_ip="10.9.9.9"))
+
+    assert blank != null
+
+
+def test_tempo_csv_separates_a_sequence_across_attack_clusters(service):
+    a = service._tempo_csv_row_to_finding(_csv_row(sequence_id="s1", attack_id="a1"))
+    b = service._tempo_csv_row_to_finding(_csv_row(sequence_id="s1", attack_id="a2"))
+
+    assert a["finding_id"] != b["finding_id"]
+
+
+# --- hash width -----------------------------------------------------------
+
+
+def test_the_id_hash_is_64_bits(service):
+    assert ID_HASH_WIDTH == 16
+    assert len(_id(service, _parquet_row()).rsplit("-", 1)[1]) == 16
+
+
+# --- the missing column is reported --------------------------------------
+
+
+def test_a_missing_sequence_id_column_warns_once_not_per_row(service, caplog):
+    with caplog.at_level("WARNING"):
+        for i in range(20):
+            _id(service, _parquet_row(focal_ip=f"10.0.0.{i}"))
+
+    warnings = [r for r in caplog.records if "No 'sequence_id' column" in r.message]
+    assert len(warnings) == 1
+
+
+def test_no_warning_when_sequence_id_is_present(service, caplog):
+    with caplog.at_level("WARNING"):
+        _id(service, _parquet_row(sequence_id="seq-1"))
+
+    assert not [r for r in caplog.records if "No 'sequence_id' column" in r.message]

--- a/tests/unit/test_ingestion_jobs.py
+++ b/tests/unit/test_ingestion_jobs.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from services import ingestion_service  # noqa: E402
+from services.ingestion_jobs import (  # noqa: E402
+    FAILED,
+    RUNNING,
+    SUCCEEDED,
+    IngestionJob,
+    IngestionJobConflict,
+    IngestionJobRegistry,
+    run_job,
+    summarize_stats,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _stats(**overrides):
+    base = {
+        "findings_total": 0,
+        "findings_imported": 0,
+        "findings_skipped": 0,
+        "findings_errors": 0,
+        "cases_total": 0,
+        "cases_imported": 0,
+        "cases_skipped": 0,
+        "cases_errors": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+class _FakeService:
+    def __init__(self, result=None, raises=None, on_ingest=None):
+        self.stats = _stats()
+        self._result = result
+        self._raises = raises
+        self._on_ingest = on_ingest
+        self.calls = []
+
+    def _ingest_file_by_format(self, file_path, fmt, data_type="finding"):
+        self.calls.append((Path(file_path), fmt, data_type))
+        if self._raises is not None:
+            raise self._raises
+        if self._on_ingest is not None:
+            self._on_ingest(self.stats)
+        self.stats.update(self._result or {})
+        return self.stats
+
+
+@pytest.fixture
+def spooled(tmp_path):
+    path = tmp_path / "upload.parquet"
+    path.write_bytes(b"payload")
+    return path
+
+
+def _patch_service(monkeypatch, service):
+    monkeypatch.setattr(ingestion_service, "IngestionService", lambda: service)
+
+
+# --- summarize_stats ------------------------------------------------------
+
+
+def test_summarize_reports_success_for_a_pure_import():
+    success, message = summarize_stats(_stats(findings_imported=3))
+    assert success is True
+    assert message == "Imported 3 findings"
+
+
+def test_summarize_counts_all_duplicates_as_success():
+    success, message = summarize_stats(_stats(findings_skipped=5))
+    assert success is True
+    assert message == "Skipped 5 duplicate findings"
+
+
+def test_summarize_fails_when_any_row_errored():
+    success, message = summarize_stats(_stats(findings_imported=2, findings_errors=1))
+    assert success is False
+    assert "1 finding errors" in message
+
+
+def test_summarize_fails_on_an_empty_ingest():
+    success, message = summarize_stats(_stats())
+    assert success is False
+    assert message == "No data imported"
+
+
+# --- job lifecycle --------------------------------------------------------
+
+
+def test_run_job_records_success_and_deletes_the_spooled_file(monkeypatch, spooled):
+    _patch_service(monkeypatch, _FakeService(result={"findings_imported": 7}))
+    job = IngestionJob("export.parquet", "parquet", "finding")
+
+    run_job(job, spooled)
+
+    assert job.status == SUCCEEDED
+    assert job.message == "Imported 7 findings"
+    assert job.error is None
+    assert job.finished_at is not None
+    assert not spooled.exists()
+
+
+def test_run_job_records_failure_and_still_deletes_the_spooled_file(
+    monkeypatch, spooled
+):
+    _patch_service(monkeypatch, _FakeService(raises=ValueError("bad parquet")))
+    job = IngestionJob("export.parquet", "parquet", "finding")
+
+    run_job(job, spooled)
+
+    assert job.status == FAILED
+    assert "bad parquet" in job.error
+    assert not spooled.exists()
+
+
+def test_a_row_error_marks_the_job_failed(monkeypatch, spooled):
+    _patch_service(
+        monkeypatch,
+        _FakeService(result={"findings_imported": 1, "findings_errors": 2}),
+    )
+    job = IngestionJob("export.csv", "csv", "finding")
+
+    run_job(job, spooled)
+
+    assert job.status == FAILED
+    assert "2 finding errors" in job.message
+
+
+def test_run_job_forwards_the_declared_data_type(monkeypatch, spooled):
+    service = _FakeService(result={"cases_imported": 1})
+    _patch_service(monkeypatch, service)
+    job = IngestionJob("cases.jsonl", "jsonl", "case")
+
+    run_job(job, spooled)
+
+    assert service.calls == [(spooled, "jsonl", "case")]
+
+
+# --- progress -------------------------------------------------------------
+
+
+def test_progress_is_readable_while_the_job_runs(monkeypatch, spooled):
+    job = IngestionJob("export.parquet", "parquet", "finding")
+    seen = []
+
+    def mid_run(stats):
+        stats["findings_total"] = 10
+        stats["findings_imported"] = 4
+        seen.append(job.snapshot())
+
+    _patch_service(monkeypatch, _FakeService(result={}, on_ingest=mid_run))
+    run_job(job, spooled)
+
+    assert seen[0]["status"] == RUNNING
+    assert seen[0]["processed"] == 4
+    assert seen[0]["total"] == 10
+    assert seen[0]["determinate"] is True
+
+
+def test_row_counting_formats_are_not_reported_as_determinate():
+    assert IngestionJob("a.csv", "csv", "finding").snapshot()["determinate"] is False
+    assert (
+        IngestionJob("a.jsonl", "jsonl", "finding").snapshot()["determinate"] is False
+    )
+    assert IngestionJob("a.json", "json", "finding").snapshot()["determinate"] is True
+
+
+def test_processed_counts_skips_and_errors_not_just_imports(monkeypatch, spooled):
+    _patch_service(
+        monkeypatch,
+        _FakeService(
+            result={
+                "findings_total": 6,
+                "findings_imported": 2,
+                "findings_skipped": 3,
+                "findings_errors": 1,
+            }
+        ),
+    )
+    job = IngestionJob("export.parquet", "parquet", "finding")
+
+    run_job(job, spooled)
+
+    assert job.snapshot()["processed"] == 6
+
+
+# --- registry -------------------------------------------------------------
+
+
+def test_registry_admits_only_one_running_job():
+    registry = IngestionJobRegistry()
+    first = IngestionJob("a.parquet", "parquet", "finding")
+    registry.start(first)
+
+    with pytest.raises(IngestionJobConflict) as excinfo:
+        registry.start(IngestionJob("b.parquet", "parquet", "finding"))
+
+    assert excinfo.value.active is first
+
+
+def test_a_finished_job_frees_the_slot():
+    registry = IngestionJobRegistry()
+    first = IngestionJob("a.parquet", "parquet", "finding")
+    registry.start(first)
+    first.finish("Imported 1 findings")
+
+    registry.start(IngestionJob("b.parquet", "parquet", "finding"))
+
+    assert registry.active().filename == "b.parquet"
+
+
+def test_a_failed_job_frees_the_slot():
+    registry = IngestionJobRegistry()
+    first = IngestionJob("a.parquet", "parquet", "finding")
+    registry.start(first)
+    first.fail("boom")
+
+    registry.start(IngestionJob("b.parquet", "parquet", "finding"))
+
+    assert registry.active().filename == "b.parquet"
+
+
+def test_recent_lists_newest_first():
+    registry = IngestionJobRegistry()
+    for name in ("a", "b", "c"):
+        job = IngestionJob(f"{name}.parquet", "parquet", "finding")
+        registry.start(job)
+        job.finish("done")
+
+    assert [j.filename for j in registry.recent()] == [
+        "c.parquet",
+        "b.parquet",
+        "a.parquet",
+    ]
+
+
+def test_registry_is_bounded():
+    registry = IngestionJobRegistry(max_tracked=2)
+    for name in ("a", "b", "c"):
+        job = IngestionJob(f"{name}.parquet", "parquet", "finding")
+        registry.start(job)
+        job.finish("done")
+
+    assert [j.filename for j in registry.recent()] == ["c.parquet", "b.parquet"]
+
+
+def test_get_returns_none_for_an_unknown_job():
+    assert IngestionJobRegistry().get("ing-nope") is None

--- a/tests/unit/test_ingestion_upload_api.py
+++ b/tests/unit/test_ingestion_upload_api.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_BACKEND_DIR = _REPO_ROOT / "backend"
+for p in (str(_REPO_ROOT), str(_BACKEND_DIR)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from backend.api import ingestion as ingestion_api  # noqa: E402
+from services import ingestion_service  # noqa: E402
+from services.ingestion_jobs import IngestionJobRegistry  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeService:
+    gate: threading.Event = None
+    result: dict = {}
+    calls: list = []
+
+    def __init__(self):
+        self.stats = {
+            "findings_total": 0,
+            "findings_imported": 0,
+            "findings_skipped": 0,
+            "findings_errors": 0,
+            "cases_total": 0,
+            "cases_imported": 0,
+            "cases_skipped": 0,
+            "cases_errors": 0,
+        }
+
+    def _ingest_file_by_format(self, file_path, fmt, data_type="finding"):
+        type(self).calls.append((fmt, data_type))
+        if type(self).gate is not None:
+            type(self).gate.wait(timeout=5)
+        self.stats.update(type(self).result)
+        return self.stats
+
+
+@pytest.fixture
+def client(monkeypatch):
+    _FakeService.gate = None
+    _FakeService.result = {"findings_total": 2, "findings_imported": 2}
+    _FakeService.calls = []
+
+    registry = IngestionJobRegistry()
+    monkeypatch.setattr(ingestion_api, "get_job_registry", lambda: registry)
+    monkeypatch.setattr(ingestion_service, "IngestionService", lambda: _FakeService())
+
+    app = FastAPI()
+    app.include_router(ingestion_api.router, prefix="/api/ingest")
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def _upload(client, name="export.parquet", body=b"payload", data_type="finding"):
+    return client.post(
+        "/api/ingest/upload",
+        files={"file": (name, body, "application/octet-stream")},
+        data={"data_type": data_type},
+    )
+
+
+def _await_terminal(client, job_id, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        job = client.get(f"/api/ingest/jobs/{job_id}").json()
+        if job["status"] != "running":
+            return job
+        time.sleep(0.05)
+    raise AssertionError(f"job {job_id} never finished")
+
+
+def test_upload_is_accepted_without_waiting_for_the_ingest(client):
+    response = _upload(client)
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["status"] == "running"
+    assert body["filename"] == "export.parquet"
+    assert body["format"] == "parquet"
+    assert body["determinate"] is True
+
+
+def test_the_job_reaches_success_and_reports_its_stats(client):
+    job_id = _upload(client).json()["job_id"]
+
+    job = _await_terminal(client, job_id)
+
+    assert job["status"] == "succeeded"
+    assert job["message"] == "Imported 2 findings"
+    assert job["processed"] == 2
+    assert job["total"] == 2
+
+
+def test_format_is_detected_from_the_extension(client):
+    assert _upload(client, name="a.csv").json()["format"] == "csv"
+    assert _upload(client, name="a.ndjson").json()["format"] == "jsonl"
+
+
+def test_an_unknown_extension_is_rejected(client):
+    response = _upload(client, name="notes.txt")
+
+    assert response.status_code == 400
+    assert "Unable to detect file format" in response.json()["detail"]
+
+
+def test_an_unknown_data_type_is_rejected(client):
+    response = _upload(client, data_type="widget")
+
+    assert response.status_code == 400
+    assert "data_type" in response.json()["detail"]
+
+
+def test_an_oversized_upload_is_rejected_before_a_job_is_created(client, monkeypatch):
+    monkeypatch.setattr(ingestion_api, "MAX_UPLOAD_SIZE_BYTES", 8)
+
+    response = _upload(client, body=b"x" * 64)
+
+    assert response.status_code == 413
+    assert client.get("/api/ingest/jobs").json() == []
+
+
+def test_a_second_upload_is_refused_while_one_is_running(client):
+    _FakeService.gate = threading.Event()
+    try:
+        first = _upload(client, name="first.parquet")
+        assert first.status_code == 202
+
+        second = _upload(client, name="second.parquet")
+
+        assert second.status_code == 409
+        assert "first.parquet" in second.json()["detail"]
+    finally:
+        _FakeService.gate.set()
+    _await_terminal(client, first.json()["job_id"])
+
+
+def test_the_slot_is_released_once_the_running_job_finishes(client):
+    first = _upload(client, name="first.parquet")
+    _await_terminal(client, first.json()["job_id"])
+
+    assert _upload(client, name="second.parquet").status_code == 202
+
+
+def test_jobs_are_listed_newest_first_for_re_attach(client):
+    first = _upload(client, name="first.parquet").json()["job_id"]
+    _await_terminal(client, first)
+    second = _upload(client, name="second.parquet").json()["job_id"]
+    _await_terminal(client, second)
+
+    listed = client.get("/api/ingest/jobs").json()
+
+    assert [j["filename"] for j in listed] == ["second.parquet", "first.parquet"]
+
+
+def test_polling_an_unknown_job_is_a_404(client):
+    response = client.get("/api/ingest/jobs/ing-missing")
+
+    assert response.status_code == 404
+
+
+def test_the_declared_data_type_reaches_the_service(client):
+    job_id = _upload(client, name="cases.jsonl", data_type="case").json()["job_id"]
+    _await_terminal(client, job_id)
+
+    assert _FakeService.calls == [("jsonl", "case")]


### PR DESCRIPTION
Fixes #500

- Background job instead of a blocking request — a multi-minute parquet ingest ran synchronously in the handler. The client's 15s timeout aborted it, and the blocking call froze the event loop for everyone. Upload now spools to disk, returns 202 + job id, ingests on a worker thread; frontend polls GET /ingest/jobs/{id}. Upload UI also moved out of the S3 card it was orphaned under.

- Duplicate finding_ids from missing id columns — rows with no sequence_id/attack_id all hashed the empty string and collapsed onto one finding_id (silent data loss reported as "duplicates"). Now derives an id from identifying columns when none is declared, and widens the hash 8→16 hex chars to avoid collisions on large files

- Generic schema support + bulk insert — non-LogLM parquet (netflow, vendor exports) is now detected by column presence and ingested generically as unscored evidence via an alias table, keeping the full row in raw_features. Added bulk_create_findings so ingestion dedups/inserts per-batch instead of per-row.

- Efficiency pass on the pre-existing CSV/JSONL/JSON/string ingestion paths — they were still doing a per-row SELECT+INSERT through ingest_finding, the same N+1 pattern the parquet path was just fixed for. Wired them through the same _ingest_finding_batch/bulk_create_findings path in chunks of 1000, and dropped ~85 lines of docstring bloat across both files with no behavior change (verified by tests).

-> need time series analysis tool to analyze data in different ways, but this is a good step in direction of l7 adoption too.