### PR TITLE
reorg(splunk): drop the federation adapter shim (follow-up to #527)

### DIFF
--- a/daemon/federation/adapters/splunk.py
+++ b/daemon/federation/adapters/splunk.py
@@ -1,7 +1,0 @@
-"""Deprecated shim: moved to core.integrations.splunk.adapter (reorg #483).
-
-Importing re-runs the register_adapter() side effect so the federation
-registry's builtin import still registers Splunk. Removed in #489.
-"""
-
-from core.integrations.splunk.adapter import SplunkAdapter  # noqa: F401

--- a/daemon/federation/registry.py
+++ b/daemon/federation/registry.py
@@ -87,7 +87,10 @@ def _ensure_builtins_loaded() -> None:
             crowdstrike,
             elastic,
             microsoft_defender,
-            splunk,
         )
+
+        # Splunk lives in its vertical slice; import the adapter module directly
+        # for the same module-scope register_adapter() side effect.
+        from core.integrations.splunk import adapter as _splunk_adapter  # noqa: F401
     except Exception as e:
         logger.warning("Failed to load builtin federation adapters: %s", e)


### PR DESCRIPTION
Removes the second (and final) Splunk re-export shim — follow-up to #527, which removed `services/splunk_service.py` before this one could ride along in the same merge.

`daemon/federation/adapters/splunk.py` was a re-export shim whose only purpose was to trigger `core.integrations.splunk.adapter`'s module-scope `register_adapter()` when the federation registry loads its builtins. The registry's builtin loader now imports `core.integrations.splunk.adapter` directly for the same side effect, and the shim is deleted.

Part of the no-shim reorg decision (#481): callers are repointed in-PR and a stale old-path import fails closed.

**Verification**
- `daemon/federation/adapters/splunk.py` deleted; no `daemon.federation.adapters.splunk` references remain in the tree
- `registry.list_adapters()` still yields all six builtins including `splunk`
- `daemon/federation/registry.py` compiles

Ref #481. Completes the Splunk shim cleanup started in #527.
