### PR TITLE
fix(llm): sync Bifrost keys via the keys API

### DIFF
--- a/core/llm/bifrost/admin.py
+++ b/core/llm/bifrost/admin.py
@@ -1,16 +1,27 @@
 """Bifrost management API helper.
 
-Bifrost exposes a REST admin API at ``${BIFROST_URL}/api/providers/{name}``
-that lets us update provider keys at runtime without a container restart.
-This module is the one place the backend talks to that API, so the flow
-is: user edits a key in the UI → ``llm_providers`` endpoint writes to the
-secrets manager → this module pushes the new value to Bifrost → Bifrost
-uses it for subsequent requests.
+Bifrost exposes a REST admin API that lets us update provider credentials at
+runtime without a container restart. This module is the one place the backend
+talks to that API, so the flow is: user edits a key in the UI →
+``llm_providers`` endpoint writes to the secrets manager → this module pushes
+the new value to Bifrost → Bifrost uses it for subsequent requests.
 
-The previous architecture had Bifrost read ``env.ANTHROPIC_API_KEY`` from
-its container env, which diverged from whatever the UI had written to the
-secrets manager under ``llm_provider_<id>_api_key``. Pushing via the API
-keeps a single source of truth in the secrets manager.
+The alternative would be letting Bifrost read ``env.ANTHROPIC_API_KEY`` from
+its container env, which diverges from whatever the UI wrote to the secrets
+manager under ``llm_provider_<id>_api_key``. Pushing via the API keeps a
+single source of truth in the secrets manager, and is why the seeded
+``config.json`` key is an empty placeholder rather than a real credential.
+
+Three properties of that API shape the code below, all learned the hard way:
+
+* **Keys are a subresource.** They live at ``/api/providers/{name}/keys``,
+  *not* on the ``/api/providers/{name}`` document — which returns no ``keys``
+  field at all.
+* **Secrets are masked on read** (``sk-a****key``) and a write that echoes the
+  mask is accepted with a 200, storing the mask as the credential. So values
+  are always re-read from the secrets store, never round-tripped.
+* **A key must carry a non-empty value.** There is no models-only update, and
+  clearing a credential means deleting the key rather than blanking it.
 """
 
 from __future__ import annotations
@@ -22,6 +33,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from core.config import get_settings
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 5.0
@@ -38,71 +50,188 @@ def _bifrost_base_url() -> str:
     return get_settings().bifrost_url.rstrip("/")
 
 
-def _get_provider(name: str, client: httpx.Client) -> Optional[Dict[str, Any]]:
+# Providers whose Bifrost key is not an API secret we own. Ollama's key holds
+# a URL under ``ollama_key_config`` with an empty ``value``, and its allow-list
+# is the static wildcard, so there is nothing for us to push.
+_UNMANAGED_PROVIDER_TYPES = frozenset({"ollama"})
+
+# Read-only/derived fields Bifrost returns but rejects or ignores on write.
+# ``value`` is dropped separately — see the module docstring on masking.
+_KEY_READBACK_ONLY = frozenset({"id", "config_hash", "status", "description"})
+
+# Key ``status`` values observed from Bifrost that do not indicate a problem:
+# "success" means it listed models with the credential, "unknown" means it has
+# not checked yet. Anything else (e.g. "list_models_failed") gets a warning —
+# an unrecognized value is worth one line of noise, whereas guessing at extra
+# members here would silence the exact failure this check exists to catch.
+_KEY_STATUS_OK = frozenset({"success", "unknown"})
+
+
+def _keys_url(provider_name: str, key_id: Optional[str] = None) -> str:
+    base = f"{_bifrost_base_url()}/api/providers/{provider_name}/keys"
+    return f"{base}/{key_id}" if key_id else base
+
+
+def _get_provider_keys(
+    name: str, client: httpx.Client
+) -> Optional[List[Dict[str, Any]]]:
+    """Return ``name``'s configured keys, or None if the provider is absent.
+
+    An empty list means "provider exists, no keys yet" — distinct from None,
+    which is why callers branch on ``is None`` rather than truthiness.
+    """
     try:
-        r = client.get(
-            f"{_bifrost_base_url()}/api/providers/{name}", timeout=_DEFAULT_TIMEOUT
-        )
+        r = client.get(_keys_url(name), timeout=_DEFAULT_TIMEOUT)
         if r.status_code == 404:
             logger.debug("Bifrost: provider %s not configured", name)
             return None
         r.raise_for_status()
-        return r.json()
+        return r.json().get("keys") or []
     except Exception as e:
-        logger.warning("Bifrost: could not fetch provider %s: %s", name, e)
+        logger.warning("Bifrost: could not fetch keys for provider %s: %s", name, e)
         return None
 
 
