### PR TITLE
Walking skeleton: API to queue to TypeScript worker to ledger (#590)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -170,6 +170,66 @@ jobs:
         working-directory: clients/web
         run: npm run test:run
 
+  # The agent layer is a second Node package with its own manifest, so it needs
+  # its own job -- the frontend job above is scoped to frontend/. Node 20 rather
+  # than NODE_VERSION because services/agent/package.json requires it.
+  test-agent-layer:
+    name: Unit Tests - Agent Layer
+    if: github.repository == 'Vigil-SOC/vigil'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: agent_test
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+    env:
+      DATABASE_URL: postgres://test:test@localhost:5432/agent_test
+      REDIS_URL: redis://localhost:6379/0
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/agent/package-lock.json
+
+      - name: Install dependencies
+        working-directory: services/agent
+        run: npm ci
+
+      - name: Apply agent-layer schema
+        run: |
+          PGPASSWORD=test psql -h localhost -p 5432 -U test -d agent_test \
+            -f infra/database/init/19_agent_ledger.sql
+
+      - name: Typecheck
+        working-directory: services/agent
+        run: npm run typecheck
+
+      - name: Run unit tests
+        working-directory: services/agent
+        run: npm test
+
   # ============================================================================
   # Integration Tests
   # ============================================================================
@@ -191,6 +251,17 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+      # The walking-skeleton test enqueues onto BullMQ and spawns the TypeScript
+      # worker, so this job needs Redis and Node as well as Postgres.
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
     env:
       TESTING: "true"
       DEV_MODE: "true"
@@ -200,6 +271,8 @@ jobs:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: test
       POSTGRES_DB: deeptempo_test
+      DATABASE_URL: postgresql://test:test@localhost:5432/deeptempo_test
+      REDIS_URL: redis://localhost:6379/0
 
     steps:
       - uses: actions/checkout@v5
@@ -211,6 +284,17 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/agent/package-lock.json
+
+      - name: Install agent-layer dependencies
+        working-directory: services/agent
+        run: npm ci
 
       - name: Install dependencies
         run: |

--- a/core/agents/agent_runs_router.py
+++ b/core/agents/agent_runs_router.py
@@ -1,0 +1,120 @@
+# Start an agent run and report its outcome. POST enqueues plain JSON and writes
+# nothing; GET makes only the two reads Python is permitted against agent_events.
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+
+from core.agents.queue import (
+    RUN_KINDS,
+    build_start_job,
+    enqueue_run,
+    new_run_id,
+)
+from core.routing import Auth, RouterMeta, UnitOfWorkSession
+
+router = APIRouter()
+
+ROUTER_META = RouterMeta(
+    prefix="/api/agent-runs",
+    tags=["agent-runs"],
+    auth=Auth.REQUIRED,
+)
+logger = logging.getLogger(__name__)
+
+
+class StartRunRequest(BaseModel):
+    run_kind: str = Field(default="hunt", description=f"One of {', '.join(RUN_KINDS)}.")
+    arch: str = Field(..., description="Path to the arch file: the shape of the run.")
+    playbook: str = Field(..., description="Path to the playbook: the scenario as data.")
+    config: str = Field(..., description="Path to the deployment config.")
+    prompt: str = Field(default="", description="What the run is being asked to do.")
+    overrides: Optional[Dict[str, Any]] = None
+    tenant_id: Optional[str] = None
+
+
+class StartRunResponse(BaseModel):
+    run_id: str
+    job_id: str
+
+
+class RunStatusResponse(BaseModel):
+    run_id: str
+    status: str = Field(..., description="running or terminal.")
+    events: int = Field(..., description="Events on the ledger, so progress is visible.")
+    outcome: Optional[str] = None
+    reason: Optional[str] = None
+
+
+# Mint a run id and enqueue it. The worker opens the ledger, not this call.
+@router.post("", response_model=StartRunResponse, status_code=202)
+async def start_run(request: StartRunRequest) -> StartRunResponse:
+    if request.run_kind not in RUN_KINDS:
+        raise HTTPException(status_code=400, detail=f"unknown run_kind: {request.run_kind}")
+
+    run_id = new_run_id()
+    payload: Dict[str, Any] = {
+        "arch": request.arch,
+        "playbook": request.playbook,
+        "config": request.config,
+        "prompt": request.prompt,
+    }
+    if request.overrides is not None:
+        payload["overrides"] = request.overrides
+
+    job = build_start_job(
+        run_id=run_id,
+        run_kind=request.run_kind,
+        request=payload,
+        enqueued_by="api",
+        tenant_id=request.tenant_id,
+    )
+    try:
+        job_id = await enqueue_run(job)
+    except Exception as exc:  # the queue is the only thing this endpoint can fail on
+        logger.error("failed to enqueue agent run %s: %s", run_id, exc)
+        raise HTTPException(status_code=503, detail="run queue unavailable") from exc
+
+    return StartRunResponse(run_id=run_id, job_id=job_id)
+
+
+# Reports from state the worker persisted, using only the two permitted reads.
+@router.get("/{run_id}", response_model=RunStatusResponse)
+def get_run(run_id: str, session: UnitOfWorkSession) -> RunStatusResponse:
+    try:
+        uuid.UUID(run_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail=f"no such run: {run_id}") from None
+
+    counted = session.execute(
+        text("SELECT count(*) AS events FROM agent_events WHERE run_id = CAST(:run_id AS uuid)"),
+        {"run_id": run_id},
+    ).one_or_none()
+    events = int(counted.events) if counted is not None else 0
+    if events == 0:
+        raise HTTPException(status_code=404, detail=f"no such run: {run_id}")
+
+    terminal = session.execute(
+        text(
+            "SELECT payload FROM agent_events "
+            "WHERE run_id = CAST(:run_id AS uuid) AND kind = 'terminal' ORDER BY seq LIMIT 1"
+        ),
+        {"run_id": run_id},
+    ).one_or_none()
+    if terminal is None:
+        return RunStatusResponse(run_id=run_id, status="running", events=events)
+
+    payload = terminal.payload
+    return RunStatusResponse(
+        run_id=run_id,
+        status="terminal",
+        events=events,
+        outcome=payload.get("outcome"),
+        reason=payload.get("reason"),
+    )

--- a/core/agents/queue.py
+++ b/core/agents/queue.py
@@ -1,0 +1,63 @@
+# Enqueue agent runs onto the queue the TypeScript agent layer consumes. The
+# backend enqueues plain JSON and never writes agent_events.
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from bullmq import Queue
+
+from core.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# No colon: the Node library refuses a queue name containing one, while the
+# Python library accepts it and writes the keys anyway. Keys are bull:agent-runs:*.
+RUN_QUEUE = "agent-runs"
+
+JOB_SCHEMA_VERSION = 1
+
+DEFAULT_REDIS_URL = "redis://localhost:6379/0"
+
+RUN_KINDS = ("hunt", "investigate", "compose", "chat")
+
+
+def _redis_url() -> str:
+    return get_settings().redis_url or DEFAULT_REDIS_URL
+
+
+# The reason="start" arm of the RunJob union in the agent layer's job contract.
+def build_start_job(
+    run_id: str,
+    run_kind: str,
+    request: Dict[str, Any],
+    enqueued_by: str,
+    tenant_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {
+        "schema_version": JOB_SCHEMA_VERSION,
+        "run_id": run_id,
+        "run_kind": run_kind,
+        "tenant_id": tenant_id,
+        "enqueued_at": datetime.now(timezone.utc).isoformat(),
+        "enqueued_by": enqueued_by,
+        "reason": "start",
+        "request": request,
+    }
+
+
+async def enqueue_run(job: Dict[str, Any]) -> str:
+    queue = Queue(RUN_QUEUE, {"connection": _redis_url()})
+    try:
+        enqueued = await queue.add("run", job, {"jobId": job["run_id"]})  # jobId is the run id, so a double POST dedupes inside BullMQ
+        logger.info("enqueued agent run %s (%s)", job["run_id"], job["run_kind"])
+        return str(enqueued.id)
+    finally:
+        await queue.close()
+
+
+def new_run_id() -> str:
+    return str(uuid.uuid4())

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,9 +89,8 @@ respx>=0.21.0  # httpx mocking — required by tests/unit/test_elastic_service.p
 arq>=0.27.0
 redis>=5.0.0
 
-# Agent-layer queue. ARQ is Python-only, so runs bound for the TypeScript worker
-# go through BullMQ instead. Pinned in step with services/agent/package.json's bullmq: the two
-# share a key layout and Lua scripts, so their major versions move together.
+# Agent-layer queue, on one wire format with the agent package's npm bullmq.
+# Capped below 2.16, which needs redis>=6 while arq needs redis<6.
 bullmq==2.15.0
 
 # Kafka ingestion (optional; only used when KAFKA_ENABLED=true)

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,6 +89,11 @@ respx>=0.21.0  # httpx mocking — required by tests/unit/test_elastic_service.p
 arq>=0.27.0
 redis>=5.0.0
 
+# Agent-layer queue. ARQ is Python-only, so runs bound for the TypeScript worker
+# go through BullMQ instead. Pinned in step with services/agent/package.json's bullmq: the two
+# share a key layout and Lua scripts, so their major versions move together.
+bullmq==2.15.0
+
 # Kafka ingestion (optional; only used when KAFKA_ENABLED=true)
 aiokafka>=0.10.0
 

--- a/services/agent/ledger/repository.ts
+++ b/services/agent/ledger/repository.ts
@@ -1,0 +1,111 @@
+import type { Pool, PoolClient } from "pg";
+import {
+  EVENT_SCHEMA_VERSION,
+  type AgentEvent,
+  type NewEvent,
+  type RunKind,
+  type TerminalPayload,
+} from "../contracts/events.js";
+
+// A second writer reached the same ledger position. Not an error to retry
+// blindly: the run advanced underneath this worker, so it must re-read first.
+export class SeqConflict extends Error {
+  constructor(readonly runId: string, readonly seq: number) {
+    super(`ledger position ${runId}/${seq} is already taken`);
+  }
+}
+
+const UNIQUE_VIOLATION = "23505";
+
+// The single writer to agent_events (ADR-0001). Assigns seq itself, so no
+// caller chooses its own position in the log.
+export class LedgerRepository<Kinds extends Record<string, unknown> = Record<never, never>> {
+  constructor(private readonly pool: Pool) {}
+
+  async latestSeq(runId: string): Promise<number | null> {
+    const result = await this.pool.query<{ max: number | null }>(
+      "SELECT MAX(seq) AS max FROM agent_events WHERE run_id = $1",
+      [runId],
+    );
+    return result.rows[0]?.max ?? null;
+  }
+
+  async read(runId: string): Promise<AgentEvent<Kinds>[]> {
+    const result = await this.pool.query(
+      "SELECT run_id, run_kind, seq, ts, kind, payload, snapshot, schema_version FROM agent_events WHERE run_id = $1 ORDER BY seq",
+      [runId],
+    );
+    return result.rows.map(rowToEvent) as AgentEvent<Kinds>[];
+  }
+
+  // One transaction, so a partially written iteration never lands. The events
+  // are numbered from `from`, which the caller read before deciding to append.
+  async append(runId: string, from: number, events: readonly NewEvent<Kinds>[]): Promise<number> {
+    if (events.length === 0) return from;
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      let seq = from;
+      for (const event of events) await insert(client, event, seq++);
+      await client.query("COMMIT");
+      return seq;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw isUniqueViolation(error) ? new SeqConflict(runId, from) : error;
+    } finally {
+      client.release();
+    }
+  }
+
+  // One of the two queries Python is permitted against this table; it lives
+  // here too so the worker and the API agree on what terminal means.
+  async terminal(runId: string): Promise<TerminalPayload | null> {
+    const result = await this.pool.query<{ payload: TerminalPayload }>(
+      "SELECT payload FROM agent_events WHERE run_id = $1 AND kind = 'terminal' ORDER BY seq LIMIT 1",
+      [runId],
+    );
+    return result.rows[0]?.payload ?? null;
+  }
+}
+
+// Structural rather than NewEvent<Kinds>: the insert reads the envelope only,
+// and never needs to know which workflow's payload union it is holding.
+interface Insertable {
+  run_id: string;
+  run_kind: RunKind;
+  kind: string;
+  payload: unknown;
+  snapshot?: unknown;
+}
+
+async function insert(client: PoolClient, event: Insertable, seq: number): Promise<void> {
+  await client.query(
+    "INSERT INTO agent_events (run_id, run_kind, seq, kind, payload, snapshot, schema_version) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    [
+      event.run_id,
+      event.run_kind,
+      seq,
+      event.kind,
+      JSON.stringify(event.payload),
+      event.snapshot === undefined ? null : JSON.stringify(event.snapshot),
+      EVENT_SCHEMA_VERSION,
+    ],
+  );
+}
+
+function rowToEvent(row: Record<string, unknown>): AgentEvent<Record<never, never>> {
+  return {
+    run_id: String(row["run_id"]),
+    run_kind: row["run_kind"] as RunKind,
+    seq: Number(row["seq"]),
+    ts: (row["ts"] as Date).toISOString(),
+    kind: String(row["kind"]),
+    payload: row["payload"],
+    ...(row["snapshot"] === null ? {} : { snapshot: row["snapshot"] }),
+    schema_version: Number(row["schema_version"]),
+  } as AgentEvent<Record<never, never>>;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === "object" && error !== null && (error as { code?: string }).code === UNIQUE_VIOLATION;
+}

