### PR TITLE
fix(db): track in-place JSONB mutations so case timeline events persist

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -24,9 +24,19 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from pgvector.sqlalchemy import Vector
 import uuid
+
+# Collection columns that are appended to in place (``obj.col.append(...)``) must
+# be declared with ``MutableList.as_mutable(JSONB)``. A plain JSONB column gives
+# SQLAlchemy no way to observe an in-place mutation, so the attribute never
+# becomes dirty, no UPDATE is emitted, and the append is silently discarded on
+# commit — see issue #543, where case auto-assignment and escalation events were
+# being lost exactly this way. Wrapping makes the next ``.append()`` anyone
+# writes correct by default rather than correct-if-they-remembered.
+MutableJSONBList = MutableList.as_mutable(JSONB)
 
 # Fixed width for the findings vector column; sources of other dimensions
 # (LogLM 512) are zero-padded/truncated to this before storage.
@@ -199,22 +209,26 @@ class Case(Base):
     assignee: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
 
     # Tags (array of strings)
-    tags: Mapped[List[str]] = mapped_column(ARRAY(String), nullable=True, default=[])
+    tags: Mapped[List[str]] = mapped_column(ARRAY(String), nullable=True, default=list)
 
     # Notes (JSONB array)
-    notes: Mapped[List[dict]] = mapped_column(JSONB, nullable=True, default=[])
+    notes: Mapped[List[dict]] = mapped_column(
+        MutableJSONBList, nullable=True, default=list
+    )
 
     # Timeline events (JSONB array)
-    timeline: Mapped[List[dict]] = mapped_column(JSONB, nullable=False, default=[])
+    timeline: Mapped[List[dict]] = mapped_column(
+        MutableJSONBList, nullable=False, default=list
+    )
 
     # Activities (JSONB array)
     activities: Mapped[Optional[List[dict]]] = mapped_column(
-        JSONB, nullable=True, default=[]
+        MutableJSONBList, nullable=True, default=list
     )
 
     # Resolution steps (JSONB array)
     resolution_steps: Mapped[Optional[List[dict]]] = mapped_column(
-        JSONB, nullable=True, default=[]
+        MutableJSONBList, nullable=True, default=list
     )
 
     # MITRE ATT&CK techniques
@@ -535,7 +549,7 @@ class UserPreference(Base):
     user_id: Mapped[str] = mapped_column(String(100), primary_key=True)
 
     # Preferences as flexible JSONB
-    preferences: Mapped[dict] = mapped_column(JSONB, nullable=False, default={})
+    preferences: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
 
     # User metadata
     display_name: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
@@ -586,7 +600,7 @@ class IntegrationConfig(Base):
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     # Configuration (non-sensitive only)
-    config: Mapped[dict] = mapped_column(JSONB, nullable=False, default={})
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
 
     # Metadata
     integration_name: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
@@ -1120,9 +1134,11 @@ class CaseEvidence(Base):
     collected_by: Mapped[str] = mapped_column(String(100), nullable=False)
     collected_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
 
-    # Chain of custody (JSONB array of custody entries)
+    # Chain of custody (JSONB array of custody entries). Mutable-tracked: an
+    # append that silently vanished would be a hole in an evidence audit trail.
+    # #549 moves this to its own table, which removes the exposure entirely.
     chain_of_custody: Mapped[List[dict]] = mapped_column(
-        JSONB, nullable=False, default=[]
+        MutableJSONBList, nullable=False, default=list
     )
 
     # Analysis results
@@ -1388,7 +1404,7 @@ class CaseTemplate(Base):
 
     # Task templates (JSONB array)
     task_templates: Mapped[List[dict]] = mapped_column(
-        JSONB, nullable=False, default=[]
+        JSONB, nullable=False, default=list
     )
 
     # Playbook steps (JSONB array)
@@ -1871,7 +1887,9 @@ class User(Base):
     # MFA
     mfa_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     mfa_secret: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    mfa_recovery_codes: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    mfa_recovery_codes: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list
+    )
 
     # Session tracking
     last_login: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
@@ -1947,7 +1965,7 @@ class Role(Base):
     description: Mapped[str] = mapped_column(Text, nullable=False)
 
     # Permissions (JSONB for flexibility)
-    permissions: Mapped[dict] = mapped_column(JSONB, nullable=False, default={})
+    permissions: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
 
     # System role flag (cannot be deleted/modified)
     is_system_role: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