-def push_provider_key(provider_name: str, key_value: str) -> bool:
-    """Update the first configured key on ``provider_name`` with ``key_value``.
+def _log_key_health(provider_name: str, payload: Dict[str, Any]) -> None:
+    """Log Bifrost's own verdict on a key it just accepted.
 
-    We take the current provider document, replace the key value with a
-    literal (``from_env: false``), and PUT it back. This is idempotent —
-    pushing the same value twice is a no-op from Anthropic's perspective.
-
-    Returns True on success. Any failure is logged and returns False so
-    the caller's CRUD flow never breaks on a Bifrost hiccup.
+    Bifrost validates the credential upstream on write and reports the result
+    on the response (e.g. ``status="list_models_failed"`` with
+    ``description="invalid x-api-key"``). A 2xx therefore means "stored", not
+    "works" — surface the difference rather than reporting a bad key as OK.
     """
-    if not provider_name:
+    status = payload.get("status")
+    if status and status not in _KEY_STATUS_OK:
+        logger.warning(
+            "Bifrost: provider %s key stored but reports status=%s (%s)",
+            provider_name,
+            status,
+            payload.get("description") or "no detail",
+        )
+
+
+def _upsert_provider_key(
+    provider_name: str,
+    client: httpx.Client,
+    *,
+    key_value: str,
+    models: Optional[List[str]] = None,
+) -> bool:
+    """Create or replace ``provider_name``'s key with ``key_value``.
+
+    ``key_value`` must be the real secret from the secrets store, never a
+    value read back from Bifrost (see the module docstring on masking).
+
+    ``models`` replaces the allow-list; omit it to carry the existing one
+    forward. There is no models-only update — every write carries the secret.
+    """
+    keys = _get_provider_keys(provider_name, client)
+    if keys is None:
         return False
-    with httpx.Client() as client:
-        prov = _get_provider(provider_name, client)
-        if prov is None:
-            return False
-        keys = prov.get("keys") or []
-        if not keys:
+
+    existing = keys[0] if keys else None
+    body: Dict[str, Any] = {
+        k: v for k, v in (existing or {}).items() if k not in _KEY_READBACK_ONLY
+    }
+    body.setdefault("name", f"default-{provider_name}-key")
+    body.setdefault("weight", 1)
+    body.setdefault("enabled", True)
+    body["value"] = {"value": key_value, "type": "plain_text"}
+    if models is not None:
+        body["models"] = models
+    body.setdefault("models", [])
+
+    verb = "PUT" if existing else "POST"
+    url = (
+        _keys_url(provider_name, existing["id"])
+        if existing
+        else _keys_url(provider_name)
+    )
+    try:
+        r = (
+            client.put(url, json=body, timeout=_DEFAULT_TIMEOUT)
+            if existing
+            else client.post(url, json=body, timeout=_DEFAULT_TIMEOUT)
+        )
+        if r.status_code >= 400:
             logger.warning(
-                "Bifrost: provider %s has no keys slot to update", provider_name
+                "Bifrost: %s %s returned %s: %s",
+                verb,
+                url,
+                r.status_code,
+                r.text[:200],
             )
             return False
-        # Update the first key. Bifrost's current config seeds exactly one
-        # key per provider; multi-key rotation is a separate feature.
-        keys[0]["value"] = {
-            "value": key_value,
-            "env_var": "",
-            "from_env": False,
-        }
         try:
-            r = client.put(
-                f"{_bifrost_base_url()}/api/providers/{provider_name}",
-                json=prov,
-                timeout=_DEFAULT_TIMEOUT,
+            _log_key_health(provider_name, r.json())
+        except Exception:  # noqa: BLE001 - health logging must never fail a write
+            pass
+        return True
+    except Exception as e:
+        logger.warning("Bifrost: %s %s failed: %s", verb, url, e)
+        return False
+
+
+def _delete_provider_keys(provider_name: str, client: httpx.Client) -> bool:
+    """Remove ``provider_name``'s keys — the only way to clear a credential.
+
+    Deleting is safe because ``_upsert_provider_key`` recreates the key from
+    nothing when one is next configured.
+    """
+    keys = _get_provider_keys(provider_name, client)
+    if keys is None:
+        return False
+    if not keys:
+        return True
+    ok = True
+    for key in keys:
+        try:
+            r = client.delete(
+                _keys_url(provider_name, key["id"]), timeout=_DEFAULT_TIMEOUT
             )
             if r.status_code >= 400:
                 logger.warning(
-                    "Bifrost: PUT /api/providers/%s returned %s: %s",
+                    "Bifrost: DELETE key %s on %s returned %s: %s",
+                    key.get("id"),
                     provider_name,
                     r.status_code,
                     r.text[:200],
                 )
-                return False
-            logger.info("Bifrost: pushed updated key for provider %s", provider_name)
-            return True
+                ok = False
         except Exception as e:
             logger.warning(
-                "Bifrost: PUT /api/providers/%s failed: %s", provider_name, e
+                "Bifrost: DELETE key %s on %s failed: %s",
+                key.get("id"),
+                provider_name,
+                e,
             )
-            return False
+            ok = False
+    return ok
+
+
+def push_provider_key(provider_name: str, key_value: str) -> bool:
+    """Set ``provider_name``'s Bifrost credential to ``key_value``.
+
+    Creates the key if the provider has none, otherwise replaces the existing
+    one in place. An empty ``key_value`` clears the credential by deleting the
+    key. The existing model allow-list is carried forward untouched.
+
+    Returns True on success. Any failure is logged and returns False so the
+    caller's CRUD flow never breaks on a Bifrost hiccup — callers that surface
+    the result to a user should report that False rather than swallow it.
+    """
+    if not provider_name:
+        return False
+    if provider_name in _UNMANAGED_PROVIDER_TYPES:
+        logger.debug("Bifrost: provider %s manages its own key", provider_name)
+        return True
+    with httpx.Client() as client:
+        if not key_value:
+            return _delete_provider_keys(provider_name, client)
+        ok = _upsert_provider_key(provider_name, client, key_value=key_value)
+        if ok:
+            logger.info("Bifrost: pushed updated key for provider %s", provider_name)
+        return ok
 
 
 def sync_all_provider_keys() -> Dict[str, bool]:
@@ -149,14 +278,21 @@ def sync_all_provider_keys() -> Dict[str, bool]:
     return results
 
 
-def sync_provider_models(provider_type: str, model_ids: list[str]) -> bool:
+def sync_provider_models(
+    provider_type: str, model_ids: list[str], *, key_value: Optional[str]
+) -> bool:
     """Update Bifrost's allow-list of routable models for ``provider_type``.
 
