### PR TITLE
fix(integrations): move to httpx, unblock the loop

### DIFF
--- a/core/integrations/crowdstrike/adapter.py
+++ b/core/integrations/crowdstrike/adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
@@ -73,7 +74,8 @@ class CrowdStrikeAdapter:
             cutoff = datetime.utcnow() - timedelta(minutes=1)
 
         try:
-            detections = svc.get_detections(
+            detections = await asyncio.to_thread(
+                svc.get_detections,
                 filter_query=f"created_timestamp:>='{cutoff.isoformat()}Z'",
                 limit=max_items,
             ) or []

--- a/core/integrations/crowdstrike/client.py
+++ b/core/integrations/crowdstrike/client.py
@@ -1,11 +1,18 @@
 """CrowdStrike Falcon API service for detection polling and host management."""
 
 import logging
-import requests
+import httpx
 from typing import Optional, List, Dict, Any
 from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
+
+# Every call site already passes timeout=30; this is the client-level floor
+# so a future call that forgets one still cannot hang forever.
+DEFAULT_TIMEOUT = 30.0
+
+# httpx defaults to follow_redirects=False; requests followed redirects.
+_FOLLOW_REDIRECTS = True
 
 
 class CrowdStrikeService:
@@ -18,7 +25,10 @@ class CrowdStrikeService:
         self.base_url = base_url.rstrip('/')
         self.access_token: Optional[str] = None
         self.token_expiry: Optional[datetime] = None
-        self.session = requests.Session()
+        self.session = httpx.Client(
+            timeout=DEFAULT_TIMEOUT,
+            follow_redirects=_FOLLOW_REDIRECTS,
+        )
     
     def _ensure_authenticated(self) -> bool:
         """Ensure we have a valid access token."""

--- a/core/integrations/crowdstrike/client.py
+++ b/core/integrations/crowdstrike/client.py
@@ -7,11 +7,10 @@ from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 
-# Every call site already passes timeout=30; this is the client-level floor
-# so a future call that forgets one still cannot hang forever.
+# Client-level floor; every call site also passes timeout=30 explicitly.
 DEFAULT_TIMEOUT = 30.0
 
-# httpx defaults to follow_redirects=False; requests followed redirects.
+# requests followed redirects by default; httpx does not.
 _FOLLOW_REDIRECTS = True
 
 

--- a/core/integrations/microsoft_defender/ingestion.py
+++ b/core/integrations/microsoft_defender/ingestion.py
@@ -4,6 +4,7 @@ Microsoft Defender Ingestion Service - Ingest alerts from Microsoft Defender for
 Fetches security alerts from Microsoft Defender and converts them to findings.
 """
 
+import asyncio
 import logging
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta
@@ -92,8 +93,10 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
             List of raw alert dictionaries
         """
         try:
-            # Get access token
-            token = self._get_access_token()
+            # Get access token. Both the token exchange and the alert fetch
+            # below are blocking HTTP, so they go to a worker thread rather
+            # than stalling the caller's event loop (execution model, #461).
+            token = await asyncio.to_thread(self._get_access_token)
             if not token:
                 return []
             
@@ -117,7 +120,8 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
                 '$orderby': 'alertCreationTime desc'
             }
             
-            response = httpx.get(
+            response = await asyncio.to_thread(
+                httpx.get,
                 api_url,
                 headers=headers,
                 params=params,

--- a/core/integrations/microsoft_defender/ingestion.py
+++ b/core/integrations/microsoft_defender/ingestion.py
@@ -8,12 +8,20 @@ import logging
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta
 import uuid
-import requests
+import httpx
 
 from core.ingestion.siem_ingestion_service import SIEMIngestionService
 from core.config import get_integration_config
 
 logger = logging.getLogger(__name__)
+
+# Neither call site passed a timeout and requests defaults to None, so a
+# stalled Microsoft endpoint could hang the poll indefinitely.
+DEFAULT_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=10.0, pool=5.0)
+
+# httpx defaults to follow_redirects=False; requests followed redirects.
+# Microsoft's login endpoints do redirect, so this one matters.
+_FOLLOW_REDIRECTS = True
 
 
 class MicrosoftDefenderIngestion(SIEMIngestionService):
@@ -51,7 +59,12 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
                 'grant_type': 'client_credentials'
             }
             
-            response = requests.post(token_url, data=token_data)
+            response = httpx.post(
+                token_url,
+                data=token_data,
+                timeout=DEFAULT_TIMEOUT,
+                follow_redirects=_FOLLOW_REDIRECTS,
+            )
             response.raise_for_status()
             
             self.access_token = response.json()['access_token']
@@ -104,7 +117,13 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
                 '$orderby': 'alertCreationTime desc'
             }
             
-            response = requests.get(api_url, headers=headers, params=params)
+            response = httpx.get(
+                api_url,
+                headers=headers,
+                params=params,
+                timeout=DEFAULT_TIMEOUT,
+                follow_redirects=_FOLLOW_REDIRECTS,
+            )
             response.raise_for_status()
             
             alerts = response.json().get('value', [])
@@ -112,7 +131,7 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
             logger.info(f"Fetched {len(alerts)} alerts from Microsoft Defender")
             return alerts
         
-        except requests.exceptions.RequestException as e:
+        except (httpx.HTTPError, httpx.InvalidURL) as e:
             logger.error(f"Microsoft Defender API error: {e}")
             return []
         except Exception as e:

--- a/core/integrations/microsoft_defender/ingestion.py
+++ b/core/integrations/microsoft_defender/ingestion.py
@@ -16,12 +16,11 @@ from core.config import get_integration_config
 
 logger = logging.getLogger(__name__)
 
-# Neither call site passed a timeout and requests defaults to None, so a
-# stalled Microsoft endpoint could hang the poll indefinitely.
+# Neither call site passed a timeout, and requests defaulted to none.
 DEFAULT_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=10.0, pool=5.0)
 
-# httpx defaults to follow_redirects=False; requests followed redirects.
-# Microsoft's login endpoints do redirect, so this one matters.
+# requests followed redirects by default, httpx does not — and Microsoft's
+# login endpoints redirect.
 _FOLLOW_REDIRECTS = True
 
 
@@ -93,9 +92,8 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
             List of raw alert dictionaries
         """
         try:
-            # Get access token. Both the token exchange and the alert fetch
-            # below are blocking HTTP, so they go to a worker thread rather
-            # than stalling the caller's event loop (execution model, #461).
+            # Token exchange and the alert fetch below are both blocking
+            # HTTP; this method is async by interface, so offload them.
             token = await asyncio.to_thread(self._get_access_token)
             if not token:
                 return []

--- a/core/integrations/splunk/adapter.py
+++ b/core/integrations/splunk/adapter.py
@@ -95,8 +95,7 @@ class SplunkAdapter:
         for query_tmpl in _QUERIES:
             query = query_tmpl.format(limit=max_items)
             try:
-                # Blocking: polls the search job with time.sleep for up to
-                # ~60s. Keep it off the federation loop (#461).
+                # search() polls its job with time.sleep for up to ~60s.
                 results = await asyncio.to_thread(
                     svc.search,
                     query=query,

--- a/core/integrations/splunk/adapter.py
+++ b/core/integrations/splunk/adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from datetime import datetime
@@ -94,7 +95,10 @@ class SplunkAdapter:
         for query_tmpl in _QUERIES:
             query = query_tmpl.format(limit=max_items)
             try:
-                results = svc.search(
+                # Blocking: polls the search job with time.sleep for up to
+                # ~60s. Keep it off the federation loop (#461).
+                results = await asyncio.to_thread(
+                    svc.search,
                     query=query,
                     earliest_time=earliest_time,
                     latest_time="now",

--- a/core/integrations/splunk/client.py
+++ b/core/integrations/splunk/client.py
@@ -1,14 +1,29 @@
 """Splunk API service for data enrichment."""
 
 import logging
-import requests
+import httpx
 from typing import Optional, List, Dict
-import urllib3
 
-# Disable SSL warnings for self-signed certificates
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+# NOTE: urllib3.disable_warnings() used to live here to silence
+# InsecureRequestWarning for verify_ssl=False deployments. httpx does not
+# use urllib3 and emits no such warning, so it was dropped along with the
+# requests dependency.
 
 logger = logging.getLogger(__name__)
+
+# requests defaults to no timeout, so every call in this module could hang
+# forever against an unresponsive Splunk — and search() is invoked from the
+# daemon's poll loop. Give the client an explicit budget instead. read is
+# generous because a results fetch can return max_count events.
+DEFAULT_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=5.0)
+
+# httpx defaults to follow_redirects=False; requests followed redirects.
+_FOLLOW_REDIRECTS = True
+
+# httpx.InvalidURL is not an httpx.HTTPError, but requests folded both into
+# RequestException. Catch both so a malformed server_url keeps returning a
+# clean failure instead of escaping the handler.
+_HTTP_ERRORS = (httpx.HTTPError, httpx.InvalidURL)
 
 
 class SplunkService:
@@ -29,15 +44,18 @@ class SplunkService:
         self.username = username
         self.password = password
         self.verify_ssl = verify_ssl
-        self.session = requests.Session()
-        self.session.verify = verify_ssl
+        # verify and timeout are constructor-only on httpx.Client (unlike
+        # requests.Session, where they could be assigned afterwards).
+        self.session = httpx.Client(
+            verify=verify_ssl,
+            timeout=DEFAULT_TIMEOUT,
+            follow_redirects=_FOLLOW_REDIRECTS,
+            headers={
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Accept': 'application/json',
+            },
+        )
         self.session_key: Optional[str] = None
-        
-        # Set default headers
-        self.session.headers.update({
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Accept': 'application/json'
-        })
     
     def authenticate(self) -> bool:
         """
@@ -98,20 +116,24 @@ class SplunkService:
             else:
                 return False, f"Connection failed: HTTP {response.status_code}"
         
-        except requests.exceptions.RequestException as e:
+        except _HTTP_ERRORS as e:
             return False, f"Connection error: {str(e)}"
     
     def search(self, query: str, earliest_time: str = "-24h", 
                latest_time: str = "now", max_count: int = 1000) -> Optional[List[Dict]]:
         """
         Execute a search query in Splunk.
-        
+
+        Blocking: this polls the search job with time.sleep and can take up
+        to ~60s. That is fine on a worker thread, but async callers must go
+        through asyncio.to_thread — never await-free on the event loop.
+
         Args:
             query: SPL (Splunk Processing Language) query
             earliest_time: Earliest time for search (default: -24h)
             latest_time: Latest time for search (default: now)
             max_count: Maximum number of results to return
-        
+
         Returns:
             List of result dictionaries, or None if error
         """

--- a/core/integrations/splunk/client.py
+++ b/core/integrations/splunk/client.py
@@ -4,25 +4,22 @@ import logging
 import httpx
 from typing import Optional, List, Dict
 
-# NOTE: urllib3.disable_warnings() used to live here to silence
-# InsecureRequestWarning for verify_ssl=False deployments. httpx does not
-# use urllib3 and emits no such warning, so it was dropped along with the
-# requests dependency.
+# urllib3.disable_warnings() used to live here to silence
+# InsecureRequestWarning; httpx doesn't use urllib3 and emits no such
+# warning.
 
 logger = logging.getLogger(__name__)
 
-# requests defaults to no timeout, so every call in this module could hang
-# forever against an unresponsive Splunk — and search() is invoked from the
-# daemon's poll loop. Give the client an explicit budget instead. read is
-# generous because a results fetch can return max_count events.
+# requests defaulted to no timeout and no call site passed one, so every
+# request here could hang forever. read is generous because a results fetch
+# can return max_count events.
 DEFAULT_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=5.0)
 
-# httpx defaults to follow_redirects=False; requests followed redirects.
+# requests followed redirects by default; httpx does not.
 _FOLLOW_REDIRECTS = True
 
-# httpx.InvalidURL is not an httpx.HTTPError, but requests folded both into
-# RequestException. Catch both so a malformed server_url keeps returning a
-# clean failure instead of escaping the handler.
+# httpx.InvalidURL sits outside the httpx.HTTPError tree, but requests
+# folded both into RequestException.
 _HTTP_ERRORS = (httpx.HTTPError, httpx.InvalidURL)
 
 
@@ -44,8 +41,8 @@ class SplunkService:
         self.username = username
         self.password = password
         self.verify_ssl = verify_ssl
-        # verify and timeout are constructor-only on httpx.Client (unlike
-        # requests.Session, where they could be assigned afterwards).
+        # verify/timeout are constructor-only on httpx.Client; requests
+        # allowed session.verify to be assigned afterwards.
         self.session = httpx.Client(
             verify=verify_ssl,
             timeout=DEFAULT_TIMEOUT,

--- a/core/integrations/vstrike/client.py
+++ b/core/integrations/vstrike/client.py
@@ -26,13 +26,23 @@ import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
-import requests
+import httpx
 
 from core.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 30
+
+# `requests` folded every transport failure into RequestException, but
+# httpx.InvalidURL sits outside the httpx.HTTPError tree — so a malformed
+# VSTRIKE_BASE_URL would escape a bare `except httpx.HTTPError` and 500 the
+# caller instead of returning None. Catch both to keep the old contract.
+_HTTP_ERRORS = (httpx.HTTPError, httpx.InvalidURL)
+
+# httpx defaults to follow_redirects=False; requests followed redirects.
+# Passed on every call so the swap is behaviour-preserving.
+_FOLLOW_REDIRECTS = True
 
 # MCP JSON-RPC endpoint exposed by VStrike. Confirmed live against
 # https://vstrike.net — VStrike replies with `text/event-stream`.
@@ -59,7 +69,7 @@ class VStrikeToolNotImplemented(RuntimeError):
     """
 
 
-def _parse_response_body(resp: requests.Response) -> Any:
+def _parse_response_body(resp: httpx.Response) -> Any:
     """Return the JSON body of a response, tolerating SSE framing.
 
     VStrike's MCP endpoint replies with `text/event-stream` even though the
@@ -221,7 +231,7 @@ class VStrikeService:
             "Content-Type": "application/json",
         }
 