@@ -1997,7 +2015,9 @@ class Investigation(Base):
     workflow_id: Mapped[str] = mapped_column(String(50), nullable=False)
 
     trigger_type: Mapped[str] = mapped_column(String(30), nullable=False)
-    trigger_ids: Mapped[List[dict]] = mapped_column(JSONB, nullable=False, default=[])
+    trigger_ids: Mapped[List[dict]] = mapped_column(
+        JSONB, nullable=False, default=list
+    )
 
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="queued")
 
@@ -2094,7 +2114,7 @@ class InvestigationLog(Base):
         DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
     )
     event_type: Mapped[str] = mapped_column(String(30), nullable=False)
-    details: Mapped[dict] = mapped_column(JSONB, nullable=False, default={})
+    details: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     tokens_used: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     __table_args__ = (

--- a/tests/integration/test_case_timeline_persistence.py
+++ b/tests/integration/test_case_timeline_persistence.py
@@ -1,0 +1,137 @@
+"""End-to-end proof for issue #543: an in-place timeline append survives commit.
+
+The unit tests in ``tests/unit/test_jsonb_mutation_tracking.py`` assert the
+*mechanism* (columns coerce to ``MutableList``, appends fire change events) and
+need no database. This asserts the *symptom* is gone: append via the ORM, commit,
+re-read in a **fresh session**, and the event is still there.
+
+Requires Postgres, because the columns are `JSONB`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "backend"))
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-only-secret-not-for-prod")
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _database():
+    """Initialise the DatabaseManager.
+
+    CI runs `init_database()` as a separate job step before pytest; doing it here
+    too keeps the file runnable standalone. `create_all` is idempotent, so this is
+    safe when the schema already exists. Skips rather than fails when no Postgres
+    is reachable, so the file does not break a machine without the stack up.
+    """
+    from database.connection import init_database
+
+    try:
+        init_database()
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"Postgres not available for integration test: {exc}")
+
+
+@pytest.fixture
+def case_id():
+    """A unique id so parallel or repeated runs cannot collide."""
+    return f"case-543-{uuid.uuid4().hex[:12]}"
+
+
+@pytest.fixture
+def session():
+    from database.connection import get_db_session
+
+    s = get_db_session()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def _fresh_session():
+    """A session with its own identity map, so a read cannot be served from the
+    first session's cache — otherwise the test could pass on a stale object
+    without the row ever having been written."""
+    from database.connection import get_db_session
+
+    return get_db_session()
+
+
+@pytest.fixture
+def a_case(session, case_id):
+    from database.models import Case
+
+    case = Case(case_id=case_id, title="issue #543 timeline persistence", timeline=[])
+    session.add(case)
+    session.commit()
+    yield case
+    # Clean up regardless of assertion outcome.
+    s = _fresh_session()
+    try:
+        row = s.query(Case).filter(Case.case_id == case_id).first()
+        if row is not None:
+            s.delete(row)
+            s.commit()
+    finally:
+        s.close()
+
+
+def test_in_place_timeline_append_persists(session, a_case, case_id):
+    """The exact pattern `case_workflow_service.py:403` and `:470` use.
+
+    Before the fix this committed silently and the event was gone — no error, no
+    warning, just a missing audit entry.
+    """
+    from database.models import Case
+
+    a_case.timeline.append({"timestamp": "2026-08-03T00:00:00", "event": "escalated"})
+    session.commit()
+
+    s = _fresh_session()
+    try:
+        reread = s.query(Case).filter(Case.case_id == case_id).first()
+        assert reread is not None, "case row vanished"
+        events = [e.get("event") for e in (reread.timeline or [])]
+        assert "escalated" in events, (
+            "in-place timeline append was not persisted — the mutation-tracking "
+            "fix for #543 has regressed"
+        )
+    finally:
+        s.close()
+
+
+def test_repeated_appends_all_persist(session, a_case, case_id):
+    """Several appends in one transaction must all survive.
+
+    Guards a subtler variant: tracking that fires only on the first mutation
+    would pass the test above and still lose later events.
+    """
+    from database.models import Case
+
+    for i in range(3):
+        a_case.timeline.append(
+            {"timestamp": f"2026-08-03T0{i}:00:00", "event": f"e{i}"}
+        )
+    session.commit()
+
+    s = _fresh_session()
+    try:
+        reread = s.query(Case).filter(Case.case_id == case_id).first()
+        events = [e.get("event") for e in (reread.timeline or [])]
+        assert events == ["e0", "e1", "e2"], (
+            f"expected all three in order, got {events}"
+        )
+    finally:
+        s.close()

--- a/tests/unit/test_jsonb_mutation_tracking.py
+++ b/tests/unit/test_jsonb_mutation_tracking.py
@@ -1,0 +1,114 @@
+"""Guard the mutation-tracking fix for issue #543.
+
+`obj.col.append(...)` on a plain `JSONB` column gives SQLAlchemy no way to see
+the change: the attribute never becomes dirty, no UPDATE is emitted, and the
+append is silently discarded on commit. That is not a hypothetical — case
+auto-assignment (`services/case_workflow_service.py:403`) and escalation
+(`:470`) were losing their timeline entries exactly this way.
+
+The fix declares the appendable collection columns with
+`MutableList.as_mutable(JSONB)`. These tests assert the mechanism rather than
+the symptom, so they need no database and run in the main unit gate. The
+end-to-end proof (append → commit → re-read in a fresh session) lives in
+`tests/integration/test_case_timeline_persistence.py`, which needs Postgres.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "backend"))
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-only-secret-not-for-prod")
+
+pytestmark = pytest.mark.unit
+
+
+#: Columns appended to in place today, plus the rest of the same family on the
+#: same models. Each entry is (model attribute path, why it must be tracked).
+TRACKED_COLLECTIONS = [
+    ("Case", "timeline", "case_workflow_service appends lifecycle events in place"),
+    ("Case", "activities", "backend/api/cases.py appends the merge activity in place"),
+    ("Case", "notes", "same family; the next .append() must be safe by default"),
+    ("Case", "resolution_steps", "same family"),
+    ("CaseEvidence", "chain_of_custody", "a lost append is a hole in an audit trail"),
+]
+
+
+@pytest.mark.parametrize("model_name,attr,reason", TRACKED_COLLECTIONS)
+def test_collection_column_is_mutation_tracked(model_name, attr, reason):
+    """Assigning a plain list must coerce to a change-tracking MutableList.
+
+    Coercion on assignment is exactly what a plain JSONB column does not do, so
+    this fails before the fix and is the precondition for an in-place append
+    ever being persisted. ``reason`` documents why each column is in scope.
+    """
+    from sqlalchemy.ext.mutable import MutableList
+
+    import database.models as models
+
+    model = getattr(models, model_name)
+    obj = model()
+    setattr(obj, attr, [{"seed": True}])
+
+    value = getattr(obj, attr)
+    assert isinstance(value, MutableList), (
+        f"{model_name}.{attr} is not mutation-tracked, so an in-place append "
+        f"would be silently discarded ({reason}). Declare it with "
+        f"MutableList.as_mutable(JSONB) — see issue #543."
+    )
+
+
+@pytest.mark.parametrize("model_name,attr,reason", TRACKED_COLLECTIONS)
+def test_in_place_append_emits_a_change_event(model_name, attr, reason):
+    """An in-place append must notify SQLAlchemy's mutable-extension listeners.
+
+    This is the behaviour the fix buys: `MutableList.changed()` fires, which is
+    what marks the parent attribute dirty so an UPDATE is emitted.
+    """
+    import database.models as models
+
+    model = getattr(models, model_name)
+    obj = model()
+    setattr(obj, attr, [])
+
+    collection = getattr(obj, attr)
+    fired = []
+    # `changed()` is the hook the extension calls to propagate a mutation up to
+    # the owning attribute. Spying on it proves the append is observable without
+    # needing a session or a database.
+    original_changed = collection.changed
+    collection.changed = lambda *a, **kw: (fired.append(True), original_changed())[1]
+
+    collection.append({"appended": True})
+
+    assert fired, (
+        f"appending to {model_name}.{attr} did not signal a change; the append "
+        f"would be lost on commit ({reason})."
+    )
+
+
+def test_no_collection_column_uses_a_shared_mutable_default():
+    """`default=[]` is one list object shared by every instance.
+
+    SQLAlchemy treats a non-callable default as a scalar constant, so every row
+    inserted without an explicit value gets the *same* list. `default=list` is a
+    factory and gives each row its own. The codebase already used `default=list`
+    in 13 places and `default=[]` in 8 — this pins the correct form so the two
+    conventions cannot drift back apart.
+    """
+    source = (REPO / "database" / "models.py").read_text()
+    assert "default=[]" not in source, (
+        "database/models.py contains `default=[]`, a shared mutable default. "
+        "Use `default=list` so each row gets its own collection."
+    )
+    assert "default={}" not in source, (
+        "database/models.py contains `default={}`, a shared mutable default. "
+        "Use `default=dict`."
+    )


