### PR TITLE
ci: run tests/security/ on pull requests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -126,7 +126,23 @@ jobs:
           TESTING: "true"
           CLAUDE_API_KEY: ${{ secrets.CLAUDEAPI }}
           ANTHROPIC_API_KEY: ${{ secrets.CLAUDEAPI }}
-      
+
+      # tests/security/ is path-scoped out of the unit and integration jobs, so
+      # until now nothing ran it on a pull request — only nightly.yml, i.e. after
+      # merge. Its own step (rather than widening the path above) keeps a security
+      # failure legible instead of buried in ~1000 unit tests.
+      #
+      # DEV_MODE and JWT_SECRET_KEY must be explicit: backend/middleware/auth.py
+      # defaults DEV_MODE to false, and with no .env in CI an unset JWT_SECRET_KEY
+      # makes _load_jwt_secret() raise. --no-cov keeps this step from overwriting
+      # the coverage.xml the Codecov step below uploads.
+      - name: Run security tests
+        run: pytest tests/security/ -v --no-cov
+        env:
+          TESTING: "true"
+          DEV_MODE: "false"
+          JWT_SECRET_KEY: "ci-only-not-a-real-secret"
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
## What

Adds a `Run security tests` step to the existing `test-unit-backend` job so `tests/security/` runs on every pull request.

## Why

`tests/security/` holds **84 tests across 4 files** — including the deny-by-default assertions added after the 2026-05 disclosure — and **no pull-request job ran any of them**. `ci-cd.yml` runs `tests/unit/` and `tests/integration/` only, both path-scoped, so the whole directory was visible solely to `nightly.yml` (`pytest tests/`, 02:00 UTC) — after a regression had already merged.

| File | Tests | Asserts |
|---|---|---|
| `test_unauth_endpoints.py` | 40 | unauthenticated requests to the disclosure's routes return 401/403; authenticated non-admins get 403 |
| `test_path_traversal.py` | 22 | integration IDs reject `../` traversal |
| `test_ssrf.py` | 21 | provider URLs reject private/link-local targets |
| `test_route_auth_coverage.py` | 1 | every `/api/*` route requires auth or is on `PUBLIC_API_PATHS` |

## Decisions worth reviewing

**Its own step, not a widened path.** Running `pytest tests/security/` separately rather than extending `pytest tests/unit/` keeps a security failure legible in the job log instead of buried among ~1000 unit tests.

**`DEV_MODE` and `JWT_SECRET_KEY` are explicit, not defensive.** `backend/middleware/auth.py:24` defaults `DEV_MODE` to `false`, and with no `.env` in CI an unset `JWT_SECRET_KEY` makes `_load_jwt_secret()` raise. `test_route_auth_coverage.py` never sets it — that file currently only works because `test_unauth_endpoints.py` calls `os.environ.setdefault("JWT_SECRET_KEY", ...)` at *collection* time while the coverage test imports `backend.main` lazily inside its test body. CI must not depend on that accidental cross-file ordering.

**`--no-cov`.** Stops the step from overwriting the `coverage.xml` that the Codecov step immediately below uploads.

## Scope

Test *content* is unchanged; this only makes existing tests run. Nothing else in CI changes.

Note that `test_route_auth_coverage.py` is itself **vacuous** under FastAPI 0.137.1 — it examines 1 route out of 359 and passes unconditionally — so it will pass without asserting anything until #532 lands. The other 83 assertions become real immediately, which is why this is worth landing on its own.

For the record, the auth boundary is **currently intact**: 359 effective `/api/*` routes, 351 requiring auth, 7 un-authed and all 7 on `PUBLIC_API_PATHS`, 0 unprotected. This restores regression protection; it is not a live-vulnerability fix.

## Testing

```
$ env TESTING=true DEV_MODE=false JWT_SECRET_KEY=ci-only-not-a-real-secret \
    pytest tests/security/ -v --no-cov
84 passed, 5 warnings in 7.64s
```

Also verified: the workflow YAML parses, the new step lands between `Run unit tests` and `Upload coverage to Codecov`, and `--no-cov` leaves `coverage.xml` untouched.

Clean-environment behaviour (no `.env`) is proven by this PR's own CI run — that could not be verified locally without moving the developer's `.env`.

One incidental change: the blank line above the new step previously held trailing whitespace and is now genuinely blank.

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)