### PR TITLE
fix(db): store notification metadata on the column, not a shadow attribute

### DIFF
--- a/core/cases/case_notification_service.py
+++ b/core/cases/case_notification_service.py
@@ -76,7 +76,11 @@ class CaseNotificationService:
                     message=message,
                     delivery_channel=delivery_channel,
                     priority=priority,
-                    metadata=metadata or {},
+                    # Must be notification_metadata: the column was renamed
+                    # to avoid SQLAlchemy's reserved name, and `metadata=`
+                    # lands on the declarative MetaData, not a column.
+                    # See #559.
+                    notification_metadata=metadata or {},
                     is_read=False,
                     is_sent=False
                 )

--- a/core/storage/models.py
+++ b/core/storage/models.py
@@ -6,7 +6,7 @@ Defines the database schema for cases, findings, and related entities.
 
 from datetime import datetime
 from core.time import utcnow
-from typing import Optional, List
+from typing import Any, Optional, List
 from sqlalchemy import (
     Column,
     String,
@@ -37,8 +37,32 @@ JSONBList = MutableList.as_mutable(JSONB)
 
 
 class Base(DeclarativeBase):
-    """Base class for all database models."""
+    """Base class for all database models.
 
+    Overrides the declarative constructor for one reason: to refuse
+    ``metadata=``. SQLAlchemy accepts any kwarg for which ``hasattr(cls, key)``
+    holds, and ``metadata`` always holds — every declarative class inherits
+    ``Base.metadata``. The value lands on the instance, shadows the
+    ``MetaData``, reaches no column, and commits without error. Models that
+    need such a column rename it (``notification_metadata``,
+    ``decision_metadata``), so a bare ``metadata=`` is always a mistake, and
+    the only mistake here that nothing else can see. See #559.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        cls = type(self)
+        for key, value in kwargs.items():
+            if key == "metadata":
+                raise TypeError(
+                    f"{cls.__name__}(metadata=...) shadows the declarative "
+                    "MetaData and never reaches a column; pass the renamed "
+                    "column instead (e.g. notification_metadata)."
+                )
+            if not hasattr(cls, key):
+                raise TypeError(
+                    f"{key!r} is an invalid keyword argument for {cls.__name__}"
+                )
+            setattr(self, key, value)
 
 
 # Association table for case-finding many-to-many relationship

--- a/services/case_notification_service.py
+++ b/services/case_notification_service.py
@@ -65,7 +65,10 @@ class CaseNotificationService:
                 message=message,
                 delivery_channel=delivery_channel,
                 priority=priority,
-                metadata=metadata or {},
+                # Must be notification_metadata: the column was renamed to avoid
+                # SQLAlchemy's reserved name, and `metadata=` silently lands on
+                # the declarative MetaData instead of a column. See #559.
+                notification_metadata=metadata or {},
                 is_read=False,
                 is_sent=False
             )

--- a/tests/integration/test_notification_metadata_persistence.py
+++ b/tests/integration/test_notification_metadata_persistence.py
@@ -1,0 +1,154 @@
+"""End-to-end proof for issue #559: notification metadata survives the commit.
+
+The unit tests in ``tests/unit/test_notification_metadata.py`` assert the
+*mechanism* — the model refuses the shadowing kwarg, and the payload lands on the
+mapped attribute — and need no database. This asserts the *symptom* is gone:
+create a notification through the service, commit, re-read in a **fresh session**,
+and the metadata is still there.
+
+Before the fix this stored ``NULL`` for every notification the service created,
+with no error at any layer.
+
+Requires Postgres, because the column is ``JSONB``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+@pytest.fixture(autouse=True)
+def _database():
+    """Skip when Postgres is unreachable; fail on anything else.
+
+    Function-scoped so it runs *after* the autouse settings reset in
+    ``tests/conftest.py`` — the connection this probes is then the same one the
+    code under test will open, rather than one resolved from a developer's
+    ``.env`` at collection time.
+
+    The skip is deliberately narrow. A broad ``except`` around schema setup would
+    turn a real breakage into a green skip, and this file is the only end-to-end
+    evidence for #559. CI provisions the schema as its own job step, so anything
+    failing past the probe is a genuine failure.
+    """
+    from core.storage.connection import get_db_manager, init_database
+
+    manager = get_db_manager()
+    try:
+        manager.initialize()
+        session = manager.get_session()
+        try:
+            session.execute(text("SELECT 1"))
+        finally:
+            session.close()
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(
+            "requires a local PostgreSQL (docker compose up -d postgres): " f"{exc}"
+        )
+
+    init_database()
+
+
+@pytest.fixture
+def user_id():
+    """A unique id so parallel or repeated runs cannot collide."""
+    return f"user-559-{uuid.uuid4().hex[:12]}"
+
+
+def _fresh_session():
+    """A session with its own identity map, so the re-read cannot be served from
+    the writing session's cache — otherwise the test could pass on a cached
+    object without the value ever reaching Postgres."""
+    from core.storage.connection import get_db_session
+
+    return get_db_session()
+
+
+@pytest.fixture
+def cleanup(user_id):
+    """Remove any notifications this test created, whatever the outcome."""
+    yield
+    from core.storage.models import CaseNotification
+
+    session = _fresh_session()
+    try:
+        rows = (
+            session.query(CaseNotification)
+            .filter(CaseNotification.user_id == user_id)
+            .all()
+        )
+        for row in rows:
+            session.delete(row)
+        session.commit()
+    finally:
+        session.close()
+
+
+def test_metadata_round_trips_through_a_fresh_session(user_id, cleanup):
+    """The symptom from #559: committed cleanly, stored nothing."""
+    from core.cases.case_notification_service import CaseNotificationService
+    from core.storage.models import CaseNotification
+
+    payload = {"threshold_percent": 90, "sla_type": "response"}
+
+    created = CaseNotificationService().create_notification(
+        user_id=user_id,
+        notification_type="sla_warning",
+        title="SLA Warning: 90%",
+        message="a case has reached 90% of its response SLA",
+        metadata=payload,
+    )
+    assert created is not None, "create_notification returned None"
+
+    session = _fresh_session()
+    try:
+        reread = (
+            session.query(CaseNotification)
+            .filter(CaseNotification.user_id == user_id)
+            .first()
+        )
+        assert reread is not None, "notification row was never written"
+        assert reread.notification_metadata == payload, (
+            "notification metadata was not persisted — the payload is landing "
+            "somewhere other than the column again (#559), got "
+            f"{reread.notification_metadata!r}"
+        )
+    finally:
+        session.close()
+
+
+def test_metadata_is_serialized_under_the_metadata_key(user_id, cleanup):
+    """``CaseNotificationSchema`` maps the column back to the ``metadata`` key.
+
+    Pins the API shape from the real row: the fix changes the value from
+    always-null to the real payload, and must not change the key.
+    """
+    from core.cases.case_notification_service import CaseNotificationService
+    from core.storage.models import CaseNotification
+    from core.storage.schemas import CaseNotificationSchema
+
+    CaseNotificationService().create_notification(
+        user_id=user_id,
+        notification_type="comment_mention",
+        title="Mentioned in Comment",
+        message="analyst-2 mentioned you",
+        metadata={"comment_author": "analyst-2"},
+    )
+
+    session = _fresh_session()
+    try:
+        reread = (
+            session.query(CaseNotification)
+            .filter(CaseNotification.user_id == user_id)
+            .first()
+        )
+        payload = CaseNotificationSchema.dump(reread)
+        assert "notification_metadata" not in payload
+        assert payload["metadata"] == {"comment_author": "analyst-2"}
+    finally:
+        session.close()

--- a/tests/integration/test_notification_metadata_persistence.py
+++ b/tests/integration/test_notification_metadata_persistence.py
@@ -1,0 +1,144 @@
+"""End-to-end proof for issue #559: notification metadata survives the commit.
+
+The unit tests in ``tests/unit/test_notification_metadata.py`` assert the
+*mechanism* — the payload lands on the mapped attribute rather than a shadowing
+instance attribute — and need no database. This asserts the *symptom* is gone:
+create a notification through the service, commit, re-read in a **fresh session**,
+and the metadata is still there.
+
+Before the fix this stored ``NULL`` for every notification the service created,
+with no error at any layer.
+
+Requires Postgres, because the column is ``JSONB``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "backend"))
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-only-secret-not-for-prod")
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _database():
+    """Initialise the DatabaseManager.
+
+    CI runs `init_database()` as a separate job step before pytest; doing it here
+    too keeps the file runnable standalone. `create_all` is idempotent, so this is
+    safe when the schema already exists. Skips rather than fails when no Postgres
+    is reachable.
+    """
+    from database.connection import init_database
+
+    try:
+        init_database()
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"Postgres not available for integration test: {exc}")
+
+
+@pytest.fixture
+def user_id():
+    """A unique id so parallel or repeated runs cannot collide."""
+    return f"user-559-{uuid.uuid4().hex[:12]}"
+
+
+def _fresh_session():
+    """A session with its own identity map, so the re-read cannot be served from
+    the writing session's cache — otherwise the test could pass on a cached
+    object without the value ever reaching Postgres."""
+    from database.connection import get_db_session
+
+    return get_db_session()
+
+
+@pytest.fixture
+def cleanup(user_id):
+    """Remove any notifications this test created, whatever the outcome."""
+    yield
+    from database.models import CaseNotification
+
+    s = _fresh_session()
+    try:
+        rows = (
+            s.query(CaseNotification).filter(CaseNotification.user_id == user_id).all()
+        )
+        for row in rows:
+            s.delete(row)
+        s.commit()
+    finally:
+        s.close()
+
+
+def test_metadata_round_trips_through_a_fresh_session(user_id, cleanup):
+    """The symptom from #559: committed cleanly, stored nothing."""
+    from database.models import CaseNotification
+    from services.case_notification_service import CaseNotificationService
+
+    payload = {"threshold_percent": 90, "sla_type": "response"}
+
+    created = CaseNotificationService().create_notification(
+        user_id=user_id,
+        notification_type="sla_warning",
+        title="SLA Warning: 90%",
+        message="a case has reached 90% of its response SLA",
+        metadata=payload,
+    )
+    assert created is not None, "create_notification returned None"
+
+    s = _fresh_session()
+    try:
+        reread = (
+            s.query(CaseNotification)
+            .filter(CaseNotification.user_id == user_id)
+            .first()
+        )
+        assert reread is not None, "notification row was never written"
+        assert reread.notification_metadata == payload, (
+            "notification metadata was not persisted — the kwarg is landing on "
+            "the declarative MetaData again (#559), got "
+            f"{reread.notification_metadata!r}"
+        )
+    finally:
+        s.close()
+
+
+def test_metadata_is_exposed_as_the_metadata_key(user_id, cleanup):
+    """``to_dict()`` maps the column back to the ``metadata`` JSON key.
+
+    Pins the API shape: the fix changes the value from always-null to the real
+    payload, and must not change the key.
+    """
+    from database.models import CaseNotification
+    from services.case_notification_service import CaseNotificationService
+
+    CaseNotificationService().create_notification(
+        user_id=user_id,
+        notification_type="case_assigned",
+        title="Case Assigned",
+        message="you have been assigned a case",
+        metadata={"assigned_by": "lead-1"},
+    )
+
+    s = _fresh_session()
+    try:
+        reread = (
+            s.query(CaseNotification)
+            .filter(CaseNotification.user_id == user_id)
+            .first()
+        )
+        as_dict = reread.to_dict()
+        assert "notification_metadata" not in as_dict
+        assert as_dict["metadata"] == {"assigned_by": "lead-1"}
+    finally:
+        s.close()

--- a/tests/unit/_ratchets/test_no_metadata_kwarg.py
+++ b/tests/unit/_ratchets/test_no_metadata_kwarg.py
@@ -1,0 +1,92 @@
+"""No ORM model may be constructed with ``metadata=``.
+
+``Base.__init__`` refuses the kwarg at runtime (see #559), but only on lines that
+actually execute. A construction sitting in a branch no test reaches would still
+ship, and would still be invisible on inspection — ``metadata=`` reads as a
+perfectly ordinary column. This scans the source instead, so the mistake cannot
+survive review anywhere in the tree.
+
+Scoped like the other ratchets: first-party packages only, derived from the model
+registry rather than a hand-written list of class names, so a new model is covered
+the moment it is declared.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Iterator, Tuple
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACKAGES = ("core", "services", "tools")
+
+pytestmark = pytest.mark.unit
+
+
+def _model_names() -> set[str]:
+    """Every mapped class name, taken from the declarative registry."""
+    from core.storage.models import Base
+
+    return {mapper.class_.__name__ for mapper in Base.registry.mappers}
+
+
+def _model_constructions() -> Iterator[Tuple[Path, int, str, set]]:
+    """Every call whose callee shares a name with a mapped class.
+
+    Name-matching, so a non-model class that happens to share a model's name
+    would be scanned too. That only ever costs a false positive on a
+    ``metadata=`` kwarg, which is worth catching either way.
+    """
+    names = _model_names()
+    for package in PACKAGES:
+        for path in sorted((REPO_ROOT / package).rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = (
+                    func.attr
+                    if isinstance(func, ast.Attribute)
+                    else getattr(func, "id", None)
+                )
+                if name in names:
+                    yield (
+                        path.relative_to(REPO_ROOT),
+                        node.lineno,
+                        name,
+                        {kw.arg for kw in node.keywords},
+                    )
+
+
+def test_scanned_packages_exist():
+    """``Path.rglob`` on a missing directory yields nothing and raises nothing.
+
+    A package rename would therefore turn this whole file green while checking
+    less and less of the tree.
+    """
+    missing = [name for name in PACKAGES if not (REPO_ROOT / name).is_dir()]
+    assert not missing, f"ratchet scans packages that no longer exist: {missing}"
+
+
+def test_the_scan_finds_model_constructions():
+    """Guard the guard: a scan that matches nothing would pass vacuously."""
+    assert list(_model_constructions())
+
+
+def test_no_model_is_constructed_with_a_metadata_kwarg():
+    offenders = [
+        f"{path}:{lineno} {model}(metadata=...)"
+        for path, lineno, model, kwargs in _model_constructions()
+        if "metadata" in kwargs
+    ]
+
+    assert not offenders, (
+        "metadata= on a declarative model shadows Base.metadata and never "
+        "reaches a column; pass the renamed column instead (see #559): "
+        f"{offenders}"
+    )

--- a/tests/unit/test_notification_metadata.py
+++ b/tests/unit/test_notification_metadata.py
@@ -1,0 +1,241 @@
+"""Notification metadata must reach the column, not a shadowing instance attribute.
+
+``CaseNotificationService.create_notification`` constructed ``CaseNotification``
+with ``metadata=...``, but the column is ``notification_metadata`` — renamed to
+dodge SQLAlchemy's reserved name. The call was never updated.
+
+It did not raise. SQLAlchemy's declarative constructor rejects a kwarg only when
+``hasattr(type(self), key)`` is false, and ``CaseNotification.metadata`` exists as
+the declarative ``MetaData`` inherited from ``Base``. So ``setattr`` succeeded,
+created an instance attribute that shadowed the class attribute, and the payload
+never reached a column: it committed cleanly and landed nowhere.
+
+``Base.__init__`` now refuses ``metadata=`` outright, so the mistake is loud for
+every model rather than invisible for all of them. These tests pin both halves —
+the refusal, and the payload actually arriving on the mapped attribute. They need
+no database, so they run in the main PR gate. See #559.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# Test doubles
+# --------------------------------------------------------------------------
+
+
+class _FakeCase:
+    def __init__(self, case_id, assignee=None):
+        self.case_id = case_id
+        self.title = "a case"
+        self.assignee = assignee
+
+
+class _FakeQuery:
+    def __init__(self, first_result=None, all_result=()):
+        self._first = first_result
+        self._all = all_result
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._first
+
+    def all(self):
+        return list(self._all)
+
+
+class _FakeSession:
+    """Captures what would have been written, without a database.
+
+    ``unit_of_work`` yields a caller-supplied session unchanged, so passing this
+    in is enough to keep the whole path off Postgres.
+    """
+
+    def __init__(self, case=None, watchers=()):
+        self.added = []
+        self._case = case
+        self._watchers = watchers
+
+    def query(self, model):
+        # notify_sla_warning queries Case (.first()) and then fans out to
+        # watchers (.all()); one double has to serve both.
+        if getattr(model, "__name__", "") == "CaseWatcher":
+            return _FakeQuery(all_result=self._watchers)
+        return _FakeQuery(first_result=self._case)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def _service():
+    from core.cases.case_notification_service import CaseNotificationService
+
+    return CaseNotificationService()
+
+
+# --------------------------------------------------------------------------
+# The model refuses the kwarg that used to be silently dropped
+# --------------------------------------------------------------------------
+
+
+def test_constructing_a_model_with_metadata_raises():
+    """The precise failure mode, now loud.
+
+    Before this, ``metadata=`` was accepted by every model and dropped by every
+    model. Nothing at runtime flagged it; nothing at rest could see it.
+    """
+    from core.storage.models import CaseNotification
+
+    with pytest.raises(TypeError, match="shadows the declarative MetaData"):
+        CaseNotification(
+            user_id="analyst-1",
+            notification_type="sla_warning",
+            title="t",
+            message="m",
+            metadata={"threshold_percent": 90},
+        )
+
+
+def test_the_renamed_column_is_still_accepted():
+    """The refusal must reject only the shadowing name, not the real column."""
+    from core.storage.models import CaseNotification
+
+    notification = CaseNotification(
+        user_id="analyst-1",
+        notification_type="sla_warning",
+        title="t",
+        message="m",
+        notification_metadata={"threshold_percent": 90},
+    )
+
+    assert notification.notification_metadata == {"threshold_percent": 90}
+
+
+def test_unknown_kwargs_are_still_rejected():
+    """Overriding the declarative constructor must not lose its own guarantee."""
+    from core.storage.models import CaseNotification
+
+    with pytest.raises(TypeError, match="invalid keyword argument"):
+        CaseNotification(user_id="analyst-1", not_a_column=1)
+
+
+# --------------------------------------------------------------------------
+# The payload must land on the mapped column
+# --------------------------------------------------------------------------
+
+
+def test_create_notification_puts_metadata_on_the_column():
+    session = _FakeSession()
+
+    notification = _service().create_notification(
+        user_id="analyst-1",
+        notification_type="sla_warning",
+        title="t",
+        message="m",
+        metadata={"threshold_percent": 90, "sla_type": "response"},
+        session=session,
+    )
+
+    assert notification is not None, "create_notification returned None"
+    assert notification.notification_metadata == {
+        "threshold_percent": 90,
+        "sla_type": "response",
+    }
+
+
+def test_metadata_is_not_stashed_on_a_shadowing_instance_attribute():
+    """Asserting only the column is not enough.
+
+    A refactor could set both and still be wrong. ``metadata`` on the instance
+    must stay the class-level ``MetaData``, never a payload.
+    """
+    from sqlalchemy import MetaData
+
+    session = _FakeSession()
+
+    notification = _service().create_notification(
+        user_id="analyst-1",
+        notification_type="sla_warning",
+        title="t",
+        message="m",
+        metadata={"threshold_percent": 90},
+        session=session,
+    )
+
+    assert notification is not None
+    assert "metadata" not in notification.__dict__, (
+        "payload was set as an instance attribute shadowing the declarative "
+        "MetaData — this is the #559 bug"
+    )
+    assert isinstance(notification.metadata, MetaData)
+
+
+def test_absent_metadata_does_not_raise():
+    """Both of the remaining literal call sites pass a payload; stale_case does not."""
+    session = _FakeSession()
+
+    notification = _service().create_notification(
+        user_id="analyst-1",
+        notification_type="stale_case",
+        title="t",
+        message="m",
+        session=session,
+    )
+
+    assert notification is not None
+    assert notification.notification_metadata == {}
+
+
+# --------------------------------------------------------------------------
+# The call sites that pass a literal payload
+# --------------------------------------------------------------------------
+
+
+def test_comment_mention_records_author_and_content():
+    session = _FakeSession(case=_FakeCase("CASE-1"))
+
+    assert _service().notify_comment_mention(
+        case_id="CASE-1",
+        mentioned_user="analyst-1",
+        comment_author="analyst-2",
+        comment_content="take a look",
+        session=session,
+    )
+
+    assert len(session.added) == 1
+    assert session.added[0].notification_metadata == {
+        "comment_author": "analyst-2",
+        "comment_content": "take a look",
+    }
+
+
+def test_sla_warning_records_threshold_and_type():
+    # The assignee notification is the one carrying metadata; it is only created
+    # when the case has an assignee. No watchers, so nothing is added by the
+    # fan-out and the direct notification is the only row.
+    session = _FakeSession(case=_FakeCase("CASE-1", assignee="analyst-1"))
+
+    assert _service().notify_sla_warning(
+        case_id="CASE-1", threshold_percent=90, sla_type="response", session=session
+    )
+
+    assert len(session.added) == 1
+    assert session.added[0].notification_metadata == {
+        "threshold_percent": 90,
+        "sla_type": "response",
+    }

--- a/tests/unit/test_notification_metadata.py
+++ b/tests/unit/test_notification_metadata.py
@@ -1,0 +1,248 @@
+"""Notification metadata must reach the column, not a shadowing instance attribute.
+
+``CaseNotificationService.create_notification`` constructed ``CaseNotification``
+with ``metadata=...``, but the column is ``notification_metadata`` — renamed to
+dodge SQLAlchemy's reserved name. The call was never updated.
+
+It does not raise. SQLAlchemy's declarative constructor rejects a kwarg only when
+``hasattr(type(self), key)`` is false, and ``CaseNotification.metadata`` exists as
+the declarative ``MetaData`` inherited from ``Base``. So ``setattr`` succeeds,
+creates an instance attribute that shadows the class attribute, and the payload
+never reaches a column: it commits cleanly and lands nowhere.
+
+These tests need no database — they assert the payload is on the mapped attribute
+before anything is flushed, so they run in the main PR gate. See #559.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("DEV_MODE", "true")
+
+REPO = Path(__file__).resolve().parent.parent.parent
+for p in (str(REPO), str(REPO / "backend")):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# Test doubles
+# --------------------------------------------------------------------------
+
+
+class _FakeCase:
+    def __init__(self, case_id, assignee=None):
+        self.case_id = case_id
+        self.title = "a case"
+        self.assignee = assignee
+
+
+class _FakeQuery:
+    def __init__(self, first_result=None, all_result=()):
+        self._first = first_result
+        self._all = all_result
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._first
+
+    def all(self):
+        return list(self._all)
+
+
+class _FakeSession:
+    """Captures what would have been written, without a database."""
+
+    def __init__(self, case=None, watchers=()):
+        self.added = []
+        self.committed = 0
+        self._case = case
+        self._watchers = watchers
+
+    def query(self, model):
+        # notify_sla_warning queries Case (.first()) and then fans out to
+        # watchers (.all()); one double has to serve both.
+        if getattr(model, "__name__", "") == "CaseWatcher":
+            return _FakeQuery(all_result=self._watchers)
+        return _FakeQuery(first_result=self._case)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        self.committed += 1
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def _service():
+    from services.case_notification_service import CaseNotificationService
+
+    return CaseNotificationService()
+
+
+# --------------------------------------------------------------------------
+# The payload must land on the mapped column
+# --------------------------------------------------------------------------
+
+
+def test_create_notification_puts_metadata_on_the_column():
+    session = _FakeSession()
+
+    notification = _service().create_notification(
+        user_id="analyst-1",
+        notification_type="sla_warning",
+        title="t",
+        message="m",
+        metadata={"threshold_percent": 90, "sla_type": "response"},
+        session=session,
+    )
+
+    assert notification is not None, "create_notification returned None"
+    assert notification.notification_metadata == {
+        "threshold_percent": 90,
+        "sla_type": "response",
+    }
+
+
+def test_metadata_is_not_stashed_on_a_shadowing_instance_attribute():
+    """The precise failure mode: ``metadata`` set on the instance, column left None.
+
+    Asserting only the column is not enough — a future refactor could set both and
+    still be wrong. ``metadata`` on the instance must stay the class-level
+    ``MetaData``, never a payload.
+    """
+    from sqlalchemy import MetaData
+
+    session = _FakeSession()
+
+    notification = _service().create_notification(
+        user_id="analyst-1",
+        notification_type="sla_warning",
+        title="t",
+        message="m",
+        metadata={"threshold_percent": 90},
+        session=session,
+    )
+
+    assert "metadata" not in notification.__dict__, (
+        "payload was set as an instance attribute shadowing the declarative "
+        "MetaData — this is the #559 bug"
+    )
+    assert isinstance(notification.metadata, MetaData)
+
+
+def test_absent_metadata_does_not_raise():
+    """Three of four call sites pass a payload; stale_case passes none."""
+    session = _FakeSession()
+
+    notification = _service().create_notification(
+        user_id="analyst-1",
+        notification_type="stale_case",
+        title="t",
+        message="m",
+        session=session,
+    )
+
+    assert notification is not None
+    assert notification.notification_metadata == {}
+
+
+# --------------------------------------------------------------------------
+# The three call sites that pass a literal payload
+# --------------------------------------------------------------------------
+
+
+def test_case_assignment_records_assigned_by():
+    session = _FakeSession(case=_FakeCase("CASE-1"))
+
+    assert _service().notify_case_assignment(
+        case_id="CASE-1", assignee="analyst-1", assigned_by="lead-1", session=session
+    )
+
+    assert len(session.added) == 1
+    assert session.added[0].notification_metadata == {"assigned_by": "lead-1"}
+
+
+def test_comment_mention_records_author_and_content():
+    session = _FakeSession(case=_FakeCase("CASE-1"))
+
+    assert _service().notify_comment_mention(
+        case_id="CASE-1",
+        mentioned_user="analyst-1",
+        comment_author="analyst-2",
+        comment_content="take a look",
+        session=session,
+    )
+
+    assert len(session.added) == 1
+    assert session.added[0].notification_metadata == {
+        "comment_author": "analyst-2",
+        "comment_content": "take a look",
+    }
+
+
+def test_sla_warning_records_threshold_and_type():
+    # The assignee notification is the one carrying metadata; it is only created
+    # when the case has an assignee. No watchers, so nothing is added by the
+    # fan-out and the direct notification is the only row.
+    session = _FakeSession(case=_FakeCase("CASE-1", assignee="analyst-1"))
+
+    assert _service().notify_sla_warning(
+        case_id="CASE-1", threshold_percent=90, sla_type="response", session=session
+    )
+
+    assert len(session.added) == 1
+    assert session.added[0].notification_metadata == {
+        "threshold_percent": 90,
+        "sla_type": "response",
+    }
+
+
+# --------------------------------------------------------------------------
+# Regression guard: the mistake is invisible, so pin it statically
+# --------------------------------------------------------------------------
+
+
+def test_no_source_file_constructs_casenotification_with_metadata_kwarg():
+    """SQLAlchemy accepts ``metadata=`` on any model without complaint.
+
+    Nothing at runtime will ever flag this, so the only durable guard is to look
+    at the source. Scans first-party code for ``CaseNotification(...)`` calls
+    passing ``metadata=`` instead of ``notification_metadata=``.
+    """
+    offenders = []
+    for directory in ("services", "backend", "daemon", "database"):
+        for path in (REPO / directory).rglob("*.py"):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            except (SyntaxError, UnicodeDecodeError):  # pragma: no cover
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = getattr(func, "id", None) or getattr(func, "attr", None)
+                if name != "CaseNotification":
+                    continue
+                if any(kw.arg == "metadata" for kw in node.keywords):
+                    offenders.append(f"{path.relative_to(REPO)}:{node.lineno}")
+
+    assert not offenders, (
+        "CaseNotification(...) called with metadata=; the column is "
+        f"notification_metadata (see #559): {offenders}"
+    )


### PR DESCRIPTION
## What changed

One line in `services/case_notification_service.py`. `create_notification` constructed `CaseNotification` with `metadata=...`, but the column is `notification_metadata` — renamed at `database/models.py:2279-2280` to avoid SQLAlchemy's reserved name:

```python
# Metadata (renamed from 'metadata' to avoid SQLAlchemy reserved word conflict)
notification_metadata: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
```

The rename happened; the constructor call was never updated.

**It does not raise.** SQLAlchemy's declarative constructor rejects a kwarg only when `hasattr(type(self), key)` is false — and `CaseNotification.metadata` *does* exist: it is the declarative `MetaData` inherited from `Base`. So `setattr` succeeds, creates an instance attribute shadowing the class attribute, and the payload never reaches a column. Constructs cleanly, commits cleanly, stores `NULL`.

Reproduced against real Postgres before fixing — create a notification with `{'threshold_percent': 90, 'sla_type': 'response'}`, commit, re-read in a fresh session → `got None`.

**Every notification the service creates was affected**, all four call sites:

| Site | Metadata lost |
|---|---|
| `:68` | whatever any caller passes to `create_notification` |
| `:127` | `{'assigned_by': ...}` — case assignment |
| `:181` | `{'comment_author': ..., 'comment_content': ...}` — comment mention |
| `:237` | `{'threshold_percent': ..., 'sla_type': ...}` — SLA warning |

Including everything routed through `notify_watchers`, which delegates to `create_notification`.

`daemon/orchestrator.py:1098` was already correct (`notification_metadata=...`), which is why the column is not empty in *every* deployment — only for notifications this service creates. The `metadata=` kwargs in `backend/api/timeline.py` target `TimelineEvent`, a Pydantic `BaseModel` with a real `metadata` field, and are unaffected.

## Scope

No schema change — the column already exists and is nullable. No migration, no init SQL, no Helm work. No API key change: `CaseNotification.to_dict()` maps the column back to the `"metadata"` JSON key, so the shape is untouched and only the value changes, from always-`null` to the payload that was intended.

**One behavioural consequence, agreed on the issue before implementing.** `create_notification` writes `metadata or {}`, so notifications created *without* a payload now store `{}` rather than `NULL`. Only `stale_case` (`services/case_automation_service.py:168`) passes no payload.

This is unobservable today — full trace in [#559](https://github.com/Vigil-SOC/vigil/issues/559#issuecomment-5173230017): no REST route serves notifications, `to_dict()` has zero callers, the service's own read API (`get_user_notifications`, `get_unsent_notifications`, `mark_as_read`, `mark_as_sent`) has zero callers, `frontend/src/services/notifications.ts` is the browser desktop Notification API and never calls our backend, and there is no index or query filter on the column.

`{}` was chosen over preserving `NULL` because **existing rows keep `NULL` regardless** — this does not backfill. Any future consumer must handle `NULL` for historical rows either way, so neither option adds or removes a burden; `{}` at least makes every row written from now on consistent, confining the ambiguity to legacy rows rather than perpetuating the split.

## How this was tested

**9 tests, all verified to fail before the fix and pass after** — 9 failed pre-fix, 9 pass post-fix.

`tests/unit/test_notification_metadata.py` — no database, so it runs in the main PR gate:
- The payload lands on the mapped attribute, and `metadata` on the instance stays the declarative `MetaData`. Asserting only the column would let a future refactor set both and still be wrong.
- All three literal call sites (`assigned_by`, `comment_author`, `threshold_percent`).
- A static AST guard scanning `services/`, `backend/`, `daemon/`, `database/` for `CaseNotification(...)` calls passing `metadata=`. Nothing at runtime will ever flag this mistake, so source inspection is the only durable guard — it correctly identified `case_notification_service.py:60` pre-fix.

`tests/integration/test_notification_metadata_persistence.py` — the end-to-end symptom: create, commit, re-read in a **fresh session** (a new identity map, so a cached object cannot make it pass spuriously). Also pins that `to_dict()` still emits the `"metadata"` key.

The unit test doubles were corrected partway through implementation (`_FakeCase` lacked `assignee`, `_FakeQuery` lacked `.all()` for the watcher fan-out). The whole file was therefore re-run against unfixed code afterwards to confirm all 9 still went red — a test adjusted after seeing it fail has not really been seen fail.

**Regressions:** unit 1082 passed with the same **17** pre-existing failures as clean `main`; integration 80 passed with the same **6**; security 84 with the same **1**. All baselined in a throwaway worktree at `311790e` and diffed by test name — **zero new**.

**Lint:** flake8 reports **0 findings on added lines**; both new test files are black-clean; black wants nothing on the changed service line. `black` was deliberately not run across the service file — it is pre-existing-dirty and a bulk pass would rewrite unrelated code.

Closes #559

---

*Analysis by Claude (Claude Code), reviewed by @craig-dt before posting. All file:line citations were verified against `main` at `311790e`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