### PR DESCRIPTION
## The bug

Case timeline events are being **silently discarded**. `case.timeline.append(...)` mutates a `JSONB` column in place; no JSONB column was wrapped in `MutableList`, and `flag_modified` appears **nowhere** in the codebase — so SQLAlchemy never marks the attribute dirty and emits no `UPDATE`. The commit succeeds, nothing errors, the event is gone.

Reproduced against real Postgres before fixing — three appends, one commit, re-read in a fresh session:

```
E  AssertionError: expected all three in order, got []
```

Every event lost. Two of the three append sites in `services/case_workflow_service.py` were affected:

| Site | Event | Before |
|---|---|---|
| L310 | playbook step applied | ✅ worked — but only incidentally, because it happens to call `session.merge(case)` |
| L403 | **case auto-assigned to an analyst** | ❌ **silently discarded** |
| L470 | **case escalated** (`Escalated to {x}: {reason}`) | ❌ **silently discarded** |

So auto-assignment and escalation never appeared in a case timeline. Both are exactly what an analyst or auditor would go looking for after the fact.

**`cases.activities` was unaffected**, and it's worth saying why rather than leaving it ambiguous: every write there goes through explicit assignment rather than in-place mutation — `update_case(case_id, activities=...)` at `backend/api/cases.py:345`, and the merge path rebuilds the list with `+` at `:1112-1113`, which is also why the later `.append()` at `:1138` *does* persist. The bug is specific to the in-place pattern.

