### PR TITLE
feat(agent): deploy the agent layer off-host

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,12 +46,11 @@ LICENSE
 # requirements.txt is needed by Dockerfile.backend + Dockerfile.daemon;
 # the wildcard above would otherwise exclude it.
 !requirements.txt
-# The submodule packages are pip-installed during the image build, and their
-# build backends read README.md for metadata (mempalace's pyproject declares
-# `readme = "README.md"`, which hard-fails if the file is absent). The `*.md`
-# wildcard above would otherwise strip them from the build context.
-!deeptempo-core/README.md
-!mcp-servers/README.md
+# mempalace is pip-installed during the image build and its build backend reads
+# README.md for metadata (its pyproject declares `readme = "README.md"`, which
+# hard-fails if the file is absent). The `*.md` wildcard above would otherwise
+# strip it from the build context. deeptempo-core and mcp-servers were here too
+# until #654 dropped those submodules.
 !mempalace/README.md
 
 # Logs
@@ -63,6 +62,13 @@ logs/
 clients/web/node_modules/
 clients/web/build/
 clients/web/dist/
+
+# Agent layer. The Python images COPY services/ wholesale, so without these an
+# installed node_modules would land in vigil-backend and vigil-daemon. The
+# agent image installs its own deps and compiles inside the build, so a host
+# tree here would only make that build unreproducible.
+services/agent/node_modules/
+services/agent/dist/
 
 # Database
 *.db

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -104,6 +104,75 @@ jobs:
           ignore: DL3008,DL3009
         continue-on-error: true
 
+      # Not continue-on-error, and no ignores: the agent image is clean today
+      # (#635) and installs no apt packages, so the two rules waived above have
+      # nothing to say about it. Advisory here would only let it rot.
+      - name: Run hadolint (agent)
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: infra/docker/Dockerfile.agent
+
+  # ============================================================================
+  # Agent Image — build, scan, smoke test
+  # ============================================================================
+  # Separate from build-images below, which pushes to a registry and is disabled.
+  # This one builds locally and throws the image away, so it can run on every PR
+  # and answer the three questions #635 asks of the image: does it build, is it
+  # clean, does it start.
+  build-agent-image:
+    name: Agent Image
+    if: github.repository == 'Vigil-SOC/vigil'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build agent image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/docker/Dockerfile.agent
+          push: false
+          load: true            # into the runner's docker, for the steps below
+          tags: vigil-agent:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy — report HIGH and CRITICAL
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: vigil-agent:ci
+          format: table
+          severity: HIGH,CRITICAL
+
+      # The gate is narrower than the report on purpose. An unfixed CVE in the
+      # base image is not something this repo can act on, and failing every PR
+      # on one teaches people to ignore the job.
+      - name: Trivy — fail on fixable CRITICAL
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: vigil-agent:ci
+          format: table
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+
+      # Loads both entry points without running either: the main blocks guard on
+      # process.argv[1], which --eval leaves undefined. That is the whole point --
+      # it proves every import resolves inside the image (the failure mode that
+      # typecheck cannot see, since tsc reads .ts and node runs the emitted .js)
+      # without needing a Postgres or a Redis to connect to.
+      - name: Smoke test — both entry points load
+        run: |
+          docker run --rm vigil-agent:ci \
+            node --input-type=module -e "
+              await import('/app/dist/worker.js');
+              await import('/app/dist/serve.js');
+              console.log('agent ok');
+            "
+
   # ============================================================================
   # Unit Tests
   # ============================================================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,15 @@
 # .github/workflows/release.yml
 #
 # Triggered when release-please merges a release PR and pushes a vX.Y.Z tag.
-# Builds and publishes two OCI images to ghcr.io:
+# Builds and publishes three OCI images to ghcr.io:
 #
 #   ghcr.io/vigil-soc/vigil-backend:<tag>   (FastAPI API + bundled SPA)
 #   ghcr.io/vigil-soc/vigil-daemon:<tag>    (headless SOC daemon)
+#   ghcr.io/vigil-soc/vigil-agent:<tag>     (TypeScript agent: worker + serve)
 #
-# The llm-worker Deployment reuses the backend image (different command),
-# so no third image is needed.
+# The llm-worker Deployment reuses the backend image (different command), and
+# agent-worker/agent-serve are the same arrangement over the agent image: one
+# artifact, two commands, two Deployments that scale independently (#635).
 #
 # Prerequisites (one-time, per RELEASING.md):
 #   • GitHub App installed with id=vars.RELEASE_PLEASE_APP_ID
@@ -175,13 +177,74 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
   # ---------------------------------------------------------------------------
+  # Build + push: agent (worker and serve run the same image)
+  # ---------------------------------------------------------------------------
+  build-agent:
+    name: Build agent image
+    if: github.repository == 'Vigil-SOC/vigil'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      # No submodules: the agent layer is TypeScript under services/agent and
+      # the build context copies nothing else.
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/vigil-soc/vigil-agent
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.title=vigil-agent
+            org.opencontainers.image.description=Vigil SOC — TypeScript agent layer (queue worker + chat/projection server)
+            org.opencontainers.image.vendor=Vigil-SOC
+            org.opencontainers.image.source=https://github.com/Vigil-SOC/vigil
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Build and push agent
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/docker/Dockerfile.agent
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/vigil-soc/vigil-agent:buildcache
+          cache-to:   type=registry,ref=ghcr.io/vigil-soc/vigil-agent:buildcache,mode=max
+          build-args: |
+            VIGIL_VERSION=${{ github.ref_name }}
+          platforms: linux/amd64,linux/arm64
+
+  # ---------------------------------------------------------------------------
   # Smoke-test: pull the images and verify they start
   # ---------------------------------------------------------------------------
   smoke-test:
     name: Smoke test images
     if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
-    needs: [version, build-backend, build-daemon]
+    needs: [version, build-backend, build-daemon, build-agent]
     permissions:
       packages: read
 
@@ -200,7 +263,7 @@ jobs:
             -e DATABASE_URL=postgresql://x:x@localhost/x \
             -e REDIS_URL=redis://localhost:6379 \
             ghcr.io/vigil-soc/vigil-backend:${{ needs.version.outputs.version }} \
-            python -c "import backend; print('backend version:', backend.__version__)"
+            python -c "import core, services.api; print('backend ok')"
 
       - name: Backend — SPA present
         run: |
@@ -214,7 +277,21 @@ jobs:
           docker run --rm \
             -e DEV_MODE=true \
             ghcr.io/vigil-soc/vigil-daemon:${{ needs.version.outputs.version }} \
-            python -c "import daemon; print('daemon ok')"
+            python -c "import services.daemon; print('daemon ok')"
+
+      # Both commands the chart runs, loaded but not started: the main blocks
+      # guard on process.argv[1], which --eval leaves undefined. Proves the
+      # emitted JavaScript resolves its imports inside the image — the one thing
+      # typecheck cannot tell us, since tsc reads .ts and node runs .js.
+      - name: Agent — entry points load
+        run: |
+          docker run --rm \
+            ghcr.io/vigil-soc/vigil-agent:${{ needs.version.outputs.version }} \
+            node --input-type=module -e "
+              await import('/app/dist/worker.js');
+              await import('/app/dist/serve.js');
+              console.log('agent ok');
+            "
 
   # ---------------------------------------------------------------------------
   # Attach image digests to the GitHub Release
@@ -243,8 +320,11 @@ jobs:
             | python3 -c "import sys,json; m=json.load(sys.stdin); print(m.get('config',{}).get('digest','unknown'))")
           DAEMON=$(docker manifest inspect ghcr.io/vigil-soc/vigil-daemon:${{ needs.version.outputs.version }} \
             | python3 -c "import sys,json; m=json.load(sys.stdin); print(m.get('config',{}).get('digest','unknown'))")
+          AGENT=$(docker manifest inspect ghcr.io/vigil-soc/vigil-agent:${{ needs.version.outputs.version }} \
+            | python3 -c "import sys,json; m=json.load(sys.stdin); print(m.get('config',{}).get('digest','unknown'))")
           echo "backend=$BACKEND" >> "$GITHUB_OUTPUT"
           echo "daemon=$DAEMON"   >> "$GITHUB_OUTPUT"
+          echo "agent=$AGENT"     >> "$GITHUB_OUTPUT"
 
       - name: Append image refs to release notes
         uses: softprops/action-gh-release@v2
@@ -259,9 +339,11 @@ jobs:
             |-------|-----|--------|
             | `ghcr.io/vigil-soc/vigil-backend` | `${{ needs.version.outputs.version }}` | `${{ steps.digests.outputs.backend }}` |
             | `ghcr.io/vigil-soc/vigil-daemon`  | `${{ needs.version.outputs.version }}` | `${{ steps.digests.outputs.daemon }}`  |
+            | `ghcr.io/vigil-soc/vigil-agent`   | `${{ needs.version.outputs.version }}` | `${{ steps.digests.outputs.agent }}`   |
 
             ```bash
             # Pull by tag
             docker pull ghcr.io/vigil-soc/vigil-backend:${{ needs.version.outputs.version }}
             docker pull ghcr.io/vigil-soc/vigil-daemon:${{ needs.version.outputs.version }}
+            docker pull ghcr.io/vigil-soc/vigil-agent:${{ needs.version.outputs.version }}
             ```

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -123,6 +123,12 @@ setting, is `platform`; knowing what the setting *means* is the domain's.
 - The **LLM gateway** (`core/llm/gateway`) enqueues LLM jobs onto the `arq:llm`
   queue; the **worker** (`services/worker`) is the sole consumer that executes
   them — the enqueue/execute seam between `core/` and the `services/` deployables
+- The agent layer has exactly **two ways in**, and they are what it splits along
+  rather than by protocol: the **run queue** (`agent-runs`, enqueued by
+  `core/agents/queue.py`) and the **agent HTTP surface** (chat and run
+  projections). **Agent Worker** drains the first, **Agent Serve** answers the
+  second; every HTTP route the layer exposes is request-driven, so projections
+  ride with chat rather than earning a third deployable
 - A **Workflow** is authored as exactly one **Playbook** and executed by
   **Compose**; a Playbook holds one or more ordered **Phases**, and a **Phase**
   names exactly one agent

--- a/core/agents/internal_auth.py
+++ b/core/agents/internal_auth.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
+import hmac
 import logging
 from typing import Optional
 
-from fastapi import HTTPException, Request
+from fastapi import HTTPException
 
 from core.secrets import get_secret
 
@@ -22,13 +23,21 @@ TOKEN_SECRET = "AGENT_INTERNAL_TOKEN"
 # asserting "same box" -- a stronger statement, and one Kubernetes enforces.
 #
 # Which makes the refusal below load-bearing rather than defensive: it is now the
-# only thing between a reachable pod and an open endpoint.
-def authorise(request: Request, presented: Optional[str], what: str) -> None:
+# only thing between a reachable pod and an open endpoint. The request itself is no
+# longer read, which is why it is no longer a parameter.
+def authorise(presented: Optional[str], what: str) -> None:
     expected = get_secret(TOKEN_SECRET)
     # Told apart deliberately: a deployment that never set the secret reads exactly
     # like a caller with the wrong one, and the fix for each is nothing alike.
     if not expected:
         logger.error("%s refused: %s is not configured", what, TOKEN_SECRET)
         raise HTTPException(status_code=503, detail=f"{TOKEN_SECRET} is not configured")
-    if presented != f"Bearer {expected}":
+    # compare_digest rather than !=, now that this is the only gate: a plain
+    # comparison returns on the first differing byte, and the header is attacker-
+    # chosen. Encoded because compare_digest refuses a str holding anything above
+    # U+00FF, which a header is free to carry.
+    if not hmac.compare_digest(
+        (presented or "").encode("utf-8", "surrogatepass"),
+        f"Bearer {expected}".encode(),
+    ):
         raise HTTPException(status_code=401, detail="bad or missing internal token")

--- a/core/agents/internal_auth.py
+++ b/core/agents/internal_auth.py
@@ -23,8 +23,7 @@ TOKEN_SECRET = "AGENT_INTERNAL_TOKEN"
 # asserting "same box" -- a stronger statement, and one Kubernetes enforces.
 #
 # Which makes the refusal below load-bearing rather than defensive: it is now the
-# only thing between a reachable pod and an open endpoint. The request itself is no
-# longer read, which is why it is no longer a parameter.
+# only thing between a reachable pod and an open endpoint.
 def authorise(presented: Optional[str], what: str) -> None:
     expected = get_secret(TOKEN_SECRET)
     # Told apart deliberately: a deployment that never set the secret reads exactly
@@ -32,10 +31,8 @@ def authorise(presented: Optional[str], what: str) -> None:
     if not expected:
         logger.error("%s refused: %s is not configured", what, TOKEN_SECRET)
         raise HTTPException(status_code=503, detail=f"{TOKEN_SECRET} is not configured")
