### PR TITLE
T18 · One egress: collapse the second schema, and gate it

### DIFF
--- a/core/llm/router/router.py
+++ b/core/llm/router/router.py
@@ -89,14 +89,6 @@ def _block_on_injection() -> bool:
     return get_settings().prompt_injection_block
 
 
-def select_path(
-    provider: ProviderSpec, *, enable_thinking: bool = False
-) -> DispatchPath:
-    """All traffic goes through Bifrost; kept for backwards-compatible callers."""
-    del provider, enable_thinking
-    return "bifrost"
-
-
 def _normalize_openai_tool_calls(tool_calls: Any) -> Optional[List[Dict[str, Any]]]:
     if not tool_calls:
         return None
@@ -259,12 +251,6 @@ class LLMRouter:
 
     # ---- path selection --------------------------------------------------
 
-    @staticmethod
-    def select_path(
-        provider: ProviderSpec, *, enable_thinking: bool = False
-    ) -> DispatchPath:
-        return select_path(provider, enable_thinking=enable_thinking)
-
     # ---- dispatch --------------------------------------------------------
 
     async def dispatch(
@@ -303,20 +289,9 @@ class LLMRouter:
         extra_headers_or_none: Optional[Dict[str, str]] = (
             extra_headers if extra_headers else None
         )
-        if provider.provider_type == "anthropic":
-            return await _wrap_budget_errors(
-                self._dispatch_anthropic(
-                    provider=provider,
-                    messages=messages,
-                    system_prompt=system_prompt,
-                    model=model,
-                    max_tokens=max_tokens,
-                    tools=tools,
-                    enable_thinking=enable_thinking,
-                    thinking_budget=thinking_budget,
-                    extra_headers=extra_headers_or_none,
-                )
-            )
+        # One schema out (ADR 0011). Anthropic used to take Bifrost's /anthropic
+        # passthrough to keep extended thinking and cache_control; both were
+        # traded away, and by #632 nothing asked for either.
         return await _wrap_budget_errors(
             self._dispatch_bifrost_openai(
                 provider=provider,
@@ -346,10 +321,8 @@ class LLMRouter:
     ) -> Dict[str, Any]:
         from openai import AsyncOpenAI  # lazy — avoids hard dep for tests
 
-        from core.llm.router.format import (
-            anthropic_messages_to_openai,
-            anthropic_tools_to_openai,
-        )
+        from core.llm.router.format import (anthropic_messages_to_openai,
+                                            anthropic_tools_to_openai)
 
         # Callers (the daemon tool loop, workflows) build conversations in
         # Anthropic shape — assistant tool_use blocks, user tool_result blocks,
@@ -433,10 +406,8 @@ class LLMRouter:
         usage) for non-Anthropic Bifrost providers."""
         from openai import AsyncOpenAI
 
-        from core.llm.router.format import (
-            anthropic_messages_to_openai,
-            anthropic_tools_to_openai,
-        )
+        from core.llm.router.format import (anthropic_messages_to_openai,
+                                            anthropic_tools_to_openai)
 
         messages, system_prompt = _pre_dispatch_sanitize(messages, system_prompt)
         model = model or provider.default_model
@@ -507,96 +478,6 @@ class LLMRouter:
             content = getattr(chunk.choices[0].delta, "content", None)
             if content:
                 yield {"type": "text", "content": content}
-
-    async def _dispatch_anthropic(
-        self,
-        *,
-        provider: ProviderSpec,
-        messages: List[Dict[str, Any]],
-        system_prompt: Optional[str],
-        model: str,
-        max_tokens: int,
-        tools: Optional[List[Dict[str, Any]]],
-        enable_thinking: bool,
-        thinking_budget: int,
-        extra_headers: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, Any]:
-        from core.llm.providers.clients import create_async_anthropic_client
-        from core.llm.defaults import build_thinking_kwargs
-
-        api_key: Optional[str] = None
-        if provider.api_key_ref:
-            api_key = get_secret(provider.api_key_ref)
-        if not api_key:
-            # Fall back to the common key names so local dev still works.
-            api_key = get_secret("ANTHROPIC_API_KEY") or get_secret("CLAUDE_API_KEY")
-        if not api_key:
-            raise RuntimeError(
-                f"Anthropic provider '{provider.provider_id}' has no resolvable API key"
-            )
-
-        # Anthropic traffic routes through Bifrost's /anthropic passthrough,
-        # which preserves extended thinking + cache_control. See
-        # scripts/bifrost_capability_probe.py for the merge-blocking verification.
-        client = create_async_anthropic_client(api_key, timeout=1800.0)
-        kwargs: Dict[str, Any] = {
-            "model": model,
-            "max_tokens": max_tokens,
-            "messages": messages,
-        }
-        if system_prompt:
-            kwargs["system"] = system_prompt
-        if tools:
-            kwargs["tools"] = tools
-        if enable_thinking:
-            # Model-aware: newer Anthropic models reject the budget_tokens
-            # shape and require adaptive thinking + output_config.effort.
-            kwargs.update(build_thinking_kwargs(model, thinking_budget))
-        if extra_headers:
-            kwargs["extra_headers"] = extra_headers
-
-        try:
-            resp = await client.messages.create(**kwargs)
-            # Anthropic returns a list of content blocks (text, thinking, tool_use).
-            text_parts: List[str] = []
-            thinking_parts: List[str] = []
-            tool_uses: List[Dict[str, Any]] = []
-            for block in resp.content:
-                btype = getattr(block, "type", None)
-                if btype == "text":
-                    text_parts.append(getattr(block, "text", ""))
-                elif btype == "thinking":
-                    thinking_parts.append(getattr(block, "thinking", ""))
-                elif btype == "tool_use":
-                    tool_uses.append(
-                        {
-                            "id": getattr(block, "id", None),
-                            "name": getattr(block, "name", None),
-                            "input": getattr(block, "input", None),
-                        }
-                    )
-
-            usage = getattr(resp, "usage", None)
-            return {
-                "content": "".join(text_parts),
-                "thinking": "".join(thinking_parts) or None,
-                "tool_calls": tool_uses or None,
-                "model": resp.model,
-                "input_tokens": getattr(usage, "input_tokens", 0) if usage else 0,
-                "output_tokens": getattr(usage, "output_tokens", 0) if usage else 0,
-                "cache_read_tokens": (
-                    getattr(usage, "cache_read_input_tokens", 0) if usage else 0
-                ),
-                "cache_creation_tokens": (
-                    getattr(usage, "cache_creation_input_tokens", 0) if usage else 0
-                ),
-                "provider": provider.provider_type,
-                "path": "bifrost",
-            }
-        finally:
-            # The async Anthropic client also holds an httpx connection pool;
-            # close it so connections don't leak per non-streaming call.
-            await client.close()
 
 
 # ---------------------------------------------------------------------------

--- a/services/worker/jobs.py
+++ b/services/worker/jobs.py
@@ -141,22 +141,6 @@ async def llm_call(
         return {"content": "", "type": "error", "error": error_msg}
 
 
-def _is_default_anthropic_spec(spec) -> bool:
-    # Only the seeded row is safe for the shared ClaudeService, which resolves its
-    # key from these env names. Any other row has its own ref and needs the router.
-    if spec.provider_type != "anthropic":
-        return False
-    ref = spec.api_key_ref
-    if ref is None:
-        return True
-    return ref in {
-        "CLAUDE_API_KEY",
-        "ANTHROPIC_API_KEY",
-        "claude_api_key",
-        "anthropic_api_key",
-    }
-
-
 async def _maybe_dispatch_via_router(
     ctx: Dict[str, Any],
     *,
@@ -194,16 +178,9 @@ async def _maybe_dispatch_via_router(
         )
         return None
 
-    # All traffic now routes through Bifrost (GH #84 PR-B). We still hand off
-    # default-anthropic-with-thinking calls to the shared ClaudeService so
-    # they get its full tool-use loop, context reduction, and session
-    # management — that logic lives in ClaudeService, not here. Non-default
-    # Anthropic providers have their own api_key_ref and must dispatch through
-    # the router so _dispatch_anthropic resolves that per-provider secret
-    # (not CLAUDE_API_KEY).
-    if enable_thinking and _is_default_anthropic_spec(spec):
-        return None
-
+    # The fallback this used to take was ClaudeService's tool loop, context
+    # reduction and session management. None of the three exist (#629, #631,
+    # #632), so every provider dispatches the one way.
     rate_limiter: asyncio.Semaphore = ctx["rate_limiter"]
     await rate_limiter.acquire()
     try:

--- a/tests/unit/_ratchets/test_one_egress.py
+++ b/tests/unit/_ratchets/test_one_egress.py
@@ -1,0 +1,172 @@
+"""One egress: every LLM call leaves through Bifrost, on one schema.
+
+ADR 0011 decided this and nothing enforced it. `main` reached models four ways —
+llm_gateway, llm_router, llm_format, llm_clients — plus provider-specific paths
+inside claude_service and openai_agent_service. That count was not designed: each
+was the reasonable local choice for one caller, and review did not stop it
+reaching four.
+
+A constraint that matters is expressed as something that fails.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACKAGES = ("core", "services")
+
+# Constructing a provider SDK client. Matched on the callee name, because the
+# import spelling varies and the construction is what costs money.
+CLIENTS = {"Anthropic", "AsyncAnthropic", "OpenAI", "AsyncOpenAI"}
+
+# The sanctioned sites, and why each one is allowed to build a client.
+ALLOWED_CONSTRUCTION = {
+    # The single source of truth for Anthropic client construction.
+    "core/llm/providers/clients.py",
+    # The one OpenAI-shaped egress: every dispatch and stream goes out here.
+    "core/llm/router/router.py",
+    # Key validation has to reach the real upstream to verify a user-supplied
+    # credential, so it cannot go through the gateway. The documented exception.
+    "services/api/routers/llm_providers.py",
+}
+
+# A provider host named in a base_url. Reaching one directly is the bypass this
+# ratchet exists to catch, whatever client is used to do it.
+PROVIDER_HOSTS = (
+    "api.anthropic.com",
+    "api.openai.com",
+    "generativelanguage.googleapis.com",
+)
+
+# Where naming a provider host is the point rather than a bypass.
+ALLOWED_HOSTS = {
+    # Validates a key against the real upstream before we store it.
+    "services/api/routers/llm_providers.py",
+    # Describes providers to the UI; dials none of them.
+    "core/llm/providers/registry.py",
+    "core/llm/providers/discovery.py",
+    # The SSRF allow-list. It names these hosts to *refuse* everything else,
+    # which is the opposite of a bypass.
+    "core/platform/url_safety.py",
+}
+
+
+def python_files() -> list[Path]:
+    files: list[Path] = []
+    for package in PACKAGES:
+        for path in (REPO_ROOT / package).rglob("*.py"):
+            if any(
+                part in ("__pycache__", "node_modules", "venv") for part in path.parts
+            ):
+                continue
+            files.append(path)
+    return sorted(files)
+
+
+def _relative(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def constructions_in(path: Path) -> list[tuple[int, str]]:
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError:
+        return []
+
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = (
+            node.func.id
+            if isinstance(node.func, ast.Name)
+            else getattr(node.func, "attr", "")
+        )
+        if name in CLIENTS:
+            found.append((node.lineno, name))
+    return found
+
+
+def _docstrings(tree: ast.AST) -> set[int]:
+    """Prose about an egress is not an egress."""
+    lines = set()
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        first = node.body[0] if node.body else None
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            lines.add(first.value.lineno)
+    return lines
+
+
+def hosts_in(path: Path) -> list[tuple[int, str]]:
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError:
+        return []
+
+    prose = _docstrings(tree)
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        if node.lineno in prose:
+            continue
+        for host in PROVIDER_HOSTS:
+            if host in node.value:
+                found.append((node.lineno, host))
+    return found
+
+
+@pytest.mark.unit
+def test_no_provider_client_is_built_outside_the_sanctioned_sites():
+    violations = [
+        f"{_relative(path)}:{line}: builds {name} directly"
+        for path in python_files()
+        if _relative(path) not in ALLOWED_CONSTRUCTION
+        for line, name in constructions_in(path)
+    ]
+    assert not violations, (
+        "A provider client was constructed outside the one egress. Dispatch through "
+        "core/llm/router/router.py, or in the harness through services/agent/core/wire.ts:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+@pytest.mark.unit
+def test_no_provider_host_is_dialled_directly():
+    violations = [
+        f"{_relative(path)}:{line}: names {host}"
+        for path in python_files()
+        if _relative(path) not in ALLOWED_HOSTS
+        for line, host in hosts_in(path)
+    ]
+    assert not violations, (
+        "A provider host was named outside the key-validation exception. All traffic "
+        "goes to BIFROST_URL; the gateway decides which provider it reaches:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+@pytest.mark.unit
+def test_the_allow_lists_stay_honest():
+    # An entry that stops constructing a client, or stops existing, must come off
+    # the list -- otherwise the ratchet quietly widens as files are refactored.
+    stale = [
+        entry
+        for entry in ALLOWED_CONSTRUCTION
+        if not (REPO_ROOT / entry).exists() or not constructions_in(REPO_ROOT / entry)
+    ]
+    assert (
+        not stale
+    ), "ALLOWED_CONSTRUCTION entries no longer build a client:\n  " + "\n  ".join(stale)

--- a/tests/unit/llm/test_llm_router.py
+++ b/tests/unit/llm/test_llm_router.py
@@ -16,12 +16,8 @@ import pytest
 REPO = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(REPO))
 
-from core.llm.router.router import (
-    LLMRouter,
-    ProviderSpec,
-    provider_spec_from_row,
-    select_path,
-)
+from core.llm.router.router import (LLMRouter, ProviderSpec,
+                                    provider_spec_from_row)
 
 pytestmark = pytest.mark.unit
 
@@ -62,32 +58,6 @@ def _openai_spec() -> ProviderSpec:
 # ---------------------------------------------------------------------------
 # Path selection (pure logic)
 # ---------------------------------------------------------------------------
-
-
-def test_path_anthropic_with_thinking_uses_bifrost():
-    """GH #84 PR-B: all Anthropic traffic goes through Bifrost, even thinking."""
-    assert select_path(_anthropic_spec(), enable_thinking=True) == "bifrost"
-
-
-def test_path_anthropic_without_thinking_uses_bifrost():
-    assert select_path(_anthropic_spec(), enable_thinking=False) == "bifrost"
-
-
-def test_path_openai_always_uses_bifrost():
-    assert select_path(_openai_spec(), enable_thinking=False) == "bifrost"
-    assert select_path(_openai_spec(), enable_thinking=True) == "bifrost"
-
-
-def test_path_ollama_always_uses_bifrost():
-    assert select_path(_ollama_spec(), enable_thinking=True) == "bifrost"
-
-
-def test_router_class_method_matches_free_function():
-    spec = _anthropic_spec()
-    router = LLMRouter()
-    assert router.select_path(spec, enable_thinking=True) == select_path(
-        spec, enable_thinking=True
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -206,67 +176,6 @@ async def test_dispatch_bifrost_translates_anthropic_tools_and_messages():
 # ---------------------------------------------------------------------------
 # Dispatch — Anthropic direct branch
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_dispatch_anthropic_with_thinking_routes_through_bifrost():
-    """GH #84 PR-B: Anthropic thinking calls use Bifrost's /anthropic passthrough.
-
-    The Anthropic SDK is still the client the router builds, but its
-    ``base_url`` points at Bifrost so extended thinking + prompt caching
-    round-trip unchanged while Bifrost handles caching + observability.
-    """
-    router = LLMRouter(bifrost_url="http://test-bifrost:8080")
-    thinking_block = SimpleNamespace(type="thinking", thinking="inner reasoning")
-    text_block = SimpleNamespace(type="text", text="the answer")
-    fake_resp = SimpleNamespace(
-        content=[thinking_block, text_block],
-        model="claude-sonnet-4-5-20250929",
-        usage=SimpleNamespace(
-            input_tokens=12,
-            output_tokens=34,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-        ),
-    )
-    mock_client = MagicMock()
-    # Dispatchers close the client in a finally block to avoid leaking the
-    # httpx pool; make .close() awaitable so the real cleanup path runs.
-    mock_client.close = AsyncMock()
-    mock_client.messages.create = AsyncMock(return_value=fake_resp)
-
-    # Router builds its Anthropic client via core.llm.providers.clients.create_async_anthropic_client,
-    # which in turn instantiates anthropic.AsyncAnthropic with base_url=<bifrost>/anthropic.
-    with patch("anthropic.AsyncAnthropic", return_value=mock_client) as ac_ctor, patch(
-        "core.llm.router.router.get_secret", return_value="sk-ant-fake"
-    ), patch.dict("os.environ", {"BIFROST_URL": "http://test-bifrost:8080"}):
-        out = await router.dispatch(
-            provider=_anthropic_spec(),
-            messages=[{"role": "user", "content": "ponder"}],
-            enable_thinking=True,
-            thinking_budget=4096,
-        )
-
-    ac_ctor.assert_called_once_with(
-        api_key="sk-ant-fake",
-        base_url="http://test-bifrost:8080/anthropic",
-        timeout=1800.0,
-    )
-    kwargs = mock_client.messages.create.call_args.kwargs
-    assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 4096}
-    assert kwargs["model"] == "claude-sonnet-4-5-20250929"
-    assert kwargs["messages"] == [{"role": "user", "content": "ponder"}]
-
-    assert out["path"] == "bifrost"
-    assert out["provider"] == "anthropic"
-    assert out["content"] == "the answer"
-    assert out["thinking"] == "inner reasoning"
-    assert out["input_tokens"] == 12
-    assert out["output_tokens"] == 34
-    assert out["cache_read_tokens"] == 0
-    assert out["cache_creation_tokens"] == 0
-    # The Anthropic dispatcher must close its client (no httpx pool leak).
-    mock_client.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -395,41 +304,6 @@ async def test_dispatch_omits_extra_headers_when_no_interaction_id():
 
     kwargs = mock_client.chat.completions.create.call_args.kwargs
     assert "extra_headers" not in kwargs
-
-
-@pytest.mark.asyncio
-async def test_dispatch_propagates_interaction_id_anthropic():
-    """Same correlation header on the Anthropic dispatch path."""
-    router = LLMRouter(bifrost_url="http://test-bifrost:8080")
-    fake_resp = SimpleNamespace(
-        content=[SimpleNamespace(type="text", text="ok")],
-        model="claude-sonnet-4-5-20250929",
-        usage=SimpleNamespace(
-            input_tokens=1,
-            output_tokens=1,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-        ),
-    )
-    mock_client = MagicMock()
-    # Dispatchers close the client in a finally block to avoid leaking the
-    # httpx pool; make .close() awaitable so the real cleanup path runs.
-    mock_client.close = AsyncMock()
-    mock_client.messages.create = AsyncMock(return_value=fake_resp)
-
-    interaction_id = "uuid-bbbb-2222"
-    with patch("anthropic.AsyncAnthropic", return_value=mock_client), patch(
-        "core.llm.router.router.get_secret", return_value="sk-ant-fake"
-    ):
-        await router.dispatch(
-            provider=_anthropic_spec(),
-            messages=[{"role": "user", "content": "hi"}],
-            interaction_id=interaction_id,
-        )
-
-    headers = mock_client.messages.create.call_args.kwargs.get("extra_headers")
-    assert headers is not None
-    assert headers.get("x-bf-lh-vigil-interaction-id") == interaction_id
 
 
 @pytest.mark.asyncio
@@ -582,20 +456,6 @@ async def test_dispatch_does_not_swallow_non_budget_errors():
     assert not isinstance(excinfo.value, BudgetExceeded)
 
 
-@pytest.mark.asyncio
-async def test_anthropic_dispatch_raises_when_no_key():
-    router = LLMRouter()
-    with patch("core.llm.router.router.get_secret", return_value=None), patch.dict(
-        "os.environ", {"ANTHROPIC_API_KEY": "", "CLAUDE_API_KEY": ""}, clear=False
-    ):
-        with pytest.raises(RuntimeError, match="no resolvable API key"):
-            await router.dispatch(
-                provider=_anthropic_spec(),
-                messages=[{"role": "user", "content": "hi"}],
-                enable_thinking=True,
-            )
-
-
 # ---------------------------------------------------------------------------
 # provider_spec_from_row
 # ---------------------------------------------------------------------------
@@ -605,162 +465,6 @@ async def test_anthropic_dispatch_raises_when_no_key():
 # Non-default Anthropic providers must route through the router so the
 # per-provider api_key_ref is resolved (regression for PR #103 review).
 # ---------------------------------------------------------------------------
-
-
-def test_is_default_anthropic_recognizes_legacy_refs():
-    from services.worker.jobs import _is_default_anthropic_spec
-
-    default_key = ProviderSpec(
-        provider_id="anthropic-default",
-        provider_type="anthropic",
-        base_url=None,
-        api_key_ref="CLAUDE_API_KEY",
-        default_model="claude-sonnet-4-5-20250929",
-        config={},
-    )
-    legacy_key = ProviderSpec(
-        provider_id="anthropic-default",
-        provider_type="anthropic",
-        base_url=None,
-        api_key_ref="ANTHROPIC_API_KEY",
-        default_model="claude-sonnet-4-5-20250929",
-        config={},
-    )
-    per_provider = ProviderSpec(
-        provider_id="anthropic-team",
-        provider_type="anthropic",
-        base_url=None,
-        api_key_ref="llm_provider_anthropic-team_api_key",
-        default_model="claude-sonnet-4-5-20250929",
-        config={},
-    )
-    no_ref = ProviderSpec(
-        provider_id="anthropic-anon",
-        provider_type="anthropic",
-        base_url=None,
-        api_key_ref=None,
-        default_model="claude-sonnet-4-5-20250929",
-        config={},
-    )
-    openai = _openai_spec()
-    assert _is_default_anthropic_spec(default_key) is True
-    assert _is_default_anthropic_spec(legacy_key) is True
-    assert _is_default_anthropic_spec(no_ref) is True  # falls back to env
-    assert _is_default_anthropic_spec(per_provider) is False
-    assert _is_default_anthropic_spec(openai) is False
-
-
-@pytest.mark.asyncio
-async def test_non_default_anthropic_with_thinking_dispatches_via_router(monkeypatch):
-    """PR #103 review regression: a non-default Anthropic provider with
-    enable_thinking=True must be dispatched via LLMRouter so the
-    per-provider api_key_ref is used, NOT the shared ClaudeService
-    whose key is CLAUDE_API_KEY.
-    """
-    from services.worker.jobs import _maybe_dispatch_via_router
-
-    per_provider = ProviderSpec(
-        provider_id="anthropic-team",
-        provider_type="anthropic",
-        base_url=None,
-        api_key_ref="llm_provider_anthropic-team_api_key",
-        default_model="claude-sonnet-4-5-20250929",
-        config={},
-    )
-
-    mock_router = MagicMock()
-    mock_router.select_path = MagicMock(return_value="bifrost")
-    mock_router.dispatch = AsyncMock(
-        return_value={
-            "content": "ok",
-            "path": "bifrost",
-            "provider": "anthropic",
-            "input_tokens": 1,
-            "output_tokens": 1,
-            "model": "x",
-        }
-    )
-
-    import asyncio
-
-    ctx = {
-        "llm_router": mock_router,
-        "rate_limiter": asyncio.Semaphore(1),
-    }
-
-    with patch(
-        "core.llm.router.router.get_provider_spec",
-        return_value=per_provider,
-    ):
-        result = await _maybe_dispatch_via_router(
-            ctx,
-            provider_id="anthropic-team",
-            messages=[{"role": "user", "content": "think hard"}],
-            system_prompt=None,
-            model="claude-sonnet-4-5-20250929",
-            max_tokens=100,
-            temperature=None,
-            tools=None,
-            enable_thinking=True,
-            thinking_budget=4096,
-        )
-
-    # We MUST have dispatched via the router (not returned None which would
-    # fall back to the shared ClaudeService with the wrong key).
-    assert result is not None
-    mock_router.dispatch.assert_awaited_once()
-    dispatch_kwargs = mock_router.dispatch.call_args.kwargs
-    assert dispatch_kwargs["provider"].api_key_ref == (
-        "llm_provider_anthropic-team_api_key"
-    )
-    assert dispatch_kwargs["enable_thinking"] is True
-
-
-@pytest.mark.asyncio
-async def test_default_anthropic_with_thinking_still_falls_back():
-    """Default Anthropic row with thinking=True should keep using the
-    shared ClaudeService (return None), preserving prompt caching and
-    the tool-use loop that lives there.
-    """
-    from services.worker.jobs import _maybe_dispatch_via_router
-
-    default_spec = ProviderSpec(
-        provider_id="anthropic-default",
-        provider_type="anthropic",
-        base_url=None,
-        api_key_ref="CLAUDE_API_KEY",
-        default_model="claude-sonnet-4-5-20250929",
-        config={},
-    )
-
-    mock_router = MagicMock()
-    mock_router.select_path = MagicMock(return_value="bifrost")
-    mock_router.dispatch = AsyncMock()
-
-    import asyncio
-
-    ctx = {
-        "llm_router": mock_router,
-        "rate_limiter": asyncio.Semaphore(1),
-    }
-    with patch(
-        "core.llm.router.router.get_provider_spec",
-        return_value=default_spec,
-    ):
-        result = await _maybe_dispatch_via_router(
-            ctx,
-            provider_id="anthropic-default",
-            messages=[{"role": "user", "content": "think hard"}],
-            system_prompt=None,
-            model="claude-sonnet-4-5-20250929",
-            max_tokens=100,
-            temperature=None,
-            tools=None,
-            enable_thinking=True,
-            thinking_budget=4096,
-        )
-    assert result is None
-    mock_router.dispatch.assert_not_awaited()
 
 
 def test_provider_spec_from_row_copies_fields():
@@ -972,3 +676,23 @@ async def test_stream_openai_raw_closes_client_on_early_disconnect():
         await agen.aclose()  # simulate consumer disconnect mid-stream
 
     mock_client.close.assert_awaited_once()
+
+
+# Dropped with the second schema (#644). Every one asserted something about
+# choosing between two egress paths, and there is one:
+#
+#   test_path_* and test_router_class_method_matches_free_function — select_path
+#     returned the constant "bifrost" for every provider before it was deleted.
+#     What it was really pinning is now a ratchet:
+#     tests/unit/_ratchets/test_one_egress.py.
+#
+#   test_dispatch_anthropic_*, test_anthropic_dispatch_raises_when_no_key,
+#   test_dispatch_propagates_interaction_id_anthropic — _dispatch_anthropic took
+#     Bifrost's /anthropic passthrough to keep extended thinking and
+#     cache_control. ADR 0011 traded both away and by #632 nothing requested
+#     either, so the passthrough preserved features with no caller. The OpenAI
+#     equivalents of these cases are kept above.
+#
+#   test_*_anthropic_with_thinking_* and test_is_default_anthropic_recognizes_
+#   legacy_refs — the fallback they described handed default-Anthropic thinking
+#     calls to ClaudeService for its tool loop. That loop went in #631.

--- a/tests/unit/llm/test_llm_router_sanitize_hook.py
+++ b/tests/unit/llm/test_llm_router_sanitize_hook.py
@@ -5,20 +5,18 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 REPO = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(REPO))
 
-from core.llm.router.router import (  # noqa: E402
-    LLMRouter,
-    ProviderSpec,
-    _pre_dispatch_sanitize,
-    _wrap_tool_results_in_messages,
-)
+from core.llm.router.router import (LLMRouter, ProviderSpec,  # noqa: E402
+                                    _pre_dispatch_sanitize,
+                                    _wrap_tool_results_in_messages)
 from core.llm.security import PromptInjectionBlocked  # noqa: E402
 
 pytestmark = pytest.mark.unit
@@ -153,29 +151,24 @@ def test_pre_dispatch_clean_corpus_silent(caplog, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_dispatch_invokes_sanitize_hook(monkeypatch):
-    """Tool_result blocks must be wrapped before they hit Anthropic SDK."""
+    """Tool_result blocks must be wrapped before they leave for the provider.
+
+    Asserted on the Anthropic SDK path until #644 collapsed the two schemas.
+    The hook runs in dispatch(), ahead of the translation, so the guarantee is
+    the same one on the surviving OpenAI egress.
+    """
     monkeypatch.delenv("PROMPT_INJECTION_BLOCK", raising=False)
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
 
-    captured: Dict[str, Any] = {}
+    fake_resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="", tool_calls=None))],
+        model="claude-sonnet-4-5-20250929",
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=fake_resp)
 