## The fix

Declare the appendable collection columns with `MutableList.as_mutable(JSONB)`, via a named `MutableJSONBList` alias carrying the explanation. Preferred over sprinkling `flag_modified()` at each call site, because the next `.append()` anyone writes is then correct **by default** rather than correct-if-remembered.

Applied to the four `cases` collections plus `case_evidence.chain_of_custody` — a vanished append there would be a hole in an evidence audit trail. (#549 moves that column to its own table, removing the exposure entirely; this is the interim guard.)

**Also fixes every shared-mutable default in the file:** 8 × `default=[]` and 4 × `default={}` become `default=list` / `default=dict`. SQLAlchemy treats a non-callable default as a scalar constant, so all rows shared one object. The file already used the factory form in 23 places — this removes the second convention, and a test pins it so the two can't drift apart again.

## Tests — both verified to fail before the fix

**`tests/unit/test_jsonb_mutation_tracking.py`** — 11 tests, **no database**, so they run in the main PR gate. Asserts each column coerces to `MutableList` and that an in-place append fires a change event, plus the no-shared-defaults guard.

```
pre-fix:   11 failed
post-fix:  11 passed
```

**`tests/integration/test_case_timeline_persistence.py`** — the end-to-end symptom. Appends, commits, re-reads in a **fresh session** with its own identity map, so a stale cached object can't make it pass spuriously. Also covers repeated appends in one transaction, which catches tracking that fires only on the first mutation.

```
pre-fix:   expected all three in order, got []
post-fix:  2 passed
```

## Regressions

| Suite | Result |
|---|---|
| unit | **1070 passed**, 13 failed — the same 13 pre-existing failures |
| security | **84 passed** |
| integration | 6 failed — **identical to the 6 on clean `main`** |

The integration baseline was taken in a throwaway worktree at `311790e` rather than assumed: **zero new failures**.

## Scope

No schema change, so no migration, no init-SQL and no Helm work. No API change — `Case.to_dict()` output is unchanged. This is ORM-layer only, and it's worth landing regardless of whether #544 and #545 are ever approved.

Found while auditing the JSONB columns for #468 (#546); it's the reason `cases.timeline` and `case_evidence.chain_of_custody` are classified promote rather than keep.

Closes #543
Relates to #468, #544, #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)