### PR TITLE
refactor(di): retire the get_X_service singletons

### DIFF
--- a/core/agents/agent_ai_generator.py
+++ b/core/agents/agent_ai_generator.py
@@ -3,13 +3,16 @@ import logging
 import re
 from typing import Any, Dict, List, Optional
 
+from core.integrations.mcp.registry import MCPRegistry
+
 logger = logging.getLogger(__name__)
 
 
 class AgentAIGenerator:
     """Generates / refines draft custom agent configurations from natural language."""
 
-    def __init__(self) -> None:
+    def __init__(self, mcp_registry: Optional[MCPRegistry] = None) -> None:
+        self._mcp_registry = mcp_registry
         self._mcp_tool_names_cache: Optional[List[str]] = None
 
     async def generate(
@@ -229,9 +232,7 @@ class AgentAIGenerator:
         if self._mcp_tool_names_cache is not None:
             return self._mcp_tool_names_cache
         try:
-            from core.integrations.mcp.registry import get_mcp_registry
-
-            registry = get_mcp_registry()
+            registry = self._mcp_registry or MCPRegistry()
             names = list(registry.get_tool_names() or [])
         except Exception as e:
             logger.debug(f"MCP registry unavailable: {e}")
@@ -302,14 +303,3 @@ class AgentAIGenerator:
             "max_tokens": max_tokens,
             "enable_thinking": bool(draft.get("enable_thinking") or False),
         }
-
-
-_generator: Optional[AgentAIGenerator] = None
-
-
-def get_agent_ai_generator() -> AgentAIGenerator:
-    """Return the singleton AgentAIGenerator instance."""
-    global _generator
-    if _generator is None:
-        _generator = AgentAIGenerator()
-    return _generator