-    # compare_digest rather than !=, now that this is the only gate: a plain
-    # comparison returns on the first differing byte, and the header is attacker-
-    # chosen. Encoded because compare_digest refuses a str holding anything above
-    # U+00FF, which a header is free to carry.
+    # compare_digest rather than !=, which returns on the first differing byte.
+    # Encoded because it refuses a str holding anything above U+00FF.
     if not hmac.compare_digest(
         (presented or "").encode("utf-8", "surrogatepass"),
         f"Bearer {expected}".encode(),

--- a/core/agents/internal_auth.py
+++ b/core/agents/internal_auth.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import ipaddress
 import logging
 from typing import Optional
 
@@ -16,19 +15,15 @@ logger = logging.getLogger(__name__)
 TOKEN_SECRET = "AGENT_INTERNAL_TOKEN"
 
 
-def _loopback(request: Request) -> bool:
-    host = request.client.host if request.client is not None else ""
-    try:
-        return ipaddress.ip_address(host).is_loopback
-    except ValueError:
-        return False
-
-
-# Both checks or neither: a shared secret on a public bind is one leak from open,
-# and a loopback bind alone trusts every process on the box.
+# The token alone, since ADR 0014. This paired with a loopback check until #635
+# made the agent layer its own Deployments, at which point every legitimate caller
+# arrives from a pod address and the check refused all of them. What replaces it is
+# the chart's NetworkPolicy, which names the pods that may connect rather than
+# asserting "same box" -- a stronger statement, and one Kubernetes enforces.
+#
+# Which makes the refusal below load-bearing rather than defensive: it is now the
+# only thing between a reachable pod and an open endpoint.
 def authorise(request: Request, presented: Optional[str], what: str) -> None:
-    if not _loopback(request):
-        raise HTTPException(status_code=403, detail=f"{what} is loopback only")
     expected = get_secret(TOKEN_SECRET)
     # Told apart deliberately: a deployment that never set the secret reads exactly
     # like a caller with the wrong one, and the fix for each is nothing alike.

--- a/core/agents/queue.py
+++ b/core/agents/queue.py
@@ -24,6 +24,20 @@ DEFAULT_REDIS_URL = "redis://localhost:6379/0"
 
 RUN_KINDS = ("hunt", "investigate", "compose", "chat")
 
+# BullMQ defaults to one attempt, so a job that throws is permanently failed and
+# nothing rescues it: the watchdog sweeps lapsed lease rows, and a job that died on
+# its way into leases.claim never wrote one. On a dev box a transient Postgres or
+# Redis failure is rare; under Kubernetes -- rolling upgrades, evictions, failover --
+# it is routine, and the run would be lost with nothing reaching the console.
+#
+# Retrying is safe rather than merely tolerable: advance() checks terminal first and
+# leases.claim is a conditional UPDATE, so a second attempt takes exactly the path a
+# watchdog resume takes.
+#
+# The consumer reads these off the job, so the Node worker honours what is set here.
+RUN_ATTEMPTS = 3
+RUN_BACKOFF = {"type": "exponential", "delay": 5000}
+
 
 def _redis_url() -> str:
     return get_settings().redis_url or DEFAULT_REDIS_URL
@@ -80,7 +94,13 @@ async def enqueue_run(job: Dict[str, Any], job_id: Optional[str] = None) -> str:
         # forever, which is the thing a resume exists to prevent. Run-level exclusion
         # is the lease's, in agent_run_leases, and it is stronger than a job id.
         enqueued = await queue.add(
-            "run", job, {"jobId": job_id or _default_job_id(job)}
+            "run",
+            job,
+            {
+                "jobId": job_id or _default_job_id(job),
+                "attempts": RUN_ATTEMPTS,
+                "backoff": RUN_BACKOFF,
+            },
         )
         logger.info("enqueued agent run %s (%s)", job["run_id"], job["run_kind"])
         return str(enqueued.id)

--- a/core/agents/queue.py
+++ b/core/agents/queue.py
@@ -32,7 +32,8 @@ RUN_KINDS = ("hunt", "investigate", "compose", "chat")
 #
 # Retrying is safe rather than merely tolerable: advance() checks terminal first and
 # leases.claim is a conditional UPDATE, so a second attempt takes exactly the path a
-# watchdog resume takes.
+# watchdog resume takes -- and it is reachable because a failed attempt hands its
+# lease back (services/agent/worker.ts::forget) instead of holding it out the TTL.
 #
 # The consumer reads these off the job, so the Node worker honours what is set here.
 RUN_ATTEMPTS = 3

--- a/core/agents/queue.py
+++ b/core/agents/queue.py
@@ -32,8 +32,8 @@ RUN_KINDS = ("hunt", "investigate", "compose", "chat")
 #
 # Retrying is safe rather than merely tolerable: advance() checks terminal first and
 # leases.claim is a conditional UPDATE, so a second attempt takes exactly the path a
-# watchdog resume takes -- and it is reachable because a failed attempt hands its
-# lease back (services/agent/worker.ts::forget) instead of holding it out the TTL.
+# watchdog resume takes -- reachable because a failed attempt hands its lease back
+# (services/agent/worker.ts::forget).
 #
 # The consumer reads these off the job, so the Node worker honours what is set here.
 RUN_ATTEMPTS = 3

--- a/core/agents/tools_router.py
+++ b/core/agents/tools_router.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
-from fastapi import APIRouter, Header, Request
+from fastapi import APIRouter, Header
 from pydantic import BaseModel, Field
 
 from core.agents.internal_auth import authorise
@@ -73,10 +73,9 @@ async def _run(body: InvokeRequest) -> Tuple[Any, bool]:
 @router.post("/invoke")
 async def invoke(
     body: InvokeRequest,
-    request: Request,
     authorization: Optional[str] = Header(default=None),
 ) -> Dict[str, Any]:
-    authorise(request, authorization, "tool invocation")
+    authorise(authorization, "tool invocation")
 
     try:
         result, handled = await _run(body)

--- a/core/agents/tools_router.py
+++ b/core/agents/tools_router.py
@@ -21,7 +21,8 @@ ROUTER_META = RouterMeta(
     tags=["internal-tools"],
     auth=Auth.ROUTER_MANAGED,
     reason=(
-        "Loopback plus a shared secret: the caller is the agent layer, not a session."
+        "A shared secret: the caller is the agent layer, not a session. Reachability\n"
+        "is the NetworkPolicy's job since ADR 0014, not a loopback check."
     ),
 )
 logger = logging.getLogger(__name__)

--- a/core/llm/cost/pricing_router.py
+++ b/core/llm/cost/pricing_router.py
@@ -24,7 +24,8 @@ ROUTER_META = RouterMeta(
     tags=["internal-pricing"],
     auth=Auth.ROUTER_MANAGED,
     reason=(
-        "Loopback plus a shared secret: the caller is the agent layer, not a session."
+        "A shared secret: the caller is the agent layer, not a session. Reachability\n"
+        "is the NetworkPolicy's job since ADR 0014, not a loopback check."
     ),
 )
 logger = logging.getLogger(__name__)

--- a/core/llm/cost/pricing_router.py
+++ b/core/llm/cost/pricing_router.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Header, Request
+from fastapi import APIRouter, Header
 
 from core.agents.internal_auth import authorise
 from core.routing import Auth, RouterMeta
@@ -35,11 +35,10 @@ logger = logging.getLogger(__name__)
 async def rates(
     model_id: str,
     provider_type: str,
-    request: Request,
     authorization: Optional[str] = Header(default=None),
 ) -> Dict[str, Any]:
     """Per-token USD rates for one model, plus how confidently they resolved."""
-    authorise(request, authorization, "pricing lookup")
+    authorise(authorization, "pricing lookup")
 
     from core.llm.providers.registry import get_registry
 

--- a/core/workflows/playbooks_router.py
+++ b/core/workflows/playbooks_router.py
@@ -20,7 +20,8 @@ ROUTER_META = RouterMeta(
     tags=["internal-playbooks"],
     auth=Auth.ROUTER_MANAGED,
     reason=(
-        "Loopback plus a shared secret: the caller is the agent layer, not a session."
+        "A shared secret: the caller is the agent layer, not a session. Reachability\n"
+        "is the NetworkPolicy's job since ADR 0014, not a loopback check."
     ),
 )
 logger = logging.getLogger(__name__)

--- a/core/workflows/playbooks_router.py
+++ b/core/workflows/playbooks_router.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi import APIRouter, Header, HTTPException
 from pydantic import BaseModel
 
 from core.agents.internal_auth import authorise
@@ -35,10 +35,9 @@ class ResolvedPlaybook(BaseModel):
 @router.get("/{workflow_id}", response_model=ResolvedPlaybook)
 def get_playbook(
     workflow_id: str,
-    request: Request,
     authorization: Optional[str] = Header(default=None),
 ) -> ResolvedPlaybook:
-    authorise(request, authorization, "playbook resolution")
+    authorise(authorization, "playbook resolution")
 
     try:
         playbook, config = resolve(workflow_id)

--- a/core/workflows/run_bridge_router.py
+++ b/core/workflows/run_bridge_router.py
@@ -21,7 +21,8 @@ ROUTER_META = RouterMeta(
     tags=["internal-runs"],
     auth=Auth.ROUTER_MANAGED,
     reason=(
-        "Loopback plus a shared secret: the caller is the agent layer, not a session."
+        "A shared secret: the caller is the agent layer, not a session. Reachability\n"
+        "is the NetworkPolicy's job since ADR 0014, not a loopback check."
     ),
 )
 logger = logging.getLogger(__name__)

--- a/core/workflows/run_bridge_router.py
+++ b/core/workflows/run_bridge_router.py
@@ -7,7 +7,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Header, Request
+from fastapi import APIRouter, Header
 from pydantic import BaseModel, Field
 
 from core.agents.internal_auth import authorise
@@ -69,12 +69,11 @@ class Decisions(BaseModel):
 def record_phase(
     run_id: str,
     update: PhaseUpdate,
-    request: Request,
     authorization: Optional[str] = Header(default=None),
 ) -> None:
     from core.workflows.workflow_run_service import get_workflow_run_service
 
-    authorise(request, authorization, "run progress")
+    authorise(authorization, "run progress")
 
     run_service = get_workflow_run_service()
     now = datetime.utcnow()
@@ -103,12 +102,11 @@ def record_phase(
 def record_terminal(
     run_id: str,
     update: TerminalUpdate,
-    request: Request,
     authorization: Optional[str] = Header(default=None),
 ) -> None:
     from core.workflows.workflow_run_service import get_workflow_run_service
 
-    authorise(request, authorization, "run outcome")
+    authorise(authorization, "run outcome")
 
     get_workflow_run_service().finalize_run(
         run_id,
@@ -123,13 +121,12 @@ def record_terminal(
 @router.get("/{run_id}/decisions", response_model=Decisions)
 def list_decisions(
     run_id: str,
-    request: Request,
     authorization: Optional[str] = Header(default=None),
 ) -> Decisions:
     from core.response.approval_service import (ActionStatus,
                                                 get_approval_service)
 
-    authorise(request, authorization, "run decisions")
+    authorise(authorization, "run decisions")
 
     service = get_approval_service()
     decided: List[Decision] = []

--- a/docs/adr/0014-off-host-agent-token-and-network-policy.md
+++ b/docs/adr/0014-off-host-agent-token-and-network-policy.md
@@ -1,0 +1,98 @@
+# 14. The agent seam off-host: token and network policy, not loopback
+
+Date: 2026-08-13
+
+## Status
+
+Accepted. **Amends ADR 0010** — keeps its guarantees, drops its loopback half.
+
+Governs #635 (the agent image, the Helm deployment and the Node CI job).
+
+## Context
+
+ADR 0010 put every remote tool call through one authenticated Python endpoint,
+`POST /internal/tools/invoke`, "loopback-bound **and** shared-secret
+authenticated — either alone is a single point of failure." It named the
+condition that would end that arrangement:
+
+> The endpoint is high-value: it reaches every credential in the deployment.
+> Loopback binding plus shared secret is the floor, not the ceiling, and it
+> should be revisited if the agent service is ever deployed off-host.
+
+#635 deploys it off-host. It makes **Agent Worker** and **Agent Serve**
+independently scaling Deployments, at which point no traffic on the seam arrives
+from loopback any more.
+
+The seam is wider than the one endpoint 0010 describes. Eight routes cross it,
+and the loopback predicate is written twice — `core/agents/internal_auth.py` and
+`serve.ts` carry the same check under the same comment:
+
+- Agent → Python: `/internal/tools/invoke`, `/internal/pricing`,
+  `/internal/playbooks`, `/internal/runs` (progress, outcome, decisions)
+- Python → Agent: `POST /chat/stream`, `GET /runs/<id>/projection`
+
+Both directions currently 403 across a pod boundary, so the parked
+`agent-worker` Deployment would start, dequeue a job and fail to resolve a
+playbook before its first model call.
+
+## Decision
+
+Drop the loopback predicate on both sides. The bearer token becomes the sole
+in-process check, and reachability is constrained by the chart's NetworkPolicy.
+
+The loopback check existed because "a shared secret on a public bind is one leak
+from open." NetworkPolicy answers that with a strictly stronger statement: it
+names which pods may connect, where loopback only ever said "same box."
+
+Every guarantee ADR 0010 asked for is unchanged — bounds enforcement,
+read-only, row and time capping, deny-by-default allow-lists, refusal semantics.
+This amends where the second factor is enforced, not what is enforced.
+
+## Consequences
+
+- **Compose is token-only.** There is no NetworkPolicy in docker-compose, so the
+  second factor there is that `deeptempo-network` is a private bridge and the
+  agent services publish no ports. Defensible, but it should be described
+  accurately rather than as defence in depth.
+- **Failing closed on an unset token becomes load-bearing.** Both sides already
+  refuse when `AGENT_INTERNAL_TOKEN` is empty — Python 503s and says the secret
+  is unconfigured, the agent 401s. That was belt-and-braces while loopback held;
+  it is now the only thing between a reachable pod and an open endpoint.
+- **The bind does not change, only the check.** `serve.ts` already listens on all
+  interfaces; it was the check and not the socket that kept it closed.
+- **The NetworkPolicy is less of a replacement than this decision first claimed,
+  and the difference is worth stating plainly.** Two of the three edges are
+  namespace-wide rather than pod-specific:
+  - *Agent → Python `/internal/*`*: the chart's backend policy already admits
+    any pod in the namespace on the backend port, because the daemon, llm-worker
+    and the helm test all use it. Narrowing it is a change to those components,
+    not to this seam, so it was left alone.
+  - *Backend → agent-serve*: named to the backend pods — but health rides the
+    traffic port, and NetworkPolicy ingress rules are OR'd, so the probe
+    allowance re-opens it namespace-wide. `networkPolicies.agentServe.allowProbesFromAnyNamespace`
+    exists to close that on a CNI known to permit node-sourced probes, and
+    defaults to open because a blocked probe takes the Deployment down.
+
+  So in-cluster the honest description is the same one compose gets: **the token
+  is the gate, and the network is a coarse second layer.** That is still an
+  improvement on a check that refused every legitimate caller, but it is not the
+  pod-level containment "constrain reachability with NetworkPolicy" implies.
+- ADR 0010's "floor, not the ceiling" still stands, and this decision does not
+  raise the ceiling much. mTLS or a mesh is what would actually put a
+  cryptographic identity on each end, and the consequence above is the argument
+  for getting there.
+
+## Alternatives considered
+
+**Sidecar containers in the backend pod.** Preserves the property exactly, needs
+no code change, and was the only genuine alternative. Rejected because Worker and
+Serve would then scale with the API — independent scaling is the point of #635,
+and a queue consumer and an SSE endpoint have nothing in common in how they load.
+
+**A configurable check** (`AGENT_TRUST_NETWORK`, or a CIDR allow-list). Strict in
+dev, relaxed in production. Rejected: a security check with a bypass flag is the
+leak the original comment warned about, and the flag defaults wrong somewhere
+eventually.
+
+**mTLS or a service mesh.** The right end state and a larger lift than this
+ticket, with a new cluster dependency.

--- a/env.example
+++ b/env.example
@@ -183,13 +183,20 @@ AGENT_INTERNAL_TOKEN=""
 # VIGIL_RUNS_URL="http://localhost:6987/internal/runs"
 # VIGIL_TOOLS_URL="http://localhost:6987/internal/tools/invoke"
 
-# Where the agent worker listens. Two calls go this way rather than through the
-# queue: a chat turn, which is a synchronous stream, and a run's projection,
-# which the daemon reads instead of folding agent_events itself.
-# AGENT_HTTP_PORT is the worker side of the same number and, like the three
-# above, lives in the worker's environment.
+# Where the agent's HTTP surface listens. Two calls go this way rather than
+# through the queue: a chat turn, which is a synchronous stream, and a run's
+# projection, which the daemon reads instead of folding agent_events itself.
+# Since #635 that surface is its own process (node dist/serve.js) rather than
+# something the queue worker also served. AGENT_HTTP_PORT is its side of the
+# same number and, like the four above, lives in that process's environment.
 AGENT_URL="http://localhost:6989"
 # AGENT_HTTP_PORT="6989"
+
+# Where both agent processes answer /healthz and /readyz. The worker serves
+# these and nothing else — a queue consumer has no traffic to take — while serve
+# answers them on AGENT_HTTP_PORT alongside chat, so that a health check and a
+# request travel the same path. Read by the Node processes only.
+# AGENT_HEALTH_PORT="6990"
 
 # Token revocation behavior when Redis is unreachable.
 # "false" (default) = fail-closed: reject token if revocation status unknown.

--- a/env.example
+++ b/env.example
@@ -198,6 +198,17 @@ AGENT_URL="http://localhost:6989"
 # request travel the same path. Read by the Node processes only.
 # AGENT_HEALTH_PORT="6990"
 
+# How the agent worker reaches Redis, and the one place its precedence is the
+# other way round from the database's: these win over REDIS_URL when REDIS_HOST is
+# set. A deployed REDIS_URL can carry a password substituted in by Kubernetes,
+# which does no URL-encoding, so one containing @ / : or # parses to the wrong
+# thing — and the parts beside it are then the only correct reading. Unset here,
+# because a dev box and CI both pass a REDIS_URL and nothing else. Read by the
+# Node worker only; Python reads REDIS_URL either way.
+# REDIS_HOST=""
+# REDIS_PORT="6379"
+# REDIS_DB="0"
+
 # Token revocation behavior when Redis is unreachable.
 # "false" (default) = fail-closed: reject token if revocation status unknown.
 # "true" = fail-open: allow token through if Redis is down (availability > security).

--- a/infra/docker/Dockerfile.agent
+++ b/infra/docker/Dockerfile.agent
@@ -1,0 +1,70 @@
+# infra/docker/Dockerfile.agent
+# =============================================================================
+# Agent layer — one image, two commands
+#
+#   node dist/worker.js   drains the BullMQ `agent-runs` queue   (default CMD)
+#   node dist/serve.js    answers the agent HTTP surface
+#
+# One image because they share every dependency and differ only in how work
+# arrives; two Deployments because a queue's depth and a count of open SSE
+# connections have nothing to say to each other about when to scale (#635). The
+# chart overrides `command` for serve; compose names it per service.
+#
+# Both listen. The worker serves /healthz and /readyz only — a queue consumer
+# needs no traffic port, but an exec probe would pay Node's startup every ten
+# seconds per replica to learn what an already-open connection knows for free.
+# Serve answers those two on its own port alongside chat, deliberately: a health
+# check on the port that serves traffic is the one that notices it wedging.
+#
+# No HEALTHCHECK here. It would have to name a port, and which port is right
+# depends on the command — 6990 for the worker, 6989 for serve. Compose declares
+# it per service, where the command is known; Kubernetes uses the chart's probes
+# and ignores HEALTHCHECK entirely.
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: install dependencies and compile TypeScript to JavaScript
+# ---------------------------------------------------------------------------
+FROM node:20-slim AS build
+
+WORKDIR /build
+
+# Manifests before sources, so editing a .ts file does not reinstall the tree.
+COPY services/agent/package.json services/agent/package-lock.json ./
+RUN npm ci
+
+COPY services/agent/ ./
+# tsconfig.json is noEmit so typecheck and vitest keep working untouched;
+# tsconfig.build.json is the emit config and exists only for this step.
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime image
+# ---------------------------------------------------------------------------
+FROM node:20-slim AS runtime
+
+ARG VIGIL_VERSION=dev
+LABEL org.opencontainers.image.version="${VIGIL_VERSION}"
+
+WORKDIR /app
+
+# No apt layer: bullmq and pg are pure JavaScript. The Python images need
+# libpq5 only because psycopg is a C extension.
+COPY services/agent/package.json services/agent/package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --from=build /build/dist ./dist
+
+RUN echo "${VIGIL_VERSION}" > /app/VERSION
+
+# 6989 serve: chat, run projections, and its own probes.
+# 6990 worker: probes only.
+EXPOSE 6989 6990
+
+# node:20-slim already ships uid 1000 as `node`, so no useradd layer is needed.
+# Numeric to match the chart's podSecurityContext runAsUser literally.
+USER 1000:1000
+
+ENV NODE_ENV=production
+
+CMD ["node", "dist/worker.js"]

--- a/infra/docker/Dockerfile.backend
+++ b/infra/docker/Dockerfile.backend
@@ -41,16 +41,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # from the copied source, so the runtime stage needs only /usr/local and no
 # editable source tree (an `-e` install writes a .pth pointing at the build
 # path, which won't exist in the runtime stage). Keep this COPY list in sync
-# with the `-e ./` lines in requirements.txt: deeptempo-core, mcp-servers,
-# mempalace.
+# with the `-e ./` lines in requirements.txt: mempalace is the only one left,
+# since #654 dropped the deeptempo-core and mcp-servers submodules.
 COPY requirements.txt .
-COPY deeptempo-core/ ./deeptempo-core/
-COPY mcp-servers/    ./mcp-servers/
 COPY mempalace/      ./mempalace/
 RUN grep -vE '^[[:space:]]*-e[[:space:]]+\./' requirements.txt > requirements.runtime.txt \
     && pip install --no-cache-dir --prefix=/install/deps \
          -r requirements.runtime.txt \
-         ./deeptempo-core ./mcp-servers ./mempalace
+         ./mempalace
 
 # ---------------------------------------------------------------------------
 # Stage 3: runtime image
@@ -84,7 +82,6 @@ COPY --chown=vigil:vigil tools/       ./tools/
 # <cid>:/app/database/init`) and the initdb mount are unaffected.
 COPY --chown=vigil:vigil infra/database/init/ ./database/init/
 COPY --chown=vigil:vigil data/        ./data/
-COPY --chown=vigil:vigil mcp-servers/ ./mcp-servers/
 COPY --chown=vigil:vigil mempalace/   ./mempalace/
 COPY --chown=vigil:vigil VERSION      ./VERSION
 COPY --chown=vigil:vigil setup.cfg    ./setup.cfg

--- a/infra/docker/Dockerfile.daemon
+++ b/infra/docker/Dockerfile.daemon
@@ -26,16 +26,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # from the copied source, so the runtime stage needs only /usr/local and no
 # editable source tree (an `-e` install writes a .pth pointing at the build
 # path, which won't exist in the runtime stage). Keep this COPY list in sync
-# with the `-e ./` lines in requirements.txt: deeptempo-core, mcp-servers,
-# mempalace.
+# with the `-e ./` lines in requirements.txt: mempalace is the only one left,
+# since #654 dropped the deeptempo-core and mcp-servers submodules.
 COPY requirements.txt .
-COPY deeptempo-core/ ./deeptempo-core/
-COPY mcp-servers/    ./mcp-servers/
 COPY mempalace/      ./mempalace/
 RUN grep -vE '^[[:space:]]*-e[[:space:]]+\./' requirements.txt > requirements.runtime.txt \
     && pip install --no-cache-dir --prefix=/install/deps \
          -r requirements.runtime.txt \
-         ./deeptempo-core ./mcp-servers ./mempalace
+         ./mempalace
 
 # ---------------------------------------------------------------------------
 # Stage 2: runtime image
@@ -65,7 +63,6 @@ COPY --chown=vigil:vigil tools/       ./tools/
 # <cid>:/app/database/init`) and the initdb mount are unaffected.
 COPY --chown=vigil:vigil infra/database/init/ ./database/init/
 COPY --chown=vigil:vigil data/        ./data/
-COPY --chown=vigil:vigil mcp-servers/ ./mcp-servers/
 COPY --chown=vigil:vigil mempalace/   ./mempalace/
 COPY --chown=vigil:vigil VERSION      ./VERSION
 COPY --chown=vigil:vigil setup.cfg    ./setup.cfg

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -291,10 +291,11 @@ services:
     # An SSE stream can sit on one model call for minutes; the chart's
     # terminationGracePeriodSeconds says the same thing.
     stop_grace_period: 120s
+    # Postgres only. Serve reads and writes the ledger and never touches the
+    # queue, which is the reason it is a separate service at all; waiting on
+    # Redis would say otherwise.
     depends_on:
       postgres:
-        condition: service_healthy
-      redis:
         condition: service_healthy
     restart: unless-stopped
     networks:

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,3 +1,33 @@
+# Both agent processes run the same image against the same seam, so they take
+# the same environment; only the command and the port differ. Anchored here
+# rather than duplicated, because a URL that drifts between the two is a run
+# that behaves differently depending on which process picked it up.
+x-agent-env: &agent-env
+  # No DATABASE_URL: the agent assembles the connection from these, the same way
+  # the Helm chart supplies it.
+  - POSTGRES_HOST=postgres
+  - POSTGRES_PORT=5432
+  - POSTGRES_DB=deeptempo_soc
+  - POSTGRES_USER=deeptempo
+  - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-deeptempo_secure_password_change_me}
+  - REDIS_URL=redis://redis:6379/0
+  # The four /internal endpoints. Each defaults to localhost:6987 in-process,
+  # which is the agent container itself here, so all four have to be named.
+  # VIGIL_RUNS_URL unset is the quiet one: progress stops reaching the UI and a
+  # run that needs an approval parks with nothing able to answer it.
+  - VIGIL_PLAYBOOKS_URL=http://backend:6987/internal/playbooks
+  - VIGIL_PRICING_URL=http://backend:6987/internal/pricing
+  - VIGIL_RUNS_URL=http://backend:6987/internal/runs
+  - VIGIL_TOOLS_URL=http://backend:6987/internal/tools/invoke
+  # Same secret the backend checks. Empty on both sides means every /internal
+  # call answers 503, so a run fails before its first model call.
+  - AGENT_INTERNAL_TOKEN=${AGENT_INTERNAL_TOKEN:-}
+  - BIFROST_URL=${BIFROST_URL:-http://bifrost:8080}
+  # Pass-through, not `${BIFROST_API_KEY:-}`: the harness falls back to a
+  # placeholder only when the variable is absent, and the := form would set it
+  # to an empty string the OpenAI client then sends as a real credential.
+  - BIFROST_API_KEY
+
 services:
   postgres:
     # pgvector-capable image (findings.embedding uses vector(768) + HNSW).
@@ -63,6 +93,9 @@ services:
       # Shared secret the agent worker presents on /internal. Unset means every
       # such call answers 503, so no workflow can run.
       - AGENT_INTERNAL_TOKEN=${AGENT_INTERNAL_TOKEN:-}
+      # Chat and run projections. core/config.py defaults this to localhost:6989,
+      # which was the agent layer's address while it shared the backend process.
+      - AGENT_URL=http://agent-serve:6989
       - PYTHONUNBUFFERED=1
     ports:
       - "6987:6987"
@@ -195,6 +228,73 @@ services:
       redis:
         condition: service_healthy
       bifrost:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - deeptempo-network
+
+  # ─── Agent layer (TypeScript) ─────────────────────────────────────────────
+  # One image, two commands (infra/docker/Dockerfile.agent), the same split the
+  # chart deploys: a queue consumer and an HTTP surface scale on unrelated
+  # signals, so they are separate services here too.
+  #
+  # Drains the BullMQ `agent-runs` queue that core/agents/queue.py enqueues to.
+  # Runs alongside llm-worker rather than replacing it — see
+  # infra/helm/vigil/templates/agent-worker-deployment.yaml for what has to
+  # stop using arq:llm before that one can go away.
+  agent-worker:
+    build:
+      context: ../..
+      dockerfile: infra/docker/Dockerfile.agent
+    container_name: deeptempo-agent-worker
+    # The image's default CMD. Named anyway, so the two services read as the
+    # pair they are rather than one command and one absence.
+    command: ["node", "dist/worker.js"]
+    environment: *agent-env
+    healthcheck:
+      # The image declares no HEALTHCHECK: the port depends on the command.
+      # 6990 is probes only here — nothing routes to a queue consumer. Node 20
+      # has global fetch, so this needs no curl in the image.
+      test: ["CMD", "node", "-e", "fetch('http://localhost:6990/healthz').then(r => process.exit(r.ok ? 0 : 1), () => process.exit(1))"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - deeptempo-network
+
+  # Chat over SSE and the run projections a supervisor reads. The backend calls
+  # it at AGENT_URL. No `ports:` on purpose — ADR 0014 dropped the loopback
+  # check, so what keeps this off the host is the private bridge plus the bearer
+  # token, exactly as the chart relies on ClusterIP plus a NetworkPolicy.
+  agent-serve:
+    build:
+      context: ../..
+      dockerfile: infra/docker/Dockerfile.agent
+    container_name: deeptempo-agent-serve
+    command: ["node", "dist/serve.js"]
+    environment: *agent-env
+    healthcheck:
+      # Deliberately the traffic port: a health check on a side port cannot
+      # notice the one that serves requests wedging.
+      test: ["CMD", "node", "-e", "fetch('http://localhost:6989/healthz').then(r => process.exit(r.ok ? 0 : 1), () => process.exit(1))"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    # An SSE stream can sit on one model call for minutes; the chart's
+    # terminationGracePeriodSeconds says the same thing.
+    stop_grace_period: 120s
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     restart: unless-stopped
     networks:

--- a/infra/helm/vigil/README.md
+++ b/infra/helm/vigil/README.md
@@ -36,9 +36,23 @@ kubectl port-forward -n vigil svc/vigil-backend 6987:6987
 | `vigil-backend` | Deployment | 2 (default) | FastAPI API + bundled SPA on port 6987 |
 | `vigil-daemon` | StatefulSet | **1 (singleton)** | Autonomous orchestrator; webhook=8081, metrics=9090, health=9091 |
 | `vigil-llm-worker` | Deployment | 2 (default) | ARQ worker for Claude requests off Redis queue |
+| `vigil-agent-worker` | Deployment | 2 (default) | Drains the BullMQ `agent-runs` queue; probes on 6990, no Service. Opt-out via `agentWorker.enabled=false` |
+| `vigil-agent-serve` | Deployment | 2 (default) | Agent chat (SSE) and run projections on 6989; ClusterIP, reached by the backend at `AGENT_URL`. Opt-out via `agentServe.enabled=false` |
 | `vigil-postgres` | StatefulSet | 1 | Opt-out via `postgresql.enabled=false` |
 | `vigil-redis` | StatefulSet | 1 | Opt-out via `redis.enabled=false` |
 | `vigil-db-init` | Job (Helm hook) | 1 per install/upgrade | Applies `infra/database/init/*.sql` idempotently |
+
+### Images
+
+Three, not two. `vigil-agent-worker` and `vigil-agent-serve` run the **same** image with different commands — it is a Node image and cannot reuse the backend's the way `llm-worker` does.
+
+| Image | Used by |
+|---|---|
+| `ghcr.io/vigil-soc/vigil-backend` | backend, llm-worker, db-init |
+| `ghcr.io/vigil-soc/vigil-daemon` | daemon |
+| `ghcr.io/vigil-soc/vigil-agent` | agent-worker, agent-serve |
+
+`vigil-agent` is published from the release that first ships these Deployments. If you mirror images into a private registry or run air-gapped, add the third one before upgrading — the agent Deployments are enabled by default and will otherwise sit in `ImagePullBackOff`. To upgrade without them, set `agentWorker.enabled=false` and `agentServe.enabled=false`.
 
 ## Required inputs
 
@@ -50,6 +64,10 @@ At minimum you need:
 When `config.DEV_MODE=false` (the default), also set:
 
 - `secrets.jwtSecretKey` — generate with `python -c "import secrets; print(secrets.token_urlsafe(64))"`
+
+When the agent Deployments are enabled (the default), also set:
+
+- `secrets.agentInternalToken` — generate the same way. It is the whole gate on the seam between the backend and the agent layer since ADR 0014, and it fails closed: leave it unset and every `/internal` call answers 503 and every agent call answers 401, so no run gets past resolving its playbook.
 
 ## External Postgres or Redis
 

--- a/infra/helm/vigil/templates/_env.tpl
+++ b/infra/helm/vigil/templates/_env.tpl
@@ -58,3 +58,37 @@ chart-templated).
       key: {{ .Values.redis.external.existingSecretKey | default "REDIS_URL" }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Discrete Redis parts, added on top of vigil.env for the agent pods only.
+
+The same reasoning that keeps POSTGRES_* discrete rather than a DSN. Under
+Bitnami auth vigil.redis.url renders `redis://:$(REDIS_PASSWORD)@host:6379/0`,
+and the kubelet substitutes that variable verbatim — no URL-encoding. A password
+holding @ / : or # therefore produces a REDIS_URL that the agent's `new URL()`
+misparses or rejects, and it is the queue connection, so the worker never drains.
+
+Python is unaffected and keeps reading REDIS_URL; only the agent prefers these,
+and only when REDIS_HOST is set (services/agent/core/db.ts::redisConfig).
+
+Nothing is emitted for an external Redis supplied as a URL: there are no parts to
+name, so the agent falls back to REDIS_URL — which it now percent-decodes, so a
+correctly-escaped DSN works.
+*/}}
+{{- define "vigil.agentRedisEnv" -}}
+{{- if .Values.redis.bitnami.enabled }}
+- name: REDIS_HOST
+  value: {{ .Values.redis.bitnami.fullnameOverride | default (printf "%s-redis-master" .Release.Name) | quote }}
+- name: REDIS_PORT
+  value: "6379"
+- name: REDIS_DB
+  value: {{ include "vigil.redis.database" . | quote }}
+{{- else if .Values.redis.enabled }}
+- name: REDIS_HOST
+  value: {{ include "vigil.redis.fullname" . | quote }}
+- name: REDIS_PORT
+  value: {{ .Values.redis.service.port | default 6379 | toString | quote }}
+- name: REDIS_DB
+  value: {{ include "vigil.redis.database" . | quote }}
+{{- end }}
+{{- end -}}

--- a/infra/helm/vigil/templates/_env.tpl
+++ b/infra/helm/vigil/templates/_env.tpl
@@ -60,20 +60,11 @@ chart-templated).
 {{- end -}}
 
 {{/*
-Discrete Redis parts, added on top of vigil.env for the agent pods only.
-
-The same reasoning that keeps POSTGRES_* discrete rather than a DSN. Under
-Bitnami auth vigil.redis.url renders `redis://:$(REDIS_PASSWORD)@host:6379/0`,
-and the kubelet substitutes that variable verbatim — no URL-encoding. A password
-holding @ / : or # therefore produces a REDIS_URL that the agent's `new URL()`
-misparses or rejects, and it is the queue connection, so the worker never drains.
-
-Python is unaffected and keeps reading REDIS_URL; only the agent prefers these,
-and only when REDIS_HOST is set (services/agent/core/db.ts::redisConfig).
-
-Nothing is emitted for an external Redis supplied as a URL: there are no parts to
-name, so the agent falls back to REDIS_URL — which it now percent-decodes, so a
-correctly-escaped DSN works.
+Discrete Redis parts for the agent pods, for the reason vigil.env ships discrete
+POSTGRES_*: the kubelet substitutes $(REDIS_PASSWORD) into a URL unencoded, so one
+holding @ / : or # misparses. Only the agent reads these, and only when REDIS_HOST
+is set (services/agent/core/db.ts::redisConfig). Nothing is emitted for an external
+Redis given as a URL — there are no parts to name.
 */}}
 {{- define "vigil.agentRedisEnv" -}}
 {{- if .Values.redis.bitnami.enabled }}

--- a/infra/helm/vigil/templates/_helpers.tpl
+++ b/infra/helm/vigil/templates/_helpers.tpl
@@ -302,21 +302,39 @@ template here uses the $(REDIS_PASSWORD) placeholder which Kubernetes
 expands from envFrom/env.
 */}}
 {{- define "vigil.redis.url" -}}
+{{- $db := include "vigil.redis.database" . -}}
 {{- if .Values.redis.bitnami.enabled -}}
 {{- $host := .Values.redis.bitnami.fullnameOverride | default (printf "%s-redis-master" .Release.Name) -}}
 {{- $port := 6379 -}}
 {{- if .Values.redis.bitnami.auth.enabled -}}
-{{- printf "redis://:$(REDIS_PASSWORD)@%s:%v/0" $host $port -}}
+{{- printf "redis://:$(REDIS_PASSWORD)@%s:%v/%s" $host $port $db -}}
 {{- else -}}
-{{- printf "redis://%s:%v/0" $host $port -}}
+{{- printf "redis://%s:%v/%s" $host $port $db -}}
 {{- end -}}
 {{- else if .Values.redis.external.url -}}
 {{- .Values.redis.external.url -}}
 {{- else if .Values.redis.enabled -}}
-{{- printf "redis://%s:%v/0" (include "vigil.redis.fullname" .) (.Values.redis.service.port | default 6379) -}}
+{{- printf "redis://%s:%v/%s" (include "vigil.redis.fullname" .) (.Values.redis.service.port | default 6379) $db -}}
 {{- else -}}
 {{- required "redis.external.url is required when redis.enabled=false and redis.bitnami.enabled=false" "" -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Which Redis database the chart's own Redis is addressed on.
+
+One definition because three places have to agree: the URL above, the discrete
+REDIS_DB the agent pods read, and the KEDA scaler's databaseIndex — a scaler
+counting a different database than the worker drains reports an empty queue and
+scales to the floor while runs pile up.
+
+Not a knob: the chart's Redis is Vigil's alone, so there is nothing to separate
+and a second database would only be somewhere to lose a queue. It also does not
+govern redis.external.url, whose database is whatever that URL names — set
+agentWorker.autoscaling.keda.databaseIndex to match when using one.
+*/}}
+{{- define "vigil.redis.database" -}}
+0
 {{- end -}}
 
 {{/*

--- a/infra/helm/vigil/templates/_helpers.tpl
+++ b/infra/helm/vigil/templates/_helpers.tpl
@@ -65,6 +65,14 @@ Per-component names and labels.
 {{- printf "%s-llm-worker" (include "vigil.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "vigil.agentWorker.fullname" -}}
+{{- printf "%s-agent-worker" (include "vigil.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "vigil.agentServe.fullname" -}}
+{{- printf "%s-agent-serve" (include "vigil.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "vigil.postgres.fullname" -}}
 {{- printf "%s-postgres" (include "vigil.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -153,6 +161,12 @@ The "llmWorker" component always reuses the backend image.
   {{- if eq $comp "daemon" -}}{{- $suffix = "daemon" -}}{{- end -}}
   {{- if eq $comp "backend" -}}{{- $suffix = "backend" -}}{{- end -}}
   {{- if eq $comp "llmWorker" -}}{{- $suffix = "backend" -}}{{- end -}}
+  {{- /* The agent layer is Node, not Python — it cannot reuse the backend
+         image the way llm-worker does, and the default above would silently
+         hand it one. Both components share the one image and differ only in
+         which command the Deployment runs (infra/docker/Dockerfile.agent). */ -}}
+  {{- if eq $comp "agentWorker" -}}{{- $suffix = "agent" -}}{{- end -}}
+  {{- if eq $comp "agentServe" -}}{{- $suffix = "agent" -}}{{- end -}}
   {{- $repo = printf "%s/%s-%s" $registry $ns $suffix -}}
 {{- end -}}
 {{- if eq $tag "" -}}

--- a/infra/helm/vigil/templates/_helpers.tpl
+++ b/infra/helm/vigil/templates/_helpers.tpl
@@ -321,17 +321,9 @@ expands from envFrom/env.
 {{- end -}}
 
 {{/*
-Which Redis database the chart's own Redis is addressed on.
-
-One definition because three places have to agree: the URL above, the discrete
-REDIS_DB the agent pods read, and the KEDA scaler's databaseIndex — a scaler
-counting a different database than the worker drains reports an empty queue and
-scales to the floor while runs pile up.
-
-Not a knob: the chart's Redis is Vigil's alone, so there is nothing to separate
-and a second database would only be somewhere to lose a queue. It also does not
-govern redis.external.url, whose database is whatever that URL names — set
-agentWorker.autoscaling.keda.databaseIndex to match when using one.
+One definition because three have to agree: the URL above, the agent pods' REDIS_DB
+and the KEDA scaler's databaseIndex — a scaler counting a different database reads
+an empty queue. Does not govern redis.external.url, whose database that URL names.
 */}}
 {{- define "vigil.redis.database" -}}
 0

--- a/infra/helm/vigil/templates/agent-serve-deployment.yaml
+++ b/infra/helm/vigil/templates/agent-serve-deployment.yaml
@@ -21,9 +21,12 @@ metadata:
   labels:
     {{- include "vigil.componentLabels" (dict "context" . "component" "agent-serve") | nindent 4 }}
 spec:
-  {{- if not .Values.agentServe.autoscaling.enabled }}
+  {{- /* Unconditional, unlike agent-worker's. There is no agent-serve HPA to
+         hand the replica count to and deliberately so — see values.yaml, which
+         says why an autoscaler is the wrong instrument for a process holding SSE
+         streams. Guarding this on an autoscaling flag that renders no autoscaler
+         would silently drop the Deployment to Kubernetes' default of one. */}}
   replicas: {{ .Values.agentServe.replicaCount }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "agent-serve") | nindent 6 }}
