### PR TITLE
test: drive the preflight coroutines with asyncio.run

### DIFF
--- a/tests/unit/test_agent_runner_preflight.py
+++ b/tests/unit/test_agent_runner_preflight.py
@@ -76,7 +76,11 @@ def _stub_estimate(high_usd: float, low_usd: float = 0.0, source: str = "exact")
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # asyncio.run() creates, drives, and closes its own event loop, so this is
+    # robust regardless of whether a prior test left a current loop set. On
+    # Python 3.13, asyncio.get_event_loop() raises when no loop is current —
+    # which happened once an async test file ran earlier in the session (#442).
+    return asyncio.run(coro)
 
 
 def test_preflight_proceeds_when_estimate_fits_budget():


### PR DESCRIPTION
Closes #442.

All 5 tests in `tests/unit/test_agent_runner_preflight.py` fail in CI's
`Unit Tests - Backend` job and pass when the file is run on its own. This is a
test-isolation bug, not a product bug.

## Cause

`_run()` drove each coroutine through the *current* event loop:

```python
def _run(coro):
    return asyncio.get_event_loop().run_until_complete(coro)
```

On Python 3.13 `asyncio.get_event_loop()` raises when no loop is current, and that
is exactly the state left behind once an async test file has already run in the same
pytest process:

```
RuntimeError: There is no current event loop in thread 'MainThread'.
<sys>:0: RuntimeWarning: coroutine 'AgentRunner._preflight_budget_blocked' was never awaited
```

So the outcome depends on collection order, which is why the file passes in
isolation and fails in the suite.

## Fix

`asyncio.run()` creates, drives, and closes its own loop, so it does not depend on a
current loop existing.

## Reproduction

#442's own repro, against Python 3.13.9:

```
pytest tests/unit/test_openai_agent_service.py \
       tests/unit/test_agent_runner_preflight.py -q

# before: 5 failed, 27 passed
# after:  32 passed
```

Full suite, diffed **by test name** against `main` at `311790e`: the only change is
those 5 tests going from red to green. No other test changes state in either
direction.

## Relationship to #451

The identical one-line change is also present in #451. It is **byte-identical**, so
the two do not conflict — verified by trial merge in both orderings:

```
git fetch origin main refs/pull/451/head:pr451
T=$(git merge-tree --write-tree origin/main HEAD)
C=$(git commit-tree $T -p origin/main -p HEAD -m trial)
git merge-tree --write-tree --name-only $C pr451   # clean, no conflict
```

It is extracted here because it is orthogonal to #451's LLM-provider-boundary work
and shouldn't wait on a 42-file feature PR: this failure is red on `main` today, and
the fix stands on its own. Nothing needs to change on #451 either way.

---

*Analysis by Claude (Claude Code), reviewed by @craig-dt before opening. The failure
and the fix were both reproduced locally on Python 3.13.9 against `main` at
`311790e`.*