-    def _get(self, path: str, **kwargs) -> requests.Response:
+    def _get(self, path: str, **kwargs) -> httpx.Response:
         """GET ``{base_url}{path}`` with JWT auth, retrying once on 401.
 
         Used by every legacy ``/api/v1/*`` topology helper. The JWT is the
@@ -230,12 +240,13 @@ class VStrikeService:
         url = f"{self.base_url}{path}"
         params = kwargs.pop("params", None)
 
-        def _do(jwt: str) -> requests.Response:
-            return requests.get(
+        def _do(jwt: str) -> httpx.Response:
+            return httpx.get(
                 url,
                 params=params,
                 timeout=self.timeout,
                 verify=self.verify_ssl,
+                follow_redirects=_FOLLOW_REDIRECTS,
                 headers=self._bearer_headers(jwt),
                 **kwargs,
             )
@@ -257,7 +268,7 @@ class VStrikeService:
             if response.status_code == 200:
                 return True, "Connection successful"
             return False, f"HTTP {response.status_code}: {response.text[:200]}"
-        except requests.exceptions.RequestException as e:
+        except _HTTP_ERRORS as e:
             return False, f"Connection error: {e}"
 
     def get_asset_topology(self, asset_id: str) -> Optional[Dict[str, Any]]:
@@ -272,7 +283,7 @@ class VStrikeService:
                 response.status_code,
             )
             return None
-        except requests.exceptions.RequestException as e:
+        except _HTTP_ERRORS as e:
             logger.error("VStrike get_asset_topology(%s) failed: %s", asset_id, e)
             return None
 
@@ -283,7 +294,7 @@ class VStrikeService:
             if response.status_code == 200:
                 return response.json().get("adjacent", [])
             return None
-        except requests.exceptions.RequestException as e:
+        except _HTTP_ERRORS as e:
             logger.error("VStrike list_adjacent(%s) failed: %s", asset_id, e)
             return None
 
@@ -294,7 +305,7 @@ class VStrikeService:
             if response.status_code == 200:
                 return response.json()
             return None
-        except requests.exceptions.RequestException as e:
+        except _HTTP_ERRORS as e:
             logger.error("VStrike get_blast_radius(%s) failed: %s", asset_id, e)
             return None
 
@@ -310,7 +321,7 @@ class VStrikeService:
             if response.status_code == 200:
                 return response.json().get("findings", [])
             return None
-        except requests.exceptions.RequestException as e:
+        except _HTTP_ERRORS as e:
             logger.error("VStrike find_findings_by_segment(%s) failed: %s", segment, e)
             return None
 
@@ -327,17 +338,18 @@ class VStrikeService:
             )
         url = f"{self.base_url}/mcp-login"
         try:
-            resp = requests.post(
+            resp = httpx.post(
                 url,
                 json={"username": self.username, "password": self.password},
                 timeout=self.timeout,
                 verify=self.verify_ssl,
+                follow_redirects=_FOLLOW_REDIRECTS,
                 headers={
                     "Content-Type": "application/json",
                     "Accept": "application/json, text/event-stream",
                 },
             )
-        except requests.exceptions.RequestException as e:
+        except _HTTP_ERRORS as e:
             raise RuntimeError(f"VStrike mcp-login failed: {e}") from e
 
         if resp.status_code != 200:
@@ -409,12 +421,13 @@ class VStrikeService:
             "params": {"name": tool_name, "arguments": arguments},
         }
 
-        def _post(jwt: str) -> requests.Response:
-            return requests.post(
+        def _post(jwt: str) -> httpx.Response:
+            return httpx.post(
                 url,
                 json=payload,
                 timeout=self.timeout,
                 verify=self.verify_ssl,
+                follow_redirects=_FOLLOW_REDIRECTS,
                 headers={
                     "Authorization": f"Bearer {jwt}",
                     "Content-Type": "application/json",
@@ -426,7 +439,7 @@ class VStrikeService:
         jwt = self._ensure_jwt()
         try:
             resp = _post(jwt)
-        except requests.exceptions.RequestException as e:
+        except _HTTP_ERRORS as e:
             raise RuntimeError(f"VStrike MCP {tool_name} failed: {e}") from e
 
         if resp.status_code == 401:
@@ -434,7 +447,7 @@ class VStrikeService:
             jwt = self._ensure_jwt()
             try:
                 resp = _post(jwt)
-            except requests.exceptions.RequestException as e:
+            except _HTTP_ERRORS as e:
                 raise RuntimeError(f"VStrike MCP {tool_name} retry failed: {e}") from e
 
         if resp.status_code != 200:
@@ -478,19 +491,20 @@ class VStrikeService:
             "params": {},
         }
 
-        def _post(jwt: str) -> requests.Response:
-            return requests.post(
+        def _post(jwt: str) -> httpx.Response:
+            return httpx.post(
                 url,
                 json=payload,
                 timeout=self.timeout,
                 verify=self.verify_ssl,
+                follow_redirects=_FOLLOW_REDIRECTS,
                 headers=self._bearer_headers(jwt),
             )
 
         jwt = self._ensure_jwt()
         try:
             resp = _post(jwt)
-        except requests.exceptions.RequestException as e:
+        except _HTTP_ERRORS as e:
             raise RuntimeError(f"VStrike MCP tools/list failed: {e}") from e
 
         if resp.status_code == 401:
@@ -498,7 +512,7 @@ class VStrikeService:
             jwt = self._ensure_jwt()
             try:
                 resp = _post(jwt)
-            except requests.exceptions.RequestException as e:
+            except _HTTP_ERRORS as e:
                 raise RuntimeError(
                     f"VStrike MCP tools/list retry failed: {e}"
                 ) from e

--- a/core/integrations/vstrike/client.py
+++ b/core/integrations/vstrike/client.py
@@ -34,14 +34,12 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 30
 
-# `requests` folded every transport failure into RequestException, but
-# httpx.InvalidURL sits outside the httpx.HTTPError tree — so a malformed
-# VSTRIKE_BASE_URL would escape a bare `except httpx.HTTPError` and 500 the
-# caller instead of returning None. Catch both to keep the old contract.
+# httpx.InvalidURL sits outside the httpx.HTTPError tree, but requests
+# folded both into RequestException — so a malformed VSTRIKE_BASE_URL would
+# escape a bare `except httpx.HTTPError` and 500 instead of returning None.
 _HTTP_ERRORS = (httpx.HTTPError, httpx.InvalidURL)
 
-# httpx defaults to follow_redirects=False; requests followed redirects.
-# Passed on every call so the swap is behaviour-preserving.
+# requests followed redirects by default; httpx does not.
 _FOLLOW_REDIRECTS = True
 
 # MCP JSON-RPC endpoint exposed by VStrike. Confirmed live against

--- a/core/integrations/vstrike/client.py
+++ b/core/integrations/vstrike/client.py
@@ -39,6 +39,14 @@ DEFAULT_TIMEOUT = 30
 # escape a bare `except httpx.HTTPError` and 500 instead of returning None.
 _HTTP_ERRORS = (httpx.HTTPError, httpx.InvalidURL)
 
+# requests.exceptions.JSONDecodeError subclassed both ValueError and
+# RequestException, so `except RequestException` also swallowed a malformed
+# body. httpx raises a plain json.JSONDecodeError, so the REST helpers have
+# to name it to keep returning None instead of raising. The MCP paths below
+# handle ValueError separately, with their own message — which is why this
+# is a second tuple rather than an addition to _HTTP_ERRORS.
+_REST_ERRORS = _HTTP_ERRORS + (ValueError,)
+
 # requests followed redirects by default; httpx does not.
 _FOLLOW_REDIRECTS = True
 
@@ -281,7 +289,7 @@ class VStrikeService:
                 response.status_code,
             )
             return None
-        except _HTTP_ERRORS as e:
+        except _REST_ERRORS as e:
             logger.error("VStrike get_asset_topology(%s) failed: %s", asset_id, e)
             return None
 
@@ -292,7 +300,7 @@ class VStrikeService:
             if response.status_code == 200:
                 return response.json().get("adjacent", [])
             return None
-        except _HTTP_ERRORS as e:
+        except _REST_ERRORS as e:
             logger.error("VStrike list_adjacent(%s) failed: %s", asset_id, e)
             return None
 
@@ -303,7 +311,7 @@ class VStrikeService:
             if response.status_code == 200:
                 return response.json()
             return None
-        except _HTTP_ERRORS as e:
+        except _REST_ERRORS as e:
             logger.error("VStrike get_blast_radius(%s) failed: %s", asset_id, e)
             return None
 
@@ -319,7 +327,7 @@ class VStrikeService:
             if response.status_code == 200:
                 return response.json().get("findings", [])
             return None
-        except _HTTP_ERRORS as e:
+        except _REST_ERRORS as e:
             logger.error("VStrike find_findings_by_segment(%s) failed: %s", segment, e)
             return None
 

--- a/core/response/autonomous_response_service.py
+++ b/core/response/autonomous_response_service.py
@@ -1,5 +1,6 @@
 """Autonomous response service with approval workflow integration."""
 
+import asyncio
 import logging
 from typing import Dict, List, Optional, Callable, Any
 from datetime import datetime
@@ -71,7 +72,10 @@ class AutonomousResponseService:
                 "low": "#36a64f"
             }
             
-            response = httpx.post(
+            # Blocking HTTP inside an async method — offload to a worker
+            # thread so escalation cannot stall the loop (#461).
+            response = await asyncio.to_thread(
+                httpx.post,
                 "https://slack.com/api/chat.postMessage",
                 headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
                 json={
@@ -120,7 +124,10 @@ class AutonomousResponseService:
                 "low": "info"
             }
             
-            response = httpx.post(
+            # Blocking HTTP inside an async method — offload to a worker
+            # thread so escalation cannot stall the loop (#461).
+            response = await asyncio.to_thread(
+                httpx.post,
                 "https://events.pagerduty.com/v2/enqueue",
                 json={
                     "routing_key": routing_key,

--- a/core/response/autonomous_response_service.py
+++ b/core/response/autonomous_response_service.py
@@ -72,8 +72,7 @@ class AutonomousResponseService:
                 "low": "#36a64f"
             }
             
-            # Blocking HTTP inside an async method — offload to a worker
-            # thread so escalation cannot stall the loop (#461).
+            # Blocking POST inside an async method — offload it.
             response = await asyncio.to_thread(
                 httpx.post,
                 "https://slack.com/api/chat.postMessage",
@@ -124,8 +123,7 @@ class AutonomousResponseService:
                 "low": "info"
             }
             
-            # Blocking HTTP inside an async method — offload to a worker
-            # thread so escalation cannot stall the loop (#461).
+            # Blocking POST inside an async method — offload it.
             response = await asyncio.to_thread(
                 httpx.post,
                 "https://events.pagerduty.com/v2/enqueue",

--- a/core/response/autonomous_response_service.py
+++ b/core/response/autonomous_response_service.py
@@ -54,8 +54,8 @@ class AutonomousResponseService:
         """Send escalation to Slack channel."""
         try:
             from core.config import get_integration_config
-            import requests
-            
+            import httpx
+
             config = get_integration_config('slack')
             token = config.get('bot_token')
             
@@ -71,7 +71,7 @@ class AutonomousResponseService:
                 "low": "#36a64f"
             }
             
-            response = requests.post(
+            response = httpx.post(
                 "https://slack.com/api/chat.postMessage",
                 headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
                 json={
@@ -84,9 +84,11 @@ class AutonomousResponseService:
                         "ts": datetime.utcnow().timestamp()
                     }]
                 },
-                timeout=30
+                timeout=30,
+                # requests followed redirects by default; httpx does not.
+                follow_redirects=True,
             )
-            
+
             if response.status_code == 200 and response.json().get("ok"):
                 logger.info(f"Slack escalation sent to {target_channel}")
                 return True
@@ -102,8 +104,8 @@ class AutonomousResponseService:
         """Send escalation to PagerDuty."""
         try:
             from core.config import get_integration_config
-            import requests
-            
+            import httpx
+
             config = get_integration_config('pagerduty')
             routing_key = config.get('routing_key') or config.get('integration_key')
             
@@ -118,7 +120,7 @@ class AutonomousResponseService:
                 "low": "info"
             }
             
-            response = requests.post(
+            response = httpx.post(
                 "https://events.pagerduty.com/v2/enqueue",
                 json={
                     "routing_key": routing_key,
@@ -130,7 +132,9 @@ class AutonomousResponseService:
                         "custom_details": {"details": details}
                     }
                 },
-                timeout=30
+                timeout=30,
+                # requests followed redirects by default; httpx does not.
+                follow_redirects=True,
             )
             
             data = response.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,12 +19,11 @@ ijson>=3.2.0
 anthropic>=0.45.0
 claude-agent-sdk>=0.1.0
 openai>=1.40.0
-# httpx is the HTTP client for every integration client (#462). It arrives
-# transitively via anthropic/openai anyway; pinned explicitly so the
-# integrations don't depend on someone else's dependency graph.
+# HTTP client for every integration client. Arrives transitively via
+# anthropic/openai; pinned so we don't rely on someone else's graph.
 httpx>=0.27.0
-# `requests` is no longer used by any integration client. Still needed by
-# scripts/ (sample-data + Splunk export helpers) and a few tests.
+# No longer used by any integration client — still needed by scripts/,
+# tests, and the MCP servers under tools/.
 requests>=2.31.0
 urllib3>=2.0.0
 boto3>=1.34.0
@@ -51,11 +50,9 @@ pgvector>=0.3.0  # pgvector column type + <=> ANN for finding embeddings
 # Optional proxy hops in front of the metadata DB and DB-shaped
 # integrations (Settings → System → Database, plus per-integration
 # proxy block). sshtunnel only loaded when the operator picks an SSH
-# tunnel. SOCKS5 support for integrations whose clients pick up
-# HTTPS_PROXY / ALL_PROXY needs a per-library backend: httpx (every
-# integration client) resolves socks5:// through socksio, while pysocks
-# covers the requests/urllib callers left in scripts/. Both are required
-# — httpx cannot use pysocks.
+# tunnel. SOCKS5 via HTTPS_PROXY / ALL_PROXY needs a per-library backend:
+# httpx cannot use pysocks, so both are required — socksio for the
+# integration clients, pysocks for the requests callers in scripts/tools.
 sshtunnel>=0.4.0
 pysocks>=1.7.1
 socksio>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,12 @@ ijson>=3.2.0
 anthropic>=0.45.0
 claude-agent-sdk>=0.1.0
 openai>=1.40.0
+# httpx is the HTTP client for every integration client (#462). It arrives
+# transitively via anthropic/openai anyway; pinned explicitly so the
+# integrations don't depend on someone else's dependency graph.
+httpx>=0.27.0
+# `requests` is no longer used by any integration client. Still needed by
+# scripts/ (sample-data + Splunk export helpers) and a few tests.
 requests>=2.31.0
 urllib3>=2.0.0
 boto3>=1.34.0
@@ -45,10 +51,14 @@ pgvector>=0.3.0  # pgvector column type + <=> ANN for finding embeddings
 # Optional proxy hops in front of the metadata DB and DB-shaped
 # integrations (Settings → System → Database, plus per-integration
 # proxy block). sshtunnel only loaded when the operator picks an SSH
-# tunnel; pysocks gives requests/urllib SOCKS5 support for
-# integrations whose clients pick up HTTPS_PROXY / ALL_PROXY.
+# tunnel. SOCKS5 support for integrations whose clients pick up
+# HTTPS_PROXY / ALL_PROXY needs a per-library backend: httpx (every
+# integration client) resolves socks5:// through socksio, while pysocks
+# covers the requests/urllib callers left in scripts/. Both are required
+# — httpx cannot use pysocks.
 sshtunnel>=0.4.0
 pysocks>=1.7.1
+socksio>=1.0.0
 
 # MCP SDK (for MCP tools)
 # Install with: pip install mcp

--- a/services/api/routers/jira_export.py
+++ b/services/api/routers/jira_export.py
@@ -18,9 +18,8 @@ from core.routing import Auth, RouterMeta, UnitOfWorkSession
 
 logger = logging.getLogger(__name__)
 
-# httpx defaults to follow_redirects=False; requests followed redirects.
-# Jira Cloud does redirect (site moves, context-path changes), so this is
-# passed on every call to keep the swap behaviour-preserving.
+# requests followed redirects by default, httpx does not — and Jira Cloud
+# redirects on site moves and context-path changes.
 _FOLLOW_REDIRECTS = True
 
 router = APIRouter()

--- a/services/api/routers/jira_export.py
+++ b/services/api/routers/jira_export.py
@@ -13,10 +13,15 @@ from services.api.middleware.auth import get_current_user
 from core.auth.auth_service import AuthService
 from core.storage.models import User, Case, Finding
 from core.config import get_integration_config
-import requests
+import httpx
 from core.routing import Auth, RouterMeta, UnitOfWorkSession
 
 logger = logging.getLogger(__name__)
+
+# httpx defaults to follow_redirects=False; requests followed redirects.
+# Jira Cloud does redirect (site moves, context-path changes), so this is
+# passed on every call to keep the swap behaviour-preserving.
+_FOLLOW_REDIRECTS = True
 
 router = APIRouter()
 
@@ -152,12 +157,13 @@ def export_case_to_jira(
             }
         }
         
-        response = requests.post(
+        response = httpx.post(
             f"{url}/rest/api/2/issue",
             auth=auth,
             headers=headers,
             json=issue_data,
-            timeout=30
+            timeout=30,
+            follow_redirects=_FOLLOW_REDIRECTS,
         )
         response.raise_for_status()
         result_data = response.json()
@@ -178,12 +184,13 @@ def export_case_to_jira(
                 }
                 
                 try:
-                    sub_response = requests.post(
+                    sub_response = httpx.post(
                         f"{url}/rest/api/2/issue",
                         auth=auth,
                         headers=headers,
                         json=subtask_data,
-                        timeout=30
+                        timeout=30,
+                        follow_redirects=_FOLLOW_REDIRECTS,
                     )
                     sub_response.raise_for_status()
                     subtasks_created += 1
@@ -202,7 +209,7 @@ def export_case_to_jira(
     
     except HTTPException:
         raise
-    except requests.exceptions.RequestException as e:
+    except (httpx.HTTPError, httpx.InvalidURL) as e:
         logger.error(f"JIRA API error: {e}")
         return JiraExportResponse(
             success=False,
@@ -275,11 +282,12 @@ def export_remediation_to_jira(
         auth = (email, token)
         headers = {"Content-Type": "application/json"}
         
-        parent_response = requests.get(
+        parent_response = httpx.get(
             f"{url}/rest/api/2/issue/{request.parent_issue_key}",
             auth=auth,
             headers=headers,
-            timeout=30
+            timeout=30,
+            follow_redirects=_FOLLOW_REDIRECTS,
         )
         parent_response.raise_for_status()
         parent_data = parent_response.json()
@@ -300,23 +308,25 @@ def export_remediation_to_jira(
             
             if request.assign_to:
                 # Try to find user by email
-                user_response = requests.get(
+                user_response = httpx.get(
                     f"{url}/rest/api/2/user/search",
                     auth=auth,
                     headers=headers,
                     params={"username": request.assign_to},
-                    timeout=30
+                    timeout=30,
+                    follow_redirects=_FOLLOW_REDIRECTS,
                 )
                 if user_response.ok and user_response.json():
                     subtask_data["fields"]["assignee"] = {"name": user_response.json()[0]["name"]}
             
             try:
-                response = requests.post(
+                response = httpx.post(
                     f"{url}/rest/api/2/issue",
                     auth=auth,
                     headers=headers,
                     json=subtask_data,
-                    timeout=30
+                    timeout=30,
+                    follow_redirects=_FOLLOW_REDIRECTS,
                 )
                 response.raise_for_status()
                 created_subtasks += 1
@@ -334,7 +344,7 @@ def export_remediation_to_jira(
     
     except HTTPException:
         raise
-    except requests.exceptions.RequestException as e:
+    except (httpx.HTTPError, httpx.InvalidURL) as e:
         logger.error(f"JIRA API error: {e}")
         return JiraExportResponse(
             success=False,

--- a/services/api/routers/jira_export.py
+++ b/services/api/routers/jira_export.py
@@ -315,7 +315,7 @@ def export_remediation_to_jira(
                     timeout=30,
                     follow_redirects=_FOLLOW_REDIRECTS,
                 )
-                if user_response.ok and user_response.json():
+                if user_response.is_success and user_response.json():
                     subtask_data["fields"]["assignee"] = {"name": user_response.json()[0]["name"]}
             
             try:

--- a/services/api/routers/vstrike.py
+++ b/services/api/routers/vstrike.py
@@ -290,7 +290,7 @@ def ingest_findings(
 
 
 @authenticated_router.get("/health", response_model=VStrikeHealthResponse)
-async def health_check() -> VStrikeHealthResponse:
+def health_check() -> VStrikeHealthResponse:
     """Check outbound connectivity to the configured VStrike server."""
     service = get_vstrike_service()
     if service is None:
@@ -313,7 +313,7 @@ async def health_check() -> VStrikeHealthResponse:
 
 
 @authenticated_router.get("/topology/asset/{asset_id}")
-async def get_asset_topology(asset_id: str) -> dict:
+def get_asset_topology(asset_id: str) -> dict:
     """Proxy to VStrike asset-topology lookup (outbound)."""
     service = get_vstrike_service()
     if service is None:
@@ -332,7 +332,7 @@ async def get_asset_topology(asset_id: str) -> dict:
 
 
 @authenticated_router.get("/topology/asset/{asset_id}/adjacent")
-async def list_adjacent_assets(asset_id: str) -> dict:
+def list_adjacent_assets(asset_id: str) -> dict:
     """Proxy to VStrike adjacent-assets lookup."""
     service = get_vstrike_service()
     if service is None:
@@ -347,7 +347,7 @@ async def list_adjacent_assets(asset_id: str) -> dict:
 
 
 @authenticated_router.get("/topology/asset/{asset_id}/blast-radius")
-async def get_blast_radius(asset_id: str) -> dict:
+def get_blast_radius(asset_id: str) -> dict:
     """Proxy to VStrike blast-radius lookup."""
     service = get_vstrike_service()
     if service is None:
@@ -367,7 +367,7 @@ async def get_blast_radius(asset_id: str) -> dict:
 
 
 @authenticated_router.post("/ui/iframe-token")
-async def ui_iframe_token() -> dict:
+def ui_iframe_token() -> dict:
     """Return a short-lived auto-login token + the iframe URL.
 
     Used by the VStrikeIframe frontend component to render