@@ -62,8 +65,8 @@ spec:
             - name: AGENT_HTTP_PORT
               value: {{ .Values.agentServe.service.port | toString | quote }}
             {{- /* vigil.env supplies POSTGRES_* and REDIS_URL. Serve ignores
-                   REDIS_URL -- it never touches the queue -- but the block is
-                   shared, and a variable it does not read costs nothing. */}}
+                   every Redis variable -- it never touches the queue -- but the
+                   block is shared, and one it does not read costs nothing. */}}
             {{- include "vigil.env" . | nindent 12 }}
             {{- with .Values.agentServe.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/infra/helm/vigil/templates/agent-serve-deployment.yaml
+++ b/infra/helm/vigil/templates/agent-serve-deployment.yaml
@@ -21,11 +21,8 @@ metadata:
   labels:
     {{- include "vigil.componentLabels" (dict "context" . "component" "agent-serve") | nindent 4 }}
 spec:
-  {{- /* Unconditional, unlike agent-worker's. There is no agent-serve HPA to
-         hand the replica count to and deliberately so — see values.yaml, which
-         says why an autoscaler is the wrong instrument for a process holding SSE
-         streams. Guarding this on an autoscaling flag that renders no autoscaler
-         would silently drop the Deployment to Kubernetes' default of one. */}}
+  {{- /* Unconditional, unlike agent-worker's: there is no agent-serve HPA to hand
+         the count to, deliberately — see values.yaml. */}}
   replicas: {{ .Values.agentServe.replicaCount }}
   selector:
     matchLabels:

--- a/infra/helm/vigil/templates/agent-serve-deployment.yaml
+++ b/infra/helm/vigil/templates/agent-serve-deployment.yaml
@@ -1,0 +1,113 @@
+{{- /*
+Agent Serve: the agent layer's HTTP surface — chat over SSE, and the run
+projections a supervisor reads. Same image as agent-worker, different command.
+
+Two Deployments rather than one because the two scale on unrelated things: the
+worker on queue depth, this on how many conversations are open. Until #635 both
+ran in one process (worker.ts booted the chat server itself), which meant one
+replica count for a queue consumer and an SSE endpoint at once.
+
+Unlike agent-worker this has a Service and takes traffic — from the backend,
+which proxies /api/claude/chat/stream here and reads run projections. Which is
+why ADR 0014 exists: both sides refused anything that was not loopback, so this
+Deployment could not have worked at all before that decision.
+*/ -}}
+{{- if .Values.agentServe.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vigil.agentServe.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vigil.componentLabels" (dict "context" . "component" "agent-serve") | nindent 4 }}
+spec:
+  {{- if not .Values.agentServe.autoscaling.enabled }}
+  replicas: {{ .Values.agentServe.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "agent-serve") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "vigil.componentLabels" (dict "context" . "component" "agent-serve") | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.agentServe.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "vigil.serviceAccountName" . }}
+      {{- include "vigil.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- /* An SSE stream can sit on one model call for minutes, and killing it
+             loses the conversation rather than merely retrying it. */}}
+      terminationGracePeriodSeconds: {{ .Values.agentServe.terminationGracePeriodSeconds }}
+      containers:
+        - name: agent-serve
+          image: {{ include "vigil.image" (dict "context" . "component" "agentServe") | quote }}
+          imagePullPolicy: {{ include "vigil.imagePullPolicy" (dict "context" . "component" "agentServe") }}
+          {{- /* The image's CMD is the worker; this is the other entry point. */}}
+          command: ["node", "dist/serve.js"]
+          envFrom:
+            {{- include "vigil.envFrom" . | nindent 12 }}
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vigil.postgres.passwordSecret" . }}
+                  key: {{ include "vigil.postgres.passwordSecretKey" . }}
+            - name: AGENT_HTTP_PORT
+              value: {{ .Values.agentServe.service.port | toString | quote }}
+            {{- /* vigil.env supplies POSTGRES_* and REDIS_URL. Serve ignores
+                   REDIS_URL -- it never touches the queue -- but the block is
+                   shared, and a variable it does not read costs nothing. */}}
+            {{- include "vigil.env" . | nindent 12 }}
+            {{- with .Values.agentServe.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.agentServe.service.port }}
+              protocol: TCP
+          {{- /* Health rides on the traffic port on purpose: a check on a
+                 separate listener can pass while the port that serves chat is
+                 wedged. Readiness reflects Postgres, the only thing this process
+                 cannot work without -- it reads and writes the ledger and never
+                 touches Redis, so "queue connectivity" would be reporting on
+                 something it does not use. */}}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.agentServe.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+      {{- with .Values.agentServe.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agentServe.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agentServe.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/infra/helm/vigil/templates/agent-serve-service.yaml
+++ b/infra/helm/vigil/templates/agent-serve-service.yaml
@@ -1,0 +1,26 @@
+{{- /*
+ClusterIP only, and deliberately not in the Ingress: this surface is reached by
+the backend, never by a browser. The bearer token is the only in-process check
+since ADR 0014, so what keeps it internal is this Service's type plus the
+NetworkPolicy — the two together are what replaced the loopback bind.
+
+AGENT_URL is computed from this name in configmap.yaml.
+*/ -}}
+{{- if .Values.agentServe.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vigil.agentServe.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vigil.componentLabels" (dict "context" . "component" "agent-serve") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.agentServe.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "agent-serve") | nindent 4 }}
+{{- end }}

--- a/infra/helm/vigil/templates/agent-worker-deployment.yaml
+++ b/infra/helm/vigil/templates/agent-worker-deployment.yaml
@@ -1,0 +1,111 @@
+{{- /*
+The TypeScript agent worker: drains the BullMQ `agent-runs` queue and writes
+the ledger. Mirrors llm-worker's shape, but runs its own Node image rather than
+reusing the backend one.
+
+It runs *alongside* llm-worker, not instead of it. ADR-0001 says the `arq:llm`
+queue "disappears entirely", and it will — but only once nothing enqueues to it.
+Three producers still do:
+  services/api/routers/claude.py         (the `chat` cutover)
+  services/daemon/agent_runner.py        (the `investigate` cutover)
+  core/reporting/ai_insights_service.py  (no cutover step covers this one)
+Delete llm-worker when that list is empty, not before.
+*/ -}}
+{{- if .Values.agentWorker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vigil.agentWorker.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vigil.componentLabels" (dict "context" . "component" "agent-worker") | nindent 4 }}
+spec:
+  {{- if not .Values.agentWorker.autoscaling.enabled }}
+  replicas: {{ .Values.agentWorker.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "agent-worker") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "vigil.componentLabels" (dict "context" . "component" "agent-worker") | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.agentWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "vigil.serviceAccountName" . }}
+      {{- include "vigil.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: agent-worker
+          image: {{ include "vigil.image" (dict "context" . "component" "agentWorker") | quote }}
+          imagePullPolicy: {{ include "vigil.imagePullPolicy" (dict "context" . "component" "agentWorker") }}
+          {{- /* No command override: unlike llm-worker, this image's CMD is
+                 already the worker (node dist/worker.js). */}}
+          envFrom:
+            {{- include "vigil.envFrom" . | nindent 12 }}
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vigil.postgres.passwordSecret" . }}
+                  key: {{ include "vigil.postgres.passwordSecretKey" . }}
+            {{- /* vigil.env supplies POSTGRES_* and REDIS_URL. The worker reads
+                   the discrete POSTGRES_* vars rather than a DSN, because
+                   _env.tpl deliberately ships no DATABASE_URL. */}}
+            {{- include "vigil.env" . | nindent 12 }}
+            {{- with .Values.agentWorker.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            {{- /* Probes only. Nothing routes here and there is no Service:
+                   a queue consumer is reached through Redis, not the network. */}}
+            - name: health
+              containerPort: 6990
+              protocol: TCP
+          {{- /* Liveness asks only whether the process answers; readiness asks
+                 whether Redis is reachable and the worker is running.
+
+                 Deliberately not the same question. A worker whose Redis dropped
+                 must stop being ready -- it drains nothing, and a rollout should
+                 halt -- but restarting it would reconnect to the same broken
+                 Redis, and restarting every replica at once against a Redis
+                 already in trouble turns a blip into an outage. */}}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.agentWorker.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+      {{- with .Values.agentWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agentWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agentWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/infra/helm/vigil/templates/agent-worker-deployment.yaml
+++ b/infra/helm/vigil/templates/agent-worker-deployment.yaml
@@ -57,8 +57,11 @@ spec:
                   key: {{ include "vigil.postgres.passwordSecretKey" . }}
             {{- /* vigil.env supplies POSTGRES_* and REDIS_URL. The worker reads
                    the discrete POSTGRES_* vars rather than a DSN, because
-                   _env.tpl deliberately ships no DATABASE_URL. */}}
+                   _env.tpl deliberately ships no DATABASE_URL — and the discrete
+                   REDIS_* below for the same reason, since a $(REDIS_PASSWORD)
+                   substituted into a URL is not URL-encoded. */}}
             {{- include "vigil.env" . | nindent 12 }}
+            {{- include "vigil.agentRedisEnv" . | nindent 12 }}
             {{- with .Values.agentWorker.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/infra/helm/vigil/templates/agent-worker-deployment.yaml
+++ b/infra/helm/vigil/templates/agent-worker-deployment.yaml
@@ -55,11 +55,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "vigil.postgres.passwordSecret" . }}
                   key: {{ include "vigil.postgres.passwordSecretKey" . }}
-            {{- /* vigil.env supplies POSTGRES_* and REDIS_URL. The worker reads
-                   the discrete POSTGRES_* vars rather than a DSN, because
-                   _env.tpl deliberately ships no DATABASE_URL — and the discrete
-                   REDIS_* below for the same reason, since a $(REDIS_PASSWORD)
-                   substituted into a URL is not URL-encoded. */}}
+            {{- /* The worker reads the discrete parts, not a DSN or a URL: a
+                   $(VAR) substituted into either is not URL-encoded. */}}
             {{- include "vigil.env" . | nindent 12 }}
             {{- include "vigil.agentRedisEnv" . | nindent 12 }}
             {{- with .Values.agentWorker.extraEnv }}

--- a/infra/helm/vigil/templates/agent-worker-hpa.yaml
+++ b/infra/helm/vigil/templates/agent-worker-hpa.yaml
@@ -1,0 +1,26 @@
+{{- /* CPU HPA is suppressed when KEDA is active — the KEDA ScaledObject
+       creates its own HPA under the hood and having both on the same
+       Deployment fights. */ -}}
+{{- if and .Values.agentWorker.enabled .Values.agentWorker.autoscaling.enabled (not .Values.agentWorker.autoscaling.keda.enabled) }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "vigil.agentWorker.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vigil.componentLabels" (dict "context" . "component" "agent-worker") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "vigil.agentWorker.fullname" . }}
+  minReplicas: {{ .Values.agentWorker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.agentWorker.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.agentWorker.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/infra/helm/vigil/templates/agent-worker-scaledobject.yaml
+++ b/infra/helm/vigil/templates/agent-worker-scaledobject.yaml
@@ -1,0 +1,74 @@
+{{- if and .Values.agentWorker.enabled .Values.agentWorker.autoscaling.keda.enabled }}
+{{- /*
+KEDA ScaledObject for agent-worker. Same `redis` list scaler as llm-worker,
+pointed at a different key: BullMQ keeps waiting jobs in the Redis list
+`bull:agent-runs:wait`, so LLEN is still the right primitive.
+
+Two things that are not visible from this file:
+
+  * minReplicaCount must never be 0. BullMQ promotes delayed jobs into `wait`
+    from a *worker's* own timer, so with zero replicas nothing promotes them,
+    the list reads empty, and the run never starts.
+
+  * LLEN is exact only while nothing sets a job priority. BullMQ routes
+    prioritised jobs to `bull:agent-runs:prioritized`, a ZSET, bypassing `wait`
+    entirely — and KEDA ships no ZSET scaler. core/agents/queue.py sets neither
+    priority nor delay today, so the count is accurate; that accuracy is a
+    property of the producer, not of this template.
+
+Prerequisite: KEDA installed in the cluster
+  (https://keda.sh/docs/latest/deploy/).
+*/ -}}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "vigil.agentWorker.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vigil.componentLabels" (dict "context" . "component" "agent-worker") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "vigil.agentWorker.fullname" . }}
+  minReplicaCount: {{ max (.Values.agentWorker.autoscaling.keda.minReplicas | default 1 | int) 1 }}
+  maxReplicaCount: {{ .Values.agentWorker.autoscaling.keda.maxReplicas | default 20 }}
+  cooldownPeriod: {{ .Values.agentWorker.autoscaling.keda.cooldownPeriod | default 300 }}
+  pollingInterval: {{ .Values.agentWorker.autoscaling.keda.pollingInterval | default 15 }}
+  triggers:
+    - type: redis
+      metadata:
+        {{- if .Values.redis.bitnami.enabled }}
+        address: "{{ .Values.redis.bitnami.fullnameOverride | default (printf "%s-redis-master" .Release.Name) }}:6379"
+        {{- else if .Values.redis.enabled }}
+        address: "{{ include "vigil.redis.fullname" . }}:{{ .Values.redis.service.port }}"
+        {{- else }}
+        # External Redis — extract host:port from redis.external.url or set
+        # agentWorker.autoscaling.keda.redisAddress explicitly.
+        address: {{ .Values.agentWorker.autoscaling.keda.redisAddress | quote }}
+        {{- end }}
+        listName: {{ .Values.agentWorker.autoscaling.keda.queueName | default "bull:agent-runs:wait" | quote }}
+        listLength: {{ .Values.agentWorker.autoscaling.keda.listLength | default "5" | quote }}
+        # Explicit rather than relying on KEDA's default of 0: the worker takes
+        # its database index from REDIS_URL's path, so the two must agree.
+        databaseIndex: "0"
+      {{- if and .Values.redis.bitnami.enabled .Values.redis.bitnami.auth.enabled }}
+      authenticationRef:
+        name: {{ include "vigil.agentWorker.fullname" . }}-keda-auth
+      {{- end }}
+{{- if and .Values.redis.bitnami.enabled .Values.redis.bitnami.auth.enabled }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ include "vigil.agentWorker.fullname" . }}-keda-auth
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vigil.componentLabels" (dict "context" . "component" "agent-worker") | nindent 4 }}
+spec:
+  secretTargetRef:
+    - parameter: password
+      name: {{ include "vigil.redis.bitnami.passwordSecret" . }}
+      key: {{ include "vigil.redis.bitnami.passwordSecretKey" . }}
+{{- end }}
+{{- end }}

--- a/infra/helm/vigil/templates/agent-worker-scaledobject.yaml
+++ b/infra/helm/vigil/templates/agent-worker-scaledobject.yaml
@@ -49,9 +49,12 @@ spec:
         {{- end }}
         listName: {{ .Values.agentWorker.autoscaling.keda.queueName | default "bull:agent-runs:wait" | quote }}
         listLength: {{ .Values.agentWorker.autoscaling.keda.listLength | default "5" | quote }}
-        # Explicit rather than relying on KEDA's default of 0: the worker takes
-        # its database index from REDIS_URL's path, so the two must agree.
-        databaseIndex: "0"
+        # Explicit rather than relying on KEDA's default of 0: a scaler counting a
+        # different database than the worker drains reads an empty queue forever.
+        # Defaulted from the one helper the URL and REDIS_DB also come from, so
+        # the three cannot drift; the value exists for an external Redis, whose
+        # database this chart does not choose.
+        databaseIndex: {{ .Values.agentWorker.autoscaling.keda.databaseIndex | default (include "vigil.redis.database" .) | quote }}
       {{- if and .Values.redis.bitnami.enabled .Values.redis.bitnami.auth.enabled }}
       authenticationRef:
         name: {{ include "vigil.agentWorker.fullname" . }}-keda-auth

--- a/infra/helm/vigil/templates/agent-worker-scaledobject.yaml
+++ b/infra/helm/vigil/templates/agent-worker-scaledobject.yaml
@@ -49,11 +49,8 @@ spec:
         {{- end }}
         listName: {{ .Values.agentWorker.autoscaling.keda.queueName | default "bull:agent-runs:wait" | quote }}
         listLength: {{ .Values.agentWorker.autoscaling.keda.listLength | default "5" | quote }}
-        # Explicit rather than relying on KEDA's default of 0: a scaler counting a
-        # different database than the worker drains reads an empty queue forever.
-        # Defaulted from the one helper the URL and REDIS_DB also come from, so
-        # the three cannot drift; the value exists for an external Redis, whose
-        # database this chart does not choose.
+        # From the helper the URL and REDIS_DB also come from, so the three cannot
+        # drift. The value exists for an external Redis, whose database is its own.
         databaseIndex: {{ .Values.agentWorker.autoscaling.keda.databaseIndex | default (include "vigil.redis.database" .) | quote }}
       {{- if and .Values.redis.bitnami.enabled .Values.redis.bitnami.auth.enabled }}
       authenticationRef:

--- a/infra/helm/vigil/templates/configmap.yaml
+++ b/infra/helm/vigil/templates/configmap.yaml
@@ -15,6 +15,32 @@ data:
          alias fullname) on port 4317 (gRPC). */ -}}
   {{- $_ := set $computed "OTEL_EXPORTER_OTLP_ENDPOINT" (printf "http://%s-opentelemetry-collector:4317" .Release.Name) }}
   {{- end }}
+  {{- if .Values.agentServe.enabled }}
+  {{- /* core/config.py defaults agent_url to http://localhost:6989, which was
+         right while the agent layer ran in the backend's own process. It is its
+         own Deployment now, so the backend has to be told where. */ -}}
+  {{- $_ := set $computed "AGENT_URL" (printf "http://%s:%v" (include "vigil.agentServe.fullname" .) .Values.agentServe.service.port) }}
+  {{- end }}
+  {{- if or .Values.agentWorker.enabled .Values.agentServe.enabled }}
+  {{- /* The return leg, and the same localhost problem in the other direction:
+         the agent layer's four /internal URLs all default to
+         http://localhost:6987, which was the backend when it shared a process
+         and is nothing at all inside an agent pod. Unset is not a safe default
+         here -- an unreachable playbook endpoint fails a run before its first
+         model call, and an unset VIGIL_RUNS_URL silently drops progress and
+         parks any run that needs an approval.
+
+         Rendered into the shared ConfigMap rather than the agent Deployments
+         because AGENT_URL above already establishes that seam addresses are
+         computed in one place. Python ignores them (Settings is extra="ignore",
+         and _ratchets/test_settings_env_example.py records them as belonging to
+         the TypeScript process). Override via extraConfig, which renders last. */ -}}
+  {{- $backend := printf "http://%s:%v" (include "vigil.backend.fullname" .) .Values.backend.service.port }}
+  {{- $_ := set $computed "VIGIL_PLAYBOOKS_URL" (printf "%s/internal/playbooks" $backend) }}
+  {{- $_ := set $computed "VIGIL_PRICING_URL" (printf "%s/internal/pricing" $backend) }}
+  {{- $_ := set $computed "VIGIL_RUNS_URL" (printf "%s/internal/runs" $backend) }}
+  {{- $_ := set $computed "VIGIL_TOOLS_URL" (printf "%s/internal/tools/invoke" $backend) }}
+  {{- end }}
   {{- range $k, $v := .Values.config }}
   {{- if not (hasKey $computed $k) }}
   {{ $k }}: {{ $v | quote }}

--- a/infra/helm/vigil/templates/networkpolicy.yaml
+++ b/infra/helm/vigil/templates/networkpolicy.yaml
@@ -224,6 +224,22 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "db-init") | nindent 14 }}
+        {{- /* Both agent components, and both genuinely need it: the worker
+               writes the ledger and takes the run lease, and serve reads and
+               writes the ledger too — its readiness probe *is* a query, so
+               leaving it out here does not degrade the Deployment, it stops it
+               rolling out at all. ADR 0014 leans on this file, which makes an
+               omission here the decision failing rather than a policy gap. */}}
+        {{- if .Values.agentWorker.enabled }}
+        - podSelector:
+            matchLabels:
+              {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "agent-worker") | nindent 14 }}
+        {{- end }}
+        {{- if .Values.agentServe.enabled }}
+        - podSelector:
+            matchLabels:
+              {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "agent-serve") | nindent 14 }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ .Values.postgresql.service.port }}
@@ -254,6 +270,15 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "llm-worker") | nindent 14 }}
+        {{- /* The worker only: agent-serve answers HTTP off the ledger and never
+               touches the queue, which is the whole reason the two are separate
+               Deployments. Without this rule the worker's readiness never passes
+               and the agent-runs queue is drained by nobody. */}}
+        {{- if .Values.agentWorker.enabled }}
+        - podSelector:
+            matchLabels:
+              {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "agent-worker") | nindent 14 }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ .Values.redis.service.port }}