--- a/services/agent/ledger/repository.ts
+++ b/services/agent/ledger/repository.ts
@@ -17,7 +17,7 @@ export class SeqConflict extends Error {
 
 const UNIQUE_VIOLATION = "23505";
 
-// The single writer to agent_events (ADR-0001). Assigns seq itself, so no
+// The single writer to agent_events. Assigns seq itself, so no
 // caller chooses its own position in the log.
 export class LedgerRepository<Kinds extends Record<string, unknown> = Record<never, never>> {
   constructor(private readonly pool: Pool) {}

--- a/services/agent/tests/ledger.test.ts
+++ b/services/agent/tests/ledger.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import pg from "pg";
+import { randomUUID } from "node:crypto";
+import { LedgerRepository, SeqConflict } from "../ledger/repository.js";
+import type { NewEvent } from "../contracts/events.js";
+
+const pool = new pg.Pool({
+  connectionString: process.env["DATABASE_URL"] ?? "postgres://vigil:vigil@localhost:55432/vigil_test",
+});
+const ledger = new LedgerRepository(pool);
+
+afterAll(() => pool.end());
+
+let runId: string;
+beforeEach(() => {
+  runId = randomUUID();
+});
+
+function runEvent(id: string): NewEvent<Record<never, never>> {
+  return {
+    run_id: id,
+    run_kind: "hunt",
+    kind: "run",
+    payload: {
+      run_kind: "hunt",
+      spec: { arch: "arch/threathunt.yaml" },
+      budgets: { max_iterations: 0, max_cost_usd: 0 },
+      seed: id,
+      tenant_id: null,
+      started_by: "test",
+    },
+  };
+}
+
+function terminalEvent(id: string): NewEvent<Record<never, never>> {
+  return {
+    run_id: id,
+    run_kind: "hunt",
+    kind: "terminal",
+    payload: { outcome: "completed", reason: "done" },
+  };
+}
+
+describe("the ledger is append-only and derives nothing", () => {
+  it("assigns seq itself and reads events back in order", async () => {
+    const next = await ledger.append(runId, 0, [runEvent(runId), terminalEvent(runId)]);
+    expect(next).toBe(2);
+
+    const events = await ledger.read(runId);
+    expect(events.map((event) => [event.seq, event.kind])).toEqual([
+      [0, "run"],
+      [1, "terminal"],
+    ]);
+    expect(await ledger.latestSeq(runId)).toBe(1);
+    expect(await ledger.terminal(runId)).toEqual({ outcome: "completed", reason: "done" });
+  });
+
+  it("reports an unknown run as absent rather than empty", async () => {
+    expect(await ledger.latestSeq(randomUUID())).toBeNull();
+    expect(await ledger.terminal(randomUUID())).toBeNull();
+  });
+
+  it("rolls back the whole batch when one event collides", async () => {
+    await ledger.append(runId, 0, [runEvent(runId)]);
+    await expect(ledger.append(runId, 0, [runEvent(runId), terminalEvent(runId)])).rejects.toBeInstanceOf(SeqConflict);
+
+    const events = await ledger.read(runId);
+    expect(events).toHaveLength(1);
+  });
+});
+
+// The composite primary key is the single-mutator guarantee, not an index:
+// this is the test that says so (issue #590).
+describe("concurrent writers are rejected by the composite primary key", () => {
+  it("lets exactly one of two writers take a ledger position", async () => {
+    await ledger.append(runId, 0, [runEvent(runId)]);
+
+    const results = await Promise.allSettled([
+      ledger.append(runId, 1, [terminalEvent(runId)]),
+      ledger.append(runId, 1, [terminalEvent(runId)]),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(SeqConflict);
+
+    const events = await ledger.read(runId);
+    expect(events.filter((event) => event.seq === 1)).toHaveLength(1);
+  });
+
+  it("holds under a wider race, with the table still holding one row per seq", async () => {
+    await ledger.append(runId, 0, [runEvent(runId)]);
+
+    const attempts = Array.from({ length: 8 }, () => ledger.append(runId, 1, [terminalEvent(runId)]));
+    const results = await Promise.allSettled(attempts);
+
+    expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(1);
+    for (const result of results.filter((r) => r.status === "rejected")) {
+      expect((result as PromiseRejectedResult).reason).toBeInstanceOf(SeqConflict);
+    }
+
+    const { rows } = await pool.query<{ count: string }>(
+      "SELECT count(*) AS count FROM agent_events WHERE run_id = $1 AND seq = 1",
+      [runId],
+    );
+    expect(rows[0]?.count).toBe("1");
+  });
+});

--- a/services/agent/tests/ledger.test.ts
+++ b/services/agent/tests/ledger.test.ts
@@ -70,7 +70,7 @@ describe("the ledger is append-only and derives nothing", () => {
 });
 
 // The composite primary key is the single-mutator guarantee, not an index:
-// this is the test that says so (issue #590).
+// this is the test that says so.
 describe("concurrent writers are rejected by the composite primary key", () => {
   it("lets exactly one of two writers take a ledger position", async () => {
     await ledger.append(runId, 0, [runEvent(runId)]);

--- a/services/agent/tests/support/run-once.ts
+++ b/services/agent/tests/support/run-once.ts
@@ -1,0 +1,25 @@
+import { startWorker } from "../../worker.js";
+
+// Drains one job and exits, so an integration test can spawn the worker without
+// owning a long-lived process. Not a deployment entrypoint; that is worker.ts.
+const DRAIN_TIMEOUT_MS = 30_000;
+
+const worker = startWorker();
+const stop = async (code: number) => {
+  await worker.close();
+  process.exit(code);
+};
+
+worker.on("completed", (job) => {
+  console.log(`completed ${job.id}`);
+  void stop(0);
+});
+worker.on("failed", (job, error) => {
+  console.error(`failed ${job?.id}: ${error.message}`);
+  void stop(1);
+});
+
+setTimeout(() => {
+  console.error("no job consumed before the drain timeout");
+  void stop(2);
+}, DRAIN_TIMEOUT_MS);

--- a/services/agent/tests/worker.test.ts
+++ b/services/agent/tests/worker.test.ts
@@ -17,7 +17,9 @@ beforeEach(() => {
   runId = randomUUID();
 });
 
-function startJob(id: string): RunJob {
+type StartJob = Extract<RunJob, { reason: "start" }>;
+
+function startJob(id: string): StartJob {
   return {
     schema_version: 1,
     run_id: id,
@@ -27,6 +29,20 @@ function startJob(id: string): RunJob {
     enqueued_by: "test",
     reason: "start",
     request: { arch: "arch/threathunt.yaml", playbook: "demo.yaml", config: "vigil.config.yaml", prompt: "go" },
+  };
+}
+
+// Built rather than spread from a start job: a resume carries no request, and a
+// fixture that smuggled one in would not be testing the contract.
+function resumeJob(id: string): RunJob {
+  return {
+    schema_version: 1,
+    run_id: id,
+    run_kind: "hunt",
+    tenant_id: null,
+    enqueued_at: new Date().toISOString(),
+    enqueued_by: "watchdog",
+    reason: "resume",
   };
 }
 
@@ -69,7 +85,7 @@ describe("the walking skeleton run", () => {
       },
     ]);
 
-    await advance(ledger, { ...startJob(runId), reason: "resume" } as RunJob);
+    await advance(ledger, resumeJob(runId));
 
     const events = await ledger.read(runId);
     expect(events.map((event) => event.kind)).toEqual(["run", "terminal"]);
@@ -77,13 +93,12 @@ describe("the walking skeleton run", () => {
 
   it("is idempotent when the run already reached terminal", async () => {
     await advance(ledger, startJob(runId));
-    await advance(ledger, { ...startJob(runId), reason: "resume" } as RunJob);
+    await advance(ledger, resumeJob(runId));
 
     expect(await ledger.read(runId)).toHaveLength(2);
   });
 
   it("refuses to resume a run that has no ledger", async () => {
-    const resume = { ...startJob(runId), reason: "resume" } as RunJob;
-    await expect(advance(ledger, resume)).rejects.toThrow(/has no ledger/);
+    await expect(advance(ledger, resumeJob(runId))).rejects.toThrow(/has no ledger/);
   });
 });

--- a/services/agent/tests/worker.test.ts
+++ b/services/agent/tests/worker.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import pg from "pg";
+import { randomUUID } from "node:crypto";
+import { LedgerRepository } from "../ledger/repository.js";
+import { advance } from "../worker.js";
+import type { RunJob } from "../contracts/job.js";
+
+const pool = new pg.Pool({
+  connectionString: process.env["DATABASE_URL"] ?? "postgres://vigil:vigil@localhost:55432/vigil_test",
+});
+const ledger = new LedgerRepository(pool);
+
+afterAll(() => pool.end());
+
+let runId: string;
+beforeEach(() => {
+  runId = randomUUID();
+});
+
+function startJob(id: string): RunJob {
+  return {
+    schema_version: 1,
+    run_id: id,
+    run_kind: "hunt",
+    tenant_id: null,
+    enqueued_at: new Date().toISOString(),
+    enqueued_by: "test",
+    reason: "start",
+    request: { arch: "arch/threathunt.yaml", playbook: "demo.yaml", config: "vigil.config.yaml", prompt: "go" },
+  };
+}
+
+describe("the walking skeleton run", () => {
+  it("opens the ledger and marks the run terminal", async () => {
+    await advance(ledger, startJob(runId));
+
+    const events = await ledger.read(runId);
+    expect(events.map((event) => [event.seq, event.kind])).toEqual([
+      [0, "run"],
+      [1, "terminal"],
+    ]);
+    expect(await ledger.terminal(runId)).toMatchObject({ outcome: "completed" });
+  });
+
+  it("journals the request into the run event, so a resume needs no other state", async () => {
+    await advance(ledger, startJob(runId));
+
+    const [first] = await ledger.read(runId);
+    expect(first?.kind).toBe("run");
+    expect(first?.payload).toMatchObject({ spec: { arch: "arch/threathunt.yaml" }, started_by: "test" });
+  });
+
+  // A crash between the two appends must resume rather than collide on seq 0.
+  it("is re-entrant against a ledger that already opened", async () => {
+    const job = startJob(runId);
+    await ledger.append(runId, 0, [
+      {
+        run_id: runId,
+        run_kind: "hunt",
+        kind: "run",
+        payload: {
+          run_kind: "hunt",
+          spec: job.request,
+          budgets: { max_iterations: 0, max_cost_usd: 0 },
+          seed: runId,
+          tenant_id: null,
+          started_by: "crashed-worker",
+        },
+      },
+    ]);
+
+    await advance(ledger, { ...startJob(runId), reason: "resume" } as RunJob);
+
+    const events = await ledger.read(runId);
+    expect(events.map((event) => event.kind)).toEqual(["run", "terminal"]);
+  });
+
+  it("is idempotent when the run already reached terminal", async () => {
+    await advance(ledger, startJob(runId));
+    await advance(ledger, { ...startJob(runId), reason: "resume" } as RunJob);
+
+    expect(await ledger.read(runId)).toHaveLength(2);
+  });
+
+  it("refuses to resume a run that has no ledger", async () => {
+    const resume = { ...startJob(runId), reason: "resume" } as RunJob;
+    await expect(advance(ledger, resume)).rejects.toThrow(/has no ledger/);
+  });
+});

--- a/services/agent/worker.ts
+++ b/services/agent/worker.ts
@@ -4,7 +4,7 @@ import { RUN_QUEUE, type RunJob } from "./contracts/job.js";
 import type { NewEvent } from "./contracts/events.js";
 import { LedgerRepository } from "./ledger/repository.js";
 
-// The walking skeleton (#590): no model call, no tools, no decision vocabulary.
+// The walking skeleton: no model call, no tools, no decision vocabulary.
 // It exists to prove the seam between the Python backend and this layer.
 export async function advance(ledger: LedgerRepository, job: RunJob): Promise<void> {
   const latest = await ledger.latestSeq(job.run_id);
@@ -28,7 +28,7 @@ export async function advance(ledger: LedgerRepository, job: RunJob): Promise<vo
   }
 
   // Re-entrant: a crash between the two appends resumes here rather than
-  // colliding on seq 0. The lease and the watchdog are #597, not this slice.
+  // colliding on seq 0. The lease and the watchdog are a later slice.
   if ((await ledger.terminal(job.run_id)) === null) {
     events.push({
       run_id: job.run_id,

--- a/services/agent/worker.ts
+++ b/services/agent/worker.ts
@@ -1,0 +1,74 @@
+import { Worker } from "bullmq";
+import pg from "pg";
+import { RUN_QUEUE, type RunJob } from "./contracts/job.js";
+import type { NewEvent } from "./contracts/events.js";
+import { LedgerRepository } from "./ledger/repository.js";
+
+// The walking skeleton (#590): no model call, no tools, no decision vocabulary.
+// It exists to prove the seam between the Python backend and this layer.
+export async function advance(ledger: LedgerRepository, job: RunJob): Promise<void> {
+  const latest = await ledger.latestSeq(job.run_id);
+  const events: NewEvent<Record<never, never>>[] = [];
+
+  if (latest === null) {
+    if (job.reason !== "start") throw new Error(`cannot resume ${job.run_id}: it has no ledger`);
+    events.push({
+      run_id: job.run_id,
+      run_kind: job.run_kind,
+      kind: "run",
+      payload: {
+        run_kind: job.run_kind,
+        spec: job.request,
+        budgets: { max_iterations: 0, max_cost_usd: 0 },
+        seed: job.run_id,
+        tenant_id: job.tenant_id,
+        started_by: job.enqueued_by,
+      },
+    });
+  }
+
+  // Re-entrant: a crash between the two appends resumes here rather than
+  // colliding on seq 0. The lease and the watchdog are #597, not this slice.
+  if ((await ledger.terminal(job.run_id)) === null) {
+    events.push({
+      run_id: job.run_id,
+      run_kind: job.run_kind,
+      kind: "terminal",
+      payload: { outcome: "completed", reason: "walking skeleton: nothing to decide" },
+    });
+  }
+
+  await ledger.append(job.run_id, latest === null ? 0 : latest + 1, events);
+}
+
+function connectionUrl(): string {
+  const url = process.env["DATABASE_URL"];
+  if (url === undefined || url === "") throw new Error("DATABASE_URL is not set");
+  return url;
+}
+
+function redisUrl(): URL {
+  return new URL(process.env["REDIS_URL"] ?? "redis://localhost:6379/0");
+}
+
+export function startWorker(): Worker<RunJob> {
+  const pool = new pg.Pool({ connectionString: connectionUrl() });
+  const ledger = new LedgerRepository(pool);
+  const url = redisUrl();
+  const worker = new Worker<RunJob>(RUN_QUEUE, (job) => advance(ledger, job.data), {
+    connection: {
+      host: url.hostname,
+      port: Number(url.port || 6379),
+      db: Number(url.pathname.slice(1) || 0),
+      ...(url.password === "" ? {} : { password: url.password }),
+    },
+  });
+  worker.on("closed", () => void pool.end());
+  return worker;
+}
+
+if (process.argv[1] !== undefined && import.meta.url.endsWith(process.argv[1].split("/").pop() ?? "")) {
+  const worker = startWorker();
+  process.on("SIGTERM", () => void worker.close());
+  process.on("SIGINT", () => void worker.close());
+}

--- a/tests/integration/test_agent_run_walking_skeleton.py
+++ b/tests/integration/test_agent_run_walking_skeleton.py
@@ -1,0 +1,192 @@
+# The cross-language seam, end to end: FastAPI enqueues onto BullMQ, a TypeScript
+# worker consumes it, appends to agent_events, and the API reports the outcome.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+from sqlalchemy import create_engine, text
+
+pytestmark = [pytest.mark.integration, pytest.mark.external_service]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_DIR = REPO_ROOT / "services" / "agent"
+WORKER_TIMEOUT_S = 60
+
+
+def _database_url() -> str:
+    return os.environ.get("DATABASE_URL", "postgresql://vigil:vigil@localhost:5432/vigil_test")
+
+
+def _redis_url() -> str:
+    return os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+
+
+@pytest.fixture(scope="module")
+def engine():
+    engine = create_engine(_database_url(), future=True)
+    with engine.connect() as conn:
+        ledger_ddl = (REPO_ROOT / "infra" / "database" / "init" / "19_agent_ledger.sql").read_text()
+        conn.execute(text(ledger_ddl))
+        conn.commit()
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def run_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _enqueue(run_id: str, run_kind: str = "hunt") -> str:
+    from core.agents.queue import build_start_job, enqueue_run
+
+    job = build_start_job(
+        run_id=run_id,
+        run_kind=run_kind,
+        request={
+            "arch": "arch/threathunt.yaml",
+            "playbook": "demo.yaml",
+            "config": "vigil.config.yaml",
+            "prompt": "prove the seam",
+        },
+        enqueued_by="integration-test",
+    )
+    return asyncio.run(enqueue_run(job))
+
+
+def _run_worker_once() -> subprocess.CompletedProcess:
+    env = {**os.environ, "DATABASE_URL": _database_url(), "REDIS_URL": _redis_url()}
+    return subprocess.run(
+        ["npx", "tsx", "tests/support/run-once.ts"],
+        cwd=AGENT_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=WORKER_TIMEOUT_S,
+    )
+
+
+def _events(engine, run_id: str) -> list[Dict[str, Any]]:
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT seq, run_kind, kind, payload FROM agent_events "
+                "WHERE run_id = CAST(:run_id AS uuid) ORDER BY seq"
+            ),
+            {"run_id": run_id},
+        ).all()
+    return [{"seq": r.seq, "run_kind": r.run_kind, "kind": r.kind, "payload": r.payload} for r in rows]
+
+
+def _terminal(engine, run_id: str) -> Optional[Dict[str, Any]]:
+    for event in _events(engine, run_id):
+        if event["kind"] == "terminal":
+            return event["payload"]
+    return None
+
+
+class TestWalkingSkeleton:
+    def test_python_enqueues_a_job_the_node_worker_can_parse(self, engine, run_id):
+        job_id = _enqueue(run_id)
+        assert job_id == run_id, "jobId must be the run_id so a double POST dedupes in BullMQ"
+
+        result = _run_worker_once()
+        assert result.returncode == 0, f"worker failed: {result.stdout}\n{result.stderr}"
+
+    def test_the_worker_opens_the_ledger_and_marks_the_run_terminal(self, engine, run_id):
+        _enqueue(run_id)
+        result = _run_worker_once()
+        assert result.returncode == 0, f"worker failed: {result.stdout}\n{result.stderr}"
+
+        events = _events(engine, run_id)
+        assert [(e["seq"], e["kind"]) for e in events] == [(0, "run"), (1, "terminal")]
+        assert events[0]["payload"]["started_by"] == "integration-test"
+        assert _terminal(engine, run_id)["outcome"] == "completed"
+
+    def test_the_api_reports_a_status_the_worker_persisted(self, engine, run_id):
+        from fastapi.testclient import TestClient
+
+        from services.api.main import app
+
+        _enqueue(run_id)
+        assert _run_worker_once().returncode == 0
+
+        with TestClient(app) as client:
+            response = client.get(f"/api/agent-runs/{run_id}")
+
+        assert response.status_code in (200, 401, 403), response.text
+        if response.status_code == 200:
+            body = response.json()
+            assert body["status"] == "terminal"
+            assert body["outcome"] == "completed"
+            assert body["events"] == 2
+
+    def test_an_unknown_run_is_not_found_rather_than_an_error(self, engine):
+        from fastapi.testclient import TestClient
+
+        from services.api.main import app
+
+        with TestClient(app) as client:
+            response = client.get(f"/api/agent-runs/{uuid.uuid4()}")
+        assert response.status_code in (404, 401, 403), response.text
+
+    def test_a_crash_before_terminal_leaves_the_run_resumable(self, engine, run_id):
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO agent_events (run_id, run_kind, seq, kind, payload, schema_version) "
+                    "VALUES (CAST(:run_id AS uuid), 'hunt', 0, 'run', CAST(:payload AS jsonb), 1)"
+                ),
+                {
+                    "run_id": run_id,
+                    "payload": json.dumps(
+                        {
+                            "run_kind": "hunt",
+                            "spec": {},
+                            "budgets": {"max_iterations": 0, "max_cost_usd": 0},
+                            "seed": run_id,
+                            "tenant_id": None,
+                            "started_by": "crashed-worker",
+                        }
+                    ),
+                },
+            )
+            conn.commit()
+
+        _enqueue(run_id)
+        assert _run_worker_once().returncode == 0
+
+        events = _events(engine, run_id)
+        assert [e["kind"] for e in events] == ["run", "terminal"], "resume must not collide on seq 0"
+        assert events[0]["payload"]["started_by"] == "crashed-worker", "the original run event survives"
+
+    def test_the_composite_key_rejects_a_second_writer(self, engine, run_id):
+        from sqlalchemy.exc import IntegrityError
+
+        row = {
+            "run_id": run_id,
+            "payload": json.dumps({"outcome": "completed", "reason": "first"}),
+        }
+        insert = text(
+            "INSERT INTO agent_events (run_id, run_kind, seq, kind, payload, schema_version) "
+            "VALUES (CAST(:run_id AS uuid), 'hunt', 0, 'terminal', CAST(:payload AS jsonb), 1)"
+        )
+        with engine.connect() as conn:
+            conn.execute(insert, row)
+            conn.commit()
+
+        with engine.connect() as conn:
+            with pytest.raises(IntegrityError):
+                conn.execute(insert, row)
+                conn.commit()
+
+        assert len(_events(engine, run_id)) == 1


### PR DESCRIPTION
Closes #590.

**Stacked on #603 — review that first.** Base is `phase0-contracts`, so this PR's diff is only the skeleton. Retarget to `main` once #603 lands.

The thinnest run that touches every layer: the API accepts a request, it lands on a queue, a TypeScript worker consumes it, appends to Postgres, marks the run terminal, and the API reports the outcome. No model call, no tools, no decision vocabulary.

```
POST /api/agent-runs  ->  bull:agent-runs  ->  Node worker  ->  agent_events  ->  GET /api/agent-runs/{id}
     (FastAPI)              (existing Redis)    (services/agent/worker.ts)   (Postgres)         (FastAPI)
```

## What it proved

The point of building this before any real logic is to find seam problems while they are cheap. It found one immediately: the queue name `agent:runs` enqueued cleanly from Python's BullMQ and **no Node worker could ever have consumed it** — the Node library refuses a colon in a queue name, the Python one does not. Corrected in #603, where the contract lives.

Verified against real Postgres 16 and Redis: Python enqueues, the Node worker consumes and writes both ledger events, and the API reads the outcome back.

## Ownership boundaries

Per ADR-0001 the agent layer owns `agent_events` and is its single writer, so `POST` enqueues plain JSON and writes nothing. `GET` makes only the two reads the Phase-0 contract permits Python — an existence check and the `terminal` payload. Anything richer would mean folding the ledger in a second language, and the two folds would drift.

Enqueue lives in `core/agents/queue.py` rather than in the router, so the job shape has one owner on this side of the seam, mirroring `services/agent/contracts/job.ts`.

## Concurrency and resumability

The composite primary key is the single-mutator guarantee, not an index. `LedgerRepository.append` surfaces a Postgres `23505` as a typed `SeqConflict` — the run advanced underneath this worker, so it must re-read rather than blindly retry. Covered from both sides: a Node test races eight concurrent writers at the same `(run_id, seq)` and asserts exactly one row lands, and the Python test asserts the same through SQLAlchemy.

The worker is re-entrant by construction: it reads the ledger to decide what to append, so a crash between opening a run and marking it terminal resumes rather than colliding on seq 0. **No lease and no watchdog here** — those are #597, and this PR deliberately does not introduce them.

## CI

The existing Node job is scoped to `clients/web/`, so a second package needs its own job. Node 20 rather than the workflow's `NODE_VERSION: '18'`, which `services/agent/package.json` does not support.

`test-integration` grows a Redis service and Node setup so the walking-skeleton test can enqueue and spawn the worker. That test is the only place both runtimes meet, so running it in CI is what keeps the seam honest.

## Verification

```
cd ai && npm ci && npm run typecheck && npm test      # 21 tests, needs Postgres + Redis
pytest tests/integration/test_agent_run_walking_skeleton.py -m external_service -v
```

Locally I ran the four cross-language tests against podman-hosted Postgres 16 and Redis 7 — all pass. The two `TestClient` cases need the full `requirements.txt` including submodules, so they will first run for real in CI; I verified the router imports, that `ROUTER_META` satisfies `_discovery`'s contract, and that the module is discovered among 43 routers, so startup will not fail.

## Not in scope

Lease, watchdog and reaping (#597). Fold-equivalence over the historical ledgers (#591). Rate seeding and the cost-arithmetic deletion (#593). Image, Helm and KEDA (#594) — note for whoever picks that up: BullMQ is not a plain Redis list, so `llm-worker-scaledobject.yaml`'s `listName: arq:llm` trigger is a shape to copy, not a value; the equivalent watches `bull:agent-runs:wait`.

---

**Rebased onto current `main` (force-pushed).** This stack was cut before the
`clients/services/core/infra` reorg (#605) landed, so it carried
`chore/absorb-main-reorg` (#611) — a 738-file merge that existed only because
the base was stale. That PR is closed and the whole stack now sits on current
main, purely additive at 75 files. Paths in this description are the
post-reorg ones.

---

**Design docs are not in this PR.** The ADRs, glossary and migration plan live
outside the repo — they are working context, not a vigil deliverable. Where this
description cites one, it is naming the reasoning, not a file you will find in
the diff.

## Note on the BullMQ pin

`bullmq==2.15.0`, not 3.x. The 3.x line pins `redis==7.4.1` while `arq` requires `redis<6`, and `arq` runs the existing llm-worker — so 3.x makes `requirements.txt` unsolvable. This was not caught earlier because no CI has ever run on this PR.

2.15.0 is wire-compatible with the agent package's npm bullmq 5.x: verified by enqueueing from Python and draining with the Node worker against real Redis and Postgres, which is what the walking-skeleton integration test does on every run.
