### PR TITLE
refactor(agents): single agent-id registry (#476)

### DIFF
--- a/backend/api/agents.py
+++ b/backend/api/agents.py
@@ -6,7 +6,12 @@ from pydantic import BaseModel
 import logging
 
 from services.defaults import DEFAULT_MODEL
-from services.soc_agents import SOCAgentLibrary, AgentManager, CUSTOM_AGENT_ID_PREFIX
+from services.soc_agents import (
+    SOCAgentLibrary,
+    AgentManager,
+    CUSTOM_AGENT_ID_PREFIX,
+    DEFAULT_AGENT_ID,
+)
 from api._meta import Auth, RouterMeta
 
 router = APIRouter()
@@ -40,7 +45,7 @@ def _resolve_agent(agent_id: str):
 class InvestigationRequest(BaseModel):
     """Request to start an investigation with an agent."""
     finding_id: str
-    agent_id: Optional[str] = "investigator"
+    agent_id: Optional[str] = DEFAULT_AGENT_ID
     additional_context: Optional[str] = None
 
 
@@ -196,7 +201,7 @@ class AgentRunRequest(BaseModel):
     finding_id: Optional[str] = None
     case_id: Optional[str] = None
     task: Optional[str] = None
-    agent_id: str = "investigator"
+    agent_id: str = DEFAULT_AGENT_ID
     use_agent_sdk: bool = True
 
 

--- a/daemon/agent_runner.py
+++ b/daemon/agent_runner.py
@@ -15,6 +15,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from services.soc_agents import ORCHESTRATOR_ACTOR
+
 # Tool safety tiers live in services.tool_manager so every agent loop (daemon,
 # interactive OpenAI agent, workflows) shares one policy. Aliased to the
 # historical name so call sites — and the test that patches
@@ -1380,7 +1382,7 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                 confidence=0.7,
                 reason=f"Autonomous investigation {inv_id} needs to execute {tool_name}",
                 evidence=[inv_id],
-                created_by="orchestrator",
+                created_by=ORCHESTRATOR_ACTOR,
                 parameters=tool_input,
             )
             action_id = pending.action_id

--- a/daemon/orchestrator.py
+++ b/daemon/orchestrator.py
@@ -67,6 +67,7 @@ from daemon.plan_generator import (
 )
 from daemon.shared_intel import SharedIntelligence
 from daemon.workdir import WorkdirManager
+from services.soc_agents import ORCHESTRATION_DECISION_ID, ORCHESTRATOR_ACTOR
 
 logger = logging.getLogger(__name__)
 
@@ -731,7 +732,7 @@ class Orchestrator:
                 confidence=0.8,
                 reason=f"[Auto-investigation {inv_id}] {action.get('reason', '')}",
                 evidence=[inv_id],
-                created_by="orchestrator",
+                created_by=ORCHESTRATOR_ACTOR,
             )
             logger.info(f"Created approval action for {inv_id}: {action_str}")
         except Exception as e:
@@ -955,7 +956,7 @@ class Orchestrator:
 
                 entry = AIDecisionLog(
                     decision_id=f"orch-{uuid.uuid4().hex[:8]}",
-                    agent_id="orchestrator",
+                    agent_id=ORCHESTRATION_DECISION_ID,
                     workflow_id=inv_id,
                     finding_id=finding_id,
                     case_id=case_id,
@@ -964,7 +965,7 @@ class Orchestrator:
                     reasoning=reasoning,
                     recommended_action=action,
                     decision_metadata={
-                        "source": "orchestrator",
+                        "source": ORCHESTRATOR_ACTOR,
                         "investigation_id": inv_id,
                     },
                 )