@@ -387,7 +387,7 @@ async def ui_iframe_token() -> dict:
 
 
 @authenticated_router.get("/ui/networks")
-async def ui_list_networks() -> dict:
+def ui_list_networks() -> dict:
     """List networks visible to the configured VStrike account."""
     service = _ui_service_or_503()
     try:
@@ -399,7 +399,7 @@ async def ui_list_networks() -> dict:
 
 
 @authenticated_router.post("/ui/load-network")
-async def ui_load_network(request: VStrikeLoadNetworkRequest) -> dict:
+def ui_load_network(request: VStrikeLoadNetworkRequest) -> dict:
     """Tell VStrike to load a network into the active iframe.
 
     VStrike pushes the actual UI command via its own WebSocket; this endpoint
@@ -415,7 +415,7 @@ async def ui_load_network(request: VStrikeLoadNetworkRequest) -> dict:
 
 
 @authenticated_router.post("/ui/killchain-replay")
-async def ui_killchain_replay(request: VStrikeKillchainReplayRequest) -> dict:
+def ui_killchain_replay(request: VStrikeKillchainReplayRequest) -> dict:
     """Walk a kill-chain through the active VStrike iframe session.
 
     Returns 501 when VStrike's MCP server hasn't shipped the
@@ -452,7 +452,7 @@ class VStrikeNodeSearchRequest(BaseModel):
 
 
 @authenticated_router.post("/nodes/search")
-async def node_search(request: VStrikeNodeSearchRequest) -> dict:
+def node_search(request: VStrikeNodeSearchRequest) -> dict:
     """Omni-search across nodes in the VStrike network."""
     service = _ui_service_or_503()
     try:
@@ -471,7 +471,7 @@ class VStrikeNodeDriftRequest(BaseModel):
 
 
 @authenticated_router.post("/nodes/drift")
-async def node_drift(request: VStrikeNodeDriftRequest) -> dict:
+def node_drift(request: VStrikeNodeDriftRequest) -> dict:
     """Return end-node state changes for the supplied node."""
     service = _ui_service_or_503()
     try:
@@ -483,7 +483,7 @@ async def node_drift(request: VStrikeNodeDriftRequest) -> dict:
 
 
 @authenticated_router.get("/storylines")
-async def list_storylines(network_id: Optional[str] = None) -> dict:
+def list_storylines(network_id: Optional[str] = None) -> dict:
     """List storylines available for the network."""
     service = _ui_service_or_503()
     try:
@@ -500,7 +500,7 @@ class VStrikeStorylineEventsRequest(BaseModel):
 
 
 @authenticated_router.post("/storylines/events")
-async def storyline_events(request: VStrikeStorylineEventsRequest) -> dict:
+def storyline_events(request: VStrikeStorylineEventsRequest) -> dict:
     """List events in a storyline along with their properties."""
     service = _ui_service_or_503()
     try:
@@ -514,7 +514,7 @@ async def storyline_events(request: VStrikeStorylineEventsRequest) -> dict:
 
 
 @authenticated_router.get("/legend-runs")
-async def list_legend_runs(network_id: Optional[str] = None) -> dict:
+def list_legend_runs(network_id: Optional[str] = None) -> dict:
     """List legend runs available for the network."""
     service = _ui_service_or_503()
     try:
@@ -531,7 +531,7 @@ class VStrikeLegendRunResultsRequest(BaseModel):
 
 
 @authenticated_router.post("/legend-runs/results")
-async def legend_run_results(request: VStrikeLegendRunResultsRequest) -> dict:
+def legend_run_results(request: VStrikeLegendRunResultsRequest) -> dict:
     """Return results for the specified legend run."""
     service = _ui_service_or_503()
     try:
@@ -555,7 +555,7 @@ class VStrikeCameraNodeRequest(BaseModel):
 
 
 @authenticated_router.post("/ui/camera-node")