-    fake_client = AsyncMock()
-
-    class _Resp:
-        content = []
-        usage = None
-        model = "claude-sonnet-4-5-20250929"
-
-    async def _fake_create(**kwargs):
-        captured.update(kwargs)
-        return _Resp()
-
-    fake_client.messages.create = _fake_create
-
-    with patch(
-        "core.llm.providers.clients.create_async_anthropic_client",
-        return_value=fake_client,
-    ):
+    with patch("openai.AsyncOpenAI", return_value=mock_client):
         router = LLMRouter()
         await router.dispatch(
             provider=_spec(),
@@ -184,11 +177,14 @@ async def test_dispatch_invokes_sanitize_hook(monkeypatch):
             max_tokens=128,
         )
 
-    sent_msgs = captured["messages"]
-    inner = sent_msgs[1]["content"][0]["content"][0]["text"]
-    assert "<vigil:tool_result" in inner
-    # Attacker close tag must have been escaped — the only </vigil:tool_result>
+    # A tool_result becomes a role:tool message on the OpenAI shape, and the
+    # wrapper the hook applied has to survive that translation intact.
+    sent = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    wrapped = next(m["content"] for m in sent if m.get("role") == "tool")
+
+    assert "<vigil:tool_result" in wrapped
+    # Attacker close tag must have been escaped -- the only </vigil:tool_result>
     # is the wrapper's own.
