### PR TITLE
reorg(splunk): drop the services.splunk_service shim

### DIFF
--- a/daemon/poller.py
+++ b/daemon/poller.py
@@ -110,7 +110,7 @@ class DataPoller:
             # Initialize Splunk service if configured
             if is_integration_enabled('splunk'):
                 try:
-                    from services.splunk_service import SplunkService
+                    from core.integrations.splunk.client import SplunkService
                     splunk_config = get_integration_config('splunk')
                     self._splunk_service = SplunkService(
                         server_url=splunk_config.get('server_url', ''),

--- a/services/splunk_service.py
+++ b/services/splunk_service.py
@@ -1,6 +1,0 @@
-"""Deprecated shim: moved to core.integrations.splunk.client (reorg #483).
-
-Removed in #489.
-"""
-
-from core.integrations.splunk.client import SplunkService  # noqa: F401


### PR DESCRIPTION
Removes the compatibility shim left by the Splunk slice (#483) and points the sole caller (`daemon/poller.py`) at `core.integrations.splunk.client` directly.

Part of the decision to drop import shims across the reorg (#481): update callers in the same PR and **fail closed** — a stale old-path import now errors in CI instead of silently resolving through a re-export.

**Changes**
- Delete `services/splunk_service.py` (6-line re-export shim)
- Repoint `daemon/poller.py` (the only importer of the old path) to `core.integrations.splunk.client`

**Verification**
- No `services.splunk_service` references remain anywhere in the tree
- `daemon/poller.py` compiles

Ref #481. Complements the no-shim policy update applied to the reorg issues.