-async def ui_camera_node(request: VStrikeCameraNodeRequest) -> dict:
+def ui_camera_node(request: VStrikeCameraNodeRequest) -> dict:
     """Move the camera to focus on the provided nodes."""
     service = _ui_service_or_503()
     try:
@@ -575,7 +575,7 @@ class VStrikeCameraPositionRequest(BaseModel):
 
 
 @authenticated_router.post("/ui/camera-position")
-async def ui_camera_position(request: VStrikeCameraPositionRequest) -> dict:
+def ui_camera_position(request: VStrikeCameraPositionRequest) -> dict:
     """Set the camera position and rotation explicitly."""
     service = _ui_service_or_503()
     try:
@@ -598,7 +598,7 @@ class VStrikeStorylineApplyRequest(BaseModel):
 
 
 @authenticated_router.post("/ui/storyline-apply")
-async def ui_storyline_apply(request: VStrikeStorylineApplyRequest) -> dict:
+def ui_storyline_apply(request: VStrikeStorylineApplyRequest) -> dict:
     """Apply the specified storyline to the active network view."""
     service = _ui_service_or_503()
     try:
@@ -619,7 +619,7 @@ class VStrikeStorylineModeRequest(BaseModel):
 
 
 @authenticated_router.post("/ui/storyline-mode")
-async def ui_storyline_mode(request: VStrikeStorylineModeRequest) -> dict:
+def ui_storyline_mode(request: VStrikeStorylineModeRequest) -> dict:
     """Set the timeslice mode for the VCR controls and reset frame counters."""
     service = _ui_service_or_503()
     try:
@@ -633,7 +633,7 @@ async def ui_storyline_mode(request: VStrikeStorylineModeRequest) -> dict:
 
 
 @authenticated_router.post("/ui/storyline-forward")
-async def ui_storyline_forward(network_id: Optional[str] = None) -> dict:
+def ui_storyline_forward(network_id: Optional[str] = None) -> dict:
     """Step forward in the storyline timeline."""
     service = _ui_service_or_503()
     try:
@@ -647,7 +647,7 @@ async def ui_storyline_forward(network_id: Optional[str] = None) -> dict:
 
 
 @authenticated_router.post("/ui/storyline-backward")
-async def ui_storyline_backward(network_id: Optional[str] = None) -> dict:
+def ui_storyline_backward(network_id: Optional[str] = None) -> dict:
     """Step backward in the storyline timeline."""
     service = _ui_service_or_503()
     try:
@@ -683,7 +683,7 @@ class VStrikeNetworkGraphRequest(_PassthroughModel):
 
 
 @authenticated_router.post("/network-graph")
-async def network_graph(request: VStrikeNetworkGraphRequest) -> dict:
+def network_graph(request: VStrikeNetworkGraphRequest) -> dict:
     """Fetch the active network graph: {label, nodes, edges, bbox}."""
     service = _ui_service_or_503()
     extras = _passthrough_extras(request, {"network_id"})
@@ -705,7 +705,7 @@ class VStrikeLegendApplyRequest(_PassthroughModel):
 
 
 @authenticated_router.post("/ui/legend-apply")
-async def ui_legend_apply(request: VStrikeLegendApplyRequest) -> dict:
+def ui_legend_apply(request: VStrikeLegendApplyRequest) -> dict:
     """Apply a legend run inside the active VStrike iframe session."""
     service = _ui_service_or_503()
     extras = _passthrough_extras(request, {"legend_run_id", "network_id"})
@@ -733,7 +733,7 @@ class VStrikeRightpanelFocusRequest(_PassthroughModel):
 
 
 @authenticated_router.post("/ui/rightpanel-focus")