-    assert inner.count("</vigil:tool_result>") == 1
+    assert wrapped.count("</vigil:tool_result>") == 1
     # The dangerous </system> opener still appears in the wrapped, escaped form.
-    assert "&lt;/system&gt;" in inner or "&lt;/system>" in inner
+    assert "&lt;/system&gt;" in wrapped or "&lt;/system>" in wrapped


### PR DESCRIPTION
Closes #644. Base is `feat/632-demolition` (#651), which must merge first.

This is the router collapse I split out of #651, plus the ratchet #644 actually asks for.

## Why this was safe to delete, and why I checked twice

`_dispatch_anthropic` took Bifrost's `/anthropic` passthrough. That passthrough was **built deliberately** (GH #84 PR-B) to preserve extended thinking and `cache_control`, with a merge-blocking probe in `scripts/bifrost_capability_probe.py`. Deleting it looks like undoing someone's careful work.

It isn't, because **nothing asks for either feature any more**:

| | |
|---|---|
| `gateway.submit_triage` / `submit_insights` | `enable_thinking=False`, hardcoded |
| `gateway.submit_chat` | defaults `False`; no caller overrides |
| `_apply_prompt_cache_controls` | deleted with the loop in #631 |
| `ClaudeService.enable_thinking` | stored in `__init__`, **read by nothing** |
| `agent.enable_thinking` (9 records) | only *reported* through `GET /agents`; never reaches a model |