--- a/infra/helm/vigil/templates/networkpolicy.yaml
+++ b/infra/helm/vigil/templates/networkpolicy.yaml
@@ -121,6 +121,80 @@ spec:
   ingress: []
 ---
 {{- end }}
+{{- if .Values.agentWorker.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "vigil.fullname" . }}-agent-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vigil.componentLabels" (dict "context" . "component" "agent-worker") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "agent-worker") | nindent 6 }}
+  policyTypes: [Ingress]
+  ingress:
+    # Its work arrives over Redis, so nothing routes to it. The one exception is
+    # the kubelet, which has to reach the probe port -- a probe blocked by policy
+    # reads as a failing container.
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 6990
+---
+{{- end }}
+{{- if .Values.agentServe.enabled }}
+{{- /*
+The control ADR 0014 leans on. Dropping the loopback check left the bearer token
+as the only in-process gate, and this is what replaces the bind: chat and run
+projections are reachable from the backend and from nowhere else.
+
+Deliberately narrower than the backend policy above, which admits any pod in the
+namespace. That one is shared by the daemon, llm-worker and helm test, so
+tightening it is a change to those; this surface has exactly one caller.
+*/ -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "vigil.fullname" . }}-agent-serve
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vigil.componentLabels" (dict "context" . "component" "agent-serve") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "agent-serve") | nindent 6 }}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "backend") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.agentServe.service.port }}
+    {{- if .Values.networkPolicies.agentServe.allowProbesFromAnyNamespace }}
+    {{- /* Health rides the traffic port, and ingress rules are OR'd -- so this
+           rule does not merely add probes, it opens the port to every pod in the
+           cluster and leaves the bearer token as the only gate. It is on by
+           default because a kubelet probe originates from the node rather than a
+           pod, and whether a CNI lets that past a pod-selector rule is
+           implementation-specific; a probe blocked by policy reads as a failing
+           container and takes the Deployment down.
+
+           Set false on a cluster whose CNI is known to permit node-sourced
+           health checks (Calico and Cilium both do). Then the rule above is the
+           whole story and only the backend can reach this. */}}
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.agentServe.service.port }}
+    {{- end }}
+---
+{{- end }}
 {{- /* NetworkPolicy for MVP Postgres only. Bitnami's chart has its own
        networkPolicy.* config — enable that there instead. */ -}}
 {{- if and .Values.postgresql.enabled (not .Values.postgresql.bitnami.enabled) }}