-    GETs the provider document, replaces ``keys[0].models`` with
-    ``model_ids``, and PUTs the result back. Empty lists are skipped —
-    wiping the allow-list to ``[]`` would cause Bifrost to reject every
-    subsequent LLM call for that provider, which we never want just
-    because an upstream API had a momentary hiccup.
+    Writes the allow-list through the provider's key, which is where Bifrost
+    stores it, so every such write carries the credential. ``key_value`` is
+    the caller's already-resolved secret for this provider type — it is passed
+    in rather than looked up here so that discovery and this sync can never
+    disagree about which secret backs a provider. A provider with no resolved
+    secret has no allow-list to sync.
+
+    Empty lists are skipped — wiping the allow-list to ``[]`` would cause
+    Bifrost to reject every subsequent LLM call for that provider, which we
+    never want just because an upstream API had a momentary hiccup.
     """
     if not provider_type:
         return False
@@ -167,58 +303,42 @@ def sync_provider_models(provider_type: str, model_ids: list[str]) -> bool:
             provider_type,
         )
         return False
-    # Self-hosted Ollama serves whatever the user pulled/built, so pin the
-    # allow-list to the wildcard rather than a finite discovered set.
-    if provider_type == "ollama":
-        normalized = ["*"]
-    else:
-        seen: set = set()
-        normalized = []
-        for mid in model_ids:
-            if not mid or mid in seen:
-                continue
-            seen.add(mid)
-            normalized.append(mid)
+    # Self-hosted Ollama serves whatever the user pulled/built, and its key
+    # holds a URL rather than a secret we own. The seeded wildcard already
+    # covers it, so there is nothing to write.
+    if provider_type in _UNMANAGED_PROVIDER_TYPES:
+        logger.debug(
+            "Bifrost sync: provider %s uses a static allow-list", provider_type
+        )
+        return True
+
+    seen: set = set()
+    normalized: List[str] = []
+    for mid in model_ids:
+        if not mid or mid in seen:
+            continue
+        seen.add(mid)
+        normalized.append(mid)
+
+    if not key_value:
+        logger.info(
+            "Bifrost sync: no resolved secret for provider %s — "
+            "skipping model allow-list sync",
+            provider_type,
+        )
+        return False
 
     with httpx.Client() as client:
-        prov = _get_provider(provider_type, client)
-        if prov is None:
-            return False
-        keys = prov.get("keys") or []
-        if not keys:
-            logger.warning(
-                "Bifrost: provider %s has no keys slot to update",
-                provider_type,
-            )
-            return False
-        keys[0]["models"] = normalized
-        try:
-            r = client.put(
-                f"{_bifrost_base_url()}/api/providers/{provider_type}",
-                json=prov,
-                timeout=_DEFAULT_TIMEOUT,
-            )
-            if r.status_code >= 400:
-                logger.warning(
-                    "Bifrost: PUT /api/providers/%s (models) returned %s: %s",
-                    provider_type,
-                    r.status_code,
-                    r.text[:200],
-                )
-                return False
+        ok = _upsert_provider_key(
+            provider_type, client, key_value=key_value, models=normalized
+        )
+        if ok:
             logger.info(
                 "Bifrost: synced %d models for provider %s",
                 len(normalized),
                 provider_type,
             )
-            return True
-        except Exception as e:
-            logger.warning(
-                "Bifrost: PUT /api/providers/%s (models) failed: %s",
-                provider_type,
-                e,
-            )
-            return False
+        return ok
 
 
 async def sync_all_provider_models() -> Dict[str, Any]:
@@ -308,6 +428,7 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
                     "provider_type": row.provider_type,
                     "base_url": row.base_url,
                     "api_key_ref": row.api_key_ref,
+                    "is_default": bool(row.is_default),
                     "config": dict(row.config or {}),
                 }
             )
@@ -322,14 +443,23 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
 
         type_union: List[str] = []
         type_seen: set = set()
+        # Bifrost holds one key per provider *type* while Vigil can hold
+        # several rows of that type, so the allow-list push below rides on a
+        # single row's secret. Prefer the default row, matching the survivor
+        # ``llm_providers._reconcile_bifrost_key_for_type`` would pick.
+        provider_rows.sort(key=lambda r: not r["is_default"])
+        type_key: Optional[str] = None
 
         for row_dict in provider_rows:
             row_ids: List[str] = []
             row_seen: set = set()
             upstream_ok = False
+            row_key = _resolve_row_key(row_dict)
+            if type_key is None:
+                type_key = row_key
 
             try:
-                meta = await _fetch_meta_for_row(row_dict, discovery)
+                meta = await _fetch_meta_for_row(row_dict, discovery, row_key)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "sync_all_provider_models: discovery failed for %s (%s): %s",
@@ -383,7 +513,9 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
             bifrost_results[provider_type] = False
             continue
 
-        bifrost_results[provider_type] = sync_provider_models(provider_type, type_union)
+        bifrost_results[provider_type] = sync_provider_models(
+            provider_type, type_union, key_value=type_key
+        )
 
     if bifrost_results:
         ok = sum(1 for v in bifrost_results.values() if v)
@@ -399,35 +531,50 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
     }
 
 
-async def _fetch_meta_for_row(row_dict: Dict[str, Any], discovery) -> Optional[list]:
-    """Call the appropriate discovery function for one provider row.
+def _resolve_row_key(row_dict: Dict[str, Any]) -> Optional[str]:
+    """Resolve one provider row's plaintext secret, or None.
 
-    Returns ``None`` when the row isn't usable (e.g. no API key). The
-    caller logs and skips.
+    The row's own ``api_key_ref`` wins; the env-held names are a fallback for
+    deployments that never wrote a per-row ref. This is the single resolver
+    for both catalog discovery and the Bifrost allow-list push, so the two
+    cannot disagree about which secret backs a provider.
     """
     from core.secrets_manager import get_secret
 
     provider_type = row_dict["provider_type"]