-async def ui_rightpanel_focus(
+def ui_rightpanel_focus(
     request: VStrikeRightpanelFocusRequest = VStrikeRightpanelFocusRequest(),
 ) -> dict:
     """Open the right-hand details panel in the VStrike iframe.

--- a/services/daemon/orchestrator.py
+++ b/services/daemon/orchestrator.py
@@ -1121,7 +1121,7 @@ class Orchestrator:
             if get_settings().daemon_slack_enabled is not True:
                 return
 
-            import requests
+            import httpx
 
             from core.config import get_integration_config
 
@@ -1144,7 +1144,7 @@ class Orchestrator:
                 ],
             }
             await asyncio.to_thread(
-                requests.post,
+                httpx.post,
                 "https://slack.com/api/chat.postMessage",
                 headers={
                     "Authorization": f"Bearer {token}",
@@ -1152,6 +1152,7 @@ class Orchestrator:
                 },
                 json=payload,
                 timeout=10,
+                follow_redirects=True,
             )
         except Exception as e:
             logger.debug(f"Slack notification failed: {e}")

--- a/services/daemon/poller.py
+++ b/services/daemon/poller.py
@@ -284,9 +284,8 @@ class DataPoller:
         findings = []
         for query in queries:
             try:
-                # SplunkService.search is blocking — it polls the search
-                # job with time.sleep for up to ~60s. Run it on a worker
-                # thread so it cannot freeze the daemon's loop (#461).
+                # search() polls its job with time.sleep for up to ~60s,
+                # which would otherwise freeze the whole daemon loop.
                 results = await asyncio.to_thread(
                     self._splunk_service.search,
                     query=query,

--- a/services/daemon/poller.py
+++ b/services/daemon/poller.py
@@ -284,7 +284,11 @@ class DataPoller:
         findings = []
         for query in queries:
             try:
-                results = self._splunk_service.search(
+                # SplunkService.search is blocking — it polls the search
+                # job with time.sleep for up to ~60s. Run it on a worker
+                # thread so it cannot freeze the daemon's loop (#461).
+                results = await asyncio.to_thread(
+                    self._splunk_service.search,
                     query=query,
                     earliest_time=earliest_time,
                     latest_time="now",
@@ -401,7 +405,8 @@ class DataPoller:
             lookback_minutes = max(self.config.crowdstrike_interval // 60 + 1, 5)
             since = datetime.utcnow() - timedelta(minutes=lookback_minutes)
             
-            detections = self._crowdstrike_service.get_detections(
+            detections = await asyncio.to_thread(
+                self._crowdstrike_service.get_detections,
                 filter_query=f"created_timestamp:>='{since.isoformat()}Z'",
                 limit=100
             )

--- a/services/daemon/processor.py
+++ b/services/daemon/processor.py
@@ -703,14 +703,15 @@ REASONING: [Brief explanation]
         # Shodan lookup
         if self._enrichment_services.get("shodan", {}).get("enabled"):
             try:
-                import requests
+                import httpx
 
                 api_key = self._enrichment_services["shodan"]["api_key"]
                 resp = await asyncio.to_thread(
-                    requests.get,
+                    httpx.get,
                     f"https://api.shodan.io/shodan/host/{ip}",
                     params={"key": api_key},
                     timeout=10,
+                    follow_redirects=True,
                 )
                 if resp.status_code == 200:
                     data = resp.json()
@@ -727,14 +728,15 @@ REASONING: [Brief explanation]
         # VirusTotal IP lookup
         if self._enrichment_services.get("virustotal", {}).get("enabled"):
             try:
-                import requests
+                import httpx
 
                 api_key = self._enrichment_services["virustotal"]["api_key"]
                 resp = await asyncio.to_thread(
-                    requests.get,
+                    httpx.get,
                     f"https://www.virustotal.com/api/v3/ip_addresses/{ip}",
                     headers={"x-apikey": api_key},
                     timeout=10,
+                    follow_redirects=True,
                 )
                 if resp.status_code == 200:
                     data = resp.json().get("data", {}).get("attributes", {})
@@ -756,14 +758,15 @@ REASONING: [Brief explanation]
             return None
 
         try:
-            import requests
+            import httpx
 
             api_key = self._enrichment_services["virustotal"]["api_key"]
             resp = await asyncio.to_thread(
-                requests.get,
+                httpx.get,
                 f"https://www.virustotal.com/api/v3/files/{hash_val}",
                 headers={"x-apikey": api_key},
                 timeout=10,
+                follow_redirects=True,
             )
             if resp.status_code == 200:
                 data = resp.json().get("data", {}).get("attributes", {})

--- a/services/daemon/responder.py
+++ b/services/daemon/responder.py
@@ -231,7 +231,7 @@ class AutonomousResponder:
                 logger.warning("Slack not configured, skipping escalation")
                 return
             
-            import requests
+            import httpx
             
             color_map = {
                 "critical": "#ff0000",
@@ -241,7 +241,7 @@ class AutonomousResponder:
             }
             
             response = await asyncio.to_thread(
-                requests.post,
+                httpx.post,
                 "https://slack.com/api/chat.postMessage",
                 headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
                 json={
@@ -254,7 +254,8 @@ class AutonomousResponder:
                         "ts": datetime.utcnow().timestamp()
                     }]
                 },
-                timeout=30
+                timeout=30,
+                follow_redirects=True,
             )
             
             if response.status_code == 200 and response.json().get("ok"):
@@ -276,12 +277,12 @@ class AutonomousResponder:
                 logger.warning("PagerDuty not configured, skipping escalation")
                 return
             
-            import requests
+            import httpx
             
             pd_severity = self.escalation_config.pagerduty_severity_map.get(severity, "warning")
             
             response = await asyncio.to_thread(
-                requests.post,
+                httpx.post,
                 "https://events.pagerduty.com/v2/enqueue",
                 json={
                     "routing_key": routing_key,
@@ -293,7 +294,8 @@ class AutonomousResponder:
                         "custom_details": {"details": details}
                     }
                 },
-                timeout=30
+                timeout=30,
+                follow_redirects=True,
             )
             
             data = response.json()

--- a/services/daemon/sandbox_poller.py
+++ b/services/daemon/sandbox_poller.py
@@ -17,7 +17,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
-import requests
+import httpx
 
 from core.config import get_settings
 from core.secrets import get_secret
@@ -171,10 +171,11 @@ class SandboxPoller:
             return None
         headers = {"Authorization": f"Token {api_key}"} if api_key else {}
         status_resp = await asyncio.to_thread(
-            requests.get,
+            httpx.get,
             f"{base}/apiv2/tasks/status/{task_id}/",
             headers=headers,
             timeout=15,
+            follow_redirects=True,
         )
         if status_resp.status_code != 200:
             return None
@@ -183,10 +184,11 @@ class SandboxPoller:
         if status != "reported":
             return None
         report_resp = await asyncio.to_thread(
-            requests.get,
+            httpx.get,
             f"{base}/apiv2/tasks/get/report/{task_id}/",
             headers=headers,
             timeout=60,
+            follow_redirects=True,
         )
         if report_resp.status_code == 200:
             return report_resp.json()
@@ -200,10 +202,11 @@ class SandboxPoller:
         if not api_key:
             return None
         resp = await asyncio.to_thread(
-            requests.get,
+            httpx.get,
             f"https://www.hybrid-analysis.com/api/v2/report/{task_id}/summary",
             headers={"api-key": api_key, "User-Agent": "Falcon Sandbox"},
             timeout=30,
+            follow_redirects=True,
         )
         if resp.status_code == 200:
             data = resp.json()
@@ -220,10 +223,11 @@ class SandboxPoller:
         if not api_key:
             return None
         resp = await asyncio.to_thread(
-            requests.get,
+            httpx.get,
             f"https://api.any.run/v1/analysis/{task_id}",
             headers={"Authorization": f"API-Key {api_key}"},
             timeout=30,
+            follow_redirects=True,
         )
         if resp.status_code == 200:
             data = resp.json()
@@ -237,10 +241,11 @@ class SandboxPoller:
         if not api_key:
             return None
         resp = await asyncio.to_thread(
-            requests.post,
+            httpx.post,
             f"{base}/v2/analysis/info",
             data={"apikey": api_key, "webid": task_id},
             timeout=30,
+            follow_redirects=True,
         )
         if resp.status_code == 200:
             data = resp.json()

--- a/services/daemon/sandbox_submitter.py
+++ b/services/daemon/sandbox_submitter.py
@@ -27,7 +27,7 @@ from typing import Any, Dict, List, Optional
 from core.config import get_settings
 from core.secrets import get_secret
 
-import requests
+import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -182,10 +182,11 @@ class SandboxSubmitter:
             return {"status": "skipped", "reason": "unknown_hash_format"}
         try:
             resp = await asyncio.to_thread(
-                requests.get,
+                httpx.get,
                 f"{url}/apiv2/tasks/search/{hash_type}/{hash_val}/",
                 headers=headers,
                 timeout=15,
+                follow_redirects=True,
             )
             if resp.status_code == 200:
                 data = resp.json()
@@ -213,11 +214,12 @@ class SandboxSubmitter:
             return {"status": "skipped", "reason": "no_api_key"}
         try:
             resp = await asyncio.to_thread(
-                requests.post,
+                httpx.post,
                 "https://www.hybrid-analysis.com/api/v2/search/hash",
                 headers={"api-key": api_key, "User-Agent": "Falcon Sandbox"},
                 data={"hash": hash_val},
                 timeout=15,
+                follow_redirects=True,
             )
             if resp.status_code == 200:
                 data = resp.json()
@@ -238,11 +240,12 @@ class SandboxSubmitter:
             return {"status": "skipped", "reason": "no_api_key"}
         try:
             resp = await asyncio.to_thread(
-                requests.get,
+                httpx.get,
                 "https://api.any.run/v1/tasks",
                 headers={"Authorization": f"API-Key {api_key}"},
                 params={"hash": hash_val},
                 timeout=15,
+                follow_redirects=True,
             )
             if resp.status_code == 200:
                 tasks = resp.json().get("data", {}).get("tasks", [])
@@ -261,10 +264,11 @@ class SandboxSubmitter:
             return {"status": "skipped", "reason": "no_api_key"}
         try:
             resp = await asyncio.to_thread(
-                requests.post,
+                httpx.post,
                 f"{base}/v2/analysis/search",
                 data={"apikey": api_key, "q": hash_val},
                 timeout=15,
+                follow_redirects=True,
             )
             if resp.status_code == 200:
                 data = resp.json().get("data", [])

--- a/tests/integration/test_vstrike_ui_routes.py
+++ b/tests/integration/test_vstrike_ui_routes.py
@@ -12,7 +12,6 @@ needed.
 
 from __future__ import annotations
 
-import asyncio
 import os
 import sys
 from pathlib import Path
@@ -52,7 +51,7 @@ def test_iframe_token_returns_token_and_url():
 
     svc = _mock_ui_service(base_url="https://vstrike.net", ui_login_token="tok-abc")
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(vstrike_module.ui_iframe_token())
+        result = vstrike_module.ui_iframe_token()
 
     assert result["token"] == "tok-abc"
     assert result["iframe_url"] == "https://vstrike.net/login?token=tok-abc"
@@ -65,7 +64,7 @@ def test_iframe_token_503_when_ui_credentials_missing():
     svc = _mock_ui_service(has_ui_credentials=False)
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(vstrike_module.ui_iframe_token())
+            vstrike_module.ui_iframe_token()
 
     assert exc_info.value.status_code == 503
     detail = exc_info.value.detail
@@ -79,7 +78,7 @@ def test_iframe_token_503_when_service_not_configured():
 
     with patch.object(vstrike_module, "get_vstrike_service", return_value=None):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(vstrike_module.ui_iframe_token())
+            vstrike_module.ui_iframe_token()
 
     assert exc_info.value.status_code == 503
 
@@ -91,7 +90,7 @@ def test_iframe_token_502_when_upstream_fails():
     svc.get_ui_login_token.side_effect = RuntimeError("upstream blew up")
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(vstrike_module.ui_iframe_token())
+            vstrike_module.ui_iframe_token()
 
     assert exc_info.value.status_code == 502
     assert "upstream" in str(exc_info.value.detail)
@@ -111,7 +110,7 @@ def test_list_networks_returns_payload():
     ]
     svc = _mock_ui_service(networks=networks)
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(vstrike_module.ui_list_networks())
+        result = vstrike_module.ui_list_networks()
 
     assert result == {"networks": networks}
 
@@ -122,7 +121,7 @@ def test_list_networks_503_without_ui_credentials():
     svc = _mock_ui_service(has_ui_credentials=False)
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(vstrike_module.ui_list_networks())
+            vstrike_module.ui_list_networks()
 
     assert exc_info.value.status_code == 503
 
@@ -138,11 +137,9 @@ def test_load_network_calls_service_with_network_id():
 
     svc = _mock_ui_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.ui_load_network(
+        result = vstrike_module.ui_load_network(
                 VStrikeLoadNetworkRequest(network_id="net-42")
             )
-        )
 
     assert result["ok"] is True
     svc.load_network_in_ui.assert_called_once_with("net-42")
@@ -156,11 +153,9 @@ def test_load_network_502_when_upstream_fails():
     svc.load_network_in_ui.side_effect = RuntimeError("connection refused")
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(
-                vstrike_module.ui_load_network(
+            vstrike_module.ui_load_network(
                     VStrikeLoadNetworkRequest(network_id="n")
                 )
-            )
 
     assert exc_info.value.status_code == 502
     assert "connection refused" in str(exc_info.value.detail)
@@ -206,9 +201,7 @@ def test_killchain_replay_passes_steps_to_service():
     svc = _mock_ui_service()
     svc.killchain_replay_in_ui.return_value = {"ok": True, "queued": 2}
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.ui_killchain_replay(_make_killchain_request())
-        )
+        result = vstrike_module.ui_killchain_replay(_make_killchain_request())
 
     assert result["ok"] is True
     svc.killchain_replay_in_ui.assert_called_once()
@@ -232,7 +225,7 @@ def test_killchain_replay_501_when_tool_not_implemented():
     )
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(vstrike_module.ui_killchain_replay(_make_killchain_request()))
+            vstrike_module.ui_killchain_replay(_make_killchain_request())
 
     assert exc_info.value.status_code == 501
     assert "ui-killchain-replay" in str(exc_info.value.detail)
@@ -245,7 +238,7 @@ def test_killchain_replay_502_on_other_runtime_errors():
     svc.killchain_replay_in_ui.side_effect = RuntimeError("transport failed")
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(vstrike_module.ui_killchain_replay(_make_killchain_request()))
+            vstrike_module.ui_killchain_replay(_make_killchain_request())
 
     assert exc_info.value.status_code == 502
     assert "transport failed" in str(exc_info.value.detail)
@@ -257,7 +250,7 @@ def test_killchain_replay_503_without_ui_credentials():
     svc = _mock_ui_service(has_ui_credentials=False)
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(vstrike_module.ui_killchain_replay(_make_killchain_request()))
+            vstrike_module.ui_killchain_replay(_make_killchain_request())
 
     assert exc_info.value.status_code == 503
 
@@ -296,11 +289,9 @@ def test_node_search_returns_results():
 
     svc = _mock_data_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.node_search(
+        result = vstrike_module.node_search(
                 VStrikeNodeSearchRequest(query="router", network_id="net-1", limit=10)
             )
-        )
 
     assert result["query"] == "router"
     assert result["results"] == [{"node_id": "n1", "node_name": "Router-A"}]
@@ -314,7 +305,7 @@ def test_node_search_503_without_ui_credentials():
     svc = _mock_data_service(has_ui_credentials=False)
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(vstrike_module.node_search(VStrikeNodeSearchRequest(query="x")))
+            vstrike_module.node_search(VStrikeNodeSearchRequest(query="x"))
 
     assert exc_info.value.status_code == 503
 
@@ -325,11 +316,9 @@ def test_node_drift_returns_drift():
 
     svc = _mock_data_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.node_drift(
+        result = vstrike_module.node_drift(
                 VStrikeNodeDriftRequest(node_id="node-1", network_id="net-1")
             )
-        )
 
     assert result["node_id"] == "node-1"
     assert result["drift"] == [{"timestamp": "t1", "source": "cve"}]
@@ -341,7 +330,7 @@ def test_list_storylines_returns_storylines():
 
     svc = _mock_data_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(vstrike_module.list_storylines("net-1"))
+        result = vstrike_module.list_storylines("net-1")
 
     assert result["storylines"] == [{"storyline_id": "s1", "name": "Exfil"}]
     svc.storyline_list.assert_called_once_with(network_id="net-1")
@@ -353,11 +342,9 @@ def test_storyline_events_returns_events():
 
     svc = _mock_data_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.storyline_events(
+        result = vstrike_module.storyline_events(
                 VStrikeStorylineEventsRequest(storyline_id="s1", network_id="net-1")
             )
-        )
 
     assert result["storyline_id"] == "s1"
     assert result["events"] == [{"event_id": "e1", "timestamp": "t1"}]
@@ -369,7 +356,7 @@ def test_list_legend_runs_returns_runs():
 
     svc = _mock_data_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(vstrike_module.list_legend_runs("net-1"))
+        result = vstrike_module.list_legend_runs("net-1")
 
     assert result["legend_runs"] == [{"legend_run_id": "lr1", "name": "CVE-2026-001"}]
     svc.legend_run_list.assert_called_once_with(network_id="net-1")
@@ -381,11 +368,9 @@ def test_legend_run_results_returns_results():
 
     svc = _mock_data_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.legend_run_results(
+        result = vstrike_module.legend_run_results(
                 VStrikeLegendRunResultsRequest(legend_run_id="lr1", network_id="net-1")
             )
-        )
 
     assert result["legend_run_id"] == "lr1"
     assert result["results"] == {"legend_run_id": "lr1", "results": {"critical": 3}}
@@ -418,11 +403,9 @@ def test_ui_camera_node_calls_service():
 
     svc = _mock_ui_control_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.ui_camera_node(
+        result = vstrike_module.ui_camera_node(
                 VStrikeCameraNodeRequest(node_ids=["n1", "n2"], network_id="net-1")
             )
-        )
 
     assert result["ok"] is True
     svc.ui_camera_node.assert_called_once_with(["n1", "n2"], network_id="net-1")
@@ -434,15 +417,13 @@ def test_ui_camera_position_calls_service():
 
     svc = _mock_ui_control_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.ui_camera_position(
+        result = vstrike_module.ui_camera_position(
                 VStrikeCameraPositionRequest(
                     position={"x": 1.0, "y": 2.0, "z": 3.0},
                     rotation={"pitch": 0.5},
                     network_id="net-1",
                 )
             )
-        )
 
     assert result["ok"] is True
     svc.ui_camera_position.assert_called_once_with(
@@ -458,11 +439,9 @@ def test_ui_storyline_apply_calls_service():
 
     svc = _mock_ui_control_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.ui_storyline_apply(
+        result = vstrike_module.ui_storyline_apply(
                 VStrikeStorylineApplyRequest(storyline_id="s1", network_id="net-1")
             )
-        )
 
     assert result["ok"] is True
     svc.ui_storyline_apply.assert_called_once_with("s1", network_id="net-1")
@@ -474,11 +453,9 @@ def test_ui_storyline_mode_calls_service():
 
     svc = _mock_ui_control_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.ui_storyline_mode(
+        result = vstrike_module.ui_storyline_mode(
                 VStrikeStorylineModeRequest(mode="replay", network_id="net-1")
             )
-        )
 
     assert result["ok"] is True
     svc.ui_storyline_mode.assert_called_once_with("replay", network_id="net-1")
@@ -489,7 +466,7 @@ def test_ui_storyline_forward_calls_service():
 
     svc = _mock_ui_control_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(vstrike_module.ui_storyline_forward("net-1"))
+        result = vstrike_module.ui_storyline_forward("net-1")
 
     assert result["ok"] is True
     svc.ui_storyline_forward.assert_called_once_with(network_id="net-1")
@@ -500,7 +477,7 @@ def test_ui_storyline_backward_calls_service():
 
     svc = _mock_ui_control_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(vstrike_module.ui_storyline_backward("net-1"))
+        result = vstrike_module.ui_storyline_backward("net-1")
 
     assert result["ok"] is True
     svc.ui_storyline_backward.assert_called_once_with(network_id="net-1")
@@ -517,9 +494,7 @@ def test_ui_camera_node_501_when_tool_not_implemented():
     )
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(
-                vstrike_module.ui_camera_node(VStrikeCameraNodeRequest(node_ids=["n1"]))
-            )
+            vstrike_module.ui_camera_node(VStrikeCameraNodeRequest(node_ids=["n1"]))
 
     assert exc_info.value.status_code == 501
 
@@ -531,7 +506,7 @@ def test_ui_storyline_forward_502_on_runtime_error():
     svc.ui_storyline_forward.side_effect = RuntimeError("websocket closed")
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(vstrike_module.ui_storyline_forward("net-1"))
+            vstrike_module.ui_storyline_forward("net-1")
 
     assert exc_info.value.status_code == 502
     assert "websocket closed" in str(exc_info.value.detail)
@@ -566,8 +541,8 @@ def test_network_graph_returns_graph():
 
     svc = _mock_new_tools_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.network_graph(VStrikeNetworkGraphRequest(network_id="net-1"))
+        result = vstrike_module.network_graph(
+            VStrikeNetworkGraphRequest(network_id="net-1")
         )
 
     assert result["network_id"] == "net-1"
@@ -583,11 +558,9 @@ def test_network_graph_502_when_upstream_empty():
     svc.network_graph_get.return_value = None
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(
-                vstrike_module.network_graph(
+            vstrike_module.network_graph(
                     VStrikeNetworkGraphRequest(network_id="net-1")
                 )
-            )
     assert exc_info.value.status_code == 502
 
 
@@ -601,7 +574,7 @@ def test_network_graph_forwards_passthrough_fields():
         {"network_id": "net-1", "focusNodeId": "n9", "depth": 2}
     )
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        asyncio.run(vstrike_module.network_graph(req))
+        vstrike_module.network_graph(req)
 
     kwargs = svc.network_graph_get.call_args.kwargs
     assert kwargs["network_id"] == "net-1"
@@ -616,11 +589,9 @@ def test_network_graph_503_without_ui_credentials():
     svc = _mock_new_tools_service(has_ui_credentials=False)
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(
-                vstrike_module.network_graph(
+            vstrike_module.network_graph(
                     VStrikeNetworkGraphRequest(network_id="net-1")
                 )
-            )
     assert exc_info.value.status_code == 503
 
 
@@ -630,11 +601,9 @@ def test_ui_legend_apply_calls_service():
 
     svc = _mock_new_tools_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.ui_legend_apply(
+        result = vstrike_module.ui_legend_apply(
                 VStrikeLegendApplyRequest(legend_run_id="lr-1", network_id="net-1")
             )
-        )
 
     assert result["ok"] is True
     svc.ui_legend_apply.assert_called_once_with("lr-1", network_id="net-1")
@@ -651,11 +620,9 @@ def test_ui_legend_apply_501_when_tool_not_implemented():
     )
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(
-                vstrike_module.ui_legend_apply(
+            vstrike_module.ui_legend_apply(
                     VStrikeLegendApplyRequest(legend_run_id="lr-1", network_id="net-1")
                 )
-            )
     assert exc_info.value.status_code == 501
 
 
@@ -667,11 +634,9 @@ def test_ui_legend_apply_502_on_runtime_error():
     svc.ui_legend_apply.side_effect = RuntimeError("upstream boom")
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(
-                vstrike_module.ui_legend_apply(
+            vstrike_module.ui_legend_apply(
                     VStrikeLegendApplyRequest(legend_run_id="lr-1", network_id="net-1")
                 )
-            )
     assert exc_info.value.status_code == 502
 
 
@@ -681,9 +646,7 @@ def test_ui_rightpanel_focus_calls_service_with_no_args():
 
     svc = _mock_new_tools_service()
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        result = asyncio.run(
-            vstrike_module.ui_rightpanel_focus(VStrikeRightpanelFocusRequest())
-        )
+        result = vstrike_module.ui_rightpanel_focus(VStrikeRightpanelFocusRequest())
 
     assert result["ok"] is True
     svc.ui_rightpanel_focus.assert_called_once_with()
@@ -697,7 +660,7 @@ def test_ui_rightpanel_focus_forwards_passthrough_fields():
     svc = _mock_new_tools_service()
     req = VStrikeRightpanelFocusRequest.model_validate({"future_field": "x"})
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
-        asyncio.run(vstrike_module.ui_rightpanel_focus(req))
+        vstrike_module.ui_rightpanel_focus(req)
 
     svc.ui_rightpanel_focus.assert_called_once_with(future_field="x")
 
@@ -709,7 +672,5 @@ def test_ui_rightpanel_focus_503_without_ui_credentials():
     svc = _mock_new_tools_service(has_ui_credentials=False)
     with patch.object(vstrike_module, "get_vstrike_service", return_value=svc):
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(
-                vstrike_module.ui_rightpanel_focus(VStrikeRightpanelFocusRequest())
-            )
+            vstrike_module.ui_rightpanel_focus(VStrikeRightpanelFocusRequest())
     assert exc_info.value.status_code == 503

--- a/tests/unit/integrations/test_blocking_offload.py
+++ b/tests/unit/integrations/test_blocking_offload.py
@@ -1,0 +1,141 @@
+"""Regression tests: integration calls must not stall the event loop.
+
+The integration clients are synchronous by design (#461: plain `def` +
+threadpool, `asyncio.to_thread` as the exception). The bug these guard
+against is an `async def` calling one directly, which freezes every other
+task on that loop for the duration of a remote call — and
+`SplunkService.search` polls its job with `time.sleep` for up to ~60s.
+
+Each test runs the async path alongside a 10ms ticker. If the blocking call
+is offloaded the ticker keeps advancing; if it is awaited on the loop the
+ticker is starved and the assertion fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# How long the stubbed remote call blocks for, and the floor on ticks we
+# expect to land during it. A loop-blocking implementation yields 0-1.
+BLOCK_SECONDS = 0.25
+MIN_TICKS = 5
+
+
+async def _tick_while(coro):
+    """Run `coro` while counting 10ms ticks that the loop manages to serve."""
+    ticks = 0
+    task = asyncio.ensure_future(coro)
+    while not task.done():
+        await asyncio.sleep(0.01)
+        ticks += 1
+    return await task, ticks
+
+
+def _blocking(return_value):
+    """A stand-in for a slow synchronous remote call."""
+
+    def _call(*args, **kwargs):
+        time.sleep(BLOCK_SECONDS)
+        return return_value
+
+    return _call
+
+
+@pytest.mark.asyncio
+async def test_splunk_federation_adapter_does_not_block_the_loop():
+    from core.integrations.splunk.adapter import _factory
+
+    adapter = _factory()
+    svc = MagicMock()
+    svc.search = _blocking([])
+
+    with patch.object(adapter, "_get_service", return_value=svc):
+        _, ticks = await _tick_while(
+            adapter.fetch(since=None, cursor={}, max_items=10)
+        )
+
+    assert ticks >= MIN_TICKS, (
+        f"loop served only {ticks} ticks during a {BLOCK_SECONDS}s Splunk "
+        "search — the call is running on the event loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_crowdstrike_federation_adapter_does_not_block_the_loop():
+    from core.integrations.crowdstrike.adapter import _factory
+
+    adapter = _factory()
+    svc = MagicMock()
+    svc.get_detections = _blocking([])
+
+    with patch.object(adapter, "_get_service", return_value=svc):
+        _, ticks = await _tick_while(
+            adapter.fetch(since=None, cursor={}, max_items=10)
+        )
+
+    assert ticks >= MIN_TICKS, (
+        f"loop served only {ticks} ticks during a {BLOCK_SECONDS}s "
+        "CrowdStrike fetch — the call is running on the event loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_defender_fetch_alerts_does_not_block_the_loop():
+    from core.integrations.microsoft_defender.ingestion import MicrosoftDefenderIngestion
+
+    with patch(
+        "core.integrations.microsoft_defender.ingestion.get_integration_config",
+        return_value={},
+    ):
+        svc = MicrosoftDefenderIngestion()
+
+    response = MagicMock()
+    response.json.return_value = {"value": []}
+    response.raise_for_status.return_value = None
+
+    with patch.object(
+        svc, "_get_access_token", _blocking("tok-1")
+    ), patch(
+        "core.integrations.microsoft_defender.ingestion.httpx.get", _blocking(response)
+    ):
+        _, ticks = await _tick_while(svc.fetch_alerts(limit=10))
+
+    # Two blocking hops here (token exchange + alert fetch), so the budget
+    # is 2 * BLOCK_SECONDS.
+    assert ticks >= MIN_TICKS, (
+        f"loop served only {ticks} ticks during the Defender fetch — a "
+        "blocking call is running on the event loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_slack_escalation_does_not_block_the_loop():
+    from core.response.autonomous_response_service import get_autonomous_response_service
+
+    svc = get_autonomous_response_service()
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"ok": True}
+
+    with patch(
+        "core.config.get_integration_config",
+        return_value={"bot_token": "xoxb-1", "default_channel": "#soc"},
+    ), patch("httpx.post", _blocking(response)):
+        _, ticks = await _tick_while(
+            svc.escalate_to_slack("something happened", "high")
+        )
+
+    assert ticks >= MIN_TICKS, (
+        f"loop served only {ticks} ticks during Slack escalation — the POST "
+        "is running on the event loop"
+    )

--- a/tests/unit/integrations/test_crowdstrike_service.py
+++ b/tests/unit/integrations/test_crowdstrike_service.py
@@ -1,0 +1,133 @@
+"""Unit tests for services/crowdstrike_service.py (httpx transport, respx-mocked).
+
+Covers the OAuth flow, the two-step detection fetch, and the containment
+actions.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import httpx
+import respx
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.integrations.crowdstrike.client import CrowdStrikeService  # noqa: E402
+
+BASE = "https://api.crowdstrike.com"
+
+
+def _service() -> CrowdStrikeService:
+    return CrowdStrikeService(client_id="cid", client_secret="csec")
+
+
+def _mock_auth() -> None:
+    """CrowdStrike returns 201 (not 200) from its OAuth2 token endpoint."""
+    respx.post(f"{BASE}/oauth2/token").mock(
+        return_value=httpx.Response(
+            201, json={"access_token": "tok-1", "expires_in": 1800}
+        )
+    )
+
+
+def test_client_is_bounded_and_follows_redirects():
+    svc = _service()
+    assert svc.session.timeout.read == 30.0
+    assert svc.session.follow_redirects is True
+
+
+@respx.mock
+def test_authenticate_sets_bearer_header():
+    _mock_auth()
+    svc = _service()
+
+    assert svc._authenticate() is True
+    assert svc.access_token == "tok-1"
+    assert svc.session.headers["Authorization"] == "Bearer tok-1"
+
+
+@respx.mock
+def test_authenticate_returns_false_on_non_201():
+    respx.post(f"{BASE}/oauth2/token").mock(return_value=httpx.Response(403))
+    assert _service()._authenticate() is False
+
+
+@respx.mock
+def test_test_connection_success():
+    _mock_auth()
+    respx.get(f"{BASE}/sensors/queries/sensors/v1").mock(
+        return_value=httpx.Response(200, json={"resources": []})
+    )
+
+    ok, message = _service().test_connection()
+    assert ok is True, message
+
+
+@respx.mock
+def test_test_connection_handles_transport_error():
+    respx.post(f"{BASE}/oauth2/token").mock(side_effect=httpx.ConnectError("refused"))
+    ok, _ = _service().test_connection()
+    assert ok is False
+
+
+@respx.mock
+def test_get_detections_resolves_ids_then_summaries():
+    _mock_auth()
+    query = respx.get(f"{BASE}/detects/queries/detects/v1").mock(
+        return_value=httpx.Response(200, json={"resources": ["ldt:1", "ldt:2"]})
+    )
+    summaries = respx.post(f"{BASE}/detects/entities/summaries/GET/v1").mock(
+        return_value=httpx.Response(
+            200, json={"resources": [{"detection_id": "ldt:1"}]}
+        )
+    )
+
+    result = _service().get_detections(filter_query="status:'new'", limit=50)
+
+    assert result == [{"detection_id": "ldt:1"}]
+    assert query.calls.last.request.url.params["filter"] == "status:'new'"
+    assert query.calls.last.request.url.params["limit"] == "50"
+    assert summaries.called
+
+
+@respx.mock
+def test_get_detections_short_circuits_when_no_ids():
+    """No detection IDs must not trigger the summaries POST."""
+    _mock_auth()
+    respx.get(f"{BASE}/detects/queries/detects/v1").mock(
+        return_value=httpx.Response(200, json={"resources": []})
+    )
+    summaries = respx.post(f"{BASE}/detects/entities/summaries/GET/v1").mock(
+        return_value=httpx.Response(200, json={"resources": []})
+    )
+
+    assert _service().get_detections() == []
+    assert not summaries.called
+
+
+@respx.mock
+def test_lift_containment_uses_the_lift_action():
+    _mock_auth()
+    action = respx.post(f"{BASE}/devices/entities/devices-actions/v2").mock(
+        return_value=httpx.Response(202, json={})
+    )
+
+    result = _service().lift_containment("host-1")
+
+    assert result["success"] is True
+    assert action.calls.last.request.url.params["action_name"] == "lift_containment"
+
+
+@respx.mock
+def test_lift_containment_reports_failure_on_error_status():
+    _mock_auth()
+    respx.post(f"{BASE}/devices/entities/devices-actions/v2").mock(
+        return_value=httpx.Response(500)
+    )
+
+    result = _service().lift_containment("host-1")
+    assert result["success"] is False

--- a/tests/unit/integrations/test_splunk_service.py
+++ b/tests/unit/integrations/test_splunk_service.py
@@ -1,0 +1,194 @@
+"""Unit tests for services/splunk_service.py (httpx transport, respx-mocked).
+
+Added alongside the requests->httpx swap (#462). The module previously had
+no HTTP-level coverage at all, which is how it shipped with *no timeout on
+any request* — a hang against an unresponsive Splunk was unbounded, and
+search() is driven by the daemon's poll loop.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.integrations.splunk.client import SplunkService  # noqa: E402
+
+BASE = "https://splunk.example.com:8089"
+
+
+def _service(**kwargs) -> SplunkService:
+    return SplunkService(
+        server_url=kwargs.get("server_url", BASE),
+        username=kwargs.get("username", "svc_vigil"),
+        password=kwargs.get("password", "secret"),
+        verify_ssl=kwargs.get("verify_ssl", False),
+    )
+
+
+def _mock_auth() -> None:
+    respx.post(f"{BASE}/services/auth/login").mock(
+        return_value=httpx.Response(200, json={"sessionKey": "sk-1"})
+    )
+
+
+# --------------------------------------------------------------------- #
+# Client configuration — the actual defect this change fixes
+# --------------------------------------------------------------------- #
+
+
+def test_client_has_an_explicit_timeout_budget():
+    """Every request must be bounded.
+
+    requests defaulted to timeout=None and not one call site passed one,
+    so an unresponsive Splunk hung the caller forever.
+    """
+    svc = _service()
+    timeout = svc.session.timeout
+
+    assert timeout.connect == 10.0
+    assert timeout.read == 60.0
+    assert timeout.write == 10.0
+    assert timeout.pool == 5.0
+
+
+def test_client_follows_redirects_like_requests_did():
+    """httpx defaults this to False; requests followed redirects."""
+    assert _service().session.follow_redirects is True
+
+
+def test_verify_ssl_is_applied_at_construction():
+    """httpx.Client takes verify only in the constructor.
+
+    requests.Session allowed `session.verify = x` afterwards, which is what
+    this module used to do — that assignment silently does nothing on httpx,
+    so a verify_ssl=False deployment would start failing on self-signed
+    certs. Constructing both ways must not raise.
+    """
+    assert _service(verify_ssl=False) is not None
+    assert _service(verify_ssl=True) is not None
+
+
+# --------------------------------------------------------------------- #
+# Transport behaviour
+# --------------------------------------------------------------------- #
+
+
+@respx.mock
+def test_authenticate_stores_session_key_and_auth_header():
+    _mock_auth()
+    svc = _service()
+
+    assert svc.authenticate() is True
+    assert svc.session_key == "sk-1"
+    assert svc.session.headers["Authorization"] == "Splunk sk-1"
+
+
+@respx.mock
+def test_test_connection_success():
+    _mock_auth()
+    respx.get(f"{BASE}/services/server/info").mock(
+        return_value=httpx.Response(200, json={"entry": []})
+    )
+
+    ok, message = _service().test_connection()
+    assert ok is True, message
+
+
+@respx.mock
+def test_test_connection_reports_network_error_without_raising():
+    """httpx.ConnectError must be caught where RequestException was."""
+    respx.post(f"{BASE}/services/auth/login").mock(
+        side_effect=httpx.ConnectError("refused")
+    )
+
+    ok, message = _service().test_connection()
+    assert ok is False
+    # authenticate() swallows the error and reports a failed auth.
+    assert message
+
+
+@respx.mock
+def test_test_connection_follows_redirects():
+    _mock_auth()
+    respx.get(f"{BASE}/services/server/info").mock(
+        return_value=httpx.Response(
+            307, headers={"Location": f"{BASE}/services/server/info/"}
+        )
+    )
+    respx.get(f"{BASE}/services/server/info/").mock(
+        return_value=httpx.Response(200, json={"entry": []})
+    )
+
+    ok, message = _service().test_connection()
+    assert ok is True, message
+
+
+@respx.mock
+def test_search_runs_the_full_job_lifecycle():
+    """create job -> poll status -> fetch results -> delete job."""
+    _mock_auth()
+    job_url = f"{BASE}/services/search/jobs"
+    respx.post(job_url).mock(return_value=httpx.Response(201, json={"sid": "sid-1"}))
+    respx.get(f"{job_url}/sid-1").mock(
+        return_value=httpx.Response(
+            200, json={"entry": [{"content": {"isDone": True}}]}
+        )
+    )
+    respx.get(f"{job_url}/sid-1/results").mock(
+        return_value=httpx.Response(200, json={"results": [{"_raw": "event-1"}]})
+    )
+    delete_route = respx.delete(f"{job_url}/sid-1").mock(
+        return_value=httpx.Response(200)
+    )
+
+    results = _service().search("index=notable", max_count=10)
+
+    assert results == [{"_raw": "event-1"}]
+    assert delete_route.called, "completed search job should be cleaned up"
+
+
+@respx.mock
+def test_search_sends_the_spl_query_as_form_data():
+    _mock_auth()
+    job_url = f"{BASE}/services/search/jobs"
+    create = respx.post(job_url).mock(
+        return_value=httpx.Response(201, json={"sid": "sid-1"})
+    )
+    respx.get(f"{job_url}/sid-1").mock(
+        return_value=httpx.Response(
+            200, json={"entry": [{"content": {"isDone": True}}]}
+        )
+    )
+    respx.get(f"{job_url}/sid-1/results").mock(
+        return_value=httpx.Response(200, json={"results": []})
+    )
+    respx.delete(f"{job_url}/sid-1").mock(return_value=httpx.Response(200))
+
+    _service().search("index=notable", earliest_time="-15m")
+
+    body = create.calls.last.request.content.decode()
+    assert "search=search+index%3Dnotable" in body
+    assert "earliest_time=-15m" in body
+
+
+@respx.mock
+def test_search_returns_none_when_job_creation_fails():
+    _mock_auth()
+    respx.post(f"{BASE}/services/search/jobs").mock(
+        return_value=httpx.Response(500, text="boom")
+    )
+
+    assert _service().search("index=notable") is None
+
+
+@pytest.mark.parametrize("trailing", ["", "/"])
+def test_server_url_trailing_slash_is_normalised(trailing):
+    assert _service(server_url=BASE + trailing).server_url == BASE

--- a/tests/unit/integrations/test_splunk_service.py
+++ b/tests/unit/integrations/test_splunk_service.py
@@ -1,9 +1,8 @@
 """Unit tests for services/splunk_service.py (httpx transport, respx-mocked).
 
-Added alongside the requests->httpx swap (#462). The module previously had
-no HTTP-level coverage at all, which is how it shipped with *no timeout on
-any request* — a hang against an unresponsive Splunk was unbounded, and
-search() is driven by the daemon's poll loop.
+The module had no HTTP-level coverage at all, which is how it shipped with
+no timeout on any request — a hang against an unresponsive Splunk was
+unbounded, and search() is driven by the daemon's poll loop.
 """
 
 from __future__ import annotations

--- a/tests/unit/integrations/test_vstrike_service.py
+++ b/tests/unit/integrations/test_vstrike_service.py
@@ -7,7 +7,9 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
+import respx
 
 ROOT = Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
@@ -81,7 +83,7 @@ def test_test_connection_success():
     svc = _service()
     _seed_jwt(svc)
     with patch(
-        "core.integrations.vstrike.client.requests.get",
+        "core.integrations.vstrike.client.httpx.get",
         return_value=_mock_response(200),
     ):
         ok, msg = svc.test_connection()
@@ -93,7 +95,7 @@ def test_test_connection_http_error():
     svc = _service()
     _seed_jwt(svc)
     with patch(
-        "core.integrations.vstrike.client.requests.get",
+        "core.integrations.vstrike.client.httpx.get",
         return_value=_mock_response(503, text="down"),
     ):
         ok, msg = svc.test_connection()
@@ -102,13 +104,13 @@ def test_test_connection_http_error():
 
 
 def test_test_connection_network_error():
-    import requests
+    import httpx
 
     svc = _service()
     _seed_jwt(svc)
     with patch(
-        "core.integrations.vstrike.client.requests.get",
-        side_effect=requests.exceptions.ConnectionError("boom"),
+        "core.integrations.vstrike.client.httpx.get",
+        side_effect=httpx.ConnectError("boom"),
     ):
         ok, msg = svc.test_connection()
     assert ok is False
@@ -120,7 +122,7 @@ def test_get_asset_topology_returns_body_on_200():
     _seed_jwt(svc)
     body = {"asset_id": "srv-01", "segment": "vlan-10"}
     with patch(
-        "core.integrations.vstrike.client.requests.get",
+        "core.integrations.vstrike.client.httpx.get",
         return_value=_mock_response(200, json_body=body),
     ):
         result = svc.get_asset_topology("srv-01")
@@ -133,7 +135,7 @@ def test_get_asset_topology_attaches_jwt_bearer():
     _seed_jwt(svc, "jwt-from-cache")
     body = {"asset_id": "srv-01"}
     with patch(
-        "core.integrations.vstrike.client.requests.get",
+        "core.integrations.vstrike.client.httpx.get",
         return_value=_mock_response(200, json_body=body),
     ) as mock_get:
         svc.get_asset_topology("srv-01")
@@ -145,7 +147,7 @@ def test_get_asset_topology_returns_none_on_error():
     svc = _service()
     _seed_jwt(svc)
     with patch(
-        "core.integrations.vstrike.client.requests.get",
+        "core.integrations.vstrike.client.httpx.get",
         return_value=_mock_response(404),
     ):
         assert svc.get_asset_topology("srv-missing") is None
@@ -163,10 +165,10 @@ def test_legacy_rest_retries_on_401_after_invalidating_jwt():
     success = _mock_response(200, json_body=body)
 
     with patch(
-        "core.integrations.vstrike.client.requests.get",
+        "core.integrations.vstrike.client.httpx.get",
         side_effect=[unauthorized, success],
     ) as mock_get, patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=refreshed_login,
     ) as mock_post:
         result = svc.get_asset_topology("srv-01")
@@ -185,7 +187,7 @@ def test_list_adjacent_returns_list():
     _seed_jwt(svc)
     body = {"adjacent": [{"asset_id": "dc-01", "hop_distance": 1}]}
     with patch(
-        "core.integrations.vstrike.client.requests.get",
+        "core.integrations.vstrike.client.httpx.get",
         return_value=_mock_response(200, json_body=body),
     ):
         adjacent = svc.list_adjacent("srv-01")
@@ -197,13 +199,97 @@ def test_find_findings_by_segment_uses_query_params():
     _seed_jwt(svc)
     body = {"findings": [{"finding_id": "f1"}]}
     with patch(
-        "core.integrations.vstrike.client.requests.get",
+        "core.integrations.vstrike.client.httpx.get",
         return_value=_mock_response(200, json_body=body),
     ) as mock_get:
         result = svc.find_findings_by_segment("dmz", limit=50)
 
     assert result == [{"finding_id": "f1"}]
     assert mock_get.call_args.kwargs["params"] == {"segment": "dmz", "limit": 50}
+
+
+# --------------------------------------------------------------------- #
+# Transport-level tests (respx). The patch-based tests above hand the
+# service a MagicMock, so they never exercise real httpx request building
+# or response parsing.
+# --------------------------------------------------------------------- #
+
+
+@respx.mock
+def test_legacy_rest_follows_redirects():
+    """`requests` followed redirects by default; httpx does not.
+
+    Without follow_redirects=True every redirected VStrike endpoint reads
+    as a bare 307 failure, and nothing else here would catch it.
+    """
+    svc = _service()
+    _seed_jwt(svc)
+    respx.get("https://vstrike.example.com/api/v1/health").mock(
+        return_value=httpx.Response(
+            307, headers={"Location": "https://vstrike.example.com/api/v1/health/"}
+        )
+    )
+    respx.get("https://vstrike.example.com/api/v1/health/").mock(
+        return_value=httpx.Response(200, json={"status": "ok"})
+    )
+
+    ok, message = svc.test_connection()
+    assert ok is True, message
+
+
+@respx.mock
+def test_mcp_post_follows_redirects():
+    """Same guard for the MCP JSON-RPC path (307 preserves the POST body)."""
+    svc = _service()
+    _seed_jwt(svc)
+    body = {"jsonrpc": "2.0", "id": 1, "result": {"networks": [{"id": "n1"}]}}
+    respx.post("https://vstrike.example.com/mcp").mock(
+        return_value=httpx.Response(
+            307, headers={"Location": "https://vstrike.example.com/mcp/v2"}
+        )
+    )
+    respx.post("https://vstrike.example.com/mcp/v2").mock(
+        return_value=httpx.Response(200, json=body)
+    )
+
+    assert svc.list_networks() == [{"id": "n1"}]
+
+
+@respx.mock
+def test_parses_sse_framed_response_from_real_httpx():
+    """`_parse_response_body` against a genuine httpx.Response.
+
+    VStrike replies to /mcp with text/event-stream. The MagicMock-based
+    tests stub `.headers` as a plain dict and `.text` as a string, so the
+    SSE branch was never run against httpx's real header casing.
+    """
+    svc = _service()
+    _seed_jwt(svc)
+    respx.post("https://vstrike.example.com/mcp").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Content-Type": "text/event-stream"},
+            text=(
+                "event: message\n"
+                'data: {"jsonrpc":"2.0","id":1,'
+                '"result":{"networks":[{"id":"n1"}]}}\n\n'
+            ),
+        )
+    )
+
+    assert svc.list_networks() == [{"id": "n1"}]
+
+
+@respx.mock
+def test_network_error_returns_none_not_raise():
+    """httpx.ConnectError must be caught where RequestException was."""
+    svc = _service()
+    _seed_jwt(svc)
+    respx.get("https://vstrike.example.com/api/v1/topology/asset/srv-01").mock(
+        side_effect=httpx.ConnectError("refused")
+    )
+
+    assert svc.get_asset_topology("srv-01") is None
 
 
 def test_get_vstrike_service_returns_none_when_unconfigured(isolate_secrets):
@@ -331,7 +417,7 @@ def test_get_vstrike_service_ui_credentials_from_integration_config(
 def test_mcp_login_caches_jwt_across_calls():
     svc = _ui_service()
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body={"token": "jwt-1"}),
     ) as mock_post:
         token1 = svc._ensure_jwt()