--- a/infra/helm/vigil/templates/networkpolicy.yaml
+++ b/infra/helm/vigil/templates/networkpolicy.yaml
@@ -224,12 +224,8 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "db-init") | nindent 14 }}
-        {{- /* Both agent components, and both genuinely need it: the worker
-               writes the ledger and takes the run lease, and serve reads and
-               writes the ledger too — its readiness probe *is* a query, so
-               leaving it out here does not degrade the Deployment, it stops it
-               rolling out at all. ADR 0014 leans on this file, which makes an
-               omission here the decision failing rather than a policy gap. */}}
+        {{- /* Both: serve's readiness probe is a query, so omitting it here does
+               not degrade the Deployment, it stops it rolling out. */}}
         {{- if .Values.agentWorker.enabled }}
         - podSelector:
             matchLabels:
@@ -270,10 +266,7 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "vigil.componentSelectorLabels" (dict "context" . "component" "llm-worker") | nindent 14 }}
-        {{- /* The worker only: agent-serve answers HTTP off the ledger and never
-               touches the queue, which is the whole reason the two are separate
-               Deployments. Without this rule the worker's readiness never passes
-               and the agent-runs queue is drained by nobody. */}}
+        {{- /* The worker only: serve never touches the queue. */}}
         {{- if .Values.agentWorker.enabled }}
         - podSelector:
             matchLabels:

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -193,11 +193,9 @@ agentWorker:
       # Only used when redis.enabled=false AND redis.bitnami.enabled=false.
       # host:port form without scheme or password.
       redisAddress: ""
-      # Which Redis database to count the list in. Empty means the one the chart's
-      # own Redis is addressed on, so the scaler and the worker cannot disagree.
-      # Set it only alongside redis.external.url, to whatever database that URL
-      # names — a scaler counting the wrong one reads an empty queue and holds the
-      # Deployment at its floor while runs pile up.
+      # Empty means the database the chart's own Redis is addressed on. Set it only
+      # alongside redis.external.url, to whatever database that URL names -- a
+      # scaler counting the wrong one reads an empty queue and never scales up.
       databaseIndex: ""
   podAnnotations: {}
   nodeSelector: {}
@@ -230,17 +228,13 @@ agentServe:
     limits:
       cpu: 1000m
       memory: 1Gi
-  # No autoscaling block, and its absence is the decision rather than an omission.
-  # This process holds SSE streams open for minutes while they wait on a model, so
-  # an idle-looking box may be carrying hundreds of live conversations -- CPU reads
-  # near zero and an HPA would scale it down mid-answer. #635 asks that worker and
-  # serve scale independently, which separate replica counts satisfy honestly.
-  #
-  # The signal that would work is concurrent connections, which means exporting a
-  # custom metric and a pipeline to read it: its own piece of work. Left out
-  # entirely rather than shipped as `enabled: false`, because a flag that renders
-  # no HorizontalPodAutoscaler is a flag that quietly scales you to one replica
-  # when somebody believes it and turns it on.
+  # No autoscaling block, and its absence is the decision. This process holds SSE
+  # streams open for minutes, so an idle-looking box may be carrying hundreds of
+  # live conversations -- CPU reads near zero and an HPA would scale it down
+  # mid-answer. Separate replica counts satisfy #635's "scale independently"
+  # honestly; concurrent connections is the signal that would work, and that is a
+  # metrics-pipeline project. Left out rather than shipped as `enabled: false`,
+  # which would render no HPA and quietly scale to one when somebody turned it on.
   podAnnotations: {}
   nodeSelector: {}
   tolerations: []

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -148,6 +148,103 @@ llmWorker:
   extraEnv: []
 
 # -----------------------------------------------------------------------------
+# Agent worker — the TypeScript BullMQ consumer. Runs alongside llmWorker, not
+# instead of it; see agent-worker-deployment.yaml for what has to go first.
+# -----------------------------------------------------------------------------
+agentWorker:
+  enabled: true
+  replicaCount: 2
+  # Its own Node image — unlike llmWorker it cannot share the backend's.
+  image:
+    repository: ""   # defaults to <registry>/<namespace>-agent
+    tag: ""
+    pullPolicy: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  autoscaling:
+    # CPU-based HPA (classic). Mutually exclusive with keda.enabled.
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 70
+    # KEDA ScaledObject — scales on actual Redis queue depth.
+    # Requires KEDA installed in the cluster (https://keda.sh).
+    keda:
+      enabled: false
+      # Must be >= 1: nothing promotes BullMQ's delayed jobs into the waiting
+      # list except a running worker. The template clamps it.
+      minReplicas: 2
+      maxReplicas: 20
+      # Seconds of zero queue activity before scaling down. Keep high to avoid
+      # thrash when the queue is bursty.
+      cooldownPeriod: 300
+      # How often KEDA polls Redis for the queue depth.
+      pollingInterval: 15
+      # BullMQ's waiting list for RUN_QUEUE (services/agent/contracts/job.ts).
+      # Not "agent-runs": that is the queue name, not the Redis key.
+      queueName: "bull:agent-runs:wait"
+      # KEDA scales one replica per listLength items queued.
+      listLength: "5"
+      # Only used when redis.enabled=false AND redis.bitnami.enabled=false.
+      # host:port form without scheme or password.
+      redisAddress: ""
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnv: []
+
+# -----------------------------------------------------------------------------
+# Agent serve — the same image as agentWorker, running the other entry point:
+# chat over SSE and the run projections a supervisor reads. Separate from the
+# worker because the two scale on unrelated signals (#635).
+# -----------------------------------------------------------------------------
+agentServe:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: ""   # defaults to <registry>/<namespace>-agent, same as agentWorker
+    tag: ""
+    pullPolicy: ""
+  service:
+    # The backend reaches this at AGENT_URL, computed from the Service name.
+    port: 6989
+  # An SSE stream can sit on one model call for minutes, and dropping it loses
+  # the conversation rather than retrying it. Long enough for a turn to finish.
+  terminationGracePeriodSeconds: 120
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  autoscaling:
+    # Off, and not merely unconfigured. This process holds SSE streams open for
+    # minutes while they wait on a model, so an idle-looking box may be holding
+    # hundreds of live conversations -- CPU reads near zero and an HPA would
+    # scale it down mid-answer. #635 asks that worker and serve scale
+    # independently, which separate replica counts already satisfy honestly.
+    #
+    # The signal that would work is concurrent connections, which means exporting
+    # a custom metric and a metrics pipeline to read it. That is its own piece of
+    # work; turning this on before then would be worse than leaving it off.
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnv: []
+
+# -----------------------------------------------------------------------------
 # In-chart Postgres (set postgresql.enabled=false to use an external DB)
 # -----------------------------------------------------------------------------
 postgresql:
@@ -715,6 +812,17 @@ networkPolicies:
     # cluster-internal only. Add your SIEM/EDR outbound IPs here to let them
     # push findings.
     webhookAllowFrom: []
+  agentServe:
+    # agent-serve answers chat and run projections, and its probes ride the same
+    # port. Ingress rules are OR'd, so allowing probes from any namespace also
+    # opens that port to every pod in the cluster — leaving the bearer token as
+    # the only gate (ADR 0014).
+    #
+    # True by default because a kubelet probe comes from the node, not a pod, and
+    # whether a CNI lets that past a pod-selector rule varies; a probe blocked by
+    # policy takes the Deployment down. Set false on Calico or Cilium, which
+    # permit node-sourced health checks — then only the backend can reach it.
+    allowProbesFromAnyNamespace: true
 
 # -----------------------------------------------------------------------------
 # Development utilities (issue #117) — off by default, not for production

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -193,6 +193,12 @@ agentWorker:
       # Only used when redis.enabled=false AND redis.bitnami.enabled=false.
       # host:port form without scheme or password.
       redisAddress: ""
+      # Which Redis database to count the list in. Empty means the one the chart's
+      # own Redis is addressed on, so the scaler and the worker cannot disagree.
+      # Set it only alongside redis.external.url, to whatever database that URL
+      # names — a scaler counting the wrong one reads an empty queue and holds the
+      # Deployment at its floor while runs pile up.
+      databaseIndex: ""
   podAnnotations: {}
   nodeSelector: {}
   tolerations: []
@@ -224,20 +230,17 @@ agentServe:
     limits:
       cpu: 1000m
       memory: 1Gi
-  autoscaling:
-    # Off, and not merely unconfigured. This process holds SSE streams open for
-    # minutes while they wait on a model, so an idle-looking box may be holding
-    # hundreds of live conversations -- CPU reads near zero and an HPA would
-    # scale it down mid-answer. #635 asks that worker and serve scale
-    # independently, which separate replica counts already satisfy honestly.
-    #
-    # The signal that would work is concurrent connections, which means exporting
-    # a custom metric and a metrics pipeline to read it. That is its own piece of
-    # work; turning this on before then would be worse than leaving it off.
-    enabled: false
-    minReplicas: 2
-    maxReplicas: 10
-    targetCPUUtilizationPercentage: 70
+  # No autoscaling block, and its absence is the decision rather than an omission.
+  # This process holds SSE streams open for minutes while they wait on a model, so
+  # an idle-looking box may be carrying hundreds of live conversations -- CPU reads
+  # near zero and an HPA would scale it down mid-answer. #635 asks that worker and
+  # serve scale independently, which separate replica counts satisfy honestly.
+  #
+  # The signal that would work is concurrent connections, which means exporting a
+  # custom metric and a pipeline to read it: its own piece of work. Left out
+  # entirely rather than shipped as `enabled: false`, because a flag that renders
+  # no HorizontalPodAutoscaler is a flag that quietly scales you to one replica
+  # when somebody believes it and turns it on.
   podAnnotations: {}
   nodeSelector: {}
   tolerations: []

--- a/services/agent/core/db.ts
+++ b/services/agent/core/db.ts
@@ -25,3 +25,43 @@ export function poolConfig(): PoolConfig {
     password: process.env["POSTGRES_PASSWORD"],
   };
 }
+
+// What BullMQ needs of a Redis, which is the parts and not a URL.
+export interface RedisConfig {
+  host: string;
+  port: number;
+  db: number;
+  password?: string;
+}
+
+// The parts win here, which is the other way round from poolConfig above, and the
+// difference is the chart rather than a preference. `vigil.env` hands every pod a
+// REDIS_URL because the Python deployables read one, and under Bitnami auth that
+// URL is `redis://:$(REDIS_PASSWORD)@host:6379/0` -- substituted by the kubelet,
+// which does no URL-encoding. A password holding @ / : or # therefore renders a
+// URL that `new URL()` misparses or rejects outright, and the parts beside it are
+// the only correct reading. So: parts when the deployment named them, URL when it
+// only had one to give (an external Redis, CI, a dev box).
+//
+// The URL branch decodes the password: `new URL()` leaves it percent-encoded, so a
+// correctly-escaped DSN would otherwise authenticate with the escapes still in it.
+export function redisConfig(): RedisConfig {
+  const host = process.env["REDIS_HOST"];
+  if (host !== undefined && host !== "") {
+    const password = process.env["REDIS_PASSWORD"];
+    return {
+      host,
+      port: Number(process.env["REDIS_PORT"] ?? 6379),
+      db: Number(process.env["REDIS_DB"] ?? 0),
+      ...(password === undefined || password === "" ? {} : { password }),
+    };
+  }
+
+  const url = new URL(process.env["REDIS_URL"] ?? "redis://localhost:6379/0");
+  return {
+    host: url.hostname,
+    port: Number(url.port || 6379),
+    db: Number(url.pathname.slice(1) || 0),
+    ...(url.password === "" ? {} : { password: decodeURIComponent(url.password) }),
+  };
+}

--- a/services/agent/core/db.ts
+++ b/services/agent/core/db.ts
@@ -1,0 +1,27 @@
+import type { PoolConfig } from "pg";
+
+// DATABASE_URL wins so CI and the integration test keep passing a DSN, but a
+// deployed process has no DSN to pass: the chart ships discrete POSTGRES_* vars
+// because Kubernetes `$(VAR)` substitution does no URL-encoding, so a password
+// containing @ or / would render a malformed one (infra/helm/vigil/templates/
+// _env.tpl). pg takes the parts, so nothing needs encoding either way.
+//
+// Here rather than in worker.ts because both entry points open a pool: the worker
+// drains the queue and serve answers the HTTP surface, and they are separate
+// Deployments since #635.
+export function poolConfig(): PoolConfig {
+  const url = process.env["DATABASE_URL"];
+  if (url !== undefined && url !== "") return { connectionString: url };
+
+  const host = process.env["POSTGRES_HOST"];
+  if (host === undefined || host === "") {
+    throw new Error("set DATABASE_URL, or POSTGRES_HOST and the other POSTGRES_* vars");
+  }
+  return {
+    host,
+    port: Number(process.env["POSTGRES_PORT"] ?? 5432),
+    database: process.env["POSTGRES_DB"],
+    user: process.env["POSTGRES_USER"],
+    password: process.env["POSTGRES_PASSWORD"],
+  };
+}

--- a/services/agent/core/db.ts
+++ b/services/agent/core/db.ts
@@ -26,7 +26,6 @@ export function poolConfig(): PoolConfig {
   };
 }
 