-    base_url = row_dict.get("base_url")
     api_key_ref = row_dict.get("api_key_ref")
+
+    if api_key_ref:
+        try:
+            val = get_secret(api_key_ref)
+            if val:
+                return val
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("secret lookup for %s failed: %s", api_key_ref, exc)
+    if provider_type == "anthropic":
+        return get_secret("ANTHROPIC_API_KEY") or get_secret("CLAUDE_API_KEY")
+    if provider_type == "openai":
+        return get_secret("OPENAI_API_KEY")
+    return None
+
+
+async def _fetch_meta_for_row(
+    row_dict: Dict[str, Any], discovery, key: Optional[str] = None
+) -> Optional[list]:
+    """Call the appropriate discovery function for one provider row.
+
+    ``key`` is the row's resolved secret from ``_resolve_row_key``; it is
+    passed in so the caller can reuse it for the Bifrost push instead of
+    resolving twice.
+
+    Returns ``None`` when the row isn't usable (e.g. no API key). The
+    caller logs and skips.
+    """
+    provider_type = row_dict["provider_type"]
+    base_url = row_dict.get("base_url")
     config = row_dict.get("config") or {}
 
-    def _resolve_key() -> Optional[str]:
-        if api_key_ref:
-            try:
-                val = get_secret(api_key_ref)
-                if val:
-                    return val
-            except Exception as exc:  # noqa: BLE001
-                logger.debug("secret lookup for %s failed: %s", api_key_ref, exc)
-        if provider_type == "anthropic":
-            return get_secret("ANTHROPIC_API_KEY") or get_secret("CLAUDE_API_KEY")
-        if provider_type == "openai":
-            return get_secret("OPENAI_API_KEY")
-        return None
-
     if provider_type == "anthropic":
