### PR TITLE
T20 · The directive inbox on the database

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -220,7 +220,8 @@ jobs:
       - name: Apply agent-layer schema
         run: |
           PGPASSWORD=test psql -h localhost -p 5432 -U test -d agent_test \
-            -f infra/database/init/19_agent_ledger.sql
+            -f infra/database/init/19_agent_ledger.sql \
+            -f infra/database/init/20_agent_directives.sql
 
       - name: Typecheck
         working-directory: services/agent

--- a/core/agents/directives.py
+++ b/core/agents/directives.py
@@ -1,0 +1,122 @@
+# Queue an operator's directive for a running agent. This is the one write Python
+# makes into agent-layer state, and it lands in agent_directives rather than
+# agent_events: enqueuing is open to any process, journaling is not. The run
+# holding the ledger is what turns a queued directive into a ledger event.
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# The vocabulary the TypeScript DIRECTIVE_KINDS declares. Duplicated across the
+# language boundary for the same reason RUN_KINDS is, and checked here so a typo
+# is a 4xx at the console rather than a directive the drain has to refuse.
+DIRECTIVE_KINDS = (
+    "note",
+    "lead",
+    "abort",
+    "extend",
+    "conclude",
+    "approve",
+    "reject",
+    "benign",
+    "gap",
+    "boost",
+)
+
+# What a directive may carry beyond its text. Anything outside this set is the
+# caller's mistake rather than something to persist and puzzle over later.
+DIRECTIVE_FIELDS = (
+    "checkpoint_id",
+    "entity_key",
+    "question_id",
+    "hypothesis_id",
+    "tenant",
+    "revoke",
+)
+
+
+class InvalidDirective(ValueError):
+    """The directive is malformed, so it is refused before it reaches the queue."""
+
+
+def new_directive_id() -> str:
+    return f"dir-{secrets.token_hex(4)}"
+
+
+def build_directive(
+    kind: str,
+    body: str,
+    actor: str,
+    fields: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    if kind not in DIRECTIVE_KINDS:
+        raise InvalidDirective(f"unknown directive kind {kind}")
+    if not actor:
+        # Attribution is the point of the record: a directive nobody owns makes
+        # the ledger unable to say who steered the run.
+        raise InvalidDirective("a directive needs an actor")
+
+    extra = fields or {}
+    unknown = sorted(set(extra) - set(DIRECTIVE_FIELDS))
+    if unknown:
+        raise InvalidDirective(f"unknown directive fields: {', '.join(unknown)}")
+
+    return {
+        "directive_id": new_directive_id(),
+        "actor": actor,
+        "kind": kind,
+        "text": body,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "origin": "inbox",
+        **{name: value for name, value in extra.items() if value is not None},
+    }
+
+
+# Idempotent on directive_id, so a retried request is not a second directive. The
+# columns are the envelope every workflow shares; the payload carries the whole
+# directive, including the fields only the workflow reads.
+def enqueue_directive(
+    session: Session,
+    run_id: str,
+    kind: str,
+    body: str,
+    actor: str,
+    fields: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    try:
+        uuid.UUID(run_id)
+    except ValueError:
+        raise InvalidDirective(f"not a run id: {run_id}") from None
+
+    directive = build_directive(kind, body, actor, fields)
+    session.execute(
+        text(
+            "INSERT INTO agent_directives "
+            "(run_id, directive_id, kind, actor, created_at, payload) "
+            "VALUES (CAST(:run_id AS uuid), :directive_id, :kind, :actor, "
+            "CAST(:created_at AS timestamptz), CAST(:payload AS jsonb)) "
+            "ON CONFLICT (directive_id) DO NOTHING"
+        ),
+        {
+            "run_id": run_id,
+            "directive_id": directive["directive_id"],
+            "kind": directive["kind"],
+            "actor": directive["actor"],
+            "created_at": directive["created_at"],
+            "payload": json.dumps(directive),
+        },
+    )
+    logger.info(
+        "queued %s directive %s for run %s", kind, directive["directive_id"], run_id
+    )
+    return directive

--- a/core/agents/directives.py
+++ b/core/agents/directives.py
@@ -49,6 +49,14 @@ class InvalidDirective(ValueError):
     """The directive is malformed, so it is refused before it reaches the queue."""
 
 
+class UnknownRun(InvalidDirective):
+    """No ledger under that run id, so nothing will ever drain the directive."""
+
+
+class RunAlreadyEnded(InvalidDirective):
+    """The run journaled its terminal event, so no drain will run again."""
+
+
 def new_directive_id() -> str:
     return f"dir-{secrets.token_hex(4)}"
 
@@ -82,6 +90,23 @@ def build_directive(
     }
 
 
+# The reads agent_runs_router already makes, in one pass: a directive is only
+# worth queueing while the run has a ledger and has not journaled its terminal.
+def _refuse_unless_running(session: Session, run_id: str) -> None:
+    row = session.execute(
+        text(
+            "SELECT count(*) AS events, "
+            "count(*) FILTER (WHERE kind = 'terminal') AS ended "
+            "FROM agent_events WHERE run_id = CAST(:run_id AS uuid)"
+        ),
+        {"run_id": run_id},
+    ).one()
+    if int(row.events) == 0:
+        raise UnknownRun(f"no such run: {run_id}")
+    if int(row.ended) > 0:
+        raise RunAlreadyEnded(f"run {run_id} has already ended")
+
+
 # Idempotent on directive_id, so a retried request is not a second directive. The
 # columns are the envelope every workflow shares; the payload carries the whole
 # directive, including the fields only the workflow reads.
@@ -97,6 +122,10 @@ def enqueue_directive(
         uuid.UUID(run_id)
     except ValueError:
         raise InvalidDirective(f"not a run id: {run_id}") from None
+
+    # A well-formed id for a run that never existed or has already ended would
+    # queue a row nothing drains, and the operator would be told it took effect.
+    _refuse_unless_running(session, run_id)
 
     directive = build_directive(kind, body, actor, fields)
     session.execute(

--- a/infra/database/init/20_agent_directives.sql
+++ b/infra/database/init/20_agent_directives.sql
@@ -1,0 +1,28 @@
+-- The operator's queue into a running agent. It sits beside agent_events rather
+-- than on it: any process may enqueue here, while the ledger keeps one writer.
+
+CREATE TABLE IF NOT EXISTS agent_directives (
+    id           bigserial   PRIMARY KEY,
+    run_id       uuid        NOT NULL,
+    directive_id text        NOT NULL UNIQUE,
+    kind         text        NOT NULL,
+    actor        text        NOT NULL,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    payload      jsonb       NOT NULL
+);
+
+COMMENT ON TABLE agent_directives IS
+    'Pending operator directives. Written by any process; drained onto agent_events by the run holding the ledger, which is what makes a directive take effect.';
+
+COMMENT ON COLUMN agent_directives.directive_id IS
+    'The directive''s identity on the ledger. Unique so a retried enqueue cannot queue the same directive twice, and so the drain can tell what it has already journaled.';
+
+COMMENT ON COLUMN agent_directives.kind IS
+    'Directive kind, validated in TypeScript against a closed union rather than constrained here, as agent_events.kind is.';
+
+COMMENT ON COLUMN agent_directives.payload IS
+    'The whole directive. The columns above are the envelope every workflow shares; everything a workflow owns its own vocabulary for stays in here, unread by the harness.';
+
+-- A drain reads one run's queue in insertion order and nothing else does.
+CREATE INDEX IF NOT EXISTS idx_agent_directives_run
+    ON agent_directives (run_id, id);

--- a/infra/helm/vigil/files/database-init/20_agent_directives.sql
+++ b/infra/helm/vigil/files/database-init/20_agent_directives.sql
@@ -1,0 +1,28 @@
+-- The operator's queue into a running agent. It sits beside agent_events rather
+-- than on it: any process may enqueue here, while the ledger keeps one writer.
+
+CREATE TABLE IF NOT EXISTS agent_directives (
+    id           bigserial   PRIMARY KEY,
+    run_id       uuid        NOT NULL,
+    directive_id text        NOT NULL UNIQUE,
+    kind         text        NOT NULL,
+    actor        text        NOT NULL,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    payload      jsonb       NOT NULL
+);
+
+COMMENT ON TABLE agent_directives IS
+    'Pending operator directives. Written by any process; drained onto agent_events by the run holding the ledger, which is what makes a directive take effect.';
+
+COMMENT ON COLUMN agent_directives.directive_id IS
+    'The directive''s identity on the ledger. Unique so a retried enqueue cannot queue the same directive twice, and so the drain can tell what it has already journaled.';
+
+COMMENT ON COLUMN agent_directives.kind IS
+    'Directive kind, validated in TypeScript against a closed union rather than constrained here, as agent_events.kind is.';
+
+COMMENT ON COLUMN agent_directives.payload IS
+    'The whole directive. The columns above are the envelope every workflow shares; everything a workflow owns its own vocabulary for stays in here, unread by the harness.';
+
+-- A drain reads one run's queue in insertion order and nothing else does.
+CREATE INDEX IF NOT EXISTS idx_agent_directives_run
+    ON agent_directives (run_id, id);

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -312,6 +312,7 @@ dbInit:
     - 17_loglm_setup.sql
     - 18_agent_decision_ids.sql
     - 19_agent_ledger.sql
+    - 20_agent_directives.sql
   resources:
     requests:
       cpu: 50m

--- a/services/agent/ledger/directives.ts
+++ b/services/agent/ledger/directives.ts
@@ -27,8 +27,8 @@ export class DirectiveRepository implements DirectiveQueue {
   }
 
   // Insertion order, because the order an operator queued two directives in is
-  // the order they meant them. Rows already on the ledger are filtered here so a
-  // long-running drain does not carry the whole queue back over the wire.
+  // the order they meant them. Excluding by id rather than by a row count is what
+  // survives a directive that commits behind one already journaled.
   async pending(runId: string, journaled: readonly string[]): Promise<Directive[]> {
     const result = await this.pool.query<{ directive_id: string; payload: Directive }>(
       `SELECT directive_id, payload FROM agent_directives

--- a/services/agent/ledger/directives.ts
+++ b/services/agent/ledger/directives.ts
@@ -1,0 +1,44 @@
+import type { Pool } from "pg";
+import type { DirectiveQueue } from "../workflows/hunt/ports.js";
+import type { Directive } from "../workflows/hunt/types.js";
+
+// The operator's queue in Postgres. It writes agent_directives and never
+// agent_events: enqueuing is open to any process, journaling is not.
+export class DirectiveRepository implements DirectiveQueue {
+  constructor(private readonly pool: Pool) {}
+
+  // Idempotent on directive_id, so a retried enqueue is not a second directive.
+  // The row carries the whole directive; the columns are the envelope a query
+  // needs to answer who steered a run and when.
+  async enqueue(runId: string, directive: Directive): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO agent_directives (run_id, directive_id, kind, actor, created_at, payload)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (directive_id) DO NOTHING`,
+      [
+        runId,
+        directive.directive_id,
+        directive.kind,
+        directive.actor,
+        directive.created_at,
+        JSON.stringify(directive),
+      ],
+    );
+  }
+
+  // Insertion order, because the order an operator queued two directives in is
+  // the order they meant them. Rows already on the ledger are filtered here so a
+  // long-running drain does not carry the whole queue back over the wire.
+  async pending(runId: string, journaled: readonly string[]): Promise<Directive[]> {
+    const result = await this.pool.query<{ directive_id: string; payload: Directive }>(
+      `SELECT directive_id, payload FROM agent_directives
+       WHERE run_id = $1 AND directive_id <> ALL($2::text[])
+       ORDER BY id`,
+      [runId, journaled],
+    );
+    // Identity comes from the column the unique constraint guards, not from the
+    // payload: a hand-written row could disagree with itself, and the drain needs
+    // an id it can exclude on the next pass.
+    return result.rows.map((row) => ({ ...row.payload, directive_id: row.directive_id }));
+  }
+}

--- a/services/agent/tests/hunt/checkpoints.test.ts
+++ b/services/agent/tests/hunt/checkpoints.test.ts
@@ -10,7 +10,7 @@ import { HuntController, HuntParked, validateDecision } from "../../workflows/hu
 import { buildDigest, scoredFrontier, suppressedEntities } from "../../workflows/hunt/digest.js";
 import { steer } from "../../workflows/hunt/inbox.js";
 import type { Journal } from "../../workflows/hunt/journal.js";
-import type { Enricher, WorkerDispatcher } from "../../workflows/hunt/ports.js";
+import type { DirectiveQueue, Enricher, WorkerDispatcher } from "../../workflows/hunt/ports.js";
 import { renderReport } from "../../workflows/hunt/report.js";
 import {
   ScriptedDecisionProvider,
@@ -119,7 +119,7 @@ describe("verdict review", () => {
       "evidence_strength"
     ] as Record<string, unknown>;
 
-    steer(started.runId, "approve", "reviewed the payloads, this holds", { checkpoint_id: checkpointId });
+    await steer(started.queue, started.runId, "approve", "reviewed the payloads, this holds", { checkpoint_id: checkpointId });
     const resumed = await reopen(started);
     await controllerFor(resumed, [INVESTIGATE]).advanceIteration();
 
@@ -139,7 +139,7 @@ describe("verdict review", () => {
     evidenceOn(started.ledger, hypothesisId, { source: "okta" });
     expect(evidenceStrength(started.ledger.projection, hypothesisId).survived_disconfirmation).toBe(false);
 
-    steer(started.runId, "approve", "reviewed the payloads, this holds", { checkpoint_id: checkpointId });
+    await steer(started.queue, started.runId, "approve", "reviewed the payloads, this holds", { checkpoint_id: checkpointId });
     const resumed = await reopen(started);
     await controllerFor(resumed, [INVESTIGATE]).advanceIteration();
 
@@ -153,9 +153,9 @@ describe("verdict review", () => {
     // A reviewer says the hunt is blind somewhere and approves in the same breath.
     // The gap they just declared must not be the one thing the approval ignores.
     for (const blind of ["no EDR on that subnet", "no CloudTrail before August", "netflow sampled at 1:100"]) {
-      steer(started.runId, "gap", blind, { hypothesis_id: hypothesisId });
+      await steer(started.queue, started.runId, "gap", blind, { hypothesis_id: hypothesisId });
     }
-    steer(started.runId, "approve", "looks right to me", { checkpoint_id: checkpointId });
+    await steer(started.queue, started.runId, "approve", "looks right to me", { checkpoint_id: checkpointId });
 
     const resumed = await reopen(started);
     await controllerFor(resumed, [INVESTIGATE]).advanceIteration();
@@ -170,7 +170,7 @@ describe("verdict review", () => {
 
   it("leaves the hypothesis active on a rejection, with the reason in the next digest", async () => {
     const { started, hypothesisId, checkpointId } = await parkedOnVerdict();
-    steer(started.runId, "reject", "the second source is the same collector under another name", {
+    await steer(started.queue, started.runId, "reject", "the second source is the same collector under another name", {
       checkpoint_id: checkpointId,
     });
 
@@ -184,8 +184,8 @@ describe("verdict review", () => {
 
   it("answers a checkpoint by id, so a stale or duplicate answer changes nothing", async () => {
     const { started, hypothesisId, checkpointId } = await parkedOnVerdict();
-    steer(started.runId, "reject", "not yet", { checkpoint_id: checkpointId });
-    steer(started.runId, "approve", "changed my mind", { checkpoint_id: checkpointId });
+    await steer(started.queue, started.runId, "reject", "not yet", { checkpoint_id: checkpointId });
+    await steer(started.queue, started.runId, "approve", "changed my mind", { checkpoint_id: checkpointId });
 
     await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
@@ -207,7 +207,7 @@ describe("verdict review", () => {
     expect(started.ledger.projection.hunt.outcome).toBeNull();
 
     const checkpointId = pendingCheckpoints(started.ledger.projection)[0]!.checkpoint_id;
-    steer(started.runId, "approve", "agreed, we are done", { checkpoint_id: checkpointId });
+    await steer(started.queue, started.runId, "approve", "agreed, we are done", { checkpoint_id: checkpointId });
     const result = await controllerFor(started.ledger, []).advanceIteration();
 
     expect(result.hunt_outcome).toBe("completed");
@@ -225,7 +225,7 @@ describe("verdict review", () => {
     await controllerFor(started.ledger, [CONCLUDE]).advanceIteration();
 
     const checkpointId = pendingCheckpoints(started.ledger.projection)[0]!.checkpoint_id;
-    steer(started.runId, "reject", "check the second host first", { checkpoint_id: checkpointId });
+    await steer(started.queue, started.runId, "reject", "check the second host first", { checkpoint_id: checkpointId });
     const result = await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
     expect(result.hunt_status).toBe("active");
@@ -243,7 +243,7 @@ describe("the start approval", () => {
     await expect(controllerFor(started.ledger, [INVESTIGATE]).advanceIteration()).rejects.toThrow(HuntParked);
 
     const checkpointId = pendingCheckpoints(started.ledger.projection)[0]!.checkpoint_id;
-    steer(started.runId, "approve", "reviewed the hypotheses", { checkpoint_id: checkpointId });
+    await steer(started.queue, started.runId, "approve", "reviewed the hypotheses", { checkpoint_id: checkpointId });
     const result = await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
     expect(result.hunt_status).toBe("active");
@@ -253,7 +253,7 @@ describe("the start approval", () => {
   it("aborts a rejected start through terminate(), so it still finalizes", async () => {
     const started = await newLedger({ checkpoints: { hypothesis_approval: "ask" } });
     const checkpointId = pendingCheckpoints(started.ledger.projection)[0]!.checkpoint_id;
-    steer(started.runId, "reject", "wrong scope, start again", { checkpoint_id: checkpointId });
+    await steer(started.queue, started.runId, "reject", "wrong scope, start again", { checkpoint_id: checkpointId });
 
     const result = await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
@@ -280,7 +280,7 @@ describe("the soft directive set", () => {
   it("binds the Hunt Lead rather than only the digest", async () => {
     const started = await newLedger();
     evidenceOn(started.ledger, started.hypothesisIds[0]!, { source: "duckdb", entities: [SEED_IP] });
-    steer(started.runId, "benign", "our own scanner", { entity_key: SEED_KEY });
+    await steer(started.queue, started.runId, "benign", "our own scanner", { entity_key: SEED_KEY });
     await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
     // Dropping it from pivot candidates only makes the lead less likely to name
@@ -318,7 +318,7 @@ describe("the soft directive set", () => {
     });
     const before = started.ledger.projection.evidence.get(evidenceId)!;
 
-    steer(started.runId, "benign", "our own scanner", { entity_key: SEED_KEY });
+    await steer(started.queue, started.runId, "benign", "our own scanner", { entity_key: SEED_KEY });
     await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
     expect([...suppressedEntities(started.ledger.projection).keys()]).toEqual([SEED_KEY]);
@@ -330,7 +330,7 @@ describe("the soft directive set", () => {
     expect(digest.entities.find((entity) => entity.value === SEED_IP.value)!.suppressed).toBe(true);
     expect(digest.notes.join(" ")).toMatch(/known-benign/);
 
-    steer(started.runId, "benign", "put it back in play", { entity_key: SEED_KEY, revoke: true });
+    await steer(started.queue, started.runId, "benign", "put it back in play", { entity_key: SEED_KEY, revoke: true });
     await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
     expect(suppressedEntities(started.ledger.projection).size).toBe(0);
@@ -347,7 +347,7 @@ describe("the soft directive set", () => {
       return [];
     };
 
-    steer(started.runId, "benign", "our own scanner", { entity_key: SEED_KEY });
+    await steer(started.queue, started.runId, "benign", "our own scanner", { entity_key: SEED_KEY });
     await controllerFor(started.ledger, [INVESTIGATE], {
       enricher,
       dispatcher: new ScriptedWorkerDispatcher([
@@ -378,7 +378,7 @@ describe("the soft directive set", () => {
     const citations = provable(started.ledger, hypothesisId);
 
     for (const text of ["no EDR on the 10.30.0.0/16 subnet", "no DNS logging before 03:00", "no proxy logs at all"]) {
-      steer(started.runId, "gap", text, { hypothesis_id: hypothesisId });
+      await steer(started.queue, started.runId, "gap", text, { hypothesis_id: hypothesisId });
     }
     await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
@@ -403,7 +403,7 @@ describe("the soft directive set", () => {
 
     expect(scoredFrontier(started.ledger.projection, 1)[0]!.question.question_id).not.toBe(buried);
 
-    steer(started.runId, "boost", "look at this one next", { question_id: buried });
+    await steer(started.queue, started.runId, "boost", "look at this one next", { question_id: buried });
     await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
     const [top] = scoredFrontier(started.ledger.projection, 2);
@@ -416,7 +416,7 @@ describe("the soft directive set", () => {
 
   it("records a premise correction as the note it already is", async () => {
     const started = await newLedger();
-    steer(started.runId, "note", "the 03:00 spike is our backup window, not exfil");
+    await steer(started.queue, started.runId, "note", "the 03:00 spike is our backup window, not exfil");
 
     const provider = new ScriptedDecisionProvider([INVESTIGATE]);
     await controllerFor(started.ledger, [], { provider }).advanceIteration();
@@ -430,11 +430,14 @@ describe("a hard abort preempts the work in flight", () => {
   // operator hitting abort mid-iteration actually looks like.
   class AbortingDispatcher implements WorkerDispatcher {
     readonly seen: string[] = [];
-    constructor(private readonly runId: string) {}
+    constructor(
+      private readonly queue: DirectiveQueue,
+      private readonly runId: string,
+    ) {}
 
     async dispatch(request: DispatchRequest): Promise<DispatchResult> {
       this.seen.push(request.focus);
-      if (this.seen.length === 1) steer(this.runId, "abort", "operator halted the hunt");
+      if (this.seen.length === 1) await steer(this.queue, this.runId, "abort", "operator halted the hunt");
       return { dispatch_id: request.dispatch_id, evidence: [], failed: false, failure_reason: "", cost_usd: 0 };
     }
   }
@@ -443,7 +446,7 @@ describe("a hard abort preempts the work in flight", () => {
     const started = await newLedger();
     for (const text of ["check 10.0.0.1", "check 10.0.0.2", "check 10.0.0.3"]) question(started.ledger, text);
 
-    const dispatcher = new AbortingDispatcher(started.runId);
+    const dispatcher = new AbortingDispatcher(started.queue, started.runId);
     await controllerFor(started.ledger, [INVESTIGATE, INVESTIGATE], { dispatcher }).advanceIteration();
 
     // One worker ran; the other two never did, and the ledger says so rather
@@ -466,7 +469,7 @@ describe("a hard abort preempts the work in flight", () => {
 describe("scope", () => {
   it("refuses a cross-tenant lead outright rather than raising a checkpoint", async () => {
     const started = await newLedger({ checkpoints: { scope_extension: "ask" }, scope: { tenant: "frothly" } });
-    steer(started.runId, "lead", "check tenant:acme for the same key");
+    await steer(started.queue, started.runId, "lead", "check tenant:acme for the same key");
 
     const result = await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
@@ -483,7 +486,7 @@ describe("scope", () => {
       checkpoints: { scope_extension: "ask" },
       scope: { tenant: "frothly", entities: ["ip:10.0.0.5"] },
     });
-    steer(started.runId, "lead", `pull on ${SEED_IP.value} as well`);
+    await steer(started.queue, started.runId, "lead", `pull on ${SEED_IP.value} as well`);
 
     await expect(controllerFor(started.ledger, [INVESTIGATE]).advanceIteration()).rejects.toThrow(HuntParked);
     const checkpoint = pendingCheckpoints(started.ledger.projection)[0]!;
@@ -491,7 +494,7 @@ describe("scope", () => {
     expect(checkpoint.question).toMatch(new RegExp(SEED_KEY.replace(/\./g, "\\.")));
     expect([...started.ledger.projection.questions.values()]).toHaveLength(0);
 
-    steer(started.runId, "approve", "yes, it is ours", { checkpoint_id: checkpoint.checkpoint_id });
+    await steer(started.queue, started.runId, "approve", "yes, it is ours", { checkpoint_id: checkpoint.checkpoint_id });
     const result = await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
     expect(result.hunt_status).toBe("active");
@@ -503,7 +506,7 @@ describe("scope", () => {
 
   it("leaves a hunt that declared no scope free of scope checkpoints", async () => {
     const started = await newLedger({ checkpoints: { scope_extension: "ask" } });
-    steer(started.runId, "lead", `check ${SEED_IP.value}`);
+    await steer(started.queue, started.runId, "lead", `check ${SEED_IP.value}`);
 
     const result = await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
@@ -521,7 +524,7 @@ describe("scope", () => {
       checkpoints: { scope_extension: "ask" },
       scope: { entity: { type: "ip", value: "10.0.0.5" } },
     });
-    steer(started.runId, "lead", `check what else ${SEED_IP.value} talked to`);
+    await steer(started.queue, started.runId, "lead", `check what else ${SEED_IP.value} talked to`);
 
     const result = await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
 
@@ -613,7 +616,7 @@ describe("the CHECKPOINT verb", () => {
     expect(checkpoint.question).toMatch(/contradicts the premise/);
     expect(checkpoint.context!["raised_by"]).toBe("hunt_lead");
 
-    steer(started.runId, "approve", "noted, keep going", { checkpoint_id: checkpoint.checkpoint_id });
+    await steer(started.queue, started.runId, "approve", "noted, keep going", { checkpoint_id: checkpoint.checkpoint_id });
     const resumed = await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
     expect(resumed.hunt_status).toBe("active");
   });
@@ -640,7 +643,7 @@ describe("the CHECKPOINT verb", () => {
 describe("the report carries the supervision", () => {
   it("names every checkpoint, who answered it, and what is still suppressed", async () => {
     const started = await newLedger({ checkpoints: { verdict_review: "auto" } });
-    steer(started.runId, "benign", "our own scanner", { entity_key: SEED_KEY });
+    await steer(started.queue, started.runId, "benign", "our own scanner", { entity_key: SEED_KEY });
     started.ledger.patch("hypothesis", started.hypothesisIds[0]!, {
       status: "parked",
       resolution_reason: "dropped",
@@ -672,7 +675,7 @@ describe("a supervised hunt end to end", () => {
     const citations = provable(started.ledger, hypothesisId);
 
     const start = pendingCheckpoints(started.ledger.projection)[0]!;
-    steer(started.runId, "approve", "hypotheses look right", { checkpoint_id: start.checkpoint_id });
+    await steer(started.queue, started.runId, "approve", "hypotheses look right", { checkpoint_id: start.checkpoint_id });
 
     const decisions: ScriptedDecision[] = [
       validate(hypothesisId, citations),
@@ -694,14 +697,14 @@ describe("a supervised hunt end to end", () => {
     current = await reopen(started, current);
     const review = pendingCheckpoints(current.projection)[0]!;
     expect(review.checkpoint_class).toBe("verdict_review");
-    steer(started.runId, "approve", "checked the payloads", { checkpoint_id: review.checkpoint_id });
+    await steer(started.queue, started.runId, "approve", "checked the payloads", { checkpoint_id: review.checkpoint_id });
 
     expect((await leg(decisions.slice(1))).result.note).toMatch(/handed off to incident response/);
     expect((await leg(decisions.slice(2))).result.hunt_status).toBe("parked");
 
     current = await reopen(started, current);
     const final = pendingCheckpoints(current.projection)[0]!;
-    steer(started.runId, "approve", "ship it", { checkpoint_id: final.checkpoint_id });
+    await steer(started.queue, started.runId, "approve", "ship it", { checkpoint_id: final.checkpoint_id });
 
     expect((await leg([])).result.hunt_outcome).toBe("completed");
     const replayed = (await reopen(started, current)).projection;

--- a/services/agent/tests/hunt/loop.test.ts
+++ b/services/agent/tests/hunt/loop.test.ts
@@ -23,19 +23,19 @@ import { CONCLUDE, controllerFor, INVESTIGATE, newLedger, question } from "../su
 
 describe("ledger", () => {
   it("appends without rewriting, and reads back the same projection", async () => {
-    const { ledger, state, runId } = await newLedger();
-    const before = (await Journal.open(state, runId)).log.map((event) => [event.seq, event.kind]);
+    const { ledger, state, queue, runId } = await newLedger();
+    const before = (await Journal.open(state, queue, runId)).log.map((event) => [event.seq, event.kind]);
     question(ledger, "which host?");
     await ledger.flush();
 
     // Append-only: the prefix the earlier events occupied is untouched, and the
     // new event is appended past it rather than rewriting anything.
-    const after = (await Journal.open(state, runId)).log.map((event) => [event.seq, event.kind]);
+    const after = (await Journal.open(state, queue, runId)).log.map((event) => [event.seq, event.kind]);
     expect(after.slice(0, before.length)).toEqual(before);
     expect(after.length).toBe(before.length + 1);
 
     expect(ledger.projection.questions.size).toBe(1);
-    expect((await Journal.open(state, runId)).projection).toEqual(ledger.projection);
+    expect((await Journal.open(state, queue, runId)).projection).toEqual(ledger.projection);
   });
 
   it("applies patches to the projection", async () => {
@@ -61,8 +61,8 @@ describe("controller", () => {
   });
 
   it("coerces unresolved hypotheses to inconclusive, never disproven", async () => {
-    const { ledger, runId } = await newLedger({ hypotheses: ["h one", "h two"] });
-    steer(runId, "abort", "operator halted the hunt");
+    const { ledger, queue, runId } = await newLedger({ hypotheses: ["h one", "h two"] });
+    await steer(queue, runId, "abort", "operator halted the hunt");
     await controllerFor(ledger, [CONCLUDE]).advanceIteration();
 
     const statuses = [...ledger.projection.hypotheses.values()].map((h) => h.status);

--- a/services/agent/tests/hunt/termination.test.ts
+++ b/services/agent/tests/hunt/termination.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../workflows/hunt/config.js";
 import { HuntParked } from "../../workflows/hunt/controller.js";
 import { steer } from "../../workflows/hunt/inbox.js";
+import type { DirectiveQueue } from "../../workflows/hunt/ports.js";
 import { ScriptedDecisionProvider } from "../../workflows/hunt/scripted.js";
 import type { Journal } from "../../workflows/hunt/journal.js";
 import { buildReport, renderReport } from "../../workflows/hunt/report.js";
@@ -192,8 +193,8 @@ describe("the budget checkpoint", () => {
   });
 
   it("un-parks on an extend that grants headroom", async () => {
-    const { ledger, runId } = await parkedHunt();
-    steer(runId, "extend", "+3 iterations");
+    const { ledger, queue, runId } = await parkedHunt();
+    await steer(queue, runId, "extend", "+3 iterations");
 
     const result = await controllerFor(ledger, [INVESTIGATE]).advanceIteration();
 
@@ -203,8 +204,8 @@ describe("the budget checkpoint", () => {
   });
 
   it("clamps an extend to the hard ceiling and says that it clamped", async () => {
-    const { ledger, runId } = await parkedHunt({ termination: { hard_max_calls: 3, hard_max_cost_usd: 12 } });
-    steer(runId, "extend", "+50 iterations and $500");
+    const { ledger, queue, runId } = await parkedHunt({ termination: { hard_max_calls: 3, hard_max_cost_usd: 12 } });
+    await steer(queue, runId, "extend", "+50 iterations and $500");
 
     await controllerFor(ledger, [INVESTIGATE]).advanceIteration();
 
@@ -216,16 +217,16 @@ describe("the budget checkpoint", () => {
   });
 
   it("stays parked when the clamp leaves no room to run", async () => {
-    const { ledger, runId } = await parkedHunt({ termination: { hard_max_calls: 1, hard_max_cost_usd: 10 } });
-    steer(runId, "extend", "+5 iterations");
+    const { ledger, queue, runId } = await parkedHunt({ termination: { hard_max_calls: 1, hard_max_cost_usd: 10 } });
+    await steer(queue, runId, "extend", "+5 iterations");
 
     await expect(controllerFor(ledger, [INVESTIGATE]).advanceIteration()).rejects.toThrow(HuntParked);
     expect(ledger.projection.directives.map((directive) => directive.text).join(" ")).toMatch(/stays parked/);
   });
 
   it("keeps the hunt parked when the grant cannot be read", async () => {
-    const { ledger, runId } = await parkedHunt();
-    steer(runId, "extend", "give it a bit more room");
+    const { ledger, queue, runId } = await parkedHunt();
+    await steer(queue, runId, "extend", "give it a bit more room");
 
     await expect(controllerFor(ledger, [INVESTIGATE]).advanceIteration()).rejects.toThrow(HuntParked);
     expect(ledger.projection.hunt.budgets.max_calls).toBe(1);
@@ -233,8 +234,8 @@ describe("the budget checkpoint", () => {
   });
 
   it("ends budget_terminated when the operator accepts the stop", async () => {
-    const { ledger, runId, hypothesisIds } = await parkedHunt();
-    steer(runId, "conclude", "we are done spending on this");
+    const { ledger, queue, runId, hypothesisIds } = await parkedHunt();
+    await steer(queue, runId, "conclude", "we are done spending on this");
 
     // Not completed: the predicate never passed, the money ran out.
     expect((await controllerFor(ledger, []).advanceIteration()).hunt_outcome).toBe("budget_terminated");
@@ -242,8 +243,8 @@ describe("the budget checkpoint", () => {
   });
 
   it("aborts from parked, not just from active", async () => {
-    const { ledger, runId } = await parkedHunt();
-    steer(runId, "abort", "operator halted the hunt");
+    const { ledger, queue, runId } = await parkedHunt();
+    await steer(queue, runId, "abort", "operator halted the hunt");
 
     expect((await controllerFor(ledger, []).advanceIteration()).hunt_outcome).toBe("aborted");
   });
@@ -310,7 +311,7 @@ describe("outcome precedence and coercion", () => {
 });
 
 describe("Finalize runs on every terminal path", () => {
-  const DRIVERS: [string, (ledger: Journal, ids: string[], runId: string) => Promise<void>][] = [
+  const DRIVERS: [string, (ledger: Journal, ids: string[], runId: string, queue: DirectiveQueue) => Promise<void>][] = [
     [
       "completed",
       async (ledger, ids) => {
@@ -327,15 +328,15 @@ describe("Finalize runs on every terminal path", () => {
     ],
     [
       "budget_terminated",
-      async (ledger, _ids, runId) => {
-        steer(runId, "conclude", "accepted");
+      async (ledger, _ids, runId, queue) => {
+        await steer(queue, runId, "conclude", "accepted");
         await controllerFor(ledger, []).advanceIteration();
       },
     ],
     [
       "aborted",
-      async (ledger, _ids, runId) => {
-        steer(runId, "abort", "halted");
+      async (ledger, _ids, runId, queue) => {
+        await steer(queue, runId, "abort", "halted");
         await controllerFor(ledger, []).advanceIteration();
       },
     ],
@@ -346,7 +347,7 @@ describe("Finalize runs on every terminal path", () => {
     if (outcome === "budget_terminated") {
       await controllerFor(started.ledger, [INVESTIGATE]).advanceIteration();
     }
-    await drive(started.ledger, started.hypothesisIds, started.runId);
+    await drive(started.ledger, started.hypothesisIds, started.runId, started.queue);
 
     expect(started.ledger.projection.hunt.outcome).toBe(outcome);
 
@@ -365,14 +366,14 @@ describe("Finalize runs on every terminal path", () => {
   });
 
   it("rebuilds the same report from the ledger alone", async () => {
-    const { ledger, state, runId, hypothesisIds } = await newLedger();
+    const { ledger, state, queue, runId, hypothesisIds } = await newLedger();
     await gapLock(ledger, hypothesisIds[0]!);
     await controllerFor(ledger, [CONCLUDE]).advanceIteration();
     await ledger.flush();
 
     // Replay-derived, so it works on any ledger rather than only on the writer's.
     const { Journal } = await import("../../workflows/hunt/journal.js");
-    const rebuilt = buildReport((await Journal.open(state, runId)).projection);
+    const rebuilt = buildReport((await Journal.open(state, queue, runId)).projection);
     expect(rebuilt).toEqual(finalized(ledger)[0]);
   });
 

--- a/services/agent/tests/integration/directives.test.ts
+++ b/services/agent/tests/integration/directives.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import pg from "pg";
+import { randomUUID } from "node:crypto";
+import { DirectiveRepository } from "../../ledger/directives.js";
+import { LedgerRepository } from "../../ledger/repository.js";
+import { drain, steer } from "../../workflows/hunt/inbox.js";
+import { Journal } from "../../workflows/hunt/journal.js";
+import type { HuntKinds } from "../../workflows/hunt/ledger.js";
+import type { HuntState } from "../../workflows/hunt/types.js";
+
+const connectionString = process.env["DATABASE_URL"] ?? "postgres://vigil:vigil@localhost:55432/vigil_test";
+
+// Two pools rather than one: the point of moving the inbox off a file is that the
+// process holding the run is not the process the operator talks to.
+const runPool = new pg.Pool({ connectionString });
+const consolePool = new pg.Pool({ connectionString });
+
+const state = new LedgerRepository<HuntKinds>(runPool);
+const held = new DirectiveRepository(runPool);
+const elsewhere = new DirectiveRepository(consolePool);
+
+afterAll(async () => {
+  await runPool.end();
+  await consolePool.end();
+});
+
+let runId: string;
+beforeEach(() => {
+  runId = randomUUID();
+});
+
+function huntState(): HuntState {
+  return {
+    hunt_id: `hunt-${runId.slice(0, 8)}`,
+    name: "a hunt with an operator watching",
+    spec: { name: "test" } as HuntState["spec"],
+    seed: runId,
+    status: "active",
+    outcome: null,
+    iteration: 0,
+    cost_usd: 0,
+    budgets: { max_calls: 4, max_cost_usd: 10, max_wall_ms: 600_000 },
+    scope: null,
+    narrative: null,
+    created_at: new Date().toISOString(),
+    terminated_at: null,
+    parked_at: null,
+    parked_reason: null,
+  } as unknown as HuntState;
+}
+
+describe("a directive crosses a process boundary to reach its run", () => {
+  it("reaches the run when it was queued from another connection entirely", async () => {
+    const ledger = await Journal.create(state, held, runId, huntState());
+
+    // The operator's side: a different pool, holding no ledger, knowing only the
+    // run id — which is all a console request carries.
+    await steer(elsewhere, runId, "note", "the 03:00 spike is our backup window");
+
+    const taken = await drain(ledger);
+    await ledger.flush();
+
+    expect(taken.map((directive) => directive.text)).toEqual(["the 03:00 spike is our backup window"]);
+    // On the ledger, which is the only thing that makes it true.
+    const reopened = await Journal.open(state, held, runId);
+    expect(reopened.projection.directives.map((directive) => directive.text)).toEqual([
+      "the 03:00 spike is our backup window",
+    ]);
+  });
+
+  it("re-runs a drain that was interrupted before it flushed, without duplicating", async () => {
+    const ledger = await Journal.create(state, held, runId, huntState());
+    await steer(elsewhere, runId, "note", "first");
+    await steer(elsewhere, runId, "note", "second");
+
+    // Drained but never flushed: the process died between the two, which is the
+    // case the queue must not have consumed anything for.
+    await drain(ledger);
+
+    const resumed = await Journal.open(state, held, runId);
+    expect(resumed.projection.directives).toHaveLength(0);
+
+    const taken = await drain(resumed);
+    await resumed.flush();
+    expect(taken.map((directive) => directive.text)).toEqual(["first", "second"]);
+
+    // And a second drain after a successful one takes nothing rather than the lot
+    // again: what the ledger holds is what the queue excludes.
+    const again = await Journal.open(state, held, runId);
+    expect(await drain(again)).toHaveLength(0);
+    expect(again.projection.directives).toHaveLength(2);
+  });
+
+  // Postgres hands out an id at INSERT but reveals the row at COMMIT, so a
+  // directive can appear *behind* one already journaled. Counting what the ledger
+  // holds and skipping that many rows would re-journal the later directive and
+  // never journal this one — which for an abort or an extend loses the operator's
+  // instruction outright.
+  it("journals a directive that only became visible after a later one", async () => {
+    const ledger = await Journal.create(state, held, runId, huntState());
+
+    const slow = await consolePool.connect();
+    try {
+      await slow.query("BEGIN");
+      await slow.query(
+        `INSERT INTO agent_directives (run_id, directive_id, kind, actor, created_at, payload)
+         VALUES ($1, $2, $3, $4, now(), $5)`,
+        [
+          runId,
+          `dir-slow-${runId.slice(0, 8)}`,
+          "note",
+          "analyst",
+          JSON.stringify({
+            directive_id: `dir-slow-${runId.slice(0, 8)}`,
+            actor: "analyst",
+            kind: "note",
+            text: "queued first, committed last",
+            created_at: new Date().toISOString(),
+            origin: "inbox",
+          }),
+        ],
+      );
+
+      // Queued second, committed first, so it holds the higher id.
+      await steer(elsewhere, runId, "note", "queued second, committed first");
+
+      const first = await drain(ledger);
+      await ledger.flush();
+      expect(first.map((directive) => directive.text)).toEqual(["queued second, committed first"]);
+
+      await slow.query("COMMIT");
+    } finally {
+      slow.release();
+    }
+
+    const resumed = await Journal.open(state, held, runId);
+    const late = await drain(resumed);
+    await resumed.flush();
+
+    expect(late.map((directive) => directive.text)).toEqual(["queued first, committed last"]);
+    expect(resumed.projection.directives.map((directive) => directive.text)).toEqual([
+      "queued second, committed first",
+      "queued first, committed last",
+    ]);
+  });
+});

--- a/services/agent/tests/support/hunt.ts
+++ b/services/agent/tests/support/hunt.ts
@@ -12,6 +12,7 @@ import {
   type Verdicts,
 } from "../../workflows/hunt/config.js";
 import { HuntController, startHunt } from "../../workflows/hunt/controller.js";
+import { InProcessDirectiveQueue } from "../../workflows/hunt/directives.js";
 import { Journal, type HuntEvent, type HuntKinds } from "../../workflows/hunt/journal.js";
 import { newId } from "../../workflows/hunt/ids.js";
 import type { Enricher, WorkerDispatcher } from "../../workflows/hunt/ports.js";
@@ -78,22 +79,25 @@ export function huntSpecFor(overrides: SpecOverrides = {}): HuntSpec {
 export interface Started {
   ledger: Journal;
   state: InProcessState<HuntKinds>;
+  queue: InProcessDirectiveQueue;
   runId: string;
   hypothesisIds: string[];
 }
 
 export async function newLedger(overrides: SpecOverrides = {}): Promise<Started> {
   const state = new InProcessState<HuntKinds>();
+  const queue = new InProcessDirectiveQueue();
   const runId = newId("run");
-  const ledger = await startHunt(state, runId, huntSpecFor(overrides));
-  return { ledger, state, runId, hypothesisIds: [...ledger.projection.hypotheses.keys()] };
+  const ledger = await startHunt(state, queue, runId, huntSpecFor(overrides));
+  return { ledger, state, queue, runId, hypothesisIds: [...ledger.projection.hypotheses.keys()] };
 }
 
 // What an operator answering a checkpoint hours later does: nothing of the
-// writing process carries over, the ledger is the whole state.
+// writing process carries over, the ledger is the whole state — and the queue is
+// re-read, so a directive queued while nobody held the ledger is still waiting.
 export async function reopen(started: Started, from?: Journal): Promise<Journal> {
   await (from ?? started.ledger).flush();
-  return Journal.open(started.state, started.runId);
+  return Journal.open(started.state, started.queue, started.runId);
 }
 
 export interface ControllerOptions {

--- a/services/agent/workflows/hunt/actor.ts
+++ b/services/agent/workflows/hunt/actor.ts
@@ -1,0 +1,8 @@
+import { userInfo } from "node:os";
+
+// Who this process is, for attribution. Its own module because both the inbox and
+// the lease need it and neither is about the other: a directive records who
+// steered a run, a lease records who holds it.
+export function actorName(): string {
+  return process.env["VIGIL_ACTOR"] || userInfo().username;
+}

--- a/services/agent/workflows/hunt/controller.ts
+++ b/services/agent/workflows/hunt/controller.ts
@@ -1350,8 +1350,14 @@ export class HuntController {
 
   // Only what an operator queued and the drain has not taken yet: a halt already
   // on the ledger has ended the hunt, and a controller note is not an abort.
+  // A queue that cannot be reached reads as no abort rather than throwing: the
+  // check runs on a timer nothing awaits, and the next drain asks again anyway.
   private async abortQueued(): Promise<boolean> {
-    return (await peek(this.ledger)).some((directive) => directive.kind === "abort");
+    try {
+      return (await peek(this.ledger)).some((directive) => directive.kind === "abort");
+    } catch {
+      return false;
+    }
   }
 
   // The only call that can lead to proven. Runs before anything is written, so

--- a/services/agent/workflows/hunt/controller.ts
+++ b/services/agent/workflows/hunt/controller.ts
@@ -18,7 +18,13 @@ import { buildDigest, focusOf, rankFrontier, suppressedEntities } from "./digest
 import { buildEntityGraph, entitiesOf, fromText, key } from "./entities.js";
 import { drain, grantOf, journalNote, peek } from "./inbox.js";
 import { Journal, type Projection } from "./journal.js";
-import type { DecisionProvider, DisconfirmationCritic, Enricher, WorkerDispatcher } from "./ports.js";
+import type {
+  DecisionProvider,
+  DirectiveQueue,
+  DisconfirmationCritic,
+  Enricher,
+  WorkerDispatcher,
+} from "./ports.js";
 import { buildReport, caseFilePath, renderCaseFile, renderReport, reportPath } from "./report.js";
 import { sanitize, sanitizeQuestion } from "./sanitize.js";
 import {
@@ -276,11 +282,16 @@ function withRejection(digest: Digest, reason: string): Digest {
   };
 }
 
-export async function startHunt(state: State<HuntKinds>, runId: string, spec: HuntSpec): Promise<Journal> {
+export async function startHunt(
+  state: State<HuntKinds>,
+  queue: DirectiveQueue,
+  runId: string,
+  spec: HuntSpec,
+): Promise<Journal> {
   const now = new Date().toISOString();
   const huntId = newId("hunt");
   const policy = (spec.checkpoints ?? DEFAULT_CHECKPOINTS).hypothesis_approval;
-  const ledger = await Journal.create(state, runId, {
+  const ledger = await Journal.create(state, queue, runId, {
     hunt_id: huntId,
     name: spec.name,
     spec,
@@ -359,8 +370,12 @@ export async function startHunt(state: State<HuntKinds>, runId: string, spec: Hu
 
 // The ledger is the resume point: the spec came with it, so nothing is re-read
 // from disk and a mid-run edit to an arch file cannot change a hunt in flight.
-export async function resumeHunt(state: State<HuntKinds>, runId: string): Promise<{ ledger: Journal; spec: HuntSpec }> {
-  const ledger = await Journal.open(state, runId);
+export async function resumeHunt(
+  state: State<HuntKinds>,
+  queue: DirectiveQueue,
+  runId: string,
+): Promise<{ ledger: Journal; spec: HuntSpec }> {
+  const ledger = await Journal.open(state, queue, runId);
   const { hunt } = ledger.projection;
   if (hunt.status === "terminal") throw new HuntAlreadyTerminal(`${hunt.hunt_id} already ended as ${hunt.outcome}`);
   return { ledger, spec: hunt.spec };
@@ -429,7 +444,7 @@ export class HuntController {
 
     // Human input is integrated at the boundary, before anything is decided on
     // it — and it is how a parked hunt is resolved, so it is drained first.
-    if (this.applyDirectives()) return this.halted();
+    if (await this.applyDirectives()) return this.halted();
 
     const suspended = this.ledger.projection.hunt;
     if (suspended.status === "parked" || suspended.status === "pending_approval") {
@@ -586,13 +601,13 @@ export class HuntController {
 
   // Returns true when the hunt ended here. A lead becomes a real lead; a note
   // only reaches the digest, so it steers without mutating anything; extend and
-  private applyDirectives(): boolean {
+  private async applyDirectives(): Promise<boolean> {
     let abort = false;
     let conclude = false;
 
     // Everything pending is journaled by the drain before any of it is applied,
     // so an operator's input is on the record even when an earlier directive in
-    for (const directive of drain(this.ledger)) {
+    for (const directive of await drain(this.ledger)) {
       if (this.ledger.projection.hunt.status === "terminal") break;
       switch (directive.kind) {
         case "abort":
@@ -1270,8 +1285,20 @@ export class HuntController {
     // One signal for the iteration, cancelled the moment an abort appears in the
     // inbox: a worker that has not started is skipped, and one already running is
     const halt = new AbortController();
+    // The check is a query now, so a slow one must not stack ticks behind it: at
+    // most one is in flight, and a tick that arrives while it is still running is
+    // dropped rather than queued.
+    let checking = false;
     const poll = setInterval(() => {
-      if (this.abortQueued()) halt.abort(new Error(CANCELLED_ON_ABORT));
+      if (checking) return;
+      checking = true;
+      void this.abortQueued()
+        .then((queued) => {
+          if (queued) halt.abort(new Error(CANCELLED_ON_ABORT));
+        })
+        .finally(() => {
+          checking = false;
+        });
     }, ABORT_POLL_MS);
     // The timer must not be what keeps the process alive once the work is done.
     poll.unref?.();
@@ -1281,7 +1308,7 @@ export class HuntController {
     const started: Promise<DispatchResult>[] = [];
     try {
       for (const request of requests) {
-        if (halt.signal.aborted || this.abortQueued()) {
+        if (halt.signal.aborted || (await this.abortQueued())) {
           started.push(
             Promise.resolve({
               dispatch_id: request.dispatch_id,
@@ -1323,8 +1350,8 @@ export class HuntController {
 
   // Only what an operator queued and the drain has not taken yet: a halt already
   // on the ledger has ended the hunt, and a controller note is not an abort.
-  private abortQueued(): boolean {
-    return peek(this.ledger).some((directive) => directive.kind === "abort");
+  private async abortQueued(): Promise<boolean> {
+    return (await peek(this.ledger)).some((directive) => directive.kind === "abort");
   }
 
   // The only call that can lead to proven. Runs before anything is written, so

--- a/services/agent/workflows/hunt/directives.ts
+++ b/services/agent/workflows/hunt/directives.ts
@@ -1,0 +1,28 @@
+import type { DirectiveQueue } from "./ports.js";
+import type { Directive } from "./types.js";
+
+// The queue without Postgres. It reproduces rather than approximates what the
+// table guarantees — insertion order, idempotence on directive_id, and no delete
+// on read — so a caller cannot tell the two implementations apart.
+export class InProcessDirectiveQueue implements DirectiveQueue {
+  private readonly runs = new Map<string, Directive[]>();
+
+  private queue(runId: string): Directive[] {
+    const existing = this.runs.get(runId);
+    if (existing !== undefined) return existing;
+    const created: Directive[] = [];
+    this.runs.set(runId, created);
+    return created;
+  }
+
+  async enqueue(runId: string, directive: Directive): Promise<void> {
+    const queue = this.queue(runId);
+    if (queue.some((queued) => queued.directive_id === directive.directive_id)) return;
+    queue.push(structuredClone(directive));
+  }
+
+  async pending(runId: string, journaled: readonly string[]): Promise<Directive[]> {
+    const taken = new Set(journaled);
+    return structuredClone(this.queue(runId).filter((directive) => !taken.has(directive.directive_id)));
+  }
+}

--- a/services/agent/workflows/hunt/inbox.ts
+++ b/services/agent/workflows/hunt/inbox.ts
@@ -4,8 +4,8 @@ import type { Journal } from "./journal.js";
 import type { DirectiveQueue } from "./ports.js";
 import { DIRECTIVE_KINDS, type BudgetGrant, type Directive, type DirectiveKind } from "./types.js";
 
-// The controller's own voice in the directive stream. Named rather than borrowed
-// from the operator so the drain can tell the two apart.
+// The controller's own voice in the directive stream. The drain tells a queued
+// directive from a controller note by id, not by this; it is for the report.
 export const CONTROLLER_ACTOR = "controller";
 
 // The stub operator a DEV_MODE deployment attributes to, so the attribution path
@@ -129,13 +129,16 @@ export async function drain(ledger: Journal): Promise<Directive[]> {
       // Journaled under its own id, as a controller note: the operator's attempt
       // is on the record, the switch never sees a kind it cannot read, and the
       // refusal happens once rather than on every drain for the rest of the run.
+      // Their own words and the kind they asked for carry into the note, because
+      // the refusal is the only thing the record will hold of the attempt.
+      const said = typeof directive.text === "string" && directive.text.length > 0 ? ` — ${directive.text}` : "";
       ledger.append({
         kind: "directive",
         payload: {
           ...directive,
           kind: "note",
           origin: "controller",
-          text: `refused a malformed directive: ${(error as Error).message}`,
+          text: `refused a malformed ${String(directive.kind)} directive: ${(error as Error).message}${said}`,
         },
       });
       continue;

--- a/services/agent/workflows/hunt/inbox.ts
+++ b/services/agent/workflows/hunt/inbox.ts
@@ -1,10 +1,8 @@
-import { appendFileSync, readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { actorName } from "./lease.js";
+import { actorName } from "./actor.js";
 import { newId } from "./ids.js";
 import type { Journal } from "./journal.js";
-import type { BudgetGrant, Directive, DirectiveKind } from "./types.js";
+import type { DirectiveQueue } from "./ports.js";
+import { DIRECTIVE_KINDS, type BudgetGrant, type Directive, type DirectiveKind } from "./types.js";
 
 // The controller's own voice in the directive stream. Named rather than borrowed
 // from the operator so the drain can tell the two apart.
@@ -14,16 +12,14 @@ export const CONTROLLER_ACTOR = "controller";
 // is exercised with auth off rather than skipped. Read here rather than in
 export const DEV_ACTOR = "dev-admin";
 
+// Only meaningful for a directive queued from this process — a console answer
+// carries the operator its own auth resolved, and passes it explicitly.
 export function directiveActor(): string {
   if (process.env["VIGIL_ACTOR"]) return actorName();
   return process.env["DEV_MODE"] === "true" ? DEV_ACTOR : actorName();
 }
 
-// A second producer alongside the workers. Any process may append here; only the
-// lease holder drains it into the ledger, so the controller stays the sole mutator.
-export function inboxPath(runId: string): string {
-  return join(process.env["VIGIL_INBOX_DIR"] || tmpdir(), `${runId}.inbox.jsonl`);
-}
+export class InvalidDirective extends Error {}
 
 // What an extension buys, read out of the operator's own words: "+5 iterations",
 // "$10 more", "5 iterations and $2.50". Parsed once at queue time so the ledger
@@ -48,12 +44,35 @@ export type DirectiveFields = Partial<
   Pick<Directive, "actor" | "checkpoint_id" | "entity_key" | "question_id" | "hypothesis_id" | "tenant" | "revoke">
 >;
 
-export function steer(
-  ledgerPath: string,
+// The envelope, checked at the boundary another process writes across. The fields
+// a workflow owns are deliberately not checked here — the workflow validates its
+// own vocabulary, and a directive that names a checkpoint that does not exist is
+// a question for the controller, not a malformed directive.
+export function validateDirective(directive: Directive): void {
+  if (typeof directive.directive_id !== "string" || directive.directive_id.length === 0) {
+    throw new InvalidDirective("a directive with no id cannot be journaled or excluded from the next drain");
+  }
+  if (!(DIRECTIVE_KINDS as readonly string[]).includes(directive.kind)) {
+    throw new InvalidDirective(`unknown directive kind ${String(directive.kind)}`);
+  }
+  if (typeof directive.actor !== "string" || directive.actor.length === 0) {
+    throw new InvalidDirective("a directive with no actor leaves the ledger unable to say who steered the run");
+  }
+  if (typeof directive.text !== "string") {
+    throw new InvalidDirective("a directive's text is what reaches the digest, so it must be a string");
+  }
+}
+
+// Queues an operator's directive. Async because the queue is shared with every
+// other process now, and it throws rather than firing the write off unawaited: an
+// enqueue that failed must reach the operator, not vanish.
+export async function steer(
+  queue: DirectiveQueue,
+  runId: string,
   kind: DirectiveKind,
   text: string,
   fields: DirectiveFields = {},
-): Directive {
+): Promise<Directive> {
   const directive: Directive = {
     directive_id: newId("dir", 4),
     actor: directiveActor(),
@@ -64,7 +83,8 @@ export function steer(
     ...(kind === "extend" ? { grant: parseGrant(text) } : {}),
     ...fields,
   };
-  appendFileSync(inboxPath(ledgerPath), `${JSON.stringify(directive)}\n`);
+  validateDirective(directive);
+  await queue.enqueue(runId, directive);
   return directive;
 }
 
@@ -83,28 +103,54 @@ export function journalNote(ledger: Journal, text: string): Directive {
   return directive;
 }
 
-function read(path: string): Directive[] {
-  try {
-    return readFileSync(path, "utf8")
-      .split("\n")
-      .filter((line) => line.trim().length > 0)
-      .map((line) => JSON.parse(line) as Directive);
-  } catch {
-    return [];
-  }
+// Everything the ledger already holds, whoever wrote it. The controller's own
+// notes were never queued, so excluding them costs nothing and keeps this one
+// question: has this directive reached the record?
+function journaled(ledger: Journal): string[] {
+  return ledger.projection.directives.map((directive) => directive.directive_id);
 }
 
 // What the next drain would take, without taking it. The hard abort reads this
 // between dispatch settlements: an operator who hit abort mid-iteration should
-export function peek(ledger: Journal): Directive[] {
-  const recorded = ledger.projection.directives.filter((directive) => directive.origin !== "controller").length;
-  return read(inboxPath(ledger.runId)).slice(recorded);
+export async function peek(ledger: Journal): Promise<Directive[]> {
+  return ledger.queue.pending(ledger.runId, journaled(ledger));
 }
 
-// Skips what the ledger already recorded rather than truncating, so the inbox
-// stays append-only and a drain interrupted halfway simply re-runs. Only
-export function drain(ledger: Journal): Directive[] {
-  const pending = peek(ledger);
-  for (const directive of pending) ledger.append({ kind: "directive", payload: directive });
-  return pending;
+// Skips what the ledger already recorded rather than deleting from the queue, so
+// a drain interrupted halfway simply re-runs. Only the run holding the ledger
+// drains, so the controller stays the sole mutator.
+export async function drain(ledger: Journal): Promise<Directive[]> {
+  const taken: Directive[] = [];
+
+  for (const directive of await peek(ledger)) {
+    try {
+      validateDirective(directive);
+    } catch (error) {
+      // Journaled under its own id, as a controller note: the operator's attempt
+      // is on the record, the switch never sees a kind it cannot read, and the
+      // refusal happens once rather than on every drain for the rest of the run.
+      ledger.append({
+        kind: "directive",
+        payload: {
+          ...directive,
+          kind: "note",
+          origin: "controller",
+          text: `refused a malformed directive: ${(error as Error).message}`,
+        },
+      });
+      continue;
+    }
+    // Normalised on the way in, not at every read: an extend queued by a writer
+    // that does not parse prose still lands on the ledger as numbers, so what was
+    // granted reads the same whoever asked. The regex stays defined once, here.
+    const journaling =
+      directive.kind === "extend" && directive.grant === undefined
+        ? { ...directive, grant: grantOf(directive) }
+        : directive;
+
+    ledger.append({ kind: "directive", payload: journaling });
+    taken.push(journaling);
+  }
+
+  return taken;
 }

--- a/services/agent/workflows/hunt/journal.ts
+++ b/services/agent/workflows/hunt/journal.ts
@@ -3,6 +3,7 @@ import type { State } from "../../core/seams.js";
 import { fold, type HuntEvent, type HuntKinds, type Projection } from "./ledger.js";
 
 export type { HuntEvent, HuntKinds, Projection } from "./ledger.js";
+import type { DirectiveQueue } from "./ports.js";
 import type { HuntState } from "./types.js";
 
 // run_id and run_kind come from the journal, not from each call site: a caller
@@ -11,6 +12,8 @@ export type Body = Omit<NewEvent<HuntKinds>, "run_id" | "run_kind">;
 
 // The controller's ledger, backed by the State seam. append stays synchronous so
 // the decision logic reads unchanged; flush is what makes an iteration durable.
+// It carries the directive queue as well: the two stores are both scoped to this
+// run, and holding them together is what lets a drain keep its signature.
 export class Journal {
   private events: HuntEvent[] = [];
   private pending: Body[] = [];
@@ -19,19 +22,31 @@ export class Journal {
 
   private constructor(
     private readonly state: State<HuntKinds>,
+    readonly queue: DirectiveQueue,
     readonly runId: string,
     private readonly runKind: RunKind,
   ) {}
 
-  static async open(state: State<HuntKinds>, runId: string, runKind: RunKind = "hunt"): Promise<Journal> {
-    const journal = new Journal(state, runId, runKind);
+  static async open(
+    state: State<HuntKinds>,
+    queue: DirectiveQueue,
+    runId: string,
+    runKind: RunKind = "hunt",
+  ): Promise<Journal> {
+    const journal = new Journal(state, queue, runId, runKind);
     journal.events = await state.read(runId);
     journal.written = journal.events.length;
     return journal;
   }
 
-  static async create(state: State<HuntKinds>, runId: string, hunt: HuntState, runKind: RunKind = "hunt"): Promise<Journal> {
-    const journal = new Journal(state, runId, runKind);
+  static async create(
+    state: State<HuntKinds>,
+    queue: DirectiveQueue,
+    runId: string,
+    hunt: HuntState,
+    runKind: RunKind = "hunt",
+  ): Promise<Journal> {
+    const journal = new Journal(state, queue, runId, runKind);
     journal.append({ kind: "run", payload: { hunt } } as unknown as Body);
     await journal.flush();
     return journal;

--- a/services/agent/workflows/hunt/lease.ts
+++ b/services/agent/workflows/hunt/lease.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { hostname, userInfo } from "node:os";
+import { hostname } from "node:os";
+import { actorName } from "./actor.js";
 
 export const DEFAULT_LEASE_TTL_MS = 600_000;
 
@@ -12,10 +13,6 @@ interface LeaseFile {
   pid: number;
   acquired_at: string;
   expires_at: string;
-}
-
-export function actorName(): string {
-  return process.env["VIGIL_ACTOR"] || userInfo().username;
 }
 
 function leasePath(ledgerPath: string): string {

--- a/services/agent/workflows/hunt/ports.ts
+++ b/services/agent/workflows/hunt/ports.ts
@@ -1,6 +1,7 @@
 import type {
   Digest,
   DecisionResult,
+  Directive,
   DispatchRequest,
   DispatchResult,
   Entity,
@@ -8,6 +9,16 @@ import type {
   NullCheckResult,
   WorkerEvidence,
 } from "./types.js";
+
+// Where a directive waits before the run takes it. Any process may enqueue; the
+// run holding the ledger is the only one that drains, so this stays a store and
+// never decides anything. It does not delete on read — what has been journaled
+// is a fact about the ledger, so the caller passes it in rather than the queue
+// tracking it.
+export interface DirectiveQueue {
+  enqueue(runId: string, directive: Directive): Promise<void>;
+  pending(runId: string, journaled: readonly string[]): Promise<Directive[]>;
+}
 
 // The Hunt Lead: one digest in, exactly one typed decision out. Implementations
 // never touch the ledger — the controller applies, validates, and persists.

--- a/services/agent/workflows/hunt/types.ts
+++ b/services/agent/workflows/hunt/types.ts
@@ -117,17 +117,22 @@ export interface Entity {
 
 // Human input, and the one thing in the ledger that is direction rather than
 // data. Applied by the controller at an iteration boundary, never written as state.
-export type DirectiveKind =
-  | "note"
-  | "lead"
-  | "abort"
-  | "extend"
-  | "conclude"
-  | "approve"
-  | "reject"
-  | "benign"
-  | "gap"
-  | "boost";
+// An array rather than a bare union because another process queues these now, so
+// the vocabulary has to be checkable at runtime and not only by the compiler.
+export const DIRECTIVE_KINDS = [
+  "note",
+  "lead",
+  "abort",
+  "extend",
+  "conclude",
+  "approve",
+  "reject",
+  "benign",
+  "gap",
+  "boost",
+] as const;
+
+export type DirectiveKind = (typeof DIRECTIVE_KINDS)[number];
 
 // What an extend buys. Parsed from the operator's text when the directive is
 // queued, so the ledger records the ask as numbers rather than prose the drain

--- a/services/agent/workflows/hunt/types.ts
+++ b/services/agent/workflows/hunt/types.ts
@@ -163,7 +163,8 @@ export interface Directive {
   // everything else — the suppression it undoes stays on the record.
   revoke?: boolean;
   // Set on the notes the controller journals itself (a refused CONCLUDE, a
-  // clamped extension). The inbox drain counts only what the operator wrote, so
+  // clamped extension), so the report can say whose voice a line is. The drain
+  // excludes by id and never reads this.
   origin?: "inbox" | "controller";
 }
 

--- a/tests/unit/agents/test_agent_directives.py
+++ b/tests/unit/agents/test_agent_directives.py
@@ -1,0 +1,74 @@
+"""The directive envelope Python writes is the one TypeScript reads back (GH #646)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from core.agents.directives import (  # noqa: E402
+    DIRECTIVE_KINDS,
+    InvalidDirective,
+    build_directive,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_carries_the_envelope_the_drain_reads():
+    directive = build_directive(
+        "note", "the 03:00 spike is our backup window", "analyst@example.com"
+    )
+
+    # Every field the TypeScript Directive requires, and origin marking it as an
+    # operator's rather than the controller's own voice.
+    assert set(directive) == {
+        "directive_id",
+        "actor",
+        "kind",
+        "text",
+        "created_at",
+        "origin",
+    }
+    assert directive["directive_id"].startswith("dir-")
+    assert directive["origin"] == "inbox"
+    assert directive["actor"] == "analyst@example.com"
+
+
+def test_refuses_a_kind_the_drain_could_not_apply():
+    with pytest.raises(InvalidDirective, match="unknown directive kind aprove"):
+        build_directive("aprove", "looks right", "analyst")
+
+
+def test_refuses_a_directive_nobody_owns():
+    # The ledger's job is to say who steered a run; an unattributed directive
+    # defeats that, so it is refused here rather than journaled.
+    with pytest.raises(InvalidDirective, match="needs an actor"):
+        build_directive("note", "someone said something", "")
+
+
+def test_refuses_a_field_the_workflow_never_reads():
+    with pytest.raises(InvalidDirective, match="unknown directive fields: checkpoint"):
+        build_directive("approve", "yes", "analyst", {"checkpoint": "chk-1"})
+
+
+def test_carries_the_fields_a_workflow_owns():
+    directive = build_directive(
+        "approve", "reviewed", "analyst", {"checkpoint_id": "chk-h1"}
+    )
+    assert directive["checkpoint_id"] == "chk-h1"
+
+
+def test_kinds_match_the_typescript_vocabulary():
+    """DIRECTIVE_KINDS is declared in two languages, so drift is the failure mode."""
+    declared = (
+        REPO / "services" / "agent" / "workflows" / "hunt" / "types.ts"
+    ).read_text()
+    block = declared.split("export const DIRECTIVE_KINDS = [")[1].split("]")[0]
+    assert sorted(DIRECTIVE_KINDS) == sorted(
+        line.strip().strip(',"') for line in block.strip().splitlines()
+    )


### PR DESCRIPTION
Closes #646.

`workflows/hunt/inbox.ts` queued directives through a local JSONL file under `tmpdir()`. A Python API handler in another process — or another container — had no way to write to it, which is what blocks #634: a console answer cannot reach the run it is answering.

The queue moves onto Postgres, beside the ledger rather than on it. Any process may enqueue; only the run holding the ledger drains. `agent_directives` is a new table with its own unique `directive_id`, so a retried enqueue is not a second directive.

## What changed

- **`DirectiveQueue` port** with two implementations: `DirectiveRepository` over `pg`, and `InProcessDirectiveQueue` for tests. The in-process one reproduces rather than approximates the table — insertion order, idempotence on `directive_id`, no delete on read.
- **The drain excludes by id, not by count.** `peek()` used to skip the first N rows, where N was the number of non-controller directives on the ledger. Postgres hands out an id at INSERT but reveals the row at COMMIT, so a directive can appear *behind* one already journaled — counting would re-journal the later one and never journal the earlier. For an abort or an extend that loses the operator's instruction outright. There is a test that opens a second connection and holds a transaction open to prove it.
- **`DIRECTIVE_KINDS` is an array, not a bare union**, because another process queues these now and the vocabulary has to be checkable at runtime. `validateDirective` checks the envelope at the boundary; a directive that fails is journaled as a refusal note under its own id, so the refusal happens once rather than on every drain.
- **`core/agents/directives.py`** is the one write Python makes into agent-layer state. It refuses an unknown kind, an unknown field, an unattributed directive, and a run that does not exist or has already ended.
- **`20_agent_directives.sql`**, in the chart bundle and in `dbInit.sqlFiles`, and applied by the agent-layer CI job.

## Review fixes in `c26017e`

- The abort check reaches Postgres now. The poller's rejection went unhandled, which under Node 20 takes the worker process down with every run on it, and the awaited check before each dispatch turned a momentary query error into an abandoned iteration. A queue that cannot be reached now reads as no abort.
- `enqueue_directive` validated the shape of a run id and nothing else, so a directive for a run that never existed or had already ended was written, reported as queued, and never drained.
- A refused directive kept only the refusal message, dropping the operator's own words and the kind they asked for.

## Acceptance criteria

- [x] A directive enqueued from a different process reaches the run
- [x] A drain interrupted halfway re-runs without duplicating directives
- [x] Only the lease holder writes directive events to the ledger
- [x] `steer()` keeps its shape — the ported tests gained `await` and the queue, nothing else
- [x] The file-backed path is deleted, not left as a fallback

## Verification

`tsc --noEmit` clean; 314 agent tests pass; 29 Python agent tests pass; `black`/`flake8`/`isort` clean. `helm template | grep apply` confirms `20_agent_directives.sql` runs in order, and the chart-bundle copy is byte-identical to `infra/database/init/`.

The integration tests under `services/agent/tests/integration/` need Postgres; CI's agent job provides it and applies both schema files.

## Not wired yet

`worker.ts` routes `hunt` through `runLead`, so `DirectiveRepository` has no production construction site and `enqueue_directive` has no router. The console endpoint is #634; reaping directives that belong to a run that died mid-flight is #633.