@@ -345,7 +431,7 @@ def test_mcp_login_caches_jwt_across_calls():
 def test_mcp_login_extracts_alternate_token_keys():
     svc = _ui_service()
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body={"jwt": "from-jwt-key"}),
     ):
         assert svc._ensure_jwt() == "from-jwt-key"
@@ -354,7 +440,7 @@ def test_mcp_login_extracts_alternate_token_keys():
 def test_mcp_login_raises_on_http_error():
     svc = _ui_service()
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(401, text="bad creds"),
     ):
         with pytest.raises(RuntimeError, match="mcp-login HTTP 401"):
@@ -364,7 +450,7 @@ def test_mcp_login_raises_on_http_error():
 def test_mcp_login_raises_when_response_missing_token():
     svc = _ui_service()
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body={"unexpected": "shape"}),
     ):
         with pytest.raises(RuntimeError, match="missing token"):
@@ -402,7 +488,7 @@ def test_call_mcp_tool_re_logs_in_on_401():
     def consume(*_args, **_kwargs):
         return sequence.pop(0)
 
-    with patch("core.integrations.vstrike.client.requests.post", side_effect=consume):
+    with patch("core.integrations.vstrike.client.httpx.post", side_effect=consume):
         token = svc.get_ui_login_token()
 
     assert token == "ui-token-xyz"