--- a/core/agents/prompts.py
+++ b/core/agents/prompts.py
@@ -54,7 +54,7 @@ Memory tool quick reference:
 """
 
 
-def _memory_palace_section() -> str:
+def _memory_palace_section(mcp_client=None) -> str:
     """Return the memory-palace prompt block, or '' if mempalace isn't
     connected (#129).
 
@@ -65,9 +65,9 @@ def _memory_palace_section() -> str:
     that don't work, which is the status quo we already tolerate.
     """
     try:
-        from core.integrations.mcp.client import get_mcp_client
+        from core.integrations.mcp.client import process_mcp_client
 
-        client = get_mcp_client()
+        client = mcp_client if mcp_client is not None else process_mcp_client()
         if client is None:
             return _MEMORY_PALACE_BLOCK
         status = client.get_connection_status() or {}
@@ -127,7 +127,7 @@ Use MCP tools (server_tool format):
 
 
 def render_base_prompt(
-    role: str, extra_principles: str = "", methodology: str = ""
+    role: str, extra_principles: str = "", methodology: str = "", mcp_client=None
 ) -> str:
     """Render BASE_PROMPT with the given fragments. Shared by built-in + custom.
 
@@ -140,5 +140,5 @@ def render_base_prompt(
         role=role,
         extra_principles=extra_principles or "",
         methodology=methodology or "",
-        memory_operations=_memory_palace_section(),
+        memory_operations=_memory_palace_section(mcp_client),
     )

--- a/core/chat/tool_executor.py
+++ b/core/chat/tool_executor.py
@@ -20,7 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 class ToolExecutor:
-    def __init__(self) -> None:
+    def __init__(self, mcp_client=None) -> None:
+        self._mcp_client = mcp_client
         self.skill_tool_index: Dict[str, Any] = {}
 
     # ------------------------------------------------------------------
@@ -197,11 +198,8 @@ class ToolExecutor:
             else:
                 server_name = None
                 actual_tool_name = tool_name
-                from core.integrations.mcp.client import get_mcp_client
-
-                mcp_client = get_mcp_client()
-                if mcp_client:
-                    for srv_name, tools in mcp_client.tools_cache.items():
+                if self._mcp_client:
+                    for srv_name, tools in self._mcp_client.tools_cache.items():
                         if any(t["name"] == tool_name for t in tools):
                             server_name = srv_name
                             break
@@ -211,11 +209,8 @@ class ToolExecutor:
                 continue
 
             try:
-                from core.integrations.mcp.client import get_mcp_client
-
-                mcp_client = get_mcp_client()
-                if mcp_client:
-                    raw = await mcp_client.call_tool(
+                if self._mcp_client:
+                    raw = await self._mcp_client.call_tool(
                         server_name, actual_tool_name, arguments, timeout=30.0
                     )
                     if isinstance(raw, dict):

--- a/core/deps.py
+++ b/core/deps.py
@@ -1,0 +1,85 @@
+"""Depends providers for the services the API builds once at startup.
+
+``services/api/main.py``'s lifespan constructs each service onto ``app.state``;
+handlers reach them through the providers here. Each provider is a module-level
+function object on purpose: ``app.dependency_overrides`` keys on identity, so a
+factory that minted a new closure per call could never be overridden in a test.
+
+This module lives in ``core/`` rather than ``services/api/`` because routers
+colocate with their domain (``core/<domain>/<name>_router.py``) and ``core`` must
+not import ``services`` — see ``.importlinter``.
+"""
+
+from typing import Optional
+
+from fastapi import Request
+
+from core.agents.agent_ai_generator import AgentAIGenerator
+from core.detections.detection_rules_service import DetectionRulesService
+from core.integrations.integration_bridge_service import IntegrationBridgeService
+from core.integrations.integration_compatibility_service import (
+    IntegrationCompatibilityService,
+)
+from core.integrations.mcp.registry import MCPRegistry
+from core.platform.demo_data_service import DemoDataService
+from core.response.approval_service import ApprovalService
+from core.workflows.custom_workflow_service import CustomWorkflowService
+from core.workflows.workflow_ai_generator import WorkflowAIGenerator
+from core.workflows.workflow_run_service import WorkflowRunService
+from core.workflows.workflows_service import WorkflowsService
+
+
+def provide_approvals(request: Request) -> ApprovalService:
+    return request.app.state.approvals
+
+
+def provide_workflows(request: Request) -> WorkflowsService:
+    return request.app.state.workflows
+
+
+def provide_custom_workflows(request: Request) -> CustomWorkflowService:
+    return request.app.state.custom_workflows
+
+
+def provide_workflow_runs(request: Request) -> WorkflowRunService:
+    return request.app.state.workflow_runs
+
+
+def provide_workflow_ai(request: Request) -> WorkflowAIGenerator:
+    return request.app.state.workflow_ai
+
+
+def provide_agent_ai(request: Request) -> AgentAIGenerator:
+    return request.app.state.agent_ai
+
+
+def provide_mcp_registry(request: Request) -> MCPRegistry:
+    return request.app.state.mcp_registry
+
+
+def provide_integration_bridge(request: Request) -> IntegrationBridgeService:
+    return request.app.state.integration_bridge
+
+
+def provide_integration_compat(request: Request) -> IntegrationCompatibilityService:
+    return request.app.state.integration_compat
+
+
+def provide_detection_rules(request: Request) -> DetectionRulesService:
+    return request.app.state.detection_rules
+
+
+# None when the MCP SDK is not installed.
+def provide_mcp_client(request: Request):
+    return request.app.state.mcp_client
+
+
+# None unless demo mode is enabled. Demo mode is toggleable at runtime via
+# POST /api/config/demo-mode, so this resolves per request rather than trusting the
+# startup snapshot; DemoDataService shares one instance either way.
+def provide_demo_data(request: Request) -> Optional[DemoDataService]:
+    from core.config import is_demo_mode
+
+    if not is_demo_mode():
+        return None
+    return request.app.state.demo_data or DemoDataService()

--- a/core/detections/detection_rules_service.py
+++ b/core/detections/detection_rules_service.py
@@ -414,12 +414,3 @@ class DetectionRulesService:
 
 
 # Global singleton
-_detection_rules_service: Optional[DetectionRulesService] = None
-
-
-def get_detection_rules_service() -> DetectionRulesService:
-    """Get or create the global DetectionRulesService instance."""
-    global _detection_rules_service
-    if _detection_rules_service is None:
-        _detection_rules_service = DetectionRulesService()
-    return _detection_rules_service

--- a/core/detections/tools.py
+++ b/core/detections/tools.py
@@ -37,9 +37,9 @@ class SecurityDetectionsTools:
     def _get_dynamic_paths(self) -> Dict:
         """Get paths from DetectionRulesService if available."""
         try:
-            from core.detections.detection_rules_service import get_detection_rules_service
-            service = get_detection_rules_service()
-            env_vars = service.get_mcp_env_vars()
+            from core.detections.detection_rules_service import DetectionRulesService
+
+            env_vars = DetectionRulesService().get_mcp_env_vars()
             
             paths = {}
             if "SIGMA_PATHS" in env_vars:

--- a/core/integrations/integration_bridge_service.py
+++ b/core/integrations/integration_bridge_service.py
@@ -410,17 +410,3 @@ class IntegrationBridgeService:
 
 
 # Global instance
-_bridge_service = None
-
-
-def get_integration_bridge() -> IntegrationBridgeService:
-    """
-    Get the global integration bridge service instance.
-
-    Returns:
-        IntegrationBridgeService instance
-    """
-    global _bridge_service
-    if _bridge_service is None:
-        _bridge_service = IntegrationBridgeService()
-    return _bridge_service

--- a/core/integrations/integration_compatibility_service.py
+++ b/core/integrations/integration_compatibility_service.py
@@ -432,12 +432,3 @@ class IntegrationCompatibilityService:
 
 
 # Singleton instance
-_compatibility_service = None
-
-
-def get_compatibility_service() -> IntegrationCompatibilityService:
-    """Get singleton compatibility service instance."""
-    global _compatibility_service
-    if _compatibility_service is None:
-        _compatibility_service = IntegrationCompatibilityService()
-    return _compatibility_service

--- a/core/integrations/mcp/client.py
+++ b/core/integrations/mcp/client.py
@@ -610,21 +610,25 @@ class MCPClient:
         logger.info("All MCP connections closed")
 
 
-# Global MCP client instance
-_mcp_client: Optional[MCPClient] = None
+# An MCPClient owns persistent stdio child processes that only its creator closes, so
+# exactly one may exist per process. The owner builds it and installs it here.
+_process_client: Optional[MCPClient] = None
 
 
-def get_mcp_client() -> Optional[MCPClient]:
-    """Get or create the global MCP client instance."""
-    global _mcp_client
-    
+def build_mcp_client() -> Optional[MCPClient]:
+    """Build a client, or None when the MCP SDK is not installed."""
     if not MCP_AVAILABLE:
         logger.warning("MCP SDK not available. Install with: pip install mcp")
         return None
+    return MCPClient(MCPService())
     
-    if _mcp_client is None:
-        mcp_service = MCPService()
-        _mcp_client = MCPClient(mcp_service)
+
+def set_process_mcp_client(client: Optional[MCPClient]) -> None:
+    global _process_client
+    _process_client = client
     
-    return _mcp_client
+
+# None until an owner (the API lifespan, daemon startup) has installed a client.
+def process_mcp_client() -> Optional[MCPClient]:
+    return _process_client
 

--- a/core/integrations/mcp/registry.py
+++ b/core/integrations/mcp/registry.py
@@ -126,12 +126,3 @@ class MCPRegistry:
 
 
 # Global singleton
-_mcp_registry: Optional[MCPRegistry] = None
-
-
-def get_mcp_registry() -> MCPRegistry:
-    """Get or create the global MCP registry instance."""
-    global _mcp_registry
-    if _mcp_registry is None:
-        _mcp_registry = MCPRegistry()
-    return _mcp_registry

--- a/core/integrations/mcp/service.py
+++ b/core/integrations/mcp/service.py
@@ -12,6 +12,8 @@ import os
 
 from core.secrets import get_secret
 from core.config import vigil_path
+from core.detections.detection_rules_service import DetectionRulesService
+from core.integrations.integration_bridge_service import IntegrationBridgeService
 
 logger = logging.getLogger(__name__)
 
@@ -212,10 +214,15 @@ class MCPService:
     _STATE_FILE = vigil_path("mcp_server_enabled.json")
     _STATE_WRITE_FILE = vigil_path("mcp_server_enabled.json", write=True)
     
-    def __init__(self, project_root: Optional[Path] = None):
+    def __init__(
+        self,
+        project_root: Optional[Path] = None,
+        integration_bridge: Optional[IntegrationBridgeService] = None,
+        detection_rules: Optional[DetectionRulesService] = None,
+    ):
         """
         Initialize the MCP service.
-        
+
         Args:
             project_root: Optional project root path. Defaults to the repo root,
                 which is where ``mcp-config.json`` and ``venv/`` live.
@@ -223,7 +230,9 @@ class MCPService:
         if project_root is None:
             # core/integrations/mcp/service.py -> repo root is four levels up.
             project_root = Path(__file__).resolve().parents[3]
-        
+
+        self._integration_bridge = integration_bridge or IntegrationBridgeService()
+        self._detection_rules = detection_rules or DetectionRulesService()
         self.project_root = Path(project_root)
         self.venv_path = self.project_root / "venv"
         
@@ -358,9 +367,7 @@ class MCPService:
         # Resolve ${<ID>_MCP_URL} placeholders from integration connectorUrls
         # (see derive_remote_mcp_env). Best-effort.
         try:
-            from core.integrations.integration_bridge_service import get_integration_bridge
-
-            get_integration_bridge().derive_remote_mcp_env()
+            self._integration_bridge.derive_remote_mcp_env()
         except Exception as e:  # pragma: no cover - defensive
             logger.debug("remote MCP env derivation skipped: %s", e)
 
@@ -445,10 +452,7 @@ class MCPService:
         
         # Add servers for enabled integrations using the integration bridge
         try:
-            from core.integrations.integration_bridge_service import get_integration_bridge
-            
-            bridge = get_integration_bridge()
-            enabled_servers = bridge.get_enabled_servers()
+            enabled_servers = self._integration_bridge.get_enabled_servers()
             
             # Get list of already loaded server names to avoid duplicates
             loaded_server_names = [s['name'] for s in server_configs]
@@ -463,7 +467,9 @@ class MCPService:
                 env_vars = server_info['env_vars']
                 
                 # Get module path for this integration
-                module_path = bridge.get_server_module_path(integration_id)
+                module_path = self._integration_bridge.get_server_module_path(
+                    integration_id
+                )
                 if not module_path:
                     logger.warning(f"No module path found for integration '{integration_id}'")
                     continue
@@ -504,10 +510,7 @@ class MCPService:
         newly added/removed rule sources without manual config editing.
         """
         try:
-            from core.detections.detection_rules_service import get_detection_rules_service
-            
-            detection_service = get_detection_rules_service()
-            dynamic_env = detection_service.get_mcp_env_vars()
+            dynamic_env = self._detection_rules.get_mcp_env_vars()
             
             if dynamic_env:
                 # Override static env vars with dynamic ones

--- a/core/llm/harness/claude.py
+++ b/core/llm/harness/claude.py
@@ -86,6 +86,9 @@ logger = logging.getLogger(__name__)
 from core.chat.session_manager import SessionManager  # noqa: E402
 from core.chat.context_manager import ContextManager  # noqa: E402
 from core.chat.tool_executor import ToolExecutor  # noqa: E402
+from core.detections.detection_rules_service import DetectionRulesService  # noqa: E402
+from core.integrations.mcp.client import process_mcp_client  # noqa: E402
+from core.integrations.mcp.registry import MCPRegistry  # noqa: E402
 
 
 class ClaudeService:
@@ -102,6 +105,9 @@ class ClaudeService:
         use_agent_sdk: bool = True,
         use_backend_tools: bool = False,
         provider_api_key_ref: Optional[str] = None,
+        mcp_client=None,
+        mcp_registry: Optional[MCPRegistry] = None,
+        detection_rules: Optional[DetectionRulesService] = None,
     ):
         """
         Initialize Claude service.
@@ -116,6 +122,10 @@ class ClaudeService:
                 Anthropic provider row (GH #88). When set, _load_api_key reads
                 this secret first before the legacy CLAUDE_API_KEY fallback chain.
         """
+        self._mcp_client = mcp_client if mcp_client is not None else process_mcp_client()
+        self._mcp_registry = mcp_registry or MCPRegistry()
+        self._detection_rules = detection_rules or DetectionRulesService()
+
         self.client: Optional[Anthropic] = None
         self.async_client: Optional[AsyncAnthropic] = None
         self.api_key: Optional[str] = None
@@ -131,7 +141,7 @@ class ClaudeService:
         # Sub-modules — own session lifecycle, context reduction, and tool dispatch.
         self._session_mgr = SessionManager()
         self._context_mgr = ContextManager()
-        self._tool_executor = ToolExecutor()
+        self._tool_executor = ToolExecutor(mcp_client=self._mcp_client)
 
         # Default system prompt with Claude 4.5 best practices
         self.default_system_prompt = self._get_default_system_prompt()
@@ -727,9 +737,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                     tools_dict = {}
 
             # If cache file didn't yield tools, fall back to in-memory cache
-            from core.integrations.mcp.client import get_mcp_client
-
-            mcp_client = get_mcp_client()
+            mcp_client = self._mcp_client
             if not tools_dict:
                 if mcp_client and mcp_client.tools_cache:
                     tools_dict = mcp_client.tools_cache
@@ -834,11 +842,8 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
     def _populate_mcp_registry(self, tools_dict: Dict):
         """Populate the MCP registry with discovered tools for dynamic tool discovery."""
         try:
-            from core.integrations.mcp.client import get_mcp_client
-            from core.integrations.mcp.registry import get_mcp_registry
-
-            registry = get_mcp_registry()
-            mcp_client = get_mcp_client()
+            registry = self._mcp_registry
+            mcp_client = self._mcp_client
 
             for server_name, server_tools in tools_dict.items():
                 # Build tool list
@@ -1854,9 +1859,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                     # Try to find tool in any server by checking tool cache
                     server_name = None
                     actual_tool_name = tool_name
-                    from core.integrations.mcp.client import get_mcp_client
-
-                    mcp_client = get_mcp_client()
+                    mcp_client = self._mcp_client
                     if mcp_client:
                         # Check which server has this tool
                         for srv_name, tools in mcp_client.tools_cache.items():
@@ -1866,9 +1869,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
 
                 if server_name:
                     try:
-                        from core.integrations.mcp.client import get_mcp_client
-
-                        mcp_client = get_mcp_client()
+                        mcp_client = self._mcp_client
                         if mcp_client:
                             # Call tool with 30 second timeout
                             result = await mcp_client.call_tool(
@@ -3331,18 +3332,15 @@ Provide only the JSON, no additional text."""
 
         try:
             # Try the MCP registry first (Phase 3) - filter to enabled only
-            from core.integrations.mcp.client import get_mcp_client
-            from core.integrations.mcp.registry import get_mcp_registry
             from core.integrations.mcp.service import MCPService
 
-            registry = get_mcp_registry()
-            all_configs = registry.get_agent_sdk_configs()
+            all_configs = self._mcp_registry.get_agent_sdk_configs()
 
             # The shared client owns the live enable/disable state. Without it,
             # build a local MCPService — it reads the same persisted state file,
             # so a server the operator disabled stays disabled. Never fall back
             # to all_configs: that would hand disabled servers to the agent.
-            client = get_mcp_client()
+            client = self._mcp_client
             enablement = (client.mcp_service if client else None) or MCPService()
             mcp_servers = [
                 c for c in all_configs if enablement.is_server_enabled(c["name"])
@@ -3358,10 +3356,7 @@ Provide only the JSON, no additional text."""
 
         # Fallback: configure security-detections MCP server directly
         try:
-            from core.detections.detection_rules_service import get_detection_rules_service
-
-            detection_service = get_detection_rules_service()
-            env_vars = detection_service.get_mcp_env_vars()
+            env_vars = self._detection_rules.get_mcp_env_vars()
 
             if env_vars:
                 mcp_servers.append(
@@ -3391,9 +3386,7 @@ Provide only the JSON, no additional text."""
         server_name, actual_tool_name = parts
 
         try:
-            from core.integrations.mcp.client import get_mcp_client
-
-            mcp_client = get_mcp_client()
+            mcp_client = self._mcp_client
             if mcp_client:
                 result = await mcp_client.call_tool(
                     server_name, actual_tool_name, arguments, timeout=30.0

--- a/core/llm/harness/openai.py
+++ b/core/llm/harness/openai.py
@@ -9,7 +9,9 @@ from collections import deque
 from typing import Any, AsyncIterator, Dict, List, Optional, Set
 
 from core.integrations.mcp import tool_manager
+from core.integrations.mcp.client import process_mcp_client
 from core.llm.router.format import anthropic_tools_to_openai
+from core.response.approval_service import ApprovalService
 from core.llm.router.router import LLMRouter, ProviderSpec
 
 logger = logging.getLogger(__name__)
@@ -88,7 +90,12 @@ class OpenAIAgentService:
         backend_tools: Optional[List[Dict[str, Any]]] = None,
         include_mcp_tools: bool = True,
         recommended_tools: Optional[List[str]] = None,
+        mcp_client=None,
+        approvals: Optional[ApprovalService] = None,
     ):
+        # mcp_client defaults to the process owner's; None when no owner started.
+        self._mcp_client = mcp_client if mcp_client is not None else process_mcp_client()
+        self._approvals = approvals or ApprovalService()
         self._backend_tools = backend_tools or self._load_backend_tools()
         self._include_mcp_tools = include_mcp_tools
         self._recommended_tools = recommended_tools
@@ -112,11 +119,8 @@ class OpenAIAgentService:
         if not self._include_mcp_tools:
             return []
         try:
-            from core.integrations.mcp.client import get_mcp_client
-
-            client = get_mcp_client()
-            if client:
-                return client.get_tools_for_claude()
+            if self._mcp_client:
+                return self._mcp_client.get_tools_for_claude()
         except Exception as exc:
             logger.debug("MCP tools unavailable: %s", exc)
         return []
@@ -576,9 +580,9 @@ class OpenAIAgentService:
         """Queue a pending approval instead of executing the tool, returning the
         message for the model and the action id to poll (None if not created)."""
         try:
-            from core.response.approval_service import ActionType, get_approval_service
+            from core.response.approval_service import ActionType
 
-            service = get_approval_service()
+            service = self._approvals
             try:
                 action_type = ActionType(tool_name)
             except ValueError:
@@ -622,9 +626,9 @@ class OpenAIAgentService:
         """Poll the approval queue until an operator decides, returning
         ``(decision, detail, waited_seconds)``. A vanished action reads as a
         rejection so an uncleared action never executes."""
-        from core.response.approval_service import ActionStatus, get_approval_service
+        from core.response.approval_service import ActionStatus
 
-        service = get_approval_service()
+        service = self._approvals
         started = time.monotonic()
         deadline = started + timeout
         while True:
@@ -663,17 +667,14 @@ class OpenAIAgentService:
                 )
             await asyncio.sleep(_APPROVAL_POLL_INTERVAL_S)
 
-    @staticmethod
     def _mark_action_executed(
-        action_id: Optional[str], result_text: str, is_error: bool
+        self, action_id: Optional[str], result_text: str, is_error: bool
     ) -> None:
         """Close out an approved action so the queue reflects what ran."""
         if not action_id:
             return
         try:
-            from core.response.approval_service import get_approval_service
-
-            service = get_approval_service()
+            service = self._approvals
             if is_error:
                 service.mark_failed(action_id, result_text[:2000])
             else:
@@ -708,10 +709,9 @@ class OpenAIAgentService:
     ) -> tuple[str, bool]:
         """Execute an MCP tool via the shared MCP client."""
         try:
-            from core.integrations.mcp.client import get_mcp_client
             from core.llm.security import wrap_tool_result
 
-            client = get_mcp_client()
+            client = self._mcp_client
             if not client:
                 return f"MCP client unavailable for tool: {tool_name}", True
 

--- a/core/platform/demo_data_service.py
+++ b/core/platform/demo_data_service.py
@@ -295,12 +295,3 @@ class DemoDataService:
         DemoDataService._initialized = False
         self._generate_demo_data()
         DemoDataService._initialized = True
-
-
-_demo_service = None
-
-def get_demo_service() -> DemoDataService:
-    global _demo_service
-    if _demo_service is None:
-        _demo_service = DemoDataService()
-    return _demo_service

--- a/core/response/approval_service.py
+++ b/core/response/approval_service.py
@@ -685,14 +685,3 @@ class ApprovalService:
                 action_id,
             )
         return log_entry
-
-
-_approval_service: Optional[ApprovalService] = None
-
-
-def get_approval_service() -> ApprovalService:
-    """Get singleton ApprovalService instance."""
-    global _approval_service
-    if _approval_service is None:
-        _approval_service = ApprovalService()
-    return _approval_service

--- a/core/response/approvals_router.py
+++ b/core/response/approvals_router.py
@@ -9,9 +9,12 @@ the paused run; rejecting cancels it with the supplied reason.
 import logging
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
+from core.deps import provide_approvals, provide_workflows
+from core.response.approval_service import ApprovalService
 from core.routing import Auth, RouterMeta
+from core.workflows.workflows_service import WorkflowsService
 
 router = APIRouter()
 
@@ -92,12 +95,10 @@ async def list_approvals(
         description="Restrict to approvals linked to this workflow run.",
     ),
     limit: int = Query(default=100, ge=1, le=500),
+    service: ApprovalService = Depends(provide_approvals),
 ):
     """List approval actions, newest first."""
-    from core.response.approval_service import (
-        ActionStatus,
-        get_approval_service,
-    )
+    from core.response.approval_service import ActionStatus
 
     status_enum: Optional[ActionStatus] = None
     if status:
@@ -106,7 +107,6 @@ async def list_approvals(
         except ValueError:
             raise HTTPException(status_code=400, detail=f"Invalid status: {status}")
 
-    service = get_approval_service()
     actions = service.list_actions(
         status=status_enum,
         workflow_run_id=workflow_run_id,
@@ -119,38 +119,39 @@ async def list_approvals(
 
 
 @router.get("/approvals/pending")
-async def list_pending_approvals() -> Dict[str, List[Dict[str, Any]]]:
+async def list_pending_approvals(
+    service: ApprovalService = Depends(provide_approvals),
+) -> Dict[str, List[Dict[str, Any]]]:
     """Shortcut: only actions with ``status=pending`` and
     ``requires_approval=True``. Used by the AI Decisions approvals tab."""
-    from core.response.approval_service import get_approval_service
-
-    service = get_approval_service()
     actions = service.list_pending_approvals()
     return {"actions": [_pending_to_dict(a) for a in actions]}
 
 
 @router.get("/approvals/{action_id}")
-async def get_approval(action_id: str):
+async def get_approval(
+    action_id: str,
+    service: ApprovalService = Depends(provide_approvals),
+):
     """Fetch a single approval action."""
-    from core.response.approval_service import get_approval_service
-
-    action = get_approval_service().get_action(action_id)
+    action = service.get_action(action_id)
     if action is None:
         raise HTTPException(status_code=404, detail=f"Approval not found: {action_id}")
     return _pending_to_dict(action)
 
 
 @router.post("/approvals/{action_id}/approve")
-async def approve_action(action_id: str, request: ApproveRequest):
+async def approve_action(
+    action_id: str,
+    request: ApproveRequest,
+    service: ApprovalService = Depends(provide_approvals),
+    workflows: WorkflowsService = Depends(provide_workflows),
+):
     """Approve a pending action.
 
     If the action is linked to a paused workflow run, the run resumes
     automatically and the resume result is included in the response.
     """
-    from core.response.approval_service import get_approval_service
-    from core.workflows.workflows_service import get_workflows_service
-
-    service = get_approval_service()
     action = service.get_action(action_id)
     if action is None:
         raise HTTPException(status_code=404, detail=f"Approval not found: {action_id}")
@@ -166,7 +167,7 @@ async def approve_action(action_id: str, request: ApproveRequest):
     }
 
     if updated.workflow_run_id:
-        resume = await get_workflows_service().resume_workflow(
+        resume = await workflows.resume_workflow(
             updated.workflow_run_id,
             "approved",
             approved_by=approved_by,
@@ -177,16 +178,17 @@ async def approve_action(action_id: str, request: ApproveRequest):
 
 
 @router.post("/approvals/{action_id}/reject")
-async def reject_action(action_id: str, request: RejectRequest):
+async def reject_action(
+    action_id: str,
+    request: RejectRequest,
+    service: ApprovalService = Depends(provide_approvals),
+    workflows: WorkflowsService = Depends(provide_workflows),
+):
     """Reject a pending action.
 
     If the action is linked to a paused workflow run, the run is
     cancelled with the supplied reason.
     """
-    from core.response.approval_service import get_approval_service
-    from core.workflows.workflows_service import get_workflows_service
-
-    service = get_approval_service()
     action = service.get_action(action_id)
     if action is None:
         raise HTTPException(status_code=404, detail=f"Approval not found: {action_id}")
@@ -204,7 +206,7 @@ async def reject_action(action_id: str, request: RejectRequest):
     }
 
     if updated.workflow_run_id:
-        resume = await get_workflows_service().resume_workflow(
+        resume = await workflows.resume_workflow(
             updated.workflow_run_id,
             "rejected",
             rejection_reason=request.reason,

--- a/core/response/autonomous_response_service.py
+++ b/core/response/autonomous_response_service.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Callable, Any
 from datetime import datetime
 
 from core.agents.builtins import AgentId
+from core.response.approval_service import ActionType, ApprovalService
 
 logger = logging.getLogger(__name__)
 
@@ -17,21 +18,11 @@ EscalationCallback = Callable[[Dict[str, Any], str, str], None]
 class AutonomousResponseService:
     """Service for managing autonomous threat response with approval workflow."""
     
-    def __init__(self):
+    def __init__(self, approvals: Optional[ApprovalService] = None):
         """Initialize autonomous response service."""
-        self.approval_service = None
+        self.approval_service = approvals or ApprovalService()
         self._escalation_callbacks: List[EscalationCallback] = []
-        self._load_services()
-    
-    def _load_services(self):
-        """Load required services."""
-        try:
-            from core.response.approval_service import get_approval_service, ActionType
-            self.approval_service = get_approval_service()
-            self.ActionType = ActionType
-        except Exception as e:
-            logger.error(f"Error loading services: {e}")
-    
+
     def register_escalation_callback(self, callback: EscalationCallback):
         """Register a callback for escalation events."""
         self._escalation_callbacks.append(callback)
@@ -323,14 +314,10 @@ Please review and approve/reject in the SOC dashboard.
         Returns:
             Action result
         """
-        if not self.approval_service:
-            logger.error("Approval service not available")
-            return {"error": "Approval service not available"}
-        
         try:
             # Create pending action
             action = self.approval_service.create_action(
-                action_type=self.ActionType.ISOLATE_HOST,
+                action_type=ActionType.ISOLATE_HOST,
                 title=f"Isolate Host: {hostname or ip_address}",
                 description=f"Network isolation of compromised host based on correlated detections.\n\n"
                            f"Indicators: {', '.join(correlation_data.get('indicators', []))}\n"
@@ -454,9 +441,6 @@ Please review and approve/reject in the SOC dashboard.
         Returns:
             List of execution results
         """
-        if not self.approval_service:
-            return []
-        
         try:
             from core.response.approval_service import ActionStatus
             
@@ -659,13 +643,4 @@ Please review and approve/reject in the SOC dashboard.
 
 
 # Singleton instance
-_autonomous_response_service: Optional[AutonomousResponseService] = None
-
-
-def get_autonomous_response_service() -> AutonomousResponseService:
-    """Get singleton AutonomousResponseService instance."""
-    global _autonomous_response_service
-    if _autonomous_response_service is None:
-        _autonomous_response_service = AutonomousResponseService()
-    return _autonomous_response_service
 

--- a/core/storage/database_data_service.py
+++ b/core/storage/database_data_service.py
@@ -40,7 +40,7 @@ class DatabaseDataService:
     # in JSON-file fallback for the rest of the process lifetime.
     _RECONNECT_INTERVAL_SECONDS = 10.0
 
-    def __init__(self, require_db: bool = False):
+    def __init__(self, require_db: bool = False, demo_data=None):
         self._db_service = None
         self._db_connected = False
         self._use_json_fallback = False
@@ -51,8 +51,9 @@ class DatabaseDataService:
 
         if self._demo_mode:
             logger.info("Demo mode enabled - using generated sample data")
-            from core.platform.demo_data_service import get_demo_service
-            self._demo_service = get_demo_service()
+            from core.platform.demo_data_service import DemoDataService
+
+            self._demo_service = demo_data or DemoDataService()
         else:
             self._init_database(require_db)
         DATA_DIR.mkdir(exist_ok=True)

--- a/core/workflows/custom_workflow_service.py
+++ b/core/workflows/custom_workflow_service.py
@@ -187,14 +187,3 @@ class CustomWorkflowService:
             wf.updated_at = datetime.utcnow()
         logger.info(f"Soft-deleted custom workflow: {workflow_id}")
         return True
-
-
-_service: Optional[CustomWorkflowService] = None
-
-
-def get_custom_workflow_service() -> CustomWorkflowService:
-    """Get the singleton CustomWorkflowService instance."""
-    global _service
-    if _service is None:
-        _service = CustomWorkflowService()
-    return _service

--- a/core/workflows/workflow_ai_generator.py
+++ b/core/workflows/workflow_ai_generator.py
@@ -11,13 +11,22 @@ import logging
 import re
 from typing import Any, Dict, List, Optional
 
+from core.integrations.mcp.registry import MCPRegistry
+from core.workflows.workflows_service import WorkflowsService
+
 logger = logging.getLogger(__name__)
 
 
 class WorkflowAIGenerator:
     """Generates draft workflow definitions from natural-language descriptions."""
 
-    def __init__(self):
+    def __init__(
+        self,
+        workflows: Optional[WorkflowsService] = None,
+        mcp_registry: Optional[MCPRegistry] = None,
+    ):
+        self._workflows = workflows
+        self._mcp_registry = mcp_registry
         self._mcp_tool_names_cache: Optional[List[str]] = None
 
     async def generate(self, description: str) -> Dict[str, Any]:
@@ -174,9 +183,7 @@ class WorkflowAIGenerator:
         if self._mcp_tool_names_cache is not None:
             return self._mcp_tool_names_cache
         try:
-            from core.integrations.mcp.registry import get_mcp_registry
-
-            registry = get_mcp_registry()
+            registry = self._mcp_registry or MCPRegistry()
             names = list(registry.get_tool_names() or [])
         except Exception as e:
             logger.debug(f"MCP registry unavailable: {e}")
@@ -186,9 +193,7 @@ class WorkflowAIGenerator:
 
     def _exemplars_context(self) -> str:
         try:
-            from core.workflows.workflows_service import get_workflows_service
-
-            service = get_workflows_service()
+            service = self._workflows or WorkflowsService()
             workflows = service.list_workflows()
         except Exception as e:
             logger.debug(f"Could not load existing workflows: {e}")
@@ -245,14 +250,3 @@ class WorkflowAIGenerator:
             "phases": phases,
             "graph_layout": {},
         }
-
-
-_generator: Optional[WorkflowAIGenerator] = None
-
-
-def get_workflow_ai_generator() -> WorkflowAIGenerator:
-    """Get the singleton WorkflowAIGenerator instance."""
-    global _generator
-    if _generator is None:
-        _generator = WorkflowAIGenerator()
-    return _generator

--- a/core/workflows/workflow_run_service.py
+++ b/core/workflows/workflow_run_service.py
@@ -252,14 +252,3 @@ class WorkflowRunService:
         except SQLAlchemyError as e:
             logger.warning("Error listing phases for run %s: %s", run_id, e)
             return []
-
-
-_service: Optional[WorkflowRunService] = None
-
-
-def get_workflow_run_service() -> WorkflowRunService:
-    """Process-wide singleton."""
-    global _service
-    if _service is None:
-        _service = WorkflowRunService()
-    return _service

--- a/core/workflows/workflows_router.py
+++ b/core/workflows/workflows_router.py
@@ -3,9 +3,21 @@
 from typing import Any, Dict, List, Optional
 
 import logging
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+from core.deps import (
+    provide_approvals,
+    provide_custom_workflows,
+    provide_workflow_ai,
+    provide_workflow_runs,
+    provide_workflows,
+)
+from core.response.approval_service import ApprovalService
 from core.routing import Auth, RouterMeta
+from core.workflows.custom_workflow_service import CustomWorkflowService
+from core.workflows.workflow_ai_generator import WorkflowAIGenerator
+from core.workflows.workflow_run_service import WorkflowRunService
+from core.workflows.workflows_service import WorkflowsService
 
 router = APIRouter()
 
@@ -89,7 +101,7 @@ class WorkflowRunCancelRequest(BaseModel):
 
 
 @router.get("/workflows")
-async def list_workflows():
+async def list_workflows(service: WorkflowsService = Depends(provide_workflows)):
     """
     List all available workflows (file-based + database-backed custom).
 
@@ -97,9 +109,6 @@ async def list_workflows():
         { workflows: [...], count: int }
     """
     try:
-        from core.workflows.workflows_service import get_workflows_service
-
-        service = get_workflows_service()
         workflows = service.list_workflows()
 
         return {"workflows": workflows, "count": len(workflows)}
@@ -110,16 +119,13 @@ async def list_workflows():
 
 # Static routes MUST come before parameterized {workflow_id} routes
 @router.post("/workflows/reload")
-async def reload_workflows():
+async def reload_workflows(service: WorkflowsService = Depends(provide_workflows)):
     """
     Force reload all file-based workflows from disk.
 
     Does not affect database-backed custom workflows.
     """
     try:
-        from core.workflows.workflows_service import get_workflows_service
-
-        service = get_workflows_service()
         service.reload()
         workflows = service.list_workflows()
 
@@ -139,12 +145,13 @@ async def reload_workflows():
 
 
 @router.get("/workflows/custom")
-async def list_custom_workflows(active_only: bool = True):
+async def list_custom_workflows(
+    active_only: bool = True,
+    service: CustomWorkflowService = Depends(provide_custom_workflows),
+):
     """List database-backed custom workflows."""
     try:
-        from core.workflows.custom_workflow_service import get_custom_workflow_service
-
-        rows = get_custom_workflow_service().list(active_only=active_only)
+        rows = service.list(active_only=active_only)
         return {"workflows": rows, "count": len(rows)}
     except Exception as e:
         logger.error(f"Error listing custom workflows: {e}")
@@ -152,12 +159,12 @@ async def list_custom_workflows(active_only: bool = True):
 
 
 @router.post("/workflows/custom", status_code=201)
-async def create_custom_workflow(payload: CustomWorkflowCreate):
+async def create_custom_workflow(
+    payload: CustomWorkflowCreate,
+    service: CustomWorkflowService = Depends(provide_custom_workflows),
+):
     """Create a new custom workflow."""
     try:
-        from core.workflows.custom_workflow_service import get_custom_workflow_service
-
-        service = get_custom_workflow_service()
         created = service.create(payload.model_dump())
         return created
     except ValueError as e:
@@ -168,12 +175,13 @@ async def create_custom_workflow(payload: CustomWorkflowCreate):
 
 
 @router.get("/workflows/custom/{workflow_id}")
-async def get_custom_workflow(workflow_id: str):
+async def get_custom_workflow(
+    workflow_id: str,
+    service: CustomWorkflowService = Depends(provide_custom_workflows),
+):
     """Fetch a single custom workflow."""
     try:
-        from core.workflows.custom_workflow_service import get_custom_workflow_service
-
-        wf = get_custom_workflow_service().get(workflow_id)
+        wf = service.get(workflow_id)
         if not wf:
             raise HTTPException(
                 status_code=404,
@@ -188,12 +196,13 @@ async def get_custom_workflow(workflow_id: str):
 
 
 @router.put("/workflows/custom/{workflow_id}")
-async def update_custom_workflow(workflow_id: str, payload: CustomWorkflowUpdate):
+async def update_custom_workflow(
+    workflow_id: str,
+    payload: CustomWorkflowUpdate,
+    service: CustomWorkflowService = Depends(provide_custom_workflows),
+):
     """Update an existing custom workflow. Increments version."""
     try:
-        from core.workflows.custom_workflow_service import get_custom_workflow_service
-
-        service = get_custom_workflow_service()
         updates = {k: v for k, v in payload.model_dump().items() if v is not None}
         updated = service.update(workflow_id, updates)
         if not updated:
@@ -212,12 +221,13 @@ async def update_custom_workflow(workflow_id: str, payload: CustomWorkflowUpdate
 
 
 @router.delete("/workflows/custom/{workflow_id}")
-async def delete_custom_workflow(workflow_id: str):
+async def delete_custom_workflow(
+    workflow_id: str,
+    service: CustomWorkflowService = Depends(provide_custom_workflows),
+):
     """Soft-delete a custom workflow (sets is_active=False)."""
     try:
-        from core.workflows.custom_workflow_service import get_custom_workflow_service
-
-        ok = get_custom_workflow_service().delete(workflow_id)
+        ok = service.delete(workflow_id)
         if not ok:
             raise HTTPException(
                 status_code=404,
@@ -237,16 +247,17 @@ async def delete_custom_workflow(workflow_id: str):
 
 
 @router.post("/workflows/generate")
-async def generate_workflow(payload: WorkflowGenerateRequest):
+async def generate_workflow(
+    payload: WorkflowGenerateRequest,
+    generator: WorkflowAIGenerator = Depends(provide_workflow_ai),
+):
     """
     Generate a draft custom workflow from a natural-language description.
 
     Does NOT save. Frontend can tweak the draft and POST to /workflows/custom.
     """
     try:
-        from core.workflows.workflow_ai_generator import get_workflow_ai_generator
-
-        result = await get_workflow_ai_generator().generate(payload.description)
+        result = await generator.generate(payload.description)
         if not result.get("success"):
             raise HTTPException(
                 status_code=502,
@@ -267,14 +278,14 @@ async def generate_workflow(payload: WorkflowGenerateRequest):
 
 
 @router.get("/workflows/{workflow_id}")
-async def get_workflow(workflow_id: str):
+async def get_workflow(
+    workflow_id: str,
+    service: WorkflowsService = Depends(provide_workflows),
+):
     """
     Get full details for a specific workflow (custom or file-based).
     """
     try:
-        from core.workflows.workflows_service import get_workflows_service
-
-        service = get_workflows_service()
         workflow = service.get_workflow_dict(workflow_id, include_body=True)
         if not workflow:
             raise HTTPException(
@@ -290,7 +301,11 @@ async def get_workflow(workflow_id: str):
 
 
 @router.post("/workflows/{workflow_id}/execute")
-async def execute_workflow(workflow_id: str, request: WorkflowExecuteRequest):
+async def execute_workflow(
+    workflow_id: str,
+    request: WorkflowExecuteRequest,
+    service: WorkflowsService = Depends(provide_workflows),
+):
     """
     Execute a workflow (custom or file-based).
 
@@ -298,10 +313,6 @@ async def execute_workflow(workflow_id: str, request: WorkflowExecuteRequest):
     methodologies, then executes it via ClaudeService.run_agent_task().
     """
     try:
-        from core.workflows.workflows_service import get_workflows_service
-
-        service = get_workflows_service()
-
         workflow = service.get_workflow(workflow_id)
         if not workflow:
             raise HTTPException(
@@ -348,7 +359,10 @@ async def execute_workflow(workflow_id: str, request: WorkflowExecuteRequest):
 
 
 @router.get("/workflows/runs/{run_id}")
-async def get_workflow_run(run_id: str):
+async def get_workflow_run(
+    run_id: str,
+    run_service: WorkflowRunService = Depends(provide_workflow_runs),
+):
     """Fetch a single workflow run by id.
 
     Includes the full ``result_summary`` plus the list of phase rows
@@ -356,9 +370,6 @@ async def get_workflow_run(run_id: str):
     (#128). For one-shot runs with no phase rows, ``phases`` is just
     an empty list.
     """
-    from core.workflows.workflow_run_service import get_workflow_run_service
-
-    run_service = get_workflow_run_service()
     row = run_service.get_run(run_id)
     if not row:
         raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
@@ -367,21 +378,21 @@ async def get_workflow_run(run_id: str):
 
 
 @router.post("/workflows/runs/{run_id}/resume")
-async def resume_workflow_run(run_id: str, request: WorkflowRunResumeRequest):
+async def resume_workflow_run(
+    run_id: str,
+    request: WorkflowRunResumeRequest,
+    run_service: WorkflowRunService = Depends(provide_workflow_runs),
+    approval_service: ApprovalService = Depends(provide_approvals),
+    workflows: WorkflowsService = Depends(provide_workflows),
+):
     """Resume a paused workflow run (#128).
 
     Looks up the run's pending approval action, approves it, and
     re-enters the phase loop. If there is no pending approval action
     linked to the run, returns 409.
     """
-    from core.response.approval_service import (
-        ActionStatus,
-        get_approval_service,
-    )
-    from core.workflows.workflow_run_service import get_workflow_run_service
-    from core.workflows.workflows_service import get_workflows_service
+    from core.response.approval_service import ActionStatus
 
-    run_service = get_workflow_run_service()
     run = run_service.get_run(run_id)
     if not run:
         raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
@@ -391,7 +402,6 @@ async def resume_workflow_run(run_id: str, request: WorkflowRunResumeRequest):
             detail=f"Run {run_id} is not paused (status={run.get('status')})",
         )
 
-    approval_service = get_approval_service()
     pending = [
         a
         for a in approval_service.list_actions(
@@ -404,7 +414,7 @@ async def resume_workflow_run(run_id: str, request: WorkflowRunResumeRequest):
             approved_by=request.approved_by or "analyst",
         )
 
-    result = await get_workflows_service().resume_workflow(
+    result = await workflows.resume_workflow(
         run_id,
         "approved",
         approved_by=request.approved_by or "analyst",
@@ -413,25 +423,24 @@ async def resume_workflow_run(run_id: str, request: WorkflowRunResumeRequest):
 
 
 @router.post("/workflows/runs/{run_id}/cancel")
-async def cancel_workflow_run(run_id: str, request: WorkflowRunCancelRequest):
+async def cancel_workflow_run(
+    run_id: str,
+    request: WorkflowRunCancelRequest,
+    run_service: WorkflowRunService = Depends(provide_workflow_runs),
+    approval_service: ApprovalService = Depends(provide_approvals),
+    workflows: WorkflowsService = Depends(provide_workflows),
+):
     """Cancel a paused or running workflow run (#128).
 
     Rejects any pending approval action on the run and finalises it
     as ``cancelled`` with the supplied reason.
     """
-    from core.response.approval_service import (
-        ActionStatus,
-        get_approval_service,
-    )
-    from core.workflows.workflow_run_service import get_workflow_run_service
-    from core.workflows.workflows_service import get_workflows_service
+    from core.response.approval_service import ActionStatus
 
-    run_service = get_workflow_run_service()
     run = run_service.get_run(run_id)
     if not run:
         raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
 
-    approval_service = get_approval_service()
     pending = [
         a
         for a in approval_service.list_actions(
@@ -446,7 +455,7 @@ async def cancel_workflow_run(run_id: str, request: WorkflowRunCancelRequest):
         )
 
     if run.get("status") == "paused":
-        result = await get_workflows_service().resume_workflow(
+        result = await workflows.resume_workflow(
             run_id,
             "rejected",
             rejection_reason=request.reason,
@@ -477,19 +486,18 @@ async def list_workflow_runs(
     status: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
+    run_service: WorkflowRunService = Depends(provide_workflow_runs),
 ):
     """List past executions of ``workflow_id``, newest first.
 
     Omits ``result_summary`` from each entry so the listing stays
     light; use GET /workflows/runs/{run_id} for the full detail.
     """
-    from core.workflows.workflow_run_service import get_workflow_run_service
-
     # Light-touch bounds so a buggy caller can't ask for 10k rows.
     limit = max(1, min(limit, 200))
     offset = max(0, offset)
 
-    runs = get_workflow_run_service().list_runs(
+    runs = run_service.list_runs(
         workflow_id=workflow_id,
         status=status,
         limit=limit,

--- a/core/workflows/workflows_service.py
+++ b/core/workflows/workflows_service.py
@@ -7,7 +7,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from core.integrations.mcp.registry import MCPRegistry
 from core.llm.defaults import DEFAULT_MODEL
+from core.response.approval_service import ActionType, ApprovalService
+from core.workflows.custom_workflow_service import CustomWorkflowService
+from core.workflows.workflow_run_service import WorkflowRunService
 
 logger = logging.getLogger(__name__)
 
@@ -233,7 +237,14 @@ def _render_custom_workflow_body(
 class WorkflowsService:
     """Service for discovering, parsing, and executing workflow definitions."""
 
-    def __init__(self, workflows_dir: Optional[Path] = None):
+    def __init__(
+        self,
+        workflows_dir: Optional[Path] = None,
+        approvals: Optional[ApprovalService] = None,
+        custom_workflows: Optional[CustomWorkflowService] = None,
+        mcp_registry: Optional[MCPRegistry] = None,
+        workflow_runs: Optional[WorkflowRunService] = None,
+    ):
         """
         Initialize workflows service.
 
@@ -245,6 +256,10 @@ class WorkflowsService:
             workflows_dir = Path(__file__).resolve().parent / "definitions"
 
         self.workflows_dir = Path(workflows_dir)
+        self._approvals = approvals or ApprovalService()
+        self._custom_workflows = custom_workflows or CustomWorkflowService()
+        self._mcp_registry = mcp_registry or MCPRegistry()
+        self._workflow_runs = workflow_runs or WorkflowRunService()
         self._cache: Dict[str, WorkflowDefinition] = {}
         self._cache_loaded_at: Optional[datetime] = None
 
@@ -297,9 +312,7 @@ class WorkflowsService:
     def _get_custom_workflow(self, workflow_id: str) -> Optional[WorkflowDefinition]:
         """Fetch a single custom workflow from the database by ID."""
         try:
-            from core.workflows.custom_workflow_service import get_custom_workflow_service
-
-            raw = get_custom_workflow_service().get(workflow_id)
+            raw = self._custom_workflows.get(workflow_id)
         except Exception as e:
             logger.debug(f"Custom workflow lookup failed for {workflow_id}: {e}")
             return None
@@ -310,9 +323,7 @@ class WorkflowsService:
     def _list_custom_workflows(self) -> List[WorkflowDefinition]:
         """List active custom workflows from the database."""
         try:
-            from core.workflows.custom_workflow_service import get_custom_workflow_service
-
-            rows = get_custom_workflow_service().list(active_only=True)
+            rows = self._custom_workflows.list(active_only=True)
         except Exception as e:
             logger.debug(f"Custom workflow listing failed: {e}")
             return []
@@ -474,12 +485,10 @@ For each phase:
         On approve, re-enters the phase loop at the paused phase. On
         reject, finalises the run as ``cancelled``.
         """
-        from core.workflows.workflow_run_service import get_workflow_run_service
-
         if decision not in ("approved", "rejected"):
             return {"success": False, "error": f"Invalid decision: {decision}"}
 
-        run_service = get_workflow_run_service()
+        run_service = self._workflow_runs
         run = run_service.get_run(run_id)
         if run is None:
             return {"success": False, "error": f"Run not found: {run_id}"}
@@ -649,7 +658,9 @@ For each phase:
 
         from core.llm.harness.openai import OpenAIAgentService
 
-        agent = OpenAIAgentService(recommended_tools=recommended_tools)
+        agent = OpenAIAgentService(
+            recommended_tools=recommended_tools, approvals=self._approvals
+        )
         return await agent.run(
             provider=spec,
             messages=[{"role": "user", "content": message}],
@@ -672,7 +683,6 @@ For each phase:
         there's no phase_id to attach an approval to."""
         from core.llm.harness.claude import ClaudeService
         from core.agents.manager import SOCAgentLibrary
-        from core.workflows.workflow_run_service import get_workflow_run_service
 
         target_context = self._build_target_context(parameters)
         all_agents = SOCAgentLibrary.get_all_agents()
@@ -694,6 +704,7 @@ For each phase:
             use_mcp_tools=True,
             use_agent_sdk=False,
             enable_thinking=True,
+            mcp_registry=self._mcp_registry,
         )
         # The oneshot composite call runs on the workflow-default assignment
         # (chat_default). Only require an Anthropic key when that resolves to
@@ -730,7 +741,7 @@ For each phase:
                 _est_err,
             )
 
-        run_service = get_workflow_run_service()
+        run_service = self._workflow_runs
         run_id = run_service.begin_run(
             workflow_id=workflow.id,
             workflow_name=workflow.name,
@@ -789,7 +800,6 @@ For each phase:
     ) -> Dict[str, Any]:
         """Phase-by-phase execution path for custom workflows (#128)."""
         from core.llm.harness.claude import ClaudeService
-        from core.workflows.workflow_run_service import get_workflow_run_service
 
         if not ClaudeService(
             use_backend_tools=False, use_mcp_tools=False, use_agent_sdk=False
@@ -799,7 +809,7 @@ For each phase:
         _, skill_tool_names = self._collect_tools(workflow, {})
 
         workflow_dict = workflow.to_dict(include_body=False)
-        run_service = get_workflow_run_service()
+        run_service = self._workflow_runs
         run_id = run_service.begin_run(
             workflow_id=workflow.id,
             workflow_name=workflow.name,
@@ -842,13 +852,11 @@ For each phase:
         """Shared phase-loop body used by both initial execute and
         resume. Walks phases from ``start_index``; pauses or completes
         the run as appropriate."""
-        from core.response.approval_service import ActionType, get_approval_service
         from core.llm.harness.claude import ClaudeService
         from core.agents.manager import SOCAgentLibrary
-        from core.workflows.workflow_run_service import get_workflow_run_service
 
-        run_service = get_workflow_run_service()
-        approval_service = get_approval_service()
+        run_service = self._workflow_runs
+        approval_service = self._approvals
         all_agents = SOCAgentLibrary.get_all_agents()
         workflow_dict = workflow.to_dict(include_body=False)
 
@@ -859,6 +867,7 @@ For each phase:
             use_mcp_tools=True,
             use_agent_sdk=False,
             enable_thinking=True,
+            mcp_registry=self._mcp_registry,
         )
 
         phase_outputs: List[Dict[str, Any]] = []
@@ -1089,10 +1098,7 @@ For each phase:
                     if tool not in all_tools:
                         all_tools.append(tool)
         try:
-            from core.integrations.mcp.registry import get_mcp_registry
-
-            registry = get_mcp_registry()
-            for name in registry.get_tool_names() or []:
+            for name in self._mcp_registry.get_tool_names() or []:
                 if name not in all_tools:
                     all_tools.append(name)
         except Exception as e:  # noqa: BLE001
@@ -1125,10 +1131,7 @@ For each phase:
                 if t not in tools:
                     tools.append(t)
         try:
-            from core.integrations.mcp.registry import get_mcp_registry
-
-            registry = get_mcp_registry()
-            for name in registry.get_tool_names() or []:
+            for name in self._mcp_registry.get_tool_names() or []:
                 if name not in tools:
                     tools.append(name)
         except Exception:  # noqa: BLE001
@@ -1308,15 +1311,3 @@ You have access to SOC tools and must ground every conclusion in tool output.
             )
 
         return "\n\n".join(parts)
-
-
-# Singleton instance
-_workflows_service: Optional[WorkflowsService] = None
-
-
-def get_workflows_service() -> WorkflowsService:
-    """Get singleton WorkflowsService instance."""
-    global _workflows_service
-    if _workflows_service is None:
-        _workflows_service = WorkflowsService()
-    return _workflows_service

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -8,6 +8,7 @@ Complete guide to testing the Vigil platform.
 - [Test Infrastructure](#test-infrastructure)
 - [Running Tests](#running-tests)
 - [Writing Tests](#writing-tests)
+- [Substituting Services](#substituting-services)
 - [Coverage Requirements](#coverage-requirements)
 - [Best Practices](#best-practices)
 
@@ -340,6 +341,75 @@ pytest -m "not slow"
 # Only integration tests
 pytest -m integration
 ```
+
+---
+
+## Substituting Services
+
+Services are constructed once by whoever owns the process and injected from
+there. Nothing reaches for a module-global accessor, so a test never has to
+monkeypatch one — it supplies its own instance. Three rules:
+
+| Where | How the service arrives |
+|---|---|
+| `services/api/main.py` lifespan | Constructs each service onto `app.state` (`_build_services`) |
+| FastAPI handlers | A `Depends` provider from `core/deps.py` reads `request.app.state.<key>` |
+| Everything else (services, daemon, LLM harnesses) | A constructor keyword argument, defaulting to a locally-built instance |
+
+`tests/unit/_ratchets/test_no_ambient_state.py` enforces this: it fails on a new
+module-level service instantiation *and* on the lazy `global _x` accessor
+shape that #459 retired.
+
+### Overriding a service in an API test
+
+Use `app.dependency_overrides`, keyed on the provider function itself. The
+handler then talks to your stub and touches no database, LLM, or MCP process.
+Full worked example: `tests/unit/api/test_service_dependency_overrides.py`.
+
+```python
+from core.deps import provide_approvals
+from core.response.approvals_router import router as approvals_router
+
+
+class StubApprovals:
+    def list_pending_approvals(self):
+        return []
+
+
+def test_pending_is_empty():
+    app = FastAPI()
+    app.include_router(approvals_router, prefix="/api")
+    app.dependency_overrides[provide_approvals] = lambda: StubApprovals()
+
+    resp = TestClient(app).get("/api/approvals/pending")
+    assert resp.json() == {"actions": []}
+```
+
+A bare `FastAPI()` like the one above runs no lifespan, so `app.state` holds
+nothing — the override *is* the wiring. If you instead build a `TestClient`
+over the real app as a context manager (`with TestClient(app) as c:`), the
+lifespan does run and populates `app.state`; overrides still win.
+
+### Overriding elsewhere
+
+Outside a request there is no `Depends`, so pass the instance in:
+
+```python
+svc = WorkflowsService(workflow_runs=WorkflowRunService(), approvals=ApprovalService())
+agent = OpenAIAgentService(approvals=stub_approvals)
+claude = ClaudeService(mcp_client=fake_client, mcp_registry=MCPRegistry())
+```
+
+### The one exception: MCPClient
+
+`MCPClient` owns persistent stdio child processes that only its creator closes,
+so exactly one may exist per process. The owner installs it
+(`set_process_mcp_client`) and `process_mcp_client()` returns it. Before any
+owner starts — which is the case in a plain unit test — it returns `None`, so
+importing the harness never spawns child processes. To supply a fake, pass
+`mcp_client=` to the constructor or override `provide_mcp_client`; only reach
+for `set_process_mcp_client` when the code under test resolves the process slot
+directly.
 
 ---
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -404,9 +404,19 @@ claude = ClaudeService(mcp_client=fake_client, mcp_registry=MCPRegistry())
 
 `MCPClient` owns persistent stdio child processes that only its creator closes,
 so exactly one may exist per process. The owner installs it
-(`set_process_mcp_client`) and `process_mcp_client()` returns it. Before any
-owner starts — which is the case in a plain unit test — it returns `None`, so
-importing the harness never spawns child processes. To supply a fake, pass
+(`set_process_mcp_client`) and `process_mcp_client()` returns it.
+
+"One per process, installed by the owner" only holds if the processes are
+enumerated. There are three, and two of them own a client:
+
+| Process | Owns an MCPClient? |
+|---|---|
+| API (`services/api/main.py` lifespan) | yes |
+| Daemon (`services/daemon/main.py` `_init_components`) | yes |
+| ARQ llm-worker (`python -m services.worker`) | **no** — it runs with `use_mcp_tools=False` and reaches data through backend tools |
+
+Before any owner starts — which is the case in a plain unit test — it returns
+`None`, so importing the harness never spawns child processes. To supply a fake, pass
 `mcp_client=` to the constructor or override `provide_mcp_client`; only reach
 for `set_process_mcp_client` when the code under test resolves the process slot
 directly.

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 # Add the repo root to sys.path so `core.*` and `services.*` resolve whether
@@ -84,11 +85,24 @@ logger = logging.getLogger(__name__)
 # Initialize Sentry as early as possible (no-op if SENTRY_DSN is unset)
 init_sentry()
 
+
+# Delegates to _startup/_shutdown, defined further down alongside the rest of the
+# startup logic; they resolve at call time so the ordering here is fine.
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await _startup(app)
+    try:
+        yield
+    finally:
+        await _shutdown(app)
+
+
 # Create FastAPI app
 app = FastAPI(
     title="Vigil SOC API",
     description="REST API for Vigil SOC Application",
     version=__version__,
+    lifespan=lifespan,
 )
 
 # Optional context path (sub-path) the whole app is served under, e.g. when
@@ -179,7 +193,7 @@ def _mcp_auto_connect_enabled() -> bool:
     return not settings.dev_mode
 
 
-async def _connect_external_services():
+async def _connect_external_services(mcp_client):
     """Connect external startup integrations (skipped under TESTING)."""
     import asyncio
 
@@ -237,10 +251,6 @@ async def _connect_external_services():
 
     logger.info("Initializing MCP client with persistent connections...")
     try:
-        from core.integrations.mcp.client import get_mcp_client
-
-        mcp_client = get_mcp_client()
-
         if mcp_client:
             mcp_service = mcp_client.mcp_service
             servers = mcp_service.list_servers()
@@ -318,12 +328,59 @@ async def _connect_external_services():
         logger.error(f"Error during MCP initialization: {e}")
 
 
-@app.on_event("startup")
-async def startup_event():
+# Constructs the process-scoped services. This is the only place they are built for
+# the API; handlers receive them through the Depends providers in core/deps.py.
+def _build_services(app: FastAPI):
+    from core.agents.agent_ai_generator import AgentAIGenerator
+    from core.config import is_demo_mode
+    from core.detections.detection_rules_service import DetectionRulesService
+    from core.integrations.integration_bridge_service import IntegrationBridgeService
+    from core.integrations.integration_compatibility_service import (
+        IntegrationCompatibilityService,
+    )
+    from core.integrations.mcp.client import build_mcp_client, set_process_mcp_client
+    from core.integrations.mcp.registry import MCPRegistry
+    from core.platform.demo_data_service import DemoDataService
+    from core.response.approval_service import ApprovalService
+    from core.workflows.custom_workflow_service import CustomWorkflowService
+    from core.workflows.workflow_ai_generator import WorkflowAIGenerator
+    from core.workflows.workflow_run_service import WorkflowRunService
+    from core.workflows.workflows_service import WorkflowsService
+
+    app.state.mcp_client = build_mcp_client()
+    set_process_mcp_client(app.state.mcp_client)
+
+    app.state.approvals = ApprovalService()
+    app.state.custom_workflows = CustomWorkflowService()
+    app.state.detection_rules = DetectionRulesService()
+    app.state.integration_bridge = IntegrationBridgeService()
+    app.state.integration_compat = IntegrationCompatibilityService()
+    app.state.mcp_registry = MCPRegistry()
+    app.state.workflow_runs = WorkflowRunService()
+
+    app.state.workflows = WorkflowsService(
+        approvals=app.state.approvals,
+        custom_workflows=app.state.custom_workflows,
+        mcp_registry=app.state.mcp_registry,
+        workflow_runs=app.state.workflow_runs,
+    )
+    app.state.workflow_ai = WorkflowAIGenerator(
+        workflows=app.state.workflows, mcp_registry=app.state.mcp_registry
+    )
+    app.state.agent_ai = AgentAIGenerator(mcp_registry=app.state.mcp_registry)
+
+    # Demo data is only generated when demo mode is on; generating it otherwise
+    # burns startup time building findings nothing will read.
+    app.state.demo_data = DemoDataService() if is_demo_mode() else None
+
+
+async def _startup(app: FastAPI):
     """Initialize database, MCP tools and check integration compatibility on startup."""
     logger.info("=" * 60)
     logger.info("Starting Vigil SOC Backend")
     logger.info("=" * 60)
+
+    _build_services(app)
 
     _testing = get_settings().testing
 
@@ -403,9 +460,7 @@ async def startup_event():
         from core.integrations.extension.trust import connector_allowlist_origins
 
         if not connector_allowlist_origins():
-            from core.integrations.integration_bridge_service import get_integration_bridge
-
-            cfg = get_integration_bridge().load_integration_config()
+            cfg = app.state.integration_bridge.load_integration_config()
             connectors = [
                 iid
                 for iid, c in (cfg.get("integrations") or {}).items()
@@ -500,9 +555,7 @@ async def startup_event():
     # Check integration compatibility
     logger.info("Checking integration compatibility...")
     try:
-        from core.integrations.integration_compatibility_service import get_compatibility_service
-
-        compat_service = get_compatibility_service()
+        compat_service = app.state.integration_compat
         system_info = compat_service.get_system_info()
         logger.info(
             f"System: Python {system_info['python_version']} on {system_info['platform']}"
@@ -533,7 +586,7 @@ async def startup_event():
             "(Bifrost sync, model catalog, LLM gateway, MCP)"
         )
     else:
-        await _connect_external_services()
+        await _connect_external_services(app.state.mcp_client)
 
     # Load custom agents from DB into the AgentManager so built-in + custom
     # agents are visible in one merged list. Lookup misses for "custom-*" IDs
@@ -547,8 +600,7 @@ async def startup_event():
         logger.warning(f"Could not preload custom agents: {e}")
 
 
-@app.on_event("shutdown")
-async def shutdown_event():
+async def _shutdown(app: FastAPI):
     """Clean up LLM gateway and MCP connections on shutdown."""
     logger.info("Shutting down LLM Gateway...")
     try:
@@ -561,9 +613,9 @@ async def shutdown_event():
 
     logger.info("Shutting down MCP connections...")
     try:
-        from core.integrations.mcp.client import get_mcp_client
+        from core.integrations.mcp.client import set_process_mcp_client
 
-        mcp_client = get_mcp_client()
+        mcp_client = getattr(app.state, "mcp_client", None)
         if mcp_client:
             # Close all MCP sessions — stdio child processes are owned by
             # the MCP SDK's stdio_client contexts, which shut down as the
@@ -571,6 +623,7 @@ async def shutdown_event():
             # down since the legacy start_server path was removed (#125).
             await mcp_client.close_all()
             logger.info("All MCP connections closed")
+        set_process_mcp_client(None)
     except Exception as e:
         logger.error(f"Error during shutdown cleanup: {e}")
 

--- a/services/api/routers/agents.py
+++ b/services/api/routers/agents.py
@@ -279,7 +279,8 @@ Use the get_case tool first to retrieve full details, then investigate all assoc
             use_backend_tools=True,
             use_mcp_tools=True,  # Enable MCP tools for dynamic enrichment
             use_agent_sdk=request.use_agent_sdk,
-            enable_thinking=agent.enable_thinking
+            enable_thinking=agent.enable_thinking,
+            mcp_registry=registry,
         )
         
         if not claude_service.has_api_key():

--- a/services/api/routers/agents.py
+++ b/services/api/routers/agents.py
@@ -1,10 +1,12 @@
 """Agents API endpoints for SOC agent management."""
 
 from typing import Optional
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 import logging
 
+from core.deps import provide_mcp_registry
+from core.integrations.mcp.registry import MCPRegistry
 from core.llm.defaults import DEFAULT_MODEL
 from core.agents.builtins import DEFAULT_AGENT_ID
 from core.agents.manager import AgentManager, CUSTOM_AGENT_ID_PREFIX
@@ -202,7 +204,10 @@ class AgentRunRequest(BaseModel):
 
 
 @router.post("/agents/run")
-async def run_agent(request: AgentRunRequest):
+async def run_agent(
+    request: AgentRunRequest,
+    registry: MCPRegistry = Depends(provide_mcp_registry),
+):
     """
     Run an agent task using Claude Agent SDK.
     
@@ -286,8 +291,6 @@ Use the get_case tool first to retrieve full details, then investigate all assoc
         # dynamically discovered MCP tools from the registry
         allowed_tools = list(agent.recommended_tools) if agent.recommended_tools else []
         try:
-            from core.integrations.mcp.registry import get_mcp_registry
-            registry = get_mcp_registry()
             mcp_tool_names = registry.get_tool_names()
             if mcp_tool_names:
                 allowed_tools.extend(mcp_tool_names)

--- a/services/api/routers/config.py
+++ b/services/api/routers/config.py
@@ -1,13 +1,19 @@
 """Configuration API endpoints."""
 
 from typing import Any, Dict, Optional, List
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from pathlib import Path
 import json
 import logging
 import os
 
+from core.deps import (
+    provide_demo_data,
+    provide_integration_bridge,
+    provide_mcp_client,
+)
+from core.integrations.integration_bridge_service import IntegrationBridgeService
 from core.routing import Auth, RouterMeta
 from core.secrets import get_secret, set_secret
 from core.storage.config_service import get_config_service
@@ -171,7 +177,7 @@ async def set_demo_mode(config: DemoModeConfig):
 
 
 @router.post("/demo-mode/reset")
-async def reset_demo_data():
+async def reset_demo_data(demo_service=Depends(provide_demo_data)):
     """
     Reset demo data to regenerate sample findings and cases.
 
@@ -179,14 +185,9 @@ async def reset_demo_data():
         Success status
     """
     try:
-        from core.config import is_demo_mode
-
-        if not is_demo_mode():
+        if demo_service is None:
             raise HTTPException(status_code=400, detail="Demo mode is not enabled")
 
-        from core.platform.demo_data_service import get_demo_service
-
-        demo_service = get_demo_service()
         demo_service.reset()
 
         return {
@@ -773,7 +774,10 @@ async def get_integrations_config():
 
 
 @router.post("/integrations")
-async def set_integrations_config(config: IntegrationsConfig):
+async def set_integrations_config(
+    config: IntegrationsConfig,
+    bridge: IntegrationBridgeService = Depends(provide_integration_bridge),
+):
     """
     Set integrations configuration.
 
@@ -835,9 +839,7 @@ async def set_integrations_config(config: IntegrationsConfig):
         # connectorUrl just saved, so static mcp-config.json remote-MCP
         # entries resolve without a separately-set env var. Best-effort.
         try:
-            from core.integrations.integration_bridge_service import get_integration_bridge
-
-            get_integration_bridge().derive_remote_mcp_env()
+            bridge.derive_remote_mcp_env()
         except Exception as e:
             logger.warning(f"Could not derive remote MCP env vars: {e}")
 
@@ -848,7 +850,9 @@ async def set_integrations_config(config: IntegrationsConfig):
 
 
 @router.get("/integrations/status")
-async def get_integrations_status():
+async def get_integrations_status(
+    bridge: IntegrationBridgeService = Depends(provide_integration_bridge),
+):
     """
     Get status of all integrations.
 
@@ -856,10 +860,6 @@ async def get_integrations_status():
         Status information for all integrations
     """
     try:
-        # Import here to avoid circular dependencies
-        from core.integrations.integration_bridge_service import get_integration_bridge
-
-        bridge = get_integration_bridge()
         statuses = bridge.get_all_integration_statuses()
 
         return {"success": True, "statuses": statuses}
@@ -869,7 +869,10 @@ async def get_integrations_status():
 
 
 @router.post("/integrations/{integration_id}/test")
-async def test_integration(integration_id: str):
+async def test_integration(
+    integration_id: str,
+    bridge: IntegrationBridgeService = Depends(provide_integration_bridge),
+):
     """
     Test an integration connection.
 
@@ -880,10 +883,6 @@ async def test_integration(integration_id: str):
         Test result with success/failure and message
     """
     try:
-        # Import here to avoid circular dependencies
-        from core.integrations.integration_bridge_service import get_integration_bridge
-
-        bridge = get_integration_bridge()
         status = bridge.get_integration_status(integration_id)
 
         if not status["configured"]:
@@ -1476,7 +1475,7 @@ def _count_memories(palace_path: Path) -> Dict[str, Any]:
 
 
 @router.get("/mempalace/health")
-async def get_mempalace_health():
+async def get_mempalace_health(mcp_client=Depends(provide_mcp_client)):
     """Health snapshot for the mempalace memory store.
 
     Aggregates MCP connection state with filesystem facts about the
@@ -1497,9 +1496,6 @@ async def get_mempalace_health():
     connected = False
     error: Optional[str] = None
     try:
-        from core.integrations.mcp.client import get_mcp_client
-
-        mcp_client = get_mcp_client()
         if mcp_client is not None:
             statuses = mcp_client.get_connection_status() or {}
             connected = bool(statuses.get("mempalace", False))

--- a/services/api/routers/custom_agents.py
+++ b/services/api/routers/custom_agents.py
@@ -7,9 +7,12 @@ manages the DB-backed custom agents, prefixed with "custom-".
 import logging
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
+from core.agents.agent_ai_generator import AgentAIGenerator
+from core.deps import provide_agent_ai, provide_mcp_registry
+from core.integrations.mcp.registry import MCPRegistry
 from core.llm.system_prompt import validate_system_prompt
 from core.agents.custom_agent_service import (
     CustomAgentAlreadyExists,
@@ -124,7 +127,9 @@ async def list_custom_agents() -> Dict[str, Any]:
 
 
 @router.get("/agents/custom/_meta/tools")
-async def list_available_tools() -> Dict[str, Any]:
+async def list_available_tools(
+    registry: MCPRegistry = Depends(provide_mcp_registry),
+) -> Dict[str, Any]:
     """Return MCP tool names grouped by server prefix for the UI multiselect.
 
     Sources, in order of preference:
@@ -135,9 +140,6 @@ async def list_available_tools() -> Dict[str, Any]:
     """
     tools: List[str] = []
     try:
-        from core.integrations.mcp.registry import get_mcp_registry
-
-        registry = get_mcp_registry()
         names = registry.get_tool_names() or []
         tools = sorted(set(names))
     except Exception as e:
@@ -186,7 +188,10 @@ async def list_available_tools() -> Dict[str, Any]:
 
 
 @router.post("/agents/custom/generate")
-async def generate_custom_agent(payload: GenerateAgentRequest) -> Dict[str, Any]:
+async def generate_custom_agent(
+    payload: GenerateAgentRequest,
+    generator: AgentAIGenerator = Depends(provide_agent_ai),
+) -> Dict[str, Any]:
     """
     AI-assisted agent generation / refinement (issue #80 Phase 2).
 
@@ -195,9 +200,7 @@ async def generate_custom_agent(payload: GenerateAgentRequest) -> Dict[str, Any]
     to iteratively refine a prior draft.
     """
     try:
-        from core.agents.agent_ai_generator import get_agent_ai_generator
-
-        result = await get_agent_ai_generator().generate(
+        result = await generator.generate(
             description=payload.description,
             current_draft=payload.current_draft,
             feedback=payload.feedback,

--- a/services/api/routers/detection_rules.py
+++ b/services/api/routers/detection_rules.py
@@ -2,8 +2,10 @@
 
 import logging
 from typing import Optional
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+from core.deps import provide_detection_rules, provide_mcp_client
+from core.detections.detection_rules_service import DetectionRulesService
 from core.routing import Auth, RouterMeta
 
 logger = logging.getLogger(__name__)
@@ -29,7 +31,9 @@ class AddSourceRequest(BaseModel):
 
 
 @router.get("/sources")
-async def list_sources():
+async def list_sources(
+    service: DetectionRulesService = Depends(provide_detection_rules),
+):
     """
     List all registered detection rule sources.
     
@@ -37,8 +41,6 @@ async def list_sources():
         List of sources with metadata (name, format, rule count, status, etc.)
     """
     try:
-        from core.detections.detection_rules_service import get_detection_rules_service
-        service = get_detection_rules_service()
         sources = service.list_sources()
         return {"sources": sources, "count": len(sources)}
     except Exception as e:
@@ -47,7 +49,10 @@ async def list_sources():
 
 
 @router.get("/sources/{source_id}")
-async def get_source(source_id: str):
+async def get_source(
+    source_id: str,
+    service: DetectionRulesService = Depends(provide_detection_rules),
+):
     """
     Get details for a specific detection rule source.
     
@@ -58,8 +63,6 @@ async def get_source(source_id: str):
         Source details
     """
     try:
-        from core.detections.detection_rules_service import get_detection_rules_service
-        service = get_detection_rules_service()
         source = service.get_source(source_id)
         if not source:
             raise HTTPException(status_code=404, detail=f"Source not found: {source_id}")
@@ -72,7 +75,10 @@ async def get_source(source_id: str):
 
 
 @router.post("/sources")
-async def add_source(request: AddSourceRequest):
+async def add_source(
+    request: AddSourceRequest,
+    service: DetectionRulesService = Depends(provide_detection_rules),
+):
     """
     Add a new detection rule source (git repo or local directory).
     
@@ -83,8 +89,6 @@ async def add_source(request: AddSourceRequest):
         The newly created source
     """
     try:
-        from core.detections.detection_rules_service import get_detection_rules_service
-        service = get_detection_rules_service()
         source = service.add_source(
             name=request.name,
             source_type=request.source_type,
@@ -103,7 +107,11 @@ async def add_source(request: AddSourceRequest):
 
 
 @router.delete("/sources/{source_id}")
-async def remove_source(source_id: str, delete_files: bool = False):
+async def remove_source(
+    source_id: str,
+    delete_files: bool = False,
+    service: DetectionRulesService = Depends(provide_detection_rules),
+):
     """
     Remove a detection rule source.
     
@@ -115,8 +123,6 @@ async def remove_source(source_id: str, delete_files: bool = False):
         Success status
     """
     try:
-        from core.detections.detection_rules_service import get_detection_rules_service
-        service = get_detection_rules_service()
         success = service.remove_source(source_id, delete_files=delete_files)
         if not success:
             raise HTTPException(status_code=404, detail=f"Source not found: {source_id}")
@@ -129,7 +135,11 @@ async def remove_source(source_id: str, delete_files: bool = False):
 
 
 @router.post("/sources/{source_id}/update")
-async def update_source(source_id: str):
+async def update_source(
+    source_id: str,
+    service: DetectionRulesService = Depends(provide_detection_rules),
+    mcp_client=Depends(provide_mcp_client),
+):
     """
     Update a single detection rule source (git pull or rescan).
     
@@ -140,12 +150,10 @@ async def update_source(source_id: str):
         Updated source details
     """
     try:
-        from core.detections.detection_rules_service import get_detection_rules_service
-        service = get_detection_rules_service()
         source = service.update_source(source_id)
         
         # After updating, restart the security-detections MCP server to rebuild index
-        await _restart_security_detections_mcp()
+        await _restart_security_detections_mcp(mcp_client, service)
         
         return {"success": True, "source": source}
     except ValueError as e:
@@ -156,7 +164,10 @@ async def update_source(source_id: str):
 
 
 @router.post("/update-all")
-async def update_all_sources():
+async def update_all_sources(
+    service: DetectionRulesService = Depends(provide_detection_rules),
+    mcp_client=Depends(provide_mcp_client),
+):
     """
     Update all detection rule sources (git pull all repos).
     
@@ -164,12 +175,10 @@ async def update_all_sources():
         Results for each source update
     """
     try:
-        from core.detections.detection_rules_service import get_detection_rules_service
-        service = get_detection_rules_service()
         results = service.update_all()
         
         # After updating all, restart the security-detections MCP server
-        await _restart_security_detections_mcp()
+        await _restart_security_detections_mcp(mcp_client, service)
         
         return {"success": True, "results": results}
     except Exception as e:
@@ -178,7 +187,9 @@ async def update_all_sources():
 
 
 @router.get("/stats")
-async def get_stats():
+async def get_stats(
+    service: DetectionRulesService = Depends(provide_detection_rules),
+):
     """
     Get aggregate detection rule statistics.
     
@@ -186,8 +197,6 @@ async def get_stats():
         Statistics including total rules, breakdown by format, and per-source counts
     """
     try:
-        from core.detections.detection_rules_service import get_detection_rules_service
-        service = get_detection_rules_service()
         stats = service.get_stats()
         return stats
     except Exception as e:
@@ -196,7 +205,9 @@ async def get_stats():
 
 
 @router.get("/mcp-env")
-async def get_mcp_env():
+async def get_mcp_env(
+    service: DetectionRulesService = Depends(provide_detection_rules),
+):
     """
     Get the environment variables that would be passed to the Security-Detections-MCP server.
     
@@ -204,8 +215,6 @@ async def get_mcp_env():
         Dictionary of environment variable names to their values
     """
     try:
-        from core.detections.detection_rules_service import get_detection_rules_service
-        service = get_detection_rules_service()
         env_vars = service.get_mcp_env_vars()
         return {"env_vars": env_vars}
     except Exception as e:
@@ -214,7 +223,10 @@ async def get_mcp_env():
 
 
 @router.post("/reload")
-async def reload_service():
+async def reload_service(
+    service: DetectionRulesService = Depends(provide_detection_rules),
+    mcp_client=Depends(provide_mcp_client),
+):
     """
     Reload the detection rules service (re-reads config and rescans all sources).
     Also restarts the security-detections MCP server.
@@ -223,8 +235,6 @@ async def reload_service():
         Success status with updated stats
     """
     try:
-        from core.detections.detection_rules_service import get_detection_rules_service
-        service = get_detection_rules_service()
         
         # Re-read config
         service._load_config()
@@ -240,7 +250,7 @@ async def reload_service():
         service._save_config()
         
         # Restart the MCP server
-        await _restart_security_detections_mcp()
+        await _restart_security_detections_mcp(mcp_client, service)
         
         stats = service.get_stats()
         return {"success": True, "stats": stats}
@@ -249,24 +259,19 @@ async def reload_service():
         raise HTTPException(status_code=500, detail=str(e))
 
 
-async def _restart_security_detections_mcp():
+async def _restart_security_detections_mcp(mcp_client, service: DetectionRulesService):
     """
     Restart the security-detections MCP server to pick up new/updated rule sources.
     This triggers a re-index of all detection rules in the MCP server.
     """
     try:
-        from core.integrations.mcp.client import get_mcp_client
-        
-        mcp_client = get_mcp_client()
         if mcp_client and mcp_client.mcp_service:
             mcp_service = mcp_client.mcp_service
             server_name = "security-detections"
             
             if server_name in mcp_service.servers:
                 # Update the server's env vars with latest paths from detection_rules_service
-                from core.detections.detection_rules_service import get_detection_rules_service
-                detection_service = get_detection_rules_service()
-                env_vars = detection_service.get_mcp_env_vars()
+                env_vars = service.get_mcp_env_vars()
                 
                 server = mcp_service.servers[server_name]
                 server.env.update(env_vars)

--- a/services/api/routers/integrations_compatibility.py
+++ b/services/api/routers/integrations_compatibility.py
@@ -16,7 +16,10 @@ import logging
 from services.api.middleware.auth import get_current_active_user
 from core.auth.auth_service import AuthService
 from core.storage.models import User
-from core.integrations.integration_compatibility_service import get_compatibility_service
+from core.deps import provide_integration_compat
+from core.integrations.integration_compatibility_service import (
+    IntegrationCompatibilityService,
+)
 from core.routing import Auth, RouterMeta
 
 router = APIRouter()
@@ -51,10 +54,10 @@ def _require_integrations_admin(current_user: User) -> None:
 @router.get("/compatibility/status")
 async def get_compatibility_status(
     current_user: User = Depends(get_current_active_user),
+    service: IntegrationCompatibilityService = Depends(provide_integration_compat),
 ):
     """Get compatibility status for all integrations."""
     try:
-        service = get_compatibility_service()
         statuses = service.get_all_statuses()
         system_info = service.get_system_info()
 
@@ -71,10 +74,10 @@ async def get_compatibility_status(
 async def get_integration_compatibility(
     integration_id: str,
     current_user: User = Depends(get_current_active_user),
+    service: IntegrationCompatibilityService = Depends(provide_integration_compat),
 ):
     """Get compatibility status for a specific integration."""
     try:
-        service = get_compatibility_service()
         status = service.get_integration_status(integration_id)
 
         if status.get("status") == "unknown":
@@ -95,6 +98,7 @@ async def get_integration_compatibility(
 async def install_package(
     request: IntegrationActionRequest,
     current_user: User = Depends(get_current_active_user),
+    service: IntegrationCompatibilityService = Depends(provide_integration_compat),
 ):
     """Install or upgrade the pinned package for a known integration.
 
@@ -105,7 +109,6 @@ async def install_package(
     """
     _require_integrations_admin(current_user)
 
-    service = get_compatibility_service()
     allowed = service.get_allowed_integration_ids()
     if request.integration_id not in allowed:
         raise HTTPException(
@@ -142,11 +145,11 @@ async def install_package(
 async def upgrade_package(
     request: IntegrationActionRequest,
     current_user: User = Depends(get_current_active_user),
+    service: IntegrationCompatibilityService = Depends(provide_integration_compat),
 ):
     """Upgrade an integration's pinned package."""
     _require_integrations_admin(current_user)
 
-    service = get_compatibility_service()
     if request.integration_id not in service.get_allowed_integration_ids():
         raise HTTPException(
             status_code=404,
@@ -179,11 +182,11 @@ async def upgrade_package(
 async def uninstall_package(
     request: IntegrationActionRequest,
     current_user: User = Depends(get_current_active_user),
+    service: IntegrationCompatibilityService = Depends(provide_integration_compat),
 ):
     """Uninstall the package backing a known integration."""
     _require_integrations_admin(current_user)
 
-    service = get_compatibility_service()
     if request.integration_id not in service.get_allowed_integration_ids():
         raise HTTPException(
             status_code=404,
@@ -215,10 +218,10 @@ async def uninstall_package(
 @router.get("/compatibility/system")
 async def get_system_info(
     current_user: User = Depends(get_current_active_user),
+    service: IntegrationCompatibilityService = Depends(provide_integration_compat),
 ):
     """Get system information including Python version."""
     try:
-        service = get_compatibility_service()
         return service.get_system_info()
     except Exception as e:
         logger.error(f"Error getting system info: {e}")

--- a/services/api/routers/mcp.py
+++ b/services/api/routers/mcp.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from services.api.middleware.auth import get_current_active_user
 from core.auth.auth_service import AuthService
+from core.deps import provide_mcp_client
 from core.storage.models import User
 from core.integrations.mcp.service import MCPService
 from core.routing import Auth, RouterMeta
@@ -53,15 +54,15 @@ def _service() -> MCPService:
     Both the API endpoints and the MCPClient used to wrap in their own
     ``MCPService()`` — two instances, two cached ``_enabled_servers``
     dicts, so ``set_server_enabled`` on A was never visible to
-    ``connect_to_server`` on B. Centralising through ``get_mcp_client()``
+    ``connect_to_server`` on B. Centralising through the process client
     ensures a single source of truth. Falls back to a local instance
     if the MCP SDK isn't installed so the introspection endpoints
     still work.
     """
     try:
-        from core.integrations.mcp.client import get_mcp_client
+        from core.integrations.mcp.client import process_mcp_client
 
-        client = get_mcp_client()
+        client = process_mcp_client()
         if client is not None:
             return client.mcp_service
     except Exception:
@@ -133,6 +134,7 @@ async def set_server_enabled(
     server_name: str,
     request: ServerEnabledRequest,
     current_user: User = Depends(get_current_active_user),
+    mcp_client=Depends(provide_mcp_client),
 ):
     """Enable or disable an MCP server and apply the change at runtime.
 
@@ -163,13 +165,6 @@ async def set_server_enabled(
     connected: Optional[bool] = None
     error: Optional[str] = None
     missing_credentials: Optional[List[str]] = None
-
-    try:
-        from core.integrations.mcp.client import get_mcp_client
-
-        mcp_client = get_mcp_client()
-    except Exception:
-        mcp_client = None
 
     if request.enabled:
         # Try to bring the server online now. Failures (missing creds,
@@ -221,16 +216,13 @@ async def set_server_enabled(
 
 
 @router.get("/connections/status")
-async def get_connections_status():
+async def get_connections_status(mcp_client=Depends(provide_mcp_client)):
     """
     Get persistent connection status for all MCP servers.
 
     Returns:
         Connection status for each server
     """
-    from core.integrations.mcp.client import get_mcp_client
-
-    mcp_client = get_mcp_client()
     if not mcp_client:
         return {"error": "MCP client not available", "connections": {}}
 
@@ -317,9 +309,9 @@ async def get_server_logs(server_name: str, lines: int = 100):
     # actually tells the user why a server isn't reachable. The log file
     # itself only exists for servers started via the monitor path.
     try:
-        from core.integrations.mcp.client import get_mcp_client
+        from core.integrations.mcp.client import process_mcp_client
 
-        last_err = get_mcp_client().get_last_error(server_name)
+        last_err = process_mcp_client().get_last_error(server_name)
         if last_err:
             logs = f"[last connect error] {last_err}\n\n{logs}"
     except Exception:

--- a/services/daemon/agent_runner.py
+++ b/services/daemon/agent_runner.py
@@ -20,7 +20,9 @@ from core.agents.builtins import ORCHESTRATOR_ACTOR
 # interactive OpenAI agent, workflows) shares one policy. Aliased to the
 # historical name so call sites — and the test that patches
 # ``daemon.agent_runner._get_tool_tier`` — stay unchanged.
+from core.integrations.mcp.registry import MCPRegistry
 from core.integrations.mcp.tool_manager import get_tool_tier as _get_tool_tier
+from core.response.approval_service import ApprovalService
 
 
 def _default_thinking_budget() -> int:
@@ -162,9 +164,19 @@ WORKDIR_TOOLS = [
 class AgentRunner:
     """Manages the pool of running sub-agent tasks."""
 
-    def __init__(self, config: OrchestratorConfig, workdir_mgr: WorkdirManager):
+    def __init__(
+        self,
+        config: OrchestratorConfig,
+        workdir_mgr: WorkdirManager,
+        approvals: Optional[ApprovalService] = None,
+        mcp_client=None,
+        mcp_registry: Optional[MCPRegistry] = None,
+    ):
         self.config = config
         self.workdir = workdir_mgr
+        self._approvals = approvals or ApprovalService()
+        self._mcp_client = mcp_client
+        self._mcp_registry = mcp_registry or MCPRegistry()
         self._active_agents: Dict[str, asyncio.Task] = {}
         self._semaphore = asyncio.Semaphore(config.max_concurrent_agents)
         self._claude_service = None
@@ -191,6 +203,8 @@ class AgentRunner:
                     use_agent_sdk=False,
                     enable_thinking=True,
                     thinking_budget=_default_thinking_budget(),
+                    mcp_client=self._mcp_client,
+                    mcp_registry=self._mcp_registry,
                 )
                 logger.info("AgentRunner: Claude service initialized")
             except Exception as e:
@@ -846,10 +860,7 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
             pass
 
         try:
-            from core.integrations.mcp.registry import get_mcp_registry
-
-            registry = get_mcp_registry()
-            mcp_schemas = registry.get_all_tools()
+            mcp_schemas = self._mcp_registry.get_all_tools()
             if mcp_schemas:
                 backend_names = {t["name"] for t in all_tools}
                 for tool in mcp_schemas:
@@ -1242,9 +1253,7 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
                 pass
 
         try:
-            from core.integrations.mcp.client import get_mcp_client
-
-            client = get_mcp_client()
+            client = self._mcp_client
             if client:
                 server_name = None
                 actual_tool_name = tool_name
@@ -1306,9 +1315,9 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
     ) -> str:
         """Create an approval request and put the agent into waiting_approval state."""
         try:
-            from core.response.approval_service import ActionType, get_approval_service
+            from core.response.approval_service import ActionType
 
-            service = get_approval_service()
+            service = self._approvals
 
             try:
                 action_type = ActionType(tool_name)
@@ -1390,9 +1399,9 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
             return None
 
         try:
-            from core.response.approval_service import ActionStatus, get_approval_service
+            from core.response.approval_service import ActionStatus
 
-            service = get_approval_service()
+            service = self._approvals
             action = service.get_action(action_id)
 
             if action is None:
@@ -1490,9 +1499,7 @@ Do NOT repeat tool calls you've already made unless checking for updates."""
             except Exception:
                 pass
         try:
-            from core.integrations.mcp.client import get_mcp_client
-
-            client = get_mcp_client()
+            client = self._mcp_client
             if client:
                 result = await client.call_tool(tool_name, tool_input)
                 if result is not None:

--- a/services/daemon/agent_runner.py
+++ b/services/daemon/agent_runner.py
@@ -20,6 +20,7 @@ from core.agents.builtins import ORCHESTRATOR_ACTOR
 # interactive OpenAI agent, workflows) shares one policy. Aliased to the
 # historical name so call sites — and the test that patches
 # ``daemon.agent_runner._get_tool_tier`` — stay unchanged.
+from core.integrations.mcp.client import process_mcp_client
 from core.integrations.mcp.registry import MCPRegistry
 from core.integrations.mcp.tool_manager import get_tool_tier as _get_tool_tier
 from core.response.approval_service import ApprovalService
@@ -175,7 +176,9 @@ class AgentRunner:
         self.config = config
         self.workdir = workdir_mgr
         self._approvals = approvals or ApprovalService()
-        self._mcp_client = mcp_client
+        self._mcp_client = (
+            mcp_client if mcp_client is not None else process_mcp_client()
+        )
         self._mcp_registry = mcp_registry or MCPRegistry()
         self._active_agents: Dict[str, asyncio.Task] = {}
         self._semaphore = asyncio.Semaphore(config.max_concurrent_agents)

--- a/services/daemon/main.py
+++ b/services/daemon/main.py
@@ -41,6 +41,7 @@ class SOCDaemon:
         self._orchestrator = None
         self._llm_worker_manager = None
         self._metrics_server = None
+        self._mcp_client = None
         
         logger.info("SOC Daemon initialized")
     
@@ -61,6 +62,11 @@ class SOCDaemon:
         logger.info("Initializing daemon components...")
         
         # Import here to avoid circular imports
+        from core.integrations.mcp.client import (build_mcp_client,
+                                                  set_process_mcp_client)
+        from core.response.approval_service import ApprovalService
+        from core.response.autonomous_response_service import \
+            AutonomousResponseService
         from services.daemon.poller import DataPoller
         from services.daemon.processor import FindingProcessor
         from services.daemon.responder import AutonomousResponder
@@ -73,9 +79,24 @@ class SOCDaemon:
         self._poller = DataPoller(self.config.polling)
         self._kafka_ingestor = KafkaIngestor(self.config.kafka)
         self._processor = FindingProcessor(self.config.processing)
-        self._responder = AutonomousResponder(self.config.response, self.config.escalation)
+        # The daemon owns its own copies: it is a separate process from the API, so
+        # nothing on the API's app.state is reachable from here.
+        self._mcp_client = build_mcp_client()
+        set_process_mcp_client(self._mcp_client)
+        approvals = ApprovalService()
+
+        self._responder = AutonomousResponder(
+            self.config.response,
+            self.config.escalation,
+            response_service=AutonomousResponseService(approvals=approvals),
+            approvals=approvals,
+        )
         self._scheduler = TaskScheduler(self.config.scheduler)
-        self._orchestrator = Orchestrator(self.config.orchestrator)
+        self._orchestrator = Orchestrator(
+            self.config.orchestrator,
+            approvals=approvals,
+            mcp_client=self._mcp_client,
+        )
         self._llm_worker_manager = LLMWorkerManager()
 
         if self.config.metrics.enabled:

--- a/services/daemon/orchestrator.py
+++ b/services/daemon/orchestrator.py
@@ -67,6 +67,7 @@ from services.daemon.plan_generator import (
 )
 from services.daemon.shared_intel import SharedIntelligence
 from services.daemon.workdir import WorkdirManager
+from core.response.approval_service import ApprovalService
 
 logger = logging.getLogger(__name__)
 
@@ -88,14 +89,26 @@ def _inv_as_dict(inv):
 class Orchestrator:
     """Master agent that manages autonomous SOC investigations."""
 
-    def __init__(self, config: OrchestratorConfig):
+    def __init__(
+        self,
+        config: OrchestratorConfig,
+        approvals: Optional[ApprovalService] = None,
+        mcp_client=None,
+    ):
         self.config = config
         self._enabled = config.enabled
         self._shutdown_event: Optional[asyncio.Event] = None
+        self._approvals = approvals or ApprovalService()
+        self._mcp_client = mcp_client
 
         self.workdir = WorkdirManager(config.workdir_base)
         self.shared_intel = SharedIntelligence()
-        self.agent_runner = AgentRunner(config, self.workdir)
+        self.agent_runner = AgentRunner(
+            config,
+            self.workdir,
+            approvals=self._approvals,
+            mcp_client=mcp_client,
+        )
 
         self.investigation_queue: asyncio.Queue = asyncio.Queue()
 
@@ -724,9 +737,9 @@ class Orchestrator:
     async def _create_approval_action(self, inv_id: str, action: Dict):
         """Create an approval action for proposed response."""
         try:
-            from core.response.approval_service import ActionType, get_approval_service
+            from core.response.approval_service import ActionType
 
-            service = get_approval_service()
+            service = self._approvals
 
             action_str = action.get("action", "unknown")
             try:
@@ -1015,9 +1028,7 @@ class Orchestrator:
 
             if case_a and case_b and case_a != case_b:
                 try:
-                    from core.integrations.mcp.client import get_mcp_client
-
-                    client = get_mcp_client()
+                    client = self._mcp_client
                     if client:
                         await client.call_tool(
                             "link_related_cases",

--- a/services/daemon/orchestrator.py
+++ b/services/daemon/orchestrator.py
@@ -67,6 +67,7 @@ from services.daemon.plan_generator import (
 )
 from services.daemon.shared_intel import SharedIntelligence
 from services.daemon.workdir import WorkdirManager
+from core.integrations.mcp.client import process_mcp_client
 from core.response.approval_service import ApprovalService
 
 logger = logging.getLogger(__name__)
@@ -99,7 +100,9 @@ class Orchestrator:
         self._enabled = config.enabled
         self._shutdown_event: Optional[asyncio.Event] = None
         self._approvals = approvals or ApprovalService()
-        self._mcp_client = mcp_client
+        self._mcp_client = (
+            mcp_client if mcp_client is not None else process_mcp_client()
+        )
 
         self.workdir = WorkdirManager(config.workdir_base)
         self.shared_intel = SharedIntelligence()
@@ -107,7 +110,7 @@ class Orchestrator:
             config,
             self.workdir,
             approvals=self._approvals,
-            mcp_client=mcp_client,
+            mcp_client=self._mcp_client,
         )
 
         self.investigation_queue: asyncio.Queue = asyncio.Queue()

--- a/services/daemon/responder.py
+++ b/services/daemon/responder.py
@@ -5,6 +5,8 @@ import logging
 from datetime import datetime
 from typing import Optional, Dict, Any
 
+from core.response.approval_service import ApprovalService
+from core.response.autonomous_response_service import AutonomousResponseService
 from services.daemon.config import ResponseConfig, EscalationConfig
 
 logger = logging.getLogger(__name__)
@@ -12,16 +14,23 @@ logger = logging.getLogger(__name__)
 
 class AutonomousResponder:
     """Handles autonomous response actions with escalation."""
-    
-    def __init__(self, response_config: ResponseConfig, escalation_config: EscalationConfig):
+
+    def __init__(
+        self,
+        response_config: ResponseConfig,
+        escalation_config: EscalationConfig,
+        response_service: AutonomousResponseService,
+        approvals: ApprovalService,
+    ):
         self.response_config = response_config
         self.escalation_config = escalation_config
         self.input_queue: asyncio.Queue = asyncio.Queue()
-        
-        # Services (lazy loaded)
-        self._response_service = None
-        self._approval_service = None
-        
+
+        self._response_service = response_service
+        self._approval_service = approvals
+        if response_config.force_manual_approval:
+            self._approval_service.set_force_manual_approval(True)
+
         # Stats
         self.stats = {
             "evaluated": 0,
@@ -31,32 +40,10 @@ class AutonomousResponder:
             "errors": 0
         }
     
-    def _init_services(self):
-        """Initialize required services."""
-        try:
-            from core.response.autonomous_response_service import get_autonomous_response_service
-            self._response_service = get_autonomous_response_service()
-            logger.info("Autonomous response service initialized")
-        except Exception as e:
-            logger.error(f"Failed to initialize response service: {e}")
-        
-        try:
-            from core.response.approval_service import get_approval_service
-            self._approval_service = get_approval_service()
-            
-            # Apply force manual approval setting
-            if self.response_config.force_manual_approval:
-                self._approval_service.set_force_manual_approval(True)
-            
-            logger.info("Approval service initialized")
-        except Exception as e:
-            logger.error(f"Failed to initialize approval service: {e}")
-    
     async def run(self, shutdown_event: asyncio.Event):
         """Run the response handler loop."""
         logger.info("Autonomous responder starting...")
-        self._init_services()
-        
+
         # Start worker tasks
         workers = [
             asyncio.create_task(self._response_worker(shutdown_event)),
@@ -96,7 +83,7 @@ class AutonomousResponder:
         """Periodically execute approved actions."""
         while not shutdown_event.is_set():
             try:
-                if self._response_service and self.response_config.auto_response_enabled:
+                if self.response_config.auto_response_enabled:
                     # Execute approved actions
                     results = self._response_service.execute_approved_actions()
                     
@@ -314,10 +301,6 @@ class AutonomousResponder:
         entity_context: Dict[str, Any]
     ):
         """Create a response action (pending or auto-approved)."""
-        if not self._response_service:
-            logger.warning("Response service not available")
-            return
-        
         if self.response_config.dry_run:
             logger.info(f"[DRY RUN] Would create {action_type} action for finding {finding.get('finding_id')}")
             return

--- a/services/worker/jobs.py
+++ b/services/worker/jobs.py
@@ -581,7 +581,7 @@ async def on_startup(ctx: Dict[str, Any]):
 
     claude_service = ClaudeService(
         use_backend_tools=True,
-        use_mcp_tools=True,
+        use_mcp_tools=False,
         use_agent_sdk=False,
         enable_thinking=True,
         thinking_budget=8000,

--- a/tests/integration/test_mcp_enable_transactional.py
+++ b/tests/integration/test_mcp_enable_transactional.py
@@ -15,6 +15,7 @@ not an end-to-end MCP spin-up.
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
 
 # Keep CSRF out of the way — exercised elsewhere.
 os.environ.setdefault("DEV_MODE", "true")
@@ -32,6 +33,18 @@ def client():
 
     with TestClient(app) as c:
         yield c
+
+
+@contextmanager
+def _override_mcp_client(client, fake_client):
+    """Swap the MCP client the handler receives (#459) for the duration."""
+    from core.deps import provide_mcp_client
+
+    client.app.dependency_overrides[provide_mcp_client] = lambda: fake_client
+    try:
+        yield
+    finally:
+        client.app.dependency_overrides.pop(provide_mcp_client, None)
 
 
 @pytest.fixture
@@ -66,9 +79,7 @@ class TestEnableTransactional:
         fake_client.get_last_error = MagicMock(return_value=None)
         fake_client.disconnect_from_server = AsyncMock(return_value=True)
 
-        with patch(
-            "core.integrations.mcp.client.get_mcp_client", return_value=fake_client
-        ):
+        with _override_mcp_client(client, fake_client):
             r = client.put(
                 "/api/mcp/servers/deeptempo-findings/enabled",
                 json={"enabled": True},
@@ -95,9 +106,7 @@ class TestEnableTransactional:
         )
         fake_client.disconnect_from_server = AsyncMock(return_value=True)
 
-        with patch(
-            "core.integrations.mcp.client.get_mcp_client", return_value=fake_client
-        ):
+        with _override_mcp_client(client, fake_client):
             r = client.put(
                 "/api/mcp/servers/virustotal/enabled",
                 json={"enabled": True},
@@ -116,9 +125,7 @@ class TestEnableTransactional:
         fake_client.connect_to_server = AsyncMock(return_value=True)
         fake_client.disconnect_from_server = AsyncMock(return_value=True)
 
-        with patch(
-            "core.integrations.mcp.client.get_mcp_client", return_value=fake_client
-        ):
+        with _override_mcp_client(client, fake_client):
             r = client.put(
                 "/api/mcp/servers/deeptempo-findings/enabled",
                 json={"enabled": False},

--- a/tests/security/test_unauth_endpoints.py
+++ b/tests/security/test_unauth_endpoints.py
@@ -59,7 +59,8 @@ def app():
     os.environ["DEV_MODE"] = "false"
     get_settings.cache_clear()
     try:
-        yield TestClient(backend_main.app)
+        with TestClient(backend_main.app) as c:
+            yield c
     finally:
         auth_module.DEV_MODE = prev
         if prev_env is None:

--- a/tests/unit/_ratchets/test_no_ambient_state.py
+++ b/tests/unit/_ratchets/test_no_ambient_state.py
@@ -39,6 +39,27 @@ SINGLETON_ALLOWED = {
 }
 
 
+# Accessors that may keep caching one instance in a module global. The first two
+# are process-scoped resources (DatabaseManager owns the connection pool,
+# IngestionJobRegistry holds in-flight job state); the rest are config/secrets
+# channels and standalone MCP tool processes, not injectable services. The 13
+# service singletons #459 retired are deliberately absent — see
+# docs/TESTING_GUIDE.md before adding anything here.
+LAZY_SINGLETON_ALLOWED = {
+    ("core/storage/connection.py", "get_db_manager"),
+    ("core/ingestion/ingestion_jobs.py", "get_job_registry"),
+    ("core/secrets_manager.py", "get_secrets_manager"),
+    ("core/storage/config_service.py", "get_config_service"),
+    ("core/llm/providers/registry.py", "get_registry"),
+    ("core/integrations/elastic/tool.py", "get_elastic_service"),
+    ("core/integrations/splunk/tool.py", "get_splunk_service"),
+    ("core/integrations/vstrike/client.py", "get_vstrike_service"),
+    # Module-private and already injectable: every caller may pass its own
+    # ``data_service``, and this only defers the connection for those that don't.
+    ("core/findings/enrichment/service.py", "_default_data_service"),
+}
+
+
 SERVICE_SUFFIXES = ("Service", "Registry", "Manager", "Client")
 
 # Not a service: the FastAPI router and the SQLAlchemy/limiter primitives are
@@ -97,6 +118,29 @@ def _module_level_services(rel_path: Path):
                 yield node.lineno, target.id, callee
 
 
+def _lazy_singleton_accessors(rel_path: Path):
+    _, tree = _parse(rel_path)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        declared = {
+            name
+            for stmt in ast.walk(node)
+            if isinstance(stmt, ast.Global)
+            for name in stmt.names
+        }
+        if not declared:
+            continue
+        for stmt in ast.walk(node):
+            if not isinstance(stmt, ast.Assign) or not isinstance(stmt.value, ast.Call):
+                continue
+            callee = _callee_name(stmt.value.func)
+            if not callee or not callee.endswith(SERVICE_SUFFIXES):
+                continue
+            if any(isinstance(t, ast.Name) and t.id in declared for t in stmt.targets):
+                yield node.lineno, node.name, callee
+
+
 @pytest.mark.unit
 def test_no_raw_env_reads():
     violations = []
@@ -123,7 +167,26 @@ def test_no_module_level_service_instantiation():
                 continue
             violations.append(f"{rel_path}:{lineno}: {name} = {callee}(...)")
     assert not violations, (
-        "Module-level service instantiation found. Build the instance inside a "
-        "get_*() accessor so import order and test isolation stay predictable.\n"
+        "Module-level service instantiation found. Construct it in the "
+        "services/api/main.py lifespan (onto app.state) and inject it with a "
+        "core/deps.py provider instead, so tests can substitute a fake.\n"
         + "\n".join(violations)
+    )
+
+
+@pytest.mark.unit
+def test_no_lazy_singleton_accessors():
+    violations = []
+    for rel_path in _python_files():
+        for lineno, func, callee in _lazy_singleton_accessors(rel_path):
+            if (rel_path.as_posix(), func) in LAZY_SINGLETON_ALLOWED:
+                continue
+            violations.append(f"{rel_path}:{lineno}: {func}() caches {callee}(...)")
+    assert not violations, (
+        "Lazy module-global singleton accessor found — the shape #459 retired. "
+        "A module global wired to a real DB/LLM/MCP connection cannot be faked "
+        "in a test. Construct the service in the services/api/main.py lifespan "
+        "(or the daemon's _init_components) and inject it: FastAPI handlers via "
+        "a core/deps.py provider, everything else via a constructor keyword "
+        "argument. See docs/TESTING_GUIDE.md.\n" + "\n".join(violations)
     )

--- a/tests/unit/api/test_service_dependency_overrides.py
+++ b/tests/unit/api/test_service_dependency_overrides.py
@@ -1,0 +1,130 @@
+# Worked example of the #459 substitution pattern: a handler's service arrives
+# through a Depends provider, so a test swaps in a stub via
+# app.dependency_overrides and never touches a database, an LLM or an MCP process.
+
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("DEV_MODE", "true")
+os.environ.setdefault("VIGIL_CSRF_ENABLED", "false")
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from core.deps import provide_approvals, provide_workflows
+from core.response.approvals_router import router as approvals_router
+
+
+def _action(action_id="ACT-1", workflow_run_id=None):
+    return SimpleNamespace(
+        action_id=action_id,
+        action_type="isolate_host",
+        title="Isolate host",
+        description="stub",
+        target="host-1",
+        confidence=0.9,
+        reason="stub",
+        evidence=[],
+        created_at="2026-01-01T00:00:00Z",
+        created_by="pytest",
+        requires_approval=True,
+        status="pending",
+        approved_at=None,
+        approved_by=None,
+        executed_at=None,
+        execution_result=None,
+        rejection_reason=None,
+        parameters={},
+        workflow_run_id=workflow_run_id,
+        workflow_phase_id=None,
+    )
+
+
+class StubApprovals:
+    def __init__(self, actions=None):
+        self.actions = actions if actions is not None else [_action()]
+        self.approved = []
+
+    def list_pending_approvals(self):
+        return self.actions
+
+    def get_action(self, action_id):
+        return next((a for a in self.actions if a.action_id == action_id), None)
+
+    def approve_action(self, action_id, approved_by=None):
+        self.approved.append((action_id, approved_by))
+        action = self.get_action(action_id)
+        action.status = "approved"
+        action.approved_by = approved_by
+        return action
+
+
+class StubWorkflows:
+    def __init__(self):
+        self.resumed = []
+
+    async def resume_workflow(self, run_id, decision, **kwargs):
+        self.resumed.append((run_id, decision, kwargs))
+        return {"success": True, "status": "completed", "run_id": run_id}
+
+
+@pytest.fixture()
+def app():
+    # A bare app with just the router under test: no lifespan runs, so nothing
+    # populates app.state and the overrides below are the only wiring.
+    application = FastAPI()
+    application.include_router(approvals_router, prefix="/api")
+    return application
+
+
+@pytest.mark.unit
+def test_pending_approvals_reads_from_the_injected_service(app):
+    stub = StubApprovals()
+    app.dependency_overrides[provide_approvals] = lambda: stub
+
+    resp = TestClient(app).get("/api/approvals/pending")
+
+    assert resp.status_code == 200
+    assert [a["action_id"] for a in resp.json()["actions"]] == ["ACT-1"]
+
+
+@pytest.mark.unit
+def test_missing_action_is_a_404(app):
+    app.dependency_overrides[provide_approvals] = lambda: StubApprovals(actions=[])
+
+    resp = TestClient(app).get("/api/approvals/does-not-exist")
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.unit
+def test_approving_a_workflow_linked_action_resumes_the_run(app):
+    approvals = StubApprovals(actions=[_action(workflow_run_id="wfr-1")])
+    workflows = StubWorkflows()
+    app.dependency_overrides[provide_approvals] = lambda: approvals
+    app.dependency_overrides[provide_workflows] = lambda: workflows
+
+    resp = TestClient(app).post(
+        "/api/approvals/ACT-1/approve", json={"approved_by": "tester"}
+    )
+
+    assert resp.status_code == 200
+    assert approvals.approved == [("ACT-1", "tester")]
+    # The run resumed through the injected WorkflowsService, not a real one.
+    assert workflows.resumed == [("wfr-1", "approved", {"approved_by": "tester"})]
+    assert resp.json()["resume_result"]["status"] == "completed"
+
+
+@pytest.mark.unit
+def test_unlinked_action_does_not_resume_any_workflow(app):
+    approvals = StubApprovals(actions=[_action(workflow_run_id=None)])
+    workflows = StubWorkflows()
+    app.dependency_overrides[provide_approvals] = lambda: approvals
+    app.dependency_overrides[provide_workflows] = lambda: workflows
+
+    resp = TestClient(app).post("/api/approvals/ACT-1/approve", json={})
+
+    assert resp.status_code == 200
+    assert workflows.resumed == []
+    assert resp.json()["resume_result"] is None

--- a/tests/unit/integrations/test_blocking_offload.py
+++ b/tests/unit/integrations/test_blocking_offload.py
@@ -120,9 +120,9 @@ async def test_defender_fetch_alerts_does_not_block_the_loop():
 
 @pytest.mark.asyncio
 async def test_slack_escalation_does_not_block_the_loop():
-    from core.response.autonomous_response_service import get_autonomous_response_service
+    from core.response.autonomous_response_service import AutonomousResponseService
 
-    svc = get_autonomous_response_service()
+    svc = AutonomousResponseService()
     response = MagicMock()
     response.status_code = 200
     response.json.return_value = {"ok": True}

--- a/tests/unit/llm/test_claude_service.py
+++ b/tests/unit/llm/test_claude_service.py
@@ -205,9 +205,8 @@ class TestClaudeServiceInitialization:
             cache_file.parent.mkdir(parents=True, exist_ok=True)
             cache_file.write_text(json.dumps(cache_data))
 
-            with patch('core.integrations.mcp.client.get_mcp_client', return_value=None):
-                with patch.object(ClaudeService, '_populate_mcp_registry'):
-                    service = ClaudeService(use_mcp_tools=True)
+            with patch.object(ClaudeService, '_populate_mcp_registry'):
+                service = ClaudeService(use_mcp_tools=True, mcp_client=None)
 
             assert len(service.mcp_tools) >= 1
             tool_names = [t["name"] for t in service.mcp_tools]
@@ -244,9 +243,8 @@ class TestClaudeServiceInitialization:
             if cache_file.exists():
                 cache_file.unlink()
 
-            with patch('core.integrations.mcp.client.get_mcp_client', return_value=mock_client):
-                with patch.object(ClaudeService, '_populate_mcp_registry'):
-                    service = ClaudeService(use_mcp_tools=True)
+            with patch.object(ClaudeService, '_populate_mcp_registry'):
+                service = ClaudeService(use_mcp_tools=True, mcp_client=mock_client)
 
             assert len(service.mcp_tools) >= 1
             tool_names = [t["name"] for t in service.mcp_tools]
@@ -271,8 +269,7 @@ class TestClaudeServiceInitialization:
             if cache_file.exists():
                 cache_file.unlink()
 
-            with patch('core.integrations.mcp.client.get_mcp_client', return_value=None):
-                service = ClaudeService(use_mcp_tools=True)
+            service = ClaudeService(use_mcp_tools=True, mcp_client=None)
 
             assert service.mcp_tools == []
         finally:
@@ -306,9 +303,8 @@ class TestClaudeServiceInitialization:
             cache_file.parent.mkdir(parents=True, exist_ok=True)
             cache_file.write_text("invalid json{")
 
-            with patch('core.integrations.mcp.client.get_mcp_client', return_value=mock_client):
-                with patch.object(ClaudeService, '_populate_mcp_registry'):
-                    service = ClaudeService(use_mcp_tools=True)
+            with patch.object(ClaudeService, '_populate_mcp_registry'):
+                service = ClaudeService(use_mcp_tools=True, mcp_client=mock_client)
 
             assert len(service.mcp_tools) >= 1
             tool_names = [t["name"] for t in service.mcp_tools]
@@ -344,14 +340,15 @@ class TestClaudeServiceInitialization:
             cache_file.parent.mkdir(parents=True, exist_ok=True)
             cache_file.write_text(json.dumps(cache_data))
 
-            with patch('asyncio.new_event_loop') as mock_new_loop, \
-                 patch('core.integrations.mcp.client.get_mcp_client') as mock_get_client:
-                # Cached tools only surface for servers connected this boot.
-                mock_get_client.return_value.get_connection_status.return_value = {
-                    "splunk": True
-                }
+            # Cached tools only surface for servers connected this boot.
+            connected_client = MagicMock()
+            connected_client.get_connection_status.return_value = {"splunk": True}
+
+            with patch('asyncio.new_event_loop') as mock_new_loop:
                 with patch.object(ClaudeService, '_populate_mcp_registry'):
-                    service = ClaudeService(use_mcp_tools=True)
+                    service = ClaudeService(
+                        use_mcp_tools=True, mcp_client=connected_client
+                    )
                 mock_new_loop.assert_not_called()
 
             assert len(service.mcp_tools) >= 1
@@ -1196,8 +1193,8 @@ class TestLoadMcpToolsCache:
             mock_cf.exists.return_value = False
             mock_repo_root.__truediv__.return_value.__truediv__.return_value = mock_cf
 
-            with patch('core.integrations.mcp.client.get_mcp_client', return_value=mock_client), \
-                 patch.object(service, '_populate_mcp_registry', lambda d: None):
+            service._mcp_client = mock_client
+            with patch.object(service, '_populate_mcp_registry', lambda d: None):
                 service._load_mcp_tools()
 
         assert len(service.mcp_tools) == 1
@@ -1212,8 +1209,8 @@ class TestLoadMcpToolsCache:
             mock_cf.exists.return_value = False
             mock_repo_root.__truediv__.return_value.__truediv__.return_value = mock_cf
 
-            with patch('core.integrations.mcp.client.get_mcp_client', return_value=None):
-                service._load_mcp_tools()
+            service._mcp_client = None
+            service._load_mcp_tools()
 
         assert service.mcp_tools == []
 
@@ -1248,8 +1245,8 @@ class TestLoadMcpToolsCache:
                     return real_open(cache_file, *args, **kwargs)
                 return real_open(path, *args, **kwargs)
 
+            service._mcp_client = mock_client
             with patch('builtins.open', side_effect=selective_open), \
-                 patch('core.integrations.mcp.client.get_mcp_client', return_value=mock_client), \
                  patch.object(service, '_populate_mcp_registry', lambda d: None):
                 service._load_mcp_tools()
 
@@ -1265,8 +1262,8 @@ class TestLoadMcpToolsCache:
             mock_cf.exists.return_value = False
             mock_repo_root.__truediv__.return_value.__truediv__.return_value = mock_cf
 
-            with patch('core.integrations.mcp.client.get_mcp_client', return_value=None), \
-                 patch('asyncio.new_event_loop') as mock_new_loop:
+            service._mcp_client = None
+            with patch('asyncio.new_event_loop') as mock_new_loop:
                 service._load_mcp_tools()
                 mock_new_loop.assert_not_called()
 
@@ -1294,8 +1291,8 @@ class TestLoadMcpToolsCache:
             mock_cf.exists.return_value = False
             mock_repo_root.__truediv__.return_value.__truediv__.return_value = mock_cf
 
-            with patch('core.integrations.mcp.client.get_mcp_client', return_value=mock_client), \
-                 patch.object(service, '_populate_mcp_registry', lambda d: None):
+            service._mcp_client = mock_client
+            with patch.object(service, '_populate_mcp_registry', lambda d: None):
                 service._load_mcp_tools()
 
         assert len(service.mcp_tools) == 1
@@ -1335,13 +1332,11 @@ class TestLoadMcpToolsCache:
                     return real_open(cache_file, *args, **kwargs)
                 return real_open(path, *args, **kwargs)
 
+            # Cached tools only surface for servers connected this boot.
+            service._mcp_client = MagicMock()
+            service._mcp_client.get_connection_status.return_value = {"splunk": True}
             with patch('builtins.open', side_effect=selective_open), \
-                 patch('core.integrations.mcp.client.get_mcp_client') as mock_get_client, \
                  patch.object(service, '_populate_mcp_registry', lambda d: None):
-                # Cached tools only surface for servers connected this boot.
-                mock_get_client.return_value.get_connection_status.return_value = {
-                    "splunk": True
-                }
                 service._load_mcp_tools()
 
         assert len(service.mcp_tools) == 1

--- a/tests/unit/llm/test_openai_agent_service.py
+++ b/tests/unit/llm/test_openai_agent_service.py
@@ -267,11 +267,8 @@ class TestToolGating:
             created.update(kwargs)
             return SimpleNamespace(action_id="ACT-1")
 
-        fake_service = SimpleNamespace(create_action=_create_action)
-        with patch(
-            "core.response.approval_service.get_approval_service",
-            return_value=fake_service,
-        ), patch("core.response.approval_service.ActionType", side_effect=ValueError):
+        agent._approvals = SimpleNamespace(create_action=_create_action)
+        with patch("core.response.approval_service.ActionType", side_effect=ValueError):
             with pytest.raises(PendingApprovalError) as exc_info:
                 await agent._execute_tool("isolate_host", '{"host": "h1"}')
 
@@ -442,9 +439,8 @@ class TestApprovalGate:
                 ]
             )
         )
-        with patch(
-            "core.response.approval_service.get_approval_service", return_value=fake_service
-        ), patch("core.llm.harness.openai._APPROVAL_POLL_INTERVAL_S", 0.0):
+        agent._approvals = fake_service
+        with patch("core.llm.harness.openai._APPROVAL_POLL_INTERVAL_S", 0.0):
             decision, _detail, _waited = await agent._await_approval("ACT-1")
         assert decision == "approved"
         assert fake_service.get_action.call_count == 3
@@ -453,10 +449,8 @@ class TestApprovalGate:
     async def test_await_approval_treats_vanished_action_as_rejected(self):
         agent = _agent()
         fake_service = SimpleNamespace(get_action=MagicMock(return_value=None))
-        with patch(
-            "core.response.approval_service.get_approval_service", return_value=fake_service
-        ):
-            decision, _detail, _waited = await agent._await_approval("ACT-1")
+        agent._approvals = fake_service
+        decision, _detail, _waited = await agent._await_approval("ACT-1")
         assert decision == "rejected"
 
     @pytest.mark.asyncio
@@ -465,9 +459,8 @@ class TestApprovalGate:
         fake_service = SimpleNamespace(
             get_action=MagicMock(return_value=_action("pending"))
         )
-        with patch(
-            "core.response.approval_service.get_approval_service", return_value=fake_service
-        ), patch("core.llm.harness.openai._APPROVAL_POLL_INTERVAL_S", 0.0):
+        agent._approvals = fake_service
+        with patch("core.llm.harness.openai._APPROVAL_POLL_INTERVAL_S", 0.0):
             decision, detail, _waited = await agent._await_approval(
                 "ACT-1", timeout=0.0
             )

--- a/tests/unit/platform/test_backend_mempalace_health.py
+++ b/tests/unit/platform/test_backend_mempalace_health.py
@@ -21,6 +21,8 @@ for p in (str(_REPO_ROOT),):
     if p not in sys.path:
         sys.path.insert(0, p)
 
+from core.deps import provide_mcp_client  # noqa: E402
+
 
 def _load_config_module():
     spec = importlib.util.spec_from_file_location(
@@ -42,19 +44,24 @@ def palace_dir(tmp_path, monkeypatch):
 
 
 @pytest.fixture()
-def client(palace_dir):
+def app(palace_dir):
+    # No lifespan runs on a bare app, so the MCP client arrives only through the
+    # provider override each test installs (#459).
     config_mod = _load_config_module()
-    app = FastAPI()
-    app.include_router(config_mod.router, prefix="/api/config")
+    application = FastAPI()
+    application.include_router(config_mod.router, prefix="/api/config")
+    application.dependency_overrides[provide_mcp_client] = lambda: None
+    return application
+
+
+@pytest.fixture()
+def client(app):
     return TestClient(app)
 
 
 @pytest.mark.unit
-def test_health_returns_shape_when_no_mcp_client(client, palace_dir, monkeypatch):
+def test_health_returns_shape_when_no_mcp_client(client, palace_dir):
     """No MCP client wired in → connected=false, no error, palace facts populated."""
-    import core.integrations.mcp.client as mcp_client_mod
-
-    monkeypatch.setattr(mcp_client_mod, "get_mcp_client", lambda: None)
 
     resp = client.get("/api/config/mempalace/health")
     assert resp.status_code == 200
@@ -70,11 +77,8 @@ def test_health_returns_shape_when_no_mcp_client(client, palace_dir, monkeypatch
 
 
 @pytest.mark.unit
-def test_health_counts_closed_cases(client, palace_dir, monkeypatch):
+def test_health_counts_closed_cases(client, palace_dir):
     """JSON files dropped in investigations/closed-cases/ should be counted."""
-    import core.integrations.mcp.client as mcp_client_mod
-
-    monkeypatch.setattr(mcp_client_mod, "get_mcp_client", lambda: None)
 
     closed = palace_dir / "investigations" / "closed-cases"
     closed.mkdir(parents=True)
@@ -95,9 +99,6 @@ def test_health_handles_missing_palace(client, tmp_path, monkeypatch):
     """If the palace path is unreachable, palace_exists must be False, not raise."""
     missing = tmp_path / "does-not-exist-xyz"
     monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(missing))
-    import core.integrations.mcp.client as mcp_client_mod
-
-    monkeypatch.setattr(mcp_client_mod, "get_mcp_client", lambda: None)
 
     resp = client.get("/api/config/mempalace/health")
     assert resp.status_code == 200
@@ -109,11 +110,10 @@ def test_health_handles_missing_palace(client, tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
-def test_health_surfaces_mcp_error(client, palace_dir, monkeypatch):
+def test_health_surfaces_mcp_error(app, client, palace_dir):
     """When the MCP client reports mempalace as connected with no error,
     the endpoint should reflect that. When disconnected with a last_error
     the error string must propagate so operators see the real failure."""
-    import core.integrations.mcp.client as mcp_client_mod
 
     class FakeClient:
         def get_connection_status(self):
@@ -122,7 +122,7 @@ def test_health_surfaces_mcp_error(client, palace_dir, monkeypatch):
         def get_last_error(self, name):
             return "stdio process exited with code 1" if name == "mempalace" else None
 
-    monkeypatch.setattr(mcp_client_mod, "get_mcp_client", lambda: FakeClient())
+    app.dependency_overrides[provide_mcp_client] = lambda: FakeClient()
 
     resp = client.get("/api/config/mempalace/health")
     data = resp.json()
@@ -131,9 +131,8 @@ def test_health_surfaces_mcp_error(client, palace_dir, monkeypatch):
 
 
 @pytest.mark.unit
-def test_health_connected_path(client, palace_dir, monkeypatch):
+def test_health_connected_path(app, client, palace_dir):
     """Happy path — MCP says connected, no error string surfaced."""
-    import core.integrations.mcp.client as mcp_client_mod
 
     class FakeClient:
         def get_connection_status(self):
@@ -142,7 +141,7 @@ def test_health_connected_path(client, palace_dir, monkeypatch):
         def get_last_error(self, name):
             return None
 
-    monkeypatch.setattr(mcp_client_mod, "get_mcp_client", lambda: FakeClient())
+    app.dependency_overrides[provide_mcp_client] = lambda: FakeClient()
 
     resp = client.get("/api/config/mempalace/health")
     data = resp.json()

--- a/tests/unit/storage/test_database_data_service_reconnect.py
+++ b/tests/unit/storage/test_database_data_service_reconnect.py
@@ -70,14 +70,9 @@ def test_db_available_short_circuits_when_already_connected():
 
 
 def test_demo_mode_never_attempts_reconnect():
-    with patch("core.storage.database_data_service.is_demo_mode", return_value=True), patch(
-        "core.storage.database_data_service.get_demo_service", create=True
-    ):
-        # Stub out the demo service factory used inside the constructor.
-        import core.storage.database_data_service as mod
-
-        mod.get_demo_service = lambda: MagicMock()  # type: ignore[attr-defined]
-        svc = DatabaseDataService()
+    with patch("core.storage.database_data_service.is_demo_mode", return_value=True):
+        # The demo service is injected, so the constructor builds no real one.
+        svc = DatabaseDataService(demo_data=MagicMock())
 
     svc._last_reconnect_attempt = 0.0
     with patch("core.storage.database_data_service.init_database") as fake_init:

--- a/tests/unit/workflows/test_workflow_phase_approval.py
+++ b/tests/unit/workflows/test_workflow_phase_approval.py
@@ -164,7 +164,7 @@ class TestPhasedExecutionPauseResume:
 
     def test_pauses_before_phase_requiring_approval(self, clean_tables):
         from core.llm.harness import claude as cs_module
-        from core.workflows.workflow_run_service import get_workflow_run_service
+        from core.workflows.workflow_run_service import WorkflowRunService
 
         workflow = _make_workflow(approval_on_phase_2=True)
         svc = self._patched_service(workflow)
@@ -184,9 +184,9 @@ class TestPhasedExecutionPauseResume:
         assert result["pending_approval_action_id"]
         assert result["paused_at_phase"] == "phase-2"
 
-        run = get_workflow_run_service().get_run(result["run_id"])
+        run = WorkflowRunService().get_run(result["run_id"])
         assert run["status"] == "paused"
-        phases = get_workflow_run_service().list_phases(result["run_id"])
+        phases = WorkflowRunService().list_phases(result["run_id"])
         by_id = {p["phase_id"]: p for p in phases}
         assert by_id["phase-1"]["status"] == "completed"
         assert by_id["phase-2"]["status"] == "pending_approval"
@@ -194,8 +194,8 @@ class TestPhasedExecutionPauseResume:
 
     def test_resume_approved_completes_run(self, clean_tables):
         from core.llm.harness import claude as cs_module
-        from core.response.approval_service import get_approval_service
-        from core.workflows.workflow_run_service import get_workflow_run_service
+        from core.response.approval_service import ApprovalService
+        from core.workflows.workflow_run_service import WorkflowRunService
 
         workflow = _make_workflow(approval_on_phase_2=True)
         svc = self._patched_service(workflow)
@@ -208,7 +208,7 @@ class TestPhasedExecutionPauseResume:
             run_id = paused["run_id"]
             action_id = paused["pending_approval_action_id"]
 
-            get_approval_service().approve_action(action_id, approved_by="tester")
+            ApprovalService().approve_action(action_id, approved_by="tester")
             result = asyncio.run(
                 svc.resume_workflow(run_id, "approved", approved_by="tester")
             )
@@ -217,9 +217,9 @@ class TestPhasedExecutionPauseResume:
         assert result["status"] == "completed"
         assert result["run_id"] == run_id
 
-        run = get_workflow_run_service().get_run(run_id)
+        run = WorkflowRunService().get_run(run_id)
         assert run["status"] == "completed"
-        phases = get_workflow_run_service().list_phases(run_id)
+        phases = WorkflowRunService().list_phases(run_id)
         statuses = {p["phase_id"]: p["status"] for p in phases}
         approval_states = {p["phase_id"]: p["approval_state"] for p in phases}
         assert statuses == {"phase-1": "completed", "phase-2": "completed"}
@@ -227,8 +227,8 @@ class TestPhasedExecutionPauseResume:
 
     def test_resume_rejected_cancels_run(self, clean_tables):
         from core.llm.harness import claude as cs_module
-        from core.response.approval_service import get_approval_service
-        from core.workflows.workflow_run_service import get_workflow_run_service
+        from core.response.approval_service import ApprovalService
+        from core.workflows.workflow_run_service import WorkflowRunService
 
         workflow = _make_workflow(approval_on_phase_2=True)
         svc = self._patched_service(workflow)
@@ -240,7 +240,7 @@ class TestPhasedExecutionPauseResume:
             run_id = paused["run_id"]
             action_id = paused["pending_approval_action_id"]
 
-            get_approval_service().reject_action(
+            ApprovalService().reject_action(
                 action_id, reason="not safe", rejected_by="tester"
             )
             result = asyncio.run(
@@ -256,17 +256,17 @@ class TestPhasedExecutionPauseResume:
         assert result["status"] == "cancelled"
         assert "not safe" in result["rejection_reason"]
 
-        run = get_workflow_run_service().get_run(run_id)
+        run = WorkflowRunService().get_run(run_id)
         assert run["status"] == "cancelled"
         assert "not safe" in (run["error"] or "")
-        phases = get_workflow_run_service().list_phases(run_id)
+        phases = WorkflowRunService().list_phases(run_id)
         by_id = {p["phase_id"]: p for p in phases}
         assert by_id["phase-2"]["status"] == "failed"
         assert by_id["phase-2"]["approval_state"] == "rejected"
 
     def test_no_approval_required_runs_straight_through(self, clean_tables):
         from core.llm.harness import claude as cs_module
-        from core.workflows.workflow_run_service import get_workflow_run_service
+        from core.workflows.workflow_run_service import WorkflowRunService
 
         workflow = _make_workflow(approval_on_phase_2=False)
         svc = self._patched_service(workflow)
@@ -278,7 +278,7 @@ class TestPhasedExecutionPauseResume:
 
         assert result["success"] is True
         assert result["status"] == "completed"
-        run = get_workflow_run_service().get_run(result["run_id"])
+        run = WorkflowRunService().get_run(result["run_id"])
         assert run["status"] == "completed"
 
 
@@ -286,16 +286,16 @@ class TestApprovalActionWorkflowLinkage:
     def test_create_action_persists_workflow_linkage(self, clean_tables):
         from core.response.approval_service import (
             ActionType,
-            get_approval_service,
+            ApprovalService,
         )
-        from core.workflows.workflow_run_service import get_workflow_run_service
+        from core.workflows.workflow_run_service import WorkflowRunService
 
-        run_id = get_workflow_run_service().begin_run(
+        run_id = WorkflowRunService().begin_run(
             workflow_id="test-phase-linkage",
             workflow_name="Linkage",
         )
         assert run_id is not None
-        svc = get_approval_service()
+        svc = ApprovalService()
         action = svc.create_action(
             action_type=ActionType.WORKFLOW_PHASE,
             title="phase approval",

--- a/tests/unit/workflows/test_workflow_run_service.py
+++ b/tests/unit/workflows/test_workflow_run_service.py
@@ -11,11 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from core.workflows.workflow_run_service import (
-    WorkflowRunService,
-    generate_run_id,
-    get_workflow_run_service,
-)
+from core.workflows.workflow_run_service import WorkflowRunService, generate_run_id
 
 
 def _db_available() -> bool:
@@ -175,10 +171,3 @@ class TestListRuns:
         # ``list_runs`` calls to_dict(include_result=False) — result_summary
         # should not be in the envelope so list responses stay small.
         assert "result_summary" not in runs[0]
-
-
-class TestSingleton:
-    def test_get_workflow_run_service_returns_same_instance(self):
-        a = get_workflow_run_service()
-        b = get_workflow_run_service()
-        assert a is b


### PR DESCRIPTION
Closes #459.

The 13 `get_X_service()` accessors were a hand-rolled service locator: a module global
wired to a real DB/LLM/MCP connection, with no seam to substitute a fake.

| Where | How the service arrives |
|---|---|
| `services/api/main.py` lifespan | `_build_services()` puts the instances on `app.state` |
| FastAPI handlers | a `Depends` provider from `core/deps.py` |
| everything else (services, daemon, LLM harnesses) | a constructor keyword argument defaulting to a locally-built instance |

`core/deps.py` sits in `core/` rather than `services/api/` because routers colocate with
their domain (`core/<domain>/*_router.py`) and `core` must not import `services` —
`.importlinter` would reject the other placement.

**MCPClient is the deliberate exception.** It owns persistent stdio children that only its
creator closes, so exactly one may exist per process. It keeps a module slot, but one the
owner installs (`set_process_mcp_client`) rather than one that lazily self-constructs — so
`process_mcp_client()` is `None` until an owner starts, and importing the harness no longer
spawns child processes.

`DemoDataService` keeps its shared class-level state: the module-level
`DatabaseDataService` instances in the routers each build one and demo edits must stay
visible across all of them. `provide_demo_data` resolves per request because demo mode is
toggleable at runtime.

---

## Follow-up: naming every owner

An owner installing a service rather than the service self-constructing only holds once the owners are enumerated. Four places where one was missing:

| Where | What happened |
|---|---|
| `tests/security/test_unauth_endpoints.py` | Built a `TestClient` with no `with` block, so no lifespan ran and every `core/deps.py` provider raised `AttributeError`. `Depends` resolves before the handler body, so the two admin-gated routes answered **500 instead of the 403 under test** — this was the red CI job. |
| `services/worker/jobs.py` | The ARQ llm-worker is a third process and installs no MCP client, so `ClaudeService(use_mcp_tools=True)` handed the model a catalogue whose every call resolved to "MCP client unavailable". It now asks for no MCP tools; backend tools reach the same data in-process. |
| `services/api/routers/agents.py` | `/agents/run` read the injected `MCPRegistry` while the `ClaudeService` it had just built populated a private one, so `allowed_tools` silently lost every MCP tool. |
| `services/daemon/{orchestrator,agent_runner}.py` | Neither fell back to `process_mcp_client()` the way the harnesses do, so the API's lazily-built orchestrator ran with no client at all. |

`docs/TESTING_GUIDE.md` now names the three processes — API, daemon, ARQ llm-worker — and which two own an `MCPClient`.
