### PR TITLE
refactor(settings): tighten lookup map typing

### DIFF
--- a/clients/web/src/redesign/screens/settings/AutoInvestigateSection.tsx
+++ b/clients/web/src/redesign/screens/settings/AutoInvestigateSection.tsx
@@ -35,7 +35,7 @@ type PresetValues = Pick<
   | 'max_total_daily_cost'
 >
 
-const PRESETS: Record<PresetKey, { label: string; summary: string; values: PresetValues }> = {
+const PRESETS = {
   conservative: {
     label: 'Conservative',
     summary: 'Minimal spend · 2 agents · tight limits',
@@ -72,7 +72,7 @@ const PRESETS: Record<PresetKey, { label: string; summary: string; values: Prese
       max_total_daily_cost: 300.0,
     },
   },
-}
+} satisfies Record<PresetKey, { label: string; summary: string; values: PresetValues }>
 
 const matchesPreset = (cfg: OrchestratorConfig, key: PresetKey) =>
   (Object.entries(PRESETS[key].values) as [keyof PresetValues, number][]).every(

--- a/clients/web/src/redesign/screens/settings/CostAnalyticsCard.tsx
+++ b/clients/web/src/redesign/screens/settings/CostAnalyticsCard.tsx
@@ -15,12 +15,12 @@ const RANGES: [CostTimeRange, string][] = [
   ['all', 'All'],
 ]
 
-const PRICING_LABEL: Record<CostModelRow['pricing_source'], { label: string; color: string }> = {
+const PRICING_LABEL = {
   exact: { label: 'exact', color: 'var(--ok)' },
   heuristic: { label: 'heuristic', color: 'var(--high)' },
   zero: { label: 'free', color: 'var(--med)' },
   unknown: { label: 'unknown', color: 'var(--crit)' },
-}
+} satisfies Record<CostModelRow['pricing_source'], { label: string; color: string }>
 
 const fmtTokens = (n: number) => (n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1_000 ? `${(n / 1_000).toFixed(1)}k` : String(n))
 const fmtCost = (n: number) => `$${n.toFixed(2)}`

--- a/clients/web/src/redesign/screens/settings/DetectionRulesPanel.tsx
+++ b/clients/web/src/redesign/screens/settings/DetectionRulesPanel.tsx
@@ -9,13 +9,16 @@ import { EmptyState, Field, Popup, Select, TextInput } from '../../shared/ui'
 import { useDetectionRules, type AddSourcePayload, type DetectionSource } from './useSettings'
 import type { SectionProps } from './types'
 
-const FORMAT_COLORS: Record<string, string> = {
-  sigma: '#2196f3',
-  splunk: '#4caf50',
-  elastic: '#ff9800',
-  kql: '#9c27b0',
-  auto: '#607d8b',
-}
+// Rule formats come back from the detection-rules API as free-form strings, so
+// the lookup has to admit a miss rather than claim every string has a colour.
+const FORMAT_COLORS = new Map([
+  ['sigma', '#2196f3'],
+  ['splunk', '#4caf50'],
+  ['elastic', '#ff9800'],
+  ['kql', '#9c27b0'],
+  ['auto', '#607d8b'],
+])
+const formatColor = (format: string) => FORMAT_COLORS.get(format) ?? 'var(--tx-3)'
 
 const SOURCE_TYPE_OPTIONS = [
   { value: 'git', label: 'Git Repository' },
@@ -126,7 +129,7 @@ export default function DetectionRulesPanel({ notify }: SectionProps) {
             <div className="flex gap-2 flex-wrap mt-2">
               <span className="chip" style={{ color: 'var(--accent-2)' }}>{fmtNum(stats.total_rules)} total rules</span>
               {Object.entries(stats.by_format).map(([fmt, count]) => (
-                <span key={fmt} className="chip" style={{ color: FORMAT_COLORS[fmt] || 'var(--tx-3)' }}>
+                <span key={fmt} className="chip" style={{ color: formatColor(fmt) }}>
                   {fmt}: {fmtNum(count)}
                 </span>
               ))}
@@ -165,7 +168,7 @@ export default function DetectionRulesPanel({ notify }: SectionProps) {
                 </span>
               </div>
               <div className="flex gap-2 flex-wrap">
-                <span className="chip" style={{ color: FORMAT_COLORS[s.format] || 'var(--tx-3)' }}>{s.format}</span>
+                <span className="chip" style={{ color: formatColor(s.format) }}>{s.format}</span>
                 <span className="chip">{fmtNum(s.rule_count)} rules</span>
               </div>
               {s.git_url && <div className="text-xs text-tx-3 break-all font-mono">{s.git_url}</div>}

--- a/clients/web/src/redesign/screens/settings/FederationSection.tsx
+++ b/clients/web/src/redesign/screens/settings/FederationSection.tsx
@@ -16,14 +16,17 @@ const SEVERITY_OPTIONS = [
   { value: 'critical', label: 'Critical only' },
 ]
 
-const SOURCE_LABELS: Record<string, string> = {
-  splunk: 'Splunk',
-  crowdstrike: 'CrowdStrike Falcon',
-  azure_sentinel: 'Azure Sentinel',
-  aws_security_hub: 'AWS Security Hub',
-  microsoft_defender: 'Microsoft Defender',
-  elastic: 'Elastic Security',
-}
+// Source ids come from the backend's federation config, which can carry sources
+// this list has never heard of — hence a lookup that can miss, falling back to
+// the raw id at the call site.
+const SOURCE_LABELS = new Map([
+  ['splunk', 'Splunk'],
+  ['crowdstrike', 'CrowdStrike Falcon'],
+  ['azure_sentinel', 'Azure Sentinel'],
+  ['aws_security_hub', 'AWS Security Hub'],
+  ['microsoft_defender', 'Microsoft Defender'],
+  ['elastic', 'Elastic Security'],
+])
 
 function formatRelative(iso: string | null): string {
   if (!iso) return 'never'
@@ -150,7 +153,7 @@ export default function FederationSection({ notify }: SectionProps) {
               <tr key={s.source_id}>
                 <td>
                   <div className="flex flex-col">
-                    <span>{SOURCE_LABELS[s.source_id] || s.source_id}</span>
+                    <span>{SOURCE_LABELS.get(s.source_id) ?? s.source_id}</span>
                     <span className="text-xs text-tx-3">
                       {s.source_id}
                       {!s.is_configured && ' · not configured'}

--- a/clients/web/src/redesign/screens/settings/IntegrationsSection.tsx
+++ b/clients/web/src/redesign/screens/settings/IntegrationsSection.tsx
@@ -71,7 +71,7 @@ function ServersPanel({ notify }: SectionProps) {
   const grouped = useMemo(() => {
     const q = search.toLowerCase()
     const match = (n: string) =>
-      !q || n.toLowerCase().includes(q) || (SERVER_DESCRIPTIONS[n] || '').toLowerCase().includes(q)
+      !q || n.toLowerCase().includes(q) || (SERVER_DESCRIPTIONS.get(n) ?? '').toLowerCase().includes(q)
     const claimed = new Set<string>()
     const out: { label: string; servers: string[] }[] = []
     for (const cat of MCP_CATEGORIES) {
@@ -185,7 +185,7 @@ function ServersPanel({ notify }: SectionProps) {
                   <div key={name} className="card card-sq p-3.5 flex flex-col gap-2">
                     <div className="flex items-center gap-2">
                       <span className="text-[13px] font-semibold text-tx truncate flex-1">
-                        {SERVER_DISPLAY_NAMES[name] || prettyServerName(name)}
+                        {SERVER_DISPLAY_NAMES.get(name) ?? prettyServerName(name)}
                       </span>
                       {WIP_SERVERS.has(name) && (
                         <span className="chip" style={{ color: 'var(--high)', fontSize: 10 }}>WIP</span>
@@ -224,7 +224,7 @@ function ServersPanel({ notify }: SectionProps) {
                       )}
                     </div>
                     <p className="text-xs text-tx-3 leading-snug line-clamp-2 min-h-[2rem]">
-                      {SERVER_DESCRIPTIONS[name] || integration?.description || 'Custom MCP integration.'}
+                      {SERVER_DESCRIPTIONS.get(name) || integration?.description || 'Custom MCP integration.'}
                     </p>
                     <div className="flex items-center gap-1.5 mt-auto">
                       <span style={{ width: 7, height: 7, borderRadius: '50%', background: dotColor }} />

--- a/clients/web/src/redesign/screens/settings/LlmProviderDialog.tsx
+++ b/clients/web/src/redesign/screens/settings/LlmProviderDialog.tsx
@@ -17,16 +17,16 @@ type ProviderType = 'anthropic' | 'openai' | 'ollama'
 
 const STEPS = ['Provider', 'Connection', 'Model & Save']
 
-const DEFAULT_BASE_URLS: Record<ProviderType, string> = {
+const DEFAULT_BASE_URLS = {
   anthropic: '',
   openai: 'https://api.openai.com/v1',
   ollama: 'http://localhost:11434',
-}
-const DEFAULT_MODEL: Record<ProviderType, string> = {
+} satisfies Record<ProviderType, string>
+const DEFAULT_MODEL = {
   anthropic: 'claude-sonnet-4-5-20250929',
   openai: 'gpt-4o-mini',
   ollama: 'llama3.1:8b',
-}
+} satisfies Record<ProviderType, string>
 const TYPE_OPTIONS: { value: ProviderType; label: string; desc: string }[] = [
   { value: 'ollama', label: 'Ollama', desc: 'Local or remote Ollama server' },
   { value: 'openai', label: 'OpenAI', desc: 'OpenAI or OpenAI-compatible endpoint' },

--- a/clients/web/src/redesign/screens/settings/SlaPoliciesSection.tsx
+++ b/clients/web/src/redesign/screens/settings/SlaPoliciesSection.tsx
@@ -24,12 +24,15 @@ const PRIORITIES = [
   { value: 'medium', label: 'Medium' },
   { value: 'low', label: 'Low' },
 ]
-const PRIORITY_COLOR: Record<string, string> = {
-  critical: 'var(--crit)',
-  high: 'var(--high)',
-  medium: 'var(--med)',
-  low: 'var(--ok)',
-}
+// Priorities arrive from the API as free-form strings, so the lookup has to
+// admit a miss rather than claim every string resolves to a colour.
+const PRIORITY_COLOR = new Map([
+  ['critical', 'var(--crit)'],
+  ['high', 'var(--high)'],
+  ['medium', 'var(--med)'],
+  ['low', 'var(--ok)'],
+])
+const priorityColor = (priority: string) => PRIORITY_COLOR.get(priority) ?? 'var(--tx-2)'
 
 interface FormState {
   name: string
@@ -215,7 +218,7 @@ export default function SlaPoliciesSection({ notify }: SectionProps) {
                   {p.name}
                   {p.description && <div className="text-xs text-tx-3 mt-0.5">{p.description}</div>}
                 </td>
-                <td><span className="tag" style={{ color: PRIORITY_COLOR[String(p.priority_level)] || 'var(--tx-2)' }}>{p.priority_level}</span></td>
+                <td><span className="tag" style={{ color: priorityColor(String(p.priority_level)) }}>{p.priority_level}</span></td>
                 <td className="muted">{p.response_time_hours}h</td>
                 <td className="muted">{p.resolution_time_hours}h</td>
                 <td>{p.is_default ? <span className="status closed"><Icon name="check2" size={12} /> Default</span> : <span className="muted">—</span>}</td>
@@ -242,7 +245,7 @@ export default function SlaPoliciesSection({ notify }: SectionProps) {
           <Field label="Description"><TextInput value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} /></Field>
           <Field label="Priority" hint={editing ? 'Priority level is fixed after creation.' : undefined}>
             {editing ? (
-              <span className="tag" style={{ color: PRIORITY_COLOR[form.priority_level] || 'var(--tx-2)' }}>{form.priority_level}</span>
+              <span className="tag" style={{ color: priorityColor(form.priority_level) }}>{form.priority_level}</span>
             ) : (
               <Select value={form.priority_level} options={PRIORITIES} onSelect={(v) => setForm({ ...form, priority_level: v })} />
             )}

--- a/clients/web/src/redesign/screens/settings/integrationsData.ts
+++ b/clients/web/src/redesign/screens/settings/integrationsData.ts
@@ -12,14 +12,14 @@ import type { IntegrationMetadata } from '../../../config/integrationSchema'
 export const HIDDEN_MCP_SERVERS = new Set(['mempalace', 'splunk-selfhosted'])
 
 /** MCP server name → integration metadata id (where they differ). */
-export const SERVER_TO_INTEGRATION: Record<string, string> = {
+export const SERVER_TO_INTEGRATION = new Map(Object.entries({
   'aws-security': 'aws-security-hub',
   'gcp-scc': 'gcp-security',
-}
+}))
 
 /** Resolve the credential-bearing integration metadata for an MCP server. */
 export function getIntegrationForServer(serverName: string): IntegrationMetadata | undefined {
-  const id = SERVER_TO_INTEGRATION[serverName] || serverName
+  const id = SERVER_TO_INTEGRATION.get(serverName) ?? serverName
   return getAllIntegrations().find((i) => i.id === id)
 }
 
@@ -34,11 +34,11 @@ export const WIP_SERVERS = new Set([
 /** Card-title overrides for `prettyServerName`. Fix casing/branding here rather
  *  than renaming the server id, which is load-bearing (mcp-config.json, backend
  *  registration, persisted enabled-state store). */
-export const SERVER_DISPLAY_NAMES: Record<string, string> = {
+export const SERVER_DISPLAY_NAMES = new Map(Object.entries({
   loglm: 'LogLM',
   'deeptempo-findings': 'Findings & Cases',
   'tempo-flow': 'Agent Workflows',
-}
+}))
 
 export interface McpCategory {
   label: string
@@ -61,7 +61,7 @@ export const MCP_CATEGORIES: McpCategory[] = [
   { label: 'Sandbox / Analysis', servers: ['joe-sandbox', 'hybrid-analysis', 'anyrun', 'url-analysis', 'ip-geolocation'] },
 ]
 
-export const SERVER_DESCRIPTIONS: Record<string, string> = {
+export const SERVER_DESCRIPTIONS = new Map(Object.entries({
   'deeptempo-findings': 'Core findings and case management. Required for the investigation workflow, case creation, and findings display.',
   'tempo-flow': 'Orchestrates multi-step agent workflows and playbook execution. Required for automated investigation chains.',
   approval: 'Human-in-the-loop approval queue for response actions (isolate host, block IP, etc.). Prevents the AI from taking destructive actions without analyst review.',
@@ -95,7 +95,7 @@ export const SERVER_DESCRIPTIONS: Record<string, string> = {
   anyrun: 'Interactive malware sandbox for real-time analysis with process monitoring and network capture.',
   'url-analysis': 'Analyze suspicious URLs for phishing indicators, redirects, and malicious content.',
   'ip-geolocation': 'Look up geographic location, ISP, and organization info for IP addresses during investigations.',
-}
+}))
 
 /** "aws-security" → "AWS Security" */
 export function prettyServerName(name: string): string {

--- a/clients/web/src/redesign/screens/settings/useSettings.ts
+++ b/clients/web/src/redesign/screens/settings/useSettings.ts
@@ -1190,13 +1190,12 @@ export function useDarktrace() {
   }, [reloadKey])
 
   const save = useCallback((next: DarktraceConfig) => {
-    const payload: {
-      enabled: boolean
-      url: string
-      max_body_kb: number
-      webhook_secret?: string
-    } = { enabled: next.enabled, url: next.url, max_body_kb: next.max_body_kb }
-    if (next.webhook_secret) payload.webhook_secret = next.webhook_secret
+    // Only send webhook_secret when the user actually entered one — a blank
+    // would otherwise overwrite the stored secret.
+    const base = { enabled: next.enabled, url: next.url, max_body_kb: next.max_body_kb }
+    const payload = next.webhook_secret
+      ? { ...base, webhook_secret: next.webhook_secret }
+      : base
     return configApi.setDarktrace(payload).then(() => setConfig((prev) => ({ ...prev, webhook_secret: '', configured: true })))
   }, [])
 


### PR DESCRIPTION
## Fixing AI Slop

The constant lookup tables in the settings screens were annotated `Record<string, string>` (or `Record<Union, V>`). For the string-keyed ones that annotation asserts something false — that *any* string key resolves to a value — so every call site quietly leaned on `|| fallback` to cover the `undefined` the type claimed was impossible.

Changes:

**Closed key sets** — `PRICING_LABEL`, `PRESETS`, `DEFAULT_BASE_URLS`, `DEFAULT_MODEL` — drop the annotation for `satisfies`. The key set is still checked against the union, but the literal's own inference survives instead of being discarded.

**Tables looked up with a runtime string** — `PRIORITY_COLOR`, `FORMAT_COLORS`, `SOURCE_LABELS`, `SERVER_TO_INTEGRATION`, `SERVER_DISPLAY_NAMES`, `SERVER_DESCRIPTIONS` — become `Map`s. `.get()` returns `string | undefined`, so the fallback at each call site is now something the compiler knows is required. These key domains genuinely are open: SLA priorities, detection-rule formats, federation source ids and MCP server names all arrive from the backend, not from these files.

Two small helpers (`priorityColor`, `formatColor`) put the fallback in one place rather than repeating it at each use. Separately, `useDarktrace.save` built its payload as an annotated object and then conditionally attached `webhook_secret`; it now picks between two complete objects, so the shape is inferred rather than declared.

## Behaviour

Unchanged. `||` was deliberately kept over `??` where a value can legitimately be an empty string (the integration description fallback); elsewhere the tables contain no empty strings, so the two are equivalent.