So the passthrough was preserving capabilities with no caller. ADR 0011 traded both away and this is the trade being completed, not reversed.

**`select_path` went too.** It returned the constant `"bifrost"` for every provider — the choice it described had already stopped existing, and the live branch was on `provider.provider_type`.

I called `_dispatch_anthropic` "provably unreachable" in #651 on the strength of `select_path` and was **wrong** — it branched on `provider_type`. That's why this is its own PR with its own reachability work rather than folded into the demolition.

## Also removed

The worker's fallback:

```python
if enable_thinking and _is_default_anthropic_spec(spec):
    return None   # ...so they get ClaudeService's tool loop, context reduction, session management
```

All three of those were deleted in #629 and #631. The branch handed traffic to a loop that no longer exists.

## The ratchet

`tests/unit/_ratchets/test_one_egress.py`, in the **unit** job as #644 requires — not the advisory lint job.

| | result |
|---|---|
| tree as it stands | passes |
| planted `AsyncAnthropic(...)` outside the sanctioned sites | **fails** |
| planted `base_url="https://api.anthropic.com"` | **fails** |
| the allow-lists staying honest | pinned by a third test |

Two deliberate exclusions, both commented:

- **Docstrings.** Prose about an egress is not an egress. `clients.py` describes the boundary in its module docstring and would otherwise trip its own ratchet.
- **`core/platform/url_safety.py`.** It names these hosts to *refuse* everything else — an SSRF allow-list is the opposite of a bypass.

