### PR TITLE
fix(integrations): hyphenated Integration IDs so cloud SIEM pollers start (#555)

### DIFF
--- a/daemon/federation/adapters/aws_security_hub.py
+++ b/daemon/federation/adapters/aws_security_hub.py
@@ -14,7 +14,7 @@ def _factory() -> FederationAdapter:
 
     return SIEMIngestionAdapter(
         name="aws_security_hub",
-        integration_id="aws_security_hub",
+        integration_id="aws-security-hub",
         default_interval=900,  # cloud cadence — Security Hub aggregates slowly
         service_factory=make_service,
         external_id_prefix="aws-securityhub",

--- a/daemon/federation/adapters/azure_sentinel.py
+++ b/daemon/federation/adapters/azure_sentinel.py
@@ -14,7 +14,7 @@ def _factory() -> FederationAdapter:
 
     return SIEMIngestionAdapter(
         name="azure_sentinel",
-        integration_id="azure_sentinel",
+        integration_id="azure-sentinel",
         default_interval=300,  # cloud SIEM cadence
         service_factory=make_service,
         external_id_prefix="azure-sentinel",

--- a/daemon/federation/adapters/microsoft_defender.py
+++ b/daemon/federation/adapters/microsoft_defender.py
@@ -14,7 +14,7 @@ def _factory() -> FederationAdapter:
 
     return SIEMIngestionAdapter(
         name="microsoft_defender",
-        integration_id="microsoft_defender",
+        integration_id="microsoft-defender",
         default_interval=60,  # EDR cadence
         service_factory=make_service,
         external_id_prefix="defender",

--- a/daemon/poller.py
+++ b/daemon/poller.py
@@ -137,7 +137,7 @@ class DataPoller:
                     logger.warning(f"Failed to initialize CrowdStrike service: {e}")
             
             # Initialize Azure Sentinel service if configured
-            if is_integration_enabled('azure_sentinel'):
+            if is_integration_enabled('azure-sentinel'):
                 try:
                     from services.azure_sentinel_ingestion import AzureSentinelIngestion
                     self._azure_sentinel_service = AzureSentinelIngestion()
@@ -146,7 +146,7 @@ class DataPoller:
                     logger.warning(f"Failed to initialize Azure Sentinel service: {e}")
             
             # Initialize AWS Security Hub service if configured
-            if is_integration_enabled('aws_security_hub'):
+            if is_integration_enabled('aws-security-hub'):
                 try:
                     from services.aws_security_hub_ingestion import AWSSecurityHubIngestion
                     self._aws_security_hub_service = AWSSecurityHubIngestion()
@@ -155,7 +155,7 @@ class DataPoller:
                     logger.warning(f"Failed to initialize AWS Security Hub service: {e}")
             
             # Initialize Microsoft Defender service if configured
-            if is_integration_enabled('microsoft_defender'):
+            if is_integration_enabled('microsoft-defender'):
                 try:
                     from services.microsoft_defender_ingestion import MicrosoftDefenderIngestion
                     self._microsoft_defender_service = MicrosoftDefenderIngestion()

--- a/services/aws_security_hub_ingestion.py
+++ b/services/aws_security_hub_ingestion.py
@@ -22,7 +22,7 @@ class AWSSecurityHubIngestion(SIEMIngestionService):
         """Initialize AWS Security Hub ingestion."""
         super().__init__()
         self.siem_name = "AWS Security Hub"
-        self.config = get_integration_config('aws_security_hub')
+        self.config = get_integration_config('aws-security-hub')
     
     async def fetch_alerts(
         self,

--- a/services/azure_sentinel_ingestion.py
+++ b/services/azure_sentinel_ingestion.py
@@ -22,7 +22,7 @@ class AzureSentinelIngestion(SIEMIngestionService):
         """Initialize Azure Sentinel ingestion."""
         super().__init__()
         self.siem_name = "Azure Sentinel"
-        self.config = get_integration_config('azure_sentinel')
+        self.config = get_integration_config('azure-sentinel')
     
     async def fetch_alerts(
         self,

--- a/services/microsoft_defender_ingestion.py
+++ b/services/microsoft_defender_ingestion.py
@@ -23,7 +23,7 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
         """Initialize Microsoft Defender ingestion."""
         super().__init__()
         self.siem_name = "Microsoft Defender"
-        self.config = get_integration_config('microsoft_defender')
+        self.config = get_integration_config('microsoft-defender')
         self.access_token = None
     
     def _get_access_token(self) -> Optional[str]:

--- a/tests/unit/test_integration_id_hyphens.py
+++ b/tests/unit/test_integration_id_hyphens.py
@@ -1,0 +1,100 @@
+"""Regression: Integration IDs for cloud SIEMs must be hyphenated (#555).
+
+Settings persist hyphenated ids (``azure-sentinel``, etc.). Enablement and
+config lookups are exact-match, so underscore forms silently never match.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+pytestmark = pytest.mark.unit
+
+CANONICAL_IDS = (
+    "azure-sentinel",
+    "aws-security-hub",
+    "microsoft-defender",
+)
+LEGACY_UNDERSCORE_IDS = (
+    "azure_sentinel",
+    "aws_security_hub",
+    "microsoft_defender",
+)
+
+# Call sites that must use Integration IDs (settings keys), not federation
+# source names / Redis namespaces / finding source labels.
+TARGET_FILES = (
+    "daemon/poller.py",
+    "services/azure_sentinel_ingestion.py",
+    "services/aws_security_hub_ingestion.py",
+    "services/microsoft_defender_ingestion.py",
+    "tools/microsoft_defender.py",
+    "daemon/federation/adapters/azure_sentinel.py",
+    "daemon/federation/adapters/aws_security_hub.py",
+    "daemon/federation/adapters/microsoft_defender.py",
+)
+
+LOOKUP_FUNCS = frozenset({"is_integration_enabled", "get_integration_config"})
+
+
+def _callee_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _string_const(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _integration_id_literals(path: Path) -> list[tuple[int, str, str]]:
+    """Return (lineno, kind, value) for Integration ID string literals."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found: list[tuple[int, str, str]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            name = _callee_name(node.func)
+            if name in LOOKUP_FUNCS and node.args:
+                value = _string_const(node.args[0])
+                if value is not None:
+                    found.append((node.lineno, name, value))
+            if name == "SIEMIngestionAdapter":
+                for kw in node.keywords:
+                    if kw.arg == "integration_id":
+                        value = _string_const(kw.value)
+                        if value is not None:
+                            found.append((node.lineno, "integration_id=", value))
+    return found
+
+
+@pytest.mark.parametrize("rel_path", TARGET_FILES)
+def test_no_legacy_underscore_integration_ids(rel_path: str):
+    literals = _integration_id_literals(REPO_ROOT / rel_path)
+    bad = [
+        (lineno, kind, value)
+        for lineno, kind, value in literals
+        if value in LEGACY_UNDERSCORE_IDS
+    ]
+    assert bad == [], (
+        f"{rel_path} still uses underscore Integration IDs "
+        f"(expected hyphenated canonical ids): {bad}"
+    )
+
+
+def test_canonical_hyphenated_ids_present_at_call_sites():
+    seen: set[str] = set()
+    for rel_path in TARGET_FILES:
+        for _lineno, _kind, value in _integration_id_literals(REPO_ROOT / rel_path):
+            if value in CANONICAL_IDS:
+                seen.add(value)
+    assert seen == set(CANONICAL_IDS)

--- a/tests/unit/test_integration_id_hyphens.py
+++ b/tests/unit/test_integration_id_hyphens.py
@@ -7,7 +7,10 @@ config lookups are exact-match, so underscore forms silently never match.
 from __future__ import annotations
 
 import ast
+import sys
+import types
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -37,6 +40,18 @@ TARGET_FILES = (
     "daemon/federation/adapters/azure_sentinel.py",
     "daemon/federation/adapters/aws_security_hub.py",
     "daemon/federation/adapters/microsoft_defender.py",
+)
+
+FEDERATION_ADAPTER_FILES = (
+    "daemon/federation/adapters/azure_sentinel.py",
+    "daemon/federation/adapters/aws_security_hub.py",
+    "daemon/federation/adapters/microsoft_defender.py",
+)
+
+INGESTION_SOURCE_FILES = (
+    ("services/azure_sentinel_ingestion.py", "azure_sentinel"),
+    ("services/aws_security_hub_ingestion.py", "aws_security_hub"),
+    ("services/microsoft_defender_ingestion.py", "microsoft_defender"),
 )
 
 LOOKUP_FUNCS = frozenset({"is_integration_enabled", "get_integration_config"})
@@ -77,6 +92,24 @@ def _integration_id_literals(path: Path) -> list[tuple[int, str, str]]:
     return found
 
 
+def _make_poller():
+    from daemon.config import PollingConfig
+    from daemon.poller import DataPoller
+
+    with (
+        patch("daemon.poller.FederationRunner"),
+        patch("daemon.poller.RedisDedupSet"),
+    ):
+        return DataPoller(PollingConfig())
+
+
+def _stub_database_data_service():
+    """Avoid importing the real DB stack (pgvector, etc.) during unit tests."""
+    module = types.ModuleType("services.database_data_service")
+    module.DatabaseDataService = MagicMock(name="DatabaseDataService")
+    return patch.dict(sys.modules, {"services.database_data_service": module})
+
+
 @pytest.mark.parametrize("rel_path", TARGET_FILES)
 def test_no_legacy_underscore_integration_ids(rel_path: str):
     literals = _integration_id_literals(REPO_ROOT / rel_path)
@@ -98,3 +131,103 @@ def test_canonical_hyphenated_ids_present_at_call_sites():
             if value in CANONICAL_IDS:
                 seen.add(value)
     assert seen == set(CANONICAL_IDS)
+
+
+@pytest.mark.parametrize("rel_path", FEDERATION_ADAPTER_FILES)
+def test_federation_source_names_remain_underscore(rel_path: str):
+    """Federation runtime names stay underscore; only integration_id is hyphenated."""
+    tree = ast.parse(
+        (REPO_ROOT / rel_path).read_text(encoding="utf-8"), filename=rel_path
+    )
+    names: list[str] = []
+    register_keys: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = _callee_name(node.func)
+        if callee == "SIEMIngestionAdapter":
+            for kw in node.keywords:
+                if kw.arg == "name":
+                    value = _string_const(kw.value)
+                    if value is not None:
+                        names.append(value)
+        if callee == "register_adapter" and node.args:
+            value = _string_const(node.args[0])
+            if value is not None:
+                register_keys.append(value)
+
+    assert names, f"{rel_path}: missing SIEMIngestionAdapter name="
+    assert register_keys, f"{rel_path}: missing register_adapter key"
+    assert all(n in LEGACY_UNDERSCORE_IDS for n in names), names
+    assert all(k in LEGACY_UNDERSCORE_IDS for k in register_keys), register_keys
+
+
+@pytest.mark.parametrize("rel_path,expected_source", INGESTION_SOURCE_FILES)
+def test_finding_data_source_values_remain_underscore(
+    rel_path: str, expected_source: str
+):
+    source = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+    assert f'"data_source": "{expected_source}"' in source
+
+
+def test_poller_inits_cloud_siem_services_when_hyphenated_ids_enabled():
+    """Settings-style hyphenated enablement must start the three cloud pollers."""
+    enabled = set(CANONICAL_IDS)
+    azure = MagicMock(name="AzureSentinelIngestion")
+    aws = MagicMock(name="AWSSecurityHubIngestion")
+    defender = MagicMock(name="MicrosoftDefenderIngestion")
+
+    with (
+        _stub_database_data_service(),
+        patch(
+            "core.config.is_integration_enabled",
+            side_effect=lambda integration_id: integration_id in enabled,
+        ),
+        patch("core.config.get_integration_config", return_value={}),
+        patch(
+            "services.azure_sentinel_ingestion.AzureSentinelIngestion",
+            return_value=azure,
+        ),
+        patch(
+            "services.aws_security_hub_ingestion.AWSSecurityHubIngestion",
+            return_value=aws,
+        ),
+        patch(
+            "services.microsoft_defender_ingestion.MicrosoftDefenderIngestion",
+            return_value=defender,
+        ),
+    ):
+        poller = _make_poller()
+        poller._init_services()
+
+    assert poller._azure_sentinel_service is azure
+    assert poller._aws_security_hub_service is aws
+    assert poller._microsoft_defender_service is defender
+
+
+def test_poller_skips_cloud_siems_when_only_underscore_ids_enabled():
+    """Underscore keys must not satisfy the hyphenated enablement checks."""
+    enabled = set(LEGACY_UNDERSCORE_IDS)
+
+    with (
+        _stub_database_data_service(),
+        patch(
+            "core.config.is_integration_enabled",
+            side_effect=lambda integration_id: integration_id in enabled,
+        ),
+        patch("core.config.get_integration_config", return_value={}),
+        patch("services.azure_sentinel_ingestion.AzureSentinelIngestion") as azure,
+        patch("services.aws_security_hub_ingestion.AWSSecurityHubIngestion") as aws,
+        patch(
+            "services.microsoft_defender_ingestion.MicrosoftDefenderIngestion"
+        ) as defender,
+    ):
+        poller = _make_poller()
+        poller._init_services()
+
+    azure.assert_not_called()
+    aws.assert_not_called()
+    defender.assert_not_called()
+    assert poller._azure_sentinel_service is None
+    assert poller._aws_security_hub_service is None
+    assert poller._microsoft_defender_service is None

--- a/tools/microsoft_defender.py
+++ b/tools/microsoft_defender.py
@@ -17,7 +17,7 @@ def result(data):
 
 
 def get_token():
-    config = get_integration_config('microsoft_defender')
+    config = get_integration_config('microsoft-defender')
     tenant = config.get('tenant_id')
     client_id = config.get('client_id')
     client_secret = config.get('client_secret')


### PR DESCRIPTION
## Summary
- Align daemon enablement/config lookups with the hyphenated Integration IDs settings already persists (`azure-sentinel`, `aws-security-hub`, `microsoft-defender`).
- Cover poller gates, ingestion `get_integration_config` calls, federation adapter `integration_id`, and the Microsoft Defender tool — without renaming Redis/stats/federation source names.
- Add focused regression tests for hyphenated call sites, poller init under hyphenated enablement, and unchanged federation/`data_source` underscore labels.

Fixes #555

## Test plan
- [x] `pytest tests/unit/test_integration_id_hyphens.py` (17 passed locally)
- [x] Confirm daemon initializes Azure Sentinel / AWS Security Hub / Microsoft Defender pollers when hyphenated Integration IDs are enabled (unit-tested via mocked `_init_services`)
- [x] Confirm federation source names / finding `data_source` values remain underscore (unit-tested; unchanged in diff)

## CI note
Earlier CI failures were GitHub hosted-runner acquisition timeouts (`The job was not acquired by Runner of type hosted even after multiple attempts`), not test failures in this change. Please re-run the workflow when runners are available.
