### PR TITLE
fix(api): uncap the sync endpoint threadpool

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -327,28 +327,6 @@ async def startup_event():
 
     _testing = get_settings().testing
 
-    # Keep the sync-endpoint threadpool in lockstep with the DB connection pool.
-    # Starlette runs `def` endpoints (and sync deps) on anyio's default thread
-    # limiter, which defaults to 40; our pool ceiling is pool_size + max_overflow
-    # (30 by default). Without this, a burst of 31+ concurrent DB-bound requests
-    # would occupy threads that then block on the pool up to DB_POOL_TIMEOUT.
-    try:
-        import anyio.to_thread
-        from core.storage.connection import get_db_manager
-
-        _pool_cfg = get_db_manager().config
-        _db_ceiling = _pool_cfg.pool_size + _pool_cfg.max_overflow
-        anyio.to_thread.current_default_thread_limiter().total_tokens = _db_ceiling
-        logger.info(
-            "Threadpool capacity set to %d to match DB pool "
-            "(pool_size=%d + max_overflow=%d)",
-            _db_ceiling,
-            _pool_cfg.pool_size,
-            _pool_cfg.max_overflow,
-        )
-    except Exception as e:  # pragma: no cover - best-effort tuning
-        logger.warning("Could not align threadpool with DB pool: %s", e)
-
     # Initialize Sentry error tracking (was never called before — bug fix)
     try:
         from core.platform.monitoring import init_sentry


### PR DESCRIPTION
Follow-up to #609. Same problem this PR originally set out to solve, opposite solution — see "What I did not do" for why it changed.

## The problem

`services/api/main.py`'s startup hook lowered anyio's default thread limiter from 40 to the DB pool ceiling — `db_pool_size + db_max_overflow`, 30 by default. The comment gave the reason: sync `def` endpoints are DB-bound, so allowing more threads than connections would only park them on the pool for up to `DB_POOL_TIMEOUT`.

#609 converted 23 outbound VStrike proxy handlers from `async def` to `def`, which was the right call — on `main` they were blocking the event loop outright, so one hung call froze the entire API. But they are the opposite shape from what the cap assumes: all 23 are pure outbound proxies with **zero** DB access — the only DB-touching route in `services/api/routers/vstrike.py` is the inbound `ingest_findings` — and each holds a token for up to the client's 30s timeout (`DEFAULT_TIMEOUT` at `core/integrations/vstrike/client.py:35`). Thirty concurrent calls against a slow VStrike took every token while the database sat idle.

## The change

Delete the cap. 22 lines out of `startup_event`, returning the limiter to anyio's default of 40.

## Why the cap could not do what it claimed

**Its invariant never held.** There are two thread pools in this process, and the cap sized one of them:

| Pool | Size | Feeds |
|---|---|---|
| anyio default limiter | 40, capped to 30 | sync `def` handlers, sync dependencies |
| event loop default executor | `min(32, cpu+4)` — 14 on a 10-core box | every `asyncio.to_thread` call |

The second pool carries DB work too — `findings.py:343`, `core/findings/enrichment/service.py:182`, `claude.py:1021`, `config.py:1519`, out of 55 `asyncio.to_thread` sites repo-wide. So even with the cap in place, concurrent DB users were bounded at **30 + 14-to-32 = 44 to 62** against a 30-connection pool. "Sync endpoints cannot outnumber DB connections" was never true under any workload; the cap only ever narrowed one of the two doors.

**It gated far more than DB-bound work.** The limiter covers *every* sync `def` handler and sync dependency — 57 sync routes across the router tree, of which VStrike is 24. `local_services` blocks on `docker compose` for up to 120s (`service_manager.start(timeout: int = 120)`), `jira_export` on Jira, `config.test_s3_connection` on boto3. None of them want a connection; all of them drew from the same 30 tokens. Fixing that endpoint-by-endpoint doesn't converge — the cap is the thing generating the work.

**It made `pool_timeout` structurally unreachable.** With tokens == pool ceiling, a thread that holds a token is guaranteed a connection, so SQLAlchemy's designed backpressure could never fire. Every overload became an untimed `CapacityLimiter` wait instead of a clear pool timeout. (Honest scope: uncapped, that only applies to requests 31-40 — request 41 waits on the same untimed limiter. This widens the band where the timeout can fire; it does not eliminate the wait.)

