### PR TITLE
Persist and render exact sequence evidence

### DIFF
--- a/clients/web/src/redesign/data/sourceEvidence.test.ts
+++ b/clients/web/src/redesign/data/sourceEvidence.test.ts
@@ -50,4 +50,68 @@ describe('parseSourceEvidence', () => {
       records: [{ response_code: 'NOERROR' }],
     })).toMatchObject({ status: 'invalid' })
   })
+
+  it('parses exact sequence flow and Modbus evidence', () => {
+    const result = parseSourceEvidence({
+      version: 2,
+      status: 'available',
+      provenance: 'joined',
+      association_basis: 'producer_membership',
+      sequence_id: 'seq-1',
+      dataset_id: 'ws3',
+      run_id: 'run-1',
+      artifact: {
+        artifact_id: 'a'.repeat(64),
+        flow_sha256: 'b'.repeat(64),
+        modbus_sha256: 'c'.repeat(64),
+      },
+      summary: {
+        text: 'Observed 2 exact flow records carrying 9 packets and 900 bytes.',
+        flow_count: 2,
+        packet_count: 9,
+        byte_count: 900,
+        protocol_counts: { '6': 2 },
+        modbus_transaction_count: 1,
+        modbus_operation_counts: { read: 1 },
+        modbus_response_counts: { ok: 1 },
+      },
+      coverage: {
+        event_start_time: 1_700_000_000_000,
+        event_end_time: 1_700_000_001_000,
+        capture_sha256s: ['d'.repeat(64)],
+        flow_membership_complete: true,
+        modbus_packet_association: true,
+      },
+      streams: {
+        netflow: {
+          schema_id: 'sequence_evidence/v1',
+          total_records: 2,
+          truncated: false,
+          records: [{
+            timestamp: '2026-08-13T12:00:00Z',
+            source_ip: '10.0.0.1',
+            destination_ip: '10.0.0.2',
+          }],
+        },
+        modbus: {
+          schema_id: 'sequence_protocol_evidence/v1',
+          total_records: 1,
+          truncated: false,
+          records: [{ operation: 'read', function_code: 3 }],
+        },
+      },
+    })
+
+    expect(result).toMatchObject({
+      version: 2,
+      sequenceId: 'seq-1',
+      datasetId: 'ws3',
+      summary: { flowCount: 2, modbusTransactionCount: 1 },
+    })
+    if (result?.version === 2) {
+      expect(result.streams.netflow.totalRecords).toBe(2)
+      expect(result.streams.modbus.records).toHaveLength(1)
+    }
+  })
+
 })

--- a/clients/web/src/redesign/data/sourceEvidence.ts
+++ b/clients/web/src/redesign/data/sourceEvidence.ts
@@ -2,7 +2,7 @@ export type SourceTelemetryKind = 'netflow' | 'dns' | 'http_session' | 'generic_
 export type SourceEvidenceStatus = 'available' | 'not_in_artifact' | 'redacted' | 'invalid'
 export type SourceEvidenceProvenance = 'embedded' | 'joined'
 
