### PR TITLE
refactor(findings): extract AI enrichment into a module (#470)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,16 @@ This file provides guidance for AI assistants (Claude Code and similar tools) wo
 
 ## Project Overview
 
-**Vigil** is an open-source, AI-native Security Operations Center (SOC) platform. It orchestrates 13 specialized AI agents via Claude to perform triage, investigation, threat hunting, forensics, and automated response across 30+ security integrations.
+**Vigil** is an open-source, AI-native Security Operations Center (SOC) platform. It orchestrates 13 specialized AI agents via Claude to perform triage, investigation, threat hunting, forensics, and automated response across 40 security integrations.
 
 **Core pillars:**
-- **Agents** — 13 specialized AI agents (Triage, Investigator, Threat Hunter, Correlator, Responder, Reporter, MITRE Analyst, Forensics, Threat Intel, Compliance, Malware Analyst, Network Analyst)
+- **Agents** — 13 agents defined in `AGENT_CONFIGS`, which is the authoritative
+  list: triage, investigator, threat_hunter, correlator, responder, reporter,
+  mitre_analyst, forensics, threat_intel, compliance, malware_analyst,
+  network_analyst, auto_responder. (The README says "12" — it omits
+  `auto_responder`.)
 - **Workflows** — Multi-agent orchestrated playbooks (Incident Response, Full Investigation, Threat Hunt, Forensic Analysis)
-- **Integrations** — 30+ tools via MCP protocol (Splunk, CrowdStrike, VirusTotal, Shodan, Timesketch, Jira, Slack, etc.)
+- **Integrations** — 40 MCP servers in `mcp-config.json` (Splunk, CrowdStrike, VirusTotal, Shodan, Timesketch, Jira, Slack, etc.). Count only dict-valued keys: the `mcpServers` object also holds 7 `_comment_*` string keys used as section separators.
 
 **Ports:**
 - Backend API: `http://localhost:6987`
@@ -64,9 +68,16 @@ vigil/
 ├── docs/                 # Detailed documentation
 ├── docker/               # docker-compose.yml + Dockerfiles
 ├── scripts/              # Init and utility shell scripts
-├── mcp-config.json       # 30+ MCP server definitions
+├── mcp-config.json       # 40 MCP server definitions (+ `_comment_*` separator keys)
 └── env.example           # Template for all 220+ environment variables
 ```
+
+> **sys.path quirk:** `backend/main.py` puts `backend/` on `sys.path`, so modules
+> there are imported *bare* — `from secrets_manager import get_secret`, not
+> `from backend.secrets_manager import …`. `setup.cfg` (`mypy_path = backend`) and
+> `pyrightconfig.json` (`extraPaths`) mirror this so static analysis resolves them.
+> Note the resulting name collisions: `backend/services/` and `backend/tools/` are
+> **not** the top-level `services/` and `tools/` packages.
 
 ---
 
@@ -96,6 +107,18 @@ cd frontend && npm run dev
 # 4. (Optional) Daemon
 ./start.sh --daemon
 ```
+
+### Desktop (Electron)
+
+```bash
+cd desktop && npm run dev    # builds TS, launches Electron
+cd desktop && npm run dist   # packages a .dmg via electron-builder
+```
+
+The desktop app drives the stack through `scripts/app_up.sh` / `app_down.sh`
+rather than `start.sh`: no `--reload`, no Vite (the built SPA is served by the
+backend at :6987), and it **forces `DEV_MODE=false`** because its login and
+first-run bootstrap are the point.
 
 ### Fresh Environment
 
@@ -138,23 +161,29 @@ Default dev login: **admin / admin123** (when `DEV_MODE=false`)
 
 ### Python (pytest)
 
-```bash
-# All tests
-pytest
+The pytest config lives at **`tests/pytest.ini`** — there is no root-level
+`pytest.ini` and no `[tool:pytest]` in `setup.cfg`. A bare `pytest` from the repo
+root therefore finds no ini file: markers go unregistered, `--asyncio-mode=auto`
+and the coverage flags are skipped, and collection starts from the CWD instead of
+`testpaths = tests`. Always scope to `tests/` (or pass `-c tests/pytest.ini`).
 
-# With coverage
-pytest --cov=. --cov-report=html
+```bash
+# All tests, with the intended config
+pytest tests/
 
 # By marker
-pytest -m unit
-pytest -m integration   # requires running PostgreSQL
-pytest -m "not slow"
+pytest tests/ -m unit
+pytest tests/ -m integration   # requires running PostgreSQL
+pytest tests/ -m "not external_service"   # what CI's main unit job runs
 
 # Specific file
-pytest tests/test_backend_tools.py -v
+pytest tests/unit/test_backend_tools.py -v
 ```
 
-Available markers: `unit`, `integration`, `slow`, `auth`, `siem`, `claude`, `database`, `api`, `daemon`, `performance`
+Available markers: `unit`, `integration`, `slow`, `auth`, `siem`, `claude`,
+`database`, `api`, `daemon`, `performance`, `external_service`.
+`--strict-markers` is on, so an unregistered marker is an error — add new ones to
+`tests/pytest.ini`.
 
 ### Frontend (vitest)
 
@@ -190,6 +219,32 @@ pre-commit run --all-files
 
 All FastAPI endpoints and service methods use `async/await`. Long-running LLM operations go through the ARQ Redis queue (worker pattern). Never add blocking I/O to endpoint handlers.
 
+**The DB layer is synchronous SQLAlchemy — there is no `AsyncSession` in this
+repo.** `database/connection.py` exposes a `sessionmaker` and a `get_db()`
+dependency yielding a plain `Session`. So don't type a dependency as
+`AsyncSession` or `await` a session call. Handlers that are fully synchronous can
+be plain `def` (FastAPI runs those in a threadpool); handlers that must stay
+`async` should push sync DB calls through `asyncio.to_thread` rather than
+blocking the loop.
+
+### LLM Traffic Routes Through Bifrost
+
+All LLM calls — including Anthropic — go through the **Bifrost** gateway
+(`BIFROST_URL`, default `http://bifrost:8080`), which layers on caching,
+centralized cost tracking, and budget enforcement.
+
+- **Never instantiate `Anthropic()` directly.** Import
+  `create_anthropic_client` / `create_async_anthropic_client` from
+  `services/llm_clients.py` — the single source of truth for client
+  construction. The one exception is key-validation endpoints that must hit the
+  real upstream to verify a user-supplied credential.
+- `services/llm_router.py` dispatches and translates Bifrost's budget/rate-limit
+  responses (HTTP 402/429) into `services.budget_service.BudgetExceeded`.
+- `services/model_registry.py` resolves component→provider+model assignments and
+  owns the pricing/capability catalog.
+- Provider API keys are **not** in `.env` — they live in the encrypted secrets
+  store and are configured via the UI.
+
 ### Service Layer
 
 Business logic lives in `services/`, not in API route handlers. Route handlers in `backend/api/` should delegate to service classes. When adding a feature:
@@ -203,7 +258,8 @@ Agents access external tools through the MCP protocol. Tool definitions live in 
 
 ### Database
 
-- PostgreSQL 16 via SQLAlchemy ORM (`services/models.py`)
+- PostgreSQL 16 via SQLAlchemy ORM — models in **`database/models.py`**, sessions
+  and the `get_db` dependency in `database/connection.py`
 - Schema initialized by `database/init/` SQL files. **Execution order
   differs by deploy path:** docker-compose mounts the directory at
   `/docker-entrypoint-initdb.d`, where Postgres runs files in
@@ -287,11 +343,14 @@ Key config variables: `DAEMON_AUTO_TRIAGE`, `DAEMON_CONFIDENCE_THRESHOLD`, `ORCH
 Follow the existing pattern:
 ```python
 # backend/api/your_feature.py
+from sqlalchemy.orm import Session
+from database.connection import get_db
+
 router = APIRouter(prefix="/api/your-feature", tags=["your-feature"])
 
 @router.get("/")
-async def list_items(db: AsyncSession = Depends(get_db)):
-    return await your_feature_service.list(db)
+async def list_items(db: Session = Depends(get_db)):
+    return your_feature_service.list(db)   # sync Session — do not await it
 ```
 Register in `backend/main.py`.
 
@@ -338,6 +397,7 @@ GitHub Actions workflows in `.github/workflows/`:
 | `ci-cd.yml` | Push/PR to main, develop | Lint → Unit Tests → Integration Tests → Security Scan → Docker Build |
 | `release-please.yml` | Push to `main`, manual | Read Conventional Commits since last tag → open/update a release PR with bumped `VERSION` / `Chart.yaml` (`appVersion` + `version`, lockstep) / `frontend/package.json` / `frontend/package-lock.json` + `CHANGELOG.md`. On merge, push `vX.Y.Z` tag and create the GitHub Release. See `RELEASING.md`. |
 | `release.yml` | Version tags (`v*.*.*`) | Build & push `vigil-backend` + `vigil-daemon` images to GHCR → Trivy scan → smoke-test that they start → annotate the GitHub Release with image digests. **Publishes images only — it does not deploy.** Does **not** create the GitHub Release object either (release-please owns that). |
+| `helm-chart.yml` | Push/PR touching `helm/` | Verify `database/init/` ↔ chart-bundle copies are in sync (`diff -r`) → `helm lint`/`template` across default, dev, and Bitnami-subchart values → kubeconform → `ct lint` |
 | `nightly.yml` | Daily 2 AM UTC | Comprehensive security & performance audits |
 
 CI runs:

--- a/backend/api/findings.py
+++ b/backend/api/findings.py
@@ -350,7 +350,7 @@ async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Q
     import asyncio
 
     # Get the finding. The data layer is synchronous SQLAlchemy, so keep it off
-    # the event loop (#518) — this handler stays async because it awaits the LLM.
+    # the event loop — this handler stays async because it awaits the LLM.
     finding = await asyncio.to_thread(data_service.get_finding, finding_id)
     if not finding:
         raise HTTPException(status_code=404, detail="Finding not found")
@@ -367,11 +367,11 @@ async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Q
             "enrichment": existing_enrichment
         }
 
-    # Generate new enrichment using the configured reporting provider.
-    # The flow itself lives in services/findings/enrichment/ so ingestion, the
-    # daemon and agents can reuse it; this handler owns only the translation
-    # from domain errors to status codes (#470). The write that used to sit here
-    # moved into that module's _persist(), which keeps the to_thread offload.
+    # Generate new enrichment using the configured reporting provider. The flow
+    # lives in services/findings/enrichment/ so ingestion, the daemon and agents
+    # can reuse it; this handler owns only the domain-error → status-code
+    # translation. The write that used to sit here moved into that module's
+    # _persist(), which keeps the to_thread offload.
     try:
         # Pass the path param, not the id off the row we just read — it's the
         # authoritative write target, exactly as the pre-extraction handler did.

--- a/backend/api/findings.py
+++ b/backend/api/findings.py
@@ -373,7 +373,11 @@ async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Q
     # from domain errors to status codes (#470). The write that used to sit here
     # moved into that module's _persist(), which keeps the to_thread offload.
     try:
-        enrichment = await enrich(finding, data_service=data_service)
+        # Pass the path param, not the id off the row we just read — it's the
+        # authoritative write target, exactly as the pre-extraction handler did.
+        enrichment = await enrich(
+            finding, finding_id=finding_id, data_service=data_service
+        )
     except FindingNotFound:
         raise HTTPException(status_code=404, detail="Finding not found")
     except NoProviderConfigured:

--- a/backend/api/findings.py
+++ b/backend/api/findings.py
@@ -6,6 +6,12 @@ from pydantic import BaseModel
 import logging
 
 from services.database_data_service import DatabaseDataService
+from services.findings.enrichment import (
+    FindingNotFound,
+    NoProviderConfigured,
+    ProviderUnavailable,
+    enrich,
+)
 from services.source_evidence import (
     normalize_finding_source_evidence,
     project_finding_source_evidence_for_list,
@@ -342,14 +348,16 @@ async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Q
         }
     """
     import asyncio
-    from datetime import datetime
-    
-    # Get the finding
+
+    # Get the finding. The data layer is synchronous SQLAlchemy, so keep it off
+    # the event loop (#518) — this handler stays async because it awaits the LLM.
     finding = await asyncio.to_thread(data_service.get_finding, finding_id)
     if not finding:
         raise HTTPException(status_code=404, detail="Finding not found")
-    
-    # Check if enrichment already exists
+
+    # Check if enrichment already exists. Caching is HTTP policy — the shared
+    # enrich() seam deliberately doesn't do this check, since `force_regenerate`
+    # is a query param and the daemon has its own freshness rules.
     existing_enrichment = finding.get('ai_enrichment')
     if existing_enrichment and not force_regenerate:
         logger.info(f"Returning cached enrichment for {finding_id}")
@@ -358,292 +366,36 @@ async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Q
             "cached": True,
             "enrichment": existing_enrichment
         }
-    
+
     # Generate new enrichment using the configured reporting provider.
+    # The flow itself lives in services/findings/enrichment/ so ingestion, the
+    # daemon and agents can reuse it; this handler owns only the translation
+    # from domain errors to status codes (#470). The write that used to sit here
+    # moved into that module's _persist(), which keeps the to_thread offload.
     try:
-        from services.llm_router import LLMRouter, get_provider_spec
-        from services.model_registry import get_registry
+        enrichment = await enrich(finding, data_service=data_service)
+    except FindingNotFound:
+        raise HTTPException(status_code=404, detail="Finding not found")
+    except NoProviderConfigured:
+        # 503 with the structured payload the chat drawer matches on to render
+        # a "Configure a provider" CTA instead of a generic error bubble.
+        from backend.api.claude import NO_PROVIDER_DETAIL
 
-        resolved_model = get_registry().resolve_model_for_component("reporting")
-        if not resolved_model:
-            from backend.api.claude import NO_PROVIDER_DETAIL
-
-            raise HTTPException(status_code=503, detail=NO_PROVIDER_DETAIL)
-
-        provider_id, model_id = resolved_model
-        provider = get_provider_spec(provider_id)
-        if provider is None:
-            raise HTTPException(
-                status_code=503,
-                detail=f"Configured provider '{provider_id}' is unavailable",
-            )
-
-        claude_service = None
-        if provider.provider_type == "anthropic":
-            from services.claude_service import ClaudeService
-
-            claude_service = ClaudeService(use_backend_tools=True, use_mcp_tools=False)
-            if not claude_service.has_api_key():
-                from backend.api.claude import NO_PROVIDER_DETAIL
-
-                raise HTTPException(status_code=503, detail=NO_PROVIDER_DETAIL)
-        
-        # Extract finding details (use `or` to guard against keys present with None values)
-        severity = finding.get('severity') or 'unknown'
-        data_source = finding.get('data_source') or 'unknown'
-        timestamp = finding.get('timestamp') or ''
-        description = finding.get('description') or ''
-        entity_context = finding.get('entity_context') or {}
-        mitre_predictions = finding.get('mitre_predictions') or {}
-        predicted_techniques = finding.get('predicted_techniques') or []
-        anomaly_score = float(finding.get('anomaly_score') or 0)
-        
-        # Build entity context string (handles both singular and plural field formats)
-        entity_str = ""
-        if entity_context:
-            src_ips = entity_context.get('src_ips') or []
-            if not src_ips and entity_context.get('src_ip'):
-                src_ips = [entity_context['src_ip']]
-            dst_ips = entity_context.get('dst_ips') or entity_context.get('dest_ips') or []
-            if not dst_ips and entity_context.get('dst_ip'):
-                dst_ips = [entity_context['dst_ip']]
-            hostnames = entity_context.get('hostnames') or []
-            if not hostnames and entity_context.get('hostname'):
-                hostnames = [entity_context['hostname']]
-            users = entity_context.get('users') or entity_context.get('usernames') or []
-            if not users and entity_context.get('user'):
-                users = [entity_context['user']]
-            
-            if src_ips:
-                entity_str += f"Source IPs: {', '.join(str(ip) for ip in src_ips[:5])}\n"
-            if dst_ips:
-                entity_str += f"Destination IPs: {', '.join(str(ip) for ip in dst_ips[:5])}\n"
-            if hostnames:
-                entity_str += f"Hostnames: {', '.join(str(h) for h in hostnames[:5])}\n"
-            if users:
-                entity_str += f"Users: {', '.join(str(u) for u in users[:5])}\n"
-        
-        # Build MITRE techniques string
-        techniques_str = ""
-        if predicted_techniques:
-            techniques_list = [
-                f"{t.get('technique_id', 'Unknown')} (confidence: {float(t.get('confidence') or 0):.2f})"
-                for t in predicted_techniques[:5]
-            ]
-            techniques_str = "\n".join(techniques_list)
-        elif mitre_predictions:
-            techniques_list = [
-                f"{tech_id} (confidence: {float(conf or 0):.2f})"
-                for tech_id, conf in sorted(mitre_predictions.items(), key=lambda x: float(x[1] or 0), reverse=True)[:5]
-            ]
-            techniques_str = "\n".join(techniques_list)
-        
-        # Construct comprehensive analysis prompt
-        prompt = f"""You are a cybersecurity analyst reviewing a security finding. Provide a comprehensive, structured analysis.
-
-FINDING DETAILS:
-=================
-Finding ID: {finding_id}
-Severity: {severity}
-Data Source: {data_source}
-Timestamp: {timestamp}
-Anomaly Score: {anomaly_score:.2f}
-
-Description:
-{description if description else 'No description available'}
-
-{f'''Entity Context:
-{entity_str}''' if entity_str else ''}
-
-{f'''MITRE ATT&CK Techniques:
-{techniques_str}''' if techniques_str else 'No MITRE techniques predicted'}
-
-ANALYSIS REQUIREMENTS:
-=======================
-Please provide a detailed analysis in the following JSON structure:
-
-{{
-    "threat_summary": "A clear, concise summary (2-3 sentences) of what this finding represents and why it matters",
-    "threat_type": "Classification of threat (e.g., 'Data Exfiltration', 'Lateral Movement', 'Command & Control', 'Malware', etc.)",
-    "potential_impact": "Detailed explanation of potential impact on the organization (3-4 sentences)",
-    "risk_level": "Overall risk assessment: 'Critical', 'High', 'Medium', or 'Low'",
-    "recommended_actions": [
-        "Immediate action item 1",
-        "Immediate action item 2",
-        "Additional investigation step 1",
-        "Additional investigation step 2"
-    ],
-    "investigation_questions": [
-        "Key question to investigate 1?",
-        "Key question to investigate 2?",
-        "Key question to investigate 3?"
-    ],
-    "indicators": {{
-        "malicious_ips": ["list any suspicious IPs mentioned"],
-        "suspicious_domains": ["list any suspicious domains"],
-        "suspicious_users": ["list any suspicious user accounts"],
-        "suspicious_processes": ["list any suspicious processes or commands"]
-    }},
-    "related_techniques": [
-        {{
-            "technique_id": "T####.###",
-            "technique_name": "Technique name",
-            "relevance": "Why this technique is relevant"
-        }}
-    ],
-    "timeline_context": "Brief explanation of what likely happened and in what order",
-    "business_context": "How this finding relates to typical business operations and what makes it anomalous",
-    "confidence_score": 0.85,
-    "analysis_notes": "Any additional context, caveats, or recommendations for the analyst"
-}}
-
-Respond ONLY with valid JSON. Be specific and actionable. Focus on helping a SOC analyst make quick, informed decisions."""
-
-        # Generate enrichment
-        logger.info(
-            "Generating AI enrichment for %s via %s/%s",
-            finding_id,
-            provider.provider_id,
-            model_id,
-        )
-        loop = asyncio.get_event_loop()
-        if provider.provider_type == "anthropic":
-            # The enrichment JSON schema is large; a tight cap truncates it.
-            response = await loop.run_in_executor(
-                None,
-                lambda: claude_service.chat(
-                    message=prompt,
-                    model=model_id,
-                    max_tokens=4096,
-                ),
-            )
-        else:
-            # Local models are slow per token; bound them tighter than the
-            # cloud path while leaving room for the full JSON object.
-            dispatch_args = {
-                "provider": provider,
-                "messages": [{"role": "user", "content": f"/no_think\n{prompt}"}],
-                "system_prompt": (
-                    "You are a cybersecurity analyst. Respond only with valid "
-                    "JSON matching the requested enrichment schema. Keep the "
-                    "response concise and do not include chain-of-thought."
-                ),
-                "model": model_id,
-                "max_tokens": 1400,
-            }
-            from services.local_ai_recovery import (
-                is_gateway_connection_error,
-                local_bifrost_recovery_enabled,
-                local_bifrost_recovery_retry_limit,
-                recover_local_bifrost,
-            )
-
-            retry_limit = local_bifrost_recovery_retry_limit()
-            for attempt in range(retry_limit + 1):
-                try:
-                    result = await LLMRouter().dispatch(**dispatch_args)
-                    break
-                except Exception as dispatch_error:
-                    eligible = (
-                        provider.provider_type == "ollama"
-                        and local_bifrost_recovery_enabled()
-                        and is_gateway_connection_error(dispatch_error)
-                    )
-                    if not eligible or attempt >= retry_limit:
-                        raise
-
-                    recovery = await recover_local_bifrost()
-                    if not recovery.ready:
-                        logger.warning(
-                            "Local Bifrost recovery for %s failed: %s",
-                            finding_id,
-                            recovery.detail,
-                        )
-                        raise
-                    logger.info(
-                        "Local Bifrost recovery for %s: %s; retrying enrichment (%s/%s)",
-                        finding_id,
-                        recovery.detail,
-                        attempt + 1,
-                        retry_limit,
-                    )
-            response = result.get("content", "")
-        
-        # Parse JSON response
-        import json
-        import re
-        
-        if not response:
-            raise ValueError("LLM provider returned an empty response")
-        
-        # Try to extract JSON from response (handle markdown code blocks)
-        json_match = re.search(r'```json\s*(\{.*?\})\s*```', response, re.DOTALL)
-        if json_match:
-            json_str = json_match.group(1)
-        else:
-            # Try to find raw JSON
-            json_match = re.search(r'\{.*\}', response, re.DOTALL)
-            if json_match:
-                json_str = json_match.group(0)
-            else:
-                json_str = response
-        
-        try:
-            enrichment = json.loads(json_str)
-        except json.JSONDecodeError:
-            # If JSON parsing fails, create structured enrichment from text response
-            enrichment = {
-                "threat_summary": "AI analysis completed - see full analysis below",
-                "threat_type": "Security Finding",
-                "potential_impact": "Requires manual review",
-                "risk_level": severity.title() if severity else "Medium",
-                "recommended_actions": ["Review the detailed analysis", "Investigate related entities"],
-                "investigation_questions": ["What is the root cause?", "Are there related events?"],
-                "indicators": {},
-                "related_techniques": [],
-                "timeline_context": "Analysis in progress",
-                "business_context": "Requires additional context",
-                "confidence_score": 0.7,
-                "analysis_notes": response[:1000],  # Store first 1000 chars as notes
-                "raw_response": response  # Store full response
-            }
-
-        # Keep the provider's original response even when it parsed cleanly.
-        # Analysts can compare the rendered fields against the local model's
-        # exact output without having to regenerate the enrichment.
-        enrichment["raw_response"] = response
-        
-        # Add metadata
-        enrichment['generated_at'] = datetime.utcnow().isoformat() + 'Z'
-        enrichment['model'] = model_id
-        enrichment['provider_id'] = provider.provider_id
-        enrichment['provider_type'] = provider.provider_type
-        
-        # Save enrichment to database
-        success = await asyncio.to_thread(
-            data_service.update_finding, finding_id, ai_enrichment=enrichment
-        )
-        
-        if not success:
-            logger.error(f"Failed to save enrichment for {finding_id}")
-            # Still return the enrichment even if saving fails
-        else:
-            logger.info(f"Successfully generated and cached enrichment for {finding_id}")
-        
-        return {
-            "finding_id": finding_id,
-            "cached": False,
-            "enrichment": enrichment
-        }
-    
-    except HTTPException:
-        raise  # preserve 503 (no provider / unavailable) so the UI can distinguish it
+        raise HTTPException(status_code=503, detail=NO_PROVIDER_DETAIL)
+    except ProviderUnavailable as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error(f"Error generating enrichment for {finding_id}: {e}")
         raise HTTPException(
             status_code=500,
             detail=f"Failed to generate enrichment: {str(e)}"
         )
+
+    return {
+        "finding_id": finding_id,
+        "cached": False,
+        "enrichment": enrichment
+    }
 
 
 @router.delete("/all")

--- a/services/findings/__init__.py
+++ b/services/findings/__init__.py
@@ -1,0 +1,1 @@
+"""Finding-scoped business logic (enrichment, …)."""

--- a/services/findings/enrichment/__init__.py
+++ b/services/findings/enrichment/__init__.py
@@ -1,22 +1,8 @@
 """Finding AI-enrichment: prompt building, provider dispatch, response parsing.
 
-Extracted from the 333-line ``get_or_generate_enrichment`` handler in
-``backend/api/findings.py`` so the flow is reachable from more than one HTTP
-path — ingestion, the daemon and agents can call the same seam (#470).
-
-The single entry point is :func:`enrich`::
-
-    from services.findings.enrichment import enrich, EnrichmentError
-
-    try:
-        payload = await enrich(finding)             # persists by default
-    except EnrichmentError as exc:
-        ...
-
-Callers that want to compose their own database write pass ``persist=False``.
-Failures are domain exceptions (see :mod:`~services.findings.enrichment.errors`),
-never ``HTTPException`` — translation to status codes belongs to the HTTP
-boundary in ``backend/api/findings.py``.
+``enrich()`` is the entry point. It persists by default; pass ``persist=False``
+to compose your own write. Failures are domain exceptions from ``errors``, never
+``HTTPException``.
 """
 
 from services.findings.enrichment.errors import (

--- a/services/findings/enrichment/__init__.py
+++ b/services/findings/enrichment/__init__.py
@@ -1,0 +1,53 @@
+"""Finding AI-enrichment: prompt building, provider dispatch, response parsing.
+
+Extracted from the 333-line ``get_or_generate_enrichment`` handler in
+``backend/api/findings.py`` so the flow is reachable from more than one HTTP
+path — ingestion, the daemon and agents can call the same seam (#470).
+
+The single entry point is :func:`enrich`::
+
+    from services.findings.enrichment import enrich, EnrichmentError
+
+    try:
+        payload = await enrich(finding)             # persists by default
+    except EnrichmentError as exc:
+        ...
+
+Callers that want to compose their own database write pass ``persist=False``.
+Failures are domain exceptions (see :mod:`~services.findings.enrichment.errors`),
+never ``HTTPException`` — translation to status codes belongs to the HTTP
+boundary in ``backend/api/findings.py``.
+"""
+
+from services.findings.enrichment.errors import (
+    EmptyProviderResponse,
+    EnrichmentError,
+    FindingNotFound,
+    NoProviderConfigured,
+    ProviderUnavailable,
+)
+from services.findings.enrichment.parse import extract_json_block, parse_enrichment
+from services.findings.enrichment.prompt import (
+    FindingSummary,
+    build_entity_string,
+    build_prompt,
+    build_techniques_string,
+    summarize_finding,
+)
+from services.findings.enrichment.service import enrich
+
+__all__ = [
+    "EmptyProviderResponse",
+    "EnrichmentError",
+    "FindingNotFound",
+    "FindingSummary",
+    "NoProviderConfigured",
+    "ProviderUnavailable",
+    "build_entity_string",
+    "build_prompt",
+    "build_techniques_string",
+    "enrich",
+    "extract_json_block",
+    "parse_enrichment",
+    "summarize_finding",
+]

--- a/services/findings/enrichment/__init__.py
+++ b/services/findings/enrichment/__init__.py
@@ -25,6 +25,7 @@ from services.findings.enrichment.errors import (
     FindingNotFound,
     NoProviderConfigured,
     ProviderUnavailable,
+    UnidentifiableFinding,
 )
 from services.findings.enrichment.parse import extract_json_block, parse_enrichment
 from services.findings.enrichment.prompt import (
@@ -43,6 +44,7 @@ __all__ = [
     "FindingSummary",
     "NoProviderConfigured",
     "ProviderUnavailable",
+    "UnidentifiableFinding",
     "build_entity_string",
     "build_prompt",
     "build_techniques_string",

--- a/services/findings/enrichment/errors.py
+++ b/services/findings/enrichment/errors.py
@@ -1,17 +1,12 @@
 """Domain exceptions for finding enrichment.
 
-The enrichment flow used to live inline in ``backend/api/findings.py`` and
-raised ``HTTPException`` straight from the business logic, which made it
-unusable from the daemon or from ingestion — neither speaks HTTP. This module
-raises these instead, and ``backend/api/findings.py`` owns the single
-``EnrichmentError`` → status-code translation (#470).
-
-Status codes the HTTP boundary maps these to:
+Status codes the HTTP boundary maps (backend/api/findings.py:373–392) these to:
 
 ===========================  ======  ==================================
 Exception                    Status  Detail
 ===========================  ======  ==================================
 ``FindingNotFound``          404     ``"Finding not found"``
+``UnidentifiableFinding``    500     ``"Failed to generate …: {exc}"``
 ``NoProviderConfigured``     503     ``claude.NO_PROVIDER_DETAIL``
 ``ProviderUnavailable``      503     ``str(exc)``
 ``EmptyProviderResponse``    500     ``"Failed to generate …: {exc}"``
@@ -30,6 +25,18 @@ class FindingNotFound(EnrichmentError):
     themselves; this guards the case where a caller hands over ``None``
     without checking, so it surfaces as a domain error rather than an
     ``AttributeError`` from deep inside prompt building.
+    """
+
+
+class UnidentifiableFinding(EnrichmentError):
+    """The finding to enrich carries no id, so the result can't be persisted.
+
+    ``update_finding("")`` matches no row and reports failure, which
+    ``_persist`` only logs — so without this guard a caller that hands over a
+    dict lacking ``finding_id`` silently loses the enrichment it just paid a
+    provider call for. Unreachable over HTTP (the path param is always
+    non-empty); it exists for the daemon/ingestion callers that pass their own
+    dicts.
     """
 
 

--- a/services/findings/enrichment/errors.py
+++ b/services/findings/enrichment/errors.py
@@ -1,0 +1,51 @@
+"""Domain exceptions for finding enrichment.
+
+The enrichment flow used to live inline in ``backend/api/findings.py`` and
+raised ``HTTPException`` straight from the business logic, which made it
+unusable from the daemon or from ingestion — neither speaks HTTP. This module
+raises these instead, and ``backend/api/findings.py`` owns the single
+``EnrichmentError`` → status-code translation (#470).
+
+Status codes the HTTP boundary maps these to:
+
+===========================  ======  ==================================
+Exception                    Status  Detail
+===========================  ======  ==================================
+``FindingNotFound``          404     ``"Finding not found"``
+``NoProviderConfigured``     503     ``claude.NO_PROVIDER_DETAIL``
+``ProviderUnavailable``      503     ``str(exc)``
+``EmptyProviderResponse``    500     ``"Failed to generate …: {exc}"``
+===========================  ======  ==================================
+"""
+
+
+class EnrichmentError(Exception):
+    """Base class for every finding-enrichment failure."""
+
+
+class FindingNotFound(EnrichmentError):
+    """The finding to enrich does not exist.
+
+    ``enrich()`` takes a finding *dict*, so callers normally fetch (and 404)
+    themselves; this guards the case where a caller hands over ``None``
+    without checking, so it surfaces as a domain error rather than an
+    ``AttributeError`` from deep inside prompt building.
+    """
+
+
+class NoProviderConfigured(EnrichmentError):
+    """No usable LLM provider is configured for the requested component.
+
+    Covers both "the registry resolved nothing" and "the resolved Anthropic
+    provider has no API key" — the HTTP boundary answers both with the
+    canonical ``NO_PROVIDER_DETAIL`` payload the chat drawer matches on to
+    render a "Configure a provider" CTA.
+    """
+
+
+class ProviderUnavailable(EnrichmentError):
+    """The registry resolved a provider id that has no provider spec row."""
+
+
+class EmptyProviderResponse(EnrichmentError):
+    """The provider returned no content to parse."""

--- a/services/findings/enrichment/errors.py
+++ b/services/findings/enrichment/errors.py
@@ -1,16 +1,8 @@
 """Domain exceptions for finding enrichment.
 
-Status codes the HTTP boundary maps (backend/api/findings.py:373–392) these to:
-
-===========================  ======  ==================================
-Exception                    Status  Detail
-===========================  ======  ==================================
-``FindingNotFound``          404     ``"Finding not found"``
-``UnidentifiableFinding``    500     ``"Failed to generate …: {exc}"``
-``NoProviderConfigured``     503     ``claude.NO_PROVIDER_DETAIL``
-``ProviderUnavailable``      503     ``str(exc)``
-``EmptyProviderResponse``    500     ``"Failed to generate …: {exc}"``
-===========================  ======  ==================================
+Raised instead of ``HTTPException`` so the flow is callable from the daemon and
+from ingestion, neither of which speaks HTTP. ``backend/api/findings.py`` maps
+these to status codes.
 """
 
 
@@ -19,39 +11,19 @@ class EnrichmentError(Exception):
 
 
 class FindingNotFound(EnrichmentError):
-    """The finding to enrich does not exist.
-
-    ``enrich()`` takes a finding *dict*, so callers normally fetch (and 404)
-    themselves; this guards the case where a caller hands over ``None``
-    without checking, so it surfaces as a domain error rather than an
-    ``AttributeError`` from deep inside prompt building.
-    """
+    """The finding to enrich is empty."""
 
 
 class UnidentifiableFinding(EnrichmentError):
-    """The finding to enrich carries no id, so the result can't be persisted.
-
-    ``update_finding("")`` matches no row and reports failure, which
-    ``_persist`` only logs — so without this guard a caller that hands over a
-    dict lacking ``finding_id`` silently loses the enrichment it just paid a
-    provider call for. Unreachable over HTTP (the path param is always
-    non-empty); it exists for the daemon/ingestion callers that pass their own
-    dicts.
-    """
+    """No finding id available, so the result can't be persisted."""
 
 
 class NoProviderConfigured(EnrichmentError):
-    """No usable LLM provider is configured for the requested component.
-
-    Covers both "the registry resolved nothing" and "the resolved Anthropic
-    provider has no API key" — the HTTP boundary answers both with the
-    canonical ``NO_PROVIDER_DETAIL`` payload the chat drawer matches on to
-    render a "Configure a provider" CTA.
-    """
+    """No usable LLM provider for the requested component."""
 
 
 class ProviderUnavailable(EnrichmentError):
-    """The registry resolved a provider id that has no provider spec row."""
+    """The resolved provider id has no provider spec row."""
 
 
 class EmptyProviderResponse(EnrichmentError):

--- a/services/findings/enrichment/parse.py
+++ b/services/findings/enrichment/parse.py
@@ -1,0 +1,69 @@
+"""Response parsing for finding enrichment.
+
+Pure functions — moved verbatim out of ``backend/api/findings.py`` (#470).
+Local models in particular wrap their JSON in markdown fences or trail prose
+after it, so extraction is deliberately forgiving and falls back to a
+synthesized payload rather than failing the request.
+"""
+
+import json
+import re
+from typing import Any, Dict, Optional
+
+from services.findings.enrichment.errors import EmptyProviderResponse
+
+_FENCED_JSON = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+_RAW_JSON = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def extract_json_block(response: str) -> str:
+    """Return the most likely JSON substring of ``response``.
+
+    Prefers a ```json fenced block, then the first ``{...}`` span, then the
+    whole response.
+    """
+    fenced = _FENCED_JSON.search(response)
+    if fenced:
+        return fenced.group(1)
+    raw = _RAW_JSON.search(response)
+    if raw:
+        return raw.group(0)
+    return response
+
+
+def parse_enrichment(response: Optional[str], *, severity: str) -> Dict[str, Any]:
+    """Parse a provider response into an enrichment payload.
+
+    Raises:
+        EmptyProviderResponse: the provider returned nothing to parse.
+    """
+    if not response:
+        raise EmptyProviderResponse("LLM provider returned an empty response")
+
+    try:
+        return json.loads(extract_json_block(response))
+    except json.JSONDecodeError:
+        # Unparseable output still carries analyst value, so synthesize a
+        # payload with the same shape the UI renders and park the raw text in
+        # analysis_notes rather than 500-ing the request.
+        return {
+            "threat_summary": "AI analysis completed - see full analysis below",
+            "threat_type": "Security Finding",
+            "potential_impact": "Requires manual review",
+            "risk_level": severity.title() if severity else "Medium",
+            "recommended_actions": [
+                "Review the detailed analysis",
+                "Investigate related entities",
+            ],
+            "investigation_questions": [
+                "What is the root cause?",
+                "Are there related events?",
+            ],
+            "indicators": {},
+            "related_techniques": [],
+            "timeline_context": "Analysis in progress",
+            "business_context": "Requires additional context",
+            "confidence_score": 0.7,
+            "analysis_notes": response[:1000],  # first 1000 chars as notes
+            "raw_response": response,  # full response
+        }

--- a/services/findings/enrichment/parse.py
+++ b/services/findings/enrichment/parse.py
@@ -1,9 +1,8 @@
 """Response parsing for finding enrichment.
 
-Pure functions — moved verbatim out of ``backend/api/findings.py`` (#470).
 Local models in particular wrap their JSON in markdown fences or trail prose
-after it, so extraction is deliberately forgiving and falls back to a
-synthesized payload rather than failing the request.
+after it, so extraction is forgiving and falls back to a synthesized payload
+rather than failing the request.
 """
 
 import json

--- a/services/findings/enrichment/prompt.py
+++ b/services/findings/enrichment/prompt.py
@@ -1,0 +1,187 @@
+"""Input shaping and prompt construction for finding enrichment.
+
+Pure functions — no provider, no database, no HTTP. Moved verbatim out of
+``backend/api/findings.py``'s ``get_or_generate_enrichment`` (#470) so the
+singular/plural entity handling and the MITRE fallback can be unit-tested
+without an HTTP round-trip.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class FindingSummary:
+    """The subset of a finding the enrichment prompt renders.
+
+    ``severity`` is carried through because the parse-failure fallback in
+    :mod:`services.findings.enrichment.parse` reuses it as ``risk_level``.
+    """
+
+    finding_id: str
+    severity: str
+    data_source: str
+    timestamp: str
+    description: str
+    anomaly_score: float
+    entity_str: str
+    techniques_str: str
+
+
+def build_entity_string(entity_context: Optional[Dict[str, Any]]) -> str:
+    """Render entity context as prompt lines.
+
+    Handles both singular and plural field formats: producers disagree on
+    whether the key is ``src_ip`` or ``src_ips`` (and ``dst_ips`` vs
+    ``dest_ips``, ``users`` vs ``usernames``), so accept every spelling.
+    """
+    entity_str = ""
+    if not entity_context:
+        return entity_str
+
+    src_ips = entity_context.get("src_ips") or []
+    if not src_ips and entity_context.get("src_ip"):
+        src_ips = [entity_context["src_ip"]]
+    dst_ips = entity_context.get("dst_ips") or entity_context.get("dest_ips") or []
+    if not dst_ips and entity_context.get("dst_ip"):
+        dst_ips = [entity_context["dst_ip"]]
+    hostnames = entity_context.get("hostnames") or []
+    if not hostnames and entity_context.get("hostname"):
+        hostnames = [entity_context["hostname"]]
+    users = entity_context.get("users") or entity_context.get("usernames") or []
+    if not users and entity_context.get("user"):
+        users = [entity_context["user"]]
+
+    if src_ips:
+        entity_str += f"Source IPs: {', '.join(str(ip) for ip in src_ips[:5])}\n"
+    if dst_ips:
+        entity_str += f"Destination IPs: {', '.join(str(ip) for ip in dst_ips[:5])}\n"
+    if hostnames:
+        entity_str += f"Hostnames: {', '.join(str(h) for h in hostnames[:5])}\n"
+    if users:
+        entity_str += f"Users: {', '.join(str(u) for u in users[:5])}\n"
+
+    return entity_str
+
+
+def build_techniques_string(
+    predicted_techniques: Optional[List[Dict[str, Any]]],
+    mitre_predictions: Optional[Dict[str, Any]],
+) -> str:
+    """Render up to five MITRE techniques as prompt lines.
+
+    ``predicted_techniques`` (already ranked by the producer) wins when
+    present; otherwise fall back to ``mitre_predictions``, sorted by
+    confidence descending.
+    """
+    if predicted_techniques:
+        return "\n".join(
+            f"{t.get('technique_id', 'Unknown')} "
+            f"(confidence: {float(t.get('confidence') or 0):.2f})"
+            for t in predicted_techniques[:5]
+        )
+    if mitre_predictions:
+        ranked = sorted(
+            mitre_predictions.items(),
+            key=lambda x: float(x[1] or 0),
+            reverse=True,
+        )[:5]
+        return "\n".join(
+            f"{tech_id} (confidence: {float(conf or 0):.2f})"
+            for tech_id, conf in ranked
+        )
+    return ""
+
+
+def summarize_finding(finding: Dict[str, Any]) -> FindingSummary:
+    """Extract the prompt inputs from a finding dict.
+
+    Uses ``or`` rather than ``dict.get`` defaults throughout: these keys are
+    frequently *present with a None value*, which a plain default wouldn't
+    catch.
+    """
+    return FindingSummary(
+        finding_id=finding.get("finding_id") or "",
+        severity=finding.get("severity") or "unknown",
+        data_source=finding.get("data_source") or "unknown",
+        timestamp=finding.get("timestamp") or "",
+        description=finding.get("description") or "",
+        anomaly_score=float(finding.get("anomaly_score") or 0),
+        entity_str=build_entity_string(finding.get("entity_context") or {}),
+        techniques_str=build_techniques_string(
+            finding.get("predicted_techniques") or [],
+            finding.get("mitre_predictions") or {},
+        ),
+    )
+
+
+def build_prompt(summary: FindingSummary) -> str:
+    """Build the enrichment analysis prompt for ``summary``."""
+    finding_id = summary.finding_id
+    severity = summary.severity
+    data_source = summary.data_source
+    timestamp = summary.timestamp
+    description = summary.description
+    anomaly_score = summary.anomaly_score
+    entity_str = summary.entity_str
+    techniques_str = summary.techniques_str
+
+    return f"""You are a cybersecurity analyst reviewing a security finding. Provide a comprehensive, structured analysis.
+
+FINDING DETAILS:
+=================
+Finding ID: {finding_id}
+Severity: {severity}
+Data Source: {data_source}
+Timestamp: {timestamp}
+Anomaly Score: {anomaly_score:.2f}
+
+Description:
+{description if description else 'No description available'}
+
+{f'''Entity Context:
+{entity_str}''' if entity_str else ''}
+
+{f'''MITRE ATT&CK Techniques:
+{techniques_str}''' if techniques_str else 'No MITRE techniques predicted'}
+
+ANALYSIS REQUIREMENTS:
+=======================
+Please provide a detailed analysis in the following JSON structure:
+
+{{
+    "threat_summary": "A clear, concise summary (2-3 sentences) of what this finding represents and why it matters",
+    "threat_type": "Classification of threat (e.g., 'Data Exfiltration', 'Lateral Movement', 'Command & Control', 'Malware', etc.)",
+    "potential_impact": "Detailed explanation of potential impact on the organization (3-4 sentences)",
+    "risk_level": "Overall risk assessment: 'Critical', 'High', 'Medium', or 'Low'",
+    "recommended_actions": [
+        "Immediate action item 1",
+        "Immediate action item 2",
+        "Additional investigation step 1",
+        "Additional investigation step 2"
+    ],
+    "investigation_questions": [
+        "Key question to investigate 1?",
+        "Key question to investigate 2?",
+        "Key question to investigate 3?"
+    ],
+    "indicators": {{
+        "malicious_ips": ["list any suspicious IPs mentioned"],
+        "suspicious_domains": ["list any suspicious domains"],
+        "suspicious_users": ["list any suspicious user accounts"],
+        "suspicious_processes": ["list any suspicious processes or commands"]
+    }},
+    "related_techniques": [
+        {{
+            "technique_id": "T####.###",
+            "technique_name": "Technique name",
+            "relevance": "Why this technique is relevant"
+        }}
+    ],
+    "timeline_context": "Brief explanation of what likely happened and in what order",
+    "business_context": "How this finding relates to typical business operations and what makes it anomalous",
+    "confidence_score": 0.85,
+    "analysis_notes": "Any additional context, caveats, or recommendations for the analyst"
+}}
+
+Respond ONLY with valid JSON. Be specific and actionable. Focus on helping a SOC analyst make quick, informed decisions."""

--- a/services/findings/enrichment/prompt.py
+++ b/services/findings/enrichment/prompt.py
@@ -93,15 +93,21 @@ def build_techniques_string(
     return ""
 
 
-def summarize_finding(finding: Dict[str, Any]) -> FindingSummary:
+def summarize_finding(
+    finding: Dict[str, Any], *, finding_id: Optional[str] = None
+) -> FindingSummary:
     """Extract the prompt inputs from a finding dict.
 
     Uses ``or`` rather than ``dict.get`` defaults throughout: these keys are
     frequently *present with a None value*, which a plain default wouldn't
     catch.
+
+    ``finding_id`` overrides the dict's own key. The HTTP handler passes the
+    path param — its authoritative id — rather than trusting the row it just
+    read back, which is what the pre-extraction handler did.
     """
     return FindingSummary(
-        finding_id=finding.get("finding_id") or "",
+        finding_id=finding_id or finding.get("finding_id") or "",
         severity=finding.get("severity") or "unknown",
         data_source=finding.get("data_source") or "unknown",
         timestamp=finding.get("timestamp") or "",

--- a/services/findings/enrichment/prompt.py
+++ b/services/findings/enrichment/prompt.py
@@ -1,9 +1,6 @@
 """Input shaping and prompt construction for finding enrichment.
 
-Pure functions — no provider, no database, no HTTP. Moved verbatim out of
-``backend/api/findings.py``'s ``get_or_generate_enrichment`` (#470) so the
-singular/plural entity handling and the MITRE fallback can be unit-tested
-without an HTTP round-trip.
+Pure functions — no provider, no database, no HTTP.
 """
 
 from dataclasses import dataclass

--- a/services/findings/enrichment/service.py
+++ b/services/findings/enrichment/service.py
@@ -1,37 +1,20 @@
 """The ``enrich()`` seam: resolve provider → dispatch → parse → stamp → persist.
 
-Extracted from ``backend/api/findings.py``'s 333-line
-``get_or_generate_enrichment`` handler (#470) so ingestion, the daemon and
-agents can reuse the flow instead of it being reachable only over HTTP.
+Extracted from ``backend/api/findings.py`` ``get_or_generate_enrichment`` handler so ingestion,
+the daemon and agents can reuse the flow instead of it being reachable only over HTTP.
 
 Behaviour is preserved exactly as it was in the handler, including two things
 that are known-imperfect and deliberately *not* fixed here:
 
-**The dispatch asymmetry.** Anthropic goes through the sync ``ClaudeService``
-on a threadpool with no retry; every other provider goes through
-``LLMRouter.dispatch`` wrapped in a retry loop with local-Bifrost recovery.
-That is existing behaviour, not a design position — unifying it while moving
-code would make any regression impossible to bisect. See #470's notes.
-
-**The ``ai_enrichment`` write is a full replace, and it has a second writer.**
-``daemon/processor.py`` writes triage keys (``ai_triage``, ``enrichment``,
-``enriched_at``, ``triage_confidence``, ``category``, ``recommended_action``,
-``triage_reasoning``) into the same JSONB column; this module writes analysis
-keys (``threat_summary``, ``potential_impact``, ``recommended_actions``, …).
-The two key sets do not overlap, so today:
-
-1. the API's cache check can return a daemon triage payload labelled as an
-   analysis ``enrichment``, and the UI reads ``undefined`` off it;
-2. persisting here wipes any daemon triage on the same finding, because
-   ``update_finding(..., ai_enrichment=...)`` replaces the whole value; and
-3. the finding then falls out of the daemon's ``ai_enrichment IS NULL``
-   backfill permanently.
-
-Fixing that is a JSONB schema change with a read-side compatibility shim, so
-it is a separate change. What this module does provide is the seam for it:
-``persist=False`` returns the payload and lets the caller compose its own
-write, so the merge policy can live in one place later without reopening this
-module.
+* **Asymmetric dispatch** — Anthropic runs on a threadpool with no retry;
+  other providers get ``LLMRouter`` + retry + local-Bifrost recovery.
+* **A full-replace write on a column with two writers** — ``daemon/processor``
+  stores triage keys (``ai_triage``, ``triage_confidence``, …) in the same
+  JSONB column this module fills with analysis keys (``threat_summary``, …),
+  and the two sets don't overlap. So: a daemon payload satisfies the API's
+  cache check but renders as ``undefined``; writing here wipes daemon triage;
+  and the finding then leaves the daemon's ``ai_enrichment IS NULL`` backfill
+  for good.
 """
 
 import asyncio
@@ -43,6 +26,7 @@ from services.findings.enrichment.errors import (
     FindingNotFound,
     NoProviderConfigured,
     ProviderUnavailable,
+    UnidentifiableFinding,
 )
 from services.findings.enrichment.parse import parse_enrichment
 from services.findings.enrichment.prompt import build_prompt, summarize_finding
@@ -216,6 +200,7 @@ async def _persist(
 async def enrich(
     finding: Dict[str, Any],
     *,
+    finding_id: Optional[str] = None,
     component: str = "reporting",
     persist: bool = True,
     data_service: Any = None,
@@ -233,6 +218,11 @@ async def enrich(
 
     Args:
         finding: The finding to enrich.
+        finding_id: Authoritative id — the write target, and what the prompt
+            reports. Overrides ``finding["finding_id"]``; pass it whenever you
+            hold the id independently of the dict (the HTTP handler passes its
+            path param). Required when ``persist`` is True and the dict carries
+            no id of its own.
         component: ``ai_model_configs`` component whose model assignment to
             use. The HTTP handler uses ``"reporting"``.
         persist: Write the result to the finding's ``ai_enrichment`` column.
@@ -243,6 +233,7 @@ async def enrich(
 
     Raises:
         FindingNotFound: ``finding`` is empty.
+        UnidentifiableFinding: ``persist`` is True but no id is available.
         NoProviderConfigured: no usable provider for ``component``.
         ProviderUnavailable: resolved provider id has no spec row.
         EmptyProviderResponse: the provider returned nothing.
@@ -250,12 +241,20 @@ async def enrich(
     if not finding:
         raise FindingNotFound("Finding not found")
 
+    finding_id = finding_id or finding.get("finding_id") or ""
+    if persist and not finding_id:
+        # update_finding("") matches no row and only logs, so refuse the call
+        # rather than paying a provider and dropping the result on the floor.
+        raise UnidentifiableFinding(
+            "Cannot persist enrichment: no finding_id was passed and the "
+            "finding dict has none. Pass finding_id=..., or persist=False."
+        )
+
     # Resolve before shaping input, so an unconfigured provider still reports
     # NoProviderConfigured rather than whatever a malformed finding raises.
     provider, model_id, claude_service = _resolve_provider(component)
 
-    summary = summarize_finding(finding)
-    finding_id = summary.finding_id
+    summary = summarize_finding(finding, finding_id=finding_id)
     prompt = build_prompt(summary)
 
     logger.info(

--- a/services/findings/enrichment/service.py
+++ b/services/findings/enrichment/service.py
@@ -1,20 +1,16 @@
 """The ``enrich()`` seam: resolve provider → dispatch → parse → stamp → persist.
 
-Extracted from ``backend/api/findings.py`` ``get_or_generate_enrichment`` handler so ingestion,
-the daemon and agents can reuse the flow instead of it being reachable only over HTTP.
+Two known-imperfect behaviours are carried over from the old inline handler
+rather than fixed here, so any regression stays bisectable:
 
-Behaviour is preserved exactly as it was in the handler, including two things
-that are known-imperfect and deliberately *not* fixed here:
-
-* **Asymmetric dispatch** — Anthropic runs on a threadpool with no retry;
-  other providers get ``LLMRouter`` + retry + local-Bifrost recovery.
-* **A full-replace write on a column with two writers** — ``daemon/processor``
-  stores triage keys (``ai_triage``, ``triage_confidence``, …) in the same
-  JSONB column this module fills with analysis keys (``threat_summary``, …),
-  and the two sets don't overlap. So: a daemon payload satisfies the API's
-  cache check but renders as ``undefined``; writing here wipes daemon triage;
-  and the finding then leaves the daemon's ``ai_enrichment IS NULL`` backfill
-  for good.
+* Dispatch is asymmetric — Anthropic runs on a threadpool with no retry; other
+  providers get ``LLMRouter`` + retry + local-Bifrost recovery.
+* The ``ai_enrichment`` write is a full replace, and ``daemon/processor`` writes
+  a disjoint set of triage keys to the same column. So a daemon payload can
+  satisfy the API's cache check yet render as ``undefined``, writing here wipes
+  daemon triage, and the finding then leaves the daemon's
+  ``ai_enrichment IS NULL`` backfill for good. ``persist=False`` is the seam for
+  fixing that separately.
 """
 
 import asyncio
@@ -177,14 +173,10 @@ async def _persist(
 ) -> bool:
     """Write ``enrichment`` to the finding's ``ai_enrichment`` column.
 
-    A **full replace**, not a merge — see the module docstring for the writer
-    collision this carries forward. A failed write is logged and swallowed:
-    the caller still gets the payload it paid a provider call for.
-
-    The write goes through ``asyncio.to_thread`` because the data layer is
-    synchronous SQLAlchemy and ``enrich()`` is called from the event loop.
-    The pre-extraction handler offloaded this same call (#518, refs #461);
-    moving it into a plain ``def`` here would have put it back on the loop.
+    A full replace, not a merge — see the module docstring. A failed write is
+    logged and swallowed: the caller still gets the payload it paid a provider
+    call for. Offloaded with ``to_thread`` because the data layer is sync
+    SQLAlchemy and this runs on the event loop.
     """
     service = data_service if data_service is not None else _default_data_service()
     success = await asyncio.to_thread(

--- a/services/findings/enrichment/service.py
+++ b/services/findings/enrichment/service.py
@@ -1,0 +1,289 @@
+"""The ``enrich()`` seam: resolve provider → dispatch → parse → stamp → persist.
+
+Extracted from ``backend/api/findings.py``'s 333-line
+``get_or_generate_enrichment`` handler (#470) so ingestion, the daemon and
+agents can reuse the flow instead of it being reachable only over HTTP.
+
+Behaviour is preserved exactly as it was in the handler, including two things
+that are known-imperfect and deliberately *not* fixed here:
+
+**The dispatch asymmetry.** Anthropic goes through the sync ``ClaudeService``
+on a threadpool with no retry; every other provider goes through
+``LLMRouter.dispatch`` wrapped in a retry loop with local-Bifrost recovery.
+That is existing behaviour, not a design position — unifying it while moving
+code would make any regression impossible to bisect. See #470's notes.
+
+**The ``ai_enrichment`` write is a full replace, and it has a second writer.**
+``daemon/processor.py`` writes triage keys (``ai_triage``, ``enrichment``,
+``enriched_at``, ``triage_confidence``, ``category``, ``recommended_action``,
+``triage_reasoning``) into the same JSONB column; this module writes analysis
+keys (``threat_summary``, ``potential_impact``, ``recommended_actions``, …).
+The two key sets do not overlap, so today:
+
+1. the API's cache check can return a daemon triage payload labelled as an
+   analysis ``enrichment``, and the UI reads ``undefined`` off it;
+2. persisting here wipes any daemon triage on the same finding, because
+   ``update_finding(..., ai_enrichment=...)`` replaces the whole value; and
+3. the finding then falls out of the daemon's ``ai_enrichment IS NULL``
+   backfill permanently.
+
+Fixing that is a JSONB schema change with a read-side compatibility shim, so
+it is a separate change. What this module does provide is the seam for it:
+``persist=False`` returns the payload and lets the caller compose its own
+write, so the merge policy can live in one place later without reopening this
+module.
+"""
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional, Tuple
+
+from services.findings.enrichment.errors import (
+    FindingNotFound,
+    NoProviderConfigured,
+    ProviderUnavailable,
+)
+from services.findings.enrichment.parse import parse_enrichment
+from services.findings.enrichment.prompt import build_prompt, summarize_finding
+
+logger = logging.getLogger(__name__)
+
+# Bounded separately per path: the enrichment JSON schema is large, so a tight
+# cap truncates it — but local models are slow per token, so they get a
+# tighter bound than the cloud path while still leaving room for the object.
+ANTHROPIC_MAX_TOKENS = 4096
+LOCAL_MAX_TOKENS = 1400
+
+LOCAL_SYSTEM_PROMPT = (
+    "You are a cybersecurity analyst. Respond only with valid "
+    "JSON matching the requested enrichment schema. Keep the "
+    "response concise and do not include chain-of-thought."
+)
+
+_data_service: Any = None
+
+
+def _default_data_service() -> Any:
+    """Lazily build this module's own ``DatabaseDataService``.
+
+    Constructing one runs ``init_database``, so it must not happen at import
+    time: callers passing ``persist=False`` (or their own ``data_service``)
+    should never pay for a connection they don't use.
+    """
+    global _data_service
+    if _data_service is None:
+        from services.database_data_service import DatabaseDataService
+
+        _data_service = DatabaseDataService()
+    return _data_service
+
+
+def _resolve_provider(component: str) -> Tuple[Any, str, Any]:
+    """Resolve ``component`` to ``(provider_spec, model_id, claude_service)``.
+
+    ``claude_service`` is None for every non-Anthropic provider — only the
+    Anthropic path uses the SDK client, and only that path needs the API-key
+    precheck (``has_api_key`` is Anthropic-specific by design).
+
+    Raises:
+        NoProviderConfigured: nothing resolved, or no Anthropic API key.
+        ProviderUnavailable: the resolved provider id has no spec row.
+    """
+    from services.llm_router import get_provider_spec
+    from services.model_registry import get_registry
+
+    resolved_model = get_registry().resolve_model_for_component(component)
+    if not resolved_model:
+        raise NoProviderConfigured(
+            f"No LLM provider is configured for component '{component}'"
+        )
+
+    provider_id, model_id = resolved_model
+    provider = get_provider_spec(provider_id)
+    if provider is None:
+        raise ProviderUnavailable(f"Configured provider '{provider_id}' is unavailable")
+
+    claude_service = None
+    if provider.provider_type == "anthropic":
+        from services.claude_service import ClaudeService
+
+        claude_service = ClaudeService(use_backend_tools=True, use_mcp_tools=False)
+        if not claude_service.has_api_key():
+            raise NoProviderConfigured(
+                f"Anthropic provider '{provider_id}' has no resolvable API key"
+            )
+
+    return provider, model_id, claude_service
+
+
+async def _dispatch(
+    *,
+    provider: Any,
+    model_id: str,
+    prompt: str,
+    claude_service: Any,
+    finding_id: str,
+) -> Optional[str]:
+    """Send ``prompt`` to ``provider`` and return the raw text response.
+
+    The two paths are asymmetric — see the module docstring. Preserved as-is.
+    """
+    loop = asyncio.get_event_loop()
+    if provider.provider_type == "anthropic":
+        # No retry here: the cloud path has never had one.
+        return await loop.run_in_executor(
+            None,
+            lambda: claude_service.chat(
+                message=prompt,
+                model=model_id,
+                max_tokens=ANTHROPIC_MAX_TOKENS,
+            ),
+        )
+
+    dispatch_args = {
+        "provider": provider,
+        "messages": [{"role": "user", "content": f"/no_think\n{prompt}"}],
+        "system_prompt": LOCAL_SYSTEM_PROMPT,
+        "model": model_id,
+        "max_tokens": LOCAL_MAX_TOKENS,
+    }
+    from services.llm_router import LLMRouter
+    from services.local_ai_recovery import (
+        is_gateway_connection_error,
+        local_bifrost_recovery_enabled,
+        local_bifrost_recovery_retry_limit,
+        recover_local_bifrost,
+    )
+
+    retry_limit = local_bifrost_recovery_retry_limit()
+    for attempt in range(retry_limit + 1):
+        try:
+            result = await LLMRouter().dispatch(**dispatch_args)
+            break
+        except Exception as dispatch_error:
+            eligible = (
+                provider.provider_type == "ollama"
+                and local_bifrost_recovery_enabled()
+                and is_gateway_connection_error(dispatch_error)
+            )
+            if not eligible or attempt >= retry_limit:
+                raise
+
+            recovery = await recover_local_bifrost()
+            if not recovery.ready:
+                logger.warning(
+                    "Local Bifrost recovery for %s failed: %s",
+                    finding_id,
+                    recovery.detail,
+                )
+                raise
+            logger.info(
+                "Local Bifrost recovery for %s: %s; retrying enrichment (%s/%s)",
+                finding_id,
+                recovery.detail,
+                attempt + 1,
+                retry_limit,
+            )
+    return result.get("content", "")
+
+
+async def _persist(
+    finding_id: str, enrichment: Dict[str, Any], data_service: Any
+) -> bool:
+    """Write ``enrichment`` to the finding's ``ai_enrichment`` column.
+
+    A **full replace**, not a merge — see the module docstring for the writer
+    collision this carries forward. A failed write is logged and swallowed:
+    the caller still gets the payload it paid a provider call for.
+
+    The write goes through ``asyncio.to_thread`` because the data layer is
+    synchronous SQLAlchemy and ``enrich()`` is called from the event loop.
+    The pre-extraction handler offloaded this same call (#518, refs #461);
+    moving it into a plain ``def`` here would have put it back on the loop.
+    """
+    service = data_service if data_service is not None else _default_data_service()
+    success = await asyncio.to_thread(
+        service.update_finding, finding_id, ai_enrichment=enrichment
+    )
+    if not success:
+        logger.error("Failed to save enrichment for %s", finding_id)
+    else:
+        logger.info("Successfully generated and cached enrichment for %s", finding_id)
+    return bool(success)
+
+
+async def enrich(
+    finding: Dict[str, Any],
+    *,
+    component: str = "reporting",
+    persist: bool = True,
+    data_service: Any = None,
+) -> Dict[str, Any]:
+    """Generate AI enrichment for ``finding``. Returns the enrichment payload.
+
+    Takes a finding *dict*, not an id: the fetch (and its 404) stays with the
+    caller, so this module needs no database access for reads, and the daemon —
+    which already holds finding dicts — doesn't re-read them.
+
+    Does **not** do a cache check. Whether an existing ``ai_enrichment`` value
+    counts as a usable cache hit is caller policy (the HTTP handler has a
+    ``force_regenerate`` query param; see also the writer collision noted in
+    the module docstring).
+
+    Args:
+        finding: The finding to enrich.
+        component: ``ai_model_configs`` component whose model assignment to
+            use. The HTTP handler uses ``"reporting"``.
+        persist: Write the result to the finding's ``ai_enrichment`` column.
+            Pass False to compose your own write.
+        data_service: Persistence target; defaults to a lazily-built
+            ``DatabaseDataService``. Pass an existing instance to avoid a
+            second one.
+
+    Raises:
+        FindingNotFound: ``finding`` is empty.
+        NoProviderConfigured: no usable provider for ``component``.
+        ProviderUnavailable: resolved provider id has no spec row.
+        EmptyProviderResponse: the provider returned nothing.
+    """
+    if not finding:
+        raise FindingNotFound("Finding not found")
+
+    # Resolve before shaping input, so an unconfigured provider still reports
+    # NoProviderConfigured rather than whatever a malformed finding raises.
+    provider, model_id, claude_service = _resolve_provider(component)
+
+    summary = summarize_finding(finding)
+    finding_id = summary.finding_id
+    prompt = build_prompt(summary)
+
+    logger.info(
+        "Generating AI enrichment for %s via %s/%s",
+        finding_id,
+        provider.provider_id,
+        model_id,
+    )
+    response = await _dispatch(
+        provider=provider,
+        model_id=model_id,
+        prompt=prompt,
+        claude_service=claude_service,
+        finding_id=finding_id,
+    )
+
+    enrichment = parse_enrichment(response, severity=summary.severity)
+
+    # Keep the provider's original response even when it parsed cleanly.
+    # Analysts can compare the rendered fields against the local model's
+    # exact output without having to regenerate the enrichment.
+    enrichment["raw_response"] = response
+    enrichment["generated_at"] = datetime.utcnow().isoformat() + "Z"
+    enrichment["model"] = model_id
+    enrichment["provider_id"] = provider.provider_id
+    enrichment["provider_type"] = provider.provider_type
+
+    if persist:
+        await _persist(finding_id, enrichment, data_service)
+
+    return enrichment

--- a/tests/unit/test_findings_enrich_endpoint.py
+++ b/tests/unit/test_findings_enrich_endpoint.py
@@ -156,6 +156,25 @@ async def test_handler_reuses_its_own_data_service_for_the_write(
     assert kwargs["data_service"] is stub_data_service
 
 
+async def test_handler_passes_the_path_param_as_the_authoritative_id(monkeypatch):
+    """The write target must be the path param, not the row's own key.
+
+    The pre-extraction handler persisted with the path param. A row whose
+    finding_id disagrees (or is absent) must not redirect or drop the write.
+    """
+    monkeypatch.setattr(
+        findings_api,
+        "data_service",
+        _StubDataService({"finding_id": None, "severity": "high"}),
+    )
+    calls = _stub_enrich(monkeypatch, result={})
+
+    await findings_api.get_or_generate_enrichment(FINDING_ID, False)
+
+    _, kwargs = calls[0]
+    assert kwargs["finding_id"] == FINDING_ID
+
+
 # ---------------------------------------------------------------------------
 # Domain error → status code
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_findings_enrich_endpoint.py
+++ b/tests/unit/test_findings_enrich_endpoint.py
@@ -1,0 +1,311 @@
+"""Unit tests for ``POST /api/findings/{id}/enrich`` (issue #470).
+
+The enrichment flow moved to ``services/findings/enrichment/``; what's left in
+the handler is cache policy plus the domain-error → status-code mapping. These
+tests pin both, so the extraction is provably behaviour-preserving:
+
+* 404 on a missing finding
+* cached hit short-circuits (and ``force_regenerate`` bypasses it)
+* ``NoProviderConfigured`` → 503 carrying the structured ``NO_PROVIDER_DETAIL``
+  payload the chat drawer matches on — *not* a bare string
+* ``ProviderUnavailable`` → 503, any other failure → 500
+* the success envelope is ``{finding_id, cached: False, enrichment}``
+
+They also cover ``_resolve_provider``'s error mapping, which is where the old
+inline ``HTTPException`` raises used to live.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+# backend/ must be on sys.path too: importing backend.api.findings cascades
+# into backend/api/__init__.py which does bare `from api.findings import ...`.
+sys.path.insert(0, str(REPO / "backend"))
+
+from fastapi import HTTPException  # noqa: E402
+
+from backend.api import findings as findings_api  # noqa: E402
+from services.findings.enrichment import (  # noqa: E402
+    EmptyProviderResponse,
+    FindingNotFound,
+    NoProviderConfigured,
+    ProviderUnavailable,
+)
+from services.findings.enrichment import service as enrichment_service  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+FINDING_ID = "f-20260803-001"
+
+
+class _StubDataService:
+    def __init__(self, finding=None):
+        self.finding = finding
+
+    def get_finding(self, finding_id):
+        return self.finding
+
+
+@pytest.fixture
+def stub_data_service(monkeypatch):
+    """Replace the module-level singleton with a stub holding one finding."""
+    stub = _StubDataService({"finding_id": FINDING_ID, "severity": "high"})
+    monkeypatch.setattr(findings_api, "data_service", stub)
+    return stub
+
+
+def _stub_enrich(monkeypatch, *, result=None, raises=None):
+    """Patch the handler's `enrich` seam; return the recorded call kwargs."""
+    calls = []
+
+    async def fake_enrich(finding, **kwargs):
+        calls.append((finding, kwargs))
+        if raises is not None:
+            raise raises
+        return result
+
+    monkeypatch.setattr(findings_api, "enrich", fake_enrich)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Fetch + cache policy
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_finding_is_404(monkeypatch):
+    monkeypatch.setattr(findings_api, "data_service", _StubDataService(None))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await findings_api.get_or_generate_enrichment(FINDING_ID, False)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Finding not found"
+
+
+async def test_existing_enrichment_is_returned_from_cache(monkeypatch):
+    cached = {"threat_summary": "already analysed"}
+    monkeypatch.setattr(
+        findings_api,
+        "data_service",
+        _StubDataService({"finding_id": FINDING_ID, "ai_enrichment": cached}),
+    )
+    calls = _stub_enrich(monkeypatch, result={"threat_summary": "fresh"})
+
+    response = await findings_api.get_or_generate_enrichment(FINDING_ID, False)
+
+    assert response == {
+        "finding_id": FINDING_ID,
+        "cached": True,
+        "enrichment": cached,
+    }
+    assert calls == [], "a cache hit must not call a provider"
+
+
+async def test_force_regenerate_bypasses_the_cache(monkeypatch):
+    monkeypatch.setattr(
+        findings_api,
+        "data_service",
+        _StubDataService(
+            {"finding_id": FINDING_ID, "ai_enrichment": {"threat_summary": "stale"}}
+        ),
+    )
+    calls = _stub_enrich(monkeypatch, result={"threat_summary": "fresh"})
+
+    response = await findings_api.get_or_generate_enrichment(FINDING_ID, True)
+
+    assert response["cached"] is False
+    assert response["enrichment"] == {"threat_summary": "fresh"}
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Success envelope + wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_success_response_shape(stub_data_service, monkeypatch):
+    enrichment = {"threat_summary": "exfil", "confidence_score": 0.9}
+    _stub_enrich(monkeypatch, result=enrichment)
+
+    response = await findings_api.get_or_generate_enrichment(FINDING_ID, False)
+
+    assert response == {
+        "finding_id": FINDING_ID,
+        "cached": False,
+        "enrichment": enrichment,
+    }
+
+
+async def test_handler_reuses_its_own_data_service_for_the_write(
+    stub_data_service, monkeypatch
+):
+    """Otherwise the module would build a second DatabaseDataService."""
+    calls = _stub_enrich(monkeypatch, result={})
+
+    await findings_api.get_or_generate_enrichment(FINDING_ID, False)
+
+    finding, kwargs = calls[0]
+    assert finding is stub_data_service.finding
+    assert kwargs["data_service"] is stub_data_service
+
+
+# ---------------------------------------------------------------------------
+# Domain error → status code
+# ---------------------------------------------------------------------------
+
+
+async def test_no_provider_configured_is_503_with_the_structured_detail(
+    stub_data_service, monkeypatch
+):
+    from backend.api.claude import NO_PROVIDER_DETAIL
+
+    _stub_enrich(monkeypatch, raises=NoProviderConfigured("nothing resolved"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await findings_api.get_or_generate_enrichment(FINDING_ID, False)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == NO_PROVIDER_DETAIL
+    assert exc_info.value.detail["code"] == "no_llm_provider_configured"
+
+
+async def test_provider_unavailable_is_503_with_the_message(
+    stub_data_service, monkeypatch
+):
+    _stub_enrich(
+        monkeypatch,
+        raises=ProviderUnavailable("Configured provider 'ollama-x' is unavailable"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await findings_api.get_or_generate_enrichment(FINDING_ID, False)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Configured provider 'ollama-x' is unavailable"
+
+
+async def test_finding_not_found_from_the_module_is_404(stub_data_service, monkeypatch):
+    _stub_enrich(monkeypatch, raises=FindingNotFound("Finding not found"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await findings_api.get_or_generate_enrichment(FINDING_ID, False)
+
+    assert exc_info.value.status_code == 404
+
+
+async def test_empty_provider_response_is_500(stub_data_service, monkeypatch):
+    _stub_enrich(
+        monkeypatch,
+        raises=EmptyProviderResponse("LLM provider returned an empty response"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await findings_api.get_or_generate_enrichment(FINDING_ID, False)
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == (
+        "Failed to generate enrichment: LLM provider returned an empty response"
+    )
+
+
+async def test_unexpected_failure_is_500(stub_data_service, monkeypatch):
+    _stub_enrich(monkeypatch, raises=RuntimeError("gateway exploded"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await findings_api.get_or_generate_enrichment(FINDING_ID, False)
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Failed to generate enrichment: gateway exploded"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_provider — the raises that used to be inline HTTPExceptions
+# ---------------------------------------------------------------------------
+
+
+class _FakeRegistry:
+    def __init__(self, resolved):
+        self.resolved = resolved
+        self.components = []
+
+    def resolve_model_for_component(self, component):
+        self.components.append(component)
+        return self.resolved
+
+
+def _patch_resolution(monkeypatch, *, resolved, provider_spec):
+    from services import llm_router, model_registry
+
+    registry = _FakeRegistry(resolved)
+    monkeypatch.setattr(model_registry, "get_registry", lambda: registry)
+    monkeypatch.setattr(llm_router, "get_provider_spec", lambda pid: provider_spec)
+    return registry
+
+
+def test_resolve_raises_no_provider_when_registry_resolves_nothing(monkeypatch):
+    _patch_resolution(monkeypatch, resolved=None, provider_spec=None)
+
+    with pytest.raises(NoProviderConfigured):
+        enrichment_service._resolve_provider("reporting")
+
+
+def test_resolve_raises_provider_unavailable_when_spec_is_missing(monkeypatch):
+    _patch_resolution(
+        monkeypatch, resolved=("ollama-x", "qwen3:8b"), provider_spec=None
+    )
+
+    with pytest.raises(ProviderUnavailable) as exc_info:
+        enrichment_service._resolve_provider("reporting")
+
+    assert str(exc_info.value) == "Configured provider 'ollama-x' is unavailable"
+
+
+def test_resolve_skips_the_claude_service_for_non_anthropic_providers(monkeypatch):
+    class _Spec:
+        provider_id = "ollama-default"
+        provider_type = "ollama"
+
+    _patch_resolution(
+        monkeypatch, resolved=("ollama-default", "qwen3:8b"), provider_spec=_Spec()
+    )
+
+    provider, model_id, claude_service = enrichment_service._resolve_provider(
+        "reporting"
+    )
+
+    assert model_id == "qwen3:8b"
+    assert provider.provider_type == "ollama"
+    assert claude_service is None
+
+
+def test_resolve_raises_no_provider_when_anthropic_has_no_api_key(monkeypatch):
+    class _Spec:
+        provider_id = "anthropic-default"
+        provider_type = "anthropic"
+
+    _patch_resolution(
+        monkeypatch,
+        resolved=("anthropic-default", "claude-opus-5"),
+        provider_spec=_Spec(),
+    )
+
+    from services import claude_service as claude_service_module
+
+    class _NoKeyClaudeService:
+        def __init__(self, **kwargs):
+            pass
+
+        def has_api_key(self):
+            return False
+
+    monkeypatch.setattr(claude_service_module, "ClaudeService", _NoKeyClaudeService)
+
+    with pytest.raises(NoProviderConfigured):
+        enrichment_service._resolve_provider("reporting")

--- a/tests/unit/test_findings_enrichment.py
+++ b/tests/unit/test_findings_enrichment.py
@@ -1,0 +1,551 @@
+"""Unit tests for the finding-enrichment module (issue #470).
+
+These cover the seam the extraction created. Before it, none of this was
+reachable without an HTTP round-trip and a live provider:
+
+* ``prompt.py`` — singular/plural entity keys, MITRE technique fallback
+* ``parse.py``  — fenced JSON, raw JSON, malformed text, empty response
+* ``service.py`` — orchestration: metadata stamping, persist on/off, and the
+  domain errors that replaced the inline ``HTTPException`` raises
+
+Provider resolution and dispatch are stubbed; nothing here touches a network
+or a database.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from services.findings.enrichment import (
+    EmptyProviderResponse,
+    FindingNotFound,
+    build_entity_string,
+    build_prompt,
+    build_techniques_string,
+    enrich,
+    extract_json_block,
+    parse_enrichment,
+    summarize_finding,
+)
+from services.findings.enrichment import service as enrichment_service
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeProvider:
+    def __init__(self, provider_type="ollama", provider_id="ollama-default"):
+        self.provider_type = provider_type
+        self.provider_id = provider_id
+
+
+class _RecordingDataService:
+    """Stands in for DatabaseDataService; records writes."""
+
+    def __init__(self, success=True):
+        self.success = success
+        self.writes = []
+
+    def update_finding(self, finding_id, **updates):
+        self.writes.append((finding_id, updates))
+        return self.success
+
+
+def _finding(**overrides):
+    finding = {
+        "finding_id": "f-20260803-001",
+        "severity": "high",
+        "data_source": "zeek",
+        "timestamp": "2026-08-03T12:00:00Z",
+        "description": "Beaconing to a rare external host",
+        "anomaly_score": 0.91,
+        "entity_context": {},
+        "mitre_predictions": {},
+        "predicted_techniques": [],
+    }
+    finding.update(overrides)
+    return finding
+
+
+@pytest.fixture
+def stub_provider(monkeypatch):
+    """Stub resolution + dispatch so ``enrich()`` runs without a provider.
+
+    Returns a mutable dict the test can retune: ``response`` is what the fake
+    provider returns, ``provider`` the resolved spec.
+    """
+    state = {
+        "provider": _FakeProvider(),
+        "model_id": "qwen3:8b",
+        "response": json.dumps({"threat_summary": "beaconing"}),
+        "prompts": [],
+    }
+
+    def fake_resolve(component):
+        state["component"] = component
+        return state["provider"], state["model_id"], None
+
+    async def fake_dispatch(*, provider, model_id, prompt, claude_service, finding_id):
+        state["prompts"].append(prompt)
+        return state["response"]
+
+    monkeypatch.setattr(enrichment_service, "_resolve_provider", fake_resolve)
+    monkeypatch.setattr(enrichment_service, "_dispatch", fake_dispatch)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# prompt.py — entity context
+# ---------------------------------------------------------------------------
+
+
+def test_entity_string_accepts_plural_keys():
+    entity_str = build_entity_string(
+        {
+            "src_ips": ["10.0.0.1", "10.0.0.2"],
+            "dst_ips": ["8.8.8.8"],
+            "hostnames": ["web-01"],
+            "users": ["alice"],
+        }
+    )
+    assert "Source IPs: 10.0.0.1, 10.0.0.2\n" in entity_str
+    assert "Destination IPs: 8.8.8.8\n" in entity_str
+    assert "Hostnames: web-01\n" in entity_str
+    assert "Users: alice\n" in entity_str
+
+
+def test_entity_string_accepts_singular_keys():
+    entity_str = build_entity_string(
+        {
+            "src_ip": "10.0.0.1",
+            "dst_ip": "8.8.8.8",
+            "hostname": "web-01",
+            "user": "alice",
+        }
+    )
+    assert entity_str == (
+        "Source IPs: 10.0.0.1\n"
+        "Destination IPs: 8.8.8.8\n"
+        "Hostnames: web-01\n"
+        "Users: alice\n"
+    )
+
+
+def test_entity_string_accepts_dest_ips_and_usernames_aliases():
+    entity_str = build_entity_string({"dest_ips": ["1.1.1.1"], "usernames": ["bob"]})
+    assert "Destination IPs: 1.1.1.1\n" in entity_str
+    assert "Users: bob\n" in entity_str
+
+
+def test_entity_string_prefers_plural_over_singular():
+    entity_str = build_entity_string({"src_ips": ["10.0.0.9"], "src_ip": "10.0.0.1"})
+    assert entity_str == "Source IPs: 10.0.0.9\n"
+
+
+def test_entity_string_caps_each_list_at_five():
+    entity_str = build_entity_string({"src_ips": [f"10.0.0.{i}" for i in range(9)]})
+    assert (
+        entity_str == "Source IPs: 10.0.0.0, 10.0.0.1, 10.0.0.2, 10.0.0.3, 10.0.0.4\n"
+    )
+
+
+def test_entity_string_is_empty_for_missing_or_empty_context():
+    assert build_entity_string(None) == ""
+    assert build_entity_string({}) == ""
+    # Keys present but None must not render an empty label.
+    assert build_entity_string({"src_ips": None, "src_ip": None}) == ""
+
+
+# ---------------------------------------------------------------------------
+# prompt.py — MITRE techniques
+# ---------------------------------------------------------------------------
+
+
+def test_predicted_techniques_win_over_mitre_predictions():
+    techniques_str = build_techniques_string(
+        [{"technique_id": "T1071.001", "confidence": 0.85}],
+        {"T1048.003": 0.99},
+    )
+    assert techniques_str == "T1071.001 (confidence: 0.85)"
+
+
+def test_mitre_predictions_fallback_is_sorted_by_confidence_desc():
+    techniques_str = build_techniques_string(
+        [],
+        {"T1000": 0.10, "T3000": 0.90, "T2000": 0.50},
+    )
+    assert techniques_str.splitlines() == [
+        "T3000 (confidence: 0.90)",
+        "T2000 (confidence: 0.50)",
+        "T1000 (confidence: 0.10)",
+    ]
+
+
+def test_mitre_predictions_fallback_caps_at_five():
+    techniques_str = build_techniques_string(
+        [], {f"T{i}000": i / 10 for i in range(1, 9)}
+    )
+    assert len(techniques_str.splitlines()) == 5
+
+
+def test_techniques_tolerate_missing_id_and_none_confidence():
+    techniques_str = build_techniques_string([{"confidence": None}], {})
+    assert techniques_str == "Unknown (confidence: 0.00)"
+    assert build_techniques_string([], {"T1000": None}) == "T1000 (confidence: 0.00)"
+
+
+def test_techniques_string_is_empty_when_nothing_predicted():
+    assert build_techniques_string([], {}) == ""
+    assert build_techniques_string(None, None) == ""
+
+
+# ---------------------------------------------------------------------------
+# prompt.py — summarize + build
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_finding_defaults_none_valued_keys():
+    summary = summarize_finding(
+        {
+            "finding_id": "f-1",
+            "severity": None,
+            "data_source": None,
+            "timestamp": None,
+            "description": None,
+            "anomaly_score": None,
+            "entity_context": None,
+            "mitre_predictions": None,
+            "predicted_techniques": None,
+        }
+    )
+    assert summary.severity == "unknown"
+    assert summary.data_source == "unknown"
+    assert summary.timestamp == ""
+    assert summary.description == ""
+    assert summary.anomaly_score == 0.0
+    assert summary.entity_str == ""
+    assert summary.techniques_str == ""
+
+
+def test_build_prompt_includes_optional_sections_when_present():
+    prompt = build_prompt(
+        summarize_finding(
+            _finding(
+                entity_context={"src_ip": "10.0.0.1"},
+                predicted_techniques=[
+                    {"technique_id": "T1071.001", "confidence": 0.85}
+                ],
+            )
+        )
+    )
+    assert "Finding ID: f-20260803-001" in prompt
+    assert "Anomaly Score: 0.91" in prompt
+    assert "Entity Context:\nSource IPs: 10.0.0.1" in prompt
+    assert "MITRE ATT&CK Techniques:\nT1071.001 (confidence: 0.85)" in prompt
+    assert "Respond ONLY with valid JSON." in prompt
+
+
+def test_build_prompt_uses_placeholders_when_sections_are_empty():
+    prompt = build_prompt(summarize_finding(_finding(description="")))
+    assert "No description available" in prompt
+    assert "No MITRE techniques predicted" in prompt
+    assert "Entity Context:" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# parse.py
+# ---------------------------------------------------------------------------
+
+
+def test_parse_extracts_fenced_json():
+    payload = {"threat_summary": "exfil", "confidence_score": 0.9}
+    response = f"Here you go:\n```json\n{json.dumps(payload)}\n```\nHope that helps."
+    assert parse_enrichment(response, severity="high") == payload
+
+
+def test_parse_extracts_raw_json_with_surrounding_prose():
+    payload = {"threat_summary": "lateral movement"}
+    response = f"Analysis follows. {json.dumps(payload)} End of analysis."
+    assert parse_enrichment(response, severity="high") == payload
+
+
+def test_parse_falls_back_to_structured_payload_on_malformed_json():
+    response = "I think this is suspicious but here is no JSON at all."
+    enrichment = parse_enrichment(response, severity="critical")
+
+    assert enrichment["threat_summary"] == (
+        "AI analysis completed - see full analysis below"
+    )
+    assert enrichment["risk_level"] == "Critical"  # severity.title()
+    assert enrichment["confidence_score"] == 0.7
+    assert enrichment["analysis_notes"] == response
+    assert enrichment["raw_response"] == response
+
+
+def test_parse_fallback_truncates_analysis_notes_but_not_raw_response():
+    response = "x" * 1500
+    enrichment = parse_enrichment(response, severity="low")
+    assert len(enrichment["analysis_notes"]) == 1000
+    assert len(enrichment["raw_response"]) == 1500
+
+
+def test_parse_fallback_defaults_risk_level_when_severity_is_blank():
+    enrichment = parse_enrichment("not json", severity="")
+    assert enrichment["risk_level"] == "Medium"
+
+
+@pytest.mark.parametrize("response", [None, ""])
+def test_parse_raises_on_empty_response(response):
+    with pytest.raises(EmptyProviderResponse):
+        parse_enrichment(response, severity="high")
+
+
+def test_extract_json_block_prefers_fence_over_later_braces():
+    response = '```json\n{"a": 1}\n```\nand also {"b": 2}'
+    assert extract_json_block(response) == '{"a": 1}'
+
+
+def test_extract_json_block_returns_response_when_no_braces():
+    assert extract_json_block("no json here") == "no json here"
+
+
+# ---------------------------------------------------------------------------
+# service.py — orchestration
+# ---------------------------------------------------------------------------
+
+
+async def test_enrich_stamps_provenance_metadata(stub_provider):
+    stub_provider["provider"] = _FakeProvider("anthropic", "anthropic-default")
+    stub_provider["model_id"] = "claude-opus-5"
+
+    enrichment = await enrich(_finding(), persist=False)
+
+    assert enrichment["threat_summary"] == "beaconing"
+    assert enrichment["model"] == "claude-opus-5"
+    assert enrichment["provider_id"] == "anthropic-default"
+    assert enrichment["provider_type"] == "anthropic"
+    assert enrichment["generated_at"].endswith("Z")
+
+
+async def test_enrich_keeps_raw_response_even_when_json_parsed_cleanly(stub_provider):
+    stub_provider["response"] = '```json\n{"threat_summary": "ok"}\n```'
+    enrichment = await enrich(_finding(), persist=False)
+    assert enrichment["raw_response"] == stub_provider["response"]
+
+
+async def test_enrich_persists_by_default(stub_provider):
+    data_service = _RecordingDataService()
+
+    enrichment = await enrich(_finding(), data_service=data_service)
+
+    assert data_service.writes == [("f-20260803-001", {"ai_enrichment": enrichment})]
+
+
+async def test_enrich_skips_write_when_persist_is_false(stub_provider):
+    data_service = _RecordingDataService()
+    await enrich(_finding(), persist=False, data_service=data_service)
+    assert data_service.writes == []
+
+
+async def test_enrich_returns_payload_even_when_the_write_fails(stub_provider):
+    data_service = _RecordingDataService(success=False)
+    enrichment = await enrich(_finding(), data_service=data_service)
+    assert enrichment["threat_summary"] == "beaconing"
+
+
+async def test_enrich_passes_component_through_to_resolution(stub_provider):
+    await enrich(_finding(), component="triage", persist=False)
+    assert stub_provider["component"] == "triage"
+
+
+async def test_enrich_defaults_to_the_reporting_component(stub_provider):
+    await enrich(_finding(), persist=False)
+    assert stub_provider["component"] == "reporting"
+
+
+async def test_enrich_rejects_an_empty_finding(stub_provider):
+    with pytest.raises(FindingNotFound):
+        await enrich({}, persist=False)
+
+
+async def test_enrich_propagates_empty_provider_response(stub_provider):
+    stub_provider["response"] = ""
+    with pytest.raises(EmptyProviderResponse):
+        await enrich(_finding(), persist=False)
+
+
+async def test_enrich_builds_the_prompt_from_the_finding(stub_provider):
+    await enrich(_finding(entity_context={"hostnames": ["db-07"]}), persist=False)
+    assert "Hostnames: db-07" in stub_provider["prompts"][0]
+
+
+# ---------------------------------------------------------------------------
+# service.py — the dispatch asymmetry
+#
+# Anthropic goes through the sync ClaudeService on a threadpool with NO retry;
+# every other provider goes through LLMRouter with a retry loop and local
+# Bifrost recovery. That asymmetry is existing behaviour carried over from the
+# handler, so pin it — if it's ever unified, these are the tests to change.
+# ---------------------------------------------------------------------------
+
+
+class _FakeClaudeService:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def chat(self, **kwargs):
+        self.calls.append(kwargs)
+        result = self.responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+async def test_anthropic_dispatch_uses_claude_service_with_the_larger_cap():
+    claude_service = _FakeClaudeService(['{"threat_summary": "ok"}'])
+
+    response = await enrichment_service._dispatch(
+        provider=_FakeProvider("anthropic", "anthropic-default"),
+        model_id="claude-opus-5",
+        prompt="PROMPT",
+        claude_service=claude_service,
+        finding_id="f-1",
+    )
+
+    assert response == '{"threat_summary": "ok"}'
+    assert claude_service.calls == [
+        {
+            "message": "PROMPT",
+            "model": "claude-opus-5",
+            "max_tokens": enrichment_service.ANTHROPIC_MAX_TOKENS,
+        }
+    ]
+
+
+async def test_anthropic_dispatch_does_not_retry():
+    """The cloud path has never had a retry. Don't add one by accident."""
+    claude_service = _FakeClaudeService(
+        [RuntimeError("upstream 529"), '{"threat_summary": "second try"}']
+    )
+
+    with pytest.raises(RuntimeError, match="upstream 529"):
+        await enrichment_service._dispatch(
+            provider=_FakeProvider("anthropic", "anthropic-default"),
+            model_id="claude-opus-5",
+            prompt="PROMPT",
+            claude_service=claude_service,
+            finding_id="f-1",
+        )
+
+    assert len(claude_service.calls) == 1
+
+
+def _patch_local_dispatch(monkeypatch, *, results, retry_limit=1, recovery_ready=True):
+    """Stub LLMRouter + local-Bifrost recovery for the non-Anthropic path."""
+    from services import llm_router, local_ai_recovery
+
+    calls = []
+
+    class _FakeRouter:
+        async def dispatch(self, **kwargs):
+            calls.append(kwargs)
+            result = results.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+    class _Recovery:
+        ready = recovery_ready
+        detail = "restarted" if recovery_ready else "still down"
+
+    async def fake_recover():
+        return _Recovery()
+
+    monkeypatch.setattr(llm_router, "LLMRouter", _FakeRouter)
+    monkeypatch.setattr(
+        local_ai_recovery, "local_bifrost_recovery_retry_limit", lambda: retry_limit
+    )
+    monkeypatch.setattr(
+        local_ai_recovery, "local_bifrost_recovery_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        local_ai_recovery, "is_gateway_connection_error", lambda err: True
+    )
+    monkeypatch.setattr(local_ai_recovery, "recover_local_bifrost", fake_recover)
+    return calls
+
+
+async def _dispatch_local(provider_type="ollama"):
+    return await enrichment_service._dispatch(
+        provider=_FakeProvider(provider_type, f"{provider_type}-default"),
+        model_id="qwen3:8b",
+        prompt="PROMPT",
+        claude_service=None,
+        finding_id="f-1",
+    )
+
+
+async def test_local_dispatch_prefixes_no_think_and_uses_the_tighter_cap(monkeypatch):
+    calls = _patch_local_dispatch(monkeypatch, results=[{"content": "OK"}])
+
+    assert await _dispatch_local() == "OK"
+
+    assert calls[0]["messages"] == [{"role": "user", "content": "/no_think\nPROMPT"}]
+    assert calls[0]["max_tokens"] == enrichment_service.LOCAL_MAX_TOKENS
+    assert calls[0]["system_prompt"] == enrichment_service.LOCAL_SYSTEM_PROMPT
+    assert calls[0]["model"] == "qwen3:8b"
+
+
+async def test_local_dispatch_retries_after_a_successful_recovery(monkeypatch):
+    calls = _patch_local_dispatch(
+        monkeypatch,
+        results=[ConnectionError("gateway down"), {"content": "OK"}],
+    )
+
+    assert await _dispatch_local() == "OK"
+    assert len(calls) == 2
+
+
+async def test_local_dispatch_reraises_when_recovery_is_not_ready(monkeypatch):
+    calls = _patch_local_dispatch(
+        monkeypatch,
+        results=[ConnectionError("gateway down")],
+        recovery_ready=False,
+    )
+
+    with pytest.raises(ConnectionError):
+        await _dispatch_local()
+    assert len(calls) == 1
+
+
+async def test_local_dispatch_stops_after_the_retry_limit(monkeypatch):
+    calls = _patch_local_dispatch(
+        monkeypatch,
+        results=[ConnectionError("down"), ConnectionError("still down")],
+        retry_limit=1,
+    )
+
+    with pytest.raises(ConnectionError, match="still down"):
+        await _dispatch_local()
+    assert len(calls) == 2
+
+
+async def test_local_dispatch_recovery_is_ollama_only(monkeypatch):
+    """`eligible` gates on provider_type == "ollama" — openai must not retry."""
+    calls = _patch_local_dispatch(monkeypatch, results=[ConnectionError("down")])
+
+    with pytest.raises(ConnectionError):
+        await _dispatch_local(provider_type="openai")
+    assert len(calls) == 1
+
+
+async def test_local_dispatch_defaults_missing_content_to_empty_string(monkeypatch):
+    _patch_local_dispatch(monkeypatch, results=[{}])
+    assert await _dispatch_local() == ""

--- a/tests/unit/test_findings_enrichment.py
+++ b/tests/unit/test_findings_enrichment.py
@@ -24,6 +24,7 @@ from services.findings.enrichment import (
     build_entity_string,
     build_prompt,
     build_techniques_string,
+    UnidentifiableFinding,
     enrich,
     extract_json_block,
     parse_enrichment,
@@ -383,6 +384,77 @@ async def test_enrich_propagates_empty_provider_response(stub_provider):
 async def test_enrich_builds_the_prompt_from_the_finding(stub_provider):
     await enrich(_finding(entity_context={"hostnames": ["db-07"]}), persist=False)
     assert "Hostnames: db-07" in stub_provider["prompts"][0]
+
+
+# ---------------------------------------------------------------------------
+# service.py — the write target
+#
+# The pre-extraction handler persisted with its path param. Deriving the write
+# target from the finding dict instead means an id-less dict silently writes to
+# update_finding(""), which matches no row and only logs — a lost write. These
+# pin the explicit id and the guard that replaced that hole.
+# ---------------------------------------------------------------------------
+
+
+async def test_explicit_finding_id_is_the_write_target(stub_provider):
+    """A caller holding the id independently must win over the dict."""
+    data_service = _RecordingDataService()
+
+    await enrich(
+        _finding(finding_id="stale-in-dict"),
+        finding_id="authoritative-id",
+        data_service=data_service,
+    )
+
+    written_id, _ = data_service.writes[0]
+    assert written_id == "authoritative-id"
+
+
+async def test_explicit_finding_id_is_what_the_prompt_reports(stub_provider):
+    await enrich(
+        _finding(finding_id="stale-in-dict"),
+        finding_id="authoritative-id",
+        persist=False,
+    )
+
+    assert "Finding ID: authoritative-id" in stub_provider["prompts"][0]
+    assert "stale-in-dict" not in stub_provider["prompts"][0]
+
+
+async def test_finding_id_falls_back_to_the_dict_when_not_passed(stub_provider):
+    data_service = _RecordingDataService()
+
+    await enrich(_finding(finding_id="from-dict"), data_service=data_service)
+
+    written_id, _ = data_service.writes[0]
+    assert written_id == "from-dict"
+
+
+@pytest.mark.parametrize("missing_id", [None, ""])
+async def test_persist_without_any_id_raises_instead_of_writing_to_empty_string(
+    stub_provider, missing_id
+):
+    """The regression this guard exists for: a silently-dropped write."""
+    data_service = _RecordingDataService()
+
+    with pytest.raises(UnidentifiableFinding):
+        await enrich(_finding(finding_id=missing_id), data_service=data_service)
+
+    assert data_service.writes == []
+
+
+async def test_the_id_guard_runs_before_any_provider_call(stub_provider):
+    """Fail fast — don't pay for a dispatch whose result can't be stored."""
+    with pytest.raises(UnidentifiableFinding):
+        await enrich(_finding(finding_id=None))
+
+    assert stub_provider["prompts"] == []
+
+
+async def test_an_id_less_finding_is_fine_when_not_persisting(stub_provider):
+    """persist=False callers compose their own write, so no id is needed."""
+    enrichment = await enrich(_finding(finding_id=None), persist=False)
+    assert enrichment["threat_summary"] == "beaconing"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #470.

Extracts the AI-enrichment flow out of `backend/api/findings.py` into
`services/findings/enrichment/` so it's reachable from more than one HTTP path.
Behaviour-preserving refactor — no functional change to
`POST /api/findings/{id}/enrich`.

## Why

`get_or_generate_enrichment` was a **333-line handler** that inlined the entire
flow: provider resolution, input shaping, prompt construction, dispatch,
response parsing, metadata stamping and persistence. "Enrich a finding with AI
analysis" could therefore only happen from that one HTTP path — ingestion, the
daemon and agents had no way to reuse it. None of the pure logic (prompt
building, JSON extraction) was unit-testable without a live provider and an
HTTP round-trip.

## What changed

New module, one seam:

```python
from services.findings.enrichment import enrich, EnrichmentError

payload = await enrich(finding)                 # persists by default
payload = await enrich(finding, persist=False)  # compose your own write
```

| File | Contents |
|---|---|
| `services/findings/enrichment/errors.py` | Domain exceptions + their status-code mapping |
| `services/findings/enrichment/prompt.py` | Input shaping + prompt build — pure functions |
| `services/findings/enrichment/parse.py` | JSON extraction + text fallback — pure functions |
| `services/findings/enrichment/service.py` | `enrich()` — resolve → dispatch → parse → stamp → persist |
| `services/findings/enrichment/__init__.py` | Public surface |

`backend/api/findings.py` (`+31 / −281`) keeps only what is genuinely HTTP
policy — fetch, cache check, and the error translation:

```python
finding = data_service.get_finding(finding_id)   # 404 stays here
...                                              # cache check stays here
enrichment = await enrich(finding, data_service=data_service)
```

The handler function drops from **333 lines to 75** (45 of them body; the rest
is its pre-existing docstring).

### No `HTTPException` in `services/`

The old code raised `HTTPException` from inside the business logic, which is
precisely what made it unusable from the daemon and from ingestion — neither
speaks HTTP. The module now raises domain errors and the handler owns the
single translation point:

| Exception | Status | Detail |
|---|---|---|
| `FindingNotFound` | 404 | `"Finding not found"` |
| `NoProviderConfigured` | 503 | `claude.NO_PROVIDER_DETAIL` (structured) |
| `ProviderUnavailable` | 503 | `str(exc)` |
| `EmptyProviderResponse` | 500 | `"Failed to generate enrichment: {exc}"` |

`NO_PROVIDER_DETAIL` deliberately stays in `backend/api/claude.py` and is
re-applied at the HTTP boundary, rather than following the module into
`services/` — three backend modules import it, and a `backend → backend` import
must not leak into the service layer. The 503 keeps carrying the structured
payload (not a bare string) so the chat drawer still renders its "Configure a
provider" CTA.

## Design choices

- **`enrich()` takes a finding `dict`, not a `finding_id`.** The fetch — and its
  404 — stays with the caller, so the module needs no database access for reads.
  The daemon already holds finding dicts.
- **No cache check inside `enrich()`.** Whether an existing `ai_enrichment`
  value is a usable cache hit is caller policy (`force_regenerate` is a query
  param), and the current check has a known bug (see below).
- **`persist=False` returns the payload without writing.** So a caller can
  compose its own write instead of the module hard-coding a destructive
  full-replace deep inside shared code.
- **`component` is a parameter** (default `"reporting"`, as the handler
  hardcoded) — other callers may want a different `ai_model_configs` component.
- **`data_service` is injectable.** Without it the module would construct a
  second `DatabaseDataService` (whose `__init__` runs `init_database`) alongside
  the API module's singleton. The handler passes its own; there's a test for it.

## Preserved as-is

**The dispatch asymmetry.** Anthropic goes through the sync `ClaudeService` on a
threadpool with `max_tokens=4096` and **no retry**; every other provider goes
through `LLMRouter.dispatch` with `max_tokens=1400`, a retry loop, and
ollama-only local-Bifrost recovery. That is existing behaviour, not a design
position — unifying it while moving code would make any regression impossible to
bisect. Seven tests now pin it so it can't drift silently. Whether the cloud path
*should* retry is a separate question.

The `run_in_executor` hop is left exactly where it is — it's the sync-in-async
seam #461 covers. `enrich()` is `async`; nothing here entrenches or resolves it.

## Known issue documented, not fixed: two writers on `ai_enrichment`

`daemon/processor.py:441` writes triage keys (`ai_triage`, `enrichment`,
`enriched_at`, `triage_confidence`, `category`, `recommended_action`,
`triage_reasoning`) into the same JSONB column this module writes analysis keys
to (`threat_summary`, `potential_impact`, `recommended_actions`, …). **The two
key sets do not overlap.** Three consequences, all live on `main` today:

1. **Cache poisoning across writers.** If the daemon triaged first,
   `POST /{id}/enrich` returns the daemon's payload labelled as `enrichment`;
   the frontend reads `undefined` off `enrichment.threat_summary`.
2. **API writes destroy daemon triage.** `update_finding(..., ai_enrichment=…)`
   is a whole-value replace, not a merge.
3. **API-enriched findings fall out of backfill permanently.** The daemon
   re-queues on `ai_enrichment IS NULL`; a non-NULL write excludes the finding
   forever.

Fixing this is a JSONB schema change needing a read-side compatibility shim for
existing rows (there's no Alembic yet — #411), so bundling it here would make
the diff unreviewable. It's spelled out in `service.py`'s module docstring, and
`persist=False` is the seam it needs. **Follow-up issue to be filed.**

## Testing

**55 new tests**, all passing:

- `tests/unit/test_findings_enrichment.py` (41) — entity singular/plural/alias
  keys, the `predicted_techniques` vs `mitre_predictions` fallback and its sort
  order, fenced/raw/malformed/empty response parsing, metadata stamping,
  `persist` on/off, and the dispatch asymmetry.
- `tests/unit/test_findings_enrich_endpoint.py` (14) — 404, cache hit,
  `force_regenerate`, both 503 shapes, 500, the success envelope, and
  `_resolve_provider`'s error mapping.

**Byte-identity proof.** The pre-refactor inline code was extracted verbatim
from `git show b0f8a94:backend/api/findings.py` and its output diffed against
the new module across **7 finding shapes** (plural keys, singular keys,
`dest_ips`/`usernames` aliases, all-absent, all-`None`-valued, empty dicts,
plural-empty-falls-back-to-singular) and **6 response shapes × 3 severities** —
prompts and parsed payloads identical, **0 mismatches**.

Full suite: `pytest tests/unit/ -m "not external_service"` → **1084 passed, 51
skipped, 0 failed**. `black` clean; `mypy` clean on the new package.

## Scope / sequencing

**not** in this PR:

- **The `ai_enrichment` collision fix** — see above; separate PR, separate review.
- **Daemon / ingestion adoption.** #470's acceptance criteria mention them, but
  no parallel AI-enrichment implementation exists in either
  (`grep -rn "ai_enrichment"` hits only `backend/api/findings.py`,
  `daemon/processor.py` and `services/database_data_service.py:210`)

⚠️ **Conflicts with #451.** That PR also modifies `backend/api/findings.py`
(`+16/−14`) and makes `LLMRouter` the sole LLM entry point, removing direct
`ClaudeService` imports. Its changes to the enrichment flow now land in
`service.py::_resolve_provider` and `_dispatch` instead of in the handler —
two small functions rather than a 333-line body. If #451 lands first, both
collapse further, likely to a single `dispatch()` call.
