### PR TITLE
fix(api): offload blocking I/O off the event loop

### DIFF
--- a/backend/api/attack.py
+++ b/backend/api/attack.py
@@ -34,7 +34,7 @@ def _parse_finding_timestamp(finding: dict) -> Optional[datetime]:
 
 
 @router.get("/layer")
-async def get_attack_layer():
+def get_attack_layer():
     """
     Get ATT&CK Navigator layer data.
 
@@ -90,7 +90,7 @@ async def get_attack_layer():
 
 
 @router.get("/techniques/rollup")
-async def get_technique_rollup(
+def get_technique_rollup(
     min_confidence: float = 0.0,
     time_range: str = Query("all", pattern="^(24h|7d|30d|all)$"),
 ):
@@ -171,7 +171,7 @@ async def get_technique_rollup(
 
 
 @router.get("/techniques/{technique_id}/findings")
-async def get_findings_by_technique(technique_id: str):
+def get_findings_by_technique(technique_id: str):
     """
     Get all findings associated with a specific technique.
 
@@ -199,7 +199,7 @@ async def get_findings_by_technique(technique_id: str):
 
 
 @router.get("/tactics/summary")
-async def get_tactics_summary():
+def get_tactics_summary():
     """
     Get summary of tactics across all findings.
 

--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -541,7 +541,7 @@ async def set_platform_database_config(config: PlatformDatabaseProxyConfig):
 
 
 @router.post("/s3/test")
-async def test_s3_connection():
+def test_s3_connection():
     """
     Test S3 connection with current configuration.
 

--- a/backend/api/findings.py
+++ b/backend/api/findings.py
@@ -27,7 +27,7 @@ class FindingFilter(BaseModel):
 
 
 @router.get("/")
