### PR TITLE
chore: gitignore graphify-out/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,6 @@ claude_analysis_*.txt
 
 # Autostart list, written by Settings -> Services (see services/autostart_config.py)
 .vigil-autostart
+
+# Generated knowledge-graph output (graphify) — ~20MB, never committed
+graphify-out/


### PR DESCRIPTION
## What

Adds `graphify-out/` to `.gitignore`.

## Why

The graphify tooling writes ~20MB of generated output to `graphify-out/` at the repo root — `graph.json` (9MB), `graph.html`, `vigil-callflow.html`, `GRAPH_REPORT.md`, `manifest.json`, and a `cache/` directory. None of it belongs in the repo, but it showed up as untracked noise in every `git status`, which makes it easy to miss real untracked files.

`.gcloudignore` already excludes the directory; this just brings `.gitignore` in line.

## How tested

`git status` no longer lists `graphify-out/`. No tracked file is newly ignored — `git ls-files graphify-out/` was already empty, so nothing is removed from the index.