### PR TITLE
docs(#486): ADR + glossary for R5 core domain shims

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,56 @@
+# Vigil SOC
+
+Vigil is an AI-native Security Operations Center: specialized AI agents perform
+triage, investigation, threat hunting, and response across many security
+integrations. This glossary fixes the language used across the codebase and
+docs. It is a glossary, not a spec — it defines what terms *mean*, not how any
+component is built.
+
+## Language — package layout (Reorg R5)
+
+**Domain**:
+A named product capability slice whose service/daemon logic is being regrouped
+under `core/<domain>/` as part of Reorg R5
+([#486](https://github.com/Vigil-SOC/vigil/issues/486)). The R5 domain list is:
+cases, workflows, threat_intel, reporting, response, detections, skills,
+storage, auth, chat, ingestion, federation, platform.
+_Avoid_: layer (that means backend/services/daemon), feature folder, module
+bucket.
+
+**Core domain package**:
+The Python package at `core/<domain>/` that holds a domain's service and daemon
+logic after a mechanical reorg. HTTP routers, schemas, SQL, and frontend stay
+outside it.
+_Avoid_: core module (ambiguous with flat `core/*.py` utilities), vertical
+slice (broader than R5's services/daemon move).
+
+**Import shim**:
+A temporary module (or mirror package) left at a pre-reorg import path that
+explicitly re-exports public names from the core domain package so existing
+callers and tests keep working. Shims are removed in Reorg R8
+([#489](https://github.com/Vigil-SOC/vigil/issues/489)).
+_Avoid_: re-export facade (unless describing the pattern), compatibility
+wrapper (too vague — shims must not change behavior).
+
+**Mechanical reorg**:
+A `git mv` of domain logic into a core domain package plus import shims, with
+no intentional behavior change. One domain per pull request.
+_Avoid_: refactor (implies logic change), cleanup (R8 removes shims; R5 only
+moves).
+
+**Chat (R5)**:
+Conversation session, context, and tool-execution packaging around the product
+chat experience (e.g. `services/chat/`). Distinct from LLM engines and the LLM
+entry point, which belong to Reorg R4
+([#485](https://github.com/Vigil-SOC/vigil/issues/485)).
+_Avoid_: using "chat" for ClaudeService, LLMRouter, or provider plumbing.
+
+## Flagged ambiguities
+
+**"Core"** is overloaded: today it names both the flat shared utilities under
+`core/*.py` (config, secrets, telemetry) and the destination for domain
+packages (`core/<domain>/`). Prefer **core domain package** for the latter and
+leave flat utilities unnamed as "platform" until the platform domain PR.
+
+**"Platform"** in R5 is the last domain PR and may absorb or clarify those flat
+`core/*.py` utilities; until then they stay put beside new domain packages.

--- a/docs/adr/0001-core-domain-regrouping-shims.md
+++ b/docs/adr/0001-core-domain-regrouping-shims.md
@@ -1,0 +1,69 @@
+# R5 regroups domain logic under `core/<domain>/` behind temporary import shims
+
+- **Status:** proposed
+- **Date:** 2026-07-30
+- **Issue:** [#486](https://github.com/Vigil-SOC/vigil/issues/486) (epic [#481](https://github.com/Vigil-SOC/vigil/issues/481))
+
+## Context
+
+Vigil's product logic is spread across layered directories (`services/`,
+`daemon/`, `backend/api/`, …). Epic #481 regroups code toward
+`core/<area>/` packages. Reorg R5 (#486) covers the remaining domains: cases,
+workflows, threat_intel, reporting, response, detections, skills, storage,
+auth, chat, ingestion, federation, and platform.
+
+Call sites overwhelmingly use `from services.<module> import <Symbol>` (and
+equivalent deep imports under packages like `daemon.federation.*` /
+`services.chat.*`). Tests patch those same module paths. A naive move would
+break imports; rewriting every caller in the same change would mix layout work
+with large diffs and raise regression risk. R8 (#489) is already reserved to
+remove temporary compatibility later.
+
+## Decision
+
+R5 is a **mechanical reorg**, delivered **one domain per pull request**:
+
+1. **Move only service/daemon domain logic** into a **core domain package** at
+   `core/<domain>/`. Leave `backend/api/`, schemas, SQL, frontend, and
+   workflow markdown definitions in place.
+2. After each `git mv`, leave an **import shim** at the old path that
+   **explicitly re-exports** the public names callers and tests already use.
+   Do not use `import *` shims.
+3. For existing packages (`daemon/federation/`, `services/chat/`, …), move the
+   whole tree and leave a **mirror shim package** so deep imports
+   (`daemon.federation.runner`, `services.chat.context_manager`, …) keep
+   working without rewriting callers in the R5 PR.
+4. Code inside a core domain package imports siblings via
+   `core.<domain>…`. External callers keep old paths until R8 removes shims.
+5. Existing flat modules already under `core/*.py` (config, secrets,
+   telemetry, …) stay put until the final **platform** domain PR.
+6. **Chat** in R5 means conversation session/context/tool-execution packaging.
+   LLM engines and the LLM entry point remain R4 (#485).
+
+## Considered options
+
+- **A — Move services/daemon only; explicit shims; one domain per PR (chosen).**
+  Matches #486's "git mv + shims / no behavior change / one domain per PR"
+  framing and preserves the dominant import and patch style in the repo.
+- **B — Move API routers and schemas with each domain.** Rejected for R5:
+  couples FastAPI wiring into every mechanical PR and is closer to a full
+  vertical-slice migration than this issue's scope.
+- **C — Rewrite all callers to `core.<domain>` in the same PR (no shims).**
+  Rejected: large blast radius, harder review, and conflicts with the planned
+  R8 shim-removal lane.
+- **D — Star-import shims (`from core… import *`).** Rejected: the codebase
+  never imports services that way; explicit re-exports make the public surface
+  and R8 cleanup obvious.
+
+## Consequences
+
+- Each R5 PR is small and reviewable, but the tree carries temporary shim
+  modules until R8.
+- Shim authors must enumerate symbols that are imported or patched; missing a
+  name fails imports/tests rather than failing silently.
+- Early R5 PRs add packages beside flat `core/*.py`; the platform PR owns the
+  harder question of whether those utilities nest under `core/platform/`.
+- Chat and LLM owners must not cross-move each other's modules; coordinate if
+  a file sits on the boundary.
+- Acceptance for #486: domain logic under `core/<domain>/`, old imports resolve
+  via shims, no intentional behavior change.


### PR DESCRIPTION
Record the mechanical reorg convention for Reorg R5: move service/daemon domain logic under core/<domain>/, leave explicit import shims at old paths, one domain per PR, no behavior change. Docs-only; no code moves yet.

Part of #486.