@@ -419,7 +505,7 @@ def test_call_mcp_tool_propagates_jsonrpc_error():
         json_body={"error": {"code": -32601, "message": "Tool not found"}},
     )
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=error_resp,
     ):
         with pytest.raises(RuntimeError, match="Tool not found"):
@@ -441,7 +527,7 @@ def test_list_networks_unwraps_mcp_content_envelope():
         }
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ):
         networks = svc.list_networks()
@@ -452,7 +538,7 @@ def test_load_network_in_ui_passes_network_id():
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body={"result": {"ok": True}}),
     ) as mock_post:
         svc.load_network_in_ui("net-42")
@@ -476,7 +562,7 @@ def test_killchain_replay_in_ui_passes_full_payload():
         },
     ]
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(
             200, json_body={"result": {"content": [{"type": "text", "text": "queued"}]}}
         ),
@@ -525,7 +611,7 @@ def test_iframe_url_embeds_token():
     svc = _ui_service(base_url="https://vstrike.net")
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(
             200, json_body={"result": {"token": "short-lived-abc"}}
         ),
@@ -553,7 +639,7 @@ def test_node_search_passes_query_and_network_id():
         }
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ) as mock_post:
         result = svc.node_search("router", network_id="net-1", limit=10)
@@ -571,7 +657,7 @@ def test_node_search_returns_none_on_error():
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(500, text="boom"),
     ):
         assert svc.node_search("x") is None
