### PR TITLE
feat(hunt): the digest leaves the fold, and a gate that proves it

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -1,0 +1,21 @@
+name: agent layer
+
+on:
+  push:
+    branches: [main, threat-hunt]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      # Includes the fold-equivalence gate over runs/*.jsonl, which is the only
+      # check that a storage or fold change left the projections and digests alone.
+      - run: npm test

--- a/ai/digest.ts
+++ b/ai/digest.ts
@@ -321,11 +321,7 @@ export function buildDigest(projection: Projection, iteration: number, policy: D
   );
   for (const record of ordered.slice(-policy.evidence_window)) kept.add(record.evidence_id);
 
-  const seen = new Set(
-    projection.decisions.flatMap((decision) =>
-      decision.digest_presented.recent_evidence.map((record) => record.evidence_id),
-    ),
-  );
+  const seen = new Set(projection.decisions.flatMap((decision) => decision.presented_evidence_ids));
   const candidates = ordered.filter((record) => !kept.has(record.evidence_id));
   for (const record of sample(candidates, policy.resurface, rng(`${hunt.seed}:${iteration}`), seen)) {
     kept.add(record.evidence_id);

--- a/ai/ledger.ts
+++ b/ai/ledger.ts
@@ -6,6 +6,7 @@ import type { HuntReport } from "./report.js";
 import {
   SCHEMA_VERSION,
   type DecisionRecord,
+  type Digest,
   type Directive,
   type DispatchRecord,
   type EvidenceLink,
@@ -25,7 +26,9 @@ export type LedgerBody =
   | { kind: "evidence"; evidence: EvidenceRecord }
   | { kind: "link"; link: EvidenceLink }
   | { kind: "dispatch"; dispatch: DispatchRecord }
-  | { kind: "decision"; decision: DecisionRecord }
+  // The digest sits beside the record, not inside it: it is the snapshot, read by
+  // replay and never by the fold, and this is the payload/snapshot split on disk.
+  | { kind: "decision"; decision: DecisionRecord; digest_presented: Digest }
   | { kind: "directive"; directive: Directive }
   | { kind: "checkpoint"; checkpoint: Checkpoint }
   | { kind: "resolution"; resolution: Resolution }
@@ -59,6 +62,37 @@ export function newId(prefix: string, bytes = 6): string {
 
 export class LedgerError extends Error {}
 
+// Ledgers written before the split carry the digest inside the decision record.
+// Hoisting it on read is the same move the store makes between its payload and
+// snapshot columns, so one reader serves both shapes.
+function hoistSnapshot(event: LedgerEvent): LedgerEvent {
+  if (event.kind !== "decision") return event;
+  const legacy = event.decision as DecisionRecord & { digest_presented?: Digest };
+  if (legacy.digest_presented === undefined) {
+    // Neither shape carries one, so the file is damaged: say so here rather than
+    // letting replay fault on it several folds later.
+    if (event.digest_presented === undefined) {
+      throw new LedgerError(`decision at seq ${event.seq} carries no digest`);
+    }
+    return event;
+  }
+  const { digest_presented, ...decision } = legacy;
+  const ids = digest_presented.recent_evidence.map((record) => record.evidence_id);
+  return { ...event, digest_presented, decision: { ...decision, presented_evidence_ids: ids } };
+}
+
+// The snapshot side of the log, in decision order. Nothing in the fold calls it.
+export function snapshots(log: readonly LedgerEvent[]): Digest[] {
+  return log.flatMap((event) => (event.kind === "decision" ? [event.digest_presented] : []));
+}
+
+export function parseLog(text: string): LedgerEvent[] {
+  return text
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => hoistSnapshot(JSON.parse(line) as LedgerEvent));
+}
+
 // Append-only JSONL. Every mutation is an event; the projection is a fold and
 // is never written back, so the file on disk is the whole audit trail.
 export class Ledger {
@@ -81,10 +115,7 @@ export class Ledger {
   static open(path: string): Ledger {
     if (!existsSync(path)) throw new LedgerError(`no such ledger: ${path}`);
     const ledger = new Ledger(path);
-    ledger.events = readFileSync(path, "utf8")
-      .split("\n")
-      .filter((line) => line.trim().length > 0)
-      .map((line) => JSON.parse(line) as LedgerEvent);
+    ledger.events = parseLog(readFileSync(path, "utf8"));
     return ledger;
   }
 

--- a/ai/llm.ts
+++ b/ai/llm.ts
@@ -6,16 +6,19 @@ import { estimateTokens, Limiter, statusOf } from "./limiter.js";
 import type { DecisionProvider, DisconfirmationCritic, WorkerDispatcher } from "./ports.js";
 import type { HuntSpec, Rates, RoleSpec } from "./spec.js";
 import { toOpenAITools, type Tool } from "./tools.js";
-import type {
-  Decision,
-  DecisionResult,
-  Digest,
-  DispatchRequest,
-  DispatchResult,
-  NullCheckInput,
-  NullCheckResult,
-  Salience,
-  ToolCall,
+import {
+  addTokens,
+  NO_TOKENS,
+  type Decision,
+  type DecisionResult,
+  type Digest,
+  type DispatchRequest,
+  type DispatchResult,
+  type NullCheckInput,
+  type NullCheckResult,
+  type Salience,
+  type TokenCounts,
+  type ToolCall,
 } from "./types.js";
 
 const MAX_TOOL_TURNS = 12;
@@ -44,6 +47,7 @@ export class LlmError extends Error {
   constructor(
     message: string,
     readonly cost_usd = 0,
+    readonly tokens: TokenCounts = NO_TOKENS,
   ) {
     super(message);
   }
@@ -66,6 +70,19 @@ export function createClient(): OpenAI {
 // silently misattributed number.
 export function costOf(rates: Rates, inputTokens: number, outputTokens: number): number {
   return (inputTokens * rates.input + outputTokens * rates.output) / 1_000_000;
+}
+
+// Two surfaces, one shape: the OpenAI route reports the cached share under
+// prompt_tokens_details, the Anthropic route under its own keys. Neither reports
+// a cache write on the OpenAI shape, so it stays zero until the gateway does.
+function tokensOf(usage: OpenAI.CompletionUsage | undefined): TokenCounts {
+  const anthropic = usage as (typeof usage & { cache_read_input_tokens?: number; cache_creation_input_tokens?: number }) | undefined;
+  return {
+    input: usage?.prompt_tokens ?? 0,
+    output: usage?.completion_tokens ?? 0,
+    cache_read: usage?.prompt_tokens_details?.cached_tokens ?? anthropic?.cache_read_input_tokens ?? 0,
+    cache_write: anthropic?.cache_creation_input_tokens ?? 0,
+  };
 }
 
 // Evidence is attacker-controlled text. It never reaches the system prompt, and
@@ -221,6 +238,7 @@ export interface LlmResult<T> {
   value: T;
   model: string;
   cost_usd: number;
+  tokens: TokenCounts;
   rejected: string[];
   // Every tool invocation and what it returned: the raw substrate behind the
   // role's answer, so the ledger holds the data and not only the prose.
@@ -250,6 +268,7 @@ export async function llm_output<T>(options: LlmOptions): Promise<LlmResult<T>> 
   const messages = [...options.messages];
   const executed: ToolCall[] = [];
   let cost = 0;
+  let tokens = NO_TOKENS;
 
   const call = async (body: Parameters<typeof client.chat.completions.create>[0]) => {
     // Before the limiter, not only inside the request: a call still queued
@@ -262,7 +281,8 @@ export async function llm_output<T>(options: LlmOptions): Promise<LlmResult<T>> 
         options.signal ? { signal: options.signal } : {},
       ),
     );
-    if (!("choices" in response)) throw new LlmError("streaming responses are not supported", cost);
+    if (!("choices" in response)) throw new LlmError("streaming responses are not supported", cost, tokens);
+    tokens = addTokens(tokens, tokensOf(response.usage));
     cost += costOf(rates, response.usage?.prompt_tokens ?? 0, response.usage?.completion_tokens ?? 0);
     return response;
   };
@@ -270,7 +290,7 @@ export async function llm_output<T>(options: LlmOptions): Promise<LlmResult<T>> 
   for (let turn = 0; turn < MAX_TOOL_TURNS && tools.length > 0; turn += 1) {
     const response = await call({ model, messages, tools: toOpenAITools(tools) });
     const message = response.choices[0]?.message;
-    if (message === undefined) throw new LlmError("model returned no message", cost);
+    if (message === undefined) throw new LlmError("model returned no message", cost, tokens);
 
     const calls = message.tool_calls ?? [];
     if (calls.length === 0) break;
@@ -299,7 +319,7 @@ export async function llm_output<T>(options: LlmOptions): Promise<LlmResult<T>> 
     ], schema);
     const parsed = tryParse(content);
     if (parsed !== undefined && validate(parsed)) {
-      return { value: parsed as T, model, cost_usd: cost, rejected, calls: executed };
+      return { value: parsed as T, model, cost_usd: cost, tokens, rejected, calls: executed };
     }
 
     const reason = parsed === undefined ? "response was not valid JSON" : formatErrors(validate);
@@ -311,7 +331,7 @@ export async function llm_output<T>(options: LlmOptions): Promise<LlmResult<T>> 
     messages.push({ role: "user", content: `That emission was rejected — ${reason}. Emit a valid decision.` });
   }
 
-  throw new LlmError(`model never emitted a valid decision: ${rejected.join(" | ")}`, cost);
+  throw new LlmError(`model never emitted a valid decision: ${rejected.join(" | ")}`, cost, tokens);
 }
 
 export const EMIT_TOOL = "emit_decision";
@@ -444,6 +464,7 @@ export class LlmDecisionProvider implements DecisionProvider {
       model_id: result.model,
       prompt_version: promptVersion("lead", this.role),
       cost_usd: result.cost_usd,
+      tokens: result.tokens,
       rejected_attempts: result.rejected,
     };
   }
@@ -491,6 +512,7 @@ export class LlmDisconfirmationCritic implements DisconfirmationCritic {
       strongest_benign_explanation: result.value.benign_explanation,
       rationale: result.value.rationale,
       cost_usd: result.cost_usd,
+      tokens: result.tokens,
       model_id: result.model,
       prompt_version: promptVersion("critic", this.role),
     };
@@ -578,6 +600,7 @@ export class LlmWorkerDispatcher implements WorkerDispatcher {
       failed: false,
       failure_reason: "",
       cost_usd: result.cost_usd,
+      tokens: result.tokens,
       calls: result.calls,
     };
   }

--- a/ai/loop.ts
+++ b/ai/loop.ts
@@ -250,6 +250,12 @@ function validateFocus(decision: Decision, projection: Projection): void {
 }
 
 // The violation goes back to the Hunt Lead as a digest note, which is where the
+// What the lead was shown, kept on the decision record so resurfacing can ask
+// what it has already seen without loading a single digest snapshot.
+function presentedEvidenceIds(digest: Digest): string[] {
+  return digest.recent_evidence.map((record) => record.evidence_id);
+}
+
 // digest already carries controller-side observations, so the re-ask needs no
 // change to the DecisionProvider port.
 function withRejection(digest: Digest, reason: string): Digest {
@@ -490,6 +496,7 @@ export class HuntController {
   ): void {
     this.ledger.append({
       kind: "decision",
+      digest_presented: presented,
       decision: {
         ...attribution,
         decision: {
@@ -500,7 +507,7 @@ export class HuntController {
         },
         decision_id: newId("dec"),
         iteration: presented.iteration,
-        digest_presented: presented,
+        presented_evidence_ids: presentedEvidenceIds(presented),
         digest_seq: digestSeq,
         cost_usd: spent,
         rejected_attempts: [...rejected],
@@ -1528,11 +1535,12 @@ export class HuntController {
     const decisionId = newId("dec");
     this.ledger.append({
       kind: "decision",
+      digest_presented: digest,
       decision: {
         ...result,
         decision_id: decisionId,
         iteration,
-        digest_presented: digest,
+        presented_evidence_ids: presentedEvidenceIds(digest),
         digest_seq: digestSeq,
         created_at: new Date().toISOString(),
       },

--- a/ai/loop.ts
+++ b/ai/loop.ts
@@ -41,7 +41,9 @@ import {
 } from "./strength.js";
 import {
   ACTIONS_REQUIRING_CITATION,
+  addTokens,
   DECISION_ACTIONS,
+  NO_TOKENS,
   OUTCOME_PRECEDENCE,
   type Budgets,
   type Decision,
@@ -61,6 +63,7 @@ import {
   type NullCheckInput,
   type NullCheckResult,
   type OpenQuestion,
+  type TokenCounts,
   type WorkerEvidence,
 } from "./types.js";
 
@@ -116,18 +119,24 @@ interface NullCheckAttempt {
   result: NullCheckResult | null;
   blocked: string;
   cost_usd: number;
+  tokens: TokenCounts;
   // Exactly what the critic was shown. A later verdict must not rest on an
   // argument that never saw half the evidence now on the record.
   argued: string[];
 }
 
-const NO_NULL_CHECK: NullCheckAttempt = { result: null, blocked: "", cost_usd: 0, argued: [] };
+const NO_NULL_CHECK: NullCheckAttempt = { result: null, blocked: "", cost_usd: 0, tokens: NO_TOKENS, argued: [] };
 
 // A call that died mid-way still spent. Duck-typed rather than reaching into the
 // LLM module, so the controller stays free of it.
 function spentBefore(error: unknown): number {
   const cost = (error as { cost_usd?: unknown }).cost_usd;
   return typeof cost === "number" ? cost : 0;
+}
+
+function tokensBefore(error: unknown): TokenCounts {
+  const tokens = (error as { tokens?: TokenCounts }).tokens;
+  return tokens === undefined ? NO_TOKENS : tokens;
 }
 
 // Raw payloads, not digest summaries: the critic argues against what was
@@ -419,6 +428,7 @@ export class HuntController {
     // would under-report spend by up to the attempt bound, which both hides
     // cost-per-verdict and lets a hunt overrun max_cost_usd.
     let spent = 0;
+    let burned = NO_TOKENS;
     let presented = digest;
     let attempts = 0;
     let expansions = 0;
@@ -430,6 +440,7 @@ export class HuntController {
       const result = await this.provider.decide(presented);
       rejected.push(...(result.rejected_attempts ?? []));
       spent += result.cost_usd;
+      burned = addTokens(burned, result.tokens ?? NO_TOKENS);
       attribution = { model_id: result.model_id, prompt_version: result.prompt_version };
 
       try {
@@ -465,6 +476,7 @@ export class HuntController {
         result: {
           ...result,
           cost_usd: spent,
+          tokens: burned,
           ...(rejected.length > 0 ? { rejected_attempts: rejected } : {}),
         },
       };
@@ -474,7 +486,7 @@ export class HuntController {
     // presented a digest and was billed for emissions. Journaling it before the
     // throw is what keeps the ledger the whole audit trail, and charging it is
     // what stops a hunt resuming its way past max_cost_usd one stall at a time.
-    this.recordStall(presented, digestSeq, rejected, spent, attribution);
+    this.recordStall(presented, digestSeq, rejected, { cost_usd: spent, tokens: burned }, attribution);
 
     throw new InvalidDecision(
       `the Hunt Lead emitted nothing valid in ${MAX_DECISION_ATTEMPTS} attempts ` +
@@ -491,7 +503,7 @@ export class HuntController {
     presented: Digest,
     digestSeq: number,
     rejected: readonly string[],
-    spent: number,
+    burn: { cost_usd: number; tokens: TokenCounts },
     attribution: { model_id: string; prompt_version: string },
   ): void {
     this.ledger.append({
@@ -509,7 +521,8 @@ export class HuntController {
         iteration: presented.iteration,
         presented_evidence_ids: presentedEvidenceIds(presented),
         digest_seq: digestSeq,
-        cost_usd: spent,
+        cost_usd: burn.cost_usd,
+        tokens: burn.tokens,
         rejected_attempts: [...rejected],
         created_at: new Date().toISOString(),
       },
@@ -517,7 +530,7 @@ export class HuntController {
 
     const hunt = this.ledger.projection.hunt;
     this.ledger.patch("hunt", hunt.hunt_id, {
-      cost_usd: Number((hunt.cost_usd + spent).toFixed(6)),
+      cost_usd: Number((hunt.cost_usd + burn.cost_usd).toFixed(6)),
     });
     // The iteration counter deliberately does not advance: a resume retries this
     // iteration. So only the cost arm of the budget can newly trip here.
@@ -1315,6 +1328,7 @@ export class HuntController {
                 // whatever wording the client threw on the way down.
                 failure_reason: halt.signal.aborted ? CANCELLED_ON_ABORT : (error as Error).message,
                 cost_usd: spentBefore(error),
+                tokens: tokensBefore(error),
               };
             }
           })(),
@@ -1355,7 +1369,7 @@ export class HuntController {
     const argued = input.evidence.map((linked) => linked.record.evidence_id);
     try {
       const result = await this.critic.argueNull(input);
-      return { result, blocked: "", cost_usd: result.cost_usd, argued };
+      return { result, blocked: "", cost_usd: result.cost_usd, tokens: result.tokens ?? NO_TOKENS, argued };
     } catch (error) {
       // A critic that cannot run fails closed. An unavailable argument is not a
       // won one, and the hunt keeps going with the hypothesis still open — but
@@ -1364,6 +1378,7 @@ export class HuntController {
         result: null,
         blocked: `the disconfirmation critic failed (${(error as Error).message}), so it stays active`,
         cost_usd: spentBefore(error),
+        tokens: tokensBefore(error),
         argued: [],
       };
     }
@@ -1392,6 +1407,7 @@ export class HuntController {
             model_id: nullCheck.model_id,
             prompt_version: nullCheck.prompt_version,
             cost_usd: nullCheck.cost_usd,
+            tokens: attempt.tokens,
           },
           salience: "notable",
           why_notable: nullCheck.rationale,
@@ -1711,6 +1727,7 @@ export class HuntController {
       status: result.failed ? "failed" : "complete",
       failure_reason: result.failed ? result.failure_reason : null,
       cost_usd: result.cost_usd,
+      tokens: result.tokens ?? NO_TOKENS,
       calls: result.calls ?? [],
     });
     // A gap record is a fact about visibility, not a finding, so it counts as

--- a/ai/replay.ts
+++ b/ai/replay.ts
@@ -70,8 +70,8 @@ export function replay(log: readonly LedgerEvent[]): ReplayReport {
       cost_usd: record.cost_usd,
       exact,
       rebuilt,
-      recorded: record.digest_presented,
-      mismatch: differs(rebuilt, record.digest_presented),
+      recorded: event.digest_presented,
+      mismatch: differs(rebuilt, event.digest_presented),
     });
   }
 

--- a/ai/types.ts
+++ b/ai/types.ts
@@ -340,7 +340,9 @@ export interface DecisionResult {
 export interface DecisionRecord extends DecisionResult {
   decision_id: string;
   iteration: number;
-  digest_presented: Digest;
+  // The digest itself is the snapshot and belongs to replay alone; these ids are
+  // the only part of it the fold's consumers read, so they stay on the record.
+  presented_evidence_ids: string[];
   // Events on the ledger when the digest was built, so replay folds exactly
   // log[0..digest_seq). The decision is journaled after its own dispatches are,
   // which is why its seq is not that boundary. Absent on pre-replay ledgers.

--- a/ai/types.ts
+++ b/ai/types.ts
@@ -305,6 +305,7 @@ export interface DispatchRecord {
   // What the worker spent and what it ran. Both land on the completion patch,
   // since the row is journaled before the worker starts.
   cost_usd: number;
+  tokens?: TokenCounts;
   calls: ToolCall[];
 }
 
@@ -328,11 +329,33 @@ export interface Focus {
   hypothesis: string | null;
 }
 
+// What cost_usd was priced from, kept so a run can be re-priced and the caching
+// work measured. cache_read is the cached share of input, not an addition to it.
+export interface TokenCounts {
+  input: number;
+  output: number;
+  cache_read: number;
+  cache_write: number;
+}
+
+export const NO_TOKENS: TokenCounts = Object.freeze({ input: 0, output: 0, cache_read: 0, cache_write: 0 });
+
+export function addTokens(left: TokenCounts, right: TokenCounts): TokenCounts {
+  return {
+    input: left.input + right.input,
+    output: left.output + right.output,
+    cache_read: left.cache_read + right.cache_read,
+    cache_write: left.cache_write + right.cache_write,
+  };
+}
+
 export interface DecisionResult {
   decision: Decision;
   model_id: string;
   prompt_version: string;
   cost_usd: number;
+  // Absent on ledgers written before token counts were journaled.
+  tokens?: TokenCounts;
   // Emissions the controller rejected before accepting one, kept so re-prompts stay visible.
   rejected_attempts?: string[];
 }
@@ -442,6 +465,7 @@ export interface DispatchResult {
   // Required, including on the failure path: a worker that burned tokens and
   // then died still spent them, and hunt.cost_usd is the budget counter.
   cost_usd: number;
+  tokens?: TokenCounts;
   calls?: ToolCall[];
 }
 
@@ -467,6 +491,7 @@ export interface NullCheckResult {
   strongest_benign_explanation: string;
   rationale: string;
   cost_usd: number;
+  tokens?: TokenCounts;
   model_id: string;
   prompt_version: string;
 }

--- a/tests/__snapshots__/equivalence.test.ts.snap
+++ b/tests/__snapshots__/equivalence.test.ts.snap
@@ -1,0 +1,297 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`fold equivalence over historical runs > covers every historical run file 1`] = `
+[
+  "hunt-0ff994280690.jsonl",
+  "hunt-403d0c29bba5.jsonl",
+  "hunt-462b6e9d6d56.jsonl",
+  "hunt-95700aa89ce9.jsonl",
+  "hunt-9a87fff30644.jsonl",
+  "hunt-b8ba4410ae0f.jsonl",
+  "hunt-dee628c23120.jsonl",
+  "hunt-edd70b7bed8c.jsonl",
+  "hunt-f34a1b93ef43.jsonl",
+  "hunt-ff7ffca4760f.jsonl",
+]
+`;
+
+exports[`fold equivalence over historical runs > hunt-0ff994280690.jsonl folds and replays as recorded 1`] = `
+{
+  "decisions": [],
+  "events": 8,
+  "inexact": 0,
+  "projection": "97515b3359ad36f8a103f84e13eaa9d6c8ec48fd7bbb1867b3fac78e9f30fa51",
+  "reproduced": 0,
+}
+`;
+
+exports[`fold equivalence over historical runs > hunt-9a87fff30644.jsonl folds and replays as recorded 1`] = `
+{
+  "decisions": [],
+  "events": 6,
+  "inexact": 0,
+  "projection": "1634a74e3547055e2f6939024e523d95e11c30b87052a2d3b153e53d2c877d30",
+  "reproduced": 0,
+}
+`;
+
+exports[`fold equivalence over historical runs > hunt-403d0c29bba5.jsonl folds and replays as recorded 1`] = `
+{
+  "decisions": [],
+  "events": 6,
+  "inexact": 0,
+  "projection": "3e57813e9b3f70c75f5ebaa39ebfb1f02928e1cb9c2d9670a2054667ffb3455e",
+  "reproduced": 0,
+}
+`;
+
+exports[`fold equivalence over historical runs > hunt-462b6e9d6d56.jsonl folds and replays as recorded 1`] = `
+{
+  "decisions": [
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-31c3e385d6af",
+      "exact": false,
+      "iteration": 1,
+      "mismatch": "rebuilt digest differs from the one presented",
+      "target": "h-28806bb3",
+    },
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-297f1b25224f",
+      "exact": false,
+      "iteration": 2,
+      "mismatch": "rebuilt digest differs from the one presented",
+      "target": "h-28806bb3",
+    },
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-4b15ecd535d8",
+      "exact": false,
+      "iteration": 3,
+      "mismatch": "rebuilt digest differs from the one presented",
+      "target": "h-aef015ce",
+    },
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-b98668ed5c61",
+      "exact": false,
+      "iteration": 4,
+      "mismatch": "rebuilt digest differs from the one presented",
+      "target": "h-aef015ce",
+    },
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-7ac299b79a56",
+      "exact": false,
+      "iteration": 5,
+      "mismatch": "rebuilt digest differs from the one presented",
+      "target": "h-aef015ce",
+    },
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-663310d5c713",
+      "exact": false,
+      "iteration": 6,
+      "mismatch": "rebuilt digest differs from the one presented",
+      "target": "h-28806bb3",
+    },
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-541c5dfbfd04",
+      "exact": false,
+      "iteration": 7,
+      "mismatch": "rebuilt digest differs from the one presented",
+      "target": "h-28806bb3",
+    },
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-2acbe3868232",
+      "exact": false,
+      "iteration": 8,
+      "mismatch": "rebuilt digest differs from the one presented",
+      "target": "h-aef015ce",
+    },
+  ],
+  "events": 409,
+  "inexact": 8,
+  "projection": "a16884c630254c52c8069a0fa5e88c1e00f67b636541e2f91ddb8d67692bd70f",
+  "reproduced": 0,
+}
+`;
+
+exports[`fold equivalence over historical runs > hunt-95700aa89ce9.jsonl folds and replays as recorded 1`] = `
+{
+  "decisions": [],
+  "events": 3,
+  "inexact": 0,
+  "projection": "6eec2c2ffb9aaa1cedd34562702fc03ce8d0d2f4f15f892352af800f0d26059c",
+  "reproduced": 0,
+}
+`;
+
+exports[`fold equivalence over historical runs > hunt-b8ba4410ae0f.jsonl folds and replays as recorded 1`] = `
+{
+  "decisions": [
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-592ee8497a1d",
+      "exact": true,
+      "iteration": 1,
+      "mismatch": null,
+      "target": "h-3431400b",
+    },
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-954b28fd4c4b",
+      "exact": true,
+      "iteration": 2,
+      "mismatch": null,
+      "target": "h-3431400b",
+    },
+    {
+      "action": "VALIDATE",
+      "decision_id": "dec-1823ec4f5797",
+      "exact": true,
+      "iteration": 3,
+      "mismatch": null,
+      "target": "h-3431400b",
+    },
+    {
+      "action": "HANDOFF_IR",
+      "decision_id": "dec-2adbb926b558",
+      "exact": true,
+      "iteration": 4,
+      "mismatch": null,
+      "target": "h-3431400b",
+    },
+    {
+      "action": "CONCLUDE",
+      "decision_id": "dec-976794b45613",
+      "exact": true,
+      "iteration": 5,
+      "mismatch": null,
+      "target": "h-3431400b",
+    },
+  ],
+  "events": 57,
+  "inexact": 0,
+  "projection": "3c57c5b5df21c0847122e491963a56323545915254eb72adfdeaa8e66ab1ee0c",
+  "reproduced": 5,
+}
+`;
+
+exports[`fold equivalence over historical runs > hunt-dee628c23120.jsonl folds and replays as recorded 1`] = `
+{
+  "decisions": [
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-799a99220986",
+      "exact": true,
+      "iteration": 1,
+      "mismatch": null,
+      "target": null,
+    },
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-025d1f9715ea",
+      "exact": true,
+      "iteration": 2,
+      "mismatch": null,
+      "target": "h-8c8ce6b4",
+    },
+    {
+      "action": "STALLED",
+      "decision_id": "dec-e0b532faca38",
+      "exact": true,
+      "iteration": 3,
+      "mismatch": null,
+      "target": null,
+    },
+  ],
+  "events": 48,
+  "inexact": 0,
+  "projection": "61e51fbd4102c8724ed076b27adfc45d2ce99fbbb28715ae6edd767a7458253f",
+  "reproduced": 3,
+}
+`;
+
+exports[`fold equivalence over historical runs > hunt-edd70b7bed8c.jsonl folds and replays as recorded 1`] = `
+{
+  "decisions": [
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-3dc801806399",
+      "exact": true,
+      "iteration": 1,
+      "mismatch": null,
+      "target": null,
+    },
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-88b7f1a08ab0",
+      "exact": true,
+      "iteration": 2,
+      "mismatch": null,
+      "target": null,
+    },
+    {
+      "action": "CONCLUDE",
+      "decision_id": "dec-69cace1f1a5b",
+      "exact": true,
+      "iteration": 3,
+      "mismatch": null,
+      "target": null,
+    },
+    {
+      "action": "VALIDATE",
+      "decision_id": "dec-371418c293b1",
+      "exact": true,
+      "iteration": 4,
+      "mismatch": null,
+      "target": "h-29203764",
+    },
+  ],
+  "events": 35,
+  "inexact": 0,
+  "projection": "c9ab49ee41ffe84986c0fa46a50013aee81522f679ccd4a2f629b4676117031b",
+  "reproduced": 4,
+}
+`;
+
+exports[`fold equivalence over historical runs > hunt-f34a1b93ef43.jsonl folds and replays as recorded 1`] = `
+{
+  "decisions": [],
+  "events": 5,
+  "inexact": 0,
+  "projection": "26221da1a92a12223231e742583fa25d7b2827d36afcc535d9118adb5a184923",
+  "reproduced": 0,
+}
+`;
+
+exports[`fold equivalence over historical runs > hunt-ff7ffca4760f.jsonl folds and replays as recorded 1`] = `
+{
+  "decisions": [
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-ac2527fdda36",
+      "exact": false,
+      "iteration": 1,
+      "mismatch": "rebuilt digest differs from the one presented",
+      "target": "h-44a7fe1c",
+    },
+    {
+      "action": "INVESTIGATE",
+      "decision_id": "dec-4d8b8c6c7eec",
+      "exact": false,
+      "iteration": 2,
+      "mismatch": "rebuilt digest differs from the one presented",
+      "target": "h-44a7fe1c",
+    },
+  ],
+  "events": 91,
+  "inexact": 2,
+  "projection": "1771701aeb4ec31b3e03235caffc9f68733b4d8d9b7a36ae65ed8f2ccb2d544e",
+  "reproduced": 0,
+}
+`;

--- a/tests/digest.test.ts
+++ b/tests/digest.test.ts
@@ -6,7 +6,7 @@ import { buildDigest, salienceFloor } from "../ai/digest.js";
 import { buildEntityGraph, entitiesOf, fromText } from "../ai/entities.js";
 import { renderDigest } from "../ai/llm.js";
 import { HuntController, MAX_EXPANSIONS, startHunt } from "../ai/loop.js";
-import { Ledger, newId } from "../ai/ledger.js";
+import { Ledger, newId, snapshots } from "../ai/ledger.js";
 import { ScriptedDecisionProvider, ScriptedWorkerDispatcher } from "../ai/scripted.js";
 import { buildSpec, DEFAULT_DIGEST, type DigestPolicy } from "../ai/spec.js";
 import type { Decision, EvidenceRecord, Salience, WorkerEvidence } from "../ai/types.js";
@@ -181,20 +181,11 @@ describe("resurfacing", () => {
 
     ledger.append({
       kind: "decision",
+      digest_presented: baseline,
       decision: {
         decision_id: newId("dec"),
         iteration: 1,
-        digest_presented: {
-          ...baseline,
-          recent_evidence: [...seen].map((evidence_id) => ({
-            evidence_id,
-            source_system: "duckdb",
-            summary: "",
-            salience: "routine" as Salience,
-            why_notable: "",
-            instruction_like: false,
-          })),
-        },
+        presented_evidence_ids: [...seen],
         decision: { action: "INVESTIGATE", rationale: "x" },
         model_id: "scripted",
         prompt_version: "v0",
@@ -384,7 +375,7 @@ describe("EXPAND", () => {
     // Two model calls, one iteration: the EXPAND cost is charged, not the turn.
     expect(result.cost_usd).toBe(1);
 
-    const digest = ledger.projection.decisions.at(-1)!.digest_presented;
+    const digest = snapshots(ledger.log).at(-1)!;
     expect(digest.expansions).toHaveLength(1);
     expect(digest.expansions[0]!.payload).toContain("45.77.53.176");
     expect(renderDigest(digest)).toContain("## Expanded payloads");
@@ -436,7 +427,7 @@ describe("EXPAND", () => {
     ]);
     await new HuntController(ledger, provider).advanceIteration();
 
-    const digest = ledger.projection.decisions.at(-1)!.digest_presented;
+    const digest = snapshots(ledger.log).at(-1)!;
     expect(digest.expansions.length).toBeLessThan(ids.length);
     expect(digest.expansions.every((e) => JSON.parse(e.payload) !== undefined)).toBe(true);
     expect(digest.notes.join(" ")).toMatch(/Too large to expand/);
@@ -464,7 +455,7 @@ describe("EXPAND", () => {
       ]),
     ).advanceIteration();
 
-    const rendered = renderDigest(ledger.projection.decisions.at(-1)!.digest_presented);
+    const rendered = renderDigest(snapshots(ledger.log).at(-1)!);
     expect(rendered.match(/<\/vigil:evidence>/g)).toHaveLength(
       rendered.match(/<vigil:evidence /g)!.length,
     );

--- a/tests/equivalence.test.ts
+++ b/tests/equivalence.test.ts
@@ -1,0 +1,81 @@
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { fold, type LedgerEvent } from "../ai/ledger.js";
+import { replay } from "../ai/replay.js";
+
+const RUNS = join(import.meta.dirname, "..", "runs");
+
+// The digest carve-out: the snapshot leaves the fold's read path, so equivalence
+// is asserted over the projection without it, and replay proves it survived.
+const OMITTED = new Set(["digest_presented", "presented_evidence_ids"]);
+
+function canonical(value: unknown): unknown {
+  if (value instanceof Map) {
+    return [...value.entries()].sort((a, b) => (a[0] < b[0] ? -1 : 1)).map(([key, item]) => [key, canonical(item)]);
+  }
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value !== null && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    const keys = Object.keys(source).filter((key) => !OMITTED.has(key)).sort();
+    return Object.fromEntries(keys.map((key) => [key, canonical(source[key])]));
+  }
+  return value;
+}
+
+export function runFiles(): string[] {
+  return readdirSync(RUNS)
+    .filter((name) => name.endsWith(".jsonl") && !name.endsWith(".inbox.jsonl"))
+    .sort();
+}
+
+export function readEvents(name: string): LedgerEvent[] {
+  return readFileSync(join(RUNS, name), "utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as LedgerEvent);
+}
+
+// Hashed rather than inlined: the projections run to megabytes, and a hash that
+// changes is the same signal as a diff that changes, for a fixture a human reads.
+function measure(events: readonly LedgerEvent[]) {
+  const report = replay(events);
+  return {
+    events: events.length,
+    projection: createHash("sha256").update(JSON.stringify(canonical(fold(events)))).digest("hex"),
+    reproduced: report.reproduced,
+    inexact: report.inexact,
+    decisions: report.decisions.map((decision) => ({
+      decision_id: decision.decision_id,
+      iteration: decision.iteration,
+      action: decision.action,
+      target: decision.target,
+      exact: decision.exact,
+      mismatch: decision.mismatch,
+    })),
+  };
+}
+
+describe("fold equivalence over historical runs", () => {
+  const files = runFiles();
+
+  it("covers every historical run file", () => {
+    expect(files).toMatchSnapshot();
+  });
+
+  for (const name of files) {
+    it(`${name} folds and replays as recorded`, () => {
+      expect(measure(readEvents(name))).toMatchSnapshot();
+    });
+  }
+
+  // Named rather than left to the snapshot: this is the run that reproduces in
+  // full, so it is the one whose regression means the digest itself has drifted.
+  it("reproduces every digest in the known-good baseline run", () => {
+    const report = replay(readEvents("hunt-b8ba4410ae0f.jsonl"));
+    expect(report.decisions).toHaveLength(5);
+    expect(report.reproduced).toBe(5);
+    expect(report.inexact).toBe(0);
+  });
+});

--- a/tests/equivalence.test.ts
+++ b/tests/equivalence.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { fold, type LedgerEvent } from "../ai/ledger.js";
+import { fold, parseLog, type LedgerEvent } from "../ai/ledger.js";
 import { replay } from "../ai/replay.js";
 
 const RUNS = join(import.meta.dirname, "..", "runs");
@@ -30,11 +30,10 @@ export function runFiles(): string[] {
     .sort();
 }
 
+// Through the ledger's own reader, so the legacy hoist is under test rather than
+// bypassed: these files are all in the pre-split shape.
 export function readEvents(name: string): LedgerEvent[] {
-  return readFileSync(join(RUNS, name), "utf8")
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as LedgerEvent);
+  return parseLog(readFileSync(join(RUNS, name), "utf8"));
 }
 
 // Hashed rather than inlined: the projections run to megabytes, and a hash that

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -8,7 +8,7 @@ import { LlmDecisionProvider, LlmWorkerDispatcher, resetEmitMode } from "../ai/l
 import { HuntController, startHunt } from "../ai/loop.js";
 import { buildSpec } from "../ai/spec.js";
 import { buildTools, closeTools, type Tool } from "../ai/tools.js";
-import { Ledger } from "../ai/ledger.js";
+import { Ledger, snapshots } from "../ai/ledger.js";
 import { replay } from "../ai/replay.js";
 
 type Body = OpenAI.Chat.ChatCompletionCreateParamsNonStreaming;
@@ -152,7 +152,7 @@ describe.skipIf(!existsSync(DATABASE))("hunt end to end (stubbed gateway, real e
     // The digest the lead saw is on the record, and the file replays to the same state.
     const decisions = ledger.projection.decisions;
     expect(decisions).toHaveLength(2);
-    expect(decisions[1]!.digest_presented.recent_evidence[0]!.summary).toContain("45.77.53.176");
+    expect(snapshots(ledger.log)[1]!.recent_evidence[0]!.summary).toContain("45.77.53.176");
     expect(Ledger.open(ledger.path).projection).toEqual(ledger.projection);
 
     // And every digest rebuilds from the prefix behind it — the determinism the

--- a/tests/llm.test.ts
+++ b/tests/llm.test.ts
@@ -161,6 +161,37 @@ describe("llm_output", () => {
     expect(result.rejected[0]).toContain("NOPE");
   });
 
+  // Both gateway surfaces report the cached share under their own key, and a
+  // re-prompt is a second billed call: totalling only the accepted one would
+  // under-report exactly the turns the caching work is measured against.
+  it("totals tokens across every billed turn, from either surface", async () => {
+    let call = 0;
+    const client = clientOf(async () => {
+      call += 1;
+      const usage =
+        call === 1
+          ? { prompt_tokens: 100, completion_tokens: 20, prompt_tokens_details: { cached_tokens: 60 } }
+          : { prompt_tokens: 40, completion_tokens: 8, cache_read_input_tokens: 10, cache_creation_input_tokens: 30 };
+      return {
+        ...completion({ role: "assistant", content: call === 1 ? '{"action":"NOPE"}' : '{"action":"CONCLUDE"}' }),
+        usage,
+      } as unknown as OpenAI.Chat.ChatCompletion;
+    });
+
+    const result = await llm_output<{ action: string }>({
+      client,
+      model: "openai/gpt-4o",
+      messages: [{ role: "user", content: "go" }],
+      schema: SCHEMA,
+      limiter: limiter(),
+      rates: { input: 1, output: 1 },
+    });
+
+    expect(result.tokens).toEqual({ input: 140, output: 28, cache_read: 70, cache_write: 30 });
+    // cache_read is a share of input, not an addition, so cost still prices input.
+    expect(result.cost_usd).toBeCloseTo(168 / 1_000_000);
+  });
+
   it("gives up rather than returning something off-schema", async () => {
     const client = clientOf(async () => completion({ role: "assistant", content: "not json at all" }));
     await expect(

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import { buildDigest } from "../ai/digest.js";
 import { steer } from "../ai/inbox.js";
-import { Ledger, newId } from "../ai/ledger.js";
+import { Ledger, newId, snapshots } from "../ai/ledger.js";
 import {
   HuntController,
   InvalidDecision,
@@ -85,7 +85,7 @@ describe("controller", () => {
     expect(result.hunt_status).toBe("terminal");
     expect(result.hunt_outcome).toBe("completed");
     expect(ledger.projection.decisions).toHaveLength(1);
-    expect(ledger.projection.decisions[0]!.digest_presented.iteration).toBe(1);
+    expect(snapshots(ledger.log)[0]!.iteration).toBe(1);
     expect(ledger.projection.hunt.cost_usd).toBe(0.25);
   });
 
@@ -189,7 +189,7 @@ describe("bounded re-prompt", () => {
 
     // The digest persisted with the accepted decision is the one that produced
     // it, so the rejection the model was shown is on the record too.
-    expect(record.digest_presented.notes.join(" ")).toMatch(/previous emission was rejected/);
+    expect(snapshots(ledger.log)[0]!.notes.join(" ")).toMatch(/previous emission was rejected/);
     expect(provider.seenDigests).toHaveLength(2);
     expect(provider.seenDigests[0]!.notes.join(" ")).not.toMatch(/previous emission was rejected/);
   });

--- a/tests/replay.test.ts
+++ b/tests/replay.test.ts
@@ -55,8 +55,7 @@ describe("replay", () => {
     const ledger = await hunt([INVESTIGATE, INVESTIGATE]);
     const tampered = ledger.log.map((event): LedgerEvent => {
       if (event.kind !== "decision" || event.decision.iteration !== 2) return event;
-      const digest = { ...event.decision.digest_presented, hunt_name: "not what was presented" };
-      return { ...event, decision: { ...event.decision, digest_presented: digest } };
+      return { ...event, digest_presented: { ...event.digest_presented, hunt_name: "not what was presented" } };
     });
 
     const report = replay(tampered);
@@ -71,10 +70,10 @@ describe("replay", () => {
     const carried = ledger.log.map((event): LedgerEvent => {
       if (event.kind !== "decision") return event;
       const digest = {
-        ...event.decision.digest_presented,
-        notes: [...event.decision.digest_presented.notes, "Your previous emission was rejected: bad."],
+        ...event.digest_presented,
+        notes: [...event.digest_presented.notes, "Your previous emission was rejected: bad."],
       };
-      return { ...event, decision: { ...event.decision, digest_presented: digest } };
+      return { ...event, digest_presented: digest };
     });
 
     expect(replay(carried).reproduced).toBe(1);

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import { drain, inboxPath, steer } from "../ai/inbox.js";
 import { Lease, LeaseHeld } from "../ai/lease.js";
-import { Ledger, newId } from "../ai/ledger.js";
+import { Ledger, newId, snapshots } from "../ai/ledger.js";
 import { HuntController, resumeHunt, startHunt } from "../ai/loop.js";
 import { ScriptedDecisionProvider, ScriptedWorkerDispatcher } from "../ai/scripted.js";
 import { buildSpec } from "../ai/spec.js";
@@ -149,7 +149,7 @@ describe("steering", () => {
     steer(ledger.path, "note", "pivot to DNS if this stalls");
 
     await controllerFor(ledger, [INVESTIGATE]).advanceIteration();
-    const digest = ledger.projection.decisions[0]!.digest_presented;
+    const digest = snapshots(ledger.log)[0]!;
     expect(digest.directives).toEqual([expect.stringContaining("pivot to DNS if this stalls")]);
     expect(ledger.projection.directives).toHaveLength(1);
   });


### PR DESCRIPTION
The storage-independent half of #591, on the file ledger. The Postgres repository is deliberately **not** here — see "What is deferred" below.

## What this does

**A fold-equivalence gate over the ten historical runs** (`tests/equivalence.test.ts`). For each run it records the event count, a hash of the canonicalised projection, and the replay report decision by decision. It is committed **first**, generated from unmodified code, so the baseline demonstrably predates the change it gates — check out `2baf2bf` and it passes on its own.

**The digest leaves the fold's read path.** `digest_presented` moves off `DecisionRecord` and sits beside it on the event, which is the `payload`/`snapshot` column split expressed where the compiler holds it: the fold clones the record, and the record no longer has a digest in it. Decision events reach 56.7 KB, so folding a long run was reading tens of megabytes to build one digest.

One consumer did read it back — `buildDigest` asks which evidence a lead has already been shown, to stop resurfacing offering the same routine record twice. That only needs the ids, so `presented_evidence_ids` goes on the record and the fold's consumer reads those instead.

Ledgers on disk carry the old shape, so `parseLog` hoists it on read. Same move the store will make between its two columns; no historical run needs rewriting.

**Token counts** — `input`, `output`, `cache_read`, `cache_write` on every decision and dispatch. Both gateway surfaces are read (OpenAI's `prompt_tokens_details`, Anthropic's `cache_*_input_tokens`), totalled across every billed turn including rejected re-prompts, and carried on `LlmError` so a failed call does not drop tokens while keeping dollars. `cache_read` is the cached share of `input`, not an addition, so **no dollar figure changes in this PR**.

## Three corrections to the issue text

1. **There are ten historical run files, not twelve.** `runs/*.jsonl` minus four `.inbox.jsonl` sidecars. Plus one `.corrupt` sidecar and a `hunt2x/` directory containing no ledger.

2. **"Every digest in those runs still replays exactly" is not true, and was not before this PR.** Three of ten reproduce fully — `hunt-b8ba4410ae0f` 5/5 (the known-good baseline, asserted by name), `hunt-dee628c23120` 3/3, `hunt-edd70b7bed8c` 4/4. `hunt-462b6e9d6d56` (8 decisions) and `hunt-ff7ffca4760f` (2) predate `digest_seq`, so replay infers where the digest was built and every decision mismatches on that boundary rather than on drift. Five runs have no decisions at all. The baseline freezes this as it stands so it cannot get worse; it does not assert a green that is not there.

3. **The DDL numbering collision is already resolved upstream.** The migration plan said `18_agent_ledger.sql`; `18_agent_decision_ids.sql` was taken. ADR-0005 already moved it to `19_`.

## Token counts are a stopgap

ADR-0005 makes `spend` its own event kind, replacing the `cost_usd` fields hung on decision and dispatch records, and re-homes them in #596. These counts sit beside those `cost_usd` fields deliberately, so both move together when that happens. Journaling them now is what #591 asks for and costs nothing extra later.

## What is deferred

#589 and #590 are finished and open as #603 and #604, against `main`, in a different layout (`ai/` as its own package with `ai/contracts/`). #603 already ships `database/init/19_agent_ledger.sql` — `agent_events`, PK `(run_id, seq)`, `payload`/`snapshot`, `run_kind` — which satisfies this issue's first three acceptance criteria, plus `TokenCounts`/`ZERO_TOKENS` in `ai/contracts/budget.ts`.

So the Postgres repository and the Postgres arm of the gate go in a second PR against `main`, stacked on #603/#604 once they land. That PR should also drop this branch's local `TokenCounts` in favour of the contract's.

`.github/workflows/agent-ci.yml` exists only because this branch has no CI at all and #604's `test-agent-layer` job runs against `ai/package.json`, which this layout does not have. **Delete it when the prototype is ported**, rather than leaving it alongside.

## Verification

- `npx tsc --noEmit` clean; `npx vitest run` — 247 passing, 16 files.
- Commit 1 verified standalone on unmodified code.
- Gate verified to bite, not pass vacuously: breaking the hoist in `parseLog` fails all five runs that have decisions plus the named baseline test. It also caught a real bug during the work — an earlier version of the test parsed the JSONL directly and bypassed the reader.
- Do not run `vitest -u`: it rewrites the baseline and silently erases the gate.

Refs #591