The key-validation exception is allow-listed by path and named in the failure message, per the AC.

## One test repointed rather than dropped

`test_dispatch_invokes_sanitize_hook` asserted that a `tool_result` block is injection-wrapped before it reaches the Anthropic SDK. The hook runs in `dispatch()`, ahead of the translation, so the guarantee survives — it now asserts the wrapper is intact **after** translation to the OpenAI `role:tool` shape, which is strictly more than it checked before.

Eleven tests in `test_llm_router.py` were dropped, each naming where its guarantee went — all of them asserted something about choosing between two egress paths.

## Verification

| | |
|---|---|
| Python unit + integration | **1,376 pass** |
| `services/agent` | **443 pass**, typecheck clean |
| fold-equivalence gate | **34/34** — unmoved |
| one-loop gate | 0 loops, 319 files |
| import-linter | 3 contracts kept |

Five Python failures remain (2 auth, 3 mcp) — the same pre-existing set.

## The transports, finally

| | main | now |
|---|---|---|
| `gateway.py` | 366 | 275 |
| `router.py` | 742 | **623** |
| `format.py` | 196 | 196 |
| `clients.py` | 72 | 72 |

`format.py` stays. It translates Anthropic-shaped *input* — callers still build messages that way — into the one OpenAI egress. That is the adapter doing its job, not a second schema.

**Python LOC, `core` + `services`: 76,908 → 70,053.**

## Acceptance criteria

- [x] A planted direct provider-client construction fails CI
- [x] A planted call to a provider host bypassing Bifrost fails CI
- [x] The key-validation exception is allow-listed by path and named in the failure message
- [x] The ratchet runs in the main unit job
