### PR TITLE
refactor: replace deprecated datetime.utcnow() with naive-UTC helper

### DIFF
--- a/core/auth/auth_service.py
+++ b/core/auth/auth_service.py
@@ -10,6 +10,7 @@ import logging
 import secrets
 import uuid
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Optional, Dict, Any, List
 import bcrypt
 import jwt
@@ -151,7 +152,7 @@ class AuthService:
             else timedelta(days=JWT_REFRESH_EXPIRATION_DAYS)
         )
 
-        now = datetime.utcnow()
+        now = utcnow()
         payload = {
             "user_id": user.user_id,
             "username": user.username,
@@ -238,7 +239,7 @@ class AuthService:
                 # Reject while locked. Lockout is authoritative even over a
                 # correct password — otherwise an attacker who eventually
                 # guesses right would bypass the wait.
-                now = datetime.utcnow()
+                now = utcnow()
                 if user.locked_until and user.locked_until > now:
                     logger.warning(
                         "Login rejected, account locked: %s until %s",

--- a/core/cases/case_automation_service.py
+++ b/core/cases/case_automation_service.py
@@ -6,7 +6,8 @@ Handles SLA monitoring, auto-assignment, escalation, and periodic tasks.
 
 import logging
 import asyncio
-from datetime import datetime, timedelta
+from datetime import timedelta
+from core.time import utcnow
 from typing import Dict, List
 
 from core.storage.unit_of_work import unit_of_work
@@ -71,7 +72,7 @@ class CaseAutomationService:
                     CaseSLA.is_paused == False
                 ).all()
 
-                current_time = datetime.utcnow()
+                current_time = utcnow()
 
                 for sla in active_slas:
                     # Get SLA status
@@ -148,7 +149,7 @@ class CaseAutomationService:
         try:
             with unit_of_work() as session:
                 # Define stale threshold (7 days)
-                stale_threshold = datetime.utcnow() - timedelta(days=7)
+                stale_threshold = utcnow() - timedelta(days=7)
 
                 # Find cases not updated recently
                 stale_cases = session.query(Case).filter(
@@ -178,7 +179,7 @@ class CaseAutomationService:
         while self.running:
             try:
                 # Calculate time until next 9 AM
-                now = datetime.utcnow()
+                now = utcnow()
                 next_run = now.replace(hour=9, minute=0, second=0, microsecond=0)
                 if now.hour >= 9:
                     next_run += timedelta(days=1)
@@ -199,7 +200,7 @@ class CaseAutomationService:
         try:
             with unit_of_work() as session:
                 # Get metrics for last 24 hours
-                yesterday = datetime.utcnow() - timedelta(days=1)
+                yesterday = utcnow() - timedelta(days=1)
                 metrics = self.metrics_service.get_dashboard_metrics(
                     start_date=yesterday,
                     session=session

--- a/core/cases/case_evidence_service.py
+++ b/core/cases/case_evidence_service.py
@@ -6,7 +6,7 @@ Handles file storage, chain of custody, and evidence tracking.
 
 import logging
 import hashlib
-from datetime import datetime
+from core.time import utcnow
 from pathlib import Path
 from typing import Dict, List, Optional
 from sqlalchemy.orm import Session
@@ -100,7 +100,7 @@ class CaseEvidenceService:
 
                 # Initialize chain of custody
                 chain_of_custody = [{
-                    'timestamp': datetime.utcnow().isoformat(),
+                    'timestamp': utcnow().isoformat(),
                     'action': 'collected',
                     'user': collected_by,
                     'notes': 'Evidence collected and added to case'
@@ -117,7 +117,7 @@ class CaseEvidenceService:
                     file_hash_sha256=file_hash_sha256,
                     source=source,
                     collected_by=collected_by,
-                    collected_at=datetime.utcnow(),
+                    collected_at=utcnow(),
                     chain_of_custody=chain_of_custody,
                     tags=tags or []
                 )
@@ -164,7 +164,7 @@ class CaseEvidenceService:
 
                 # Add new entry to chain of custody
                 entry = {
-                    'timestamp': datetime.utcnow().isoformat(),
+                    'timestamp': utcnow().isoformat(),
                     'action': action,
                     'user': user,
                     'notes': notes or ''

--- a/core/cases/case_ioc_service.py
+++ b/core/cases/case_ioc_service.py
@@ -7,6 +7,7 @@ Handles IOC tracking, enrichment, deduplication, and export.
 import logging
 import json
 from datetime import datetime
+from core.time import utcnow
 from typing import Dict, List, Optional
 from sqlalchemy.orm import Session
 from sqlalchemy import and_
@@ -81,8 +82,8 @@ class CaseIOCService:
                     threat_level=threat_level,
                     confidence=confidence,
                     source=source,
-                    first_seen=first_seen or datetime.utcnow(),
-                    last_seen=last_seen or datetime.utcnow(),
+                    first_seen=first_seen or utcnow(),
+                    last_seen=last_seen or utcnow(),
                     tags=tags or [],
                     context=context,
                     is_active=True,
@@ -267,7 +268,7 @@ class CaseIOCService:
                     'modified': ioc.updated_at.isoformat() + 'Z',
                     'pattern': f'[{stix_type}:value = \'{ioc.value}\']',
                     'pattern_type': 'stix',
-                    'valid_from': (ioc.first_seen.isoformat() + 'Z') if ioc.first_seen else datetime.utcnow().isoformat() + 'Z'
+                    'valid_from': (ioc.first_seen.isoformat() + 'Z') if ioc.first_seen else utcnow().isoformat() + 'Z'
                 }
 
                 if ioc.threat_level:

--- a/core/cases/case_metrics_service.py
+++ b/core/cases/case_metrics_service.py
@@ -6,6 +6,7 @@ Handles MTTD, MTTR, MTTA, SLA compliance, and analyst performance metrics.
 
 import logging
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Dict, Optional
 from sqlalchemy.orm import Session
 from sqlalchemy import and_
@@ -199,7 +200,7 @@ class CaseMetricsService:
             )
 
             # Cases opened per day (last 30 days)
-            thirty_days_ago = datetime.utcnow() - timedelta(days=30)
+            thirty_days_ago = utcnow() - timedelta(days=30)
             recent_cases = session.query(Case).filter(
                 Case.created_at >= thirty_days_ago
             ).all()
@@ -314,7 +315,7 @@ class CaseMetricsService:
             Dictionary with velocity data
         """
         with unit_of_work(session) as session:
-            start_date = datetime.utcnow() - timedelta(days=days)
+            start_date = utcnow() - timedelta(days=days)
 
             # Cases opened
             opened_cases = session.query(Case).filter(

--- a/core/cases/case_sla_service.py
+++ b/core/cases/case_sla_service.py
@@ -7,6 +7,7 @@ notifications, and reporting.
 
 import logging
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Dict, List, Optional, Tuple
 from sqlalchemy.orm import Session
 from sqlalchemy import and_
@@ -224,7 +225,7 @@ class CaseSLAService:
         """
         with unit_of_work(session) as session:
             if current_time is None:
-                current_time = datetime.utcnow()
+                current_time = utcnow()
 
             case_sla = session.query(CaseSLA).filter(
                 CaseSLA.case_id == case_id
@@ -274,7 +275,7 @@ class CaseSLAService:
             if not case_sla:
                 return None
 
-            current_time = datetime.utcnow()
+            current_time = utcnow()
 
             # Calculate time remaining
             response_remaining = None
@@ -377,7 +378,7 @@ class CaseSLAService:
                     return True
 
                 case_sla.is_paused = True
-                case_sla.paused_at = datetime.utcnow()
+                case_sla.paused_at = utcnow()
 
                 logger.info(f"SLA paused for case {case_id}: {reason}")
                 return True
@@ -418,7 +419,7 @@ class CaseSLAService:
                 # Calculate pause duration
                 if case_sla.paused_at:
                     pause_duration = (
-                        datetime.utcnow() - case_sla.paused_at
+                        utcnow() - case_sla.paused_at
                     ).total_seconds()
                     case_sla.total_pause_duration += int(pause_duration)
 
@@ -428,7 +429,7 @@ class CaseSLAService:
                     case_sla.resolution_due += pause_delta
 
                 case_sla.is_paused = False
-                case_sla.resumed_at = datetime.utcnow()
+                case_sla.resumed_at = utcnow()
 
                 logger.info(f"SLA resumed for case {case_id}")
                 return True
@@ -462,7 +463,7 @@ class CaseSLAService:
                 if not case_sla:
                     return False
 
-                current_time = datetime.utcnow()
+                current_time = utcnow()
                 case_sla.resolution_completed_at = current_time
                 case_sla.resolution_sla_met = current_time <= case_sla.resolution_due
 
@@ -490,7 +491,7 @@ class CaseSLAService:
             List of case dictionaries with SLA information
         """
         with unit_of_work(session) as session:
-            current_time = datetime.utcnow()
+            current_time = utcnow()
 
             # Get all active SLAs
             slas = session.query(CaseSLA).filter(

--- a/core/cases/case_workflow_service.py
+++ b/core/cases/case_workflow_service.py
@@ -6,7 +6,7 @@ and task automation.
 """
 
 import logging
-from datetime import datetime
+from core.time import utcnow
 from typing import Dict, List, Optional
 from sqlalchemy.orm import Session
 
@@ -60,7 +60,7 @@ class CaseWorkflowService:
         try:
             with unit_of_work(session) as session:
                 # Generate template ID
-                timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
+                timestamp = utcnow().strftime('%Y%m%d%H%M%S')
                 template_id = f"template-{template_type}-{timestamp}"
 
                 template = CaseTemplate(
@@ -173,7 +173,7 @@ class CaseWorkflowService:
                     return None
 
                 # Generate case ID
-                timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
+                timestamp = utcnow().strftime('%Y%m%d%H%M%S')
                 case_id = f"case-{timestamp}"
 
                 # Create case
@@ -191,7 +191,7 @@ class CaseWorkflowService:
                     ),
                     notes=[],
                     timeline=[{
-                        'timestamp': datetime.utcnow().isoformat(),
+                        'timestamp': utcnow().isoformat(),
                         'event': f'Case created from template: {template.name}'
                     }],
                     activities=[],
@@ -292,7 +292,7 @@ class CaseWorkflowService:
                 # Update case
                 case.assignee = escalated_to
                 case.timeline.append({
-                    'timestamp': datetime.utcnow().isoformat(),
+                    'timestamp': utcnow().isoformat(),
                     'event': f'Escalated to {escalated_to}: {reason}'
                 })
 

--- a/core/cases/sandbox_correlation_service.py
+++ b/core/cases/sandbox_correlation_service.py
@@ -20,7 +20,7 @@ Design notes
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
@@ -67,10 +67,10 @@ class SandboxCorrelationService:
                     file_hash_sha256=normalised.get("sha256"),
                     source=sandbox_name,
                     collected_by=collected_by,
-                    collected_at=datetime.utcnow(),
+                    collected_at=utcnow(),
                     chain_of_custody=[
                         {
-                            "timestamp": datetime.utcnow().isoformat(),
+                            "timestamp": utcnow().isoformat(),
                             "action": "collected",
                             "user": collected_by,
                             "notes": f"Retrieved from {sandbox_name} task {task_id}",
@@ -134,7 +134,7 @@ class SandboxCorrelationService:
             )
             .first()
         )
-        now = datetime.utcnow()
+        now = utcnow()
         enrichment_chunk = {
             "sandbox": source,
             "task_id": sandbox_task_id,

--- a/core/cases/sla_policies_router.py
+++ b/core/cases/sla_policies_router.py
@@ -3,7 +3,7 @@
 from typing import List, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from datetime import datetime
+from core.time import utcnow
 
 from core.storage.models import SLAPolicy
 from core.storage.schemas import CaseSchema, SLAPolicySchema
@@ -267,7 +267,7 @@ async def update_sla_policy(
             
             policy.is_default = data.is_default
         
-        policy.updated_at = datetime.utcnow()
+        policy.updated_at = utcnow()
         # Flush so the read-back sees server defaults; the request's
         # unit of work commits.
         session.flush()
@@ -359,7 +359,7 @@ async def set_default_policy(policy_id: str, session: UnitOfWorkSession):
         
         # Set this as default
         policy.is_default = True
-        policy.updated_at = datetime.utcnow()
+        policy.updated_at = utcnow()
         # Flush so the read-back sees server defaults; the request's
         # unit of work commits.
         session.flush()

--- a/core/chat/conversation_service.py
+++ b/core/chat/conversation_service.py
@@ -18,7 +18,7 @@ but return ``None``/``False`` for not-found-or-not-owned.
 """
 
 import logging
-from datetime import datetime
+from core.time import utcnow
 from typing import List, Optional
 
 from sqlalchemy import func, select
@@ -166,7 +166,7 @@ def append_message(
             session.add(msg)
 
             conv.message_count = int(conv.message_count or 0) + 1
-            conv.last_message_at = datetime.utcnow()
+            conv.last_message_at = utcnow()
             if model:
                 conv.model = model
             session.flush()
@@ -320,7 +320,7 @@ def bulk_import(user_id: Optional[str], conversations: List[dict]) -> dict:
                             cost_usd=float(m.get("cost_usd") or 0.0),
                         )
                     )
-                    last_at = datetime.utcnow()
+                    last_at = utcnow()
                 if last_at is not None:
                     conv.last_message_at = last_at
             imported += 1

--- a/core/federation/adapters/_base.py
+++ b/core/federation/adapters/_base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, Optional
 
 
@@ -27,4 +28,4 @@ def parse_cursor_since(cursor: Dict[str, Any]) -> Optional[datetime]:
 
 def fresh_cursor() -> Dict[str, Any]:
     """Cursor value to persist after a successful fetch."""
-    return {"last_poll_at": datetime.utcnow().isoformat()}
+    return {"last_poll_at": utcnow().isoformat()}

--- a/core/federation/adapters/_siem_base.py
+++ b/core/federation/adapters/_siem_base.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Any, Callable, Dict, Optional
 
 from core.config import is_integration_enabled
@@ -78,7 +79,7 @@ class SIEMIngestionAdapter:
         start_time = parse_cursor_since(cursor) or since
         if start_time is None:
             # First run: small window so we don't backfill on enable.
-            start_time = datetime.utcnow() - timedelta(minutes=1)
+            start_time = utcnow() - timedelta(minutes=1)
 
         try:
             alerts = await svc.fetch_alerts(start_time=start_time, limit=max_items)

--- a/core/federation/runner.py
+++ b/core/federation/runner.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, Optional
 
 from core.config import DEFAULT_REDIS_URL, get_settings
@@ -203,7 +203,7 @@ class FederationRunner:
                 "type": "finding",
                 "source": source_id,
                 "data": finding,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utcnow().isoformat(),
             }
         )
 

--- a/core/federation/store.py
+++ b/core/federation/store.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -136,7 +137,7 @@ def update_source(source_id: str, fields: Dict[str, Any]) -> Optional[Dict[str, 
 def record_success(
     source_id: str, *, cursor: Dict[str, Any], when: Optional[datetime] = None
 ) -> None:
-    when = when or datetime.utcnow()
+    when = when or utcnow()
     update_source(
         source_id,
         {
@@ -159,7 +160,7 @@ def record_failure(source_id: str, error: str) -> None:
             row = session.get(FederationSource, source_id)
             if row is None:
                 return
-            row.last_poll_at = datetime.utcnow()
+            row.last_poll_at = utcnow()
             row.last_error = (error or "")[:2000]
             row.consecutive_errors = (row.consecutive_errors or 0) + 1
     except Exception as e:

--- a/core/findings/enrichment/service.py
+++ b/core/findings/enrichment/service.py
@@ -15,7 +15,7 @@ rather than fixed here, so any regression stays bisectable:
 
 import asyncio
 import logging
-from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, Optional, Tuple
 
 from core.findings.enrichment.errors import (FindingNotFound,
@@ -107,7 +107,7 @@ async def _dispatch(
 
     The two paths are asymmetric — see the module docstring. Preserved as-is.
     """
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     if provider.provider_type == "anthropic":
         # No retry here: the cloud path has never had one.
         return await loop.run_in_executor(
@@ -264,7 +264,7 @@ async def enrich(
     # Analysts can compare the rendered fields against the local model's
     # exact output without having to regenerate the enrichment.
     enrichment["raw_response"] = response
-    enrichment["generated_at"] = datetime.utcnow().isoformat() + "Z"
+    enrichment["generated_at"] = utcnow().isoformat() + "Z"
     enrichment["model"] = model_id
     enrichment["provider_id"] = provider.provider_id
     enrichment["provider_type"] = provider.provider_type

--- a/core/ingestion/ingestion_service.py
+++ b/core/ingestion/ingestion_service.py
@@ -19,6 +19,7 @@ import tempfile
 from pathlib import Path
 from typing import List, Dict, Any, Union
 from datetime import datetime
+from core.time import utcnow
 from io import StringIO
 
 from core.findings.source_evidence import (
@@ -154,7 +155,7 @@ class IngestionService:
             return timestamp_value
         
         if not timestamp_value:
-            return datetime.utcnow()
+            return utcnow()
         
         # If it's a Unix timestamp (int or float)
         if isinstance(timestamp_value, (int, float)):
@@ -183,7 +184,7 @@ class IngestionService:
                 continue
         
         logger.warning(f"Could not parse timestamp: {timestamp_value}, using current time")
-        return datetime.utcnow()
+        return utcnow()
     
     def ingest_finding(self, finding_data: Dict[str, Any]) -> bool:
         """
@@ -624,7 +625,7 @@ class IngestionService:
             'embedding': embedding,
             'mitre_predictions': mitre_predictions,
             'anomaly_score': float(row.get('anomaly_score', 0.0)),
-            'timestamp': row.get('timestamp', datetime.utcnow().isoformat()),
+            'timestamp': row.get('timestamp', utcnow().isoformat()),
             'data_source': row.get('data_source', 'csv_import'),
             'entity_context': entity_context,
             'evidence_links': None,
@@ -645,7 +646,7 @@ class IngestionService:
 
         # Parse event_start as timestamp
         event_start_str = row.get('event_start', '')
-        event_ts = self.parse_timestamp(event_start_str) if event_start_str else datetime.utcnow()
+        event_ts = self.parse_timestamp(event_start_str) if event_start_str else utcnow()
 
         # sequence_id + attack_id keeps the same sequence distinct across
         # attack clusters; content identity covers rows carrying neither.
@@ -832,7 +833,7 @@ class IngestionService:
         if event_start_ms is not None:
             event_ts = datetime.utcfromtimestamp(int(event_start_ms) / 1000.0)
         else:
-            event_ts = datetime.utcnow()
+            event_ts = utcnow()
 
         unique_key = sequence_id or self._identity_fallback(
             row, PARQUET_IDENTITY_COLUMNS, 'sequence_id'
@@ -936,7 +937,7 @@ class IngestionService:
     ) -> Dict[str, Any]:
         """Unscored finding shell for a schema with no known column layout."""
         timestamp = _first_present(row, ENTITY_FIELD_ALIASES['timestamp'])
-        event_ts = self.parse_timestamp(timestamp) if timestamp is not None else datetime.utcnow()
+        event_ts = self.parse_timestamp(timestamp) if timestamp is not None else utcnow()
 
         unique_key = row_identity_key(row, tuple(sorted(row.keys())))
         id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:ID_HASH_WIDTH]

--- a/core/ingestion/kafka_consumer_service.py
+++ b/core/ingestion/kafka_consumer_service.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, Optional
 
 from core.ingestion.kafka_config import KafkaConfig
@@ -147,7 +147,7 @@ class KafkaConsumerService:
     async def _handle_message(self, topic: str, msg) -> None:
         """Decode, dedupe, and enqueue a single Kafka message."""
         self.stats["messages_consumed"] += 1
-        self.stats["last_message_at"] = datetime.utcnow().isoformat()
+        self.stats["last_message_at"] = utcnow().isoformat()
 
         try:
             raw = msg.value
@@ -187,7 +187,7 @@ class KafkaConsumerService:
                 "type": "finding",
                 "source": f"kafka:{topic}",
                 "data": finding,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utcnow().isoformat(),
             }
         )
         await self._dedup.mark_processed(finding_id)
@@ -195,4 +195,4 @@ class KafkaConsumerService:
 
     def _record_error(self, msg: str) -> None:
         self.stats["last_error"] = msg
-        self.stats["last_error_at"] = datetime.utcnow().isoformat()
+        self.stats["last_error_at"] = utcnow().isoformat()

--- a/core/integrations/aws_security_hub/ingestion.py
+++ b/core/integrations/aws_security_hub/ingestion.py
@@ -7,6 +7,7 @@ Fetches security findings from AWS Security Hub and converts them to the standar
 import logging
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta
+from core.time import utcnow
 import uuid
 
 from core.ingestion.siem_ingestion_service import SIEMIngestionService
@@ -64,9 +65,9 @@ class AWSSecurityHubIngestion(SIEMIngestionService):
             
             # Set time range
             if not start_time:
-                start_time = datetime.utcnow() - timedelta(hours=24)
+                start_time = utcnow() - timedelta(hours=24)
             if not end_time:
-                end_time = datetime.utcnow()
+                end_time = utcnow()
             
             # Build filters
             filters = {
@@ -161,7 +162,7 @@ class AWSSecurityHubIngestion(SIEMIngestionService):
                 "description": alert.get('Description', ''),
                 "severity": severity,
                 "data_source": "aws_security_hub",
-                "timestamp": alert.get('CreatedAt', datetime.utcnow().isoformat()),
+                "timestamp": alert.get('CreatedAt', utcnow().isoformat()),
                 "raw_data": alert,
                 "metadata": {
                     "aws_account_id": alert.get('AwsAccountId'),

--- a/core/integrations/azure_sentinel/ingestion.py
+++ b/core/integrations/azure_sentinel/ingestion.py
@@ -7,6 +7,7 @@ Fetches security incidents from Microsoft Sentinel (Azure Sentinel) and converts
 import logging
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta
+from core.time import utcnow
 import uuid
 
 from core.ingestion.siem_ingestion_service import SIEMIngestionService
@@ -69,9 +70,9 @@ class AzureSentinelIngestion(SIEMIngestionService):
             
             # Set time range
             if not start_time:
-                start_time = datetime.utcnow() - timedelta(hours=24)
+                start_time = utcnow() - timedelta(hours=24)
             if not end_time:
-                end_time = datetime.utcnow()
+                end_time = utcnow()
             
             # Fetch incidents
             incidents = []
@@ -138,7 +139,7 @@ class AzureSentinelIngestion(SIEMIngestionService):
                 "description": alert.get('description', ''),
                 "severity": self.normalize_severity(alert.get('severity')),
                 "data_source": "azure_sentinel",
-                "timestamp": alert.get('created_time', datetime.utcnow().isoformat()),
+                "timestamp": alert.get('created_time', utcnow().isoformat()),
                 "raw_data": alert,
                 "metadata": {
                     "incident_id": alert.get('id'),

--- a/core/integrations/cloudflare/ingestion.py
+++ b/core/integrations/cloudflare/ingestion.py
@@ -14,14 +14,14 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
 
 def _utcnow_iso() -> str:
-    return datetime.utcnow().isoformat() + "Z"
+    return utcnow().isoformat() + "Z"
 
 
 class CloudyIngestionService:

--- a/core/integrations/crowdstrike/adapter.py
+++ b/core/integrations/crowdstrike/adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Any, Dict, Optional
 
 from core.config import get_integration_config, is_integration_enabled
@@ -71,7 +72,7 @@ class CrowdStrikeAdapter:
         cutoff = parse_cursor_since(cursor) or since
         if cutoff is None:
             # First run: small window, no backfill.
-            cutoff = datetime.utcnow() - timedelta(minutes=1)
+            cutoff = utcnow() - timedelta(minutes=1)
 
         try:
             detections = await asyncio.to_thread(
@@ -120,7 +121,7 @@ def _detection_to_finding(detection: Dict[str, Any]) -> Optional[Dict[str, Any]]
         "finding_id": finding_id,
         "data_source": "crowdstrike",
         "external_id": external_id,
-        "timestamp": detection.get("created_timestamp") or datetime.utcnow().isoformat(),
+        "timestamp": detection.get("created_timestamp") or utcnow().isoformat(),
         "severity": severity,
         "status": "new",
         "title": detection.get("scenario") or "CrowdStrike Detection",

--- a/core/integrations/crowdstrike/client.py
+++ b/core/integrations/crowdstrike/client.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 from typing import Optional, List, Dict, Any
 from datetime import datetime, timedelta
+from core.time import utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class CrowdStrikeService:
     def _ensure_authenticated(self) -> bool:
         """Ensure we have a valid access token."""
         if self.access_token and self.token_expiry:
-            if datetime.utcnow() < self.token_expiry:
+            if utcnow() < self.token_expiry:
                 return True
         return self._authenticate()
     
@@ -53,7 +54,7 @@ class CrowdStrikeService:
                 data = response.json()
                 self.access_token = data.get("access_token")
                 expires_in = data.get("expires_in", 1800)
-                self.token_expiry = datetime.utcnow() + timedelta(seconds=expires_in - 60)
+                self.token_expiry = utcnow() + timedelta(seconds=expires_in - 60)
                 self.session.headers.update({
                     "Authorization": f"Bearer {self.access_token}"
                 })

--- a/core/integrations/elastic/enrichment.py
+++ b/core/integrations/elastic/enrichment.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import re
-from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 
 from core.integrations.elastic.client import ElasticService
@@ -77,7 +77,7 @@ class ElasticEnrichmentService:
     ) -> Dict[str, Any]:
         """Query Elasticsearch for each indicator type."""
         enrichment: Dict[str, Any] = {
-            "query_time": datetime.utcnow().isoformat(),
+            "query_time": utcnow().isoformat(),
             "lookback_hours": hours,
             "results": {},
             "summary": {},

--- a/core/integrations/elastic/ingestion.py
+++ b/core/integrations/elastic/ingestion.py
@@ -7,6 +7,7 @@ Fetches detection alerts via the Kibana Detections API and converts them to find
 import logging
 import uuid
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 
 from core.ingestion.siem_ingestion_service import SIEMIngestionService
@@ -63,7 +64,7 @@ class ElasticIngestion(SIEMIngestionService):
                 return []
 
             if not start_time:
-                start_time = datetime.utcnow() - timedelta(hours=24)
+                start_time = utcnow() - timedelta(hours=24)
 
             time_filter: Dict[str, Any] = {
                 "bool": {
@@ -175,7 +176,7 @@ class ElasticIngestion(SIEMIngestionService):
             return {
                 "finding_id": finding_id,
                 "data_source": "elastic",
-                "timestamp": source.get("@timestamp", datetime.utcnow().isoformat()),
+                "timestamp": source.get("@timestamp", utcnow().isoformat()),
                 "severity": severity,
                 "status": "new",
                 "title": title,

--- a/core/integrations/microsoft_defender/ingestion.py
+++ b/core/integrations/microsoft_defender/ingestion.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta
+from core.time import utcnow
 import uuid
 import httpx
 
@@ -100,9 +101,9 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
             
             # Set time range
             if not start_time:
-                start_time = datetime.utcnow() - timedelta(hours=24)
+                start_time = utcnow() - timedelta(hours=24)
             if not end_time:
-                end_time = datetime.utcnow()
+                end_time = utcnow()
             
             # Build API request
             api_url = "https://api.securitycenter.microsoft.com/api/alerts"
@@ -194,7 +195,7 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
                 "description": alert.get('description', ''),
                 "severity": self.normalize_severity(alert.get('severity')),
                 "data_source": "microsoft_defender",
-                "timestamp": alert.get('alertCreationTime', datetime.utcnow().isoformat()),
+                "timestamp": alert.get('alertCreationTime', utcnow().isoformat()),
                 "raw_data": alert,
                 "metadata": {
                     "alert_id": alert.get('id'),

--- a/core/integrations/splunk/adapter.py
+++ b/core/integrations/splunk/adapter.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import uuid
 from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, Optional
 
 from core.config import get_integration_config, is_integration_enabled
@@ -85,7 +86,7 @@ class SplunkAdapter:
         last = parse_cursor_since(cursor) or since
         if last is not None:
             # Convert to relative Splunk earliest_time (rounded up to minute)
-            delta_minutes = max(int((datetime.utcnow() - last).total_seconds() // 60) + 1, 1)
+            delta_minutes = max(int((utcnow() - last).total_seconds() // 60) + 1, 1)
             earliest_time = f"-{delta_minutes}m"
         else:
             # First run: tiny window so we don't replay history.
@@ -150,7 +151,7 @@ def _splunk_event_to_finding(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         "finding_id": finding_id,
         "data_source": "splunk",
         "external_id": external_id,
-        "timestamp": event.get("_time") or datetime.utcnow().isoformat(),
+        "timestamp": event.get("_time") or utcnow().isoformat(),
         "severity": severity,
         "status": "new",
         "title": event.get("search_name") or event.get("rule_name") or "Splunk Alert",

--- a/core/integrations/splunk/ingestion.py
+++ b/core/integrations/splunk/ingestion.py
@@ -7,6 +7,7 @@ Fetches notable events from Splunk ES and converts them to findings.
 import logging
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta
+from core.time import utcnow
 import uuid
 
 from core.ingestion.siem_ingestion_service import SIEMIngestionService
@@ -87,12 +88,12 @@ class SplunkIngestion(SIEMIngestionService):
             
             # Set time range
             if not start_time:
-                start_time = datetime.utcnow() - timedelta(hours=24)
+                start_time = utcnow() - timedelta(hours=24)
             if not end_time:
-                end_time = datetime.utcnow()
+                end_time = utcnow()
             
             # Calculate relative time
-            hours_ago = int((datetime.utcnow() - start_time).total_seconds() / 3600)
+            hours_ago = int((utcnow() - start_time).total_seconds() / 3600)
             earliest_time = f"-{hours_ago}h"
             
             # Search for notable events (Splunk ES)
@@ -196,7 +197,7 @@ class SplunkIngestion(SIEMIngestionService):
                 "description": description,
                 "severity": self.normalize_severity(severity),
                 "data_source": "splunk",
-                "timestamp": alert.get('_time', datetime.utcnow().isoformat()),
+                "timestamp": alert.get('_time', utcnow().isoformat()),
                 "raw_data": alert,
                 "metadata": {
                     "event_id": event_id,

--- a/core/reporting/ai_insights_service.py
+++ b/core/reporting/ai_insights_service.py
@@ -12,6 +12,7 @@ import json
 import logging
 from typing import List, Dict, Any
 from datetime import datetime, timezone
+from core.time import utcnow
 import asyncio
 from sqlalchemy.orm import Session
 
@@ -239,7 +240,7 @@ Provide ONLY the JSON array, no other text."""
         except ImportError:
             if not self.client:
                 raise ValueError("Claude API client not initialized")
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             message = await loop.run_in_executor(
                 None,
                 lambda: self.client.messages.create(
@@ -272,13 +273,13 @@ Provide ONLY the JSON array, no other text."""
             insights = []
             for i, insight in enumerate(insights_raw):
                 insights.append({
-                    "id": f"insight-{datetime.utcnow().timestamp()}-{i}",
+                    "id": f"insight-{utcnow().timestamp()}-{i}",
                     "type": insight.get("type", "info"),
                     "title": insight.get("title", "Insight"),
                     "description": insight.get("description", ""),
                     "confidence": insight.get("confidence", 0.7),
                     "actionable": insight.get("actionable", False),
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": utcnow().isoformat(),
                 })
             
             return insights
@@ -294,12 +295,12 @@ Provide ONLY the JSON array, no other text."""
     def _get_fallback_insights(self, metrics: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Generate fallback insights when AI service is unavailable."""
         insights = []
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = utcnow().isoformat()
         
         # Findings trend insight
         if abs(metrics['findingsChange']) > 20:
             insights.append({
-                "id": f"fallback-findings-{datetime.utcnow().timestamp()}",
+                "id": f"fallback-findings-{utcnow().timestamp()}",
                 "type": "warning" if metrics['findingsChange'] > 0 else "info",
                 "title": f"Findings {'increased' if metrics['findingsChange'] > 0 else 'decreased'} significantly",
                 "description": f"Findings changed by {metrics['findingsChange']:+.1f}% compared to previous period.",
@@ -311,7 +312,7 @@ Provide ONLY the JSON array, no other text."""
         # Response time insight
         if metrics['avgResponseTime'] > 60:
             insights.append({
-                "id": f"fallback-response-{datetime.utcnow().timestamp()}",
+                "id": f"fallback-response-{utcnow().timestamp()}",
                 "type": "warning",
                 "title": "Response time exceeds target",
                 "description": f"Average response time is {metrics['avgResponseTime']} minutes. Consider workload optimization.",
@@ -323,7 +324,7 @@ Provide ONLY the JSON array, no other text."""
         # False positive insight
         if metrics['falsePositiveRate'] > 30:
             insights.append({
-                "id": f"fallback-fp-{datetime.utcnow().timestamp()}",
+                "id": f"fallback-fp-{utcnow().timestamp()}",
                 "type": "recommendation",
                 "title": "High false positive rate detected",
                 "description": f"False positive rate is {metrics['falsePositiveRate']}%. Review detection rules for tuning.",
@@ -335,7 +336,7 @@ Provide ONLY the JSON array, no other text."""
         # Positive performance insight
         if metrics['responseTimeChange'] < -10:
             insights.append({
-                "id": f"fallback-performance-{datetime.utcnow().timestamp()}",
+                "id": f"fallback-performance-{utcnow().timestamp()}",
                 "type": "info",
                 "title": "Response time improvement",
                 "description": f"Response time improved by {abs(metrics['responseTimeChange']):.1f}%. Great work!",
@@ -345,7 +346,7 @@ Provide ONLY the JSON array, no other text."""
             })
         
         return insights if insights else [{
-            "id": f"fallback-default-{datetime.utcnow().timestamp()}",
+            "id": f"fallback-default-{utcnow().timestamp()}",
             "type": "info",
             "title": "SOC operations stable",
             "description": "All metrics are within normal ranges. Continue monitoring for changes.",

--- a/core/response/approval_service.py
+++ b/core/response/approval_service.py
@@ -16,6 +16,7 @@ other existing callers) keep working.
 import logging
 from dataclasses import dataclass
 from datetime import datetime
+from core.time import utcnow
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -283,7 +284,7 @@ class ApprovalService:
                     confidence=float(confidence),
                     reason=reason,
                     evidence=list(evidence or []),
-                    created_at=datetime.utcnow(),
+                    created_at=utcnow(),
                     created_by=created_by,
                     requires_approval=requires_approval,
                     status=status,
@@ -371,7 +372,7 @@ class ApprovalService:
                     )
                     return _row_to_pending(row)
                 row.status = ActionStatus.APPROVED.value
-                row.approved_at = datetime.utcnow()
+                row.approved_at = utcnow()
                 row.approved_by = approved_by
                 session.flush()
                 pending = _row_to_pending(row)
@@ -405,7 +406,7 @@ class ApprovalService:
                 row.status = ActionStatus.REJECTED.value
                 row.rejection_reason = reason
                 row.approved_by = rejected_by
-                row.approved_at = datetime.utcnow()
+                row.approved_at = utcnow()
                 session.flush()
                 pending = _row_to_pending(row)
             logger.info(
@@ -439,7 +440,7 @@ class ApprovalService:
                     )
                     return _row_to_pending(row)
                 row.status = ActionStatus.EXECUTED.value
-                row.executed_at = datetime.utcnow()
+                row.executed_at = utcnow()
                 row.execution_result = result
                 session.flush()
                 return _row_to_pending(row)
@@ -460,7 +461,7 @@ class ApprovalService:
                 if row is None:
                     return None
                 row.status = ActionStatus.FAILED.value
-                row.executed_at = datetime.utcnow()
+                row.executed_at = utcnow()
                 row.execution_result = {"error": error}
                 session.flush()
                 logger.error("Action %s failed: %s", action_id, error)

--- a/core/response/autonomous_response_service.py
+++ b/core/response/autonomous_response_service.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from typing import Dict, List, Optional, Callable, Any
 from datetime import datetime
+from core.time import utcnow
 
 from core.agents.builtins import AgentId
 from core.response.approval_service import ActionType, ApprovalService
@@ -75,7 +76,7 @@ class AutonomousResponseService:
                         "title": f"🚨 SOC Alert - {severity.upper()}",
                         "text": message,
                         "footer": "AI-SOC Autonomous Response",
-                        "ts": datetime.utcnow().timestamp()
+                        "ts": utcnow().timestamp()
                     }]
                 },
                 timeout=30,

--- a/core/storage/database_data_service.py
+++ b/core/storage/database_data_service.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 from typing import Optional, List, Dict, Tuple
 from datetime import datetime
+from core.time import utcnow
 import uuid
 
 import numpy as np
@@ -366,7 +367,7 @@ class DatabaseDataService:
                     embedding=finding_data.get('embedding', [0.0] * 768),
                     mitre_predictions=finding_data.get('mitre_predictions', {}),
                     anomaly_score=float(finding_data.get('anomaly_score', 0.0)),
-                    timestamp=finding_data.get('timestamp', datetime.utcnow()),
+                    timestamp=finding_data.get('timestamp', utcnow()),
                     data_source=finding_data.get('data_source', 'imported'),
                     description=finding_data.get('description'),
                     entity_context=finding_data.get('entity_context'),
@@ -458,7 +459,7 @@ class DatabaseDataService:
                 logger.error(f"Error creating case in DB: {e}")
                 return None
         elif self._use_json_fallback:
-            now = datetime.utcnow().isoformat()
+            now = utcnow().isoformat()
             case_data = {
                 'case_id': case_id,
                 'title': title,
@@ -492,7 +493,7 @@ class DatabaseDataService:
             for c in cases:
                 if c.get('case_id') == case_id:
                     c.update(updates)
-                    c['updated_at'] = datetime.utcnow().isoformat()
+                    c['updated_at'] = utcnow().isoformat()
                     return self._save_cases_json(cases)
         return False
     
@@ -577,7 +578,7 @@ class DatabaseDataService:
                         c['finding_ids'] = []
                     if finding_id not in c['finding_ids']:
                         c['finding_ids'].append(finding_id)
-                        c['updated_at'] = datetime.utcnow().isoformat()
+                        c['updated_at'] = utcnow().isoformat()
                     return self._save_cases_json(cases)
             return False
         return False
@@ -746,7 +747,7 @@ class DatabaseDataService:
                                     embedding=finding.get('embedding', [0.0] * 768),
                                     mitre_predictions=finding.get('mitre_predictions', {}),
                                     anomaly_score=float(finding.get('anomaly_score', 0.0)),
-                                    timestamp=finding.get('timestamp', datetime.utcnow()),
+                                    timestamp=finding.get('timestamp', utcnow()),
                                     data_source=finding.get('data_source', 's3_import'),
                                     entity_context=finding.get('entity_context'),
                                     evidence_links=finding.get('evidence_links'),

--- a/core/storage/models.py
+++ b/core/storage/models.py
@@ -5,6 +5,7 @@ Defines the database schema for cases, findings, and related entities.
 """
 
 from datetime import datetime
+from core.time import utcnow
 from typing import Optional, List
 from sqlalchemy import (
     Column,
@@ -56,7 +57,7 @@ case_findings = Table(
         ForeignKey("findings.finding_id", ondelete="CASCADE"),
         primary_key=True,
     ),
-    Column("added_at", DateTime, default=datetime.utcnow, nullable=False),
+    Column("added_at", DateTime, default=utcnow, nullable=False),
 )
 
 
@@ -98,13 +99,13 @@ class Finding(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -197,13 +198,13 @@ class Case(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -245,7 +246,7 @@ class SketchMapping(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     # Indexes
@@ -276,13 +277,13 @@ class AttackLayer(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -344,7 +345,7 @@ class AIDecisionLog(Base):
 
     # Timestamps
     timestamp: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     feedback_timestamp: Mapped[Optional[datetime]] = mapped_column(
         DateTime, nullable=True
@@ -388,13 +389,13 @@ class SystemConfig(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -426,13 +427,13 @@ class UserPreference(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -474,13 +475,13 @@ class IntegrationConfig(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -540,13 +541,13 @@ class FederationSource(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default=text("now()")
+        DateTime, nullable=False, default=utcnow, server_default=text("now()")
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default=text("now()"),
     )
 
@@ -582,7 +583,7 @@ class ConfigAuditLog(Base):
 
     # When
     timestamp: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     # Indexes
@@ -641,13 +642,13 @@ class SLAPolicy(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -710,13 +711,13 @@ class CaseSLA(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -772,13 +773,13 @@ class CaseComment(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -813,7 +814,7 @@ class CaseWatcher(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     # Indexes
@@ -873,13 +874,13 @@ class CaseEvidence(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -942,13 +943,13 @@ class CaseIOC(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -1007,13 +1008,13 @@ class CaseTask(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -1077,13 +1078,13 @@ class CaseTemplate(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -1128,7 +1129,7 @@ class CaseRelationship(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     # Indexes
@@ -1178,13 +1179,13 @@ class CaseMetrics(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -1228,7 +1229,7 @@ class CaseAttachment(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     # Indexes
@@ -1281,7 +1282,7 @@ class CaseClosureInfo(Base):
 
     # Timestamps
     closed_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
 
@@ -1319,7 +1320,7 @@ class CaseEscalation(Base):
 
     # Timestamps
     escalated_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     acknowledged_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     resolved_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
@@ -1372,7 +1373,7 @@ class CaseAuditLog(Base):
 
     # Timestamp
     timestamp: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     # Indexes
@@ -1440,13 +1441,13 @@ class User(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -1483,13 +1484,13 @@ class Role(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -1533,7 +1534,7 @@ class Investigation(Base):
 
     priority: Mapped[str] = mapped_column(String(20), nullable=False, default="medium")
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     started_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
@@ -1573,7 +1574,7 @@ class InvestigationLog(Base):
         nullable=False,
     )
     timestamp: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     event_type: Mapped[str] = mapped_column(String(30), nullable=False)
     details: Mapped[dict] = mapped_column(JSONB, nullable=False, default={})
@@ -1602,7 +1603,7 @@ class LLMInteractionLog(Base):
     agent_id: Mapped[Optional[str]] = mapped_column(String(60), nullable=True)
     investigation_id: Mapped[Optional[str]] = mapped_column(String(60), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     model: Mapped[str] = mapped_column(String(80), nullable=False)
     request_messages: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
@@ -1654,7 +1655,7 @@ class SharedIOC(Base):
     ioc_type: Mapped[str] = mapped_column(String(30), nullable=False)
     value: Mapped[str] = mapped_column(String(500), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     __table_args__ = (
@@ -1708,7 +1709,7 @@ class CaseNotification(Base):
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     # Indexes
@@ -1755,14 +1756,14 @@ class CustomWorkflow(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
+        default=utcnow,
         server_default="now()",
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -1798,7 +1799,7 @@ class WorkflowRun(Base):
     )
 
     started_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     duration_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
@@ -1881,7 +1882,7 @@ class ApprovalAction(Base):
         JSONB, nullable=False, default=list, server_default="[]"
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     created_by: Mapped[str] = mapped_column(String(100), nullable=False)
     requires_approval: Mapped[bool] = mapped_column(
@@ -1953,14 +1954,14 @@ class Skill(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
+        default=utcnow,
         server_default="now()",
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -1978,7 +1979,7 @@ class Skill(Base):
     @staticmethod
     def generate_skill_id() -> str:
         """Generate a new skill_id in the form s-YYYYMMDD-XXXXXXXX."""
-        ts = datetime.utcnow().strftime("%Y%m%d")
+        ts = utcnow().strftime("%Y%m%d")
         return f"s-{ts}-{uuid.uuid4().hex[:8].upper()}"
 
 
@@ -2026,13 +2027,13 @@ class CustomAgent(Base):
 
     created_by: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
 
@@ -2061,10 +2062,10 @@ class LLMProviderConfig(Base):
     last_test_success: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
     last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     __table_args__ = (
@@ -2106,10 +2107,10 @@ class AIModelConfig(Base):
     settings: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     updated_by: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     __table_args__ = (Index("idx_ai_model_configs_provider", "provider_id"),)
@@ -2137,10 +2138,10 @@ class ThreatIndicator(Base):
     valid_until: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     raw_stix: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
     first_seen: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     last_seen: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     __table_args__ = (
@@ -2183,13 +2184,13 @@ class Conversation(Base):
         Integer, nullable=False, default=0, server_default="0"
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         server_default="now()",
     )
     # Sort key for the history list; null until the first message lands.
@@ -2248,7 +2249,7 @@ class ChatMessage(Base):
         Numeric(10, 6), nullable=False, default=0, server_default="0"
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.utcnow, server_default="now()"
+        DateTime, nullable=False, default=utcnow, server_default="now()"
     )
 
     conversation: Mapped["Conversation"] = relationship(

--- a/core/storage/service.py
+++ b/core/storage/service.py
@@ -18,6 +18,7 @@ from core.storage.models import (
 from core.storage.connection import get_db_manager
 from core.storage.case_repository import CaseRepository
 from core.storage.schemas import FindingSchema
+from core.time import utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +299,7 @@ class DatabaseService:
             with self.db_manager.session_scope() as session:
                 query = select(Finding).where(Finding.ai_enrichment.is_(None))
                 if max_age_hours:
-                    cutoff = datetime.utcnow() - timedelta(hours=max_age_hours)
+                    cutoff = utcnow() - timedelta(hours=max_age_hours)
                     query = query.where(Finding.timestamp >= cutoff)
                 query = query.order_by(Finding.timestamp.asc()).limit(limit)
                 return FindingSchema.dump_many(session.execute(query).scalars().all())
@@ -374,7 +375,7 @@ class DatabaseService:
                     if hasattr(finding, key):
                         setattr(finding, key, value)
                 
-                finding.updated_at = datetime.utcnow()
+                finding.updated_at = utcnow()
                 session.flush()
                 logger.info(f"Updated finding: {finding_id}")
                 return True
@@ -430,7 +431,7 @@ class DatabaseService:
         try:
             with self.db_manager.session_scope() as session:
                 # Create case
-                now = datetime.utcnow()
+                now = utcnow()
                 case = Case(
                     case_id=case_id,
                     title=title,
@@ -558,7 +559,7 @@ class DatabaseService:
                     if hasattr(case, key):
                         setattr(case, key, value)
 
-                case.updated_at = datetime.utcnow()
+                case.updated_at = utcnow()
                 session.flush()
                 logger.info(f"Updated case: {case_id}")
                 return True
@@ -612,7 +613,7 @@ class DatabaseService:
                 
                 if finding not in case.findings:
                     case.findings.append(finding)
-                    case.updated_at = datetime.utcnow()
+                    case.updated_at = utcnow()
                     session.flush()
                     logger.info(f"Added finding {finding_id} to case {case_id}")
                 
@@ -643,7 +644,7 @@ class DatabaseService:
                 
                 if finding in case.findings:
                     case.findings.remove(finding)
-                    case.updated_at = datetime.utcnow()
+                    case.updated_at = utcnow()
                     session.flush()
                     logger.info(f"Removed finding {finding_id} from case {case_id}")
                 
@@ -702,7 +703,7 @@ class DatabaseService:
                     case_id=case_id,
                     workflow_id=workflow_id,
                     decision_metadata=decision_metadata,
-                    timestamp=datetime.utcnow()
+                    timestamp=utcnow()
                 )
                 
                 session.add(decision)
@@ -762,7 +763,7 @@ class DatabaseService:
                 decision.action_appropriateness = action_appropriateness
                 decision.actual_outcome = actual_outcome
                 decision.time_saved_minutes = time_saved_minutes
-                decision.feedback_timestamp = datetime.utcnow()
+                decision.feedback_timestamp = utcnow()
                 
                 session.flush()
                 
@@ -858,10 +859,8 @@ class DatabaseService:
             Dictionary with statistics
         """
         try:
-            from datetime import timedelta
-            
             with self.db_manager.session_scope() as session:
-                since = datetime.utcnow() - timedelta(days=days)
+                since = utcnow() - timedelta(days=days)
                 
                 query = session.query(AIDecisionLog).filter(
                     AIDecisionLog.timestamp >= since

--- a/core/threat_intel/mitre_lookup.py
+++ b/core/threat_intel/mitre_lookup.py
@@ -11,6 +11,7 @@ Findings in this codebase carry MITRE data in two shapes:
 """
 
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Iterable, Optional
 
 
@@ -21,7 +22,7 @@ def get_time_range(time_range: str) -> tuple[datetime, datetime]:
     and the API routers can both depend on it without either importing the
     other.
     """
-    end_time = datetime.utcnow()
+    end_time = utcnow()
 
     if time_range == "24h":
         start_time = end_time - timedelta(hours=24)

--- a/core/threat_intel/threat_feed_service.py
+++ b/core/threat_intel/threat_feed_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -225,7 +226,7 @@ def upsert_indicators(indicators: List[NormalizedIndicator]) -> Dict[str, int]:
     inserted = 0
     updated = 0
     skipped = 0
-    now = datetime.utcnow()
+    now = utcnow()
     with db.session_scope() as session:
         for ind in indicators:
             try:

--- a/core/time.py
+++ b/core/time.py
@@ -1,0 +1,17 @@
+"""Naive-UTC clock helper.
+
+SQLAlchemy columns in this codebase are naive ``DateTime`` (no timezone).
+``datetime.utcnow()`` is deprecated in 3.12+, but ``datetime.now(timezone.utc)``
+is aware and TypeErrors when compared to those naive column values. This helper
+is the drop-in: same naive UTC wall-clock as ``utcnow()``, without the
+deprecation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def utcnow() -> datetime:
+    """Return the current UTC time as a naive datetime."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/core/workflows/custom_workflow_service.py
+++ b/core/workflows/custom_workflow_service.py
@@ -8,7 +8,7 @@ WORKFLOW.md definitions that WorkflowsService already loads from disk.
 import logging
 import re
 import uuid
-from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select
@@ -168,7 +168,7 @@ class CustomWorkflowService:
                 if key in allowed and value is not None:
                     setattr(wf, key, value)
             wf.version = (wf.version or 1) + 1
-            wf.updated_at = datetime.utcnow()
+            wf.updated_at = utcnow()
             session.flush()
             result = CustomWorkflowSchema.dump(wf)
         logger.info(
@@ -184,6 +184,6 @@ class CustomWorkflowService:
             if not wf:
                 return False
             wf.is_active = False
-            wf.updated_at = datetime.utcnow()
+            wf.updated_at = utcnow()
         logger.info(f"Soft-deleted custom workflow: {workflow_id}")
         return True

--- a/core/workflows/run_bridge_router.py
+++ b/core/workflows/run_bridge_router.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Header
@@ -103,7 +103,7 @@ def record_phase(
 ) -> None:
     authorise(authorization, "run progress")
 
-    now = datetime.utcnow()
+    now = utcnow()
     run_service.upsert_phase(
         run_id,
         update.phase_id,
@@ -224,7 +224,7 @@ def list_decisions(
                     actor=action.approved_by or "analyst",
                     answer=answer,
                     text=action.rejection_reason or "",
-                    resolved_at=action.approved_at or datetime.utcnow().isoformat(),
+                    resolved_at=action.approved_at or utcnow().isoformat(),
                 )
             )
     return Decisions(decisions=decided)

--- a/core/workflows/workflow_run_service.py
+++ b/core/workflows/workflow_run_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select
@@ -17,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 def generate_run_id() -> str:
     """Return a new run_id shaped ``wfr-YYYYMMDD-<uuid8>``."""
-    return f"wfr-{datetime.utcnow().strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
+    return f"wfr-{utcnow().strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
 
 
 class WorkflowRunService:
@@ -57,7 +58,7 @@ class WorkflowRunService:
                     status="running",
                     triggered_by=triggered_by,
                     trigger_context=trigger_context or {},
-                    started_at=datetime.utcnow(),
+                    started_at=utcnow(),
                     skill_tools_available=list(skill_tools_available or []),
                 )
                 session.add(row)
@@ -108,7 +109,7 @@ class WorkflowRunService:
                 if row is None:
                     logger.warning("finalize_run: unknown run %s", run_id)
                     return False
-                now = datetime.utcnow()
+                now = utcnow()
                 row.status = status
                 row.finished_at = now
                 # Truncate result_summary to avoid committing megabyte

--- a/scripts/export_postgres_to_splunk.py
+++ b/scripts/export_postgres_to_splunk.py
@@ -13,7 +13,6 @@ import argparse
 import json
 import requests
 from typing import List, Dict, Any
-from core.time import utcnow
 import urllib3
 
 # Add parent directory to path for imports
@@ -21,6 +20,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from core.storage.connection import get_db_manager
 from core.storage.models import Finding, Case
+from core.time import utcnow
 from sqlalchemy import func
 
 # Disable SSL warnings for self-signed certificates

--- a/scripts/export_postgres_to_splunk.py
+++ b/scripts/export_postgres_to_splunk.py
@@ -13,7 +13,7 @@ import argparse
 import json
 import requests
 from typing import List, Dict, Any
-from datetime import datetime
+from core.time import utcnow
 import urllib3
 
 # Add parent directory to path for imports
@@ -167,7 +167,7 @@ class PostgresToSplunkExporter:
         
         # HEC format
         hec_event = {
-            "time": finding.timestamp.timestamp() if finding.timestamp else datetime.utcnow().timestamp(),
+            "time": finding.timestamp.timestamp() if finding.timestamp else utcnow().timestamp(),
             "sourcetype": "deeptempo:finding",
             "source": "postgresql_export",
             "host": "deeptempo-soc",
@@ -224,7 +224,7 @@ class PostgresToSplunkExporter:
         
         # HEC format
         hec_event = {
-            "time": case.created_at.timestamp() if case.created_at else datetime.utcnow().timestamp(),
+            "time": case.created_at.timestamp() if case.created_at else utcnow().timestamp(),
             "sourcetype": "deeptempo:case",
             "source": "postgresql_export",
             "host": "deeptempo-soc",

--- a/services/api/routers/auth.py
+++ b/services/api/routers/auth.py
@@ -6,6 +6,7 @@ Handles login, logout, token refresh, password management, and MFA.
 
 import logging
 from datetime import datetime
+from core.time import utcnow
 from typing import Annotated, List, Optional
 from fastapi import APIRouter, HTTPException, Depends, Header, Request, Response, status
 from pydantic import BaseModel, EmailStr
@@ -175,7 +176,7 @@ def _apply_new_password(user: User, plaintext: str) -> None:
     # Cap to the configured limit so the JSONB row doesn't grow unbounded.
     user.password_history = previous[:PASSWORD_HISTORY_LIMIT]
     user.password_hash = new_hash
-    user.password_changed_at = datetime.utcnow()
+    user.password_changed_at = utcnow()
 
 
 def _has_any_user(session: Session) -> bool:
@@ -291,7 +292,7 @@ async def login(
         )
     except AccountLockedError as exc:
         retry_after = max(
-            1, int((exc.locked_until - datetime.utcnow()).total_seconds())
+            1, int((exc.locked_until - utcnow()).total_seconds())
         )
         raise HTTPException(
             status_code=status.HTTP_423_LOCKED,

--- a/services/api/routers/cases.py
+++ b/services/api/routers/cases.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Dict, Any
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator
 from datetime import datetime
+from core.time import utcnow
 from pathlib import Path
 
 from services.api.middleware.auth import get_current_user
@@ -353,7 +354,7 @@ async def add_case_activity(case_id: str, activity: ActivityAdd):
     
     # Add new activity
     new_activity = {
-        'timestamp': datetime.utcnow().isoformat() + 'Z',
+        'timestamp': utcnow().isoformat() + 'Z',
         'activity_type': activity.activity_type,
         'description': activity.description,
         'details': activity.details or {}
@@ -390,7 +391,7 @@ async def add_resolution_step(case_id: str, step: ResolutionStepAdd):
     
     # Add new step
     new_step = {
-        'timestamp': datetime.utcnow().isoformat() + 'Z',
+        'timestamp': utcnow().isoformat() + 'Z',
         'description': step.description,
         'action_taken': step.action_taken,
         'result': step.result
@@ -1141,7 +1142,7 @@ async def merge_cases(case_id: str, data: MergeRequest):
         target_tags = target.tags or []
         target.tags = list(set(target_tags + source_tags))
 
-        now = datetime.utcnow()
+        now = utcnow()
         merge_activity = {
             "timestamp": now.isoformat() + "Z",
             "activity_type": "case_merged",

--- a/services/api/routers/llm_providers.py
+++ b/services/api/routers/llm_providers.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import delete as sa_delete, update
 from sqlalchemy.orm import Session
 from core.routing import Auth, RouterMeta, UnitOfWorkSession
+from core.time import utcnow
 from core.secrets import delete_secret, get_secret, set_secret
 from services.api.middleware.auth import get_current_active_user
 from core.auth.auth_service import AuthService
@@ -580,8 +581,6 @@ async def test_provider(
     if row is None:
         raise HTTPException(status_code=404, detail="provider not found")
 
-    from datetime import datetime
-
     success, error = await _probe_provider_connection(
         provider_type=row.provider_type,
         base_url=row.base_url,
@@ -590,7 +589,7 @@ async def test_provider(
         organization=(row.config or {}).get("organization"),
     )
 
-    row.last_test_at = datetime.utcnow()
+    row.last_test_at = utcnow()
     row.last_test_success = success
     row.last_error = None if success else error
 

--- a/services/daemon/main.py
+++ b/services/daemon/main.py
@@ -56,7 +56,7 @@ class SOCDaemon:
     
     def _setup_signal_handlers(self):
         """Setup graceful shutdown handlers."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         
         for sig in (signal.SIGTERM, signal.SIGINT):
             loop.add_signal_handler(sig, self._handle_shutdown)

--- a/services/daemon/metrics.py
+++ b/services/daemon/metrics.py
@@ -15,7 +15,7 @@ DAEMON_HEALTH_PORT (default 9091) exposing /health and /status.
 import asyncio
 import logging
 from collections import defaultdict
-from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict
 
 from aiohttp import web
@@ -41,7 +41,7 @@ class DaemonMetrics:
     """
 
     def __init__(self):
-        self._start_time = datetime.utcnow()
+        self._start_time = utcnow()
 
         # In-memory shadow counters (used by get_summary / get_poll_count /
         # get_total_processed which must return values synchronously).
@@ -146,7 +146,7 @@ class DaemonMetrics:
 
     def get_summary(self) -> Dict[str, Any]:
         """Get summary of all metrics (used for /status display only)."""
-        uptime = (datetime.utcnow() - self._start_time).total_seconds()
+        uptime = (utcnow() - self._start_time).total_seconds()
         total_polls = sum(self._poll_counts.values())
 
         poll_stats = {}
@@ -183,7 +183,7 @@ class DaemonMetrics:
         self._events_counts.clear()
         self._processing_count = 0
         self._processing_durations.clear()
-        self._start_time = datetime.utcnow()
+        self._start_time = utcnow()
         logger.info("Metrics reset")
 
 
@@ -203,7 +203,7 @@ class MetricsServer:
 
     def __init__(self, config: MetricsConfig):
         self.config = config
-        self._start_time = datetime.utcnow()
+        self._start_time = utcnow()
 
         # Component references (set externally)
         self.poller = None
@@ -239,8 +239,8 @@ class MetricsServer:
         """Handle health check request."""
         health: Dict[str, Any] = {
             "status": "healthy",
-            "timestamp": datetime.utcnow().isoformat(),
-            "uptime_seconds": (datetime.utcnow() - self._start_time).total_seconds(),
+            "timestamp": utcnow().isoformat(),
+            "uptime_seconds": (utcnow() - self._start_time).total_seconds(),
         }
 
         components = {}
@@ -292,7 +292,7 @@ class MetricsServer:
             "daemon": {
                 "start_time": self._start_time.isoformat(),
                 "uptime_seconds": (
-                    datetime.utcnow() - self._start_time
+                    utcnow() - self._start_time
                 ).total_seconds(),
             },
             "poller": metrics.get("poller", {}),

--- a/services/daemon/orchestrator.py
+++ b/services/daemon/orchestrator.py
@@ -15,6 +15,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 
 from core.agents.builtins import ORCHESTRATION_DECISION_ID, ORCHESTRATOR_ACTOR
@@ -347,7 +348,7 @@ class Orchestrator:
         shutdown_event: Optional[asyncio.Event] = None,
     ):
         """Core investigation creation logic."""
-        inv_id = f"inv-{datetime.utcnow().strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
+        inv_id = f"inv-{utcnow().strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
         total_steps = count_steps(workflow_id)
 
         workdir = self.workdir.create(inv_id)
@@ -516,7 +517,7 @@ class Orchestrator:
                         )
 
                 executing = self._get_investigations_by_status("executing")
-                now = datetime.utcnow()
+                now = utcnow()
 
                 for inv in executing:
                     inv_dict = _inv_as_dict(inv)
@@ -698,7 +699,7 @@ class Orchestrator:
                     logger.warning("progress for %s: row not found", inv_id)
                     return
                 inv.iteration_count = projection.get("iterations", 0)
-                inv.last_activity_at = datetime.utcnow()
+                inv.last_activity_at = utcnow()
                 # Null is "the gateway priced nothing", which is not zero spent.
                 cost = projection.get("cost_usd")
                 if cost is not None:
@@ -719,7 +720,7 @@ class Orchestrator:
 
     def _track_hourly_cost(self):
         """Track rolling hourly cost for budget enforcement."""
-        now = datetime.utcnow()
+        now = utcnow()
         cutoff = now - timedelta(hours=1)
         self._hourly_costs = [c for c in self._hourly_costs if c["ts"] > cutoff]
         hourly_total = sum(c["cost"] for c in self._hourly_costs)
@@ -915,7 +916,7 @@ class Orchestrator:
             priority = case_data.get("priority", "medium")
 
             inv_id = (
-                f"inv-{datetime.utcnow().strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
+                f"inv-{utcnow().strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
             )
             total_steps = count_steps("case-review")
 
@@ -1023,7 +1024,7 @@ class Orchestrator:
                         "proposed_actions": state.get("proposed_actions", []),
                         "completed_steps": state.get("completed_steps", []),
                         "case_id": state.get("case_id"),
-                        "completed_at": datetime.utcnow().isoformat(),
+                        "completed_at": utcnow().isoformat(),
                     },
                     indent=2,
                 )
@@ -1394,7 +1395,7 @@ class Orchestrator:
                     if notes:
                         inv.master_review_notes = notes
                     if status == "completed":
-                        inv.completed_at = datetime.utcnow()
+                        inv.completed_at = utcnow()
         except Exception as e:
             logger.error(f"Failed to update investigation status: {e}")
 

--- a/services/daemon/plan_generator.py
+++ b/services/daemon/plan_generator.py
@@ -5,7 +5,7 @@ files that sub-agents consume and modify during execution.
 """
 
 import logging
-from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -145,7 +145,7 @@ def generate_plan(
         f"case_id: {case_id or 'pending'}",
         f"workflow: {workflow_id}",
         f"priority: {primary.get('severity', 'medium')}",
-        f"created: {datetime.utcnow().isoformat()}Z",
+        f"created: {utcnow().isoformat()}Z",
         "status: planning",
         f"current_step: 1",
         "---",
@@ -213,7 +213,7 @@ def generate_case_review_plan(
         f"case_id: {case_id}",
         "workflow: case-review",
         f"priority: {priority}",
-        f"created: {datetime.utcnow().isoformat()}Z",
+        f"created: {utcnow().isoformat()}Z",
         "status: planning",
         "current_step: 1",
         "---",
@@ -322,7 +322,7 @@ def generate_initial_state(
         "current_step": 1,
         "total_steps": total_steps,
         "trigger_finding_ids": [f.get("finding_id") for f in findings if f.get("finding_id")],
-        "created_at": datetime.utcnow().isoformat(),
+        "created_at": utcnow().isoformat(),
         "completed_steps": [],
         "discovered_iocs": {},
         "discovered_entities": {},

--- a/services/daemon/poller.py
+++ b/services/daemon/poller.py
@@ -19,6 +19,7 @@ import asyncio
 import hmac
 import logging
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Optional, Dict, Any
 from dataclasses import dataclass
 
@@ -245,7 +246,7 @@ class DataPoller:
         while not shutdown_event.is_set():
             try:
                 await self._poll_splunk()
-                self._splunk_state.last_poll_time = datetime.utcnow()
+                self._splunk_state.last_poll_time = utcnow()
             except Exception as e:
                 logger.error(f"Splunk polling error: {e}")
                 self.stats["errors"] += 1
@@ -356,7 +357,7 @@ class DataPoller:
         return {
             'finding_id': finding_id,
             'data_source': 'splunk',
-            'timestamp': event.get('_time') or datetime.utcnow().isoformat(),
+            'timestamp': event.get('_time') or utcnow().isoformat(),
             'severity': severity,
             'status': 'new',
             'title': event.get('search_name') or event.get('rule_name') or 'Splunk Alert',
@@ -375,7 +376,7 @@ class DataPoller:
         while not shutdown_event.is_set():
             try:
                 await self._poll_crowdstrike()
-                self._crowdstrike_state.last_poll_time = datetime.utcnow()
+                self._crowdstrike_state.last_poll_time = utcnow()
             except Exception as e:
                 logger.error(f"CrowdStrike polling error: {e}")
                 self.stats["errors"] += 1
@@ -402,7 +403,7 @@ class DataPoller:
         try:
             # Get recent detections
             lookback_minutes = max(self.config.crowdstrike_interval // 60 + 1, 5)
-            since = datetime.utcnow() - timedelta(minutes=lookback_minutes)
+            since = utcnow() - timedelta(minutes=lookback_minutes)
             
             detections = await asyncio.to_thread(
                 self._crowdstrike_service.get_detections,
@@ -465,7 +466,7 @@ class DataPoller:
         return {
             'finding_id': finding_id,
             'data_source': 'crowdstrike',
-            'timestamp': detection.get('created_timestamp') or datetime.utcnow().isoformat(),
+            'timestamp': detection.get('created_timestamp') or utcnow().isoformat(),
             'severity': severity,
             'status': 'new',
             'title': detection.get('scenario') or 'CrowdStrike Detection',
@@ -573,7 +574,7 @@ class DataPoller:
                 "type": "finding",
                 "source": source,
                 "data": finding,
-                "timestamp": datetime.utcnow().isoformat()
+                "timestamp": utcnow().isoformat()
             })
             logger.debug(f"Enqueued finding {finding.get('finding_id')} from {source}")
         else:
@@ -594,7 +595,7 @@ class DataPoller:
         while not shutdown_event.is_set():
             try:
                 await self._poll_azure_sentinel()
-                self._azure_sentinel_state.last_poll_time = datetime.utcnow()
+                self._azure_sentinel_state.last_poll_time = utcnow()
             except Exception as e:
                 logger.error(f"Azure Sentinel polling error: {e}")
                 self.stats["errors"] += 1
@@ -637,7 +638,7 @@ class DataPoller:
         while not shutdown_event.is_set():
             try:
                 await self._poll_aws_security_hub()
-                self._aws_security_hub_state.last_poll_time = datetime.utcnow()
+                self._aws_security_hub_state.last_poll_time = utcnow()
             except Exception as e:
                 logger.error(f"AWS Security Hub polling error: {e}")
                 self.stats["errors"] += 1
@@ -680,7 +681,7 @@ class DataPoller:
         while not shutdown_event.is_set():
             try:
                 await self._poll_microsoft_defender()
-                self._microsoft_defender_state.last_poll_time = datetime.utcnow()
+                self._microsoft_defender_state.last_poll_time = utcnow()
             except Exception as e:
                 logger.error(f"Microsoft Defender polling error: {e}")
                 self.stats["errors"] += 1
@@ -723,7 +724,7 @@ class DataPoller:
         while not shutdown_event.is_set():
             try:
                 await self._poll_elastic()
-                self._elastic_state.last_poll_time = datetime.utcnow()
+                self._elastic_state.last_poll_time = utcnow()
             except Exception as e:
                 logger.error(f"Elastic Security polling error: {e}")
                 self.stats["errors"] += 1
@@ -746,7 +747,7 @@ class DataPoller:
 
         try:
             lookback_minutes = max(self.config.splunk_interval // 60 + 1, 5)
-            start_time = datetime.utcnow() - timedelta(minutes=lookback_minutes)
+            start_time = utcnow() - timedelta(minutes=lookback_minutes)
 
             alerts = await self._elastic_service.fetch_alerts(
                 start_time=start_time, limit=100

--- a/services/daemon/processor.py
+++ b/services/daemon/processor.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import time
-from datetime import datetime
+from core.time import utcnow
 from typing import Optional, Dict, List, Any
 
 from services.daemon.config import ProcessingConfig
@@ -583,7 +583,7 @@ REASONING: [Brief explanation]
 
         # Add triage metadata
         finding["ai_triage"] = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utcnow().isoformat(),
             "result": triage_result,
         }
 
@@ -644,7 +644,7 @@ REASONING: [Brief explanation]
         # enriched_at is always stamped as an "attempt" marker (it is one of
         # _AI_ANALYSIS_KEYS): a clean finding with no hits must still leave the
         # backfill's `ai_enrichment IS NULL` set, or it re-queues every sweep.
-        finding["enriched_at"] = datetime.utcnow().isoformat()
+        finding["enriched_at"] = utcnow().isoformat()
         if enrichment:
             finding["enrichment"] = enrichment
 
@@ -801,7 +801,7 @@ REASONING: [Brief explanation]
                 {
                     "type": "response_candidate",
                     "finding": finding,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": utcnow().isoformat(),
                 }
             )
             self.stats["queued_for_response"] += 1
@@ -814,7 +814,7 @@ REASONING: [Brief explanation]
                 {
                     "type": "finding",
                     "data": finding,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": utcnow().isoformat(),
                 }
             )
             self.stats["queued_for_investigation"] += 1

--- a/services/daemon/responder.py
+++ b/services/daemon/responder.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from datetime import datetime
+from core.time import utcnow
 from typing import Optional, Dict, Any
 
 from core.response.approval_service import ApprovalService
@@ -238,7 +238,7 @@ class AutonomousResponder:
                         "title": f"🚨 SOC Alert - {severity.upper()}",
                         "text": message,
                         "footer": "AI-SOC Daemon",
-                        "ts": datetime.utcnow().timestamp()
+                        "ts": utcnow().timestamp()
                     }]
                 },
                 timeout=30,

--- a/services/daemon/sandbox_poller.py
+++ b/services/daemon/sandbox_poller.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Any, Dict, Optional
 
 import httpx
@@ -111,7 +112,7 @@ class SandboxPoller:
                     reports[report_key] = {
                         "sandbox": sandbox_name,
                         "task_id": task_id,
-                        "fetched_at": datetime.utcnow().isoformat(),
+                        "fetched_at": utcnow().isoformat(),
                         "report": report,
                     }
                     sub["status"] = "reported"
@@ -263,4 +264,4 @@ class SandboxPoller:
             submitted = datetime.fromisoformat(ts)
         except ValueError:
             return False
-        return datetime.utcnow() - submitted > timedelta(seconds=self._timeout_seconds)
+        return utcnow() - submitted > timedelta(seconds=self._timeout_seconds)

--- a/services/daemon/sandbox_submitter.py
+++ b/services/daemon/sandbox_submitter.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 from core.config import get_settings
 from core.secrets import get_secret
@@ -154,7 +154,7 @@ class SandboxSubmitter:
 
         results = await asyncio.gather(*coros, return_exceptions=True)
 
-        now_iso = datetime.utcnow().isoformat()
+        now_iso = utcnow().isoformat()
         out: Dict[str, Any] = {}
         for name, res in zip(names, results):
             if isinstance(res, Exception):

--- a/services/daemon/scheduler.py
+++ b/services/daemon/scheduler.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Optional, Dict, List, Any, Callable
 from dataclasses import dataclass
 
@@ -142,13 +143,13 @@ class TaskScheduler:
             if task.run_on_start and task.enabled:
                 try:
                     await task.func()
-                    task.last_run = datetime.utcnow()
+                    task.last_run = utcnow()
                 except Exception as e:
                     logger.error(f"Startup task {task.name} failed: {e}")
         
         # Main scheduling loop
         while not shutdown_event.is_set():
-            now = datetime.utcnow()
+            now = utcnow()
             
             for task in self._tasks:
                 if not task.enabled:
@@ -205,7 +206,7 @@ class TaskScheduler:
         
         # Generate threat hunt summary
         summary = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utcnow().isoformat(),
             "findings_analyzed": len(findings),
             "patterns_detected": analysis.get("patterns", []),
             "iocs_found": len(iocs),
@@ -312,7 +313,7 @@ class TaskScheduler:
         cases = self._data_service.get_cases()
         
         # Calculate time range (last week)
-        now = datetime.utcnow()
+        now = utcnow()
         week_ago = now - timedelta(days=7)
         
         # Filter to recent findings
@@ -377,7 +378,7 @@ class TaskScheduler:
         self.stats["cleanups_run"] += 1
         
         # Calculate cutoff date
-        cutoff = datetime.utcnow() - timedelta(days=self.config.cleanup_retention_days)
+        cutoff = utcnow() - timedelta(days=self.config.cleanup_retention_days)
         
         # For now, just log what would be cleaned
         # In production, would delete old findings/processed events
@@ -418,7 +419,7 @@ class TaskScheduler:
         logger.info("Running health check...")
         
         health = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utcnow().isoformat(),
             "status": "healthy",
             "components": {}
         }

--- a/services/daemon/threat_feed_poller.py
+++ b/services/daemon/threat_feed_poller.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
+from core.time import utcnow
 from typing import Any, Dict, List, Optional
 from core.config import get_settings
 
@@ -103,7 +104,7 @@ class ThreatFeedPoller:
                 total_seen += len(indicators)
                 total_inserted += counts.get("inserted", 0)
                 total_updated += counts.get("updated", 0)
-                _last_polled[key] = datetime.utcnow() - timedelta(seconds=60)
+                _last_polled[key] = utcnow() - timedelta(seconds=60)
             except Exception as e:  # noqa: BLE001
                 logger.error("Cloudforce One poll failed for %s: %s", cid, e)
                 errors += 1

--- a/services/daemon/workdir.py
+++ b/services/daemon/workdir.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import shutil
-from datetime import datetime
+from core.time import utcnow
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -99,7 +99,7 @@ class WorkdirManager:
     
     
     def append_log(self, investigation_id: str, event: Dict[str, Any]):
-        event.setdefault("ts", datetime.utcnow().isoformat())
+        event.setdefault("ts", utcnow().isoformat())
         event.setdefault("vigil.investigation.id", investigation_id)
         # Embed current OTEL trace context so log lines are correlatable in Jaeger/Grafana
         try:

--- a/tests/unit/_ratchets/test_no_datetime_utcnow.py
+++ b/tests/unit/_ratchets/test_no_datetime_utcnow.py
@@ -1,0 +1,86 @@
+"""Forbid stdlib ``utcnow`` — use ``core.time.utcnow`` instead.
+
+Naive DateTime columns mean the replacement must stay naive; see ``core.time``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACKAGES = ("core", "services", "tools")
+HELPER = Path("core/time.py")
+
+
+def _python_files():
+    for package in PACKAGES:
+        root = REPO_ROOT / package
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            rel = path.relative_to(REPO_ROOT)
+            if rel == HELPER:
+                continue
+            yield rel
+
+
+def _utcnow_violations(rel_path: Path):
+    source = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(rel_path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute) or node.attr != "utcnow":
+            continue
+        base = node.value
+        # datetime.utcnow (call or SQLAlchemy default=)
+        if isinstance(base, ast.Name) and base.id == "datetime":
+            yield node.lineno, "datetime.utcnow"
+        # datetime.datetime.utcnow
+        elif (
+            isinstance(base, ast.Attribute)
+            and base.attr == "datetime"
+            and isinstance(base.value, ast.Name)
+            and base.value.id == "datetime"
+        ):
+            yield node.lineno, "datetime.datetime.utcnow"
+
+
+@pytest.mark.unit
+def test_no_datetime_utcnow():
+    violations = [
+        f"{rel}:{lineno}: {kind}"
+        for rel in _python_files()
+        for lineno, kind in _utcnow_violations(rel)
+    ]
+    assert not violations, (
+        "Deprecated utcnow() found. Use core.time.utcnow() "
+        "(naive UTC, matching naive DateTime columns).\n" + "\n".join(violations)
+    )
+
+
+@pytest.mark.unit
+def test_no_asyncio_get_event_loop():
+    violations = []
+    for rel in _python_files():
+        source = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(rel))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "get_event_loop"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "asyncio"
+            ):
+                violations.append(f"{rel}:{node.lineno}: asyncio.get_event_loop()")
+    assert not violations, (
+        "asyncio.get_event_loop() is deprecated in 3.10+. "
+        "Use asyncio.get_running_loop() inside a running event loop.\n"
+        + "\n".join(violations)
+    )

--- a/tests/unit/_ratchets/test_no_datetime_utcnow.py
+++ b/tests/unit/_ratchets/test_no_datetime_utcnow.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-PACKAGES = ("core", "services", "tools")
+PACKAGES = ("core", "services", "tools", "scripts")
 HELPER = Path("core/time.py")
 
 
@@ -33,6 +33,11 @@ def _utcnow_violations(rel_path: Path):
     source = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
     tree = ast.parse(source, filename=str(rel_path))
     for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "datetime":
+            for alias in node.names:
+                if alias.name == "utcnow":
+                    yield node.lineno, "from datetime import utcnow"
+            continue
         if not isinstance(node, ast.Attribute) or node.attr != "utcnow":
             continue
         base = node.value

--- a/tests/unit/api/test_ai_config_api.py
+++ b/tests/unit/api/test_ai_config_api.py
@@ -14,6 +14,8 @@ from unittest.mock import patch
 
 import pytest
 
+from core.time import utcnow
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -69,10 +71,8 @@ class _FakeSession:
 
     def refresh(self, row):
         # to_dict() reads updated_at — populate so response serialization works.
-        import datetime
-
         if hasattr(row, "updated_at") and row.updated_at is None:
-            row.updated_at = datetime.datetime.utcnow()
+            row.updated_at = utcnow()
 
 
 @pytest.fixture()

--- a/tests/unit/auth/test_auth_lockout_persistence.py
+++ b/tests/unit/auth/test_auth_lockout_persistence.py
@@ -7,7 +7,8 @@ transaction it would be discarded, the threshold would never trip, and the
 brute-force lockout would silently stop working.
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
+from core.time import utcnow
 from unittest.mock import MagicMock
 
 import pytest
@@ -83,8 +84,8 @@ def test_threshold_locks_the_account_durably(own_session, caller_session, monkey
 
     assert own_user.failed_login_count == 3
     assert own_user.locked_until is not None
-    assert own_user.locked_until > datetime.utcnow()
-    assert own_user.locked_until <= datetime.utcnow() + timedelta(
+    assert own_user.locked_until > utcnow()
+    assert own_user.locked_until <= utcnow() + timedelta(
         minutes=auth_module.LOCKOUT_DURATION_MINUTES
     )
     own_session.commit.assert_called_once()

--- a/tests/unit/daemon/test_daemon.py
+++ b/tests/unit/daemon/test_daemon.py
@@ -4,7 +4,8 @@ Tests polling, processing, auto-response, and escalation logic.
 """
 
 import pytest
-from datetime import datetime, timedelta
+from datetime import timedelta
+from core.time import utcnow
 from unittest.mock import Mock, patch, MagicMock
 
 from services.daemon.poller import DataPoller
@@ -26,7 +27,7 @@ class TestPollingLogic:
         
         next_poll = poller.calculate_next_poll(interval)
         
-        now = datetime.utcnow()
+        now = utcnow()
         expected = now + timedelta(seconds=interval)
         
         # Allow 1 second tolerance
@@ -38,7 +39,7 @@ class TestPollingLogic:
         from services.daemon.config import PollingConfig
         config = PollingConfig()
         poller = DataPoller(config)
-        last_poll = datetime.utcnow() - timedelta(seconds=400)
+        last_poll = utcnow() - timedelta(seconds=400)
         interval = 300  # 5 minutes
         
         should_poll = poller.should_poll(last_poll, interval)
@@ -51,7 +52,7 @@ class TestPollingLogic:
         from services.daemon.config import PollingConfig
         config = PollingConfig()
         poller = DataPoller(config)
-        last_poll = datetime.utcnow() - timedelta(seconds=100)
+        last_poll = utcnow() - timedelta(seconds=100)
         interval = 300  # 5 minutes
         
         should_poll = poller.should_poll(last_poll, interval)
@@ -433,7 +434,7 @@ class TestScheduledTasks:
         scheduler = TaskScheduler()
         
         retention_days = 90
-        cutoff_date = datetime.utcnow() - timedelta(days=retention_days)
+        cutoff_date = utcnow() - timedelta(days=retention_days)
         
         # Test cleanup logic
         result = scheduler.cleanup_old_data(retention_days)

--- a/tests/unit/llm/test_llm_interaction_log.py
+++ b/tests/unit/llm/test_llm_interaction_log.py
@@ -6,7 +6,7 @@ Covers:
 - ClaudeService._persist_interaction graceful failure when DB is unavailable
 """
 
-from datetime import datetime
+from core.time import utcnow
 
 
 class TestLLMInteractionLogModel:
@@ -29,7 +29,7 @@ class TestLLMInteractionLogModel:
             session_id="session-1",
             agent_id="investigator",
             investigation_id=None,
-            created_at=datetime.utcnow(),
+            created_at=utcnow(),
             model="claude-sonnet-4-5",
             request_messages=[{"role": "user", "content": "hi"}],
             thinking_enabled=True,
@@ -71,7 +71,7 @@ class TestLLMInteractionLogModel:
             session_id="session-1",
             agent_id=None,
             investigation_id=None,
-            created_at=datetime.utcnow(),
+            created_at=utcnow(),
             model="claude-sonnet-4-5",
             request_messages=[{"role": "user", "content": "hi"}],
             thinking_enabled=False,

--- a/tools/mcp/deeptempo_findings.py
+++ b/tools/mcp/deeptempo_findings.py
@@ -9,6 +9,8 @@ from typing import Optional
 import numpy as np
 from mcp.server.fastmcp import FastMCP
 
+from core.time import utcnow
+
 logger = logging.getLogger(__name__)
 mcp = FastMCP("deeptempo-findings")
 
@@ -295,7 +297,7 @@ def create_case(
 ) -> str:
     try:
         db = get_db()
-        case_id = f"case-{datetime.utcnow().strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
+        case_id = f"case-{utcnow().strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
         case = db.create_case(
             case_id=case_id,
             title=title,
@@ -352,7 +354,7 @@ def update_case(
         if add_note:
             notes = case.notes or []
             notes.append(
-                {"timestamp": datetime.utcnow().isoformat() + "Z", "note": add_note}
+                {"timestamp": utcnow().isoformat() + "Z", "note": add_note}
             )
             updates["notes"] = notes
 
@@ -420,7 +422,7 @@ def add_case_activity(
 
         activities = case.activities or []
         new_activity = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": utcnow().isoformat() + "Z",
             "activity_type": activity_type,
             "description": description,
             "details": details or {},
@@ -472,7 +474,7 @@ def add_case_timeline_entry(
 
         timeline = case.timeline or []
         new_entry = {
-            "timestamp": event_time or (datetime.utcnow().isoformat() + "Z"),
+            "timestamp": event_time or (utcnow().isoformat() + "Z"),
             "event_type": event_type,
             "description": event_description,
             "details": details or {},
@@ -562,7 +564,7 @@ def add_resolution_step(
 
         resolution_steps = case.resolution_steps or []
         new_step = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": utcnow().isoformat() + "Z",
             "description": description,
             "action_taken": action_taken,
             "result": result,
@@ -848,8 +850,6 @@ def add_case_evidence(
                            source="Palo Alto FW", tags=["c2", "exfiltration"])
     """
     try:
-        from datetime import datetime
-
         from core.storage.connection import get_db_session
         from core.storage.models import CaseEvidence
 
@@ -860,14 +860,14 @@ def add_case_evidence(
                 evidence_type=evidence_type,
                 name=name,
                 collected_by=collected_by,
-                collected_at=datetime.utcnow(),
+                collected_at=utcnow(),
                 description=description,
                 file_path=file_path,
                 source=source,
                 tags=tags or [],
                 chain_of_custody=[
                     {
-                        "timestamp": datetime.utcnow().isoformat() + "Z",
+                        "timestamp": utcnow().isoformat() + "Z",
                         "action": "collected",
                         "user": collected_by,
                         "notes": "Evidence collected and added to case",
@@ -925,8 +925,6 @@ def add_case_ioc(
                       tags=["malware", "ransomware"])
     """
     try:
-        from datetime import datetime
-
         from core.storage.connection import get_db_session
         from core.storage.models import CaseIOC
 
@@ -941,8 +939,8 @@ def add_case_ioc(
                 source=source,
                 tags=tags or [],
                 context=context,
-                first_seen=datetime.utcnow(),
-                last_seen=datetime.utcnow(),
+                first_seen=utcnow(),
+                last_seen=utcnow(),
                 is_active=True,
                 is_false_positive=False,
             )
@@ -1134,8 +1132,6 @@ def update_case_task(
         - update_case_task(5, status="completed", notes="Malware analysis complete - ransomware variant")
     """
     try:
-        from datetime import datetime
-
         from core.storage.connection import get_db_session
         from core.storage.models import CaseTask
 
@@ -1148,7 +1144,7 @@ def update_case_task(
             if status:
                 task.status = status
                 if status == "completed":
-                    task.completed_at = datetime.utcnow()
+                    task.completed_at = utcnow()
             if assignee:
                 task.assignee = assignee
 


### PR DESCRIPTION
## Summary

Repo-wide replacement of deprecated `datetime.utcnow()` (Python 3.12+) with a **naive-UTC helper**, so we kill the deprecation without mixing aware `now` against naive `DateTime` columns (option A from review).

```python
# core/time.py
def utcnow() -> datetime:
    return datetime.now(timezone.utc).replace(tzinfo=None)
```

Also folds in the last three `asyncio.get_event_loop()` sites so #541 can close.

### Changes
| Metric | Count |
|--------|------:|
| Files changed | **61** |
| `from core.time import utcnow` | **58** |
| Remaining `datetime.utcnow()` in `core/` `services/` `tools/` | **0** (helper exempt) |
| `asyncio.get_event_loop()` → `get_running_loop()` | **3** |

### Replacement rules
- `datetime.utcnow()` → `utcnow()` from `core.time`
- SQLAlchemy `default=` / `onupdate=` stay callables (`default=utcnow`)
- Existing `datetime.now(timezone.utc)` sites that were already aware are left alone
- `isoformat() + "Z"` / f-string `{isoformat()}Z` on the naive helper is correct (must not emit `+00:00Z`)
- Lockout comparisons (`auth_service` / `routers/auth`) stay naive-naive

### `get_event_loop` sites
- `core/findings/enrichment/service.py` (`run_in_executor`)
- `core/reporting/ai_insights_service.py` (same)
- `services/daemon/main.py` `_setup_signal_handlers` (called from `async def run`)

### Ratchet
`tests/unit/_ratchets/test_no_datetime_utcnow.py` — same AST style as `test_no_ambient_state.py`. Scans `core/`, `services/`, `tools/`; exempts `core/time.py`. Also forbids `asyncio.get_event_loop()`.

## Test plan
- [x] `pytest tests/unit/_ratchets/test_no_datetime_utcnow.py -q --no-cov`
- [x] `pytest tests/unit/auth/test_auth_lockout_persistence.py -q --no-cov`
- [x] daemon / llm-log / ai-config unit slices — **28 passed, 29 skipped** (skips are pre-existing daemon architecture skips)
- [ ] Full `./tests/run-tests.sh` (not run locally)

## Related
- Fixes #541