-async def get_findings(
+def get_findings(
     severity: Optional[str] = Query(None),
     data_source: Optional[str] = Query(None),
     cluster_id: Optional[int] = Query(None),
@@ -53,9 +53,9 @@ async def get_findings(
             logger.info(f"S3 sync completed: {message}")
         else:
             logger.warning(f"S3 sync failed or partial: {message}")
-    
+
     cluster_id_str = str(cluster_id) if cluster_id is not None else None
-    
+
     total = data_service.count_findings(
         severity=severity, data_source=data_source,
         cluster_id=cluster_id_str, min_anomaly_score=min_anomaly_score,
@@ -71,7 +71,7 @@ async def get_findings(
         # 1000-row page (polled every 10s) isn't several MB of vectors.
         include_embedding=False,
     )
-    
+
     return {
         "findings": [
             project_finding_source_evidence_for_list(finding) for finding in findings
@@ -84,7 +84,7 @@ async def get_findings(
 
 
 @router.get("/{finding_id}")
-async def get_finding(finding_id: str):
+def get_finding(finding_id: str):
     """
     Get a specific finding by ID.
     
@@ -101,7 +101,7 @@ async def get_finding(finding_id: str):
 
 
 @router.get("/stats/summary")
-async def get_findings_summary():
+def get_findings_summary():
     """
     Get summary statistics for findings.
     
@@ -130,7 +130,7 @@ async def get_findings_summary():
 
 
 @router.post("/export")
-async def export_findings(output_format: str = "json"):
+def export_findings(output_format: str = "json"):
     """
     Export findings to a file.
     
@@ -176,7 +176,7 @@ class BulkEnrichmentRequest(BaseModel):
 
 
 @router.patch("/{finding_id}")
-async def update_finding(finding_id: str, update: FindingUpdate):
+def update_finding(finding_id: str, update: FindingUpdate):
     """
     Update/enrich an existing finding.
     
@@ -232,7 +232,7 @@ async def update_finding(finding_id: str, update: FindingUpdate):
 
 
 @router.post("/bulk-enrich")
-async def bulk_enrich_findings(request: BulkEnrichmentRequest):
+def bulk_enrich_findings(request: BulkEnrichmentRequest):
     """
     Bulk enrich multiple findings with MITRE ATT&CK and other data.
     
@@ -345,7 +345,7 @@ async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Q
     from datetime import datetime
     
     # Get the finding
-    finding = data_service.get_finding(finding_id)
+    finding = await asyncio.to_thread(data_service.get_finding, finding_id)
     if not finding:
         raise HTTPException(status_code=404, detail="Finding not found")
     
@@ -620,7 +620,9 @@ Respond ONLY with valid JSON. Be specific and actionable. Focus on helping a SOC
         enrichment['provider_type'] = provider.provider_type
         
         # Save enrichment to database
-        success = data_service.update_finding(finding_id, ai_enrichment=enrichment)
+        success = await asyncio.to_thread(
+            data_service.update_finding, finding_id, ai_enrichment=enrichment
+        )
         
         if not success:
             logger.error(f"Failed to save enrichment for {finding_id}")
@@ -645,7 +647,7 @@ Respond ONLY with valid JSON. Be specific and actionable. Focus on helping a SOC
 
 
 @router.delete("/all")
-async def clear_all_findings():
+def clear_all_findings():
     """Delete all findings from the database."""
     try:
         from database.connection import get_session

--- a/backend/api/ingestion.py
+++ b/backend/api/ingestion.py
@@ -310,7 +310,7 @@ async def get_csv_template(data_type: str):
 
 
 @router.post("/sync-s3")
-async def sync_from_s3():
+def sync_from_s3():
     """
     Sync findings and cases from AWS S3.
     
@@ -351,7 +351,7 @@ async def sync_from_s3():
 
 @router.post("/sync-s3-folder", response_model=IngestionStats)
 @router.post("/sync-s3-parquet", response_model=IngestionStats, include_in_schema=False)
-async def sync_s3_folder(prefix: Optional[str] = Query(None)):
+def sync_s3_folder(prefix: Optional[str] = Query(None)):
     """
     Discover and ingest all supported files from an S3 prefix.
 
@@ -480,7 +480,7 @@ def _get_s3_service():
 
 
 @router.get("/s3-files")
-async def list_s3_files(prefix: Optional[str] = Query("")):
+def list_s3_files(prefix: Optional[str] = Query("")):
     """
     List files in the configured S3 bucket with metadata.
 
@@ -513,7 +513,7 @@ class S3FileIngestRequest(BaseModel):
 
 
 @router.post("/s3-file", response_model=IngestionStats)
-async def ingest_s3_file(request: S3FileIngestRequest):
+def ingest_s3_file(request: S3FileIngestRequest):
     """
     Download and ingest a single file from S3 by key.
 
@@ -581,7 +581,7 @@ async def ingest_s3_file(request: S3FileIngestRequest):
 
 
 @router.get("/s3-status")
-async def get_s3_status():
+def get_s3_status():
     """
     Get S3 connection status.
     

--- a/backend/api/jira_export.py
+++ b/backend/api/jira_export.py
@@ -46,7 +46,7 @@ class JiraExportResponse(BaseModel):
 
 
 @router.post("/cases/{case_id}/export/jira", response_model=JiraExportResponse)
-async def export_case_to_jira(
+def export_case_to_jira(
     case_id: str,
     request: JiraExportRequest,
     current_user: User = Depends(get_current_user),
@@ -212,7 +212,7 @@ async def export_case_to_jira(
 
 
 @router.post("/cases/{case_id}/remediation/jira", response_model=JiraExportResponse)
-async def export_remediation_to_jira(
+def export_remediation_to_jira(
     case_id: str,
     request: JiraRemediationExportRequest,
     current_user: User = Depends(get_current_user),

--- a/backend/api/vstrike.py
+++ b/backend/api/vstrike.py
@@ -128,7 +128,7 @@ def verify_inbound_key(
 
 
 @router.post("/findings", response_model=VStrikePushResponse)
-async def ingest_findings(
+def ingest_findings(
     request: VStrikePushRequest,
     _auth: None = Depends(verify_inbound_key),
 ) -> VStrikePushResponse:

--- a/backend/main.py
+++ b/backend/main.py
@@ -629,6 +629,28 @@ async def startup_event():
 
     _testing = os.getenv("TESTING", "false").lower() in ("true", "1", "yes")
 
+    # Keep the sync-endpoint threadpool in lockstep with the DB connection pool.
+    # Starlette runs `def` endpoints (and sync deps) on anyio's default thread
+    # limiter, which defaults to 40; our pool ceiling is pool_size + max_overflow
+    # (30 by default). Without this, a burst of 31+ concurrent DB-bound requests
+    # would occupy threads that then block on the pool up to DB_POOL_TIMEOUT.
+    try:
+        import anyio.to_thread
+        from database.connection import get_db_manager
+
+        _pool_cfg = get_db_manager().config
+        _db_ceiling = _pool_cfg.pool_size + _pool_cfg.max_overflow
+        anyio.to_thread.current_default_thread_limiter().total_tokens = _db_ceiling
+        logger.info(
+            "Threadpool capacity set to %d to match DB pool "
+            "(pool_size=%d + max_overflow=%d)",
+            _db_ceiling,
+            _pool_cfg.pool_size,
+            _pool_cfg.max_overflow,
+        )
+    except Exception as e:  # pragma: no cover - best-effort tuning
+        logger.warning("Could not align threadpool with DB pool: %s", e)
+
     # Initialize Sentry error tracking (was never called before — bug fix)
     try:
         from backend.monitoring import init_sentry

--- a/tests/integration/test_vstrike_ingest.py
+++ b/tests/integration/test_vstrike_ingest.py
@@ -131,8 +131,6 @@ def _invoke_ingest(fake_service: _FakeDataService, payload: Dict[str, Any]):
     Patches both the imported reference in `backend.api.vstrike` and the
     one used by `services.case_automation_service.cluster_findings_by_attack_path`.
     """
-    import asyncio
-
     from backend.api import vstrike as vstrike_module
     from backend.schemas.vstrike import VStrikePushRequest
 
@@ -142,7 +140,7 @@ def _invoke_ingest(fake_service: _FakeDataService, payload: Dict[str, Any]):
         "services.database_data_service.DatabaseDataService",
         return_value=fake_service,
     ):
-        response = asyncio.run(vstrike_module.ingest_findings(req))
+        response = vstrike_module.ingest_findings(req)
     return response
 
 

--- a/tests/unit/test_source_evidence.py
+++ b/tests/unit/test_source_evidence.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import importlib.util
 import json
 import sys
@@ -217,7 +216,7 @@ def test_findings_list_omits_payload_while_detail_retains_it(monkeypatch):
     finding = _finding_with_evidence()
     monkeypatch.setattr(findings_api, "data_service", _FakeDataService(finding))
 
-    list_response = asyncio.run(findings_api.get_findings(
+    list_response = findings_api.get_findings(
         severity=None,
         data_source=None,
         cluster_id=None,
@@ -229,8 +228,8 @@ def test_findings_list_omits_payload_while_detail_retains_it(monkeypatch):
         sort_by="timestamp",
         sort_order="desc",
         force_refresh=False,
-    ))
-    detail_response = asyncio.run(findings_api.get_finding("f-source-1"))
+    )
+    detail_response = findings_api.get_finding("f-source-1")
 
     listed = list_response["findings"][0]["entity_context"]["source_evidence"]
     detailed = detail_response["entity_context"]["source_evidence"]


### PR DESCRIPTION
## What & why

Adopts the sync-`def` + threadpool execution model decided in #461. Async route handlers were calling the synchronous data layer — S3/`boto3`, `requests`, sync SQLAlchemy — directly on the event loop, so one slow call (an S3 sync, a Jira export) blocked every concurrent request on the worker.

## Change

Fully-synchronous handlers become plain `def` so FastAPI runs them in the threadpool; the one handler that also `await`s the LLM (`get_or_generate_enrichment`) stays `async` with its two DB calls wrapped in `asyncio.to_thread`.

| File | Converted |
|---|---|
| `findings.py` | `get_findings` + 5 others → `def`; enrich handler → `to_thread` |
| `attack.py` | 4 handlers |
| `ingestion.py` | 5 S3 handlers |
| `jira_export.py` | 2 (blocking `requests`) |
| `config.py` | `test_s3_connection` |
| `vstrike.py` | `ingest_findings` |

**Convention:** plain `def` is the default; `asyncio.to_thread` is the exception, only for handlers that must also `await`. No behavior change beyond moving blocking work off the loop.

## Out of scope

- `cases.py` (41 handlers) → deferred to #463 (the case-repository refactor reworks that code).
- The `requests` integration clients → #462 (`httpx` swap).
- Automated lint guardrail → left for #415's lint home rather than standing up new infra.

Refs #461