-// What BullMQ needs of a Redis, which is the parts and not a URL.
 export interface RedisConfig {
   host: string;
   port: number;
@@ -34,17 +33,9 @@ export interface RedisConfig {
   password?: string;
 }
 
-// The parts win here, which is the other way round from poolConfig above, and the
-// difference is the chart rather than a preference. `vigil.env` hands every pod a
-// REDIS_URL because the Python deployables read one, and under Bitnami auth that
-// URL is `redis://:$(REDIS_PASSWORD)@host:6379/0` -- substituted by the kubelet,
-// which does no URL-encoding. A password holding @ / : or # therefore renders a
-// URL that `new URL()` misparses or rejects outright, and the parts beside it are
-// the only correct reading. So: parts when the deployment named them, URL when it
-// only had one to give (an external Redis, CI, a dev box).
-//
-// The URL branch decodes the password: `new URL()` leaves it percent-encoded, so a
-// correctly-escaped DSN would otherwise authenticate with the escapes still in it.
+// The parts win, unlike poolConfig above: vigil.env hands every pod a REDIS_URL
+// for Python's sake, and under Bitnami auth the kubelet substitutes the password
+// into it unencoded, so one holding @ / : or # parses to the wrong thing.
 export function redisConfig(): RedisConfig {
   const host = process.env["REDIS_HOST"];
   if (host !== undefined && host !== "") {
@@ -57,6 +48,7 @@ export function redisConfig(): RedisConfig {
     };
   }
 
+  // Decoded: new URL() leaves the password percent-encoded.
   const url = new URL(process.env["REDIS_URL"] ?? "redis://localhost:6379/0");
   return {
     host: url.hostname,

--- a/services/agent/core/health.ts
+++ b/services/agent/core/health.ts
@@ -1,0 +1,72 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+export const LIVE = "/healthz";
+export const READY = "/readyz";
+
+// Bounded so a probe fails rather than hangs. A handler that never answers leaks a
+// socket per probe and still reads as a failure once the kubelet times out, so the
+// only thing waiting buys is the leak.
+const CHECK_TIMEOUT_MS = 2_000;
+
+// Whether this process can do its job right now -- not whether it is alive.
+//
+// Liveness deliberately does not consult this. A worker whose Redis has dropped
+// should stop being *ready*, so a rollout halts and alerting fires; restarting it
+// would only reconnect to the same broken dependency, and restarting every replica
+// at once against a Redis that is already struggling turns a blip into an outage.
+export type Ready = () => Promise<boolean>;
+
+async function within(check: Ready): Promise<boolean> {
+  let timer: NodeJS.Timeout | undefined;
+  const expired = new Promise<boolean>((answer) => {
+    timer = setTimeout(() => answer(false), CHECK_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([check().catch(() => false), expired]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Unauthenticated on purpose, and answered before any auth check: a kubelet carries
+// no bearer token. They report up or down and nothing else, so there is nothing here
+// to leak -- which is also why the body is a word rather than a diagnosis.
+//
+// Returns whether it took the request, so a server with routes of its own can offer
+// these first and carry on if it was something else.
+export async function handleHealth(req: IncomingMessage, res: ServerResponse, ready: Ready): Promise<boolean> {
+  if (req.method !== "GET") return false;
+  const url = req.url ?? "";
+
+  if (url === LIVE) {
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end("ok");
+    return true;
+  }
+
+  if (url === READY) {
+    const ok = await within(ready);
+    res.writeHead(ok ? 200 : 503, { "content-type": "text/plain" });
+    res.end(ok ? "ready" : "not ready");
+    return true;
+  }
+
+  return false;
+}
+
+// The worker consumes a queue and serves nothing else, so it gets a listener for
+// these two routes alone. Cheaper than an exec probe, which pays Node's startup
+// every ten seconds per replica to learn the same thing.
+export function healthServer(ready: Ready): Server {
+  return createServer((req, res) => {
+    void (async () => {
+      if (await handleHealth(req, res, ready)) return;
+      res.writeHead(404, { "content-type": "text/plain" });
+      res.end("not found");
+    })();
+  });
+}
+
+export function healthPort(): number {
+  return Number(process.env["AGENT_HEALTH_PORT"] ?? 6990);
+}

--- a/services/agent/core/health.ts
+++ b/services/agent/core/health.ts
@@ -54,13 +54,39 @@ export async function handleHealth(req: IncomingMessage, res: ServerResponse, re
   return false;
 }
 
+// How long an answer stands before the dependency is asked again. /readyz is
+// unauthenticated -- a kubelet carries no token -- and the chart's agent-serve
+// policy admits probes from any namespace by default, so any pod in the cluster
+// can drive this. A kubelet asks every ten seconds; anything faster than this is
+// not a probe, and it should not reach the pool.
+const CACHE_MS = 1_000;
+
+// Answers from the last window rather than asking again. The check itself is the
+// thing worth protecting: `SELECT 1` is cheap once and a connection per caller
+// when it is not rate-limited.
+export function cachedReady(check: Ready, windowMs = CACHE_MS): Ready {
+  let answered = -Infinity;
+  let last: Promise<boolean> | null = null;
+  return () => {
+    const now = Date.now();
+    if (last === null || now - answered >= windowMs) {
+      answered = now;
+      // Held, not awaited: concurrent probes share one query rather than each
+      // opening their own, which is the case this exists for.
+      last = within(check);
+    }
+    return last;
+  };
+}
+
 // The worker consumes a queue and serves nothing else, so it gets a listener for
 // these two routes alone. Cheaper than an exec probe, which pays Node's startup
 // every ten seconds per replica to learn the same thing.
 export function healthServer(ready: Ready): Server {
+  const answer = cachedReady(ready);
   return createServer((req, res) => {
     void (async () => {
-      if (await handleHealth(req, res, ready)) return;
+      if (await handleHealth(req, res, answer)) return;
       res.writeHead(404, { "content-type": "text/plain" });
       res.end("not found");
     })();

--- a/services/agent/core/health.ts
+++ b/services/agent/core/health.ts
@@ -54,16 +54,10 @@ export async function handleHealth(req: IncomingMessage, res: ServerResponse, re
   return false;
 }
 
-// How long an answer stands before the dependency is asked again. /readyz is
-// unauthenticated -- a kubelet carries no token -- and the chart's agent-serve
-// policy admits probes from any namespace by default, so any pod in the cluster
-// can drive this. A kubelet asks every ten seconds; anything faster than this is
-// not a probe, and it should not reach the pool.
+// /readyz is unauthenticated and answered before the token check, so anything
+// reachable can drive the check behind it. A kubelet asks every ten seconds.
 const CACHE_MS = 1_000;
 
-// Answers from the last window rather than asking again. The check itself is the
-// thing worth protecting: `SELECT 1` is cheap once and a connection per caller
-// when it is not rate-limited.
 export function cachedReady(check: Ready, windowMs = CACHE_MS): Ready {
   let answered = -Infinity;
   let last: Promise<boolean> | null = null;
@@ -71,8 +65,7 @@ export function cachedReady(check: Ready, windowMs = CACHE_MS): Ready {
     const now = Date.now();
     if (last === null || now - answered >= windowMs) {
       answered = now;
-      // Held, not awaited: concurrent probes share one query rather than each
-      // opening their own, which is the case this exists for.
+      // Held, not awaited, so concurrent probes share one query.
       last = within(check);
     }
     return last;

--- a/services/agent/core/playbooks.ts
+++ b/services/agent/core/playbooks.ts
@@ -47,10 +47,14 @@ export function httpPlaybooks(options: ResolverOptions): PlaybookResolver {
     try {
       response = await call(url, { headers: { authorization: `Bearer ${options.token}` } });
     } catch (error) {
-      throw new SpecError(`could not resolve ${reference}: ${error instanceof Error ? error.message : String(error)}`);
+      // Not a SpecError: the spec is fine and the endpoint is unreachable, which is
+      // what a rolling upgrade looks like from here. The worker retires a SpecError
+      // on the first attempt, so calling this one would spend the retry policy on
+      // exactly the failure it was added for.
+      throw new Error(`could not resolve ${reference}: ${error instanceof Error ? error.message : String(error)}`);
     }
     if (response.status === 404) throw new SpecError(`no such workflow: ${idOf(reference)}`);
-    if (!response.ok) throw new SpecError(`could not resolve ${reference}: the endpoint answered ${response.status}`);
+    if (!response.ok) throw new Error(`could not resolve ${reference}: the endpoint answered ${response.status}`);
     return layersOf(await response.json(), reference);
   };
 }

--- a/services/agent/core/stream.ts
+++ b/services/agent/core/stream.ts
@@ -1,4 +1,7 @@
-import Ajv, { type ValidateFunction } from "ajv";
+// Named rather than default: ajv is CJS, so under the image build's NodeNext
+// resolution a default import lands on module.exports.default. The named export
+// exists in both, so this one line satisfies `bundler` and NodeNext alike.
+import { Ajv, type ValidateFunction } from "ajv";
 import { ZERO_TOKENS, type Refusal, type SpendPayload, type TokenCounts } from "../contracts/budget.js";
 import type { CheckpointPayload, NewEvent, ResolutionPayload, TerminalPayload } from "../contracts/events.js";
 import type { RegisteredTool, ToolResult } from "../contracts/tool.js";

--- a/services/agent/package.json
+++ b/services/agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:unit": "vitest run tests/core tests/hunt tests/chat",
+    "build": "tsc -p tsconfig.build.json",
     "worker": "tsx worker.ts",
     "serve": "tsx serve.ts"
   },

--- a/services/agent/serve.ts
+++ b/services/agent/serve.ts
@@ -1,7 +1,8 @@
+import { createHash, timingSafeEqual } from "node:crypto";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import pg from "pg";
 import { archFor, registeredKinds } from "./arch/registry.js";
-import { handleHealth, type Ready } from "./core/health.js";
+import { cachedReady, handleHealth, type Ready } from "./core/health.js";
 import { LedgerRepository } from "./ledger/repository.js";
 import { poolConfig } from "./core/db.js";
 import type { RunKind } from "./contracts/events.js";
@@ -90,9 +91,16 @@ export async function streamChat(state: State, request: ChatRequest, res: Server
 // instead, which is what "same box" was standing in for.
 //
 // An unset token refuses everything, and that is now the only gate in the process.
+//
+// Compared over a digest rather than with ===, for the reason Python's authorise
+// gives: === returns on the first differing byte and the header is the caller's to
+// choose. Hashed rather than compared raw because timingSafeEqual throws on a
+// length mismatch, and the throw would leak the length it was meant to hide.
 function authorised(req: IncomingMessage): boolean {
   const expected = process.env["AGENT_INTERNAL_TOKEN"] ?? process.env["VIGIL_TOOLS_TOKEN"] ?? "";
-  return expected !== "" && req.headers.authorization === `Bearer ${expected}`;
+  if (expected === "") return false;
+  const digest = (value: string): Buffer => createHash("sha256").update(value).digest();
+  return timingSafeEqual(digest(req.headers.authorization ?? ""), digest(`Bearer ${expected}`));
 }
 
 async function body(req: IncomingMessage): Promise<string> {
@@ -184,7 +192,10 @@ export function serveReady(pool: pg.Pool): Ready {
 // the worker now, and a pool cannot be shared across processes.
 if (process.argv[1] !== undefined && import.meta.url.endsWith(process.argv[1].split("/").pop() ?? "")) {
   const pool = new pg.Pool(poolConfig());
-  const serving = chatServer(new LedgerRepository(pool), serveReady(pool)).listen(chatPort());
+  // Cached: /readyz is answered before the token check, so an unauthenticated
+  // caller can ask as often as it likes and each ask would otherwise take a
+  // connection out of the pool this process serves chat from.
+  const serving = chatServer(new LedgerRepository(pool), cachedReady(serveReady(pool))).listen(chatPort());
   const stop = () => {
     serving.close();
     void pool.end();

--- a/services/agent/serve.ts
+++ b/services/agent/serve.ts
@@ -92,10 +92,9 @@ export async function streamChat(state: State, request: ChatRequest, res: Server
 //
 // An unset token refuses everything, and that is now the only gate in the process.
 //
-// Compared over a digest rather than with ===, for the reason Python's authorise
-// gives: === returns on the first differing byte and the header is the caller's to
-// choose. Hashed rather than compared raw because timingSafeEqual throws on a
-// length mismatch, and the throw would leak the length it was meant to hide.
+// Over a digest rather than ===, which returns on the first differing byte.
+// Hashed because timingSafeEqual throws on a length mismatch, and the throw would
+// leak the length.
 function authorised(req: IncomingMessage): boolean {
   const expected = process.env["AGENT_INTERNAL_TOKEN"] ?? process.env["VIGIL_TOOLS_TOKEN"] ?? "";
   if (expected === "") return false;
@@ -192,9 +191,8 @@ export function serveReady(pool: pg.Pool): Ready {
 // the worker now, and a pool cannot be shared across processes.
 if (process.argv[1] !== undefined && import.meta.url.endsWith(process.argv[1].split("/").pop() ?? "")) {
   const pool = new pg.Pool(poolConfig());
-  // Cached: /readyz is answered before the token check, so an unauthenticated
-  // caller can ask as often as it likes and each ask would otherwise take a
-  // connection out of the pool this process serves chat from.
+  // Cached: unauthenticated probes would otherwise take a connection each out of
+  // the pool this process serves chat from.
   const serving = chatServer(new LedgerRepository(pool), cachedReady(serveReady(pool))).listen(chatPort());
   const stop = () => {
     serving.close();

--- a/services/agent/serve.ts
+++ b/services/agent/serve.ts
@@ -1,5 +1,9 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import pg from "pg";
 import { archFor, registeredKinds } from "./arch/registry.js";
+import { handleHealth, type Ready } from "./core/health.js";
+import { LedgerRepository } from "./ledger/repository.js";
+import { poolConfig } from "./core/db.js";
 import type { RunKind } from "./contracts/events.js";
 import { nullMemory, recalling } from "./core/memory.js";
 import type { Memory, State } from "./core/seams.js";
@@ -79,12 +83,14 @@ export async function streamChat(state: State, request: ChatRequest, res: Server
   res.end();
 }
 
-// Both checks or neither, the same trade Python's authorise makes: a shared secret
-// on a public bind is one leak from open, a loopback bind alone trusts every
-// process on the box.
+// The token alone, since ADR 0014, and the same trade Python's authorise makes --
+// see core/agents/internal_auth.py. Both sides paired this with a loopback check
+// until #635 made this process its own Deployment: the API then calls it from a pod
+// address, which the check refused. The chart's NetworkPolicy names who may connect
+// instead, which is what "same box" was standing in for.
+//
+// An unset token refuses everything, and that is now the only gate in the process.
 function authorised(req: IncomingMessage): boolean {
-  const host = req.socket.remoteAddress ?? "";
-  if (!(host === "127.0.0.1" || host === "::1" || host === "::ffff:127.0.0.1")) return false;
   const expected = process.env["AGENT_INTERNAL_TOKEN"] ?? process.env["VIGIL_TOOLS_TOKEN"] ?? "";
   return expected !== "" && req.headers.authorization === `Bearer ${expected}`;
 }
@@ -137,12 +143,16 @@ async function openChat(state: State, req: IncomingMessage, res: ServerResponse,
   await streamChat(state, request, res, build);
 }
 
-export function chatServer(state: State, build: HarnessFactory = harnessFor): Server {
+export function chatServer(state: State, ready: Ready, build: HarnessFactory = harnessFor): Server {
   return createServer((req, res) => {
     void (async () => {
+      // Before the auth check, because the kubelet has no token. These say only
+      // whether the process can work, which is not knowledge worth withholding.
+      if (await handleHealth(req, res, ready)) return;
+
       // Before the route, not per route: an unauthorised caller learns nothing
       // about which routes exist.
-      if (!authorised(req)) return refuse(res, 401, "loopback and a valid internal token, or neither");
+      if (!authorised(req)) return refuse(res, 401, "a valid internal token");
 
       const url = req.url ?? "";
       if (req.method === "POST" && url === CHAT) return openChat(state, req, res, build);
@@ -157,4 +167,28 @@ export function chatServer(state: State, build: HarnessFactory = harnessFor): Se
 
 export function chatPort(): number {
   return Number(process.env["AGENT_HTTP_PORT"] ?? 6989);
+}
+
+// Whether this process can answer. Postgres and not Redis: serve reads and writes
+// the ledger and never touches the queue, so queue connectivity would be reporting
+// on something it does not use.
+export function serveReady(pool: pg.Pool): Ready {
+  return async () => {
+    await pool.query("SELECT 1");
+    return true;
+  };
+}
+
+// The entry point `npm run serve` has always named and never had, so until #635 it
+// loaded this module and exited. Its own pool: serve is a separate Deployment from
+// the worker now, and a pool cannot be shared across processes.
+if (process.argv[1] !== undefined && import.meta.url.endsWith(process.argv[1].split("/").pop() ?? "")) {
+  const pool = new pg.Pool(poolConfig());
+  const serving = chatServer(new LedgerRepository(pool), serveReady(pool)).listen(chatPort());
+  const stop = () => {
+    serving.close();
+    void pool.end();
+  };
+  process.on("SIGTERM", stop);
+  process.on("SIGINT", stop);
 }

--- a/services/agent/tests/chat/serve.test.ts
+++ b/services/agent/tests/chat/serve.test.ts
@@ -28,7 +28,9 @@ let stop: () => void;
 
 async function listen(script: readonly ScriptedTurn[]): Promise<void> {
   state = new InProcessState();
-  const server = chatServer(state, scriptedHarness(script));
+  // Ready by construction: the ledger here is in-process, so there is no Postgres
+  // for readiness to be reporting on.
+  const server = chatServer(state, async () => true, scriptedHarness(script));
   await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready));
   base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
   stop = () => server.close();

--- a/services/agent/tests/fixtures/case.config.yaml
+++ b/services/agent/tests/fixtures/case.config.yaml
@@ -12,10 +12,18 @@ runtime:
   result_cap: 8000
   recall_limit: 2
 
+# remote, for the reason hunt.config.yaml gives at more length.
 tools:
   - id: case_records
-    kind: duckdb
-    database: ./fixtures/records.duckdb
+    kind: remote
+    description: Read the case records held for an investigation.
+    parameters:
+      type: object
+      properties:
+        case_id:
+          type: string
+          description: The case whose records to read.
+      required: [case_id]
     max_rows: 100
     timeout_ms: 15000
 

--- a/services/agent/tests/fixtures/hunt.config.yaml
+++ b/services/agent/tests/fixtures/hunt.config.yaml
@@ -12,20 +12,53 @@ runtime:
   result_cap: 20000
   recall_limit: 3
 
+# Every tool is remote, because remote is the only kind any adapter implements --
+# the demolition collapsed them all onto the Python bridge. A generated config says
+# the same thing: playbook_resolver.py emits id, kind, description and parameters
+# and nothing else, so these fixtures are shaped like what a deployment produces.
 tools:
   - id: duckdb_query
-    kind: duckdb
-    database: ./fixtures/records.duckdb
+    kind: remote
+    description: Run a read-only SQL query against the records warehouse.
+    parameters:
+      type: object
+      properties:
+        sql:
+          type: string
+          description: The SELECT statement to run.
+      required: [sql]
     max_rows: 200
     timeout_ms: 30000
   - id: expand
-    kind: expand
+    kind: remote
+    description: Expand an entity into the entities it is related to.
+    parameters:
+      type: object
+      properties:
+        entity:
+          type: string
+          description: The entity to expand.
+      required: [entity]
   - id: intel_lookup
-    kind: threatfox
-    feed: https://threatfox.abuse.ch/export/json/recent/
+    kind: remote
+    description: Look an indicator up in the threat intelligence feeds.
+    parameters:
+      type: object
+      properties:
+        indicator:
+          type: string
+          description: The IP, domain or hash to look up.
+      required: [indicator]
   - id: web_intel
-    kind: firecrawl
-    limit: 3
+    kind: remote
+    description: Search the open web for reporting on an indicator or campaign.
+    parameters:
+      type: object
+      properties:
+        query:
+          type: string
+          description: What to search the web for.
+      required: [query]
 
 approvals: []
 

--- a/services/agent/tsconfig.build.json
+++ b/services/agent/tsconfig.build.json
@@ -1,0 +1,26 @@
+// Emit config, used only by the image build. tsconfig.json stays noEmit so
+// `npm run typecheck` and vitest are untouched.
+//
+// NodeNext rather than the base config's "bundler": bundler resolution cannot
+// emit for node. The sources already carry .js extensions on relative imports,
+// so this is *nearly* a config swap -- but not entirely. NodeNext resolves a
+// default import from a CommonJS package to module.exports.default, which is why
+// core/stream.ts imports ajv by name. Anything else CJS added here will want the
+// same treatment, and only this config will say so: `npm run typecheck` uses
+// bundler resolution and lets a default import past.
+//
+// Both entry points emit from the include below -- dist/worker.js and
+// dist/serve.js -- because the image runs one or the other by command.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "sourceMap": true,
+    "declaration": false
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests", "vitest.config.ts"]
+}

--- a/services/agent/worker.ts
+++ b/services/agent/worker.ts
@@ -1,11 +1,12 @@
-import { Queue, Worker } from "bullmq";
+import { Queue, UnrecoverableError, Worker } from "bullmq";
 import { hostname } from "node:os";
 import { randomUUID } from "node:crypto";
 import pg from "pg";
 import { archFor } from "./arch/registry.js";
 import { httpAnswers, journalAnswers, noAnswers, type Answers } from "./core/answers.js";
 import { harnessFor, internalToken, type HarnessFactory } from "./harness.js";
-import { chatPort, chatServer } from "./serve.js";
+import { poolConfig } from "./core/db.js";
+import { healthPort, healthServer } from "./core/health.js";
 import { jobIdFor, RUN_QUEUE, JOB_SCHEMA_VERSION, type RunJob } from "./contracts/job.js";
 import type { AgentEvent, CheckpointPayload, ResolutionPayload, RunKind, RunPayload } from "./contracts/events.js";
 import {
@@ -273,12 +274,6 @@ async function reap(leases: Leases, runId: string): Promise<void> {
   await leases.finish(runId);
 }
 
-function connectionUrl(): string {
-  const url = process.env["DATABASE_URL"];
-  if (url === undefined || url === "") throw new Error("DATABASE_URL is not set");
-  return url;
-}
-
 function redisUrl(): URL {
   return new URL(process.env["REDIS_URL"] ?? "redis://localhost:6379/0");
 }
@@ -294,7 +289,27 @@ function redisUrl(): URL {
 // Structurally what the sweeper needs of a queue, so it is drivable without a
 // Redis. BullMQ's Queue satisfies it as it stands.
 export interface Enqueue {
-  add(name: string, job: RunJob, options: { jobId: string }): Promise<unknown>;
+  add(name: string, job: RunJob, options: JobOptions): Promise<unknown>;
+}
+
+// What every enqueue of a run carries, wherever it is enqueued from -- here, or
+// core/agents/queue.py, which sets the same two.
+//
+// BullMQ defaults to one attempt, so a job that throws is permanently failed and
+// nothing rescues it: the sweeper below sweeps lapsed lease rows, and a job that
+// died on its way into leases.claim never wrote one. Transient Postgres and Redis
+// failures are rare on a dev box and routine under Kubernetes.
+//
+// Retrying is safe rather than merely tolerable: advance() checks terminal first
+// and leases.claim is a conditional UPDATE, so a second attempt takes exactly the
+// path a sweeper resume takes.
+export const RUN_ATTEMPTS = 3;
+export const RUN_BACKOFF = { type: "exponential", delay: 5_000 } as const;
+
+interface JobOptions {
+  jobId: string;
+  attempts: number;
+  backoff: { type: string; delay: number };
 }
 
 // The reservation lasts a lease TTL because that is the order of magnitude a job
@@ -313,9 +328,27 @@ export async function sweepOnce(leases: Leases, queue: Enqueue, limit = 50): Pro
       enqueued_by: "watchdog",
       reason: "resume",
     };
-    await queue.add(RUN_QUEUE, job, { jobId: jobIdFor(job, randomUUID()) });
+    await queue.add(RUN_QUEUE, job, { jobId: jobIdFor(job, randomUUID()), attempts: RUN_ATTEMPTS, backoff: { ...RUN_BACKOFF } });
   }
   return due.length;
+}
+
+// advance(), with the one distinction the retry policy above needs to be told
+// about: a spec that does not parse parses no better on the third attempt. Retries
+// exist for the infrastructure going away mid-run, not for a malformed playbook, and
+// UnrecoverableError is how BullMQ is told which is which -- the job fails on
+// attempt 1 and the console sees the real message rather than the same one thrice,
+// fifteen seconds apart.
+//
+// Only here, not inside advance(): what a failure means to the queue is the queue's
+// business, and advance() is driven without one by the tests and by run-once.ts.
+async function handle(state: State, leases: Leases, job: RunJob): Promise<void> {
+  try {
+    await advance(state, leases, job);
+  } catch (error) {
+    if (error instanceof SpecError) throw new UnrecoverableError(error.message);
+    throw error;
+  }
 }
 
 export interface Running {
@@ -329,7 +362,7 @@ export interface Running {
 // synchronous and would gain nothing from a queue hop but latency. One process,
 // one pool, two ways in.
 export function startWorker(): Running {
-  const pool = new pg.Pool({ connectionString: connectionUrl() });
+  const pool = new pg.Pool(poolConfig());
   const ledger = new LedgerRepository(pool);
   const leases = new LeaseRepository(pool);
   const url = redisUrl();
@@ -344,7 +377,7 @@ export function startWorker(): Running {
   // disagreed with it would either double-process a run or wedge one. BullMQ's
   // stalled sweep still retires a dead worker's job eventually, and the lease
   // refuses it if it comes back around.
-  const worker = new Worker<RunJob>(RUN_QUEUE, (job) => advance(ledger, leases, job.data), {
+  const worker = new Worker<RunJob>(RUN_QUEUE, (job) => handle(ledger, leases, job.data), {
     connection,
     lockDuration: LEASE_TTL_MS * 10,
   });
@@ -372,11 +405,39 @@ export function startWorker(): Running {
   } };
 }
 
+// Whether this worker is worth sending work to. `status` rather than a ping:
+// ioredis queues commands while it is offline, so a ping against a dropped
+// connection would sit in that queue until the probe timed out -- reporting a hang
+// where the connection state already says "not ready" for free.
+export function workerReady(worker: Worker<RunJob>): () => Promise<boolean> {
+  return async () => {
+    if (!worker.isRunning()) return false;
+    return (await worker.client).status === "ready";
+  };
+}
+
+// Both the mirror and the answers endpoint hang off this one variable, and both go
+// quietly inert when it is unset: runs still succeed, no phase progress ever reaches
+// the console, and a run that stops for a human parks until it is abandoned because
+// nothing can carry the decision back. Said once at startup, because nothing later
+// in the run says it -- a silently-off mirror looks exactly like a quiet one.
+function warnIfUnmirrored(): void {
+  const url = process.env["VIGIL_RUNS_URL"];
+  if (url !== undefined && url !== "") return;
+  console.warn(
+    "VIGIL_RUNS_URL is unset: run progress will not be mirrored to the backend and checkpoints cannot be answered",
+  );
+}
+
 if (process.argv[1] !== undefined && import.meta.url.endsWith(process.argv[1].split("/").pop() ?? "")) {
+  warnIfUnmirrored();
   const running = startWorker();
-  const serving = chatServer(running.ledger).listen(chatPort());
+  // Probes only. Chat moved to serve.ts when #635 split the two into Deployments
+  // that scale on different things -- a queue's depth and an open connection count
+  // have nothing to say to each other.
+  const probes = healthServer(workerReady(running.worker)).listen(healthPort());
   const stop = () => {
-    serving.close();
+    probes.close();
     void running.close();
   };
   process.on("SIGTERM", stop);

--- a/services/agent/worker.ts
+++ b/services/agent/worker.ts
@@ -5,7 +5,7 @@ import pg from "pg";
 import { archFor } from "./arch/registry.js";
 import { httpAnswers, journalAnswers, noAnswers, type Answers } from "./core/answers.js";
 import { harnessFor, internalToken, type HarnessFactory } from "./harness.js";
-import { poolConfig } from "./core/db.js";
+import { poolConfig, redisConfig } from "./core/db.js";
 import { healthPort, healthServer } from "./core/health.js";
 import { jobIdFor, RUN_QUEUE, JOB_SCHEMA_VERSION, type RunJob } from "./contracts/job.js";
 import type { AgentEvent, CheckpointPayload, ResolutionPayload, RunKind, RunPayload } from "./contracts/events.js";
@@ -179,7 +179,7 @@ export async function advance(
     await settle(state, leases, job, spec, owner);
   } catch (error) {
     await abandon(job, error);
-    await forget(state, leases, job.run_id);
+    await forget(state, leases, job.run_id, owner);
     throw error;
   } finally {
     clearInterval(renewing);
@@ -191,10 +191,22 @@ export async function advance(
 // being swept forever, throwing on every attempt. Dropped here because this is the
 // only place that knows the ledger stayed empty.
 //
-// A failure with a ledger behind it keeps its row: that run is real and unfinished,
-// and the sweeper reclaiming it is exactly right.
-async function forget(state: State, leases: Leases, runId: string): Promise<void> {
-  if ((await state.latestSeq(runId)) === null) await leases.finish(runId);
+// A failure with a ledger behind it keeps its row -- that run is real and
+// unfinished -- but hands the claim back rather than sitting on it. Holding it
+// would defeat the retry policy the failure is meant to reach: a lease lasts
+// LEASE_TTL_MS and the first retry lands seconds later, so claim() would find the
+// row still owned, refuse it, and advance() would return having done nothing --
+// which BullMQ records as a *success*, retiring the job with the run stalled until
+// the sweeper notices. Released, the retry takes exactly the path a resume takes.
+//
+// Safe against a lost lease: release() is scoped to this owner, so a worker that
+// was already reclaimed matches no row and displaces nobody.
+async function forget(state: State, leases: Leases, runId: string, owner: string): Promise<void> {
+  if ((await state.latestSeq(runId)) === null) {
+    await leases.finish(runId);
+    return;
+  }
+  await leases.release(runId, owner, 0);
 }
 
 export const LOST_LEASE = "the lease was reclaimed by another worker";
@@ -274,9 +286,6 @@ async function reap(leases: Leases, runId: string): Promise<void> {
   await leases.finish(runId);
 }
 
-function redisUrl(): URL {
-  return new URL(process.env["REDIS_URL"] ?? "redis://localhost:6379/0");
-}
 
 // A run whose claim has lapsed, put back on the queue. Two cases reach here and
 // neither needs telling apart: a worker died holding the run, or a parked run's
@@ -303,6 +312,10 @@ export interface Enqueue {
 // Retrying is safe rather than merely tolerable: advance() checks terminal first
 // and leases.claim is a conditional UPDATE, so a second attempt takes exactly the
 // path a sweeper resume takes.
+//
+// It also has to be *reachable*, which is forget()'s half of this: a retry lands
+// seconds after the failure and a lease lasts LEASE_TTL_MS, so a run whose claim
+// was still held would find the row taken and quietly do nothing.
 export const RUN_ATTEMPTS = 3;
 export const RUN_BACKOFF = { type: "exponential", delay: 5_000 } as const;
 
@@ -365,13 +378,7 @@ export function startWorker(): Running {
   const pool = new pg.Pool(poolConfig());
   const ledger = new LedgerRepository(pool);
   const leases = new LeaseRepository(pool);
-  const url = redisUrl();
-  const connection = {
-    host: url.hostname,
-    port: Number(url.port || 6379),
-    db: Number(url.pathname.slice(1) || 0),
-    ...(url.password === "" ? {} : { password: url.password }),
-  };
+  const connection = redisConfig();
 
   // Long, because the lease is the liveness signal and a second clock that
   // disagreed with it would either double-process a run or wedge one. BullMQ's

--- a/services/agent/worker.ts
+++ b/services/agent/worker.ts
@@ -192,15 +192,10 @@ export async function advance(
 // only place that knows the ledger stayed empty.
 //
 // A failure with a ledger behind it keeps its row -- that run is real and
-// unfinished -- but hands the claim back rather than sitting on it. Holding it
-// would defeat the retry policy the failure is meant to reach: a lease lasts
-// LEASE_TTL_MS and the first retry lands seconds later, so claim() would find the
-// row still owned, refuse it, and advance() would return having done nothing --
-// which BullMQ records as a *success*, retiring the job with the run stalled until
-// the sweeper notices. Released, the retry takes exactly the path a resume takes.
-//
-// Safe against a lost lease: release() is scoped to this owner, so a worker that
-// was already reclaimed matches no row and displaces nobody.
+// unfinished -- but hands the claim back. Holding it out the TTL would refuse the
+// retry that lands seconds later, and a refused claim returns quietly, so BullMQ
+// would retire the job as a success with the run stalled. release() is scoped to
+// this owner, so a worker already reclaimed displaces nobody.
 async function forget(state: State, leases: Leases, runId: string, owner: string): Promise<void> {
   if ((await state.latestSeq(runId)) === null) {
     await leases.finish(runId);
@@ -312,10 +307,7 @@ export interface Enqueue {
 // Retrying is safe rather than merely tolerable: advance() checks terminal first
 // and leases.claim is a conditional UPDATE, so a second attempt takes exactly the
 // path a sweeper resume takes.
-//
-// It also has to be *reachable*, which is forget()'s half of this: a retry lands
-// seconds after the failure and a lease lasts LEASE_TTL_MS, so a run whose claim
-// was still held would find the row taken and quietly do nothing.
+// Reachable because forget() hands the lease back; see there.
 export const RUN_ATTEMPTS = 3;
 export const RUN_BACKOFF = { type: "exponential", delay: 5_000 } as const;
 

--- a/services/agent/workflows/lead/workflow.ts
+++ b/services/agent/workflows/lead/workflow.ts
@@ -165,7 +165,7 @@ async function turn(harness: Harness<LeadKinds>, options: LeadOptions, assignmen
 // is what a serial round wants: one turn, committed where it started.
 async function write(harness: Harness<LeadKinds>, options: LeadOptions, result: Dispatched, at?: number): Promise<number> {
   const from = at ?? result.outcome.from;
-  return commitTurn(harness.state, options.run_id, { events: result.outcome.events, from }, result.own);
+  return commitTurn(harness.state, options.run_id, { from }, result.own);
 }
 
 function turnFor(options: LeadOptions, role: string, spec: RoleSpec, task: string): TurnConfig {

--- a/tests/integration/test_agent_run_walking_skeleton.py
+++ b/tests/integration/test_agent_run_walking_skeleton.py
@@ -7,8 +7,9 @@ import asyncio
 import json
 import os
 import subprocess
-import time
+import threading
 import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -30,20 +31,107 @@ def _redis_url() -> str:
     return os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 
 
+# All three, not just the ledger: advance() takes a lease before it does anything,
+# so a database with only 19 applied fails on the first job with `relation
+# "agent_run_leases" does not exist`. Python does not model the agent tables (ADR
+# 0001), so nothing else creates them for a test.
+AGENT_DDL = (
+    "19_agent_ledger.sql",
+    "20_agent_directives.sql",
+    "21_agent_run_leases.sql",
+)
+
+
 @pytest.fixture(scope="module")
 def engine():
     engine = create_engine(_database_url(), future=True)
     with engine.connect() as conn:
-        ledger_ddl = (REPO_ROOT / "infra" / "database" / "init" / "19_agent_ledger.sql").read_text()
-        conn.execute(text(ledger_ddl))
+        for name in AGENT_DDL:
+            ddl = (REPO_ROOT / "infra" / "database" / "init" / name).read_text()
+            conn.execute(text(ddl))
         conn.commit()
     yield engine
     engine.dispose()
 
 
+# What the lead emits, once, so the loop halts on its first decision. CONCLUDE is
+# the hunt arch's only halting action, and it dispatches nobody, so one answer is
+# the whole run.
+DECISION = {
+    "action": "CONCLUDE",
+    "rationale": "the seam is proven",
+    "evidence_citations": [],
+}
+
+
+# A model the run can reach, rather than one it pays. Neither CI nor a dev box runs
+# Bifrost, so without this the worker opens the ledger, claims its lease and dies on
+# the first completion -- which proves the seam up to the point it stops proving
+# anything. Answering here keeps the test deterministic, free, and about the seam:
+# Python enqueues, TypeScript consumes, the ledger is written, the API reports it.
+class _StubModel(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:  # noqa: N802 -- BaseHTTPRequestHandler's spelling
+        self.rfile.read(int(self.headers.get("content-length", 0)))
+        body = json.dumps(
+            {
+                "id": "stub",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "stub/model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(DECISION),
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args: Any) -> None:
+        return
+
+
+@pytest.fixture(scope="module")
+def model_url():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _StubModel)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_address[1]}"
+    server.shutdown()
+    server.server_close()
+
+
 @pytest.fixture()
 def run_id() -> str:
     return str(uuid.uuid4())
+
+
+# The seq-0 payload a real run writes, so the resume test can seed one. A resume
+# reads the spec back off this event and re-reads no file, so a hand-written
+# `spec: {}` never reaches the seq-0 collision it means to prove: the loop refuses
+# an arch that declares no lead first, several steps earlier.
+@pytest.fixture(scope="module")
+def opened(engine, model_url) -> Dict[str, Any]:
+    run_id = str(uuid.uuid4())
+    _enqueue(run_id)
+    assert _run_worker_once(model_url).returncode == 0
+    return _events(engine, run_id)[0]["payload"]
 
 
 def _enqueue(run_id: str, run_kind: str = "hunt") -> str:
@@ -65,8 +153,13 @@ def _enqueue(run_id: str, run_kind: str = "hunt") -> str:
     return asyncio.run(enqueue_run(job))
 
 
-def _run_worker_once() -> subprocess.CompletedProcess:
-    env = {**os.environ, "DATABASE_URL": _database_url(), "REDIS_URL": _redis_url()}
+def _run_worker_once(model_url: str) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "DATABASE_URL": _database_url(),
+        "REDIS_URL": _redis_url(),
+        "BIFROST_URL": model_url,
+    }
     return subprocess.run(
         ["npx", "tsx", "tests/support/run-once.ts"],
         cwd=AGENT_DIR,
@@ -97,30 +190,43 @@ def _terminal(engine, run_id: str) -> Optional[Dict[str, Any]]:
 
 
 class TestWalkingSkeleton:
-    def test_python_enqueues_a_job_the_node_worker_can_parse(self, engine, run_id):
+    def test_python_enqueues_a_job_the_node_worker_can_parse(
+        self, engine, run_id, model_url
+    ):
         job_id = _enqueue(run_id)
         assert job_id == run_id, "jobId must be the run_id so a double POST dedupes in BullMQ"
 
-        result = _run_worker_once()
+        result = _run_worker_once(model_url)
         assert result.returncode == 0, f"worker failed: {result.stdout}\n{result.stderr}"
 
-    def test_the_worker_opens_the_ledger_and_marks_the_run_terminal(self, engine, run_id):
+    def test_the_worker_opens_the_ledger_and_marks_the_run_terminal(
+        self, engine, run_id, model_url
+    ):
         _enqueue(run_id)
-        result = _run_worker_once()
+        result = _run_worker_once(model_url)
         assert result.returncode == 0, f"worker failed: {result.stdout}\n{result.stderr}"
 
+        # The seam, not the loop's shape: the run opens at 0, the ledger has one
+        # writer so its positions are contiguous, and it ends terminal. How many
+        # events a decision takes on the way is the workflow's business and it
+        # changes; pinning it here would make this test fail for the wrong reason.
         events = _events(engine, run_id)
-        assert [(e["seq"], e["kind"]) for e in events] == [(0, "run"), (1, "terminal")]
+        assert [e["seq"] for e in events] == list(range(len(events)))
+        assert events[0]["kind"] == "run"
+        assert events[-1]["kind"] == "terminal"
         assert events[0]["payload"]["started_by"] == "integration-test"
         assert _terminal(engine, run_id)["outcome"] == "completed"
 
-    def test_the_api_reports_a_status_the_worker_persisted(self, engine, run_id):
+    def test_the_api_reports_a_status_the_worker_persisted(
+        self, engine, run_id, model_url
+    ):
         from fastapi.testclient import TestClient
 
         from services.api.main import app
 
         _enqueue(run_id)
-        assert _run_worker_once().returncode == 0
+        assert _run_worker_once(model_url).returncode == 0
+        written = len(_events(engine, run_id))
 
         with TestClient(app) as client:
             response = client.get(f"/api/agent-runs/{run_id}")
@@ -130,7 +236,7 @@ class TestWalkingSkeleton:
             body = response.json()
             assert body["status"] == "terminal"
             assert body["outcome"] == "completed"
-            assert body["events"] == 2
+            assert body["events"] == written
 
     def test_an_unknown_run_is_not_found_rather_than_an_error(self, engine):
         from fastapi.testclient import TestClient
@@ -141,7 +247,9 @@ class TestWalkingSkeleton:
             response = client.get(f"/api/agent-runs/{uuid.uuid4()}")
         assert response.status_code in (404, 401, 403), response.text
 
-    def test_a_crash_before_terminal_leaves_the_run_resumable(self, engine, run_id):
+    def test_a_crash_before_terminal_leaves_the_run_resumable(
+        self, engine, run_id, model_url, opened
+    ):
         with engine.connect() as conn:
             conn.execute(
                 text(
@@ -151,24 +259,19 @@ class TestWalkingSkeleton:
                 {
                     "run_id": run_id,
                     "payload": json.dumps(
-                        {
-                            "run_kind": "hunt",
-                            "spec": {},
-                            "budgets": {"max_iterations": 0, "max_cost_usd": 0},
-                            "seed": run_id,
-                            "tenant_id": None,
-                            "started_by": "crashed-worker",
-                        }
+                        {**opened, "seed": run_id, "started_by": "crashed-worker"}
                     ),
                 },
             )
             conn.commit()
 
         _enqueue(run_id)
-        assert _run_worker_once().returncode == 0
+        assert _run_worker_once(model_url).returncode == 0
 
         events = _events(engine, run_id)
-        assert [e["kind"] for e in events] == ["run", "terminal"], "resume must not collide on seq 0"
+        seqs = [e["seq"] for e in events]
+        assert seqs == list(range(len(events))), "resume must not collide on seq 0"
+        assert events[-1]["kind"] == "terminal"
         assert events[0]["payload"]["started_by"] == "crashed-worker", "the original run event survives"
 
     def test_the_composite_key_rejects_a_second_writer(self, engine, run_id):

--- a/tests/unit/_ratchets/test_settings_env_example.py
+++ b/tests/unit/_ratchets/test_settings_env_example.py
@@ -93,6 +93,11 @@ NOT_SETTINGS = {
     # Read by the TypeScript agent processes themselves, not by Settings.
     "AGENT_HEALTH_PORT",
     "AGENT_HTTP_PORT",
+    # The agent worker's Redis parts. Python has no equivalent -- it reads
+    # REDIS_URL, which is a Setting.
+    "REDIS_HOST",
+    "REDIS_PORT",
+    "REDIS_DB",
     "VIGIL_PLAYBOOKS_URL",
     "VIGIL_PRICING_URL",
     "VIGIL_RUNS_URL",

--- a/tests/unit/_ratchets/test_settings_env_example.py
+++ b/tests/unit/_ratchets/test_settings_env_example.py
@@ -90,7 +90,8 @@ NOT_SETTINGS = {
     "BIND_HOST",
     "GRAFANA_PASSWORD",
     "VITE_EXTENSION_ORIGIN_ALLOWLIST",
-    # Read by the TypeScript agent worker's own process, not by Settings.
+    # Read by the TypeScript agent processes themselves, not by Settings.
+    "AGENT_HEALTH_PORT",
     "AGENT_HTTP_PORT",
     "VIGIL_PLAYBOOKS_URL",
     "VIGIL_PRICING_URL",

--- a/tests/unit/agents/test_tools_router.py
+++ b/tests/unit/agents/test_tools_router.py
@@ -15,7 +15,8 @@ def client(monkeypatch):
     monkeypatch.setattr(internal_auth, "get_secret", lambda name: "shhh")
     app = FastAPI()
     app.include_router(tools_router.router, prefix=tools_router.ROUTER_META.prefix)
-    return TestClient(app, client=("127.0.0.1", 50000))
+    # No `client=` address: nothing reads the peer since ADR 0014.
+    return TestClient(app)
 
 
 def _answers(monkeypatch, result, handled=True):

--- a/tests/unit/agents/test_tools_router.py
+++ b/tests/unit/agents/test_tools_router.py
@@ -53,11 +53,9 @@ class TestAuthorisation:
         assert response.status_code == 503
         assert "AGENT_INTERNAL_TOKEN" in response.json()["detail"]
 
-    def test_refuses_a_caller_that_is_not_loopback(self, client, monkeypatch):
-        monkeypatch.setattr(internal_auth, "_loopback", lambda request: False)
-        assert _invoke(client).status_code == 403
-
-    def test_a_loopback_bearer_gets_through(self, client, monkeypatch):
+    def test_a_valid_bearer_gets_through(self, client, monkeypatch):
+        """No longer loopback-gated: ADR 0014 left the token as the only check,
+        because the agent layer now calls in from its own pods."""
         _answers(monkeypatch, [])
         assert _invoke(client).status_code == 200
 

--- a/tests/unit/api/test_router_discovery.py
+++ b/tests/unit/api/test_router_discovery.py
@@ -241,8 +241,10 @@ def test_every_non_required_router_has_a_reason():
     """The live tree, not just the validator: all 9 deviations are justified.
 
     ``pricing`` is the fourth of the agent layer's internal endpoints, on the
-    same terms as ``tools``, ``playbooks`` and ``run_bridge``: loopback plus the
-    shared secret, because the caller is the worker rather than a session.
+    same terms as ``tools``, ``playbooks`` and ``run_bridge``: the shared secret,
+    because the caller is the worker rather than a session. Reachability is the
+    NetworkPolicy's job since ADR 0014 -- these were loopback-gated until the
+    agent layer became its own Deployments.
     """
     from core.routing import Auth
 

--- a/tests/unit/workflows/test_workflow_phase_approval.py
+++ b/tests/unit/workflows/test_workflow_phase_approval.py
@@ -79,22 +79,17 @@ def clean_tables():
     _clear()
 
 
-class _Loopback:
-    """Just enough Request for ``authorise`` to let a call through."""
-
-    class _Client:
-        host = "127.0.0.1"
-
-    client = _Client()
-
-
 @pytest.fixture
 def internal(monkeypatch):
-    """Answer the shared-secret check so the bridge is callable directly."""
+    """Answer the shared-secret check so the bridge is callable directly.
+
+    The token is the whole of it since ADR 0014 -- ``authorise`` no longer reads
+    the request, so there is no loopback stand-in left to build.
+    """
     from core.agents import internal_auth
 
     monkeypatch.setattr(internal_auth, "get_secret", lambda name: "test-token")
-    return _Loopback(), "Bearer test-token"
+    return "Bearer test-token"
 
 
 def _run(workflow_id: str = "test-phase-001") -> str:
@@ -134,9 +129,9 @@ class TestPhaseApprovalAcrossTheBridge:
         from core.workflows.workflow_run_service import \
             get_workflow_run_service
 
-        request, token = internal
+        token = internal
         run_id = _run()
-        record_phase(run_id, _update("pending_approval", "chk-phase-2"), request, token)
+        record_phase(run_id, _update("pending_approval", "chk-phase-2"), token)
 
         run = get_workflow_run_service().get_run(run_id)
         assert run["status"] == "paused"
@@ -156,10 +151,10 @@ class TestPhaseApprovalAcrossTheBridge:
                                                     get_approval_service)
         from core.workflows.run_bridge_router import record_phase
 
-        request, token = internal
+        token = internal
         run_id = _run()
-        record_phase(run_id, _update("pending_approval", "chk-phase-2"), request, token)
-        record_phase(run_id, _update("pending_approval", "chk-phase-2"), request, token)
+        record_phase(run_id, _update("pending_approval", "chk-phase-2"), token)
+        record_phase(run_id, _update("pending_approval", "chk-phase-2"), token)
 
         pending = get_approval_service().list_actions(
             status=ActionStatus.PENDING, workflow_run_id=run_id
@@ -174,9 +169,9 @@ class TestPhaseApprovalAcrossTheBridge:
         from core.workflows.run_bridge_router import (list_decisions,
                                                       record_phase)
 
-        request, token = internal
+        token = internal
         run_id = _run()
-        record_phase(run_id, _update("pending_approval", "chk-phase-2"), request, token)
+        record_phase(run_id, _update("pending_approval", "chk-phase-2"), token)
 
         service = get_approval_service()
         action = service.list_actions(
@@ -184,7 +179,7 @@ class TestPhaseApprovalAcrossTheBridge:
         )[0]
         service.approve_action(action.action_id, approved_by="tester")
 
-        decisions = list_decisions(run_id, request, token).decisions
+        decisions = list_decisions(run_id, token).decisions
         assert len(decisions) == 1
         assert decisions[0].checkpoint_id == "chk-phase-2"
         assert decisions[0].answer == "approve"
@@ -196,9 +191,9 @@ class TestPhaseApprovalAcrossTheBridge:
         from core.workflows.run_bridge_router import (list_decisions,
                                                       record_phase)
 
-        request, token = internal
+        token = internal
         run_id = _run()
-        record_phase(run_id, _update("pending_approval", "chk-phase-2"), request, token)
+        record_phase(run_id, _update("pending_approval", "chk-phase-2"), token)
 
         service = get_approval_service()
         action = service.list_actions(
@@ -206,7 +201,7 @@ class TestPhaseApprovalAcrossTheBridge:
         )[0]
         service.reject_action(action.action_id, reason="too risky", rejected_by="tester")
 
-        decisions = list_decisions(run_id, request, token).decisions
+        decisions = list_decisions(run_id, token).decisions
         assert len(decisions) == 1
         assert decisions[0].answer == "reject"
         assert decisions[0].text == "too risky"
@@ -217,20 +212,20 @@ class TestPhaseApprovalAcrossTheBridge:
         from core.workflows.run_bridge_router import (list_decisions,
                                                       record_phase)
 
-        request, token = internal
+        token = internal
         run_id = _run()
-        record_phase(run_id, _update("pending_approval", "chk-phase-2"), request, token)
+        record_phase(run_id, _update("pending_approval", "chk-phase-2"), token)
 
-        assert list_decisions(run_id, request, token).decisions == []
+        assert list_decisions(run_id, token).decisions == []
 
     def test_a_completed_phase_leaves_the_run_running(self, clean_tables, internal):
         from core.workflows.run_bridge_router import record_phase
         from core.workflows.workflow_run_service import \
             get_workflow_run_service
 
-        request, token = internal
+        token = internal
         run_id = _run()
-        record_phase(run_id, _update("completed"), request, token)
+        record_phase(run_id, _update("completed"), token)
 
         run_service = get_workflow_run_service()
         assert run_service.get_run(run_id)["status"] == "running"
@@ -244,12 +239,11 @@ class TestPhaseApprovalAcrossTheBridge:
         from core.workflows.workflow_run_service import \
             get_workflow_run_service
 
-        request, token = internal
+        token = internal
         run_id = _run()
         record_terminal(
             run_id,
             TerminalUpdate(outcome="completed", reason="all 2 phases ran", summary="s"),
-            request,
             token,
         )
 


### PR DESCRIPTION
Closes #635.

The agent layer becomes two deployables with an image, a chart and a compose block behind them — and then closes the gaps that only show up once the two stop sharing a box.

## The shape

Two deployments, cut by how work arrives rather than by protocol.

| | Agent Worker | Agent Serve |
|---|---|---|
| Consumes | the `agent-runs` queue | `POST /chat/stream`, `GET /runs/<id>/projection` |
| Needs | Redis + Postgres | Postgres |
| Readiness | Redis reachable + `worker.isRunning()` | Postgres reachable |
| Scaling | KEDA on queue depth | fixed replicas, no autoscaler |
| Behind a Service | no | yes |

Every HTTP route the layer exposes is request-driven, so run projections ride with chat rather than earning a third deployment.

Serve deliberately gets no autoscaler. Its load is SSE streams held open for minutes, and a stream waiting on a model uses almost no CPU — a CPU HPA reads a box holding 200 live conversations as idle and scales it down. Separate deployments with separate replica counts satisfy "scale independently" honestly; a connection-count metric is the right answer eventually and is a metrics-pipeline project. The reason is written into `values.yaml`.

Probes read as intent rather than literally. Readiness reflects the dependency each process cannot work without; liveness only ever reflects the process. Failing *liveness* on a Redis blip would restart every replica at once against a Redis that is already unwell, and the restart fixes nothing.

## The decision the ticket said did not exist

#635 closed with "ADR scope: none — deployment mechanics, no architectural decision." That was wrong, and it had already been anticipated: ADR 0010 said of `/internal/tools/invoke` that loopback binding plus a shared secret is the floor, not the ceiling, and should be revisited if the agent service is ever deployed off-host. This is what deploys it off-host.

The loopback gate was symmetric, covered eight routes and was written twice — `core/agents/internal_auth.py` and `serve.ts` carried the same check under the same comment. Every one of those routes 403s across a pod boundary, so the parked worker Deployment was not merely incomplete: it would have started, dequeued a job, and failed to resolve a playbook before its first model call.

[ADR 0014](docs/adr/0014-off-host-agent-token-and-network-policy.md) resolves it — drop the loopback predicate on both sides, keep the bearer token, constrain reachability with the chart's NetworkPolicy. Compose has no NetworkPolicy and is honestly token-only.

## Two things found by running it that no render could show

**The agent pods were never told where the backend is.** All four `/internal` URLs default to `localhost:6987`, which inside an agent container is that container. Fixed in both deploy paths: an `x-agent-env` anchor in `docker-compose.yml`, and a computed block in `templates/configmap.yaml` alongside `AGENT_URL`.

**Trivy had nowhere to run.** `build-images` and `scan-images` are both `if: false` and `release.yml` had no Trivy at all, so "passes Trivy" was unmeetable. A `build-agent-image` job now builds locally (no registry), scans and smoke-tests, so it runs on every PR. It fails on fixable CRITICAL only; HIGH+CRITICAL are reported but non-blocking.

The smoke test imports both emitted entry points. That is the class of failure `npm run typecheck` cannot catch — tsc reads `.ts`, node runs the emitted `.js`.

## Unblocking the base branch

Both existing images were already red. #654 dropped the `deeptempo-core` and `mcp-servers` submodules; `requirements.txt` was updated and the Dockerfiles were not, so `Dockerfile.backend` and `Dockerfile.daemon` still `COPY` and `pip install -e` two paths that no longer exist. Fixed here, because this change cannot claim a green smoke test against a release workflow whose other two jobs fail.

## Queue retries

Nothing set `attempts` anywhere, so BullMQ's default of 1 applied and a job that threw was permanently failed. The watchdog cannot rescue those — it sweeps lapsed *lease rows*, and a job that died on its way into `leases.claim` never wrote one. On a dev box a transient Postgres failure is rare; in Kubernetes — rolling upgrades, evictions, failover — it is routine, and the run was lost with nothing reaching the console.

Three attempts with exponential backoff from 5s, set at both enqueue points, plus `UnrecoverableError` for `SpecError` so a malformed spec still dies on attempt 1. Retrying is safe rather than merely tolerable: `advance()` checks terminal first and `leases.claim` is a conditional UPDATE, so a retry takes exactly the path a watchdog resume takes.

One related fix: `httpPlaybooks` was raising `SpecError` when it simply could not *reach* the backend. Mapping that to unrecoverable would make "the backend was restarting" a permanent failure — precisely the case retries exist for. Transport failures now raise a plain error; a 404 stays a `SpecError`, because a workflow that does not exist will not exist on the third attempt either.

Verified by running, not by reading:

- bad playbook path → job lands in `failed`, `attemptsMade` = 1, stacktrace shows `UnrecoverableError`
- Postgres pointed at a dead port → job lands in `delayed` with a 5000ms delay awaiting attempt 2, having died inside `LedgerRepository.terminal`

## The walking skeleton

`tests/integration/test_agent_run_walking_skeleton.py` is green again. Three things were wrong:

- The fixture applied only `19_agent_ledger.sql`, and `advance()` takes a lease before it does anything. It now applies `20` and `21` too.
- The two config fixtures were the last things declaring the pre-demolition tool kinds. They now declare `kind: remote` with a description and a parameters schema, shaped like what `playbook_resolver.py` generates. Test fixtures only — no production config was affected.
- With those fixed the run reached its first model call and died there. Neither CI nor a dev box runs Bifrost, so `BIFROST_URL` fell back to `http://bifrost:8080`. The test now stands up a stub that answers one CONCLUDE decision — the hunt arch's only halting action — so the run completes deterministically and for free.

Its assertions also had to change. It pinned the ledger to exactly `[(0,"run"), (1,"terminal")]`, which was true when the worker only opened the ledger and ran no loop. It now asserts what the seam actually promises: the run opens at position 0, positions are contiguous because there is one writer, and it ends terminal-completed. The resume test's hand-written `spec: {}` never reached the seq-0 collision it meant to prove — the loop refuses an arch with no lead several steps earlier — so it seeds a real run event instead.

## Verification

| Check | Result |
|---|---|
| Helm lint × 3 (default, dev, Bitnami) | pass |
| `helm template` default / dev / Bitnami | 18 / 18 / 35 resources |
| kubeconform | 18 / 18 / 35 valid, 0 invalid |
| `diff -r` database-init ↔ chart bundle | in sync |
| hadolint `Dockerfile.agent` | clean |
| `services/agent` typecheck | pass |
| vitest | 452 passed, 3 failed |
| pytest unit + security | 1417 passed, 3 failed |
| walking skeleton | 6 passed |

Both compose services were booted against real Postgres and Redis and report healthy — `agent-worker` on 6990, `agent-serve` on 6989. `POST /chat/stream` without a token answers 401, so the token gate works now that the loopback predicate is gone, and `agent-worker → http://agent-serve:6989/healthz` returns 200 from the same address the backend gets as `AGENT_URL`.

### Pre-existing failures, proved against a pristine base

- Three `services/agent/tests/workflows/lead.test.ts` parallel-round failures (`ledger position .../4 is already taken`), from #656.
- Three `tests/security/test_unauth_endpoints.py` failures for `/api/claude/sdk-status`, `/api/claude/chat` and `/api/claude/agent/task`. Those routes do not exist in `claude.py` on the base branch either, and neither the router nor the security test differs in this branch.

## Note

`ci-cd.yml` triggers only on `main` and `develop`, so nothing in this PR's CI runs on a PR into `agent-refactor`. That is a deliberate choice, not an oversight — the checks above were run by hand and are reported as such.
