### PR TITLE
fix(docker): clear the agent image's three fixable CRITICALs

### DIFF
--- a/infra/docker/Dockerfile.agent
+++ b/infra/docker/Dockerfile.agent
@@ -48,10 +48,19 @@ LABEL org.opencontainers.image.version="${VIGIL_VERSION}"
 
 WORKDIR /app
 
-# No apt layer: bullmq and pg are pure JavaScript. The Python images need
-# libpq5 only because psycopg is a C extension.
+# Nothing here needs apt except the base image's own gnutls, which ships two
+# fixable CRITICALs (CVE-2026-33845, CVE-2026-42010). Pinned because hadolint
+# asks for it; Trivy is what says when the pin has gone stale.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgnutls30=3.7.9-2+deb12u7 \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY services/agent/package.json services/agent/package-lock.json ./
-RUN npm ci --omit=dev && npm cache clean --force
+# npm leaves with the install that needed it: nothing invokes it at runtime, and
+# its bundled tar is the image's third fixable CRITICAL (CVE-2026-59873).
+RUN npm ci --omit=dev \
+    && npm cache clean --force \
+    && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 COPY --from=build /build/dist ./dist
 


### PR DESCRIPTION
Squash-safe half of #667: the Dockerfile change only, so it can land under this repo's squash-only policy. The merge-base half of #667 cannot be squashed and is explained there.

Trivy gates the Agent Image job on fixable CRITICALs and found three. That job is the only red check on the CI run dispatched against `agent-refactor`; the other eleven pass.

| Package | CVE | Where it comes from |
|---|---|---|
| `libgnutls30` | CVE-2026-33845, CVE-2026-42010 | Debian base layer |
| `tar` 6.2.1 | CVE-2026-59873 | **npm's bundled copy** — not in `package-lock.json` |

gnutls is upgraded to the patched Debian build and pinned, because hadolint wants a version and Trivy is what reports the pin going stale.

node-tar is not ours: it lives inside npm rather than our lockfile. npm is a build tool and nothing invokes it at runtime — `CMD` is `node dist/worker.js`, and the chart overrides `command` with node too — so it leaves along with the install that needed it. The finding goes and the image shrinks.

### Verified locally

- `hadolint` clean, with no ignores (this Dockerfile deliberately has none)
- `trivy image --severity CRITICAL --ignore-unfixed --exit-code 1` → **exit 0**
- CI's own smoke test, run verbatim against the built image → `agent ok`