-        key = _resolve_key()
         if not key:
             logger.info(
                 "Bifrost sync: no Anthropic key available for %s — skipping",
@@ -447,7 +594,7 @@ async def _fetch_meta_for_row(row_dict: Dict[str, Any], discovery) -> Optional[l
         # Without this, a self-hosted provider that discovers fine never syncs
         # into Bifrost. The caller wraps this in try/except and skips on error.
         return await discovery.fetch_openai_models(
-            _resolve_key(),
+            key,
             base_url=base_url,
             organization=config.get("organization"),
             allow_loopback=True,

--- a/tests/unit/llm/test_bifrost_admin.py
+++ b/tests/unit/llm/test_bifrost_admin.py
@@ -1,8 +1,11 @@
-"""Unit tests for core.llm.bifrost.admin sync helpers (GH #139).
+"""Unit tests for core.llm.bifrost.admin sync helpers.
 
-Verifies the new ``sync_provider_models`` path: empty-list guard, dedup,
-GET-modify-PUT flow, and error handling. httpx is monkeypatched via a
-fake client so tests don't depend on a running Bifrost.
+Covers the key upsert path against Bifrost's ``/api/providers/{name}/keys``
+subresource: empty-list guard, dedup, create-vs-update, clearing, and error
+handling. Two of these are regression tests for traps in that API — keys are
+absent from the provider document, and secrets come back masked on read, so a
+naive read-modify-write stores the mask as the credential. httpx is
+monkeypatched via a fake client so tests don't depend on a running Bifrost.
 """
 
 from __future__ import annotations
@@ -39,10 +42,21 @@ class _FakeResp:
 class _RecordingClient:
     """Mimic ``httpx.Client`` as a context manager with recorded calls."""
 
-    def __init__(self, get_payload=None, get_status=200, put_status=200):
+    def __init__(
+        self,
+        get_payload=None,
+        get_status=200,
+        put_status=200,
+        post_status=200,
+        delete_status=200,
+        write_payload=None,
+    ):
         self._get_payload = get_payload
         self._get_status = get_status
         self._put_status = put_status
+        self._post_status = post_status
+        self._delete_status = delete_status
+        self._write_payload = write_payload if write_payload is not None else {}
         self.calls: List[Dict[str, Any]] = []
 
     def __enter__(self):
@@ -51,31 +65,57 @@ class _RecordingClient:
     def __exit__(self, exc_type, exc, tb):
         return False
 
+    def _record(self, method, status, url, kwargs):
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        return _FakeResp(status, self._write_payload, "")
+
     def get(self, url, **kwargs):
         self.calls.append({"method": "GET", "url": url, "kwargs": kwargs})
         return _FakeResp(self._get_status, self._get_payload)
 
     def put(self, url, **kwargs):
-        self.calls.append({"method": "PUT", "url": url, "kwargs": kwargs})
-        return _FakeResp(self._put_status, None, "")
+        return self._record("PUT", self._put_status, url, kwargs)
+
+    def post(self, url, **kwargs):
+        return self._record("POST", self._post_status, url, kwargs)
+
+    def delete(self, url, **kwargs):
+        return self._record("DELETE", self._delete_status, url, kwargs)
+
+
+_SECRET = "sk-ant-real-secret"
+
+
+# Bifrost's read shape: one key, secret masked, allow-list alongside it.
+def _key_doc(models=None, value="sk-ant-****-masked", key_id="key-1"):
+    return {
+        "keys": [
+            {
+                "id": key_id,
+                "name": "default-anthropic-key",
+                "value": {"value": value, "type": "plain_text"},
+                "models": models if models is not None else ["old"],
+                "weight": 1,
+                "enabled": True,
+                "config_hash": "abc123",
+                "status": "unknown",
+            }
+        ],
+        "total": 1,
+    }
 
 
 def test_sync_provider_models_skips_empty_list():
     # Must not even hit the admin API — refuses to wipe the allow-list.
     with patch.object(bifrost_admin.httpx, "Client", lambda: _RecordingClient()):
-        assert bifrost_admin.sync_provider_models("anthropic", []) is False
+        assert (
+            bifrost_admin.sync_provider_models("anthropic", [], key_value=_SECRET)
+            is False
+        )
 
 
 def test_sync_provider_models_dedupes_and_preserves_order():
-    provider_doc = {
-        "keys": [
-            {
-                "value": {"value": "sk-...", "env_var": "", "from_env": False},
-                "models": ["old"],
-            }
-        ]
-    }
-    rec = _RecordingClient(get_payload=provider_doc)
+    rec = _RecordingClient(get_payload=_key_doc())
 
     with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
         ok = bifrost_admin.sync_provider_models(
@@ -87,41 +127,162 @@ def test_sync_provider_models_dedupes_and_preserves_order():
                 "",
                 "claude-haiku-3-5",
             ],
+            key_value=_SECRET,
         )
     assert ok is True
 
     put = [c for c in rec.calls if c["method"] == "PUT"][0]
     body = put["kwargs"]["json"]
-    assert body["keys"][0]["models"] == [
+    assert body["models"] == [
         "claude-opus-4-7",
         "claude-sonnet-4-6",
         "claude-haiku-3-5",
     ]
 
 
+def test_keys_are_read_from_the_keys_subresource():
+    """Regression: keys are not part of the provider document.
+
+    Reading them from ``/api/providers/{name}`` yields no ``keys`` field at
+    all, which silently disabled every sync path in this module.
+    """
+    rec = _RecordingClient(get_payload=_key_doc())
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        bifrost_admin.sync_provider_models(
+            "anthropic", ["claude-opus-4-7"], key_value=_SECRET
+        )
+
+    get = [c for c in rec.calls if c["method"] == "GET"][0]
+    assert get["url"].endswith("/api/providers/anthropic/keys")
+
+
+def test_write_never_echoes_the_masked_value_back():
+    """Regression: Bifrost masks secrets on read and accepts the mask on write.
+
+    A read-modify-write would store ``sk-ant-****-masked`` *as the credential*
+    with a 200 and no error, silently breaking a working provider. Every write
+    must carry the value from the secrets store instead.
+    """
+    masked = "sk-ant-****-masked"
+    rec = _RecordingClient(get_payload=_key_doc(value=masked))
+
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        bifrost_admin.sync_provider_models(
+            "anthropic", ["claude-opus-4-7"], key_value=_SECRET
+        )
+
+    body = [c for c in rec.calls if c["method"] == "PUT"][0]["kwargs"]["json"]
+    assert body["value"]["value"] == _SECRET
+    assert masked not in str(body)
+
+
+def test_write_strips_readback_only_fields():
+    rec = _RecordingClient(get_payload=_key_doc())
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        bifrost_admin.sync_provider_models(
+            "anthropic", ["claude-opus-4-7"], key_value=_SECRET
+        )
+
+    body = [c for c in rec.calls if c["method"] == "PUT"][0]["kwargs"]["json"]
+    for field in ("id", "config_hash", "status", "description"):
+        assert field not in body
+
+
 def test_sync_provider_models_returns_false_when_provider_missing():
     rec = _RecordingClient(get_status=404, get_payload=None)
     with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
-        ok = bifrost_admin.sync_provider_models("anthropic", ["claude-opus-4-7"])
+        ok = bifrost_admin.sync_provider_models(
+            "anthropic", ["claude-opus-4-7"], key_value=_SECRET
+        )
     assert ok is False
-    # No PUT was attempted.
-    assert not any(c["method"] == "PUT" for c in rec.calls)
+    assert not any(c["method"] in ("PUT", "POST") for c in rec.calls)
 
 
 def test_sync_provider_models_returns_false_on_put_error():
-    provider_doc = {"keys": [{"models": []}]}
-    rec = _RecordingClient(get_payload=provider_doc, put_status=500)
+    rec = _RecordingClient(get_payload=_key_doc(), put_status=500)
     with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
-        ok = bifrost_admin.sync_provider_models("openai", ["gpt-4o"])
+        ok = bifrost_admin.sync_provider_models("openai", ["gpt-4o"], key_value=_SECRET)
     assert ok is False
 
 
-def test_sync_provider_models_returns_false_when_no_keys_slot():
-    # A provider without any keys slot can't be updated.
-    rec = _RecordingClient(get_payload={"keys": []})
+def test_sync_provider_models_creates_key_when_none_exists():
+    # Bifrost accepts key creation at runtime, so an unconfigured provider is
+    # not a dead end — no placeholder slot has to be seeded up front.
+    rec = _RecordingClient(get_payload={"keys": [], "total": 0})
     with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
-        ok = bifrost_admin.sync_provider_models("anthropic", ["claude-opus-4-7"])
+        ok = bifrost_admin.sync_provider_models(
+            "anthropic", ["claude-opus-4-7"], key_value=_SECRET
+        )
+    assert ok is True
+
+    post = [c for c in rec.calls if c["method"] == "POST"][0]
+    assert post["url"].endswith("/api/providers/anthropic/keys")
+    assert post["kwargs"]["json"]["models"] == ["claude-opus-4-7"]
+
+
+def test_sync_provider_models_skips_when_no_secret_configured():
+    # Every write must carry the credential, so there is nothing to sync.
+    rec = _RecordingClient(get_payload=_key_doc())
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        ok = bifrost_admin.sync_provider_models(
+            "anthropic", ["claude-opus-4-7"], key_value=None
+        )
     assert ok is False
+    assert not rec.calls
+
+
+def test_sync_provider_models_leaves_ollama_alone():
+    # Ollama's key holds a masked URL, not a secret we own, and its allow-list
+    # is the static wildcard.
+    rec = _RecordingClient(get_payload=_key_doc())
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        ok = bifrost_admin.sync_provider_models(
+            "ollama", ["llama3.2:1b"], key_value=None
+        )
+    assert ok is True
+    assert not rec.calls
+
+
+def test_push_provider_key_updates_existing_key_in_place():
+    rec = _RecordingClient(get_payload=_key_doc(models=["claude-opus-4-7"]))
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        assert bifrost_admin.push_provider_key("anthropic", "sk-ant-new") is True
+
+    put = [c for c in rec.calls if c["method"] == "PUT"][0]
+    assert put["url"].endswith("/api/providers/anthropic/keys/key-1")
+    body = put["kwargs"]["json"]
+    assert body["value"] == {"value": "sk-ant-new", "type": "plain_text"}
+    # Carries the existing allow-list forward rather than wiping it.
+    assert body["models"] == ["claude-opus-4-7"]
+
+
+def test_push_provider_key_creates_key_when_absent():
+    rec = _RecordingClient(get_payload={"keys": [], "total": 0})
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        assert bifrost_admin.push_provider_key("anthropic", "sk-ant-new") is True
+
+    post = [c for c in rec.calls if c["method"] == "POST"][0]
+    assert post["url"].endswith("/api/providers/anthropic/keys")
+    assert post["kwargs"]["json"]["value"]["value"] == "sk-ant-new"
+
+
+def test_push_provider_key_deletes_on_empty_value():
+    # Bifrost rejects a key with an empty value, so "cleared" is a deletion.
+    rec = _RecordingClient(get_payload=_key_doc())
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        assert bifrost_admin.push_provider_key("anthropic", "") is True
+
+    delete = [c for c in rec.calls if c["method"] == "DELETE"][0]
+    assert delete["url"].endswith("/api/providers/anthropic/keys/key-1")
+    assert not any(c["method"] in ("PUT", "POST") for c in rec.calls)
+
+
+def test_push_provider_key_reports_false_on_write_error():
+    # llm_providers surfaces this to the user, so a failed push must not
+    # report success.
+    rec = _RecordingClient(get_payload=_key_doc(), put_status=500)
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        assert bifrost_admin.push_provider_key("anthropic", "sk-ant-new") is False
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +298,7 @@ class _FakeProviderRow:
         self.api_key_ref = None
         self.config = {}
         self.is_active = True
+        self.is_default = False
 
 
 class _FakeSessionScope:
@@ -218,7 +380,7 @@ def test_sync_all_populates_dropdown_cache_and_bifrost_allowlist(monkeypatch):
     _patch_db(monkeypatch, rows)
 
     # Stub the discovery fetch — returns two live models.
-    async def fake_fetch_row(row_dict, discovery):
+    async def fake_fetch_row(row_dict, discovery, key=None):
         return [_M("claude-opus-4-7"), _M("claude-haiku-4-5-20251001")]
 
     monkeypatch.setattr(ba, "_fetch_meta_for_row", fake_fetch_row)
@@ -226,7 +388,7 @@ def test_sync_all_populates_dropdown_cache_and_bifrost_allowlist(monkeypatch):
     # Capture Bifrost PUTs.
     pushed = {}
 
-    def fake_push(provider_type, model_ids):
+    def fake_push(provider_type, model_ids, *, key_value=None):
         pushed[provider_type] = list(model_ids)
         return True
 
@@ -274,7 +436,7 @@ def test_sync_all_unions_across_same_type_providers(monkeypatch):
     ]
     _patch_db(monkeypatch, rows)
 
-    async def fake_fetch_row(row_dict, discovery):
+    async def fake_fetch_row(row_dict, discovery, key=None):
         if row_dict["provider_id"] == "ant-dev":
             return [_M("claude-opus-4-7"), _M("claude-haiku-4-5-20251001")]
         return [_M("claude-opus-4-7"), _M("claude-sonnet-4-6")]
@@ -283,7 +445,7 @@ def test_sync_all_unions_across_same_type_providers(monkeypatch):
 
     pushed = {}
 
-    def fake_push(provider_type, model_ids):
+    def fake_push(provider_type, model_ids, *, key_value=None):
         pushed[provider_type] = list(model_ids)
         return True
 
@@ -323,14 +485,14 @@ def test_sync_all_falls_back_when_all_fetches_fail(monkeypatch):
     rows = [_FakeProviderRow("ant-default", "anthropic")]
     _patch_db(monkeypatch, rows)
 
-    async def fake_fetch_row(row_dict, discovery):
+    async def fake_fetch_row(row_dict, discovery, key=None):
         raise RuntimeError("upstream down")
 
     monkeypatch.setattr(ba, "_fetch_meta_for_row", fake_fetch_row)
 
     pushed = {}
 
-    def fake_push(provider_type, model_ids):
+    def fake_push(provider_type, model_ids, *, key_value=None):
         pushed[provider_type] = list(model_ids)
         return True
 
@@ -368,7 +530,7 @@ def test_sync_all_coalesces_concurrent_callers(monkeypatch):
     fetch_calls = {"n": 0}
     gate = asyncio.Event()
 
-    async def slow_fake_fetch_row(row_dict, discovery):
+    async def slow_fake_fetch_row(row_dict, discovery, key=None):
         fetch_calls["n"] += 1
         # Hold the sync open long enough for the second caller to join.
         await gate.wait()


### PR DESCRIPTION
Fixes #613.

## The break

Bifrost moved provider keys out of `GET /api/providers/{name}` into a `/keys` subresource. `core/llm/bifrost/admin.py` still read them off the provider document — which returns no `keys` field at all — so `push_provider_key` and `sync_provider_models` hit their `no keys slot to update` guard and returned `False` on every call. The key a user configures in Settings → AI / LLM Providers never reached the gateway, and chat failed with the misleading `no keys found that support model: claude-sonnet-4-6`.

All six call sites listed in the issue go through those two functions, so they were all dead by the same read.

## Three API properties this had to account for

Verified against a running `maximhq/bifrost:latest`:

1. **Keys are a subresource** — read and written at `/api/providers/{name}/keys`.
2. **Secrets are masked on read** (`sk-a****key`), and a write that echoes the mask is accepted with a **200 that stores the mask as the credential**. This is the nastiest one: a naive read-modify-write silently breaks a working provider with no error anywhere. Values are therefore always re-read from the secrets store, never round-tripped.
3. **A key must carry a non-empty value** — there is no models-only update, so every allow-list write carries the secret, and clearing a credential means deleting the key rather than blanking it.

## What changed

- Keys are **created when absent** (POST) instead of requiring a pre-seeded placeholder slot, **replaced in place** when present (PUT), and **deleted** when the credential is cleared.
- Ollama is skipped — its key holds a URL under `ollama_key_config`, not a secret we own, and its allow-list is the static wildcard.
- Read-only/derived fields (`id`, `config_hash`, `status`, `description`) are stripped before write.
- **A 2xx means "stored", not "works."** Bifrost validates the credential upstream and reports e.g. `status=list_models_failed` with `description="invalid x-api-key"` on the response body. That is now logged as a warning instead of being reported to the caller as success.
- **One resolver for provider secrets.** Catalog discovery and the allow-list push now share `_resolve_row_key`, and `sync_provider_models` takes the resolved value as a parameter rather than re-deriving it from the database. Without this the two paths disagreed: discovery falls back to env-held `ANTHROPIC_API_KEY`/`CLAUDE_API_KEY`/`OPENAI_API_KEY` when a row has no `api_key_ref`, so a deployment keyed that way would have discovered models fine and then skipped the allow-list sync.

## Tests

The old tests mocked a provider document that *included* a `keys` array, which is why they stayed green against a shape production never returns. They now model the real read shape (masked value, key `id`, allow-list alongside), and two pin the traps directly:

- `test_keys_are_read_from_the_keys_subresource`
- `test_write_never_echoes_the_masked_value_back`

Plus coverage for create-vs-update, delete-on-clear, the Ollama skip, and `False` on write error.

## Verification

- `tests/unit/llm/`: **372 passed** (363 before + 9 new).
- Full unit suite: **1358 passed**.
- `black --check` and `flake8` clean on both files.

Two `test_claude_service.py` failures show up in the full suite. They are **pre-existing and unrelated** — cross-directory env pollution triggered when `tests/unit/api/` is collected alongside `tests/unit/llm/`. Confirmed identical on clean `main` with the same test combination, and the file passes 54/54 in isolation either way. Worth its own issue.

## Notes for the reviewer

- Not run locally: `mypy` and `lint-imports` are not installed in the venv, so CI is their first execution. The change adds no cross-layer import.
- `isort --check` fails on `admin.py`, on the deferred-import block inside `_do_sync_all_provider_models`. That is pre-existing on `main` and untouched here.
- Branched from current `main` rather than `refactor/reorg-481`, since the reorg work has landed and both files are byte-identical between the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)