-export interface SourceEvidence {
+export interface LegacySourceEvidence {
   version: 1
   telemetryKind: SourceTelemetryKind
   schemaId: string
@@ -15,11 +15,71 @@ export interface SourceEvidence {
   rawTextTruncated: boolean
 }
 
+export interface SequenceEvidenceStream {
+  schemaId: string
+  totalRecords: number
+  truncated: boolean
+  records: Array<Record<string, unknown>>
+}
+
+export interface SequenceSourceEvidence {
+  version: 2
+  status: 'available'
+  provenance: 'joined'
+  telemetryKind: 'netflow'
+  schemaId: 'sequence_evidence/v1'
+  totalRecords: number
+  truncated: boolean
+  records: Array<Record<string, unknown>>
+  rawTextTruncated: false
+  associationBasis: 'producer_membership' | 'sequence_builder_replay'
+  sequenceId: string
+  datasetId: string
+  runId: string
+  artifact: {
+    artifactId: string
+    flowSha256: string
+    modbusSha256?: string
+  }
+  summary: {
+    text: string
+    flowCount: number
+    packetCount: number
+    byteCount: number
+    protocolCounts: Record<string, number>
+    modbusTransactionCount: number
+    modbusOperationCounts: Record<string, number>
+    modbusResponseCounts: Record<string, number>
+  }
+  coverage: {
+    eventStartTime: number
+    eventEndTime: number
+    captureSha256s: string[]
+    flowMembershipComplete: boolean
+    modbusPacketAssociation: boolean
+  }
+  streams: {
+    netflow: SequenceEvidenceStream
+    modbus: SequenceEvidenceStream
+  }
+}
+
+export type SourceEvidence = LegacySourceEvidence | SequenceSourceEvidence
+
+export interface SourceEvidencePage {
+  kind: 'netflow' | 'modbus'
+  total: number
+  offset: number
+  limit: number
+  records: Array<Record<string, unknown>>
+}
+
 const KINDS = new Set<SourceTelemetryKind>(['netflow', 'dns', 'http_session', 'generic_log'])
 const STATUSES = new Set<SourceEvidenceStatus>(['available', 'not_in_artifact', 'redacted', 'invalid'])
 const PROVENANCE = new Set<SourceEvidenceProvenance>(['embedded', 'joined'])
+const SHA256 = /^[a-f0-9]{64}$/
 
-function invalidEvidence(value?: Record<string, unknown>): SourceEvidence {
+function invalidEvidence(value?: Record<string, unknown>): LegacySourceEvidence {
   const kind = KINDS.has(value?.telemetry_kind as SourceTelemetryKind)
     ? value?.telemetry_kind as SourceTelemetryKind
     : 'generic_log'
@@ -58,6 +118,7 @@ export function parseSourceEvidence(value: unknown): SourceEvidence | undefined 
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return invalidEvidence()
   const raw = parsed as Record<string, unknown>
+  if (raw.version === 2) return parseSequenceEvidence(raw)
   const kind = raw.telemetry_kind as SourceTelemetryKind
   const status = raw.status as SourceEvidenceStatus
   const provenance = raw.provenance as SourceEvidenceProvenance
@@ -113,6 +174,121 @@ export function parseSourceEvidence(value: unknown): SourceEvidence | undefined 
     records,
     rawText,
     rawTextTruncated: raw.raw_text_truncated === true,
+  }
+}
+
+function objectRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function numberRecord(value: unknown): Record<string, number> | undefined {
+  if (!objectRecord(value)) return undefined
+  const entries = Object.entries(value)
+  if (!entries.every(([, count]) => typeof count === 'number' && Number.isFinite(count))) return undefined
+  return Object.fromEntries(entries) as Record<string, number>
+}
+
+function sequenceStream(value: unknown, schemaId: string): SequenceEvidenceStream | undefined {
+  if (!objectRecord(value) || value.schema_id !== schemaId) return undefined
+  const total = value.total_records
+  const truncated = value.truncated
+  const records = value.records === undefined
+    ? []
+    : Array.isArray(value.records) && value.records.every(objectRecord)
+      ? value.records
+      : undefined
+  if (
+    typeof total !== 'number'
+    || !Number.isInteger(total)
+    || total < 0
+    || typeof truncated !== 'boolean'
+    || !records
+    || total < records.length
+  ) return undefined
+  return { schemaId, totalRecords: total, truncated: truncated || total > records.length, records }
+}
+
+function parseSequenceEvidence(raw: Record<string, unknown>): SourceEvidence {
+  const artifact = objectRecord(raw.artifact) ? raw.artifact : undefined
+  const summary = objectRecord(raw.summary) ? raw.summary : undefined
+  const coverage = objectRecord(raw.coverage) ? raw.coverage : undefined
+  const streams = objectRecord(raw.streams) ? raw.streams : undefined
+  const netflow = sequenceStream(streams?.netflow, 'sequence_evidence/v1')
+  const modbus = sequenceStream(streams?.modbus, 'sequence_protocol_evidence/v1')
+  const protocolCounts = numberRecord(summary?.protocol_counts)
+  const operationCounts = numberRecord(summary?.modbus_operation_counts)
+  const responseCounts = numberRecord(summary?.modbus_response_counts)
+  const association = raw.association_basis
+  const captureHashes = coverage?.capture_sha256s
+  if (
+    raw.status !== 'available'
+    || raw.provenance !== 'joined'
+    || (association !== 'producer_membership' && association !== 'sequence_builder_replay')
+    || typeof raw.sequence_id !== 'string' || !raw.sequence_id.trim()
+    || typeof raw.dataset_id !== 'string' || !raw.dataset_id.trim()
+    || typeof raw.run_id !== 'string' || !raw.run_id.trim()
+    || !artifact
+    || typeof artifact.artifact_id !== 'string' || !SHA256.test(artifact.artifact_id)
+    || typeof artifact.flow_sha256 !== 'string' || !SHA256.test(artifact.flow_sha256)
+    || (artifact.modbus_sha256 !== null && artifact.modbus_sha256 !== undefined
+      && (typeof artifact.modbus_sha256 !== 'string' || !SHA256.test(artifact.modbus_sha256)))
+    || !summary
+    || typeof summary.text !== 'string'
+    || typeof summary.flow_count !== 'number'
+    || typeof summary.packet_count !== 'number'
+    || typeof summary.byte_count !== 'number'
+    || typeof summary.modbus_transaction_count !== 'number'
+    || !protocolCounts
+    || !operationCounts
+    || !responseCounts
+    || !coverage
+    || typeof coverage.event_start_time !== 'number'
+    || typeof coverage.event_end_time !== 'number'
+    || !Array.isArray(captureHashes)
+    || !captureHashes.every((hash) => typeof hash === 'string')
+    || typeof coverage.flow_membership_complete !== 'boolean'
+    || typeof coverage.modbus_packet_association !== 'boolean'
+    || !netflow
+    || !modbus
+  ) return invalidEvidence(raw)
+
+  return {
+    version: 2,
+    status: 'available',
+    provenance: 'joined',
+    telemetryKind: 'netflow',
+    schemaId: 'sequence_evidence/v1',
+    totalRecords: netflow.totalRecords,
+    truncated: netflow.truncated,
+    records: netflow.records,
+    rawTextTruncated: false,
+    associationBasis: association,
+    sequenceId: raw.sequence_id,
+    datasetId: raw.dataset_id,
+    runId: raw.run_id,
+    artifact: {
+      artifactId: artifact.artifact_id,
+      flowSha256: artifact.flow_sha256,
+      modbusSha256: typeof artifact.modbus_sha256 === 'string' ? artifact.modbus_sha256 : undefined,
+    },
+    summary: {
+      text: summary.text,
+      flowCount: summary.flow_count,
+      packetCount: summary.packet_count,
+      byteCount: summary.byte_count,
+      protocolCounts,
+      modbusTransactionCount: summary.modbus_transaction_count,
+      modbusOperationCounts: operationCounts,
+      modbusResponseCounts: responseCounts,
+    },
+    coverage: {
+      eventStartTime: coverage.event_start_time,
+      eventEndTime: coverage.event_end_time,
+      captureSha256s: captureHashes as string[],
+      flowMembershipComplete: coverage.flow_membership_complete,
+      modbusPacketAssociation: coverage.modbus_packet_association,
+    },
+    streams: { netflow, modbus },
   }
 }
 

--- a/clients/web/src/redesign/screens/dashboard/FindingPopup.tsx
+++ b/clients/web/src/redesign/screens/dashboard/FindingPopup.tsx
@@ -380,7 +380,7 @@ export default function FindingPopup({
             </div>
           )}
 
-          <SourceEvidenceSection evidence={sourceEvidence} />
+          <SourceEvidenceSection evidence={sourceEvidence} findingId={raw.finding_id} />
 
           {/* AI enrichment — on-demand */}
           <div className="modal-section">

--- a/clients/web/src/redesign/screens/dashboard/SourceEvidenceSection.tsx
+++ b/clients/web/src/redesign/screens/dashboard/SourceEvidenceSection.tsx
@@ -1,5 +1,11 @@
-import { SOURCE_TELEMETRY_LABELS, type SourceEvidence } from '../../data/sourceEvidence'
-import type { ReactNode } from 'react'
+import {
+  SOURCE_TELEMETRY_LABELS,
+  type LegacySourceEvidence,
+  type SequenceSourceEvidence,
+  type SourceEvidence,
+} from '../../data/sourceEvidence'
+import { findingsApi } from '../../../services/api'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
 
 const EMPTY = '—'
 
@@ -12,6 +18,11 @@ function displayValue(value: unknown): string {
   } catch {
     return String(value)
   }
+}
+
+function compactValue(value: unknown, maxLength = 120): string {
+  const rendered = displayValue(value)
+  return rendered.length > maxLength ? `${rendered.slice(0, maxLength - 1)}…` : rendered
 }
 
 function endpoint(ip: unknown, port: unknown): string {
@@ -27,7 +38,7 @@ function TableRegion({ label, children }: { label: string; children: ReactNode }
   )
 }
 
-function NetFlowTable({ evidence }: { evidence: SourceEvidence }) {
+function NetFlowTable({ records }: { records: Array<Record<string, unknown>> }) {
   return (
     <TableRegion label="NetFlow source evidence table">
       <table className="source-evidence-table">
@@ -37,7 +48,7 @@ function NetFlowTable({ evidence }: { evidence: SourceEvidence }) {
           <th scope="col">Protocol</th><th scope="col">Packets F/B</th>
           <th scope="col">Bytes F/B</th><th scope="col">Duration</th>
         </tr></thead>
-        <tbody>{evidence.records.map((record, index) => (
+        <tbody>{records.map((record, index) => (
           <tr key={`${displayValue(record.timestamp)}-${index}`}>
             <td className="mono">{displayValue(record.timestamp)}</td>
             <td className="mono">{endpoint(record.source_ip, record.source_port)}</td>
@@ -53,7 +64,7 @@ function NetFlowTable({ evidence }: { evidence: SourceEvidence }) {
   )
 }
 
-function DnsTable({ evidence }: { evidence: SourceEvidence }) {
+function DnsTable({ evidence }: { evidence: LegacySourceEvidence }) {
   return (
     <TableRegion label="DNS source evidence table">
       <table className="source-evidence-table">
@@ -80,6 +91,38 @@ function DnsTable({ evidence }: { evidence: SourceEvidence }) {
   )
 }
 
+function ModbusTable({ records }: { records: Array<Record<string, unknown>> }) {
+  return (
+    <TableRegion label="Modbus source evidence table">
+      <table className="source-evidence-table">
+        <caption className="sr-only">Packet-associated Modbus transactions in this sequence</caption>
+        <thead><tr>
+          <th scope="col">Time</th><th scope="col">Operation</th><th scope="col">Function</th>
+          <th scope="col">Unit</th><th scope="col">Address / quantity</th><th scope="col">Response</th>
+          <th scope="col">Values</th><th scope="col">Latency</th><th scope="col">Packets</th>
+        </tr></thead>
+        <tbody>{records.map((record, index) => (
+          <tr key={`${displayValue(record.timestamp)}-${displayValue(record.transaction_id)}-${index}`}>
+            <td className="mono">{displayValue(record.timestamp)}</td>
+            <td>{displayValue(record.operation)}</td>
+            <td>{displayValue(record.function_name ?? record.function_code)}</td>
+            <td className="mono">{displayValue(record.unit_id)}</td>
+            <td className="mono">
+              {displayValue(record.address ?? record.write_address)} / {displayValue(record.quantity ?? record.write_quantity)}
+            </td>
+            <td>{displayValue(record.response_status)}</td>
+            <td className="mono" title={displayValue(record.register_values ?? record.coil_values)}>
+              {compactValue(record.register_values ?? record.coil_values)}
+            </td>
+            <td className="mono">{record.latency_usec === undefined ? EMPTY : `${displayValue(record.latency_usec)} µs`}</td>
+            <td className="mono">{displayValue(record.request_packet)} / {displayValue(record.response_packet)}</td>
+          </tr>
+        ))}</tbody>
+      </table>
+    </TableRegion>
+  )
+}
+
 function recordHeading(record: Record<string, unknown>, index: number): string {
   const parts = [record.timestamp, record.event_type, record.method, record.path, record.message]
     .filter((value) => typeof value === 'string' && value.trim())
@@ -87,7 +130,7 @@ function recordHeading(record: Record<string, unknown>, index: number): string {
   return parts.join(' · ') || `Record ${index + 1}`
 }
 
-function StructuredRecords({ evidence }: { evidence: SourceEvidence }) {
+function StructuredRecords({ evidence }: { evidence: LegacySourceEvidence }) {
   return (
     <div className="source-evidence-records" aria-label="Structured source evidence records">
       {evidence.records.map((record, index) => (
@@ -104,14 +147,121 @@ function StructuredRecords({ evidence }: { evidence: SourceEvidence }) {
   )
 }
 
-const STATUS_MESSAGES: Record<Exclude<SourceEvidence['status'], 'available'>, string> = {
+const STATUS_MESSAGES: Record<Exclude<LegacySourceEvidence['status'], 'available'>, string> = {
   not_in_artifact: 'Source evidence was not included in the ingested artifact.',
   redacted: 'Source evidence is present but was redacted before ingestion.',
   invalid: 'Source evidence was present but did not match the declared schema.',
 }
 
-export function SourceEvidenceSection({ evidence }: { evidence?: SourceEvidence }) {
+function SequenceStream({
+  findingId,
+  evidence,
+  kind,
+}: {
+  findingId: string
+  evidence: SequenceSourceEvidence
+  kind: 'netflow' | 'modbus'
+}) {
+  const stream = evidence.streams[kind]
+  const [offset, setOffset] = useState(0)
+  const [records, setRecords] = useState(stream.records)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const pageSize = 100
+
+  const load = useCallback(async (nextOffset: number) => {
+    setLoading(true)
+    setError('')
+    try {
+      const response = await findingsApi.getSourceEvidence(findingId, {
+        kind,
+        offset: nextOffset,
+        limit: pageSize,
+      })
+      const page = response.data
+      if (!page || !Array.isArray(page.records)) throw new Error('Invalid evidence page')
+      setRecords(page.records)
+      setOffset(nextOffset)
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Could not load evidence records')
+    } finally {
+      setLoading(false)
+    }
+  }, [findingId, kind])
+
+  useEffect(() => {
+    if (stream.totalRecords > 0 && stream.records.length === 0) void load(0)
+  }, [load, stream.records.length, stream.totalRecords])
+
+  if (stream.totalRecords === 0) {
+    return kind === 'modbus' ? (
+      <p className="source-evidence-caption">No packet-associated Modbus transactions occur in this sequence.</p>
+    ) : null
+  }
+  return (
+    <section aria-label={`${kind} sequence evidence`}>
+      <h5>{kind === 'netflow' ? 'Normalized flows' : 'Modbus transactions'}</h5>
+      {kind === 'netflow' ? <NetFlowTable records={records} /> : <ModbusTable records={records} />}
+      <div className="source-evidence-pagination">
+        <button className="btn ghost" disabled={loading || offset === 0} onClick={() => load(Math.max(0, offset - pageSize))}>Previous</button>
+        <span className="mono">
+          {offset + 1}–{Math.min(offset + records.length, stream.totalRecords)} of {stream.totalRecords}
+        </span>
+        <button className="btn ghost" disabled={loading || offset + records.length >= stream.totalRecords} onClick={() => load(offset + pageSize)}>Next</button>
+      </div>
+      {error && <p role="alert" className="source-evidence-caption">{error}</p>}
+    </section>
+  )
+}
+
+function SequenceEvidenceView({ findingId, evidence }: { findingId: string; evidence: SequenceSourceEvidence }) {
+  const start = new Date(evidence.coverage.eventStartTime).toISOString()
+  const end = new Date(evidence.coverage.eventEndTime).toISOString()
+  return (
+    <details className="modal-section source-evidence">
+      <summary>
+        <span>Source evidence</span>
+        <span className="tag">Exact sequence</span>
+        <span className="source-evidence-count">{evidence.summary.flowCount} flows</span>
+      </summary>
+      <p className="source-evidence-summary">{evidence.summary.text}</p>
+      <p className="source-evidence-caption">
+        Sequence <span className="mono">{evidence.sequenceId}</span>
+        {' · '}{evidence.associationBasis === 'producer_membership' ? 'producer-declared membership' : 'validated sequence-builder replay'}
+        {' · '}{start} to {end}
+      </p>
+      <p className="source-evidence-caption">
+        Dataset <span className="mono">{evidence.datasetId}</span>
+        {' · '}run <span className="mono">{evidence.runId}</span>
+        {' · '}{evidence.coverage.captureSha256s.length} capture hash{evidence.coverage.captureSha256s.length === 1 ? '' : 'es'}
+      </p>
+      <details className="source-evidence-provenance">
+        <summary>Provenance and integrity</summary>
+        <dl>
+          <div><dt>Evidence artifact</dt><dd className="mono">{evidence.artifact.artifactId}</dd></div>
+          <div><dt>Flow SHA-256</dt><dd className="mono">{evidence.artifact.flowSha256}</dd></div>
+          {evidence.artifact.modbusSha256 && (
+            <div><dt>Modbus SHA-256</dt><dd className="mono">{evidence.artifact.modbusSha256}</dd></div>
+          )}
+          {evidence.coverage.captureSha256s.map((hash, index) => (
+            <div key={hash}><dt>Capture SHA-256 {index + 1}</dt><dd className="mono">{hash}</dd></div>
+          ))}
+          <div><dt>Preview</dt><dd>
+            {evidence.streams.netflow.truncated || evidence.streams.modbus.truncated
+              ? 'Bounded previews; all records remain available through pagination.'
+              : 'All records fit in the attached previews.'}
+          </dd></div>
+        </dl>
+      </details>
+      <SequenceStream key={`${evidence.artifact.artifactId}-netflow`} findingId={findingId} evidence={evidence} kind="netflow" />
+      <SequenceStream key={`${evidence.artifact.artifactId}-modbus`} findingId={findingId} evidence={evidence} kind="modbus" />
+    </details>
+  )
+}
+
+export function SourceEvidenceSection({ evidence, findingId }: { evidence?: SourceEvidence; findingId: string }) {
   if (!evidence) return null
+  if (evidence.version === 2) return <SequenceEvidenceView findingId={findingId} evidence={evidence} />
   const kindLabel = SOURCE_TELEMETRY_LABELS[evidence.telemetryKind]
 
   if (evidence.status !== 'available') {
@@ -139,7 +289,7 @@ export function SourceEvidenceSection({ evidence }: { evidence?: SourceEvidence 
         {' · '}schema <span className="mono">{evidence.schemaId}</span>
         {evidence.truncated ? ' · preview truncated' : ''}
       </p>
-      {recordCount > 0 && evidence.telemetryKind === 'netflow' && <NetFlowTable evidence={evidence} />}
+      {recordCount > 0 && evidence.telemetryKind === 'netflow' && <NetFlowTable records={evidence.records} />}
       {recordCount > 0 && evidence.telemetryKind === 'dns' && <DnsTable evidence={evidence} />}
       {recordCount > 0 && (evidence.telemetryKind === 'http_session' || evidence.telemetryKind === 'generic_log') && (
         <StructuredRecords evidence={evidence} />

--- a/clients/web/src/redesign/styles.css
+++ b/clients/web/src/redesign/styles.css
@@ -5629,6 +5629,57 @@
       line-height: 1.5;
    }
 
+   .source-evidence-summary {
+     margin: 12px 0 6px;
+     color: var(--tx-1);
+     line-height: 1.5;
+   }
+
+   .source-evidence h5 {
+     margin: 14px 0 8px;
+   }
+
+   .source-evidence-provenance {
+     margin: 0 14px 12px;
+     padding: 8px 10px;
+     border: 1px solid var(--line-soft);
+     border-radius: var(--r);
+     font-size: 12px;
+   }
+
+   .source-evidence-provenance>summary {
+     cursor: pointer;
+     font-weight: 600;
+   }
+
+   .source-evidence-provenance dl {
+     margin: 8px 0 0;
+   }
+
+   .source-evidence-provenance dl>div {
+     display: grid;
+     grid-template-columns: minmax(120px, 0.3fr) minmax(0, 1fr);
+     gap: 10px;
+     padding: 4px 0;
+   }
+
+   .source-evidence-provenance dt {
+     color: var(--tx-3);
+   }
+
+   .source-evidence-provenance dd {
+     margin: 0;
+     overflow-wrap: anywhere;
+   }
+
+   .source-evidence-pagination {
+     display: flex;
+     align-items: center;
+     justify-content: flex-end;
+     gap: 10px;
+     margin-top: 8px;
+   }
+
    .source-evidence-table-scroll {
       overflow-x: auto;
       border-top: 1px solid var(--line);

--- a/clients/web/src/services/api.ts
+++ b/clients/web/src/services/api.ts
@@ -185,6 +185,11 @@ export const findingsApi = {
   }) => api.get('/findings/', { params }),
   
   getById: (id: string) => api.get(`/findings/${id}`),
+
+  getSourceEvidence: (
+    id: string,
+    params: { kind: 'netflow' | 'modbus'; offset?: number; limit?: number },
+  ) => api.get(`/findings/${id}/source-evidence`, { params }),
   
   getSummary: () => api.get('/findings/stats/summary'),
   
@@ -468,6 +473,170 @@ export const mcpApi = {
     api.put(`/mcp/servers/${name}/enabled`, { enabled }),
 }
 
+
+// VStrike (CloudCurrent) integration API
+// Routes are mounted at /api/integrations/vstrike; axios baseURL is /api.
+export const vstrikeApi = {
+  health: () => api.get('/integrations/vstrike/health'),
+
+  // 503 with detail.missing=['username','password'] when UI creds unset.
+  iframeToken: () =>
+    api.post<{ token: string; iframe_url: string }>(
+      '/integrations/vstrike/ui/iframe-token',
+    ),
+
+  listNetworks: () =>
+    api.get<{ networks: Array<Record<string, any>> }>(
+      '/integrations/vstrike/ui/networks',
+    ),
+
+  loadNetwork: (network_id: string) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/load-network',
+      { network_id },
+    ),
+
+  // Kill-chain replay — instructs VStrike to walk a sequence of nodes in the
+  // active iframe session. 501 when VStrike's MCP server hasn't shipped the
+  // `ui-killchain-replay` tool yet; the caller surfaces that as a snackbar.
+  killchainReplay: (
+    network_id: string,
+    steps: Array<{
+      node_id: string
+      timestamp: string
+      technique?: string
+      label?: string
+      dwell_ms?: number
+    }>,
+    opts?: { loop?: boolean; autoPlay?: boolean },
+  ) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/killchain-replay',
+      {
+        network_id,
+        steps,
+        loop: opts?.loop ?? false,
+        auto_play: opts?.autoPlay ?? true,
+      },
+    ),
+
+  // -------------------------------------------------------------------------
+  // Data-plane proxies (node search, drift, storylines, legends)
+  // -------------------------------------------------------------------------
+
+  nodeSearch: (query: string, network_id?: string, limit?: number) =>
+    api.post<{ query: string; results: Array<Record<string, any>> }>(
+      '/integrations/vstrike/nodes/search',
+      { query, network_id, limit },
+    ),
+
+  nodeDrift: (node_id: string, network_id?: string) =>
+    api.post<{ node_id: string; drift: Array<Record<string, any>> }>(
+      '/integrations/vstrike/nodes/drift',
+      { node_id, network_id },
+    ),
+
+  listStorylines: (network_id?: string) =>
+    api.get<{ network_id?: string; storylines: Array<Record<string, any>> }>(
+      '/integrations/vstrike/storylines',
+      { params: { network_id } },
+    ),
+
+  storylineEvents: (storyline_id: string, network_id?: string) =>
+    api.post<{ storyline_id: string; events: Array<Record<string, any>> }>(
+      '/integrations/vstrike/storylines/events',
+      { storyline_id, network_id },
+    ),
+
+  listLegendRuns: (network_id?: string) =>
+    api.get<{ network_id?: string; legend_runs: Array<Record<string, any>> }>(
+      '/integrations/vstrike/legend-runs',
+      { params: { network_id } },
+    ),
+
+  legendRunResults: (legend_run_id: string, network_id?: string) =>
+    api.post<{ legend_run_id: string; results: Record<string, any> }>(
+      '/integrations/vstrike/legend-runs/results',
+      { legend_run_id, network_id },
+    ),
+
+  // -------------------------------------------------------------------------
+  // UI control plane (camera, storyline, VCR playback)
+  // -------------------------------------------------------------------------
+
+  uiCameraNode: (node_ids: string[], network_id?: string) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/camera-node',
+      { node_ids, network_id },
+    ),
+
+  uiCameraPosition: (
+    position: Record<string, number>,
+    rotation?: Record<string, number>,
+    network_id?: string,
+  ) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/camera-position',
+      { position, rotation, network_id },
+    ),
+
+  uiStorylineApply: (storyline_id: string, network_id?: string) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/storyline-apply',
+      { storyline_id, network_id },
+    ),
+
+  uiStorylineMode: (mode: string, network_id?: string) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/storyline-mode',
+      { mode, network_id },
+    ),
+
+  uiStorylineForward: (network_id?: string) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/storyline-forward',
+      { network_id },
+    ),
+
+  uiStorylineBackward: (network_id?: string) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/storyline-backward',
+      { network_id },
+    ),
+
+  // -------------------------------------------------------------------------
+  // Net-new VStrike tools (network-graph-get, ui-legend-apply,
+  // ui-rightpanel-focus). The `extra` bag lets callers forward additional
+  // fields verbatim, matching the defensive shape on the backend.
+  // -------------------------------------------------------------------------
+
+  networkGraph: (network_id?: string, extra?: Record<string, any>) =>
+    api.post<{
+      network_id?: string
+      graph: {
+        label?: string
+        nodes: Array<Record<string, any>>
+        edges: Array<Record<string, any>>
+        bbox?: any
+      }
+    }>('/integrations/vstrike/network-graph', { network_id, ...(extra ?? {}) }),
+
+  uiLegendApply: (
+    legend_run_id: string,
+    network_id?: string,
+    extra?: Record<string, any>,
+  ) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/legend-apply',
+      { legend_run_id, network_id, ...(extra ?? {}) },
+    ),
+
+  uiRightpanelFocus: (extra?: Record<string, any>) =>
+    api.post<{ ok: boolean; result: any }>(
+      '/integrations/vstrike/ui/rightpanel-focus',
+      { ...(extra ?? {}) },
+    ),
+}
 
 // Claude API
 export const claudeApi = {

--- a/core/config.py
+++ b/core/config.py
@@ -56,6 +56,8 @@ class Settings(BaseSettings):
     data_backend: str = "database"
     autostart_services: Optional[str] = None
     max_upload_size_mb: int = 500
+    evidence_store_path: str = ""
+    evidence_store_max_mb: int = 10_240
     vigil_context_path: str = ""
     vigil_frontend_url: str = ""
     mempalace_palace_path: Optional[str] = None

--- a/core/findings/evidence_store.py
+++ b/core/findings/evidence_store.py
@@ -1,0 +1,651 @@
+"""Immutable, bounded storage and deterministic presentation for sequence evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+from core.config import get_settings, vigil_path
+
+
+FLOW_SCHEMA = "sequence_evidence/v1"
+MODBUS_SCHEMA = "sequence_protocol_evidence/v1"
+EVIDENCE_ENVELOPE_VERSION = 2
+PREVIEW_LIMIT = 100
+ALLOWED_FLOW_ASSOCIATIONS = {"producer_membership", "sequence_builder_replay"}
+ARTIFACT_ID = re.compile(r"^[a-f0-9]{64}$")
+SHA256 = re.compile(r"^[a-f0-9]{64}$")
+
+
+class SequenceEvidenceError(ValueError):
+    pass
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _iso_ms(value: object) -> str:
+    return datetime.fromtimestamp(int(value) / 1000, tz=timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _finite_number(value: object, default: float = 0.0) -> float:
+    try:
+        rendered = float(value)
+    except (TypeError, ValueError):
+        return default
+    return rendered if math.isfinite(rendered) else default
+
+
+def _required_int(
+    value: object,
+    label: str,
+    *,
+    minimum: Optional[int] = None,
+    maximum: Optional[int] = None,
+) -> int:
+    if isinstance(value, bool) or (
+        isinstance(value, float) and (not math.isfinite(value) or not value.is_integer())
+    ):
+        raise SequenceEvidenceError(f"{label} must be an integer")
+    try:
+        rendered = int(value)
+    except (TypeError, ValueError) as exc:
+        raise SequenceEvidenceError(f"{label} must be an integer") from exc
+    if minimum is not None and rendered < minimum:
+        raise SequenceEvidenceError(f"{label} must be at least {minimum}")
+    if maximum is not None and rendered > maximum:
+        raise SequenceEvidenceError(f"{label} must be at most {maximum}")
+    return rendered
+
+
+def _required_finite(value: object, label: str, *, minimum: float = 0.0) -> float:
+    if isinstance(value, bool):
+        raise SequenceEvidenceError(f"{label} must be numeric")
+    try:
+        rendered = float(value)
+    except (TypeError, ValueError) as exc:
+        raise SequenceEvidenceError(f"{label} must be numeric") from exc
+    if not math.isfinite(rendered) or rendered < minimum:
+        raise SequenceEvidenceError(f"{label} must be finite and at least {minimum}")
+    return rendered
+
+
+def _endpoint_key(a_ip: object, a_port: object, b_ip: object, b_port: object) -> tuple:
+    return tuple(
+        sorted(
+            (
+                (
+                    str(a_ip or ""),
+                    _required_int(a_port, "endpoint port", minimum=0, maximum=65535),
+                ),
+                (
+                    str(b_ip or ""),
+                    _required_int(b_port, "endpoint port", minimum=0, maximum=65535),
+                ),
+            )
+        )
+    )
+
+
+def _flow_record(row: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "flow_id": row.get("flow_id"),
+        "sequence_row_ordinal": int(row.get("sequence_row_ordinal") or 0),
+        "timestamp": _iso_ms(row["timestamp_ms"]),
+        "source_ip": row.get("src_ip"),
+        "source_port": row.get("src_port"),
+        "destination_ip": row.get("dest_ip"),
+        "destination_port": row.get("dest_port"),
+        "protocol": row.get("protocol"),
+        "forward_packets": int(row.get("fwd_pkts") or 0),
+        "backward_packets": int(row.get("bwd_pkts") or 0),
+        "forward_bytes": _finite_number(row.get("fwd_bytes")),
+        "backward_bytes": _finite_number(row.get("bwd_bytes")),
+        "duration_ms": round(_finite_number(row.get("flow_dur")) * 1000, 3),
+        "capture_id": row.get("capture_id"),
+        "capture_sha256": row.get("capture_sha256"),
+        "first_packet": row.get("first_packet"),
+        "last_packet": row.get("last_packet"),
+    }
+
+
+def _modbus_record(row: Mapping[str, Any]) -> Dict[str, Any]:
+    timestamp = row.get("timestamp")
+    timestamp_rendered = (
+        _iso_ms(int(timestamp) // 1000)
+        if timestamp is not None and abs(int(timestamp)) >= 100_000_000_000_000
+        else _iso_ms(timestamp or 0)
+    )
+    keys = (
+        "flow_id",
+        "capture_id",
+        "capture_sha256",
+        "client_ip",
+        "client_port",
+        "server_ip",
+        "server_port",
+        "transaction_id",
+        "unit_id",
+        "function_code",
+        "function_name",
+        "operation",
+        "address",
+        "quantity",
+        "write_address",
+        "write_quantity",
+        "register_values",
+        "coil_values",
+        "request_seen",
+        "response_seen",
+        "response_status",
+        "exception_code",
+        "exception_name",
+        "latency_usec",
+        "request_packet",
+        "response_packet",
+        "parser_warning",
+    )
+    return {"timestamp": timestamp_rendered, **{key: row.get(key) for key in keys}}
+
+
+def _table_rows(path: Path) -> list[dict[str, Any]]:
+    try:
+        import pyarrow.parquet as pq
+    except ImportError as exc:  # pragma: no cover - deployment image includes pyarrow
+        raise SequenceEvidenceError("pyarrow is required for sequence evidence") from exc
+    return pq.ParquetFile(path).read().to_pylist()
+
+
+@dataclass(frozen=True)
+class StoredEvidence:
+    artifact_id: str
+    flow_sha256: str
+    modbus_sha256: Optional[str]
+    root: Path
+
+    def public_ref(self) -> Dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "flow_sha256": self.flow_sha256,
+            "modbus_sha256": self.modbus_sha256,
+        }
+
+
+class SequenceEvidenceBundle:
+    """Validated run evidence, grouped by exact producer sequence identity."""
+
+    def __init__(
+        self,
+        flow_path: Path,
+        modbus_path: Optional[Path],
+        *,
+        expected_run_id: Optional[str] = None,
+    ) -> None:
+        self.flow_path = Path(flow_path)
+        self.modbus_path = Path(modbus_path) if modbus_path else None
+        self.flow_rows = _table_rows(self.flow_path)
+        self.modbus_rows = _table_rows(self.modbus_path) if self.modbus_path else []
+        self.flows_by_sequence: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        self.modbus_by_sequence: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        self._validate(expected_run_id)
+
+    def _validate(self, expected_run_id: Optional[str]) -> None:
+        if not self.flow_rows:
+            raise SequenceEvidenceError("sequence evidence contains no flow rows")
+        seen_flow_ids: set[str] = set()
+        flow_sequence: dict[str, str] = {}
+        flow_by_id: dict[str, dict[str, Any]] = {}
+        run_ids: set[str] = set()
+        dataset_ids: set[str] = set()
+        tenant_ids: set[str] = set()
+        association_bases: set[str] = set()
+        for row in self.flow_rows:
+            if row.get("evidence_schema_version") != FLOW_SCHEMA:
+                raise SequenceEvidenceError("unsupported flow evidence schema")
+            association_basis = str(row.get("association_basis") or "")
+            if association_basis not in ALLOWED_FLOW_ASSOCIATIONS:
+                raise SequenceEvidenceError("flow evidence is not exact sequence membership")
+            association_bases.add(association_basis)
+            sequence_id = str(row.get("sequence_id") or "")
+            flow_id = str(row.get("flow_id") or "")
+            if not sequence_id or not flow_id or flow_id in seen_flow_ids:
+                raise SequenceEvidenceError("flow evidence has missing/duplicate identities")
+            _required_int(row.get("sequence_row_ordinal"), "sequence_row_ordinal", minimum=0)
+            _required_int(row.get("row_count"), "row_count", minimum=1)
+            chunk_start = _required_int(row.get("chunk_start_ms"), "chunk_start_ms")
+            chunk_end = _required_int(
+                row.get("chunk_end_ms"), "chunk_end_ms", minimum=chunk_start
+            )
+            event_start = _required_int(row.get("event_start_time"), "event_start_time")
+            event_end = _required_int(
+                row.get("event_end_time"), "event_end_time", minimum=event_start
+            )
+            timestamp_ms = _required_int(row.get("timestamp_ms"), "timestamp_ms")
+            _iso_ms(timestamp_ms)
+            if not event_start <= timestamp_ms <= event_end:
+                raise SequenceEvidenceError("flow timestamp is outside event coverage")
+            if not str(row.get("src_ip") or "") or not str(row.get("dest_ip") or ""):
+                raise SequenceEvidenceError("flow evidence has a missing endpoint")
+            _required_int(row.get("src_port"), "src_port", minimum=0, maximum=65535)
+            _required_int(row.get("dest_port"), "dest_port", minimum=0, maximum=65535)
+            _required_int(row.get("fwd_pkts"), "fwd_pkts", minimum=0)
+            _required_int(row.get("bwd_pkts"), "bwd_pkts", minimum=0)
+            _required_finite(row.get("fwd_bytes"), "fwd_bytes")
+            _required_finite(row.get("bwd_bytes"), "bwd_bytes")
+            _required_finite(row.get("flow_dur"), "flow_dur")
+            capture_sha = row.get("capture_sha256")
+            if capture_sha is not None and not SHA256.fullmatch(str(capture_sha)):
+                raise SequenceEvidenceError("flow evidence has an invalid capture SHA-256")
+            first_packet = row.get("first_packet")
+            last_packet = row.get("last_packet")
+            if (first_packet is None) != (last_packet is None):
+                raise SequenceEvidenceError("flow packet provenance is incomplete")
+            if first_packet is not None:
+                first = _required_int(first_packet, "first_packet", minimum=1)
+                last = _required_int(last_packet, "last_packet", minimum=first)
+                if not str(row.get("capture_id") or "") or capture_sha is None:
+                    raise SequenceEvidenceError(
+                        "packet-addressable flow evidence lacks capture provenance"
+                    )
+                if last < first:  # pragma: no cover - guarded by minimum
+                    raise SequenceEvidenceError("flow packet provenance is reversed")
+            seen_flow_ids.add(flow_id)
+            flow_sequence[flow_id] = sequence_id
+            flow_by_id[flow_id] = row
+            run_ids.add(str(row.get("run_id") or ""))
+            dataset_ids.add(str(row.get("dataset_id") or ""))
+            tenant = str(row.get("tenant") or "")
+            focal_ip = str(row.get("focal_ip") or "")
+            engaged_ip = str(row.get("engaged_ip") or "")
+            if not tenant or not focal_ip or not engaged_ip:
+                raise SequenceEvidenceError(
+                    "flow evidence lacks tenant or sequence endpoint identity"
+                )
+            if {focal_ip, engaged_ip} != {
+                str(row.get("src_ip")),
+                str(row.get("dest_ip")),
+            }:
+                raise SequenceEvidenceError(
+                    "flow endpoints do not match the sequence endpoint pair"
+                )
+            tenant_ids.add(tenant)
+            self.flows_by_sequence[sequence_id].append(row)
+        if len(run_ids) != 1 or "" in run_ids:
+            raise SequenceEvidenceError(f"flow evidence must contain one run_id: {run_ids}")
+        if len(dataset_ids) != 1 or "" in dataset_ids:
+            raise SequenceEvidenceError(
+                f"flow evidence must contain one dataset_id: {dataset_ids}"
+            )
+        if len(tenant_ids) != 1:
+            raise SequenceEvidenceError(
+                f"flow evidence must contain one tenant: {tenant_ids}"
+            )
+        if len(association_bases) != 1:
+            raise SequenceEvidenceError(
+                "flow evidence cannot mix exact association methods"
+            )
+        self.run_id = next(iter(run_ids))
+        self.dataset_id = next(iter(dataset_ids))
+        self.tenant = next(iter(tenant_ids))
+        self.association_basis = next(iter(association_bases))
+        if expected_run_id and self.run_id != expected_run_id:
+            raise SequenceEvidenceError(
+                f"evidence run_id mismatch: {self.run_id} != {expected_run_id}"
+            )
+        for sequence_id, rows in self.flows_by_sequence.items():
+            rows.sort(key=lambda row: int(row.get("sequence_row_ordinal") or 0))
+            ordinals = [int(row.get("sequence_row_ordinal") or 0) for row in rows]
+            declared = {int(row.get("row_count") or 0) for row in rows}
+            if ordinals != list(range(len(rows))) or declared != {len(rows)}:
+                raise SequenceEvidenceError(
+                    f"flow evidence membership mismatch for {sequence_id}"
+                )
+            metadata = {
+                (
+                    str(row.get("focal_ip") or ""),
+                    str(row.get("engaged_ip") or ""),
+                    _required_int(row.get("chunk_start_ms"), "chunk_start_ms"),
+                    _required_int(row.get("chunk_end_ms"), "chunk_end_ms"),
+                    _required_int(row.get("event_start_time"), "event_start_time"),
+                    _required_int(row.get("event_end_time"), "event_end_time"),
+                )
+                for row in rows
+            }
+            if len(metadata) != 1:
+                raise SequenceEvidenceError(
+                    f"flow evidence metadata mismatch for {sequence_id}"
+                )
+            _, _, chunk_start, chunk_end, event_start, event_end = next(iter(metadata))
+            timestamps = [int(row["timestamp_ms"]) for row in rows]
+            if (
+                timestamps[0] != chunk_start
+                or timestamps[-1] != chunk_end
+                or min(timestamps) != event_start
+                or max(timestamps) != event_end
+            ):
+                raise SequenceEvidenceError(
+                    f"flow evidence coverage mismatch for {sequence_id}"
+                )
+
+        known_flow_ids = seen_flow_ids
+        seen_observations: set[tuple[str, int]] = set()
+        for row in self.modbus_rows:
+            if row.get("evidence_schema_version") != MODBUS_SCHEMA:
+                raise SequenceEvidenceError("unsupported Modbus evidence schema")
+            if row.get("association_basis") != "capture_packet_to_flow":
+                raise SequenceEvidenceError("Modbus evidence is not packet-associated")
+            sequence_id = str(row.get("sequence_id") or "")
+            if sequence_id not in self.flows_by_sequence:
+                raise SequenceEvidenceError(
+                    f"Modbus evidence references unknown sequence: {sequence_id}"
+                )
+            flow_id = str(row.get("flow_id") or "")
+            if flow_id not in known_flow_ids:
+                raise SequenceEvidenceError("Modbus evidence references unknown flow_id")
+            if flow_sequence[flow_id] != sequence_id:
+                raise SequenceEvidenceError(
+                    "Modbus evidence flow_id belongs to a different sequence"
+                )
+            if str(row.get("run_id") or "") != self.run_id:
+                raise SequenceEvidenceError("Modbus evidence run_id mismatch")
+            if str(row.get("dataset_id") or "") != self.dataset_id:
+                raise SequenceEvidenceError("Modbus evidence dataset_id mismatch")
+            flow = flow_by_id[flow_id]
+            if str(row.get("capture_id") or "") != str(flow.get("capture_id") or ""):
+                raise SequenceEvidenceError("Modbus evidence capture_id mismatch")
+            if str(row.get("capture_sha256") or "") != str(
+                flow.get("capture_sha256") or ""
+            ):
+                raise SequenceEvidenceError("Modbus evidence capture SHA-256 mismatch")
+            if _endpoint_key(
+                row.get("client_ip"),
+                row.get("client_port"),
+                row.get("server_ip"),
+                row.get("server_port"),
+            ) != _endpoint_key(
+                flow.get("src_ip"),
+                flow.get("src_port"),
+                flow.get("dest_ip"),
+                flow.get("dest_port"),
+            ):
+                raise SequenceEvidenceError("Modbus evidence endpoint mismatch")
+            packet_refs = [
+                _required_int(value, label, minimum=1)
+                for label, value in (
+                    ("request_packet", row.get("request_packet")),
+                    ("response_packet", row.get("response_packet")),
+                )
+                if value is not None
+            ]
+            if not packet_refs or flow.get("first_packet") is None:
+                raise SequenceEvidenceError("Modbus evidence lacks exact packet provenance")
+            first = int(flow["first_packet"])
+            last = int(flow["last_packet"])
+            if any(packet < first or packet > last for packet in packet_refs):
+                raise SequenceEvidenceError("Modbus packet reference is outside its flow")
+            capture_id = str(row.get("capture_id") or "")
+            ordinal = _required_int(
+                row.get("observation_ordinal"), "observation_ordinal", minimum=0
+            )
+            observation_id = (capture_id, ordinal)
+            if observation_id in seen_observations:
+                raise SequenceEvidenceError("Modbus evidence has a duplicate observation")
+            seen_observations.add(observation_id)
+            _required_int(row.get("timestamp"), "Modbus timestamp")
+            _modbus_record(row)
+            self.modbus_by_sequence[sequence_id].append(row)
+
+    def has_sequence(self, sequence_id: str, expected_rows: Optional[int] = None) -> bool:
+        rows = self.flows_by_sequence.get(sequence_id, [])
+        return bool(rows) and (expected_rows is None or len(rows) == expected_rows)
+
+    def envelope(self, sequence_id: str, stored: StoredEvidence) -> Dict[str, Any]:
+        flows = self.flows_by_sequence.get(sequence_id)
+        if not flows:
+            raise SequenceEvidenceError(f"no exact evidence for sequence {sequence_id}")
+        modbus = self.modbus_by_sequence.get(sequence_id, [])
+        flow_preview = [_flow_record(row) for row in flows[:PREVIEW_LIMIT]]
+        modbus_preview = [_modbus_record(row) for row in modbus[:PREVIEW_LIMIT]]
+        packet_count = sum(
+            int(row.get("fwd_pkts") or 0) + int(row.get("bwd_pkts") or 0)
+            for row in flows
+        )
+        byte_count = sum(
+            _finite_number(row.get("fwd_bytes")) + _finite_number(row.get("bwd_bytes"))
+            for row in flows
+        )
+        protocol_counts = Counter(str(row.get("protocol") or "unknown") for row in flows)
+        operation_counts = Counter(str(row.get("operation") or "unknown") for row in modbus)
+        response_counts = Counter(str(row.get("response_status") or "unknown") for row in modbus)
+        timestamps = [int(row["timestamp_ms"]) for row in flows]
+        capture_hashes = sorted(
+            {str(row["capture_sha256"]) for row in flows if row.get("capture_sha256")}
+        )
+        summary_text = (
+            f"Observed {len(flows)} exact flow records carrying {packet_count} packets "
+            f"and {int(byte_count)} bytes."
+        )
+        if modbus:
+            summary_text += (
+                f" The same sequence contains {len(modbus)} packet-associated Modbus "
+                f"transactions ({operation_counts.get('read', 0)} reads, "
+                f"{operation_counts.get('write', 0)} writes)."
+            )
+        return {
+            "version": EVIDENCE_ENVELOPE_VERSION,
+            "status": "available",
+            "provenance": "joined",
+            "association_basis": str(flows[0]["association_basis"]),
+            "sequence_id": sequence_id,
+            "dataset_id": self.dataset_id,
+            "run_id": self.run_id,
+            "artifact": stored.public_ref(),
+            "summary": {
+                "text": summary_text,
+                "flow_count": len(flows),
+                "packet_count": packet_count,
+                "byte_count": int(byte_count),
+                "protocol_counts": dict(sorted(protocol_counts.items())),
+                "modbus_transaction_count": len(modbus),
+                "modbus_operation_counts": dict(sorted(operation_counts.items())),
+                "modbus_response_counts": dict(sorted(response_counts.items())),
+            },
+            "coverage": {
+                "event_start_time": min(timestamps),
+                "event_end_time": max(timestamps),
+                "capture_sha256s": capture_hashes,
+                "flow_membership_complete": True,
+                "modbus_packet_association": True,
+            },
+            "streams": {
+                "netflow": {
+                    "schema_id": FLOW_SCHEMA,
+                    "total_records": len(flows),
+                    "truncated": len(flows) > len(flow_preview),
+                    "records": flow_preview,
+                },
+                "modbus": {
+                    "schema_id": MODBUS_SCHEMA,
+                    "total_records": len(modbus),
+                    "truncated": len(modbus) > len(modbus_preview),
+                    "records": modbus_preview,
+                },
+            },
+        }
+
+
+class SequenceEvidenceStore:
+    def __init__(self, root: Optional[Path] = None, max_bytes: Optional[int] = None) -> None:
+        settings = get_settings()
+        configured = str(getattr(settings, "evidence_store_path", "") or "").strip()
+        self.root = Path(root or configured or vigil_path("evidence", write=True))
+        configured_max = int(getattr(settings, "evidence_store_max_mb", 10_240)) * 1024 * 1024
+        self.max_bytes = configured_max if max_bytes is None else int(max_bytes)
+        if self.max_bytes < 1:
+            raise SequenceEvidenceError("evidence store size limit must be positive")
+
+    def _stored_bytes(self) -> int:
+        if not self.root.exists():
+            return 0
+        return sum(
+            path.stat().st_size
+            for path in self.root.rglob("*")
+            if path.is_file() and not path.is_symlink()
+        )
+
+    def persist(self, bundle: SequenceEvidenceBundle) -> StoredEvidence:
+        flow_sha = _sha256(bundle.flow_path)
+        modbus_sha = _sha256(bundle.modbus_path) if bundle.modbus_path else None
+        digest = hashlib.sha256(
+            f"vigil-sequence-evidence/v1\0{bundle.run_id}\0{flow_sha}\0{modbus_sha or ''}".encode()
+        ).hexdigest()
+        destination = self.root / digest
+        files = [(bundle.flow_path, destination / "sequence-evidence.parquet", flow_sha)]
+        if bundle.modbus_path:
+            files.append(
+                (bundle.modbus_path, destination / "sequence-modbus-evidence.parquet", modbus_sha)
+            )
+        manifest = {
+            "schema": "vigil_sequence_evidence_store/v1",
+            "artifact_id": digest,
+            "dataset_id": bundle.dataset_id,
+            "run_id": bundle.run_id,
+            "flow_sha256": flow_sha,
+            "modbus_sha256": modbus_sha,
+            "sequence_count": len(bundle.flows_by_sequence),
+            "flow_count": len(bundle.flow_rows),
+            "modbus_count": len(bundle.modbus_rows),
+        }
+        manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode()
+        manifest_path = destination / "manifest.json"
+        additional_bytes = sum(
+            source.stat().st_size for source, target, _ in files if not target.exists()
+        )
+        if not manifest_path.exists():
+            additional_bytes += len(manifest_bytes)
+        if self._stored_bytes() + additional_bytes > self.max_bytes:
+            raise SequenceEvidenceError(
+                "evidence store capacity exceeded; apply the governed evidence retention procedure"
+            )
+        destination.mkdir(parents=True, exist_ok=True)
+        for source, target, expected_sha in files:
+            assert expected_sha is not None
+            if target.exists():
+                if _sha256(target) != expected_sha:
+                    raise SequenceEvidenceError(f"immutable evidence collision: {target}")
+                continue
+            temporary = target.with_suffix(target.suffix + f".{os.getpid()}.partial")
+            shutil.copyfile(source, temporary)
+            if _sha256(temporary) != expected_sha:
+                temporary.unlink(missing_ok=True)
+                raise SequenceEvidenceError("evidence copy hash mismatch")
+            os.replace(temporary, target)
+            os.chmod(target, 0o440)
+        if manifest_path.exists():
+            try:
+                existing_manifest = json.loads(manifest_path.read_text())
+            except (OSError, ValueError) as exc:
+                raise SequenceEvidenceError(
+                    f"invalid immutable evidence manifest: {manifest_path}"
+                ) from exc
+            if existing_manifest != manifest:
+                raise SequenceEvidenceError(
+                    f"immutable evidence manifest collision: {manifest_path}"
+                )
+        else:
+            temporary = manifest_path.with_suffix(".json.partial")
+            temporary.write_bytes(manifest_bytes)
+            os.replace(temporary, manifest_path)
+            os.chmod(manifest_path, 0o440)
+        os.chmod(destination, 0o550)
+        return StoredEvidence(digest, flow_sha, modbus_sha, destination)
+
+    def query(
+        self,
+        *,
+        artifact_id: str,
+        sequence_id: str,
+        kind: str,
+        offset: int,
+        limit: int,
+        expected_run_id: Optional[str] = None,
+        expected_dataset_id: Optional[str] = None,
+        expected_sha256: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if not ARTIFACT_ID.fullmatch(artifact_id):
+            raise SequenceEvidenceError("invalid evidence artifact identity")
+        if not sequence_id:
+            raise SequenceEvidenceError("sequence_id is required")
+        if kind not in {"netflow", "modbus"}:
+            raise SequenceEvidenceError("kind must be netflow or modbus")
+        if offset < 0 or limit < 1 or limit > 500:
+            raise SequenceEvidenceError("invalid evidence page bounds")
+        manifest_path = self.root / artifact_id / "manifest.json"
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (OSError, ValueError) as exc:
+            raise SequenceEvidenceError("evidence store manifest is missing or invalid") from exc
+        if manifest.get("artifact_id") != artifact_id:
+            raise SequenceEvidenceError("evidence store artifact identity mismatch")
+        if expected_run_id and manifest.get("run_id") != expected_run_id:
+            raise SequenceEvidenceError("evidence store run provenance mismatch")
+        if expected_dataset_id and manifest.get("dataset_id") != expected_dataset_id:
+            raise SequenceEvidenceError("evidence store dataset provenance mismatch")
+        filename = (
+            "sequence-evidence.parquet"
+            if kind == "netflow"
+            else "sequence-modbus-evidence.parquet"
+        )
+        path = self.root / artifact_id / filename
+        expected_sha = (
+            manifest.get("flow_sha256")
+            if kind == "netflow"
+            else manifest.get("modbus_sha256")
+        )
+        if expected_sha256 and expected_sha != expected_sha256:
+            raise SequenceEvidenceError("evidence store artifact hash mismatch")
+        if expected_sha is None and kind == "modbus":
+            return {"kind": kind, "total": 0, "offset": offset, "limit": limit, "records": []}
+        if not path.is_file() or _sha256(path) != expected_sha:
+            raise SequenceEvidenceError("evidence store file is missing or corrupt")
+        try:
+            import pyarrow.dataset as ds
+        except ImportError as exc:  # pragma: no cover - deployment image includes pyarrow
+            raise SequenceEvidenceError("pyarrow is required for sequence evidence") from exc
+        rows = ds.dataset(path, format="parquet").to_table(
+            filter=ds.field("sequence_id") == sequence_id
+        ).to_pylist()
+        if kind == "netflow":
+            rows.sort(key=lambda row: int(row.get("sequence_row_ordinal") or 0))
+            normalize = _flow_record
+        else:
+            rows.sort(
+                key=lambda row: (
+                    int(row.get("timestamp") or 0),
+                    int(row.get("observation_ordinal") or 0),
+                )
+            )
+            normalize = _modbus_record
+        return {
+            "kind": kind,
+            "total": len(rows),
+            "offset": offset,
+            "limit": limit,
+            "records": [normalize(row) for row in rows[offset : offset + limit]],
+        }

--- a/core/findings/source_evidence.py
+++ b/core/findings/source_evidence.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from collections.abc import Mapping
 from datetime import date, datetime
 from typing import Any, Dict, Optional
 
 
 SOURCE_EVIDENCE_VERSION = 1
+SEQUENCE_EVIDENCE_VERSION = 2
 SOURCE_EVIDENCE_PREVIEW_LIMIT = 100
 SOURCE_EVIDENCE_RAW_TEXT_LIMIT = 65_536
 
@@ -127,6 +129,8 @@ def normalize_source_evidence(
         return _invalid_evidence(fallback_kind, default_schema_id)
 
     version = parsed.get("version", SOURCE_EVIDENCE_VERSION)
+    if version == SEQUENCE_EVIDENCE_VERSION:
+        return _normalize_sequence_evidence(parsed)
     kind = _telemetry_kind(parsed.get("telemetry_kind")) or fallback_kind
     schema_id = _text(parsed.get("schema_id")) or _text(default_schema_id)
     status = _text(parsed.get("status"))
@@ -211,6 +215,116 @@ def normalize_source_evidence(
             supplied_raw_text_truncated or raw_text_truncated
         )
     return envelope
+
+
+def _normalize_sequence_evidence(parsed: Mapping[str, Any]) -> Dict[str, Any]:
+    """Validate the joined, immutable sequence-evidence envelope.
+
+    Version 2 deliberately has no free-form raw payload.  It carries a
+    deterministic summary, bounded record previews, and an immutable artifact
+    reference used by the paginated evidence endpoint.
+    """
+    status = _text(parsed.get("status"))
+    provenance = _text(parsed.get("provenance"))
+    association_basis = _text(parsed.get("association_basis"))
+    sequence_id = _text(parsed.get("sequence_id"))
+    dataset_id = _text(parsed.get("dataset_id"))
+    run_id = _text(parsed.get("run_id"))
+    artifact = parsed.get("artifact")
+    summary = parsed.get("summary")
+    coverage = parsed.get("coverage")
+    streams = parsed.get("streams")
+    if (
+        status != "available"
+        or provenance != "joined"
+        or association_basis not in {"producer_membership", "sequence_builder_replay"}
+        or not all((sequence_id, dataset_id, run_id))
+        or not isinstance(artifact, Mapping)
+        or not isinstance(summary, Mapping)
+        or not isinstance(coverage, Mapping)
+        or not isinstance(streams, Mapping)
+    ):
+        return _invalid_evidence()
+
+    artifact_id = _text(artifact.get("artifact_id"))
+    flow_sha256 = _text(artifact.get("flow_sha256"))
+    modbus_sha256 = _text(artifact.get("modbus_sha256"))
+    if (
+        not artifact_id
+        or re.fullmatch(r"[a-f0-9]{64}", artifact_id) is None
+        or not flow_sha256
+        or re.fullmatch(r"[a-f0-9]{64}", flow_sha256) is None
+        or (
+            modbus_sha256 is not None
+            and re.fullmatch(r"[a-f0-9]{64}", modbus_sha256) is None
+        )
+    ):
+        return _invalid_evidence()
+
+    normalized_streams: Dict[str, Any] = {}
+    for kind, expected_schema in (
+        ("netflow", "sequence_evidence/v1"),
+        ("modbus", "sequence_protocol_evidence/v1"),
+    ):
+        stream = streams.get(kind)
+        if not isinstance(stream, Mapping) or stream.get("schema_id") != expected_schema:
+            return _invalid_evidence()
+        raw_records = stream.get("records", [])
+        if not isinstance(raw_records, (list, tuple)):
+            return _invalid_evidence()
+        records = [
+            _json_safe(record)
+            for record in raw_records[:SOURCE_EVIDENCE_PREVIEW_LIMIT]
+            if isinstance(record, Mapping)
+        ]
+        if len(records) != min(len(raw_records), SOURCE_EVIDENCE_PREVIEW_LIMIT):
+            return _invalid_evidence()
+        try:
+            total_records = int(stream.get("total_records", len(raw_records)))
+        except (TypeError, ValueError):
+            return _invalid_evidence()
+        if total_records < len(records) or total_records < 0:
+            return _invalid_evidence()
+        truncated = stream.get("truncated", False)
+        if not isinstance(truncated, bool):
+            return _invalid_evidence()
+        normalized_streams[kind] = {
+            "schema_id": expected_schema,
+            "total_records": total_records,
+            "truncated": bool(
+                truncated
+                or total_records > len(records)
+                or len(raw_records) > len(records)
+            ),
+            "records": records,
+        }
+
+    normalized_summary = _json_safe(summary)
+    normalized_coverage = _json_safe(coverage)
+    if not isinstance(normalized_summary, Mapping) or not isinstance(
+        normalized_coverage, Mapping
+    ):
+        return _invalid_evidence()
+    if not _text(normalized_summary.get("text")):
+        return _invalid_evidence()
+
+    return {
+        "version": SEQUENCE_EVIDENCE_VERSION,
+        "status": "available",
+        "provenance": "joined",
+        "association_basis": association_basis,
+        "sequence_id": sequence_id,
+        "dataset_id": dataset_id,
+        "run_id": run_id,
+        "artifact": {
+            "artifact_id": artifact_id,
+            "flow_sha256": flow_sha256,
+            "modbus_sha256": modbus_sha256,
+        },
+        "summary": dict(normalized_summary),
+        "coverage": dict(normalized_coverage),
+        "streams": normalized_streams,
+    }
 
 
 def source_evidence_from_loglm_row(row: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
@@ -346,6 +460,15 @@ def project_finding_source_evidence_for_list(finding: Dict[str, Any]) -> Dict[st
     projected_evidence = dict(evidence)
     projected_evidence.pop("records", None)
     projected_evidence.pop("raw_text", None)
+    streams = projected_evidence.get("streams")
+    if isinstance(streams, Mapping):
+        projected_streams = {}
+        for kind, stream in streams.items():
+            if isinstance(stream, Mapping):
+                projected_stream = dict(stream)
+                projected_stream.pop("records", None)
+                projected_streams[kind] = projected_stream
+        projected_evidence["streams"] = projected_streams
     projected_evidence["payload_included"] = False
     projected_context["source_evidence"] = projected_evidence
     projected["entity_context"] = projected_context

--- a/core/ingestion/ingestion_jobs.py
+++ b/core/ingestion/ingestion_jobs.py
@@ -151,20 +151,39 @@ def summarize_stats(stats: Dict[str, int]) -> tuple:
         messages.append(f"{stats['findings_errors']} finding errors")
     if stats.get("cases_errors", 0) > 0:
         messages.append(f"{stats['cases_errors']} case errors")
+    if stats.get("evidence_attached", 0) > 0:
+        messages.append(f"Attached exact evidence to {stats['evidence_attached']} findings")
+    if stats.get("evidence_unchanged", 0) > 0:
+        messages.append(
+            f"Verified evidence on {stats['evidence_unchanged']} unchanged findings"
+        )
 
     return success, ". ".join(messages) if messages else "No data imported"
 
 
-def run_job(job: IngestionJob, source_path: Path) -> None:
+def run_job(
+    job: IngestionJob,
+    source_path: Path,
+    evidence_path: Optional[Path] = None,
+    protocol_evidence_path: Optional[Path] = None,
+) -> None:
     """Ingest source_path on a worker thread, then delete it. Never raises."""
     from core.ingestion.ingestion_service import IngestionService
 
     try:
         service = IngestionService()
         job.track(service.stats)
-        stats = service._ingest_file_by_format(
-            source_path, job.format, data_type=job.data_type
-        )
+        if evidence_path is not None:
+            stats = service.ingest_parquet_file(
+                source_path,
+                evidence_file_path=evidence_path,
+                protocol_evidence_file_path=protocol_evidence_path,
+                merge_source_evidence=True,
+            )
+        else:
+            stats = service._ingest_file_by_format(
+                source_path, job.format, data_type=job.data_type
+            )
         success, message = summarize_stats(stats or {})
         if success:
             job.finish(message)
@@ -175,3 +194,7 @@ def run_job(job: IngestionJob, source_path: Path) -> None:
         job.fail(f"Ingestion failed: {e}")
     finally:
         source_path.unlink(missing_ok=True)
+        if evidence_path is not None:
+            evidence_path.unlink(missing_ok=True)
+        if protocol_evidence_path is not None:
+            protocol_evidence_path.unlink(missing_ok=True)

--- a/core/ingestion/ingestion_service.py
+++ b/core/ingestion/ingestion_service.py
@@ -17,13 +17,18 @@ import hashlib
 import logging
 import tempfile
 from pathlib import Path
-from typing import List, Dict, Any, Union
+from typing import List, Dict, Any, Optional, Union
 from datetime import datetime
 from io import StringIO
 
 from core.findings.source_evidence import (
     normalize_finding_source_evidence,
     source_evidence_from_loglm_row,
+)
+from core.findings.evidence_store import (
+    SequenceEvidenceBundle,
+    SequenceEvidenceError,
+    SequenceEvidenceStore,
 )
 
 logger = logging.getLogger(__name__)
@@ -115,6 +120,8 @@ class IngestionService:
             'cases_imported': 0,
             'cases_skipped': 0,
             'cases_errors': 0,
+            'evidence_attached': 0,
+            'evidence_unchanged': 0,
         }
         self._identity_warned: set = set()
 
@@ -264,7 +271,95 @@ class IngestionService:
             logger.error(f"Error ingesting finding {finding_id}: {e}")
             return False
 
-    def _ingest_finding_batch(self, finding_dicts: List[Dict[str, Any]]) -> None:
+    @staticmethod
+    def _joined_sequence_evidence(finding_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        context = finding_data.get('entity_context')
+        if not isinstance(context, dict):
+            return None
+        evidence = context.get('source_evidence')
+        if (
+            isinstance(evidence, dict)
+            and evidence.get('version') == 2
+            and evidence.get('status') == 'available'
+        ):
+            return evidence
+        return None
+
+    def _merge_existing_source_evidence(self, finding_data: Dict[str, Any]) -> None:
+        """Attach validated v2 evidence without changing finding identity/verdict."""
+        evidence = self._joined_sequence_evidence(finding_data)
+        if evidence is None:
+            return
+        finding_id = finding_data['finding_id']
+        if self.use_database and self.db_service:
+            existing = self.db_service.get_finding(finding_id)
+            if existing is None:
+                raise SequenceEvidenceError(
+                    f"finding disappeared while attaching evidence: {finding_id}"
+                )
+            context = dict(existing.entity_context or {})
+            if context.get('source_evidence') == evidence:
+                self.stats['evidence_unchanged'] += 1
+                return
+            context['source_evidence'] = evidence
+            if not self.db_service.update_finding(finding_id, entity_context=context):
+                raise SequenceEvidenceError(
+                    f"failed to attach evidence to finding: {finding_id}"
+                )
+            self.stats['evidence_attached'] += 1
+            return
+
+        from core.storage.database_data_service import DatabaseDataService
+
+        data_service = DatabaseDataService()
+        existing = data_service.get_finding(finding_id)
+        if not existing:
+            raise SequenceEvidenceError(
+                f"finding disappeared while attaching evidence: {finding_id}"
+            )
+        context = dict(existing.get('entity_context') or {})
+        if context.get('source_evidence') == evidence:
+            self.stats['evidence_unchanged'] += 1
+            return
+        context['source_evidence'] = evidence
+        if not data_service.update_finding(finding_id, entity_context=context):
+            raise SequenceEvidenceError(
+                f"failed to attach evidence to finding: {finding_id}"
+            )
+        self.stats['evidence_attached'] += 1
+
+    @staticmethod
+    def _imported_finding_ids(
+        result: Dict[str, Any], findings: List[Dict[str, Any]]
+    ) -> set[str]:
+        """Return identities inserted by the bulk write, failing closed on ambiguity."""
+        expected = int(result.get('imported', 0))
+        valid_ids = {str(finding['finding_id']) for finding in findings}
+        raw_ids = result.get('imported_ids')
+        if raw_ids is None:
+            # Compatibility for all-or-nothing test doubles and older adapters.
+            if expected == 0:
+                return set()
+            if expected == len(valid_ids) and int(result.get('skipped', 0)) == 0:
+                return valid_ids
+            raise SequenceEvidenceError(
+                "bulk finding write did not identify newly inserted findings"
+            )
+        if not isinstance(raw_ids, (list, tuple, set)):
+            raise SequenceEvidenceError("bulk finding imported_ids must be a collection")
+        imported_ids = {str(value) for value in raw_ids if str(value)}
+        if len(imported_ids) != expected or not imported_ids.issubset(valid_ids):
+            raise SequenceEvidenceError(
+                "bulk finding imported_ids do not match the import result"
+            )
+        return imported_ids
+
+    def _ingest_finding_batch(
+        self,
+        finding_dicts: List[Dict[str, Any]],
+        *,
+        merge_source_evidence: bool = False,
+    ) -> None:
         """Bulk-dedup and insert a batch in one DB round trip, vs. per-row ingest_finding."""
         if not finding_dicts:
             return
@@ -272,6 +367,8 @@ class IngestionService:
         if not self.use_database or not self.db_service:
             for finding_data in finding_dicts:
                 self.ingest_finding(finding_data)
+                if merge_source_evidence:
+                    self._merge_existing_source_evidence(finding_data)
             return
 
         valid = []
@@ -298,9 +395,22 @@ class IngestionService:
             self.stats['findings_imported'] += result['imported']
             self.stats['findings_skipped'] += result['skipped']
             self.stats['findings_errors'] += result.get('errors', 0)
+            if result.get('errors', 0) == 0 and merge_source_evidence:
+                imported_ids = self._imported_finding_ids(result, valid)
+                by_id = {str(item['finding_id']): item for item in valid}
+                for finding_id, finding_data in by_id.items():
+                    if self._joined_sequence_evidence(finding_data) is None:
+                        continue
+                    if finding_id in imported_ids:
+                        # The exact evidence envelope was inserted atomically with the row.
+                        self.stats['evidence_attached'] += 1
+                    else:
+                        self._merge_existing_source_evidence(finding_data)
         except Exception as e:
             logger.error(f"Error bulk ingesting findings: {e}")
             self.stats['findings_errors'] += len(valid)
+            if isinstance(e, SequenceEvidenceError):
+                raise
 
     def _ingest_findings_batched(self, findings, batch_size: int = 1000) -> None:
         """Feed an iterable of finding dicts through _ingest_finding_batch in chunks."""
@@ -754,7 +864,10 @@ class IngestionService:
     def ingest_parquet_file(
         self,
         file_path: Union[str, Path],
-        data_source: str = 'flow'
+        data_source: str = 'flow',
+        evidence_file_path: Optional[Union[str, Path]] = None,
+        protocol_evidence_file_path: Optional[Union[str, Path]] = None,
+        merge_source_evidence: bool = False,
     ) -> Dict[str, Any]:
         """LogLM embedding exports route through _parquet_row_to_finding; anything
         else ingests generically via _generic_row_to_finding."""
@@ -778,6 +891,31 @@ class IngestionService:
             schema_kind = self._detect_parquet_schema(col_names)
             logger.info(f"Detected parquet schema: {schema_kind}")
 
+            evidence_bundle = None
+            stored_evidence = None
+            if evidence_file_path is not None:
+                if schema_kind != 'loglm':
+                    raise SequenceEvidenceError(
+                        "sequence evidence may only accompany a LogLM finding parquet"
+                    )
+                evidence_bundle = SequenceEvidenceBundle(
+                    Path(evidence_file_path),
+                    Path(protocol_evidence_file_path)
+                    if protocol_evidence_file_path is not None
+                    else None,
+                )
+                self._preflight_sequence_evidence(parquet_file, evidence_bundle)
+                stored_evidence = SequenceEvidenceStore().persist(evidence_bundle)
+                logger.info(
+                    "Validated sequence evidence artifact %s for %s sequences",
+                    stored_evidence.artifact_id,
+                    len(evidence_bundle.flows_by_sequence),
+                )
+            elif protocol_evidence_file_path is not None:
+                raise SequenceEvidenceError(
+                    "protocol evidence requires the sequence flow evidence file"
+                )
+
             sampled_first_row = False
             batch_size = 1000
             for batch in parquet_file.iter_batches(batch_size=batch_size):
@@ -792,13 +930,25 @@ class IngestionService:
                             logger.info(f"Parquet sample row (types+values): {sample}")
                             sampled_first_row = True
                         if schema_kind == 'loglm':
-                            finding_batch.append(self._parquet_row_to_finding(row, data_source))
+                            finding = self._parquet_row_to_finding(row, data_source)
+                            if evidence_bundle is not None and stored_evidence is not None:
+                                sequence_id = str(row.get('sequence_id') or '')
+                                finding['entity_context']['source_evidence'] = (
+                                    evidence_bundle.envelope(sequence_id, stored_evidence)
+                                )
+                                finding['entity_context']['evidence_availability'] = 'available'
+                            finding_batch.append(finding)
                         else:
                             finding_batch.append(self._generic_row_to_finding(row, data_source))
                     except Exception as e:
                         logger.error(f"Error processing parquet row: {e}")
                         self.stats['findings_errors'] += 1
-                self._ingest_finding_batch(finding_batch)
+                self._ingest_finding_batch(
+                    finding_batch,
+                    merge_source_evidence=bool(
+                        merge_source_evidence and evidence_bundle is not None
+                    ),
+                )
 
             logger.info(f"Parquet ingestion complete: {self.stats}")
             return self.stats
@@ -806,9 +956,60 @@ class IngestionService:
         except ImportError:
             logger.error("pyarrow is required for parquet ingestion: pip install pyarrow")
             return self.stats
+        except SequenceEvidenceError:
+            self.stats['findings_errors'] = max(
+                self.stats['findings_errors'], self.stats['findings_total'] or 1
+            )
+            raise
         except Exception as e:
             logger.error(f"Error ingesting parquet file: {e}")
             return self.stats
+
+    @staticmethod
+    def _preflight_sequence_evidence(parquet_file, bundle: SequenceEvidenceBundle) -> None:
+        """Validate all finding/evidence joins before persisting or ingesting."""
+        available = set(parquet_file.schema_arrow.names)
+        required = {'sequence_id', 'row_count'}
+        missing = required - available
+        if missing:
+            raise SequenceEvidenceError(
+                f"finding parquet lacks evidence join columns: {sorted(missing)}"
+            )
+        columns = [
+            column
+            for column in ('sequence_id', 'row_count', 'run_id', 'dataset_id')
+            if column in available
+        ]
+        seen: set[str] = set()
+        for batch in parquet_file.iter_batches(columns=columns, batch_size=1000):
+            values = batch.to_pydict()
+            for index in range(batch.num_rows):
+                sequence_id = str(values['sequence_id'][index] or '')
+                if not sequence_id or sequence_id in seen:
+                    raise SequenceEvidenceError(
+                        f"finding parquet has missing/duplicate sequence_id: {sequence_id!r}"
+                    )
+                seen.add(sequence_id)
+                row_count = int(values['row_count'][index] or 0)
+                if not bundle.has_sequence(sequence_id, row_count):
+                    raise SequenceEvidenceError(
+                        f"no exact {row_count}-row evidence membership for {sequence_id}"
+                    )
+                if 'run_id' in values:
+                    run_id = str(values['run_id'][index] or '')
+                    if run_id and run_id != bundle.run_id:
+                        raise SequenceEvidenceError(
+                            f"run_id mismatch for {sequence_id}: {run_id} != {bundle.run_id}"
+                        )
+                if 'dataset_id' in values:
+                    dataset_id = str(values['dataset_id'][index] or '')
+                    if dataset_id and dataset_id != bundle.dataset_id:
+                        raise SequenceEvidenceError(
+                            f"dataset_id mismatch for {sequence_id}: "
+                            f"{dataset_id} != {bundle.dataset_id}"
+                        )
+        if not seen:
+            raise SequenceEvidenceError("finding parquet contains no sequences")
 
     def _parquet_row_to_finding(
         self,

--- a/core/ingestion/ingestion_service.py
+++ b/core/ingestion/ingestion_service.py
@@ -86,6 +86,38 @@ def row_identity_key(row: Dict[str, Any], columns: tuple) -> str:
     return '|'.join(parts)
 
 
+def _coerce_optional_verdict(value: Any, field_name: str) -> Optional[bool]:
+    """Normalize an optional boolean verdict and reject ambiguous values."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(value)
+    normalized = str(value).strip().lower()
+    if normalized in {"true", "1", "yes", "malicious", "attack"}:
+        return True
+    if normalized in {"false", "0", "no", "benign", "normal", "clean"}:
+        return False
+    raise ValueError(f"Invalid {field_name} verdict: {value!r}")
+
+
+def _label_verdict(value: Any) -> Optional[bool]:
+    """Map recognized source labels to an attack/benign verdict."""
+    if value is None:
+        return None
+    normalized = str(value).strip().lower().replace("_", "-")
+    if normalized in {
+        "malicious", "attack", "anomalous", "threat", "1", "true"
+    }:
+        return True
+    if normalized in {
+        "benign", "normal", "clean", "non-malicious", "0", "false"
+    }:
+        return False
+    return None
+
+
 class IngestionService:
     """Service for ingesting data from various formats into the database."""
     
@@ -1090,8 +1122,51 @@ class IngestionService:
             'dst_ip': row.get('engaged_ip'),
             'incident_pred': incident_pred,
             'confidence_score': anomaly_score,
+            'prediction_confidence': (
+                float(confidence) if confidence is not None else 0.85
+            ),
+            'verdict': 'attack' if is_attack else 'benign',
             'sequence_id': sequence_id,
         }
+
+        # ``malicious`` and ``label`` are source ground truth, not aliases for
+        # the model's ``incident_pred``. Keep them separate so false positives
+        # and false negatives remain visible in downstream evidence views.
+        malicious_verdict = _coerce_optional_verdict(
+            row.get('malicious'), 'malicious'
+        )
+        label_verdict = _label_verdict(row.get('label'))
+        if (
+            malicious_verdict is not None
+            and label_verdict is not None
+            and malicious_verdict != label_verdict
+        ):
+            raise ValueError(
+                "Contradictory ground truth: malicious and label disagree"
+            )
+        ground_truth_verdict = (
+            malicious_verdict
+            if malicious_verdict is not None
+            else label_verdict
+        )
+        if ground_truth_verdict is not None:
+            entity_context.update({
+                'ground_truth_malicious': ground_truth_verdict,
+                'ground_truth_verdict': (
+                    'attack' if ground_truth_verdict else 'benign'
+                ),
+                'ground_truth_source': (
+                    'malicious'
+                    if malicious_verdict is not None
+                    else 'label'
+                ),
+                'prediction_matches_ground_truth': (
+                    ground_truth_verdict == is_attack
+                ),
+            })
+        for source_field in ('malicious', 'label'):
+            if row.get(source_field) is not None:
+                entity_context[source_field] = row[source_field]
 
         if row.get('event_start_time') is not None:
             entity_context['event_start_time'] = int(row['event_start_time'])

--- a/core/storage/service.py
+++ b/core/storage/service.py
@@ -95,11 +95,11 @@ class DatabaseService:
             logger.error(f"Error creating finding {finding_id}: {e}")
             return None
 
-    def bulk_create_findings(self, rows: List[Dict[str, Any]]) -> Dict[str, int]:
+    def bulk_create_findings(self, rows: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Dedup + insert many findings in one transaction; per-row create_finding
         doesn't scale to hundred-thousand-row parquet files."""
         if not rows:
-            return {'imported': 0, 'skipped': 0}
+            return {'imported': 0, 'skipped': 0, 'imported_ids': []}
 
         by_id = {r['finding_id']: r for r in rows}
         ids = list(by_id.keys())
@@ -129,10 +129,19 @@ class DatabaseService:
                         status=r.get('status', 'new'),
                     ))
                 session.flush()
-                return {'imported': len(new_ids), 'skipped': len(rows) - len(new_ids)}
+                return {
+                    'imported': len(new_ids),
+                    'skipped': len(rows) - len(new_ids),
+                    'imported_ids': new_ids,
+                }
         except Exception as e:
             logger.error(f"Error bulk-creating findings: {e}")
-            return {'imported': 0, 'skipped': 0, 'errors': len(rows)}
+            return {
+                'imported': 0,
+                'skipped': 0,
+                'errors': len(rows),
+                'imported_ids': [],
+            }
 
     def get_finding(self, finding_id: str) -> Optional[Finding]:
         """

--- a/docs/SOURCE_EVIDENCE.md
+++ b/docs/SOURCE_EVIDENCE.md
@@ -1,71 +1,47 @@
 # Structured source evidence
 
-Vigil can retain a bounded preview of the source records that produced a
-finding. The preview lives at `finding.entity_context.source_evidence`, so it
-does not require a database migration. Finding list responses retain only the
-envelope metadata with `payload_included: false`;
-`GET /api/findings/{finding_id}` returns the payload.
+Vigil supports two source-evidence contracts inside
+`finding.entity_context.source_evidence`. Finding-list responses retain only
+the envelope; finding detail and the evidence paging endpoint expose records.
 
-## Contract
+## Embedded evidence (version 1)
 
-```json
-{
-  "version": 1,
-  "telemetry_kind": "netflow",
-  "schema_id": "netflow.v1",
-  "status": "available",
-  "provenance": "embedded",
-  "total_records": 150,
-  "truncated": true,
-  "records": [],
-  "raw_text": "optional source-native text"
-}
-```
+Version 1 accepts a bounded producer-owned preview for NetFlow, DNS, HTTP
+sessions, or generic logs. It records a versioned schema ID, availability
+state, provenance, total record count, truncation, and up to 100 records. It is
+appropriate when the finding artifact itself carries the source preview.
 
-`telemetry_kind` is the renderer selector, not `finding.data_source`. Supported
-values are `netflow`, `dns`, `http_session`, and `generic_log`. This lets the
-capability apply to network flows, DNS, Layer 7 sessions, and other logs without
-forcing unrelated schemas into a NetFlow table. `schema_id` remains owned by
-the producer and should be versioned when its record fields change.
+## Exact sequence evidence (version 2)
 
-`status` is one of:
+For LogLM findings, ingestion may receive two immutable companion Parquet
+artifacts:
 
-- `available`: at least one structured record or non-empty `raw_text` exists.
-- `not_in_artifact`: the source artifact did not include raw evidence.
-- `redacted`: evidence existed but was intentionally removed before ingestion.
-- `invalid`: evidence was supplied but failed contract validation.
+- `sequence_evidence/v1`: normalized flow rows with exact `sequence_id`,
+  ordered membership, flow identity, run/dataset identity, endpoints, counters,
+  capture hash, and packet bounds.
+- `sequence_protocol_evidence/v1`: Modbus observations joined to one of those
+  flows by capture, endpoints, and packet references.
 
-No envelope means the finding has no declared source-evidence capability, so
-the finding dialog hides the section. The other non-available states render a
-short, truthful message.
+Vigil validates all identities and joins before mutating findings. It then
+stores the companions under a content-addressed artifact ID and attaches a
+version-2 envelope to each finding. Duplicate finding imports may update that
+evidence reference but do not rewrite the finding verdict or identity.
 
-## LogLM Parquet inputs
+`GET /api/findings/{finding_id}/source-evidence` accepts `kind=netflow|modbus`,
+`offset`, and `limit` (maximum 500). The UI renders a deterministic behavioral
+summary plus paginated flow and Modbus tables. Any LLM-generated prose remains
+separate from these source-backed facts.
 
-The preferred Parquet column is `source_evidence`, containing the object above
-or its JSON representation. Current artifacts with `events_json` and/or
-`sequence` are adapted during ingestion:
+The store defaults to 10,240 MiB and is configured by
+`EVIDENCE_STORE_PATH`/`EVIDENCE_STORE_MAX_MB`. It fails closed when capacity is
+exhausted; it does not evict artifacts still referenced by findings. Companion
+files contain normalized metadata and provenance, never raw PCAP or payload.
 
-- `events_json` becomes ordered `records`.
-- `sequence` becomes `raw_text`.
-- `source_evidence_kind` explicitly selects the telemetry renderer. If absent,
-  these legacy columns use `generic_log` rather than guessing from
-  `data_source="flow"`.
-- Optional columns are `source_evidence_schema_id`, `source_evidence_status`,
-  `source_evidence_provenance`, and `source_evidence_total_records`.
+## Truth boundaries
 
-Ingestion retains at most 100 structured records and 64 KiB of raw text per
-finding, records truncation metadata, converts non-finite numbers to `null`,
-and never lets malformed evidence prevent the finding itself from ingesting.
-
-## Canonical record fields
-
-The built-in tables recognize these v1 field names:
-
-- NetFlow: `timestamp`, `source_ip`, `source_port`, `destination_ip`,
-  `destination_port`, `protocol`, `forward_packets`, `backward_packets`,
-  `forward_bytes`, `backward_bytes`, `duration_ms`.
-- DNS: `timestamp`, `client_ip`, `server_ip`, `query`, `query_type`, `answer`,
-  `response_code`, `ttl`.
-
-HTTP-session and generic-log records render as ordered, expandable key/value
-records so source fields remain visible without inventing a universal schema.
+- A model finding is not proof of attack.
+- Observed endpoint traffic is not an inferred network topology.
+- Missing evidence remains unavailable; Vigil does not reconstruct records
+  from token bins or ask an LLM to invent them.
+- Capture hashes and packet references prove artifact linkage only when the
+  upstream custody and manifest gates also pass.

--- a/env.example
+++ b/env.example
@@ -105,6 +105,12 @@ POSTGRES_PASSWORD="deeptempo_secure_password_change_me"
 # demo_mode in general_config.json.
 # DEMO_MODE=false
 
+# Immutable exact flow/Modbus evidence attached to imported findings. Leave the
+# path empty to use Vigil's managed data directory; the size limit is MiB and
+# causes new evidence imports to fail closed when exhausted.
+# EVIDENCE_STORE_PATH=""
+# EVIDENCE_STORE_MAX_MB=10240
+
 # -----------------------------------------------------------------------------
 # Redis (LLM job queue + session store)
 # -----------------------------------------------------------------------------

--- a/services/api/routers/findings.py
+++ b/services/api/routers/findings.py
@@ -1,5 +1,6 @@
 """Findings API endpoints."""
 
+from collections.abc import Mapping
 from typing import List, Optional, Dict, Any
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
@@ -17,6 +18,7 @@ from core.findings.source_evidence import (
     normalize_finding_source_evidence,
     project_finding_source_evidence_for_list,
 )
+from core.findings.evidence_store import SequenceEvidenceError, SequenceEvidenceStore
 from core.routing import Auth, RouterMeta, UnitOfWorkSession
 
 router = APIRouter()
@@ -86,6 +88,47 @@ def get_findings(
         "limit": limit,
         "has_more": (offset + limit) < total,
     }
+
+
+@router.get("/{finding_id}/source-evidence")
+def get_finding_source_evidence(
+    finding_id: str,
+    kind: str = Query("netflow", pattern="^(netflow|modbus)$"),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=500),
+):
+    """Page immutable flow or Modbus records for one exact LogLM sequence."""
+    finding = data_service.get_finding(finding_id)
+    if not finding:
+        raise HTTPException(status_code=404, detail="Finding not found")
+    normalized = normalize_finding_source_evidence(finding)
+    context = normalized.get("entity_context")
+    evidence = context.get("source_evidence") if isinstance(context, Mapping) else None
+    if not isinstance(evidence, Mapping) or evidence.get("version") != 2:
+        raise HTTPException(
+            status_code=404,
+            detail="Exact sequence evidence is not attached to this finding",
+        )
+    artifact = evidence.get("artifact")
+    if not isinstance(artifact, Mapping):
+        raise HTTPException(status_code=422, detail="Invalid evidence artifact reference")
+    try:
+        return SequenceEvidenceStore().query(
+            artifact_id=str(artifact.get("artifact_id") or ""),
+            sequence_id=str(evidence.get("sequence_id") or ""),
+            kind=kind,
+            offset=offset,
+            limit=limit,
+            expected_run_id=str(evidence.get("run_id") or ""),
+            expected_dataset_id=str(evidence.get("dataset_id") or ""),
+            expected_sha256=(
+                str(artifact.get("flow_sha256") or "")
+                if kind == "netflow"
+                else str(artifact.get("modbus_sha256") or "") or None
+            ),
+        )
+    except SequenceEvidenceError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.get("/{finding_id}")

--- a/services/api/routers/ingestion.py
+++ b/services/api/routers/ingestion.py
@@ -110,6 +110,8 @@ async def _spool_upload(file: UploadFile, suffix: str) -> Path:
 @router.post("/upload", response_model=IngestionJobStatus, status_code=202)
 async def upload_and_ingest_file(
     file: UploadFile = File(...),
+    evidence_file: Optional[UploadFile] = File(None),
+    protocol_evidence_file: Optional[UploadFile] = File(None),
     data_type: str = Form("finding"),
     format: Optional[str] = Form(None)
 ):
@@ -129,19 +131,56 @@ async def upload_and_ingest_file(
     if format not in ['json', 'csv', 'jsonl', 'parquet']:
         raise HTTPException(status_code=400, detail="format must be 'json', 'csv', 'jsonl', or 'parquet'")
 
-    temp_path = await _spool_upload(file, f'.{format}')
+    if evidence_file is not None and (format != 'parquet' or data_type != 'finding'):
+        raise HTTPException(
+            status_code=400,
+            detail="sequence evidence requires a parquet finding upload",
+        )
+    if protocol_evidence_file is not None and evidence_file is None:
+        raise HTTPException(
+            status_code=400,
+            detail="protocol evidence requires sequence flow evidence",
+        )
+
+    temp_paths: list[Path] = []
+    try:
+        temp_path = await _spool_upload(file, f'.{format}')
+        temp_paths.append(temp_path)
+        evidence_path = None
+        protocol_evidence_path = None
+        if evidence_file is not None:
+            evidence_path = await _spool_upload(evidence_file, '.evidence.parquet')
+            temp_paths.append(evidence_path)
+        if protocol_evidence_file is not None:
+            protocol_evidence_path = await _spool_upload(
+                protocol_evidence_file, '.protocol-evidence.parquet'
+            )
+            temp_paths.append(protocol_evidence_path)
+    except Exception:
+        for path in temp_paths:
+            path.unlink(missing_ok=True)
+        raise
 
     job = IngestionJob(filename=filename, fmt=format, data_type=data_type)
     try:
         get_job_registry().start(job)
     except IngestionJobConflict as conflict:
-        temp_path.unlink(missing_ok=True)
+        for path in temp_paths:
+            path.unlink(missing_ok=True)
         raise HTTPException(
             status_code=409,
             detail=f"Already ingesting '{conflict.active.filename}'. Wait for it to finish."
         )
 
-    task = asyncio.create_task(run_in_threadpool(run_job, job, temp_path))
+    task = asyncio.create_task(
+        run_in_threadpool(
+            run_job,
+            job,
+            temp_path,
+            evidence_path,
+            protocol_evidence_path,
+        )
+    )
     _running_tasks.add(task)
     task.add_done_callback(_running_tasks.discard)
 

--- a/tests/unit/findings/test_sequence_evidence.py
+++ b/tests/unit/findings/test_sequence_evidence.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import copy
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from core.findings.evidence_store import (
+    SequenceEvidenceBundle,
+    SequenceEvidenceError,
+    SequenceEvidenceStore,
+)
+
+
+def flow_rows() -> list[dict]:
+    base = {
+        "evidence_schema_version": "sequence_evidence/v1",
+        "association_basis": "producer_membership",
+        "sequence_id": "seq-1",
+        "dataset_id": "ws3",
+        "run_id": "run-1",
+        "tenant": "tac",
+        "focal_ip": "10.0.0.1",
+        "engaged_ip": "10.0.0.2",
+        "row_count": 2,
+        "chunk_start_ms": 1_700_000_000_000,
+        "chunk_end_ms": 1_700_000_001_000,
+        "event_start_time": 1_700_000_000_000,
+        "event_end_time": 1_700_000_001_000,
+        "src_ip": "10.0.0.1",
+        "dest_ip": "10.0.0.2",
+        "src_port": 41000,
+        "dest_port": 502,
+        "fwd_bytes": 100.0,
+        "bwd_bytes": 80.0,
+        "fwd_pkts": 2,
+        "bwd_pkts": 1,
+        "flow_dur": 0.25,
+        "protocol": "6",
+        "source_file": "capture.parquet",
+        "capture_id": "capture",
+        "capture_sha256": "a" * 64,
+        "first_packet": 1,
+        "last_packet": 4,
+    }
+    return [
+        {**base, "flow_id": "flow-1", "sequence_row_ordinal": 0, "timestamp_ms": 1_700_000_000_000},
+        {**base, "flow_id": "flow-2", "sequence_row_ordinal": 1, "timestamp_ms": 1_700_000_001_000},
+    ]
+
+
+def modbus_rows() -> list[dict]:
+    return [{
+        "evidence_schema_version": "sequence_protocol_evidence/v1",
+        "association_basis": "capture_packet_to_flow",
+        "sequence_id": "seq-1",
+        "flow_id": "flow-1",
+        "dataset_id": "ws3",
+        "run_id": "run-1",
+        "capture_id": "capture",
+        "capture_sha256": "a" * 64,
+        "observation_ordinal": 0,
+        "timestamp": 1_700_000_000_000_000,
+        "client_ip": "10.0.0.1",
+        "client_port": 41000,
+        "server_ip": "10.0.0.2",
+        "server_port": 502,
+        "transaction_id": 7,
+        "unit_id": 1,
+        "function_code": 3,
+        "function_name": "Read Holding Registers",
+        "operation": "read",
+        "address": 100,
+        "quantity": 2,
+        "response_status": "ok",
+        "latency_usec": 250,
+        "request_packet": 2,
+        "response_packet": 3,
+    }]
+
+
+def write(path, rows) -> None:
+    pq.write_table(pa.Table.from_pylist(rows), path)
+
+
+def test_store_builds_deterministic_envelope_and_pages_records(tmp_path):
+    flow_path = tmp_path / "flows.parquet"
+    modbus_path = tmp_path / "modbus.parquet"
+    write(flow_path, flow_rows())
+    write(modbus_path, modbus_rows())
+
+    bundle = SequenceEvidenceBundle(flow_path, modbus_path, expected_run_id="run-1")
+    store = SequenceEvidenceStore(root=tmp_path / "store")
+    stored = store.persist(bundle)
+    envelope = bundle.envelope("seq-1", stored)
+
+    assert envelope["version"] == 2
+    assert envelope["summary"]["flow_count"] == 2
+    assert envelope["summary"]["modbus_transaction_count"] == 1
+    assert "Observed 2 exact flow records" in envelope["summary"]["text"]
+    page = store.query(
+        artifact_id=stored.artifact_id,
+        sequence_id="seq-1",
+        kind="netflow",
+        offset=1,
+        limit=1,
+    )
+    assert page["total"] == 2
+    assert [record["flow_id"] for record in page["records"]] == ["flow-2"]
+
+
+def test_bundle_fails_closed_on_inexact_membership(tmp_path):
+    rows = copy.deepcopy(flow_rows())
+    rows[1]["sequence_row_ordinal"] = 3
+    flow_path = tmp_path / "bad.parquet"
+    write(flow_path, rows)
+    with pytest.raises(SequenceEvidenceError, match="membership mismatch"):
+        SequenceEvidenceBundle(flow_path, None)
+
+
+def test_bundle_rejects_mixed_exact_association_methods(tmp_path):
+    rows = copy.deepcopy(flow_rows())
+    rows[1]["association_basis"] = "sequence_builder_replay"
+    flow_path = tmp_path / "mixed-association.parquet"
+    write(flow_path, rows)
+    with pytest.raises(SequenceEvidenceError, match="cannot mix"):
+        SequenceEvidenceBundle(flow_path, None)
+
+
+def test_bundle_rejects_fractional_integer_fields(tmp_path):
+    rows = copy.deepcopy(flow_rows())
+    rows[0]["sequence_row_ordinal"] = 0.5
+    flow_path = tmp_path / "fractional-ordinal.parquet"
+    write(flow_path, rows)
+    with pytest.raises(SequenceEvidenceError, match="must be an integer"):
+        SequenceEvidenceBundle(flow_path, None)
+
+
+def test_bundle_rejects_protocol_flow_from_another_sequence(tmp_path):
+    rows = copy.deepcopy(flow_rows())
+    rows[0]["row_count"] = 1
+    rows[1].update(sequence_id="seq-2", sequence_row_ordinal=0, row_count=1)
+    for row in rows:
+        row["chunk_start_ms"] = row["timestamp_ms"]
+        row["chunk_end_ms"] = row["timestamp_ms"]
+        row["event_start_time"] = row["timestamp_ms"]
+        row["event_end_time"] = row["timestamp_ms"]
+    protocol = copy.deepcopy(modbus_rows())
+    protocol[0]["flow_id"] = "flow-2"
+    flow_path = tmp_path / "flows.parquet"
+    modbus_path = tmp_path / "modbus.parquet"
+    write(flow_path, rows)
+    write(modbus_path, protocol)
+    with pytest.raises(SequenceEvidenceError, match="different sequence"):
+        SequenceEvidenceBundle(flow_path, modbus_path)
+
+
+def test_store_fails_closed_at_capacity(tmp_path):
+    flow_path = tmp_path / "flows.parquet"
+    write(flow_path, flow_rows())
+    bundle = SequenceEvidenceBundle(flow_path, None)
+    with pytest.raises(SequenceEvidenceError, match="capacity exceeded"):
+        SequenceEvidenceStore(root=tmp_path / "store", max_bytes=1).persist(bundle)
+
+
+def test_query_rechecks_finding_provenance_against_store_manifest(tmp_path):
+    flow_path = tmp_path / "flows.parquet"
+    write(flow_path, flow_rows())
+    store = SequenceEvidenceStore(root=tmp_path / "store")
+    stored = store.persist(SequenceEvidenceBundle(flow_path, None))
+    with pytest.raises(SequenceEvidenceError, match="run provenance mismatch"):
+        store.query(
+            artifact_id=stored.artifact_id,
+            sequence_id="seq-1",
+            kind="netflow",
+            offset=0,
+            limit=10,
+            expected_run_id="another-run",
+        )

--- a/tests/unit/ingestion/test_loglm_ground_truth.py
+++ b/tests/unit/ingestion/test_loglm_ground_truth.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+
+from core.ingestion.ingestion_service import IngestionService
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def service():
+    instance = IngestionService.__new__(IngestionService)
+    instance._identity_warned = set()
+    return instance
+
+
+def _row(**overrides):
+    row = {
+        "sequence_id": "seq-1",
+        "event_start_time": 1_785_000_000_000,
+        "event_end_time": 1_785_000_060_000,
+        "focal_ip": "10.0.0.1",
+        "engaged_ip": "10.0.0.2",
+        "embedding": [0.1, 0.2],
+        "incident_pred": 0,
+        "confidence_score": 0.93,
+        "malicious": False,
+        "label": "Benign",
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.mark.parametrize(
+    ("incident_pred", "malicious", "label", "expected_match"),
+    [
+        (1, False, "Benign", False),
+        (0, True, "Attack", False),
+        (1, True, "Attack", True),
+    ],
+)
+def test_prediction_and_ground_truth_are_kept_separate(
+    service, incident_pred, malicious, label, expected_match
+):
+    finding = service._parquet_row_to_finding(
+        _row(
+            incident_pred=incident_pred,
+            malicious=malicious,
+            label=label,
+        )
+    )
+
+    context = finding["entity_context"]
+    assert context["verdict"] == ("attack" if incident_pred else "benign")
+    assert context["prediction_confidence"] == pytest.approx(0.93)
+    assert context["ground_truth_malicious"] is malicious
+    assert context["ground_truth_verdict"] == (
+        "attack" if malicious else "benign"
+    )
+    assert context["ground_truth_source"] == "malicious"
+    assert context["prediction_matches_ground_truth"] is expected_match
+    assert context["malicious"] is malicious
+    assert context["label"] == label
+
+
+def test_label_only_ground_truth_is_preserved(service):
+    finding = service._parquet_row_to_finding(
+        _row(malicious=None, label="Attack", incident_pred=0)
+    )
+
+    context = finding["entity_context"]
+    assert context["ground_truth_malicious"] is True
+    assert context["ground_truth_source"] == "label"
+    assert context["prediction_matches_ground_truth"] is False
+
+
+def test_contradictory_source_labels_are_rejected(service):
+    with pytest.raises(ValueError, match="Contradictory ground truth"):
+        service._parquet_row_to_finding(
+            _row(malicious=False, label="Attack")
+        )

--- a/tests/unit/ingestion/test_sequence_evidence_ingestion.py
+++ b/tests/unit/ingestion/test_sequence_evidence_ingestion.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from core.config import get_settings
+from core.ingestion.ingestion_service import IngestionService
+
+
+def test_companion_evidence_is_preflighted_and_merged_into_duplicate(tmp_path, monkeypatch):
+    finding_path = tmp_path / "findings.parquet"
+    flow_path = tmp_path / "sequence-evidence.parquet"
+    protocol_path = tmp_path / "sequence-modbus-evidence.parquet"
+    pq.write_table(pa.Table.from_pylist([{
+        "sequence_id": "sequence-001",
+        "row_count": 1,
+        "event_start_time": 1_784_653_712_000,
+        "event_end_time": 1_784_653_712_000,
+        "embedding": [0.01, 0.02],
+        "incident_pred": 0,
+        "confidence_score": 0.93,
+        "dataset_id": "ws3",
+        "run_id": "run-001",
+    }]), finding_path)
+    pq.write_table(pa.Table.from_pylist([{
+        "evidence_schema_version": "sequence_evidence/v1",
+        "association_basis": "producer_membership",
+        "sequence_id": "sequence-001",
+        "sequence_row_ordinal": 0,
+        "flow_id": "flow-001",
+        "dataset_id": "ws3",
+        "run_id": "run-001",
+        "tenant": "tac",
+        "focal_ip": "10.0.0.1",
+        "engaged_ip": "10.0.0.2",
+        "row_count": 1,
+        "chunk_start_ms": 1_784_653_712_000,
+        "chunk_end_ms": 1_784_653_712_000,
+        "event_start_time": 1_784_653_712_000,
+        "event_end_time": 1_784_653_712_000,
+        "timestamp_ms": 1_784_653_712_000,
+        "src_ip": "10.0.0.1",
+        "dest_ip": "10.0.0.2",
+        "src_port": 40000,
+        "dest_port": 502,
+        "fwd_bytes": 10.0,
+        "bwd_bytes": 20.0,
+        "fwd_pkts": 1,
+        "bwd_pkts": 1,
+        "flow_dur": 0.1,
+        "protocol": "6",
+        "source_file": "capture.parquet",
+        "capture_id": "capture",
+        "capture_sha256": "66" * 32,
+        "first_packet": 1,
+        "last_packet": 2,
+    }]), flow_path)
+    pq.write_table(pa.table({
+        "evidence_schema_version": pa.array([], type=pa.string()),
+        "association_basis": pa.array([], type=pa.string()),
+        "sequence_id": pa.array([], type=pa.string()),
+        "flow_id": pa.array([], type=pa.string()),
+        "dataset_id": pa.array([], type=pa.string()),
+        "run_id": pa.array([], type=pa.string()),
+    }), protocol_path)
+
+    existing = SimpleNamespace(entity_context={"sequence_id": "sequence-001"})
+
+    class ExistingDatabase:
+        def bulk_create_findings(self, findings):
+            return {"imported": 0, "skipped": len(findings)}
+
+        def get_finding(self, finding_id):
+            return existing
+
+        def update_finding(self, finding_id, **updates):
+            existing.entity_context = updates["entity_context"]
+            return True
+
+    monkeypatch.setenv("EVIDENCE_STORE_PATH", str(tmp_path / "store"))
+    get_settings.cache_clear()
+    service = IngestionService.__new__(IngestionService)
+    service._identity_warned = set()
+    service.use_database = True
+    service.db_service = ExistingDatabase()
+    service.stats = {
+        "findings_total": 0,
+        "findings_imported": 0,
+        "findings_skipped": 0,
+        "findings_errors": 0,
+        "cases_total": 0,
+        "cases_imported": 0,
+        "cases_skipped": 0,
+        "cases_errors": 0,
+        "evidence_attached": 0,
+        "evidence_unchanged": 0,
+    }
+    stats = service.ingest_parquet_file(
+        finding_path,
+        evidence_file_path=flow_path,
+        protocol_evidence_file_path=protocol_path,
+        merge_source_evidence=True,
+    )
+    get_settings.cache_clear()
+
+    assert stats["findings_skipped"] == 1
+    assert stats["evidence_attached"] == 1
+    assert existing.entity_context["source_evidence"]["version"] == 2
+    assert existing.entity_context["source_evidence"]["summary"]["flow_count"] == 1
+
+
+def test_new_finding_counts_atomically_inserted_evidence_as_attached():
+    evidence = {
+        "version": 2,
+        "status": "available",
+        "provenance": "joined",
+        "association_basis": "producer_membership",
+        "sequence_id": "sequence-001",
+        "dataset_id": "ws3",
+        "run_id": "run-001",
+        "artifact": {
+            "artifact_id": "aa" * 32,
+            "flow_sha256": "bb" * 32,
+            "modbus_sha256": None,
+        },
+        "summary": {"text": "Observed one exact flow."},
+        "coverage": {},
+        "streams": {
+            "netflow": {
+                "schema_id": "sequence_evidence/v1",
+                "total_records": 1,
+                "truncated": True,
+                "records": [],
+            },
+            "modbus": {
+                "schema_id": "sequence_protocol_evidence/v1",
+                "total_records": 0,
+                "truncated": False,
+                "records": [],
+            },
+        },
+    }
+
+    class InsertDatabase:
+        def bulk_create_findings(self, findings):
+            return {
+                "imported": 1,
+                "skipped": 0,
+                "imported_ids": [findings[0]["finding_id"]],
+            }
+
+        def get_finding(self, finding_id):  # pragma: no cover - must not be called
+            raise AssertionError(f"unexpected duplicate lookup for {finding_id}")
+
+    service = IngestionService.__new__(IngestionService)
+    service.use_database = True
+    service.db_service = InsertDatabase()
+    service.stats = {
+        "findings_total": 0,
+        "findings_imported": 0,
+        "findings_skipped": 0,
+        "findings_errors": 0,
+        "cases_total": 0,
+        "cases_imported": 0,
+        "cases_skipped": 0,
+        "cases_errors": 0,
+        "evidence_attached": 0,
+        "evidence_unchanged": 0,
+    }
+    service._ingest_finding_batch(
+        [{
+            "finding_id": "finding-001",
+            "timestamp": "2026-08-13T12:00:00Z",
+            "anomaly_score": 0.1,
+            "entity_context": {"source_evidence": evidence},
+        }],
+        merge_source_evidence=True,
+    )
+
+    assert service.stats["findings_imported"] == 1
+    assert service.stats["evidence_attached"] == 1
+    assert service.stats["evidence_unchanged"] == 0


### PR DESCRIPTION
## Summary

- ingest `sequence-evidence.parquet` alongside finding artifacts and attach it idempotently to findings
- validate schema version, exact sequence joins, hashes, and provenance before persistence
- store immutable, content-addressed evidence in a bounded local evidence store
- expose paginated evidence APIs and render deterministic flow and Modbus summaries/tables in finding details
- show coverage, capture provenance, truncation, and evidence-unavailable states explicitly

## Why

Vigil currently receives finding rows but not the original normalized flows that produced each sequence. This change makes raw-flow and Modbus detail independently inspectable without asking an LLM to invent or reconstruct evidence.

The displayed entities are observed endpoints and protocol observations, not inferred asset ownership or network topology.

## Validation

- targeted backend suite — 47 passed
- source-evidence UI tests — 4 passed
- production frontend build passed