**It was never reviewed on its own merits.** `270dd98` was the third commit of #518, whose subject and body are about handler shape ("Adopts the sync-`def` + threadpool execution model decided in #461"). #461's acceptance criteria are an ADR plus one reference slice — limiter sizing appears nowhere in them, and the ADR was never written (`docs/adr/` still does not exist). Nothing has read the cap back since: no test, no doc, no other call site references `current_default_thread_limiter` or `total_tokens`. Its only documentation was its own comment.

## What this does not fix

**40 is an unopinionated number, not a safe one.** It is anyio's default, not a figure derived from this app. VStrike is 24 of the 57 sync routes in the tree — 42% of everything the limiter gates — and each can hold a token for 30s, so 40 tokens is about 1.7 vstrike routers. The residual starvation mode is unchanged in kind; only the threshold moves, 30 → 40.

That is deliberate. Backpressure belongs at the resource it protects — `DB_POOL_TIMEOUT` for the pool, a per-vendor limit for a slow integration — not in a global thread budget that every future endpoint has to reason about. Picking a new global number here would re-create the same unenforced premise one size up. The framework default is the "no opinion" position, and the opinion should be expressed per-resource.

**No change to Postgres connection pressure.** SQLAlchemy hard-caps checkouts at `pool_size + max_overflow` regardless of how many threads ask, so the ceiling stays 30 per process — 60 across the two workers in `infra/docker/Dockerfile.backend:116`, exactly as before.

## What I did not do

- **Add a decorator to move the 23 proxies to a different pool.** This PR's first two commits did that (`offload_outbound` in `core/routing.py`, backed by `asyncio.to_thread`). Two reasons it came out. It doesn't work: `asyncio.to_thread` submits to the event loop's default executor, which — per the table above — already carries DB work. Measured, a 10ms DB read waited 2.52s behind 20 in-flight proxy calls, so the queue moved rather than cleared. And it added a "decorated handlers must not touch the database" contract that nothing enforced — the same unenforced-premise shape as the cap it was working around.
- **Shorten the 30s VStrike client timeout.** `network_graph` and `killchain_replay` may legitimately exceed an interactive budget, so a blanket cut turns slow-but-working calls into 502s.
- **Cap concurrency inside the VStrike client.** This is the right tool if the residual exposure ever matters — a semaphore scoped to one integration, sized for that vendor. It needs 40 concurrent slow proxy calls to bite, which isn't current load. Left as a follow-up rather than guessed at here — see below.

## Verification

- App imports, `startup_event` runs clean, and `current_default_thread_limiter().total_tokens` reads 40 afterwards. This is the only verification that exercises the diff — no test in the tree references the limiter, so the suites below pass identically with and without this change. They are here to show nothing else moved, not as coverage.
- `tests/unit/integrations/test_blocking_offload.py` (the guard encoding #461's decision) and `tests/integration/test_vstrike_ui_routes.py`: **41 passed**. The VStrike route tests pass unmodified — the churn the decorator forced on them is gone.
- Dropping the block also drops a startup `get_db_manager()` call. No side effect lost: `DatabaseManager.__init__` builds a `DatabaseConfig` and nothing else — no engine, no connection — and the engine is created later in the same `startup_event` via `init_database()`. One behaviour change in the right direction: a malformed DB config now surfaces there as a fatal log instead of being swallowed by this block's `except Exception` as a warning.
- `flake8 --max-line-length=120`, `black --check` and `isort --check-only` on `services/api/main.py` are byte-identical to the same three commands on unmodified `main` (13 pre-existing E402 from the intentional `sys.path` block). No new findings.

## Follow-ups

This line was added on 30 Jul and removed on 11 Aug with the reasoning living only in PR bodies both times. To stop it churning again:

- A comment at the deletion site recording that the threadpool is deliberately left at the default and why.
- The #461 ADR, whose acceptance criterion is still open — the execution model now has two decisions attached to it and no written home for either.
- A semaphore in the VStrike client, if 40 concurrent slow proxy calls ever becomes real load.