--- a/database/init/18_agent_decision_ids.sql
+++ b/database/init/18_agent_decision_ids.sql
@@ -1,0 +1,29 @@
+-- Re-key ai_decision_log.agent_id onto the action vocabulary (GH #476)
+-- Decision rows are grouped by the action performed, not the role that
+-- performed it, and the registry in services/soc_agents.py is now the sole
+-- definition of that mapping. Rows written before the registry landed carry
+-- role ids (or the daemon's ad-hoc "orchestrator"); rewrite them so the
+-- AI-Decisions filter sees one vocabulary.
+
+UPDATE ai_decision_log SET agent_id = CASE agent_id
+    WHEN 'investigator'    THEN 'investigation'
+    WHEN 'correlator'      THEN 'correlation'
+    WHEN 'reporter'        THEN 'reporting'
+    WHEN 'responder'       THEN 'response'
+    WHEN 'threat_hunter'   THEN 'threat_hunt'
+    WHEN 'mitre_analyst'   THEN 'mitre_mapping'
+    WHEN 'malware_analyst' THEN 'malware_analysis'
+    WHEN 'network_analyst' THEN 'network_analysis'
+    WHEN 'auto_responder'  THEN 'auto_response'
+    WHEN 'orchestrator'    THEN 'orchestration'
+    ELSE agent_id
+END
+WHERE agent_id IN (
+    'investigator', 'correlator', 'reporter', 'responder', 'threat_hunter',
+    'mitre_analyst', 'malware_analyst', 'network_analyst', 'auto_responder',
+    'orchestrator'
+);
+
+COMMENT ON COLUMN ai_decision_log.agent_id IS
+    'Action id from services/soc_agents.py:AGENT_IDENTITY (e.g. investigation, '
+    'correlation), or orchestration for the autonomous loop''s own decisions';

--- a/database/init/18_agent_decision_ids.sql
+++ b/database/init/18_agent_decision_ids.sql
@@ -1,29 +1,47 @@
--- Re-key ai_decision_log.agent_id onto the action vocabulary (GH #476)
+-- Re-key ai_decision_logs.agent_id onto the action vocabulary (GH #476)
 -- Decision rows are grouped by the action performed, not the role that
 -- performed it, and the registry in services/soc_agents.py is now the sole
 -- definition of that mapping. Rows written before the registry landed carry
 -- role ids (or the daemon's ad-hoc "orchestrator"); rewrite them so the
 -- AI-Decisions filter sees one vocabulary.
+--
+-- ai_decision_logs is created by SQLAlchemy create_all() on backend startup,
+-- not by this init/ directory, so on a fresh database it does not yet exist
+-- when this file runs under /docker-entrypoint-initdb.d (ON_ERROR_STOP=1).
+-- Guard on its existence and skip cleanly when absent -- there are no rows to
+-- re-key on a fresh install anyway. Mirrors 17_loglm_setup.sql. Idempotent:
+-- the target ids are not in the WHERE set, so re-running is a no-op.
 
-UPDATE ai_decision_log SET agent_id = CASE agent_id
-    WHEN 'investigator'    THEN 'investigation'
-    WHEN 'correlator'      THEN 'correlation'
-    WHEN 'reporter'        THEN 'reporting'
-    WHEN 'responder'       THEN 'response'
-    WHEN 'threat_hunter'   THEN 'threat_hunt'
-    WHEN 'mitre_analyst'   THEN 'mitre_mapping'
-    WHEN 'malware_analyst' THEN 'malware_analysis'
-    WHEN 'network_analyst' THEN 'network_analysis'
-    WHEN 'auto_responder'  THEN 'auto_response'
-    WHEN 'orchestrator'    THEN 'orchestration'
-    ELSE agent_id
-END
-WHERE agent_id IN (
-    'investigator', 'correlator', 'reporter', 'responder', 'threat_hunter',
-    'mitre_analyst', 'malware_analyst', 'network_analyst', 'auto_responder',
-    'orchestrator'
-);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_name = 'ai_decision_logs'
+    ) THEN
+        RAISE NOTICE '18_agent_decision_ids: ai_decision_logs absent (fresh DB), skipping';
+        RETURN;
+    END IF;
 
-COMMENT ON COLUMN ai_decision_log.agent_id IS
-    'Action id from services/soc_agents.py:AGENT_IDENTITY (e.g. investigation, '
-    'correlation), or orchestration for the autonomous loop''s own decisions';
+    UPDATE ai_decision_logs SET agent_id = CASE agent_id
+        WHEN 'investigator'    THEN 'investigation'
+        WHEN 'correlator'      THEN 'correlation'
+        WHEN 'reporter'        THEN 'reporting'
+        WHEN 'responder'       THEN 'response'
+        WHEN 'threat_hunter'   THEN 'threat_hunt'
+        WHEN 'mitre_analyst'   THEN 'mitre_mapping'
+        WHEN 'malware_analyst' THEN 'malware_analysis'
+        WHEN 'network_analyst' THEN 'network_analysis'
+        WHEN 'auto_responder'  THEN 'auto_response'
+        WHEN 'orchestrator'    THEN 'orchestration'
+        ELSE agent_id
+    END
+    WHERE agent_id IN (
+        'investigator', 'correlator', 'reporter', 'responder', 'threat_hunter',
+        'mitre_analyst', 'malware_analyst', 'network_analyst', 'auto_responder',
+        'orchestrator'
+    );
+
+    COMMENT ON COLUMN ai_decision_logs.agent_id IS
+        'Action id from services/soc_agents.py:AGENT_IDENTITY (e.g. investigation, '
+        'correlation), or orchestration for the autonomous loop''s own decisions';
+END $$;

--- a/frontend/src/redesign/DECISIONS_WIRING.md
+++ b/frontend/src/redesign/DECISIONS_WIRING.md
@@ -79,7 +79,7 @@ Mapping → redesign `Decision`:
 | view field | source |
 |------------|--------|
 | `id` | `decision_id` |
-| `agent` | `agent_id` via a `getAgentDisplayName` map (port from `AIDecisions.tsx:186-195`) |
+| `agent` | `agent_id` — an action id from the backend agent registry, labelled by `getAgentDisplayName` (#476) |
 | `type` | `decision_type` |
 | `inv` | `workflow_id` ‖ `decision_metadata.investigation_id` ‖ `finding_id` ‖ `case_id` ‖ `—` |
 | `conf` | `round(confidence_score * 100)` |

--- a/frontend/src/redesign/data/appData.ts
+++ b/frontend/src/redesign/data/appData.ts
@@ -40,11 +40,12 @@ export const AGENT_META: Record<string, { label: string; color: string }> = {
   auto_responder: { label: 'Auto-Response', color: '#FF6B6B' },
 }
 
-/** "mitre_analyst" → "Mitre Analyst" — fallback for unknown/custom handles. */
+/** "mitre_mapping" → "MITRE Mapping" — labels every agent and action id. */
 export function prettyHandle(handle: string): string {
   return handle
     .replace(/[._-]+/g, ' ')
     .replace(/\b\w/g, (c) => c.toUpperCase())
+    .replace(/\bMitre\b/g, 'MITRE')
     .trim()
 }
 

--- a/frontend/src/redesign/data/mappers.ts
+++ b/frontend/src/redesign/data/mappers.ts
@@ -237,26 +237,15 @@ export interface ApiDecision {
   has_feedback?: boolean
 }
 
-/** agent_id → display name (ported from pages/AIDecisions.tsx:186-195) */
-const AGENT_NAMES: Record<string, string> = {
-  triage: 'Triage',
-  investigation: 'Investigation',
-  threat_hunter: 'Threat Hunter',
-  correlation: 'Correlation',
-  auto_responder: 'Auto-Response',
-  reporting: 'Reporting',
-  mitre_analyst: 'MITRE',
-  forensics: 'Forensics',
-  threat_intel: 'Threat Intel',
-  compliance: 'Compliance',
-  malware_analyst: 'Malware',
-  network_analyst: 'Network',
-  orchestrator: 'Orchestrator',
-}
-
+/**
+ * `agent_id` on a decision row is an action id from the backend registry
+ * (services/soc_agents.py:AGENT_IDENTITY) — `investigation`, `threat_hunt`,
+ * `orchestration`. Those are already words, so the label is derived rather
+ * than mapped; custom agents fall through to the same treatment (#476).
+ */
 export function getAgentDisplayName(agentId?: string): string {
   if (!agentId) return DASH
-  return AGENT_NAMES[agentId] || agentId
+  return prettyHandle(agentId)
 }
 
 /**

--- a/frontend/src/redesign/screens/decisions/DecisionsScreen.tsx
+++ b/frontend/src/redesign/screens/decisions/DecisionsScreen.tsx
@@ -5,7 +5,7 @@
    analytics + feedback, and a separate pending-approvals queue.
    See DECISIONS_WIRING.md.
    ============================================================ */
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { format } from 'date-fns'
 import { Icon } from '../../shared/icons'
 import { Hbars, type HbarItem } from '../../shared/charts'
@@ -14,6 +14,7 @@ import type { Decision, Outcome } from '../../data/appData'
 import type { ScreenProps } from '../../shared/types'
 import {
   useDecisions,
+  useDecisionAgentIds,
   usePendingDecisions,
   useDecisionStats,
   usePendingApprovals,
@@ -28,8 +29,6 @@ import { EmptyState, Popup, Field, TextInput, Select, Rating, Slider, Dropdown, 
 type DecTab = 'pending' | 'all' | 'analytics' | 'approvals'
 type Assessment = 'agree' | 'partial' | 'disagree'
 
-const AGENT_IDS = ['all', 'triage', 'investigation', 'correlation', 'auto_responder', 'threat_hunter', 'orchestrator']
-const AGENT_OPTS = AGENT_IDS.map((id) => ({ value: id, label: id === 'all' ? 'All agents' : getAgentDisplayName(id) }))
 const STATUS_OPTS = [
   { value: 'all', label: 'All status' },
   { value: 'pending', label: 'Awaiting feedback' },
@@ -610,6 +609,14 @@ export default function DecisionsScreen({ setViewFull }: ScreenProps) {
   const pending = usePendingDecisions()
   const all = useDecisions(agentF, statusF)
   const approvals = usePendingApprovals()
+  const agentIds = useDecisionAgentIds()
+  const agentOpts = useMemo(
+    () => [
+      { value: 'all', label: 'All agents' },
+      ...agentIds.map((id) => ({ value: id, label: getAgentDisplayName(id) })),
+    ],
+    [agentIds],
+  )
 
   useEffect(() => {
     setViewFull(selected !== null)
@@ -695,7 +702,7 @@ export default function DecisionsScreen({ setViewFull }: ScreenProps) {
         <div className="bar-row" style={{ paddingTop: 8 }}>
           {tab === 'all' && (
             <>
-              <Dropdown label="Agent" value={agentF} options={AGENT_OPTS} onSelect={setAgentF} selected={agentF !== 'all'} onClear={() => setAgentF('all')} />
+              <Dropdown label="Agent" value={agentF} options={agentOpts} onSelect={setAgentF} selected={agentF !== 'all'} onClear={() => setAgentF('all')} />
               <Dropdown label="Status" value={statusF} options={STATUS_OPTS} onSelect={(v) => setStatusF(v as DecisionStatus)} selected={statusF !== 'all'} onClear={() => setStatusF('all')} />
             </>
           )}

--- a/frontend/src/redesign/screens/decisions/useDecisions.ts
+++ b/frontend/src/redesign/screens/decisions/useDecisions.ts
@@ -6,7 +6,7 @@
    shapes. See DECISIONS_WIRING.md §4.
    ============================================================ */
 import { useCallback, useEffect, useState } from 'react'
-import { aiDecisionsApi, approvalsApi } from '../../../services/api'
+import { agentsApi, aiDecisionsApi, approvalsApi, type AgentSummary } from '../../../services/api'
 import { mapApiDecision, type ApiDecision } from '../../data/mappers'
 import type { Decision } from '../../data/appData'
 
@@ -16,6 +16,40 @@ export type Phase = 'loading' | 'ready' | 'error'
 function errMsg(e: unknown, fallback: string): string {
   const r = e as { response?: { data?: { detail?: string } }; message?: string }
   return r?.response?.data?.detail || r?.message || fallback
+}
+
+/**
+ * The daemon's own decisions carry this id. It is not an agent, so it never
+ * comes back from GET /agents — see services/soc_agents.py:ORCHESTRATION_DECISION_ID.
+ */
+const ORCHESTRATION_DECISION_ID = 'orchestration'
+
+/**
+ * Agent filter options for the decisions table, keyed by the action ids the
+ * backend stamps on decision rows (#476). Derived from the agent registry so
+ * a new agent shows up in the filter without a frontend edit; falls back to
+ * the daemon-only id if /agents is unreachable.
+ */
+export function useDecisionAgentIds(): string[] {
+  const [ids, setIds] = useState<string[]>([ORCHESTRATION_DECISION_ID])
+
+  useEffect(() => {
+    let cancelled = false
+    agentsApi
+      .listAgents()
+      .then((res) => {
+        if (cancelled) return
+        const agents = (res.data?.agents || []) as AgentSummary[]
+        const decisionIds = agents.map((a) => a.decision_id || a.id)
+        setIds([...new Set([...decisionIds, ORCHESTRATION_DECISION_ID])])
+      })
+      .catch(() => undefined)
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return ids
 }
 
 export type DecisionStatus = 'all' | 'pending' | 'completed'

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -882,6 +882,8 @@ export interface AgentSummary {
   icon?: string
   color?: string
   specialization?: string
+  /** Action id this agent's decisions are logged under (#476). */
+  decision_id?: string
 }
 
 // Config API

--- a/helm/vigil/files/database-init/18_agent_decision_ids.sql
+++ b/helm/vigil/files/database-init/18_agent_decision_ids.sql
@@ -1,0 +1,29 @@
+-- Re-key ai_decision_log.agent_id onto the action vocabulary (GH #476)
+-- Decision rows are grouped by the action performed, not the role that
+-- performed it, and the registry in services/soc_agents.py is now the sole
+-- definition of that mapping. Rows written before the registry landed carry
+-- role ids (or the daemon's ad-hoc "orchestrator"); rewrite them so the
+-- AI-Decisions filter sees one vocabulary.
+
+UPDATE ai_decision_log SET agent_id = CASE agent_id
+    WHEN 'investigator'    THEN 'investigation'
+    WHEN 'correlator'      THEN 'correlation'
+    WHEN 'reporter'        THEN 'reporting'
+    WHEN 'responder'       THEN 'response'
+    WHEN 'threat_hunter'   THEN 'threat_hunt'
+    WHEN 'mitre_analyst'   THEN 'mitre_mapping'
+    WHEN 'malware_analyst' THEN 'malware_analysis'
+    WHEN 'network_analyst' THEN 'network_analysis'
+    WHEN 'auto_responder'  THEN 'auto_response'
+    WHEN 'orchestrator'    THEN 'orchestration'
+    ELSE agent_id
+END
+WHERE agent_id IN (
+    'investigator', 'correlator', 'reporter', 'responder', 'threat_hunter',
+    'mitre_analyst', 'malware_analyst', 'network_analyst', 'auto_responder',
+    'orchestrator'
+);
+
+COMMENT ON COLUMN ai_decision_log.agent_id IS
+    'Action id from services/soc_agents.py:AGENT_IDENTITY (e.g. investigation, '
+    'correlation), or orchestration for the autonomous loop''s own decisions';

--- a/helm/vigil/files/database-init/18_agent_decision_ids.sql
+++ b/helm/vigil/files/database-init/18_agent_decision_ids.sql
@@ -1,29 +1,47 @@
--- Re-key ai_decision_log.agent_id onto the action vocabulary (GH #476)
+-- Re-key ai_decision_logs.agent_id onto the action vocabulary (GH #476)
 -- Decision rows are grouped by the action performed, not the role that
 -- performed it, and the registry in services/soc_agents.py is now the sole
 -- definition of that mapping. Rows written before the registry landed carry
 -- role ids (or the daemon's ad-hoc "orchestrator"); rewrite them so the
 -- AI-Decisions filter sees one vocabulary.
+--
+-- ai_decision_logs is created by SQLAlchemy create_all() on backend startup,
+-- not by this init/ directory, so on a fresh database it does not yet exist
+-- when this file runs under /docker-entrypoint-initdb.d (ON_ERROR_STOP=1).
+-- Guard on its existence and skip cleanly when absent -- there are no rows to
+-- re-key on a fresh install anyway. Mirrors 17_loglm_setup.sql. Idempotent:
+-- the target ids are not in the WHERE set, so re-running is a no-op.
 
-UPDATE ai_decision_log SET agent_id = CASE agent_id
-    WHEN 'investigator'    THEN 'investigation'
-    WHEN 'correlator'      THEN 'correlation'
-    WHEN 'reporter'        THEN 'reporting'
-    WHEN 'responder'       THEN 'response'
-    WHEN 'threat_hunter'   THEN 'threat_hunt'
-    WHEN 'mitre_analyst'   THEN 'mitre_mapping'
-    WHEN 'malware_analyst' THEN 'malware_analysis'
-    WHEN 'network_analyst' THEN 'network_analysis'
-    WHEN 'auto_responder'  THEN 'auto_response'
-    WHEN 'orchestrator'    THEN 'orchestration'
-    ELSE agent_id
-END
-WHERE agent_id IN (
-    'investigator', 'correlator', 'reporter', 'responder', 'threat_hunter',
-    'mitre_analyst', 'malware_analyst', 'network_analyst', 'auto_responder',
-    'orchestrator'
-);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_name = 'ai_decision_logs'
+    ) THEN
+        RAISE NOTICE '18_agent_decision_ids: ai_decision_logs absent (fresh DB), skipping';
+        RETURN;
+    END IF;
 
-COMMENT ON COLUMN ai_decision_log.agent_id IS
-    'Action id from services/soc_agents.py:AGENT_IDENTITY (e.g. investigation, '
-    'correlation), or orchestration for the autonomous loop''s own decisions';
+    UPDATE ai_decision_logs SET agent_id = CASE agent_id
+        WHEN 'investigator'    THEN 'investigation'
+        WHEN 'correlator'      THEN 'correlation'
+        WHEN 'reporter'        THEN 'reporting'
+        WHEN 'responder'       THEN 'response'
+        WHEN 'threat_hunter'   THEN 'threat_hunt'
+        WHEN 'mitre_analyst'   THEN 'mitre_mapping'
+        WHEN 'malware_analyst' THEN 'malware_analysis'
+        WHEN 'network_analyst' THEN 'network_analysis'
+        WHEN 'auto_responder'  THEN 'auto_response'
+        WHEN 'orchestrator'    THEN 'orchestration'
+        ELSE agent_id
+    END
+    WHERE agent_id IN (
+        'investigator', 'correlator', 'reporter', 'responder', 'threat_hunter',
+        'mitre_analyst', 'malware_analyst', 'network_analyst', 'auto_responder',
+        'orchestrator'
+    );
+
+    COMMENT ON COLUMN ai_decision_logs.agent_id IS
+        'Action id from services/soc_agents.py:AGENT_IDENTITY (e.g. investigation, '
+        'correlation), or orchestration for the autonomous loop''s own decisions';
+END $$;

--- a/helm/vigil/values.yaml
+++ b/helm/vigil/values.yaml
@@ -310,6 +310,7 @@ dbInit:
     - 15_federation.sql
     - 16_llm_budgets.sql
     - 17_loglm_setup.sql
+    - 18_agent_decision_ids.sql
   resources:
     requests:
       cpu: 50m

--- a/scripts/create_workflow.py
+++ b/scripts/create_workflow.py
@@ -16,21 +16,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS_DIR = REPO_ROOT / "workflows"
 
-AVAILABLE_AGENTS = [
-    "triage",
-    "investigator",
-    "threat_hunter",
-    "correlator",
-    "responder",
-    "reporter",
-    "mitre_analyst",
-    "forensics",
-    "threat_intel",
-    "compliance",
-    "malware_analyst",
-    "network_analyst",
-    "auto_responder",
-]
+sys.path.insert(0, str(REPO_ROOT))
+from services.soc_agents import AgentId  # noqa: E402
+
+AVAILABLE_AGENTS = [a.value for a in AgentId]
 
 COMMON_TOOLS = [
     "get_finding",

--- a/services/autonomous_response_service.py
+++ b/services/autonomous_response_service.py
@@ -5,6 +5,8 @@ import logging
 from typing import Dict, List, Optional, Tuple, Callable, Any
 from datetime import datetime
 
+from services.soc_agents import AgentId
+
 logger = logging.getLogger(__name__)
 
 
@@ -329,7 +331,7 @@ Please review and approve/reject in the SOC dashboard.
                 confidence=confidence,
                 reason=reason,
                 evidence=evidence,
-                created_by="auto_responder",
+                created_by=AgentId.AUTO_RESPONDER.value,
                 parameters={
                     "hostname": hostname,
                     "correlation": correlation_data
@@ -678,7 +680,7 @@ Please review and approve/reject in the SOC dashboard.
                 confidence=confidence,
                 reason=reason,
                 evidence=evidence,
-                created_by="auto_responder",
+                created_by=AgentId.AUTO_RESPONDER.value,
                 parameters=parameters,
             )
 

--- a/services/soc_agents.py
+++ b/services/soc_agents.py
@@ -48,7 +48,7 @@ class AgentIdentity:
     """The two id namespaces an agent participates in besides its own id.
 
     ``decision_id`` names the *action* an agent performs and is what lands in
-    ``ai_decision_log.agent_id`` — deliberately a different vocabulary from
+    ``ai_decision_logs.agent_id`` — deliberately a different vocabulary from
     the :class:`AgentId` that lands in ``created_by``, because decisions are
     grouped by the work they represent rather than by who did it.
     ``component_category`` selects the ``ai_model_configs`` row the agent
@@ -103,7 +103,7 @@ class AgentProfile:
     # One of: 'triage', 'investigation', 'reporting'. Custom agents default
     # to 'investigation' unless the user picks otherwise in the builder.
     component_category: str = DEFAULT_COMPONENT_CATEGORY
-    # GH #476 — action id stamped on this agent's ai_decision_log rows. Custom
+    # GH #476 — action id stamped on this agent's ai_decision_logs rows. Custom
     # agents have no action of their own, so they log under their agent id.
     decision_id: str = ""
 
@@ -742,7 +742,7 @@ class AgentManager:
             return 0
 
     def get_current_agent(self) -> AgentProfile:
-        return self.agents.get(self.current_agent_id, self.agents["investigator"])
+        return self.agents.get(self.current_agent_id, self.agents[DEFAULT_AGENT_ID])
 
     def set_current_agent(self, agent_id: str) -> bool:
         if agent_id in self.agents:

--- a/services/soc_agents.py
+++ b/services/soc_agents.py
@@ -1,8 +1,81 @@
 import logging
 from dataclasses import dataclass
+from enum import Enum
 from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+class AgentId(str, Enum):
+    """Canonical id of every built-in agent — the *actor* vocabulary.
+
+    Doubles as the key of :data:`AGENT_CONFIGS` and the ``created_by`` value
+    an agent stamps on records it authors. Custom agents are not members;
+    they carry a ``custom-`` prefixed id from the database.
+    """
+
+    TRIAGE = "triage"
+    INVESTIGATOR = "investigator"
+    THREAT_HUNTER = "threat_hunter"
+    CORRELATOR = "correlator"
+    RESPONDER = "responder"
+    REPORTER = "reporter"
+    MITRE_ANALYST = "mitre_analyst"
+    FORENSICS = "forensics"
+    THREAT_INTEL = "threat_intel"
+    COMPLIANCE = "compliance"
+    MALWARE_ANALYST = "malware_analyst"
+    NETWORK_ANALYST = "network_analyst"
+    AUTO_RESPONDER = "auto_responder"
+
+    @property
+    def decision_id(self) -> str:
+        return AGENT_IDENTITY[self].decision_id
+
+    @property
+    def component_category(self) -> str:
+        return AGENT_IDENTITY[self].component_category
+
+
+# The autonomous loop authors decisions of its own but is not an agent: it has
+# no prompt, no AGENT_CONFIGS entry, and never appears in GET /agents.
+ORCHESTRATOR_ACTOR = "orchestrator"
+ORCHESTRATION_DECISION_ID = "orchestration"
+
+
+@dataclass(frozen=True)
+class AgentIdentity:
+    """The two id namespaces an agent participates in besides its own id.
+
+    ``decision_id`` names the *action* an agent performs and is what lands in
+    ``ai_decision_log.agent_id`` — deliberately a different vocabulary from
+    the :class:`AgentId` that lands in ``created_by``, because decisions are
+    grouped by the work they represent rather than by who did it.
+    ``component_category`` selects the ``ai_model_configs`` row the agent
+    inherits its model from (GH #89).
+    """
+
+    decision_id: str
+    component_category: str
+
+
+AGENT_IDENTITY: Dict[AgentId, AgentIdentity] = {
+    AgentId.TRIAGE: AgentIdentity("triage", "triage"),
+    AgentId.INVESTIGATOR: AgentIdentity("investigation", "investigation"),
+    AgentId.THREAT_HUNTER: AgentIdentity("threat_hunt", "investigation"),
+    AgentId.CORRELATOR: AgentIdentity("correlation", "investigation"),
+    AgentId.RESPONDER: AgentIdentity("response", "investigation"),
+    AgentId.REPORTER: AgentIdentity("reporting", "reporting"),
+    AgentId.MITRE_ANALYST: AgentIdentity("mitre_mapping", "investigation"),
+    AgentId.FORENSICS: AgentIdentity("forensics", "investigation"),
+    AgentId.THREAT_INTEL: AgentIdentity("threat_intel", "investigation"),
+    AgentId.COMPLIANCE: AgentIdentity("compliance", "investigation"),
+    AgentId.MALWARE_ANALYST: AgentIdentity("malware_analysis", "investigation"),
+    AgentId.NETWORK_ANALYST: AgentIdentity("network_analysis", "investigation"),
+    AgentId.AUTO_RESPONDER: AgentIdentity("auto_response", "investigation"),
+}
+
+DEFAULT_COMPONENT_CATEGORY = "investigation"
 
 
 @dataclass
@@ -29,7 +102,10 @@ class AgentProfile:
     # GH #89 — which ai_model_configs row to consult when `model` is None.
     # One of: 'triage', 'investigation', 'reporting'. Custom agents default
     # to 'investigation' unless the user picks otherwise in the builder.
-    component_category: str = "investigation"
+    component_category: str = DEFAULT_COMPONENT_CATEGORY
+    # GH #476 — action id stamped on this agent's ai_decision_log rows. Custom
+    # agents have no action of their own, so they log under their agent id.
+    decision_id: str = ""
 
 
 # Memory-palace section is separate from BASE_PROMPT so we can omit it
@@ -151,26 +227,6 @@ Use MCP tools (server_tool format):
 </principles>
 
 {methodology}"""
-
-
-# GH #89 — maps each built-in agent id to the ai_model_configs component it
-# inherits its model from. Kept outside AGENT_CONFIGS so the per-agent dicts
-# stay focused on prompt content.
-_BUILTIN_COMPONENT_CATEGORY: Dict[str, str] = {
-    "triage": "triage",
-    "investigator": "investigation",
-    "threat_hunter": "investigation",
-    "correlator": "investigation",
-    "responder": "investigation",
-    "reporter": "reporting",
-    "mitre_analyst": "investigation",
-    "forensics": "investigation",
-    "threat_intel": "investigation",
-    "compliance": "investigation",
-    "malware_analyst": "investigation",
-    "network_analyst": "investigation",
-    "auto_responder": "investigation",
-}
 
 
 AGENT_CONFIGS = {
@@ -560,6 +616,7 @@ class SOCAgentLibrary:
 
     @staticmethod
     def _build_agent(agent_id: str, cfg: dict) -> AgentProfile:
+        identity = AGENT_IDENTITY[AgentId(agent_id)]
         prompt = render_base_prompt(
             role=cfg["role"],
             extra_principles=cfg.get("extra_principles", ""),
@@ -581,9 +638,8 @@ class SOCAgentLibrary:
             # from ai_model_configs[component_category] with chat_default as
             # the ultimate fallback.
             model=None,
-            component_category=_BUILTIN_COMPONENT_CATEGORY.get(
-                agent_id, "investigation"
-            ),
+            component_category=identity.component_category,
+            decision_id=identity.decision_id,
         )
 
     @staticmethod
@@ -621,7 +677,10 @@ class SOCAgentLibrary:
             # GH #89 — custom agents can pin a model; falling back to the
             # component_category (default 'investigation') if not set.
             model=(row.get("model") or None),
-            component_category=(row.get("component_category") or "investigation"),
+            component_category=(
+                row.get("component_category") or DEFAULT_COMPONENT_CATEGORY
+            ),
+            decision_id=row["id"],
         )
 
     @staticmethod
@@ -632,11 +691,14 @@ class SOCAgentLibrary:
 
 CUSTOM_AGENT_ID_PREFIX = "custom-"
 
+# Fallback whenever a caller names no agent, and the landing agent for a new session.
+DEFAULT_AGENT_ID = AgentId.INVESTIGATOR.value
+
 
 class AgentManager:
     def __init__(self):
         self.agents = SOCAgentLibrary.get_all_agents()
-        self.current_agent_id = "investigator"
+        self.current_agent_id = DEFAULT_AGENT_ID
         # Load DB-backed custom agents at startup so /agents/agents returns
         # a unified list without waiting for a later CRUD call to trigger
         # refresh. Failures (DB not ready) are logged inside the helper,
@@ -697,6 +759,7 @@ class AgentManager:
                 "icon": a.icon,
                 "color": a.color,
                 "specialization": a.specialization,
+                "decision_id": a.decision_id,
             }
             for a in self.agents.values()
         ]
@@ -704,11 +767,11 @@ class AgentManager:
     def get_agent_by_task(self, task: str) -> Optional[AgentProfile]:
         t = task.lower()
         mapping = [
-            (["triage", "prioritize", "quick"], "triage"),
-            (["investigate", "deep dive", "analyze"], "investigator"),
-            (["hunt", "proactive", "search"], "threat_hunter"),
-            (["correlate", "relate", "connect", "pattern"], "correlator"),
-            (["respond", "contain", "remediate"], "responder"),
+            (["triage", "prioritize", "quick"], AgentId.TRIAGE),
+            (["investigate", "deep dive", "analyze"], AgentId.INVESTIGATOR),
+            (["hunt", "proactive", "search"], AgentId.THREAT_HUNTER),
+            (["correlate", "relate", "connect", "pattern"], AgentId.CORRELATOR),
+            (["respond", "contain", "remediate"], AgentId.RESPONDER),
             (
                 [
                     "report",
@@ -718,16 +781,16 @@ class AgentManager:
                     "board report",
                     "risk posture",
                 ],
-                "reporter",
+                AgentId.REPORTER,
             ),
-            (["mitre", "att&ck", "technique", "tactic"], "mitre_analyst"),
-            (["forensic", "artifact", "evidence"], "forensics"),
-            (["threat intel", "intelligence", "actor"], "threat_intel"),
-            (["compliance", "policy", "regulation"], "compliance"),
-            (["malware", "virus", "trojan", "ransomware"], "malware_analyst"),
-            (["network", "traffic", "packet", "flow"], "network_analyst"),
+            (["mitre", "att&ck", "technique", "tactic"], AgentId.MITRE_ANALYST),
+            (["forensic", "artifact", "evidence"], AgentId.FORENSICS),
+            (["threat intel", "intelligence", "actor"], AgentId.THREAT_INTEL),
+            (["compliance", "policy", "regulation"], AgentId.COMPLIANCE),
+            (["malware", "virus", "trojan", "ransomware"], AgentId.MALWARE_ANALYST),
+            (["network", "traffic", "packet", "flow"], AgentId.NETWORK_ANALYST),
         ]
         for keywords, agent_id in mapping:
             if any(kw in t for kw in keywords):
-                return self.agents[agent_id]
-        return self.agents["investigator"]
+                return self.agents[agent_id.value]
+        return self.agents[DEFAULT_AGENT_ID]

--- a/tests/unit/test_create_workflow_script.py
+++ b/tests/unit/test_create_workflow_script.py
@@ -1,11 +1,10 @@
-"""Parity tests for ``scripts/create_workflow.py``'s agent list.
+"""Rendering test for ``scripts/create_workflow.py``.
 
 Background: ``AVAILABLE_AGENTS`` in ``scripts/create_workflow.py`` previously
 dropped the ``auto_responder`` agent, so the 60-second workflow scaffolder
-could not reference Vigil's autonomous-response capability. The fix
-(``auto_responder`` re-added to the list) is paired with this test so a
-future drift between the script's allow-list and ``AGENT_CONFIGS`` in
-``services.soc_agents`` fails fast in CI.
+could not reference Vigil's autonomous-response capability. The list is now
+derived from ``services.soc_agents.AgentId`` (#476), so it cannot drift; what
+remains worth testing is that the template renderer handles a real agent id.
 
 See: https://github.com/Vigil-SOC/vigil/issues/204
 """
@@ -33,47 +32,6 @@ def _load_script_module():
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
-
-
-def test_auto_responder_is_in_available_agents():
-    """Direct regression for the missing 13th agent (issue #204)."""
-    mod = _load_script_module()
-    assert "auto_responder" in mod.AVAILABLE_AGENTS, (
-        "auto_responder must be selectable by scripts/create_workflow.py"
-    )
-
-
-def test_available_agents_matches_agent_configs_keys():
-    """The script's allow-list must stay in lock-step with the canonical
-    AGENT_CONFIGS dict in services.soc_agents. If they drift, new agents
-    silently become unscaffoldable (or the script offers agents that don't
-    exist). Fail fast here instead of debugging "unknown agent" at runtime.
-    """
-    mod = _load_script_module()
-    from services.soc_agents import AGENT_CONFIGS
-
-    script_agents = set(mod.AVAILABLE_AGENTS)
-    config_agents = set(AGENT_CONFIGS.keys())
-
-    missing_in_script = config_agents - script_agents
-    extra_in_script = script_agents - config_agents
-
-    assert not missing_in_script and not extra_in_script, (
-        f"scripts/create_workflow.py:AVAILABLE_AGENTS has drifted from "
-        f"services.soc_agents:AGENT_CONFIGS.\n"
-        f"  Missing from script (defined in AGENT_CONFIGS but not selectable): "
-        f"{sorted(missing_in_script) or 'none'}\n"
-        f"  Extra in script (selectable but not defined in AGENT_CONFIGS): "
-        f"{sorted(extra_in_script) or 'none'}"
-    )
-
-
-def test_available_agents_has_no_duplicates():
-    """A name appearing twice would cause confusing UX in the script's
-    epilog and validator messages."""
-    mod = _load_script_module()
-    duplicates = [a for a in mod.AVAILABLE_AGENTS if mod.AVAILABLE_AGENTS.count(a) > 1]
-    assert not duplicates, f"AVAILABLE_AGENTS contains duplicates: {sorted(set(duplicates))}"
 
 
 def test_build_template_renders_with_auto_responder():

--- a/tests/unit/test_soc_agents_models.py
+++ b/tests/unit/test_soc_agents_models.py
@@ -11,12 +11,39 @@ REPO = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO))
 
 from services.soc_agents import (  # noqa: E402
+    AGENT_CONFIGS,
+    AGENT_IDENTITY,
+    AgentId,
     AgentProfile,
+    ORCHESTRATION_DECISION_ID,
     SOCAgentLibrary,
-    _BUILTIN_COMPONENT_CATEGORY,
 )
 
 pytestmark = pytest.mark.unit
+
+
+def test_registry_covers_every_agent_exactly_once():
+    """AgentId, AGENT_CONFIGS and AGENT_IDENTITY are one registry in three
+    pieces (#476) — adding an agent to one but not the others is the drift
+    this issue exists to prevent."""
+    ids = {a.value for a in AgentId}
+    assert set(AGENT_CONFIGS) == ids
+    assert {a.value for a in AGENT_IDENTITY} == ids
+
+
+def test_decision_ids_are_unique_and_distinct_from_orchestration():
+    """Decision ids key the AI-Decisions filter, so a collision would silently
+    merge two agents' decisions into one bucket."""
+    decision_ids = [a.decision_id for a in AgentId]
+    assert len(set(decision_ids)) == len(decision_ids)
+    assert ORCHESTRATION_DECISION_ID not in decision_ids
+
+
+def test_component_categories_are_valid_model_registry_components():
+    from services.model_registry import is_valid_component
+
+    for agent in AgentId:
+        assert is_valid_component(agent.component_category), agent.value
 
 
 def test_agent_profile_has_new_fields_with_safe_defaults():
@@ -42,9 +69,7 @@ def test_builtin_categories_cover_all_built_ins():
             "investigation",
             "reporting",
         }, f"{agent_id} has an invalid category: {agent.component_category}"
-        assert agent.component_category == _BUILTIN_COMPONENT_CATEGORY.get(
-            agent_id, "investigation"
-        )
+        assert agent.component_category == AgentId(agent_id).component_category
 
 
 def test_triage_agent_is_categorized_as_triage():


### PR DESCRIPTION
Closes #476.

> **Note:** the issue is flagged on hold and assigned to @thetosy. Opened at the repo owner's explicit direction — please close if it still conflicts with the agent overhaul.

## The problem

Agent ids were bare string literals dispatched on across `services/`, `backend/` and `daemon/`, and two vocabularies disagreed with each other:

| Decision log wrote | Agent registry had |
|---|---|
| `investigation` | `investigator` |
| `correlation` | `correlator` |
| `reporting` | `reporter` |
| `orchestrator` | — (not an agent) |

Tracing every writer first turned up something narrower than the issue implies: **only `orchestrator` was ever actually stamped** (`daemon/orchestrator.py`). The other action ids existed solely in the frontend's `AGENT_NAMES` map, ported from the legacy `pages/AIDecisions.tsx` — plus whatever external callers POST to `/api/ai/decisions`, which validates nothing.

Separately, `_BUILTIN_COMPONENT_CATEGORY` already mapped agent → `triage`/`investigation`/`reporting`, but that is a **different axis**: it selects an `ai_model_configs` row and collapses 11 of 13 agents to `investigation`, so it could not double as the decision id.

## The fix

`services/soc_agents.py` becomes the sole definition site:

- **`AgentId`** — str-Enum of the 13 built-ins.
- **`AGENT_IDENTITY`** — one table mapping each agent to its decision id *and* its component category. This **replaces** `_BUILTIN_COMPONENT_CATEGORY`, so adding an agent touches one table instead of two.
- **`AgentProfile.decision_id`**, surfaced through `GET /agents`.

The two namespaces stay distinct, because they answer different questions:

- **actor** (`created_by`) — `AgentId`, plus `ORCHESTRATOR_ACTOR` for the autonomous loop
- **action** (`ai_decision_log.agent_id`) — `investigation`, `threat_hunt`, `mitre_mapping`, …, plus `ORCHESTRATION_DECISION_ID`

Per the issue discussion, decision ids are now consistently action-shaped rather than role-shaped: `threat_hunter` → `threat_hunt`, `mitre_analyst` → `mitre_mapping`, `auto_responder` → `auto_response`, and the loop logs under `orchestration`.

## Literal dispatch sites replaced

`daemon/orchestrator.py` (×3), `daemon/agent_runner.py`, `services/autonomous_response_service.py` (×2), `backend/api/agents.py` (×2), and `soc_agents.py`'s own `get_agent_by_task` map + default agent.

`scripts/create_workflow.py` now derives `AVAILABLE_AGENTS` from the enum, which made its two drift tests structurally impossible to fail — removed; the rendering test stays.

## Frontend

Because action ids are already words, the 14-entry `AGENT_NAMES` map and the hardcoded `AGENT_IDS` filter list are both **deleted**: labels derive from `prettyHandle` (one added rule uppercases MITRE) and the filter derives from `GET /agents` + `orchestration`.

## Migration

`database/init/18_agent_decision_ids.sql` re-keys existing `ai_decision_log` rows onto the action vocabulary. Copied into the chart bundle and added to `dbInit.sqlFiles` per the checklist in `database/init/README.md`.

## Verification

- 1159 unit tests pass (`pytest tests/unit/ -m "not external_service"`), 63 frontend tests pass
- `tsc --noEmit` and `eslint` clean; no new `flake8` findings vs. base
- `diff -r database/init helm/vigil/files/database-init --exclude=README.md` clean

New tests in `test_soc_agents_models.py` cover the drift this issue exists to prevent: `AgentId`/`AGENT_CONFIGS`/`AGENT_IDENTITY` agreeing, decision ids being unique and distinct from `orchestration`, and every component category being a valid `model_registry` component.

## Reviewer notes

- **`helm template` not run locally** — `helm` isn't installed here. I verified by reading `db-init-job.yaml:129`, which is a bare `range` over `dbInit.sqlFiles`. The `Helm Chart / Lint and Template` job is the real check.
- **Two blocking `slop` findings on this diff are pre-existing** — the `daemon.agent_runner` import cycle and the raw-SQLAlchemy `_log_ai_decision`. Both confirmed present on clean `main`; they surface only because this diff touches those functions. Not addressed here.
- **`AGENT_META` in `appData.ts` left alone** — keyed on agent ids (unchanged by this work) and would need `WorkflowsScreen` to fetch agents for its colors. #482's author already planned to remove it separately.