@@ -591,7 +677,7 @@ def test_node_drift_get_passes_node_id():
         }
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ) as mock_post:
         result = svc.node_drift_get("node-1", network_id="net-1")
@@ -617,7 +703,7 @@ def test_storyline_list_returns_storylines():
         }
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ):
         result = svc.storyline_list(network_id="net-1")
@@ -643,7 +729,7 @@ def test_storyline_list_unwraps_vstrike_structured_content():
         }
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ):
         result = svc.storyline_list(network_id="net-1")
@@ -664,7 +750,7 @@ def test_storyline_events_get_passes_storyline_id():
         }
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ) as mock_post:
         result = svc.storyline_events_get("s1", network_id="net-1")
@@ -689,7 +775,7 @@ def test_legend_run_list_returns_runs():
         }
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ):
         result = svc.legend_run_list(network_id="net-1")
@@ -714,7 +800,7 @@ def test_legend_run_list_unwraps_vstrike_structured_content():
         }
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ):
         result = svc.legend_run_list(network_id="net-1")
@@ -735,7 +821,7 @@ def test_legend_run_results_get_returns_dict():
         }
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ) as mock_post:
         result = svc.legend_run_results_get("lr1", network_id="net-1")
@@ -755,7 +841,7 @@ def test_ui_camera_node_passes_node_ids():
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body={"result": {"ok": True}}),
     ) as mock_post:
         svc.ui_camera_node(["n1", "n2"], network_id="net-1")
@@ -771,7 +857,7 @@ def test_ui_camera_position_passes_position_and_rotation():
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body={"result": {"ok": True}}),
     ) as mock_post:
         svc.ui_camera_position(
@@ -792,7 +878,7 @@ def test_ui_storyline_apply_passes_storyline_id():
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body={"result": {"ok": True}}),
     ) as mock_post:
         svc.ui_storyline_apply("s1", network_id="net-1")
@@ -806,7 +892,7 @@ def test_ui_storyline_mode_passes_mode():
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body={"result": {"ok": True}}),
     ) as mock_post:
         svc.ui_storyline_mode("replay", network_id="net-1")
@@ -820,7 +906,7 @@ def test_ui_storyline_forward_passes_network_id():
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body={"result": {"ok": True}}),
     ) as mock_post:
         svc.ui_storyline_forward(network_id="net-1")
@@ -834,7 +920,7 @@ def test_ui_storyline_backward_passes_network_id():
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body={"result": {"ok": True}}),
     ) as mock_post:
         svc.ui_storyline_backward(network_id="net-1")
@@ -867,7 +953,7 @@ def test_mcp_login_extracts_jsonwebtoken_field():
     """VStrike's /mcp-login returns the JWT under the `jsonwebtoken` key."""
     svc = _ui_service()
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(
             200, json_body={"jsonwebtoken": "eyJ...real.jwt..."}
         ),
@@ -879,7 +965,7 @@ def test_mcp_login_handles_sse_response():
     """Even /mcp-login may come back as text/event-stream."""
     svc = _ui_service()
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_sse_response({"jsonwebtoken": "sse-jwt"}),
     ):
         assert svc._ensure_jwt() == "sse-jwt"
@@ -902,7 +988,7 @@ def test_call_mcp_tool_parses_sse_with_structured_content():
         "id": 2,
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_sse_response(body),
     ):
         token = svc.get_ui_login_token()
@@ -931,7 +1017,7 @@ def test_list_networks_parses_sse_with_structured_content():
         "id": 3,
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_sse_response(body),
     ):
         networks = svc.list_networks()
@@ -953,7 +1039,7 @@ def test_call_mcp_tool_raises_on_tool_is_error():
         "id": 1,
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_sse_response(body),
     ):
         with pytest.raises(RuntimeError, match="tool error"):
@@ -981,7 +1067,7 @@ def test_network_graph_get_unwraps_structured_content():
         "id": 1,
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ) as mock_post:
         result = svc.network_graph_get(network_id="net-1")
@@ -1003,7 +1089,7 @@ def test_network_graph_get_unwraps_text_envelope():
         "id": 1,
     }
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ):
         result = svc.network_graph_get(network_id="net-1")
@@ -1016,7 +1102,7 @@ def test_network_graph_get_forwards_unknown_kwargs():
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     body = {"result": {"label": "x", "nodes": [], "edges": []}}
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ) as mock_post:
         svc.network_graph_get(network_id="net-1", focusNodeId="n1", depth=2)
@@ -1031,7 +1117,7 @@ def test_network_graph_get_returns_none_on_runtime_error():
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(500, text="boom"),
     ):
         assert svc.network_graph_get(network_id="net-1") is None
@@ -1042,7 +1128,7 @@ def test_ui_legend_apply_passes_legend_run_id():
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     body = {"result": {"ok": True}, "jsonrpc": "2.0", "id": 1}
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ) as mock_post:
         svc.ui_legend_apply("lr-1", network_id="net-1")
@@ -1059,7 +1145,7 @@ def test_ui_legend_apply_forwards_unknown_kwargs():
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     body = {"result": {"ok": True}}
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ) as mock_post:
         svc.ui_legend_apply("lr-1", network_id="net-1", overlay="dim")
@@ -1075,7 +1161,7 @@ def test_ui_rightpanel_focus_sends_empty_args():
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     body = {"result": {"ok": True}, "jsonrpc": "2.0", "id": 1}
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ) as mock_post:
         svc.ui_rightpanel_focus()
@@ -1091,7 +1177,7 @@ def test_ui_rightpanel_focus_forwards_extras_for_future_compat():
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     body = {"result": {"ok": True}}
     with patch(
-        "core.integrations.vstrike.client.requests.post",
+        "core.integrations.vstrike.client.httpx.post",
         return_value=_mock_response(200, json_body=body),
     ) as mock_post:
         svc.ui_rightpanel_focus(future_field="x")

--- a/tests/unit/integrations/test_vstrike_service.py
+++ b/tests/unit/integrations/test_vstrike_service.py
@@ -292,6 +292,49 @@ def test_network_error_returns_none_not_raise():
     assert svc.get_asset_topology("srv-01") is None
 
 
+@respx.mock
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("get_asset_topology", "/api/v1/topology/asset/srv-01"),
+        ("list_adjacent", "/api/v1/topology/asset/srv-01/adjacent"),
+        ("get_blast_radius", "/api/v1/topology/asset/srv-01/blast-radius"),
+    ],
+)
+def test_malformed_json_body_returns_none_not_raise(method, path):
+    """A 200 with a non-JSON body must not escape as an exception.
+
+    requests.exceptions.JSONDecodeError subclassed both ValueError and
+    RequestException, so the old `except RequestException` swallowed this.
+    httpx raises a plain json.JSONDecodeError, which is not an
+    httpx.HTTPError — without _REST_ERRORS these would 500 the proxy
+    endpoint instead of returning None (which the API turns into a 502).
+    """
+    svc = _service()
+    _seed_jwt(svc)
+    respx.get(f"https://vstrike.example.com{path}").mock(
+        return_value=httpx.Response(
+            200, text="<html>gateway</html>",
+            headers={"Content-Type": "application/json"},
+        )
+    )
+
+    assert getattr(svc, method)("srv-01") is None
+
+
+@respx.mock
+def test_malformed_json_body_on_findings_returns_none():
+    svc = _service()
+    _seed_jwt(svc)
+    respx.get("https://vstrike.example.com/api/v1/findings").mock(
+        return_value=httpx.Response(
+            200, text="not json", headers={"Content-Type": "application/json"}
+        )
+    )
+
+    assert svc.find_findings_by_segment("dmz") is None
+
+
 def test_get_vstrike_service_returns_none_when_unconfigured(isolate_secrets):
     isolate_secrets.delenv("VSTRIKE_BASE_URL", raising=False)
     isolate_secrets.delenv("VSTRIKE_USERNAME", raising=False)


### PR DESCRIPTION
Closes #462.

Moves every integration client off `requests` and onto `httpx`, and closes
the event-loop holes that the swap alone would have left open.

Excludes the 13 `tools/` MCP servers — they run as separate subprocesses, so
they never touch the API event loop.

## What changed

### The swap — two rules, applied uniformly

Chosen so connection lifecycle is identical:

| Original | Becomes | Why |
|---|---|---|
| `requests.Session()` | `httpx.Client()` | A reused session existed — a client is the faithful translation |
| bare `requests.get/post` | `httpx.get/post` | Both build a throwaway client per call |

I did not introduce a shared client cache for `vstrike_service`:
`get_vstrike_service()` builds a new service per request, so a per-instance
client would leak a pool per API call, and a module-level cache would change
TLS-session reuse and failure modes. Possible follow-up.

### The blocking fixes

**`backend/api/vstrike.py` — 23 handlers were on the event loop.**

The 23 outbound-proxy handlers — `health_check`, `get_asset_topology`,
`list_adjacent_assets`, `get_blast_radius` and 19 more — were still
`async def` calling the synchronous, `requests`-backed `VStrikeService`
directly on the loop.

**Six more sites** where an `async def` called a sync client directly, all
fixed with `asyncio.to_thread` — the pattern `daemon/sandbox_poller.py`
already used:

| File | Site |
|---|---|
| `daemon/poller.py` | `_poll_splunk`, `_poll_crowdstrike` |
| `daemon/federation/adapters/{splunk,crowdstrike}.py` | `fetch()` |
| `services/microsoft_defender_ingestion.py` | `fetch_alerts` (async by interface; fixing it covers both callers) |
| `services/autonomous_response_service.py` | Slack + PagerDuty escalation |

`SplunkService.search`: polls its job with `time.sleep(1)` × 60, so a slow Splunk froze the **entire daemon loop**, not
just that poll.

### Migration details that aren't cosmetic

| | |
|---|---|
| **Redirects** | `requests` followed them by default, httpx does not. `follow_redirects=True` is passed at every call site — this is silent if you get it wrong, and it matters for Jira Cloud and Microsoft's login endpoints. |
| **`httpx.InvalidURL` is not an `httpx.HTTPError`** | requests folded both into `RequestException`. A bare `except httpx.HTTPError` would let a malformed base URL escape and 500 instead of returning `None`. Every handler catches both. |
| **`verify` is constructor-only on `httpx.Client`** | `splunk_service.py:35` did `self.session.verify = verify_ssl` — a silent no-op on httpx that would have broken self-signed deployments. Moved into the constructor. |
| **SOCKS5** | `requirements.txt` documents SOCKS proxying via `HTTPS_PROXY`/`ALL_PROXY` backed by `pysocks` — which **httpx cannot use**. Added `socksio`; kept `pysocks` for the `requests` callers left in `scripts/`/`tools/`. |
| **httpx was never pinned** | Only `respx` was. It arrived transitively via `anthropic`/`openai`. Now explicit. |
| **`urllib3.disable_warnings`** | Dropped from `splunk_service` — httpx doesn't use urllib3 and emits no `InsecureRequestWarning`. |

### On "timeouts and retry behavior preserved"

- **Retries:** nothing to preserve — confirmed no file uses `HTTPAdapter` or
  `urllib3.Retry`. VStrike's JWT re-auth-and-retry is application-level and
  is untouched.
- **Timeouts:** preserved where they existed. But **`SplunkService` passed
  no timeout on any of its 6 requests**, and neither did either Defender
  call — with requests' `None` default that's an unbounded hang against an
  unresponsive vendor. Those were **added**, not preserved. Flagging it as a
  deliberate behaviour change rather than pretending it's a no-op.

## Tests

+31 new tests. Both suites run on `main` and this branch show identical
failure counts (42 unit / 15 integration — all environmental: missing
`openai`, `anthropic`, `sentry_sdk`, uninitialised DB).

- `test_splunk_service.py` (new, 13) and `test_crowdstrike_service.py`
  (new, 10) — first HTTP-level coverage either module has had
- `test_blocking_offload.py` (new, 4) — runs each async path against a
  10ms ticker and asserts the loop kept serving
- `test_vstrike_service.py` +4 respx; existing 61 retargeted to `httpx`
- `test_vstrike_ui_routes.py` — 37 `asyncio.run(...)` wrappers unwrapped

Both new guard families fail against the unfixed code: reverting
`follow_redirects` fails the redirect tests, stashing the `to_thread`
changes fails all 4 offload tests.

## Commits

| SHA | |
|---|---|
| `d4cb308` | `chore(deps): pin httpx and add socksio for SOCKS5 parity` |
| `17c16fb` | `refactor(vstrike): move the outbound client to httpx` |
| `05a4ea0` | `fix(api): run the VStrike proxy handlers off the event loop` |
| `cd3dc47` | `refactor(splunk): move to httpx and bound every request` |
| `6e4b44c` | `refactor(edr,response): move the remaining clients to httpx` |
| `0d522e5` | `fix(daemon,services): keep integration calls off the event loop` |
| `1a37ccd` | `refactor(jira): move the export client to httpx` |
| `b4e939c` | `refactor(daemon): move the enrichment and sandbox calls to httpx` |
| `29aa145` | `docs: tighten the httpx migration comments` |
