### PR TITLE
style: clean services and core, and let the linters gate

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,20 +45,17 @@ jobs:
           uv venv
           uv pip install flake8 black isort mypy import-linter
 
-      # Advisory until the tree is clean: these three report 2383 flake8
-      # violations and 124 unformatted files today, so making them gate is a
-      # separate change that has to land the cleanup with it.
+      # These gate now. Advisory is how the tree drifted to 2383 flake8
+      # violations and 124 unformatted files while CI stayed green, which the
+      # commit below clears. setup.cfg is the one config; black needs no flags.
       - name: Run flake8
-        run: uv run flake8 services/ core/ --max-line-length=120 --exclude=venv,__pycache__
-        continue-on-error: true
+        run: uv run flake8 services/ core/
 
       - name: Run black
-        run: uv run black --check services/ core/ --exclude=venv
-        continue-on-error: true
+        run: uv run black --check services/ core/
 
       - name: Run isort
         run: uv run isort --check-only services/ core/
-        continue-on-error: true
 
       # Still advisory: the annotation backlog is real work, not a formatting pass.
       - name: Run mypy

--- a/core/agents/agent_ai_generator.py
+++ b/core/agents/agent_ai_generator.py
@@ -119,8 +119,7 @@ class AgentAIGenerator:
             "icon": "Single uppercase letter (e.g. 'P')",
             "color": "Hex color like '#8e44ad'",
             "role": (
-                "Short role phrase for BASE_PROMPT "
-                "(e.g. 'phishing specialist')"
+                "Short role phrase for BASE_PROMPT " "(e.g. 'phishing specialist')"
             ),
             "extra_principles": (
                 "Bullet list of additional principles, one per line prefixed "
@@ -170,7 +169,7 @@ class AgentAIGenerator:
                 (
                     "## Requirements\n"
                     "- `role` is a short noun phrase. It renders as "
-                    "\"You are a SOC {role} in the Vigil SOC platform.\"\n"
+                    '"You are a SOC {role} in the Vigil SOC platform."\n'
                     "- `extra_principles` is added AFTER Vigil's baseline "
                     "principles. Use '- ' bullets, one per line.\n"
                     "- `methodology` is a numbered step list (1., 2., 3., ...) "

--- a/core/agents/builtins.py
+++ b/core/agents/builtins.py
@@ -224,7 +224,14 @@ Confidence scoring:
         "id": "reporter",
         "decision_id": "reporting",
         "component_category": "reporting",
-        "task_keywords": ["report", "summary", "document", "board brief", "board report", "risk posture"],
+        "task_keywords": [
+            "report",
+            "summary",
+            "document",
+            "board brief",
+            "board report",
+            "risk posture",
+        ],
         "role": "Reporting Agent specializing in clear communication",
         "name": "Reporting Agent",
         "icon": "W",
@@ -283,7 +290,11 @@ Confidence scoring:
         "color": "#FFD3B6",
         "description": "Attack pattern and technique analysis",
         "specialization": "MITRE ATT&CK Analysis",
-        "recommended_tools": ["get_finding", "get_technique_rollup", "create_attack_layer"],
+        "recommended_tools": [
+            "get_finding",
+            "get_technique_rollup",
+            "create_attack_layer",
+        ],
         "max_tokens": 16384,
         "enable_thinking": True,
         "thinking_budget": 6000,
@@ -497,5 +508,3 @@ Confidence scoring:
 </methodology>""",
     },
 ]
-
-

--- a/core/agents/custom_agent_service.py
+++ b/core/agents/custom_agent_service.py
@@ -4,11 +4,11 @@ import logging
 import re
 from typing import Any, Dict, List, Optional
 
+from core.agents.manager import CUSTOM_AGENT_ID_PREFIX
+from core.agents.prompts import render_base_prompt
 from core.storage.connection import get_db_manager
 from core.storage.models import CustomAgent
 from core.storage.schemas import CustomAgentSchema
-from core.agents.manager import CUSTOM_AGENT_ID_PREFIX
-from core.agents.prompts import render_base_prompt
 
 logger = logging.getLogger(__name__)
 

--- a/core/agents/prompts.py
+++ b/core/agents/prompts.py
@@ -4,7 +4,6 @@
 agent records so the record data stays free of prompt-template text.
 """
 
-
 # Memory-palace section is separate from BASE_PROMPT so we can omit it
 # entirely when the mempalace MCP server isn't connected (#129). Before
 # this split, agents were *always* told they had access to 14

--- a/core/auth/auth_service.py
+++ b/core/auth/auth_service.py
@@ -10,16 +10,17 @@ import logging
 import secrets
 import uuid
 from datetime import datetime, timedelta
-from typing import Optional, Dict, Any, List
+from typing import Any, Dict, List, Optional
+
 import bcrypt
 import jwt
 import pyotp
 from cryptography.fernet import Fernet
 from sqlalchemy.orm import Session
 
-from core.storage.models import User, Role
 from core.config import get_settings
 from core.secrets import get_secret
+from core.storage.models import Role, User
 from core.storage.unit_of_work import unit_of_work
 
 logger = logging.getLogger(__name__)

--- a/core/auth/password_reset.py
+++ b/core/auth/password_reset.py
@@ -47,6 +47,7 @@ def _ttl_seconds() -> int:
 def _get_serializer() -> URLSafeTimedSerializer:
     # Import lazily so tests can stub JWT_SECRET_KEY via env before auth_service loads.
     from core.auth.auth_service import JWT_SECRET_KEY
+
     return URLSafeTimedSerializer(JWT_SECRET_KEY, salt=RESET_TOKEN_PURPOSE)
 
 
@@ -67,7 +68,9 @@ def _redis_client():
     try:
         from redis import asyncio as redis_asyncio
     except Exception as exc:
-        logger.warning("redis.asyncio unavailable: %s — reset single-use check disabled", exc)
+        logger.warning(
+            "redis.asyncio unavailable: %s — reset single-use check disabled", exc
+        )
         return None
     url = get_settings().redis_url or DEFAULT_REDIS_URL
     _reset_redis_client = redis_asyncio.from_url(url, decode_responses=True)

--- a/core/auth/password_validator.py
+++ b/core/auth/password_validator.py
@@ -10,7 +10,9 @@ from core.config import get_settings
 
 logger = logging.getLogger(__name__)
 
-_BLOCKLIST_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "common_passwords.txt"
+_BLOCKLIST_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "data" / "common_passwords.txt"
+)
 _blocklist: Optional[frozenset] = None
 
 
@@ -38,7 +40,8 @@ def _get_blocklist() -> frozenset:
     try:
         with open(_BLOCKLIST_PATH, encoding="utf-8") as f:
             _blocklist = frozenset(
-                line.strip().lower() for line in f
+                line.strip().lower()
+                for line in f
                 if line.strip() and not line.startswith("#")
             )
     except FileNotFoundError:
@@ -61,9 +64,17 @@ def validate_password_strength(
     All kwargs are test overrides; production uses env/defaults.
     user_inputs: terms (username, email) zxcvbn penalizes if embedded.
     """
-    limit = min_length if min_length is not None else get_settings().auth_min_password_length
-    byte_ceiling = max_bytes if max_bytes is not None else get_settings().auth_max_password_bytes
-    threshold = min_score if min_score is not None else get_settings().auth_min_zxcvbn_score
+    limit = (
+        min_length
+        if min_length is not None
+        else get_settings().auth_min_password_length
+    )
+    byte_ceiling = (
+        max_bytes if max_bytes is not None else get_settings().auth_max_password_bytes
+    )
+    threshold = (
+        min_score if min_score is not None else get_settings().auth_min_zxcvbn_score
+    )
     # zxcvbn scores run 0-4; clamp so a misconfigured 5+ can't reject every
     # password and a negative value can't underflow the check.
     threshold = max(0, min(4, threshold))
@@ -80,7 +91,11 @@ def validate_password_strength(
             suggestions=["Use a shorter passphrase."],
         )
 
-    block = frozenset(b.lower() for b in blocklist) if blocklist is not None else _get_blocklist()
+    block = (
+        frozenset(b.lower() for b in blocklist)
+        if blocklist is not None
+        else _get_blocklist()
+    )
     if password.lower() in block:
         raise PasswordPolicyError(
             "Password is too common — choose something more unique",

--- a/core/cases/case_automation_service.py
+++ b/core/cases/case_automation_service.py
@@ -4,24 +4,24 @@ Case Automation Service - Scheduled jobs and automated workflows.
 Handles SLA monitoring, auto-assignment, escalation, and periodic tasks.
 """
 
-import logging
 import asyncio
+import logging
 from datetime import datetime, timedelta
 from typing import Dict, List
 
-from core.storage.unit_of_work import unit_of_work
-from core.storage.models import Case, CaseSLA
+from core.cases.case_metrics_service import CaseMetricsService
+from core.cases.case_notification_service import CaseNotificationService
 from core.cases.case_sla_service import CaseSLAService
 from core.cases.case_workflow_service import CaseWorkflowService
-from core.cases.case_notification_service import CaseNotificationService
-from core.cases.case_metrics_service import CaseMetricsService
+from core.storage.models import Case, CaseSLA
+from core.storage.unit_of_work import unit_of_work
 
 logger = logging.getLogger(__name__)
 
 
 class CaseAutomationService:
     """Service for automated case workflows and scheduled tasks."""
-    
+
     def __init__(self):
         """Initialize the automation service."""
         self.sla_service = CaseSLAService()
@@ -29,27 +29,27 @@ class CaseAutomationService:
         self.notification_service = CaseNotificationService()
         self.metrics_service = CaseMetricsService()
         self.running = False
-    
+
     async def start(self):
         """Start all automation tasks."""
         self.running = True
         logger.info("Starting case automation service")
-        
+
         # Start all scheduled tasks
         tasks = [
             self.sla_monitor_task(),
             self.metrics_update_task(),
             self.stale_case_detector_task(),
-            self.digest_generator_task()
+            self.digest_generator_task(),
         ]
-        
+
         await asyncio.gather(*tasks, return_exceptions=True)
-    
+
     async def stop(self):
         """Stop automation service."""
         self.running = False
         logger.info("Stopping case automation service")
-    
+
     async def sla_monitor_task(self):
         """Monitor SLAs and send alerts."""
         while self.running:
@@ -60,16 +60,20 @@ class CaseAutomationService:
             except Exception as e:
                 logger.error(f"Error in SLA monitor task: {e}")
                 await asyncio.sleep(60)
-    
+
     async def _check_sla_deadlines(self):
         """Check SLA deadlines and send notifications."""
         try:
             with unit_of_work() as session:
                 # Get all active SLAs
-                active_slas = session.query(CaseSLA).filter(
-                    CaseSLA.resolution_completed_at == None,
-                    CaseSLA.is_paused == False
-                ).all()
+                active_slas = (
+                    session.query(CaseSLA)
+                    .filter(
+                        CaseSLA.resolution_completed_at.is_(None),
+                        CaseSLA.is_paused.is_(False),
+                    )
+                    .all()
+                )
 
                 current_time = datetime.utcnow()
 
@@ -80,31 +84,36 @@ class CaseAutomationService:
                         continue
 
                     # Check if we need to send notifications
-                    response_pct = status.get('response_percent_elapsed', 0)
-                    resolution_pct = status.get('resolution_percent_elapsed', 0)
+                    response_pct = status.get("response_percent_elapsed", 0)
+                    resolution_pct = status.get("resolution_percent_elapsed", 0)
 
                     # Send notifications at 75%, 90%, 100% thresholds
                     thresholds = [75, 90, 100]
                     for threshold in thresholds:
                         if response_pct >= threshold and not sla.response_completed_at:
                             self.notification_service.notify_sla_warning(
-                                sla.case_id, threshold, 'response', session
+                                sla.case_id, threshold, "response", session
                             )
 
-                        if resolution_pct >= threshold and not sla.resolution_completed_at:
+                        if (
+                            resolution_pct >= threshold
+                            and not sla.resolution_completed_at
+                        ):
                             self.notification_service.notify_sla_warning(
-                                sla.case_id, threshold, 'resolution', session
+                                sla.case_id, threshold, "resolution", session
                             )
 
                     # Mark as breached if over 100%
-                    if (resolution_pct >= 100 or response_pct >= 100) and not sla.breached:
+                    if (
+                        resolution_pct >= 100 or response_pct >= 100
+                    ) and not sla.breached:
                         sla.breached = True
                         sla.breach_time = current_time
                         sla.breach_reason = "SLA deadline exceeded"
 
         except Exception as e:
             logger.error(f"Error checking SLA deadlines: {e}")
-    
+
     async def metrics_update_task(self):
         """Update case metrics periodically."""
         while self.running:
@@ -115,15 +124,17 @@ class CaseAutomationService:
             except Exception as e:
                 logger.error(f"Error in metrics update task: {e}")
                 await asyncio.sleep(3600)
-    
+
     async def _update_case_metrics(self):
         """Update metrics for all open cases."""
         try:
             with unit_of_work() as session:
                 # Get all open cases
-                open_cases = session.query(Case).filter(
-                    Case.status.in_(['open', 'in-progress', 'investigating'])
-                ).all()
+                open_cases = (
+                    session.query(Case)
+                    .filter(Case.status.in_(["open", "in-progress", "investigating"]))
+                    .all()
+                )
 
                 for case in open_cases:
                     self.metrics_service.calculate_case_metrics(case.case_id, session)
@@ -131,7 +142,7 @@ class CaseAutomationService:
                 logger.info(f"Updated metrics for {len(open_cases)} cases")
         except Exception as e:
             logger.error(f"Error updating case metrics: {e}")
-    
+
     async def stale_case_detector_task(self):
         """Detect and flag stale cases."""
         while self.running:
@@ -142,7 +153,7 @@ class CaseAutomationService:
             except Exception as e:
                 logger.error(f"Error in stale case detector: {e}")
                 await asyncio.sleep(86400)
-    
+
     async def _detect_stale_cases(self):
         """Detect cases with no activity for extended periods."""
         try:
@@ -151,28 +162,32 @@ class CaseAutomationService:
                 stale_threshold = datetime.utcnow() - timedelta(days=7)
 
                 # Find cases not updated recently
-                stale_cases = session.query(Case).filter(
-                    Case.status.in_(['open', 'in-progress', 'investigating']),
-                    Case.updated_at < stale_threshold
-                ).all()
+                stale_cases = (
+                    session.query(Case)
+                    .filter(
+                        Case.status.in_(["open", "in-progress", "investigating"]),
+                        Case.updated_at < stale_threshold,
+                    )
+                    .all()
+                )
 
                 for case in stale_cases:
                     # Notify assignee
                     if case.assignee:
                         self.notification_service.create_notification(
                             user_id=case.assignee,
-                            notification_type='stale_case',
-                            title='Stale Case Alert',
+                            notification_type="stale_case",
+                            title="Stale Case Alert",
                             message=f'Case "{case.title}" has had no activity for 7+ days',
                             case_id=case.case_id,
-                            priority='normal',
-                            session=session
+                            priority="normal",
+                            session=session,
                         )
 
                 logger.info(f"Detected {len(stale_cases)} stale cases")
         except Exception as e:
             logger.error(f"Error detecting stale cases: {e}")
-    
+
     async def digest_generator_task(self):
         """Generate daily digest emails."""
         while self.running:
@@ -182,18 +197,18 @@ class CaseAutomationService:
                 next_run = now.replace(hour=9, minute=0, second=0, microsecond=0)
                 if now.hour >= 9:
                     next_run += timedelta(days=1)
-                
+
                 wait_seconds = (next_run - now).total_seconds()
                 logger.info(f"Next digest in {wait_seconds/3600:.1f} hours")
-                
+
                 await asyncio.sleep(wait_seconds)
-                
+
                 logger.info("Generating daily digest")
                 await self._generate_daily_digest()
             except Exception as e:
                 logger.error(f"Error in digest generator: {e}")
                 await asyncio.sleep(3600)
-    
+
     async def _generate_daily_digest(self):
         """Generate and send daily digest."""
         try:
@@ -201,20 +216,19 @@ class CaseAutomationService:
                 # Get metrics for last 24 hours
                 yesterday = datetime.utcnow() - timedelta(days=1)
                 metrics = self.metrics_service.get_dashboard_metrics(
-                    start_date=yesterday,
-                    session=session
+                    start_date=yesterday, session=session
                 )
 
                 # Get breached cases
                 breached = self.sla_service.get_breached_cases(session)
 
                 # In a real implementation, would send digest emails here
-                logger.info(f"Daily digest: {metrics.get('total_cases', 0)} total cases, "
-                           f"{len(breached)} breached")
+                logger.info(
+                    f"Daily digest: {metrics.get('total_cases', 0)} total cases, "
+                    f"{len(breached)} breached"
+                )
         except Exception as e:
             logger.error(f"Error generating digest: {e}")
-    
-    
 
 
 # Singleton instance
@@ -280,9 +294,7 @@ def cluster_findings_by_attack_path(finding_ids: List[str]) -> List[str]:
         priority = severity  # treat severity as priority for VStrike cases
         mission_systems = sorted(
             {
-                (f.get("entity_context") or {})
-                .get("vstrike", {})
-                .get("mission_system")
+                (f.get("entity_context") or {}).get("vstrike", {}).get("mission_system")
                 for f in findings
                 if (f.get("entity_context") or {})
                 .get("vstrike", {})
@@ -317,4 +329,3 @@ def cluster_findings_by_attack_path(finding_ids: List[str]) -> List[str]:
             )
 
     return created_case_ids
-

--- a/core/cases/case_collaboration_service.py
+++ b/core/cases/case_collaboration_service.py
@@ -6,11 +6,12 @@ Handles case comments, @mentions, watchers, and activity feeds.
 
 import logging
 from typing import Dict, List, Optional
-from sqlalchemy.orm import Session
-from sqlalchemy import and_
 
-from core.storage.models import CaseComment, CaseWatcher
+from sqlalchemy import and_
+from sqlalchemy.orm import Session
+
 from core.cases.case_notification_service import CaseNotificationService
+from core.storage.models import CaseComment, CaseWatcher
 from core.storage.unit_of_work import unit_of_work
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ class CaseCollaborationService:
         author: str,
         content: str,
         parent_comment_id: Optional[int] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Optional[CaseComment]:
         """
         Add a comment to a case.
@@ -56,7 +57,7 @@ class CaseCollaborationService:
                     content=content,
                     mentions=mentions,
                     is_edited=False,
-                    is_deleted=False
+                    is_deleted=False,
                 )
 
                 session.add(comment)
@@ -69,16 +70,16 @@ class CaseCollaborationService:
                             mentioned_user=mentioned_user,
                             comment_author=author,
                             comment_content=content,
-                            session=session
+                            session=session,
                         )
 
                 # Notify watchers
                 self.notification_service.notify_watchers(
                     case_id=case_id,
-                    notification_type='new_comment',
-                    title='New Comment',
-                    message=f'{author} added a comment',
-                    session=session
+                    notification_type="new_comment",
+                    title="New Comment",
+                    message=f"{author} added a comment",
+                    session=session,
                 )
 
                 logger.info(f"Added comment to case {case_id} by {author}")
@@ -89,10 +90,7 @@ class CaseCollaborationService:
             return None
 
     def update_comment(
-        self,
-        comment_id: int,
-        new_content: str,
-        session: Optional[Session] = None
+        self, comment_id: int, new_content: str, session: Optional[Session] = None
     ) -> bool:
         """
         Update a comment.
@@ -107,9 +105,11 @@ class CaseCollaborationService:
         """
         try:
             with unit_of_work(session) as session:
-                comment = session.query(CaseComment).filter(
-                    CaseComment.comment_id == comment_id
-                ).first()
+                comment = (
+                    session.query(CaseComment)
+                    .filter(CaseComment.comment_id == comment_id)
+                    .first()
+                )
 
                 if not comment:
                     return False
@@ -131,7 +131,7 @@ class CaseCollaborationService:
         self,
         comment_id: int,
         soft_delete: bool = True,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> bool:
         """
         Delete a comment.
@@ -146,9 +146,11 @@ class CaseCollaborationService:
         """
         try:
             with unit_of_work(session) as session:
-                comment = session.query(CaseComment).filter(
-                    CaseComment.comment_id == comment_id
-                ).first()
+                comment = (
+                    session.query(CaseComment)
+                    .filter(CaseComment.comment_id == comment_id)
+                    .first()
+                )
 
                 if not comment:
                     return False
@@ -169,7 +171,7 @@ class CaseCollaborationService:
         self,
         case_id: str,
         include_deleted: bool = False,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> List[CaseComment]:
         """
         Get all comments for a case.
@@ -183,12 +185,10 @@ class CaseCollaborationService:
             List of CaseComment objects
         """
         with unit_of_work(session) as session:
-            query = session.query(CaseComment).filter(
-                CaseComment.case_id == case_id
-            )
+            query = session.query(CaseComment).filter(CaseComment.case_id == case_id)
 
             if not include_deleted:
-                query = query.filter(CaseComment.is_deleted == False)
+                query = query.filter(CaseComment.is_deleted.is_(False))
 
             return query.order_by(CaseComment.created_at.asc()).all()
 
@@ -197,7 +197,7 @@ class CaseCollaborationService:
         case_id: str,
         user_id: str,
         notification_preferences: Optional[Dict] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Optional[CaseWatcher]:
         """
         Add a watcher to a case.
@@ -214,12 +214,16 @@ class CaseCollaborationService:
         try:
             with unit_of_work(session) as session:
                 # Check if already watching
-                existing = session.query(CaseWatcher).filter(
-                    and_(
-                        CaseWatcher.case_id == case_id,
-                        CaseWatcher.user_id == user_id
+                existing = (
+                    session.query(CaseWatcher)
+                    .filter(
+                        and_(
+                            CaseWatcher.case_id == case_id,
+                            CaseWatcher.user_id == user_id,
+                        )
                     )
-                ).first()
+                    .first()
+                )
 
                 if existing:
                     logger.info(f"User {user_id} already watching case {case_id}")
@@ -228,7 +232,7 @@ class CaseCollaborationService:
                 watcher = CaseWatcher(
                     case_id=case_id,
                     user_id=user_id,
-                    notification_preferences=notification_preferences or {}
+                    notification_preferences=notification_preferences or {},
                 )
 
                 session.add(watcher)
@@ -241,10 +245,7 @@ class CaseCollaborationService:
             return None
 
     def remove_watcher(
-        self,
-        case_id: str,
-        user_id: str,
-        session: Optional[Session] = None
+        self, case_id: str, user_id: str, session: Optional[Session] = None
     ) -> bool:
         """
         Remove a watcher from a case.
@@ -259,12 +260,16 @@ class CaseCollaborationService:
         """
         try:
             with unit_of_work(session) as session:
-                watcher = session.query(CaseWatcher).filter(
-                    and_(
-                        CaseWatcher.case_id == case_id,
-                        CaseWatcher.user_id == user_id
+                watcher = (
+                    session.query(CaseWatcher)
+                    .filter(
+                        and_(
+                            CaseWatcher.case_id == case_id,
+                            CaseWatcher.user_id == user_id,
+                        )
                     )
-                ).first()
+                    .first()
+                )
 
                 if not watcher:
                     return False
@@ -279,9 +284,7 @@ class CaseCollaborationService:
             return False
 
     def get_case_watchers(
-        self,
-        case_id: str,
-        session: Optional[Session] = None
+        self, case_id: str, session: Optional[Session] = None
     ) -> List[CaseWatcher]:
         """
         Get all watchers for a case.
@@ -294,6 +297,6 @@ class CaseCollaborationService:
             List of CaseWatcher objects
         """
         with unit_of_work(session) as session:
-            return session.query(CaseWatcher).filter(
-                CaseWatcher.case_id == case_id
-            ).all()
+            return (
+                session.query(CaseWatcher).filter(CaseWatcher.case_id == case_id).all()
+            )

--- a/core/cases/case_evidence_service.py
+++ b/core/cases/case_evidence_service.py
@@ -4,11 +4,12 @@ Case Evidence Service - Evidence and artifact management.
 Handles file storage, chain of custody, and evidence tracking.
 """
 
-import logging
 import hashlib
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
+
 from sqlalchemy.orm import Session
 
 from core.storage.models import CaseEvidence
@@ -19,41 +20,37 @@ logger = logging.getLogger(__name__)
 
 class CaseEvidenceService:
     """Service for managing case evidence."""
-    
+
     def __init__(self, storage_path: str = "./evidence"):
         """
         Initialize the evidence service.
-        
+
         Args:
             storage_path: Path to evidence storage directory
         """
         self.storage_path = Path(storage_path)
         self.storage_path.mkdir(parents=True, exist_ok=True)
-    
+
     def calculate_file_hashes(self, file_path: Path) -> Dict[str, str]:
         """
         Calculate MD5 and SHA256 hashes of a file.
-        
+
         Args:
             file_path: Path to file
-        
+
         Returns:
             Dictionary with md5 and sha256 hashes
         """
         md5_hash = hashlib.md5()
         sha256_hash = hashlib.sha256()
-        
-        with open(file_path, 'rb') as f:
-            for chunk in iter(lambda: f.read(4096), b''):
+
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
                 md5_hash.update(chunk)
                 sha256_hash.update(chunk)
-        
-        return {
-            'md5': md5_hash.hexdigest(),
-            'sha256': sha256_hash.hexdigest()
-        }
-    
-    
+
+        return {"md5": md5_hash.hexdigest(), "sha256": sha256_hash.hexdigest()}
+
     def add_evidence(
         self,
         case_id: str,
@@ -64,11 +61,11 @@ class CaseEvidenceService:
         file_path: Optional[str] = None,
         source: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Optional[CaseEvidence]:
         """
         Add evidence to a case.
-        
+
         Args:
             case_id: Case ID
             evidence_type: Type of evidence
@@ -79,7 +76,7 @@ class CaseEvidenceService:
             source: Evidence source
             tags: Tags
             session: Database session (optional)
-        
+
         Returns:
             Created CaseEvidence or None
         """
@@ -94,17 +91,19 @@ class CaseEvidenceService:
                     full_path = self.storage_path / file_path
                     if full_path.exists():
                         hashes = self.calculate_file_hashes(full_path)
-                        file_hash_md5 = hashes['md5']
-                        file_hash_sha256 = hashes['sha256']
+                        file_hash_md5 = hashes["md5"]
+                        file_hash_sha256 = hashes["sha256"]
                         file_size = full_path.stat().st_size
 
                 # Initialize chain of custody
-                chain_of_custody = [{
-                    'timestamp': datetime.utcnow().isoformat(),
-                    'action': 'collected',
-                    'user': collected_by,
-                    'notes': 'Evidence collected and added to case'
-                }]
+                chain_of_custody = [
+                    {
+                        "timestamp": datetime.utcnow().isoformat(),
+                        "action": "collected",
+                        "user": collected_by,
+                        "notes": "Evidence collected and added to case",
+                    }
+                ]
 
                 evidence = CaseEvidence(
                     case_id=case_id,
@@ -119,7 +118,7 @@ class CaseEvidenceService:
                     collected_by=collected_by,
                     collected_at=datetime.utcnow(),
                     chain_of_custody=chain_of_custody,
-                    tags=tags or []
+                    tags=tags or [],
                 )
 
                 session.add(evidence)
@@ -130,33 +129,35 @@ class CaseEvidenceService:
         except Exception as e:
             logger.error(f"Error adding evidence: {e}")
             return None
-    
+
     def add_chain_of_custody_entry(
         self,
         evidence_id: int,
         action: str,
         user: str,
         notes: Optional[str] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> bool:
         """
         Add an entry to evidence chain of custody.
-        
+
         Args:
             evidence_id: Evidence ID
             action: Action taken (accessed, transferred, analyzed, etc.)
             user: User who performed the action
             notes: Additional notes
             session: Database session (optional)
-        
+
         Returns:
             True if successful
         """
         try:
             with unit_of_work(session) as session:
-                evidence = session.query(CaseEvidence).filter(
-                    CaseEvidence.evidence_id == evidence_id
-                ).first()
+                evidence = (
+                    session.query(CaseEvidence)
+                    .filter(CaseEvidence.evidence_id == evidence_id)
+                    .first()
+                )
 
                 if not evidence:
                     logger.error(f"Evidence {evidence_id} not found")
@@ -164,10 +165,10 @@ class CaseEvidenceService:
 
                 # Add new entry to chain of custody
                 entry = {
-                    'timestamp': datetime.utcnow().isoformat(),
-                    'action': action,
-                    'user': user,
-                    'notes': notes or ''
+                    "timestamp": datetime.utcnow().isoformat(),
+                    "action": action,
+                    "user": user,
+                    "notes": notes or "",
                 }
 
                 chain = evidence.chain_of_custody or []
@@ -183,32 +184,28 @@ class CaseEvidenceService:
         except Exception as e:
             logger.error(f"Error adding chain of custody entry: {e}")
             return False
-    
+
     def get_case_evidence(
         self,
         case_id: str,
         evidence_type: Optional[str] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> List[CaseEvidence]:
         """
         Get all evidence for a case.
-        
+
         Args:
             case_id: Case ID
             evidence_type: Filter by evidence type
             session: Database session (optional)
-        
+
         Returns:
             List of CaseEvidence objects
         """
         with unit_of_work(session) as session:
-            query = session.query(CaseEvidence).filter(
-                CaseEvidence.case_id == case_id
-            )
+            query = session.query(CaseEvidence).filter(CaseEvidence.case_id == case_id)
 
             if evidence_type:
                 query = query.filter(CaseEvidence.evidence_type == evidence_type)
 
             return query.order_by(CaseEvidence.collected_at.desc()).all()
-    
-

--- a/core/cases/case_ioc_service.py
+++ b/core/cases/case_ioc_service.py
@@ -4,12 +4,13 @@ Case IOC Service - Indicator of Compromise management.
 Handles IOC tracking, enrichment, deduplication, and export.
 """
 
-import logging
 import json
+import logging
 from datetime import datetime
 from typing import Dict, List, Optional
-from sqlalchemy.orm import Session
+
 from sqlalchemy import and_
+from sqlalchemy.orm import Session
 
 from core.storage.models import CaseIOC
 from core.storage.unit_of_work import unit_of_work
@@ -19,10 +20,10 @@ logger = logging.getLogger(__name__)
 
 class CaseIOCService:
     """Service for managing case IOCs."""
-    
+
     def __init__(self):
         """Initialize the IOC service."""
-    
+
     def add_ioc(
         self,
         case_id: str,
@@ -35,11 +36,11 @@ class CaseIOCService:
         last_seen: Optional[datetime] = None,
         tags: Optional[List[str]] = None,
         context: Optional[str] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Optional[CaseIOC]:
         """
         Add an IOC to a case.
-        
+
         Args:
             case_id: Case ID
             ioc_type: IOC type (ip, domain, hash, url, email, etc.)
@@ -52,20 +53,24 @@ class CaseIOCService:
             tags: Tags
             context: Additional context
             session: Database session (optional)
-        
+
         Returns:
             Created CaseIOC or None
         """
         try:
             with unit_of_work(session) as session:
                 # Check for existing IOC to avoid duplicates
-                existing = session.query(CaseIOC).filter(
-                    and_(
-                        CaseIOC.case_id == case_id,
-                        CaseIOC.ioc_type == ioc_type,
-                        CaseIOC.value == value
+                existing = (
+                    session.query(CaseIOC)
+                    .filter(
+                        and_(
+                            CaseIOC.case_id == case_id,
+                            CaseIOC.ioc_type == ioc_type,
+                            CaseIOC.value == value,
+                        )
                     )
-                ).first()
+                    .first()
+                )
 
                 if existing:
                     # Update last_seen if provided
@@ -86,7 +91,7 @@ class CaseIOCService:
                     tags=tags or [],
                     context=context,
                     is_active=True,
-                    is_false_positive=False
+                    is_false_positive=False,
                 )
 
                 session.add(ioc)
@@ -97,21 +102,18 @@ class CaseIOCService:
         except Exception as e:
             logger.error(f"Error adding IOC: {e}")
             return None
-    
+
     def bulk_add_iocs(
-        self,
-        case_id: str,
-        iocs: List[Dict],
-        session: Optional[Session] = None
+        self, case_id: str, iocs: List[Dict], session: Optional[Session] = None
     ) -> int:
         """
         Bulk add IOCs to a case.
-        
+
         Args:
             case_id: Case ID
             iocs: List of IOC dictionaries
             session: Database session (optional)
-        
+
         Returns:
             Number of IOCs added
         """
@@ -119,67 +121,60 @@ class CaseIOCService:
         for ioc_data in iocs:
             result = self.add_ioc(
                 case_id=case_id,
-                ioc_type=ioc_data.get('ioc_type', 'unknown'),
-                value=ioc_data.get('value', ''),
-                threat_level=ioc_data.get('threat_level'),
-                confidence=ioc_data.get('confidence'),
-                source=ioc_data.get('source'),
-                first_seen=ioc_data.get('first_seen'),
-                last_seen=ioc_data.get('last_seen'),
-                tags=ioc_data.get('tags'),
-                context=ioc_data.get('context'),
-                session=session
+                ioc_type=ioc_data.get("ioc_type", "unknown"),
+                value=ioc_data.get("value", ""),
+                threat_level=ioc_data.get("threat_level"),
+                confidence=ioc_data.get("confidence"),
+                source=ioc_data.get("source"),
+                first_seen=ioc_data.get("first_seen"),
+                last_seen=ioc_data.get("last_seen"),
+                tags=ioc_data.get("tags"),
+                context=ioc_data.get("context"),
+                session=session,
             )
             if result:
                 count += 1
-        
+
         return count
-    
-    
+
     def get_case_iocs(
         self,
         case_id: str,
         ioc_type: Optional[str] = None,
         active_only: bool = False,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> List[CaseIOC]:
         """
         Get all IOCs for a case.
-        
+
         Args:
             case_id: Case ID
             ioc_type: Filter by IOC type
             active_only: Only return active IOCs
             session: Database session (optional)
-        
+
         Returns:
             List of CaseIOC objects
         """
         with unit_of_work(session) as session:
-            query = session.query(CaseIOC).filter(
-                CaseIOC.case_id == case_id
-            )
+            query = session.query(CaseIOC).filter(CaseIOC.case_id == case_id)
 
             if ioc_type:
                 query = query.filter(CaseIOC.ioc_type == ioc_type)
 
             if active_only:
-                query = query.filter(CaseIOC.is_active == True)
+                query = query.filter(CaseIOC.is_active.is_(True))
 
             return query.order_by(CaseIOC.threat_level.desc()).all()
-    
-    def export_iocs_json(
-        self,
-        case_id: str,
-        session: Optional[Session] = None
-    ) -> str:
+
+    def export_iocs_json(self, case_id: str, session: Optional[Session] = None) -> str:
         """
         Export case IOCs as JSON.
-        
+
         Args:
             case_id: Case ID
             session: Database session (optional)
-        
+
         Returns:
             JSON string
         """
@@ -188,39 +183,41 @@ class CaseIOCService:
 
             ioc_list = []
             for ioc in iocs:
-                ioc_list.append({
-                    'type': ioc.ioc_type,
-                    'value': ioc.value,
-                    'threat_level': ioc.threat_level,
-                    'confidence': ioc.confidence,
-                    'source': ioc.source,
-                    'first_seen': ioc.first_seen.isoformat() if ioc.first_seen else None,
-                    'last_seen': ioc.last_seen.isoformat() if ioc.last_seen else None,
-                    'tags': ioc.tags,
-                    'context': ioc.context
-                })
+                ioc_list.append(
+                    {
+                        "type": ioc.ioc_type,
+                        "value": ioc.value,
+                        "threat_level": ioc.threat_level,
+                        "confidence": ioc.confidence,
+                        "source": ioc.source,
+                        "first_seen": (
+                            ioc.first_seen.isoformat() if ioc.first_seen else None
+                        ),
+                        "last_seen": (
+                            ioc.last_seen.isoformat() if ioc.last_seen else None
+                        ),
+                        "tags": ioc.tags,
+                        "context": ioc.context,
+                    }
+                )
 
             return json.dumps(ioc_list, indent=2)
-    
-    def export_iocs_csv(
-        self,
-        case_id: str,
-        session: Optional[Session] = None
-    ) -> str:
+
+    def export_iocs_csv(self, case_id: str, session: Optional[Session] = None) -> str:
         """
         Export case IOCs as CSV.
-        
+
         Args:
             case_id: Case ID
             session: Database session (optional)
-        
+
         Returns:
             CSV string
         """
         with unit_of_work(session) as session:
             iocs = self.get_case_iocs(case_id, session=session)
 
-            lines = ['type,value,threat_level,confidence,source,first_seen,last_seen']
+            lines = ["type,value,threat_level,confidence,source,first_seen,last_seen"]
             for ioc in iocs:
                 lines.append(
                     f'{ioc.ioc_type},{ioc.value},{ioc.threat_level or ""},'
@@ -229,20 +226,16 @@ class CaseIOCService:
                     f'{ioc.last_seen.isoformat() if ioc.last_seen else ""}'
                 )
 
-            return '\n'.join(lines)
-    
-    def export_iocs_stix(
-        self,
-        case_id: str,
-        session: Optional[Session] = None
-    ) -> Dict:
+            return "\n".join(lines)
+
+    def export_iocs_stix(self, case_id: str, session: Optional[Session] = None) -> Dict:
         """
         Export case IOCs in STIX 2.1 format.
-        
+
         Args:
             case_id: Case ID
             session: Database session (optional)
-        
+
         Returns:
             STIX bundle dictionary
         """
@@ -250,47 +243,46 @@ class CaseIOCService:
             iocs = self.get_case_iocs(case_id, session=session)
 
             # Build STIX bundle
-            bundle = {
-                'type': 'bundle',
-                'id': f'bundle--{case_id}',
-                'objects': []
-            }
+            bundle = {"type": "bundle", "id": f"bundle--{case_id}", "objects": []}
 
             for ioc in iocs:
                 # Map IOC type to STIX type
                 stix_type = self._map_ioc_to_stix_type(ioc.ioc_type)
 
                 stix_obj = {
-                    'type': 'indicator',
-                    'id': f'indicator--{ioc.ioc_id}',
-                    'created': ioc.created_at.isoformat() + 'Z',
-                    'modified': ioc.updated_at.isoformat() + 'Z',
-                    'pattern': f'[{stix_type}:value = \'{ioc.value}\']',
-                    'pattern_type': 'stix',
-                    'valid_from': (ioc.first_seen.isoformat() + 'Z') if ioc.first_seen else datetime.utcnow().isoformat() + 'Z'
+                    "type": "indicator",
+                    "id": f"indicator--{ioc.ioc_id}",
+                    "created": ioc.created_at.isoformat() + "Z",
+                    "modified": ioc.updated_at.isoformat() + "Z",
+                    "pattern": f"[{stix_type}:value = '{ioc.value}']",
+                    "pattern_type": "stix",
+                    "valid_from": (
+                        (ioc.first_seen.isoformat() + "Z")
+                        if ioc.first_seen
+                        else datetime.utcnow().isoformat() + "Z"
+                    ),
                 }
 
                 if ioc.threat_level:
-                    stix_obj['labels'] = [ioc.threat_level]
+                    stix_obj["labels"] = [ioc.threat_level]
 
-                bundle['objects'].append(stix_obj)
+                bundle["objects"].append(stix_obj)
 
             return bundle
-    
+
     def _map_ioc_to_stix_type(self, ioc_type: str) -> str:
         """Map IOC type to STIX observable type."""
         mapping = {
-            'ip': 'ipv4-addr',
-            'ipv4': 'ipv4-addr',
-            'ipv6': 'ipv6-addr',
-            'domain': 'domain-name',
-            'url': 'url',
-            'email': 'email-addr',
-            'hash': 'file',
-            'md5': 'file',
-            'sha1': 'file',
-            'sha256': 'file',
-            'file_name': 'file'
+            "ip": "ipv4-addr",
+            "ipv4": "ipv4-addr",
+            "ipv6": "ipv6-addr",
+            "domain": "domain-name",
+            "url": "url",
+            "email": "email-addr",
+            "hash": "file",
+            "md5": "file",
+            "sha1": "file",
+            "sha256": "file",
+            "file_name": "file",
         }
-        return mapping.get(ioc_type.lower(), 'x-custom-observable')
-
+        return mapping.get(ioc_type.lower(), "x-custom-observable")

--- a/core/cases/case_metrics_router.py
+++ b/core/cases/case_metrics_router.py
@@ -1,12 +1,13 @@
 """Case Metrics API endpoints."""
 
-from typing import Optional
-from fastapi import APIRouter, HTTPException
 from datetime import datetime
+from typing import Optional
 
-from core.storage.schemas import CaseMetricsSchema
+from fastapi import APIRouter, HTTPException
+
 from core.cases.case_metrics_service import CaseMetricsService
 from core.routing import Auth, RouterMeta, UnitOfWorkSession
+from core.storage.schemas import CaseMetricsSchema
 
 router = APIRouter()
 
@@ -20,16 +21,15 @@ metrics_service = CaseMetricsService()
 
 @router.get("/dashboard")
 async def get_dashboard(
-    start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None
+    start_date: Optional[datetime] = None, end_date: Optional[datetime] = None
 ):
     """
     Get dashboard metrics.
-    
+
     Args:
         start_date: Start date filter
         end_date: End date filter
-    
+
     Returns:
         Dashboard metrics
     """
@@ -39,20 +39,20 @@ async def get_dashboard(
 
 @router.get("/sla-compliance")
 async def get_sla_compliance(
-    start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None
+    start_date: Optional[datetime] = None, end_date: Optional[datetime] = None
 ):
     """
     Get SLA compliance report.
-    
+
     Args:
         start_date: Start date filter
         end_date: End date filter
-    
+
     Returns:
         SLA compliance statistics
     """
     from core.cases.case_sla_service import CaseSLAService
+
     sla_service = CaseSLAService()
     report = sla_service.get_sla_compliance_report(start_date, end_date)
     return report
@@ -62,22 +62,20 @@ async def get_sla_compliance(
 async def get_analyst_performance(
     analyst_id: str,
     start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None,
 ):
     """
     Get analyst performance metrics.
-    
+
     Args:
         analyst_id: Analyst user ID
         start_date: Start date filter
         end_date: End date filter
-    
+
     Returns:
         Analyst performance metrics
     """
-    metrics = metrics_service.get_analyst_performance(
-        analyst_id, start_date, end_date
-    )
+    metrics = metrics_service.get_analyst_performance(analyst_id, start_date, end_date)
     return metrics
 
 
@@ -86,25 +84,24 @@ async def get_mttr(
     session: UnitOfWorkSession,
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
-    priority: Optional[str] = None
+    priority: Optional[str] = None,
 ):
     """
     Get Mean Time To Resolve metrics.
-    
+
     Args:
         start_date: Start date filter
         end_date: End date filter
         priority: Filter by priority
-    
+
     Returns:
         MTTR metrics by priority and trend data
     """
-    from core.storage.models import Case, CaseMetrics
     from collections import defaultdict
-    
-    query = session.query(Case).filter(
-        Case.status.in_(["resolved", "closed"])
-    )
+
+    from core.storage.models import Case, CaseMetrics
+
+    query = session.query(Case).filter(Case.status.in_(["resolved", "closed"]))
 
     if start_date:
         query = query.filter(Case.created_at >= start_date)
@@ -121,9 +118,11 @@ async def get_mttr(
     mttr_by_date = defaultdict(lambda: {"mttd": [], "mttr": []})
 
     for case in cases:
-        metrics = session.query(CaseMetrics).filter(
-            CaseMetrics.case_id == case.case_id
-        ).first()
+        metrics = (
+            session.query(CaseMetrics)
+            .filter(CaseMetrics.case_id == case.case_id)
+            .first()
+        )
 
         if metrics and metrics.time_to_resolve:
             mttr_overall.append(metrics.time_to_resolve)
@@ -135,11 +134,15 @@ async def get_mttr(
 
             # By date (for trends)
             date_key = case.created_at.strftime("%Y-%m-%d")
-            mttr_by_date[date_key]["mttr"].append(metrics.time_to_resolve / 3600)  # hours
+            mttr_by_date[date_key]["mttr"].append(
+                metrics.time_to_resolve / 3600
+            )  # hours
 
             # Also add MTTD for trend comparison
             if metrics.time_to_respond:
-                mttr_by_date[date_key]["mttd"].append(metrics.time_to_respond / 3600)  # hours
+                mttr_by_date[date_key]["mttd"].append(
+                    metrics.time_to_respond / 3600
+                )  # hours
 
     # Calculate averages
     avg_mttr = sum(mttr_overall) / len(mttr_overall) if mttr_overall else 0
@@ -154,18 +157,20 @@ async def get_mttr(
     # Prepare trend data
     trend_data = []
     for date, times in sorted(mttr_by_date.items()):
-        trend_data.append({
-            "date": date,
-            "mttd": sum(times["mttd"]) / len(times["mttd"]) if times["mttd"] else 0,
-            "mttr": sum(times["mttr"]) / len(times["mttr"]) if times["mttr"] else 0
-        })
+        trend_data.append(
+            {
+                "date": date,
+                "mttd": sum(times["mttd"]) / len(times["mttd"]) if times["mttd"] else 0,
+                "mttr": sum(times["mttr"]) / len(times["mttr"]) if times["mttr"] else 0,
+            }
+        )
 
     return {
         "average_mttr_seconds": avg_mttr,
         "average_mttr_hours": avg_mttr_hours,
         "mttr_by_priority": avg_by_priority_hours,
         "trend_data": trend_data,
-        "total_cases": len(cases)
+        "total_cases": len(cases),
     }
 
 
@@ -173,10 +178,10 @@ async def get_mttr(
 async def get_velocity(days: int = 30):
     """
     Get case velocity (opened vs closed).
-    
+
     Args:
         days: Number of days to analyze
-    
+
     Returns:
         Velocity data
     """
@@ -188,10 +193,10 @@ async def get_velocity(days: int = 30):
 async def calculate_case_metrics(case_id: str):
     """
     Calculate/update metrics for a case.
-    
+
     Args:
         case_id: Case ID
-    
+
     Returns:
         Calculated metrics
     """
@@ -205,11 +210,12 @@ async def calculate_case_metrics(case_id: str):
 async def get_breached_cases():
     """
     Get all cases with SLA breaches.
-    
+
     Returns:
         List of breached cases
     """
     from core.cases.case_sla_service import CaseSLAService
+
     sla_service = CaseSLAService()
     breached = sla_service.get_breached_cases()
     return {"breached_cases": breached}
@@ -217,16 +223,15 @@ async def get_breached_cases():
 
 @router.get("/summary")
 async def get_summary(
-    start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None
+    start_date: Optional[datetime] = None, end_date: Optional[datetime] = None
 ):
     """
     Get summary metrics for cases.
-    
+
     Args:
         start_date: Start date filter
         end_date: End date filter
-    
+
     Returns:
         Summary metrics including total cases, open cases, etc.
     """
@@ -246,21 +251,21 @@ async def get_mttd(
     session: UnitOfWorkSession,
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
-    priority: Optional[str] = None
+    priority: Optional[str] = None,
 ):
     """
     Get Mean Time To Detect metrics.
-    
+
     Args:
         start_date: Start date filter
         end_date: End date filter
         priority: Filter by priority
-    
+
     Returns:
         MTTD metrics by priority
     """
     from core.storage.models import Case, CaseMetrics
-    
+
     query = session.query(Case)
 
     if start_date:
@@ -277,9 +282,11 @@ async def get_mttd(
     mttd_overall = []
 
     for case in cases:
-        metrics = session.query(CaseMetrics).filter(
-            CaseMetrics.case_id == case.case_id
-        ).first()
+        metrics = (
+            session.query(CaseMetrics)
+            .filter(CaseMetrics.case_id == case.case_id)
+            .first()
+        )
 
         if metrics and metrics.time_to_respond:
             mttd_overall.append(metrics.time_to_respond)
@@ -302,7 +309,7 @@ async def get_mttd(
         "average_mttd_seconds": avg_mttd,
         "average_mttd_hours": avg_mttd_hours,
         "mttd_by_priority": avg_by_priority_hours,
-        "total_cases": len(cases)
+        "total_cases": len(cases),
     }
 
 
@@ -310,20 +317,20 @@ async def get_mttd(
 async def get_by_priority(
     session: UnitOfWorkSession,
     start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None,
 ):
     """
     Get case counts by priority.
-    
+
     Args:
         start_date: Start date filter
         end_date: End date filter
-    
+
     Returns:
         Case counts broken down by priority
     """
     from core.storage.models import Case
-    
+
     query = session.query(Case)
 
     if start_date:
@@ -342,7 +349,7 @@ async def get_by_priority(
             priority_data[priority] = {
                 "priority": priority,
                 "count": 0,
-                "closed_count": 0
+                "closed_count": 0,
             }
 
         priority_data[priority]["count"] += 1
@@ -352,8 +359,7 @@ async def get_by_priority(
     # Sort by priority order
     priority_order = {"critical": 0, "high": 1, "medium": 2, "low": 3, "unknown": 4}
     priority_breakdown = sorted(
-        priority_data.values(),
-        key=lambda x: priority_order.get(x["priority"], 99)
+        priority_data.values(), key=lambda x: priority_order.get(x["priority"], 99)
     )
 
     return {"priority_breakdown": priority_breakdown}
@@ -363,20 +369,20 @@ async def get_by_priority(
 async def get_by_status(
     session: UnitOfWorkSession,
     start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None,
 ):
     """
     Get case counts by status.
-    
+
     Args:
         start_date: Start date filter
         end_date: End date filter
-    
+
     Returns:
         Case counts broken down by status
     """
     from core.storage.models import Case
-    
+
     query = session.query(Case)
 
     if start_date:
@@ -392,10 +398,7 @@ async def get_by_status(
         status = case.status or "unknown"
 
         if status not in status_data:
-            status_data[status] = {
-                "status": status,
-                "count": 0
-            }
+            status_data[status] = {"status": status, "count": 0}
 
         status_data[status]["count"] += 1
 
@@ -408,20 +411,20 @@ async def get_by_status(
 async def get_all_analyst_performance(
     session: UnitOfWorkSession,
     start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None,
 ):
     """
     Get performance metrics for all analysts.
-    
+
     Args:
         start_date: Start date filter
         end_date: End date filter
-    
+
     Returns:
         Performance metrics for all analysts
     """
     from core.storage.models import Case, CaseMetrics
-    
+
     query = session.query(Case)
 
     if start_date:
@@ -443,7 +446,7 @@ async def get_all_analyst_performance(
                 "cases_assigned": 0,
                 "cases_resolved": 0,
                 "avg_resolution_time": 0,
-                "resolution_times": []
+                "resolution_times": [],
             }
 
         analyst_data[assignee]["cases_assigned"] += 1
@@ -452,9 +455,11 @@ async def get_all_analyst_performance(
             analyst_data[assignee]["cases_resolved"] += 1
 
             # Get resolution time
-            metrics = session.query(CaseMetrics).filter(
-                CaseMetrics.case_id == case.case_id
-            ).first()
+            metrics = (
+                session.query(CaseMetrics)
+                .filter(CaseMetrics.case_id == case.case_id)
+                .first()
+            )
 
             if metrics and metrics.time_to_resolve:
                 analyst_data[assignee]["resolution_times"].append(
@@ -465,7 +470,9 @@ async def get_all_analyst_performance(
     analyst_performance = []
     for analyst_id, data in analyst_data.items():
         if data["resolution_times"]:
-            data["avg_resolution_time"] = sum(data["resolution_times"]) / len(data["resolution_times"])
+            data["avg_resolution_time"] = sum(data["resolution_times"]) / len(
+                data["resolution_times"]
+            )
         else:
             data["avg_resolution_time"] = 0
 
@@ -478,4 +485,3 @@ async def get_all_analyst_performance(
     analyst_performance.sort(key=lambda x: x["cases_assigned"], reverse=True)
 
     return {"analyst_performance": analyst_performance}
-

--- a/core/cases/case_metrics_service.py
+++ b/core/cases/case_metrics_service.py
@@ -7,8 +7,9 @@ Handles MTTD, MTTR, MTTA, SLA compliance, and analyst performance metrics.
 import logging
 from datetime import datetime, timedelta
 from typing import Dict, Optional
-from sqlalchemy.orm import Session
+
 from sqlalchemy import and_
+from sqlalchemy.orm import Session
 
 from core.storage.models import Case, CaseMetrics, CaseSLA, CaseTask
 from core.storage.unit_of_work import unit_of_work
@@ -18,22 +19,20 @@ logger = logging.getLogger(__name__)
 
 class CaseMetricsService:
     """Service for calculating and managing case metrics."""
-    
+
     def __init__(self):
         """Initialize the metrics service."""
-    
+
     def calculate_case_metrics(
-        self,
-        case_id: str,
-        session: Optional[Session] = None
+        self, case_id: str, session: Optional[Session] = None
     ) -> Optional[CaseMetrics]:
         """
         Calculate or update metrics for a case.
-        
+
         Args:
             case_id: Case ID
             session: Database session (optional)
-        
+
         Returns:
             CaseMetrics object or None
         """
@@ -44,9 +43,11 @@ class CaseMetricsService:
                     return None
 
                 # Get or create metrics record
-                metrics = session.query(CaseMetrics).filter(
-                    CaseMetrics.case_id == case_id
-                ).first()
+                metrics = (
+                    session.query(CaseMetrics)
+                    .filter(CaseMetrics.case_id == case_id)
+                    .first()
+                )
 
                 if not metrics:
                     metrics = CaseMetrics(case_id=case_id)
@@ -58,18 +59,18 @@ class CaseMetricsService:
                 # Time to respond (first activity/comment)
                 if case.activities and len(case.activities) > 0:
                     first_activity = min(
-                        activity.get('timestamp', case_created.isoformat())
+                        activity.get("timestamp", case_created.isoformat())
                         for activity in case.activities
                     )
                     first_activity_dt = datetime.fromisoformat(
-                        first_activity.replace('Z', '+00:00')
+                        first_activity.replace("Z", "+00:00")
                     )
                     metrics.time_to_respond = int(
                         (first_activity_dt - case_created).total_seconds()
                     )
 
                 # Time to resolve (case closed/resolved)
-                if case.status in ['resolved', 'closed']:
+                if case.status in ["resolved", "closed"]:
                     if case.updated_at:
                         metrics.time_to_resolve = int(
                             (case.updated_at - case_created).total_seconds()
@@ -78,35 +79,37 @@ class CaseMetricsService:
                 # Count activities
                 from core.storage.models import CaseComment, CaseEvidence, CaseIOC
 
-                metrics.comment_count = session.query(CaseComment).filter(
-                    CaseComment.case_id == case_id
-                ).count()
+                metrics.comment_count = (
+                    session.query(CaseComment)
+                    .filter(CaseComment.case_id == case_id)
+                    .count()
+                )
 
-                metrics.evidence_count = session.query(CaseEvidence).filter(
-                    CaseEvidence.case_id == case_id
-                ).count()
+                metrics.evidence_count = (
+                    session.query(CaseEvidence)
+                    .filter(CaseEvidence.case_id == case_id)
+                    .count()
+                )
 
-                metrics.ioc_count = session.query(CaseIOC).filter(
-                    CaseIOC.case_id == case_id
-                ).count()
+                metrics.ioc_count = (
+                    session.query(CaseIOC).filter(CaseIOC.case_id == case_id).count()
+                )
 
-                metrics.task_count = session.query(CaseTask).filter(
-                    CaseTask.case_id == case_id
-                ).count()
+                metrics.task_count = (
+                    session.query(CaseTask).filter(CaseTask.case_id == case_id).count()
+                )
 
                 # Calculate total work hours from tasks
-                tasks = session.query(CaseTask).filter(
-                    CaseTask.case_id == case_id
-                ).all()
-                total_hours = sum(
-                    task.actual_hours or 0 for task in tasks
+                tasks = (
+                    session.query(CaseTask).filter(CaseTask.case_id == case_id).all()
                 )
+                total_hours = sum(task.actual_hours or 0 for task in tasks)
                 metrics.total_work_hours = total_hours if total_hours > 0 else None
 
                 # Get SLA compliance
-                case_sla = session.query(CaseSLA).filter(
-                    CaseSLA.case_id == case_id
-                ).first()
+                case_sla = (
+                    session.query(CaseSLA).filter(CaseSLA.case_id == case_id).first()
+                )
 
                 if case_sla:
                     metrics.response_sla_met = case_sla.response_sla_met
@@ -114,12 +117,12 @@ class CaseMetricsService:
 
                     # Overall SLA met if both are met (or not applicable)
                     response_ok = (
-                        case_sla.response_sla_met == True or
-                        case_sla.response_completed_at is None
+                        case_sla.response_sla_met
+                        or case_sla.response_completed_at is None
                     )
                     resolution_ok = (
-                        case_sla.resolution_sla_met == True or
-                        case_sla.resolution_completed_at is None
+                        case_sla.resolution_sla_met
+                        or case_sla.resolution_completed_at is None
                     )
                     metrics.sla_met = response_ok and resolution_ok
 
@@ -129,21 +132,21 @@ class CaseMetricsService:
         except Exception as e:
             logger.error(f"Error calculating case metrics: {e}")
             return None
-    
+
     def get_dashboard_metrics(
         self,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Dict:
         """
         Get dashboard metrics for cases.
-        
+
         Args:
             start_date: Start date filter
             end_date: End date filter
             session: Database session (optional)
-        
+
         Returns:
             Dictionary with dashboard metrics
         """
@@ -171,15 +174,19 @@ class CaseMetricsService:
                 priority_counts[priority] = priority_counts.get(priority, 0) + 1
 
             # Calculate average resolution time
-            resolved_cases = [c for c in all_cases if c.status in ['resolved', 'closed']]
+            resolved_cases = [
+                c for c in all_cases if c.status in ["resolved", "closed"]
+            ]
             avg_resolution_time = None
             if resolved_cases:
                 total_time = 0
                 count = 0
                 for case in resolved_cases:
-                    metrics = session.query(CaseMetrics).filter(
-                        CaseMetrics.case_id == case.case_id
-                    ).first()
+                    metrics = (
+                        session.query(CaseMetrics)
+                        .filter(CaseMetrics.case_id == case.case_id)
+                        .first()
+                    )
                     if metrics and metrics.time_to_resolve:
                         total_time += metrics.time_to_resolve
                         count += 1
@@ -189,20 +196,21 @@ class CaseMetricsService:
 
             # SLA compliance
             total_with_sla = session.query(CaseSLA).count()
-            sla_met_count = session.query(CaseSLA).filter(
-                CaseSLA.resolution_sla_met == True
-            ).count()
+            sla_met_count = (
+                session.query(CaseSLA)
+                .filter(CaseSLA.resolution_sla_met.is_(True))
+                .count()
+            )
 
             sla_compliance_rate = (
-                (sla_met_count / total_with_sla * 100)
-                if total_with_sla > 0 else 0.0
+                (sla_met_count / total_with_sla * 100) if total_with_sla > 0 else 0.0
             )
 
             # Cases opened per day (last 30 days)
             thirty_days_ago = datetime.utcnow() - timedelta(days=30)
-            recent_cases = session.query(Case).filter(
-                Case.created_at >= thirty_days_ago
-            ).all()
+            recent_cases = (
+                session.query(Case).filter(Case.created_at >= thirty_days_ago).all()
+            )
 
             cases_per_day = {}
             for case in recent_cases:
@@ -210,32 +218,38 @@ class CaseMetricsService:
                 cases_per_day[day] = cases_per_day.get(day, 0) + 1
 
             return {
-                'total_cases': len(all_cases),
-                'status_breakdown': status_counts,
-                'priority_breakdown': priority_counts,
-                'average_resolution_time_seconds': avg_resolution_time,
-                'sla_compliance_rate': sla_compliance_rate,
-                'cases_per_day': cases_per_day,
-                'resolved_cases_count': len(resolved_cases),
-                'open_cases_count': len([c for c in all_cases if c.status in ['open', 'in-progress', 'investigating']])
+                "total_cases": len(all_cases),
+                "status_breakdown": status_counts,
+                "priority_breakdown": priority_counts,
+                "average_resolution_time_seconds": avg_resolution_time,
+                "sla_compliance_rate": sla_compliance_rate,
+                "cases_per_day": cases_per_day,
+                "resolved_cases_count": len(resolved_cases),
+                "open_cases_count": len(
+                    [
+                        c
+                        for c in all_cases
+                        if c.status in ["open", "in-progress", "investigating"]
+                    ]
+                ),
             }
-    
+
     def get_analyst_performance(
         self,
         analyst_id: str,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Dict:
         """
         Get performance metrics for an analyst.
-        
+
         Args:
             analyst_id: Analyst user ID
             start_date: Start date filter
             end_date: End date filter
             session: Database session (optional)
-        
+
         Returns:
             Dictionary with analyst performance metrics
         """
@@ -252,8 +266,16 @@ class CaseMetricsService:
 
             # Calculate metrics
             total_cases = len(cases)
-            resolved_cases = len([c for c in cases if c.status in ['resolved', 'closed']])
-            open_cases = len([c for c in cases if c.status in ['open', 'in-progress', 'investigating']])
+            resolved_cases = len(
+                [c for c in cases if c.status in ["resolved", "closed"]]
+            )
+            open_cases = len(
+                [
+                    c
+                    for c in cases
+                    if c.status in ["open", "in-progress", "investigating"]
+                ]
+            )
 
             # Average resolution time
             avg_resolution_time = None
@@ -261,10 +283,12 @@ class CaseMetricsService:
                 total_time = 0
                 count = 0
                 for case in cases:
-                    if case.status in ['resolved', 'closed']:
-                        metrics = session.query(CaseMetrics).filter(
-                            CaseMetrics.case_id == case.case_id
-                        ).first()
+                    if case.status in ["resolved", "closed"]:
+                        metrics = (
+                            session.query(CaseMetrics)
+                            .filter(CaseMetrics.case_id == case.case_id)
+                            .first()
+                        )
                         if metrics and metrics.time_to_resolve:
                             total_time += metrics.time_to_resolve
                             count += 1
@@ -275,41 +299,43 @@ class CaseMetricsService:
             # SLA compliance
             analyst_slas = []
             for case in cases:
-                case_sla = session.query(CaseSLA).filter(
-                    CaseSLA.case_id == case.case_id
-                ).first()
+                case_sla = (
+                    session.query(CaseSLA)
+                    .filter(CaseSLA.case_id == case.case_id)
+                    .first()
+                )
                 if case_sla:
                     analyst_slas.append(case_sla)
 
-            sla_met_count = len([s for s in analyst_slas if s.resolution_sla_met == True])
+            sla_met_count = len([s for s in analyst_slas if s.resolution_sla_met])
             sla_compliance = (
                 (sla_met_count / len(analyst_slas) * 100)
-                if len(analyst_slas) > 0 else 0.0
+                if len(analyst_slas) > 0
+                else 0.0
             )
 
             return {
-                'analyst_id': analyst_id,
-                'total_cases': total_cases,
-                'resolved_cases': resolved_cases,
-                'open_cases': open_cases,
-                'resolution_rate': (resolved_cases / total_cases * 100) if total_cases > 0 else 0.0,
-                'average_resolution_time_seconds': avg_resolution_time,
-                'sla_compliance_rate': sla_compliance
+                "analyst_id": analyst_id,
+                "total_cases": total_cases,
+                "resolved_cases": resolved_cases,
+                "open_cases": open_cases,
+                "resolution_rate": (
+                    (resolved_cases / total_cases * 100) if total_cases > 0 else 0.0
+                ),
+                "average_resolution_time_seconds": avg_resolution_time,
+                "sla_compliance_rate": sla_compliance,
             }
-    
-    
+
     def get_case_velocity(
-        self,
-        days: int = 30,
-        session: Optional[Session] = None
+        self, days: int = 30, session: Optional[Session] = None
     ) -> Dict:
         """
         Get case velocity (cases opened vs closed over time).
-        
+
         Args:
             days: Number of days to analyze
             session: Database session (optional)
-        
+
         Returns:
             Dictionary with velocity data
         """
@@ -317,17 +343,21 @@ class CaseMetricsService:
             start_date = datetime.utcnow() - timedelta(days=days)
 
             # Cases opened
-            opened_cases = session.query(Case).filter(
-                Case.created_at >= start_date
-            ).all()
+            opened_cases = (
+                session.query(Case).filter(Case.created_at >= start_date).all()
+            )
 
             # Cases closed
-            closed_cases = session.query(Case).filter(
-                and_(
-                    Case.updated_at >= start_date,
-                    Case.status.in_(['resolved', 'closed'])
+            closed_cases = (
+                session.query(Case)
+                .filter(
+                    and_(
+                        Case.updated_at >= start_date,
+                        Case.status.in_(["resolved", "closed"]),
+                    )
                 )
-            ).all()
+                .all()
+            )
 
             # Group by day
             opened_by_day = {}
@@ -347,15 +377,14 @@ class CaseMetricsService:
                 opened = opened_by_day.get(day, 0)
                 closed = closed_by_day.get(day, 0)
                 velocity[day] = {
-                    'opened': opened,
-                    'closed': closed,
-                    'net': opened - closed
+                    "opened": opened,
+                    "closed": closed,
+                    "net": opened - closed,
                 }
 
             return {
-                'period_days': days,
-                'total_opened': len(opened_cases),
-                'total_closed': len(closed_cases),
-                'velocity_by_day': velocity
+                "period_days": days,
+                "total_opened": len(opened_cases),
+                "total_closed": len(closed_cases),
+                "velocity_by_day": velocity,
             }
-

--- a/core/cases/case_notification_service.py
+++ b/core/cases/case_notification_service.py
@@ -7,9 +7,10 @@ Handles notifications for case events via UI, email, Slack, Teams, and PagerDuty
 import logging
 import re
 from typing import Dict, List, Optional
+
 from sqlalchemy.orm import Session
 
-from core.storage.models import CaseNotification, CaseWatcher, Case
+from core.storage.models import Case, CaseNotification, CaseWatcher
 from core.storage.unit_of_work import unit_of_work
 
 logger = logging.getLogger(__name__)
@@ -17,10 +18,10 @@ logger = logging.getLogger(__name__)
 
 class CaseNotificationService:
     """Service for managing case notifications."""
-    
+
     def __init__(self):
         """Initialize the notification service."""
-    
+
     def create_notification(
         self,
         user_id: str,
@@ -28,14 +29,14 @@ class CaseNotificationService:
         title: str,
         message: str,
         case_id: Optional[str] = None,
-        delivery_channel: str = 'ui',
-        priority: str = 'normal',
+        delivery_channel: str = "ui",
+        priority: str = "normal",
         metadata: Optional[Dict] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Optional[CaseNotification]:
         """
         Create a notification for a user.
-        
+
         Args:
             user_id: User ID to notify
             notification_type: Type of notification
@@ -46,7 +47,7 @@ class CaseNotificationService:
             priority: Priority (low, normal, high, urgent)
             metadata: Additional metadata
             session: Database session (optional)
-        
+
         Returns:
             Created CaseNotification or None
         """
@@ -62,39 +63,36 @@ class CaseNotificationService:
                     priority=priority,
                     metadata=metadata or {},
                     is_read=False,
-                    is_sent=False
+                    is_sent=False,
                 )
 
                 session.add(notification)
 
-                logger.info(
-                    f"Created notification for {user_id}: {notification_type}"
-                )
+                logger.info(f"Created notification for {user_id}: {notification_type}")
                 return notification
 
         except Exception as e:
             logger.error(f"Error creating notification: {e}")
             return None
-    
-    
+
     def notify_comment_mention(
         self,
         case_id: str,
         mentioned_user: str,
         comment_author: str,
         comment_content: str,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> bool:
         """
         Notify user about being mentioned in a comment.
-        
+
         Args:
             case_id: Case ID
             mentioned_user: User who was mentioned
             comment_author: Author of the comment
             comment_content: Comment content
             session: Database session (optional)
-        
+
         Returns:
             True if successful
         """
@@ -105,43 +103,44 @@ class CaseNotificationService:
 
             # Truncate comment for notification
             truncated_comment = (
-                comment_content[:100] + '...'
-                if len(comment_content) > 100 else comment_content
+                comment_content[:100] + "..."
+                if len(comment_content) > 100
+                else comment_content
             )
 
             self.create_notification(
                 user_id=mentioned_user,
-                notification_type='comment_mention',
-                title='Mentioned in Comment',
+                notification_type="comment_mention",
+                title="Mentioned in Comment",
                 message=f'{comment_author} mentioned you in case "{case.title}": {truncated_comment}',
                 case_id=case_id,
-                delivery_channel='ui',
-                priority='normal',
+                delivery_channel="ui",
+                priority="normal",
                 metadata={
-                    'comment_author': comment_author,
-                    'comment_content': comment_content
+                    "comment_author": comment_author,
+                    "comment_content": comment_content,
                 },
-                session=session
+                session=session,
             )
 
             return True
-    
+
     def notify_sla_warning(
         self,
         case_id: str,
         threshold_percent: int,
         sla_type: str,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> bool:
         """
         Notify about approaching SLA deadline.
-        
+
         Args:
             case_id: Case ID
             threshold_percent: Percentage of SLA elapsed
             sla_type: Type of SLA (response or resolution)
             session: Database session (optional)
-        
+
         Returns:
             True if successful
         """
@@ -152,52 +151,52 @@ class CaseNotificationService:
 
             # Notify assignee if assigned
             if case.assignee:
-                urgency = 'urgent' if threshold_percent >= 90 else 'high'
+                urgency = "urgent" if threshold_percent >= 90 else "high"
 
                 self.create_notification(
                     user_id=case.assignee,
-                    notification_type='sla_warning',
-                    title=f'SLA Warning: {threshold_percent}% Elapsed',
+                    notification_type="sla_warning",
+                    title=f"SLA Warning: {threshold_percent}% Elapsed",
                     message=(
                         f'Case "{case.title}" has reached {threshold_percent}% '
-                        f'of its {sla_type} SLA deadline'
+                        f"of its {sla_type} SLA deadline"
                     ),
                     case_id=case_id,
-                    delivery_channel='ui',
+                    delivery_channel="ui",
                     priority=urgency,
                     metadata={
-                        'threshold_percent': threshold_percent,
-                        'sla_type': sla_type
+                        "threshold_percent": threshold_percent,
+                        "sla_type": sla_type,
                     },
-                    session=session
+                    session=session,
                 )
 
             # Also notify watchers
             self.notify_watchers(
                 case_id=case_id,
-                notification_type='sla_warning',
-                title=f'SLA Warning: {threshold_percent}%',
+                notification_type="sla_warning",
+                title=f"SLA Warning: {threshold_percent}%",
                 message=(
                     f'Case "{case.title}" has reached {threshold_percent}% '
-                    f'of its {sla_type} SLA deadline'
+                    f"of its {sla_type} SLA deadline"
                 ),
-                session=session
+                session=session,
             )
 
             return True
-    
+
     def notify_watchers(
         self,
         case_id: str,
         notification_type: str,
         title: str,
         message: str,
-        priority: str = 'normal',
-        session: Optional[Session] = None
+        priority: str = "normal",
+        session: Optional[Session] = None,
     ) -> int:
         """
         Notify all watchers of a case.
-        
+
         Args:
             case_id: Case ID
             notification_type: Type of notification
@@ -205,14 +204,14 @@ class CaseNotificationService:
             message: Notification message
             priority: Priority level
             session: Database session (optional)
-        
+
         Returns:
             Number of notifications created
         """
         with unit_of_work(session) as session:
-            watchers = session.query(CaseWatcher).filter(
-                CaseWatcher.case_id == case_id
-            ).all()
+            watchers = (
+                session.query(CaseWatcher).filter(CaseWatcher.case_id == case_id).all()
+            )
 
             count = 0
             for watcher in watchers:
@@ -225,27 +224,25 @@ class CaseNotificationService:
                         title=title,
                         message=message,
                         case_id=case_id,
-                        delivery_channel='ui',
+                        delivery_channel="ui",
                         priority=priority,
-                        session=session
+                        session=session,
                     )
                     count += 1
 
             return count
-    
+
     def extract_mentions(self, text: str) -> List[str]:
         """
         Extract @mentions from text.
-        
+
         Args:
             text: Text to parse
-        
+
         Returns:
             List of mentioned usernames
         """
         # Pattern: @username (alphanumeric, underscore, hyphen, period)
-        pattern = r'@([\w.-]+)'
+        pattern = r"@([\w.-]+)"
         mentions = re.findall(pattern, text)
         return list(set(mentions))  # Remove duplicates
-    
-

--- a/core/cases/case_search_router.py
+++ b/core/cases/case_search_router.py
@@ -1,9 +1,10 @@
 """Advanced Case Search API endpoints."""
 
+from datetime import datetime
 from typing import List, Optional
+
 from fastapi import APIRouter
 from pydantic import BaseModel
-from datetime import datetime
 
 from core.cases.case_search_service import CaseSearchService
 from core.routing import Auth, RouterMeta
@@ -20,6 +21,7 @@ search_service = CaseSearchService()
 
 class AdvancedSearch(BaseModel):
     """Advanced search request."""
+
     query_text: Optional[str] = None
     status: Optional[List[str]] = None
     priority: Optional[List[str]] = None
@@ -39,10 +41,10 @@ class AdvancedSearch(BaseModel):
 async def advanced_search(data: AdvancedSearch):
     """
     Perform advanced case search.
-    
+
     Args:
         data: Search parameters
-    
+
     Returns:
         Search results with pagination
     """
@@ -59,7 +61,7 @@ async def advanced_search(data: AdvancedSearch):
         updated_before=data.updated_before,
         has_sla_breach=data.has_sla_breach,
         limit=data.limit,
-        offset=data.offset
+        offset=data.offset,
     )
     return results
 
@@ -69,17 +71,17 @@ async def full_text_search(
     query: str,
     search_comments: bool = True,
     search_evidence: bool = True,
-    limit: int = 50
+    limit: int = 50,
 ):
     """
     Full-text search across cases and related entities.
-    
+
     Args:
         query: Search query
         search_comments: Include comments
         search_evidence: Include evidence
         limit: Maximum results
-    
+
     Returns:
         Search results grouped by type
     """
@@ -93,11 +95,11 @@ async def full_text_search(
 async def search_by_ioc(ioc_value: str, ioc_type: Optional[str] = None):
     """
     Find cases containing a specific IOC.
-    
+
     Args:
         ioc_value: IOC value to search
         ioc_type: Optional IOC type filter
-    
+
     Returns:
         Cases containing the IOC
     """
@@ -109,14 +111,13 @@ async def search_by_ioc(ioc_value: str, ioc_type: Optional[str] = None):
 async def get_related_cases(case_id: str, max_results: int = 10):
     """
     Find cases related to a given case.
-    
+
     Args:
         case_id: Case ID
         max_results: Maximum results to return
-    
+
     Returns:
         Related cases with similarity scores
     """
     related = search_service.get_related_cases(case_id, max_results)
     return {"related_cases": related}
-

--- a/core/cases/case_search_service.py
+++ b/core/cases/case_search_service.py
@@ -7,12 +7,13 @@ Handles full-text search, complex queries, and saved searches.
 import logging
 from datetime import datetime
 from typing import Dict, List, Optional
-from sqlalchemy.orm import Session
-from sqlalchemy import and_, or_
 
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import Session
+
+from core.storage.case_repository import CaseRepository
 from core.storage.models import Case, CaseComment, CaseEvidence, CaseIOC
 from core.storage.schemas import CaseSchema
-from core.storage.case_repository import CaseRepository
 from core.storage.unit_of_work import unit_of_work
 
 logger = logging.getLogger(__name__)
@@ -20,10 +21,10 @@ logger = logging.getLogger(__name__)
 
 class CaseSearchService:
     """Service for searching cases."""
-    
+
     def __init__(self):
         """Initialize the search service."""
-    
+
     def search_cases(
         self,
         query_text: Optional[str] = None,
@@ -39,11 +40,11 @@ class CaseSearchService:
         has_sla_breach: Optional[bool] = None,
         limit: int = 100,
         offset: int = 0,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Dict:
         """
         Search cases with advanced filters.
-        
+
         Args:
             query_text: Full-text search query
             status: List of statuses to filter by
@@ -59,7 +60,7 @@ class CaseSearchService:
             limit: Maximum results to return
             offset: Results offset for pagination
             session: Database session (optional)
-        
+
         Returns:
             Dictionary with results and metadata
         """
@@ -81,120 +82,127 @@ class CaseSearchService:
             )
 
             return {
-                'results': CaseSchema.dump_many(cases),
-                'total': total_count,
-                'limit': limit,
-                'offset': offset,
-                'has_more': (offset + len(cases)) < total_count
+                "results": CaseSchema.dump_many(cases),
+                "total": total_count,
+                "limit": limit,
+                "offset": offset,
+                "has_more": (offset + len(cases)) < total_count,
             }
-    
+
     def search_full_text(
         self,
         query_text: str,
         search_comments: bool = True,
         search_evidence: bool = True,
         limit: int = 50,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Dict:
         """
         Perform full-text search across cases and related entities.
-        
+
         Args:
             query_text: Search query
             search_comments: Include comments in search
             search_evidence: Include evidence in search
             limit: Maximum results
             session: Database session (optional)
-        
+
         Returns:
             Dictionary with search results
         """
         with unit_of_work(session) as session:
             search_pattern = f"%{query_text}%"
-            results = {
-                'cases': [],
-                'comments': [],
-                'evidence': []
-            }
+            results = {"cases": [], "comments": [], "evidence": []}
 
             # Search cases
-            cases = session.query(Case).filter(
-                or_(
-                    Case.title.ilike(search_pattern),
-                    Case.description.ilike(search_pattern)
+            cases = (
+                session.query(Case)
+                .filter(
+                    or_(
+                        Case.title.ilike(search_pattern),
+                        Case.description.ilike(search_pattern),
+                    )
                 )
-            ).limit(limit).all()
+                .limit(limit)
+                .all()
+            )
 
-            results['cases'] = [
+            results["cases"] = [
                 {
-                    'case_id': case.case_id,
-                    'title': case.title,
-                    'description': case.description,
-                    'match_type': 'case'
+                    "case_id": case.case_id,
+                    "title": case.title,
+                    "description": case.description,
+                    "match_type": "case",
                 }
                 for case in cases
             ]
 
             # Search comments
             if search_comments:
-                comments = session.query(CaseComment).filter(
-                    CaseComment.content.ilike(search_pattern)
-                ).limit(limit).all()
+                comments = (
+                    session.query(CaseComment)
+                    .filter(CaseComment.content.ilike(search_pattern))
+                    .limit(limit)
+                    .all()
+                )
 
-                results['comments'] = [
+                results["comments"] = [
                     {
-                        'case_id': comment.case_id,
-                        'comment_id': comment.comment_id,
-                        'author': comment.author,
-                        'content': comment.content,
-                        'match_type': 'comment'
+                        "case_id": comment.case_id,
+                        "comment_id": comment.comment_id,
+                        "author": comment.author,
+                        "content": comment.content,
+                        "match_type": "comment",
                     }
                     for comment in comments
                 ]
 
             # Search evidence
             if search_evidence:
-                evidence_items = session.query(CaseEvidence).filter(
-                    or_(
-                        CaseEvidence.name.ilike(search_pattern),
-                        CaseEvidence.description.ilike(search_pattern)
+                evidence_items = (
+                    session.query(CaseEvidence)
+                    .filter(
+                        or_(
+                            CaseEvidence.name.ilike(search_pattern),
+                            CaseEvidence.description.ilike(search_pattern),
+                        )
                     )
-                ).limit(limit).all()
+                    .limit(limit)
+                    .all()
+                )
 
-                results['evidence'] = [
+                results["evidence"] = [
                     {
-                        'case_id': evidence.case_id,
-                        'evidence_id': evidence.evidence_id,
-                        'name': evidence.name,
-                        'description': evidence.description,
-                        'match_type': 'evidence'
+                        "case_id": evidence.case_id,
+                        "evidence_id": evidence.evidence_id,
+                        "name": evidence.name,
+                        "description": evidence.description,
+                        "match_type": "evidence",
                     }
                     for evidence in evidence_items
                 ]
 
             return results
-    
+
     def search_by_ioc(
         self,
         ioc_value: str,
         ioc_type: Optional[str] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> List[Dict]:
         """
         Find cases containing a specific IOC.
-        
+
         Args:
             ioc_value: IOC value to search for
             ioc_type: Optional IOC type filter
             session: Database session (optional)
-        
+
         Returns:
             List of cases containing the IOC
         """
         with unit_of_work(session) as session:
-            query = session.query(CaseIOC).filter(
-                CaseIOC.value.ilike(f"%{ioc_value}%")
-            )
+            query = session.query(CaseIOC).filter(CaseIOC.value.ilike(f"%{ioc_value}%"))
 
             if ioc_type:
                 query = query.filter(CaseIOC.ioc_type == ioc_type)
@@ -205,32 +213,27 @@ class CaseSearchService:
             case_ids = list(set(ioc.case_id for ioc in iocs))
 
             # Get cases
-            cases = session.query(Case).filter(
-                Case.case_id.in_(case_ids)
-            ).all()
+            cases = session.query(Case).filter(Case.case_id.in_(case_ids)).all()
 
             return CaseSchema.dump_many(cases)
 
     def get_related_cases(
-        self,
-        case_id: str,
-        max_results: int = 10,
-        session: Optional[Session] = None
+        self, case_id: str, max_results: int = 10, session: Optional[Session] = None
     ) -> List[Dict]:
         """
         Find cases related to a given case.
-        
+
         Finds cases with:
         - Shared IOCs
         - Same MITRE techniques
         - Similar time windows
         - Explicit relationships
-        
+
         Args:
             case_id: Case ID
             max_results: Maximum results to return
             session: Database session (optional)
-        
+
         Returns:
             List of related cases with similarity scores
         """
@@ -242,63 +245,68 @@ class CaseSearchService:
             related_cases = {}
 
             # Find cases with shared IOCs
-            case_iocs = session.query(CaseIOC).filter(
-                CaseIOC.case_id == case_id
-            ).all()
+            case_iocs = session.query(CaseIOC).filter(CaseIOC.case_id == case_id).all()
 
             ioc_values = [ioc.value for ioc in case_iocs]
             if ioc_values:
-                shared_ioc_cases = session.query(CaseIOC).filter(
-                    and_(
-                        CaseIOC.value.in_(ioc_values),
-                        CaseIOC.case_id != case_id
+                shared_ioc_cases = (
+                    session.query(CaseIOC)
+                    .filter(
+                        and_(CaseIOC.value.in_(ioc_values), CaseIOC.case_id != case_id)
                     )
-                ).all()
+                    .all()
+                )
 
                 for ioc in shared_ioc_cases:
                     if ioc.case_id not in related_cases:
-                        related_cases[ioc.case_id] = {'score': 0, 'reasons': []}
-                    related_cases[ioc.case_id]['score'] += 10
-                    related_cases[ioc.case_id]['reasons'].append('shared_ioc')
+                        related_cases[ioc.case_id] = {"score": 0, "reasons": []}
+                    related_cases[ioc.case_id]["score"] += 10
+                    related_cases[ioc.case_id]["reasons"].append("shared_ioc")
 
             # Find cases with same MITRE techniques
             if case.mitre_techniques:
-                similar_technique_cases = session.query(Case).filter(
-                    and_(
-                        Case.case_id != case_id,
-                        Case.mitre_techniques.overlap(case.mitre_techniques)
+                similar_technique_cases = (
+                    session.query(Case)
+                    .filter(
+                        and_(
+                            Case.case_id != case_id,
+                            Case.mitre_techniques.overlap(case.mitre_techniques),
+                        )
                     )
-                ).all()
+                    .all()
+                )
 
                 for similar_case in similar_technique_cases:
                     if similar_case.case_id not in related_cases:
-                        related_cases[similar_case.case_id] = {'score': 0, 'reasons': []}
+                        related_cases[similar_case.case_id] = {
+                            "score": 0,
+                            "reasons": [],
+                        }
 
                     # Calculate overlap score
                     overlap = len(
                         set(case.mitre_techniques) & set(similar_case.mitre_techniques)
                     )
-                    related_cases[similar_case.case_id]['score'] += overlap * 5
-                    related_cases[similar_case.case_id]['reasons'].append('shared_mitre_techniques')
+                    related_cases[similar_case.case_id]["score"] += overlap * 5
+                    related_cases[similar_case.case_id]["reasons"].append(
+                        "shared_mitre_techniques"
+                    )
 
             # Sort by score and get top results
             sorted_cases = sorted(
-                related_cases.items(),
-                key=lambda x: x[1]['score'],
-                reverse=True
+                related_cases.items(), key=lambda x: x[1]["score"], reverse=True
             )[:max_results]
 
             # Get full case data
             result = []
             for case_id_rel, meta in sorted_cases:
-                rel_case = session.query(Case).filter(
-                    Case.case_id == case_id_rel
-                ).first()
+                rel_case = (
+                    session.query(Case).filter(Case.case_id == case_id_rel).first()
+                )
                 if rel_case:
                     case_dict = CaseSchema.dump(rel_case)
-                    case_dict['similarity_score'] = meta['score']
-                    case_dict['similarity_reasons'] = meta['reasons']
+                    case_dict["similarity_score"] = meta["score"]
+                    case_dict["similarity_reasons"] = meta["reasons"]
                     result.append(case_dict)
 
             return result
-

--- a/core/cases/case_sla_service.py
+++ b/core/cases/case_sla_service.py
@@ -8,8 +8,9 @@ notifications, and reporting.
 import logging
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
-from sqlalchemy.orm import Session
+
 from sqlalchemy import and_
+from sqlalchemy.orm import Session
 
 from core.storage.models import Case, CaseSLA, SLAPolicy
 from core.storage.unit_of_work import unit_of_work
@@ -19,16 +20,16 @@ logger = logging.getLogger(__name__)
 
 class BusinessHoursCalculator:
     """Calculates time deltas considering business hours."""
-    
+
     def __init__(
         self,
         business_start_hour: int = 9,
         business_end_hour: int = 17,
-        business_days: List[int] = None  # 0=Monday, 6=Sunday
+        business_days: List[int] = None,  # 0=Monday, 6=Sunday
     ):
         """
         Initialize business hours calculator.
-        
+
         Args:
             business_start_hour: Start of business day (24h format)
             business_end_hour: End of business day (24h format)
@@ -38,7 +39,7 @@ class BusinessHoursCalculator:
         self.business_end_hour = business_end_hour
         self.business_days = business_days or [0, 1, 2, 3, 4]  # Mon-Fri default
         self.business_hours_per_day = business_end_hour - business_start_hour
-    
+
     def is_business_hours(self, dt: datetime) -> bool:
         """Check if datetime falls within business hours."""
         if dt.weekday() not in self.business_days:
@@ -46,32 +47,32 @@ class BusinessHoursCalculator:
         if dt.hour < self.business_start_hour or dt.hour >= self.business_end_hour:
             return False
         return True
-    
+
     def add_business_hours(self, start_time: datetime, hours: float) -> datetime:
         """
         Add business hours to a datetime.
-        
+
         Args:
             start_time: Starting datetime
             hours: Number of business hours to add
-        
+
         Returns:
             Datetime after adding business hours
         """
         if hours <= 0:
             return start_time
-        
+
         current = start_time
         remaining_hours = hours
-        
+
         # Move to next business hour if starting outside business hours
         if not self.is_business_hours(current):
             current = self._next_business_hour(current)
-        
+
         while remaining_hours > 0:
             # Calculate hours remaining in current business day
             hours_left_today = self.business_end_hour - current.hour
-            
+
             if remaining_hours <= hours_left_today:
                 # Can finish today
                 current = current + timedelta(hours=remaining_hours)
@@ -79,53 +80,57 @@ class BusinessHoursCalculator:
             else:
                 # Move to end of business day and continue tomorrow
                 remaining_hours -= hours_left_today
-                current = current.replace(hour=self.business_end_hour, minute=0, second=0)
+                current = current.replace(
+                    hour=self.business_end_hour, minute=0, second=0
+                )
                 current = self._next_business_hour(current)
-        
+
         return current
-    
+
     def _next_business_hour(self, dt: datetime) -> datetime:
         """Get the next business hour after the given datetime."""
         current = dt
-        
+
         # If within business day but after hours, move to next business day start
-        if current.weekday() in self.business_days and current.hour >= self.business_end_hour:
+        if (
+            current.weekday() in self.business_days
+            and current.hour >= self.business_end_hour
+        ):
             current = current + timedelta(days=1)
             current = current.replace(hour=self.business_start_hour, minute=0, second=0)
-        
+
         # Keep advancing until we hit a business day
         while current.weekday() not in self.business_days:
             current = current + timedelta(days=1)
-        
+
         # Set to business start hour if before it
         if current.hour < self.business_start_hour:
             current = current.replace(hour=self.business_start_hour, minute=0, second=0)
-        
+
         return current
-    
 
 
 class CaseSLAService:
     """Service for managing case SLAs."""
-    
+
     def __init__(self):
         """Initialize the SLA service."""
         self.business_hours_calc = BusinessHoursCalculator()
-    
+
     def assign_sla_to_case(
         self,
         case_id: str,
         sla_policy_id: Optional[str] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Optional[CaseSLA]:
         """
         Assign an SLA policy to a case.
-        
+
         Args:
             case_id: Case ID
             sla_policy_id: SLA policy ID (if None, uses default for priority)
             session: Database session (optional)
-        
+
         Returns:
             Created CaseSLA object or None
         """
@@ -138,27 +143,33 @@ class CaseSLAService:
                     return None
 
                 # Check if SLA already assigned
-                existing_sla = session.query(CaseSLA).filter(
-                    CaseSLA.case_id == case_id
-                ).first()
+                existing_sla = (
+                    session.query(CaseSLA).filter(CaseSLA.case_id == case_id).first()
+                )
                 if existing_sla:
                     logger.warning(f"SLA already assigned to case {case_id}")
                     return existing_sla
 
                 # Get SLA policy
                 if sla_policy_id:
-                    policy = session.query(SLAPolicy).filter(
-                        SLAPolicy.policy_id == sla_policy_id
-                    ).first()
+                    policy = (
+                        session.query(SLAPolicy)
+                        .filter(SLAPolicy.policy_id == sla_policy_id)
+                        .first()
+                    )
                 else:
                     # Get default policy for case priority
-                    policy = session.query(SLAPolicy).filter(
-                        and_(
-                            SLAPolicy.priority_level == case.priority,
-                            SLAPolicy.is_default == True,
-                            SLAPolicy.is_active == True
+                    policy = (
+                        session.query(SLAPolicy)
+                        .filter(
+                            and_(
+                                SLAPolicy.priority_level == case.priority,
+                                SLAPolicy.is_default.is_(True),
+                                SLAPolicy.is_active.is_(True),
+                            )
                         )
-                    ).first()
+                        .first()
+                    )
 
                 if not policy:
                     logger.error(f"No SLA policy found for case {case_id}")
@@ -169,16 +180,18 @@ class CaseSLAService:
 
                 if policy.business_hours_only:
                     response_due = self.business_hours_calc.add_business_hours(
-                        case_created,
-                        policy.response_time_hours
+                        case_created, policy.response_time_hours
                     )
                     resolution_due = self.business_hours_calc.add_business_hours(
-                        case_created,
-                        policy.resolution_time_hours
+                        case_created, policy.resolution_time_hours
                     )
                 else:
-                    response_due = case_created + timedelta(hours=policy.response_time_hours)
-                    resolution_due = case_created + timedelta(hours=policy.resolution_time_hours)
+                    response_due = case_created + timedelta(
+                        hours=policy.response_time_hours
+                    )
+                    resolution_due = case_created + timedelta(
+                        hours=policy.resolution_time_hours
+                    )
 
                 # Create SLA record
                 case_sla = CaseSLA(
@@ -188,7 +201,7 @@ class CaseSLAService:
                     resolution_due=resolution_due,
                     breached=False,
                     is_paused=False,
-                    total_pause_duration=0
+                    total_pause_duration=0,
                 )
 
                 session.add(case_sla)
@@ -203,21 +216,21 @@ class CaseSLAService:
         except Exception as e:
             logger.error(f"Error assigning SLA to case {case_id}: {e}")
             return None
-    
+
     def check_sla_breach(
         self,
         case_id: str,
         current_time: Optional[datetime] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Tuple[bool, Optional[str]]:
         """
         Check if a case has breached its SLA.
-        
+
         Args:
             case_id: Case ID
             current_time: Time to check against (defaults to now)
             session: Database session (optional)
-        
+
         Returns:
             Tuple of (is_breached, breach_type) where breach_type is
             'response', 'resolution', or None
@@ -226,9 +239,7 @@ class CaseSLAService:
             if current_time is None:
                 current_time = datetime.utcnow()
 
-            case_sla = session.query(CaseSLA).filter(
-                CaseSLA.case_id == case_id
-            ).first()
+            case_sla = session.query(CaseSLA).filter(CaseSLA.case_id == case_id).first()
 
             if not case_sla:
                 return False, None
@@ -242,34 +253,30 @@ class CaseSLAService:
             # Check response SLA
             if not case_sla.response_completed_at:
                 if effective_time > case_sla.response_due:
-                    return True, 'response'
+                    return True, "response"
 
             # Check resolution SLA
             if not case_sla.resolution_completed_at:
                 if effective_time > case_sla.resolution_due:
-                    return True, 'resolution'
+                    return True, "resolution"
 
             return False, None
-    
+
     def get_sla_status(
-        self,
-        case_id: str,
-        session: Optional[Session] = None
+        self, case_id: str, session: Optional[Session] = None
     ) -> Optional[Dict]:
         """
         Get comprehensive SLA status for a case.
-        
+
         Args:
             case_id: Case ID
             session: Database session (optional)
-        
+
         Returns:
             Dictionary with SLA status details
         """
         with unit_of_work(session) as session:
-            case_sla = session.query(CaseSLA).filter(
-                CaseSLA.case_id == case_id
-            ).first()
+            case_sla = session.query(CaseSLA).filter(CaseSLA.case_id == case_id).first()
 
             if not case_sla:
                 return None
@@ -291,10 +298,11 @@ class CaseSLAService:
                 elapsed_response_time = (
                     current_time - case_sla.created_at
                 ).total_seconds()
-                response_percent_elapsed = min(
-                    100.0,
-                    (elapsed_response_time / total_response_time) * 100
-                ) if total_response_time > 0 else 0.0
+                response_percent_elapsed = (
+                    min(100.0, (elapsed_response_time / total_response_time) * 100)
+                    if total_response_time > 0
+                    else 0.0
+                )
 
             if not case_sla.resolution_completed_at and not case_sla.is_paused:
                 resolution_delta = case_sla.resolution_due - current_time
@@ -305,68 +313,67 @@ class CaseSLAService:
                 elapsed_resolution_time = (
                     current_time - case_sla.created_at
                 ).total_seconds()
-                resolution_percent_elapsed = min(
-                    100.0,
-                    (elapsed_resolution_time / total_resolution_time) * 100
-                ) if total_resolution_time > 0 else 0.0
+                resolution_percent_elapsed = (
+                    min(100.0, (elapsed_resolution_time / total_resolution_time) * 100)
+                    if total_resolution_time > 0
+                    else 0.0
+                )
 
             # Determine status
             is_breached, breach_type = self.check_sla_breach(
-                case_id,
-                current_time,
-                session
+                case_id, current_time, session
             )
 
             # Determine health status
-            health_status = 'healthy'
+            health_status = "healthy"
             if is_breached:
-                health_status = 'breached'
+                health_status = "breached"
             elif response_percent_elapsed >= 90 or resolution_percent_elapsed >= 90:
-                health_status = 'critical'
+                health_status = "critical"
             elif response_percent_elapsed >= 75 or resolution_percent_elapsed >= 75:
-                health_status = 'warning'
+                health_status = "warning"
 
             return {
-                'case_id': case_id,
-                'sla_policy_id': case_sla.sla_policy_id,
-                'response_due': case_sla.response_due.isoformat(),
-                'resolution_due': case_sla.resolution_due.isoformat(),
-                'response_remaining_seconds': response_remaining,
-                'resolution_remaining_seconds': resolution_remaining,
-                'response_percent_elapsed': response_percent_elapsed,
-                'resolution_percent_elapsed': resolution_percent_elapsed,
-                'response_completed': case_sla.response_completed_at is not None,
-                'resolution_completed': case_sla.resolution_completed_at is not None,
-                'response_sla_met': case_sla.response_sla_met,
-                'resolution_sla_met': case_sla.resolution_sla_met,
-                'is_breached': is_breached,
-                'breach_type': breach_type,
-                'is_paused': case_sla.is_paused,
-                'health_status': health_status
+                "case_id": case_id,
+                "sla_policy_id": case_sla.sla_policy_id,
+                "response_due": case_sla.response_due.isoformat(),
+                "resolution_due": case_sla.resolution_due.isoformat(),
+                "response_remaining_seconds": response_remaining,
+                "resolution_remaining_seconds": resolution_remaining,
+                "response_percent_elapsed": response_percent_elapsed,
+                "resolution_percent_elapsed": resolution_percent_elapsed,
+                "response_completed": case_sla.response_completed_at is not None,
+                "resolution_completed": case_sla.resolution_completed_at is not None,
+                "response_sla_met": case_sla.response_sla_met,
+                "resolution_sla_met": case_sla.resolution_sla_met,
+                "is_breached": is_breached,
+                "breach_type": breach_type,
+                "is_paused": case_sla.is_paused,
+                "health_status": health_status,
             }
-    
+
     def pause_sla(
         self,
         case_id: str,
         reason: Optional[str] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> bool:
         """
         Pause SLA timer for a case.
-        
+
         Args:
             case_id: Case ID
             reason: Reason for pausing
             session: Database session (optional)
-        
+
         Returns:
             True if successful
         """
         try:
             with unit_of_work(session) as session:
-                case_sla = session.query(CaseSLA).filter(
-                    CaseSLA.case_id == case_id
-                ).first()
+                case_sla = (
+                    session.query(CaseSLA).filter(CaseSLA.case_id == case_id).first()
+                )
 
                 if not case_sla:
                     logger.error(f"No SLA found for case {case_id}")
@@ -385,27 +392,23 @@ class CaseSLAService:
         except Exception as e:
             logger.error(f"Error pausing SLA for case {case_id}: {e}")
             return False
-    
-    def resume_sla(
-        self,
-        case_id: str,
-        session: Optional[Session] = None
-    ) -> bool:
+
+    def resume_sla(self, case_id: str, session: Optional[Session] = None) -> bool:
         """
         Resume SLA timer for a case.
-        
+
         Args:
             case_id: Case ID
             session: Database session (optional)
-        
+
         Returns:
             True if successful
         """
         try:
             with unit_of_work(session) as session:
-                case_sla = session.query(CaseSLA).filter(
-                    CaseSLA.case_id == case_id
-                ).first()
+                case_sla = (
+                    session.query(CaseSLA).filter(CaseSLA.case_id == case_id).first()
+                )
 
                 if not case_sla:
                     logger.error(f"No SLA found for case {case_id}")
@@ -436,28 +439,25 @@ class CaseSLAService:
         except Exception as e:
             logger.error(f"Error resuming SLA for case {case_id}: {e}")
             return False
-    
-    
+
     def mark_resolution_complete(
-        self,
-        case_id: str,
-        session: Optional[Session] = None
+        self, case_id: str, session: Optional[Session] = None
     ) -> bool:
         """
         Mark that case resolution has been completed.
-        
+
         Args:
             case_id: Case ID
             session: Database session (optional)
-        
+
         Returns:
             True if successful
         """
         try:
             with unit_of_work(session) as session:
-                case_sla = session.query(CaseSLA).filter(
-                    CaseSLA.case_id == case_id
-                ).first()
+                case_sla = (
+                    session.query(CaseSLA).filter(CaseSLA.case_id == case_id).first()
+                )
 
                 if not case_sla:
                     return False
@@ -475,17 +475,14 @@ class CaseSLAService:
         except Exception as e:
             logger.error(f"Error marking resolution complete for case {case_id}: {e}")
             return False
-    
-    def get_breached_cases(
-        self,
-        session: Optional[Session] = None
-    ) -> List[Dict]:
+
+    def get_breached_cases(self, session: Optional[Session] = None) -> List[Dict]:
         """
         Get all cases that have breached their SLA.
-        
+
         Args:
             session: Database session (optional)
-        
+
         Returns:
             List of case dictionaries with SLA information
         """
@@ -493,51 +490,55 @@ class CaseSLAService:
             current_time = datetime.utcnow()
 
             # Get all active SLAs
-            slas = session.query(CaseSLA).filter(
-                and_(
-                    CaseSLA.resolution_completed_at == None,
-                    CaseSLA.is_paused == False
+            slas = (
+                session.query(CaseSLA)
+                .filter(
+                    and_(
+                        CaseSLA.resolution_completed_at.is_(None),
+                        CaseSLA.is_paused.is_(False),
+                    )
                 )
-            ).all()
+                .all()
+            )
 
             breached_cases = []
             for sla in slas:
                 is_breached, breach_type = self.check_sla_breach(
-                    sla.case_id,
-                    current_time,
-                    session
+                    sla.case_id, current_time, session
                 )
                 if is_breached:
-                    case = session.query(Case).filter(
-                        Case.case_id == sla.case_id
-                    ).first()
+                    case = (
+                        session.query(Case).filter(Case.case_id == sla.case_id).first()
+                    )
                     if case:
-                        breached_cases.append({
-                            'case_id': case.case_id,
-                            'title': case.title,
-                            'priority': case.priority,
-                            'status': case.status,
-                            'breach_type': breach_type,
-                            'response_due': sla.response_due.isoformat(),
-                            'resolution_due': sla.resolution_due.isoformat()
-                        })
+                        breached_cases.append(
+                            {
+                                "case_id": case.case_id,
+                                "title": case.title,
+                                "priority": case.priority,
+                                "status": case.status,
+                                "breach_type": breach_type,
+                                "response_due": sla.response_due.isoformat(),
+                                "resolution_due": sla.resolution_due.isoformat(),
+                            }
+                        )
 
             return breached_cases
-    
+
     def get_sla_compliance_report(
         self,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Dict:
         """
         Generate SLA compliance report.
-        
+
         Args:
             start_date: Report start date
             end_date: Report end date
             session: Database session (optional)
-        
+
         Returns:
             Dictionary with compliance statistics
         """
@@ -562,20 +563,21 @@ class CaseSLAService:
             )
 
             return {
-                'total_cases': total_cases,
-                'response_sla_met': response_met,
-                'response_sla_completed': response_completed,
-                'response_compliance_rate': (
+                "total_cases": total_cases,
+                "response_sla_met": response_met,
+                "response_sla_completed": response_completed,
+                "response_compliance_rate": (
                     (response_met / response_completed * 100)
-                    if response_completed > 0 else 0.0
+                    if response_completed > 0
+                    else 0.0
                 ),
-                'resolution_sla_met': resolution_met,
-                'resolution_sla_completed': resolution_completed,
-                'resolution_compliance_rate': (
+                "resolution_sla_met": resolution_met,
+                "resolution_sla_completed": resolution_completed,
+                "resolution_compliance_rate": (
                     (resolution_met / resolution_completed * 100)
-                    if resolution_completed > 0 else 0.0
+                    if resolution_completed > 0
+                    else 0.0
                 ),
-                'start_date': start_date.isoformat() if start_date else None,
-                'end_date': end_date.isoformat() if end_date else None
+                "start_date": start_date.isoformat() if start_date else None,
+                "end_date": end_date.isoformat() if end_date else None,
             }
-

--- a/core/cases/case_templates_router.py
+++ b/core/cases/case_templates_router.py
@@ -1,12 +1,13 @@
 """Case Templates API endpoints."""
 
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
+
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from core.storage.schemas import CaseSchema, CaseTemplateSchema
 from core.cases.case_workflow_service import CaseWorkflowService
 from core.routing import Auth, RouterMeta
+from core.storage.schemas import CaseSchema, CaseTemplateSchema
 
 router = APIRouter()
 
@@ -20,6 +21,7 @@ workflow_service = CaseWorkflowService()
 
 class TemplateCreate(BaseModel):
     """Create template request."""
+
     name: str
     template_type: str
     description: Optional[str] = None
@@ -34,6 +36,7 @@ class TemplateCreate(BaseModel):
 
 class TemplateUpdate(BaseModel):
     """Update template request."""
+
     name: Optional[str] = None
     description: Optional[str] = None
     default_priority: Optional[str] = None
@@ -48,6 +51,7 @@ class TemplateUpdate(BaseModel):
 
 class CaseFromTemplate(BaseModel):
     """Create case from template."""
+
     title: str
     description: Optional[str] = None
     assignee: Optional[str] = None
@@ -59,11 +63,11 @@ class CaseFromTemplate(BaseModel):
 async def list_templates(template_type: Optional[str] = None, active_only: bool = True):
     """
     List all case templates.
-    
+
     Args:
         template_type: Filter by template type
         active_only: Only return active templates
-    
+
     Returns:
         List of templates
     """
@@ -75,10 +79,10 @@ async def list_templates(template_type: Optional[str] = None, active_only: bool 
 async def get_template(template_id: str):
     """
     Get a specific template.
-    
+
     Args:
         template_id: Template ID
-    
+
     Returns:
         Template details
     """
@@ -92,10 +96,10 @@ async def get_template(template_id: str):
 async def create_template(data: TemplateCreate):
     """
     Create a new case template.
-    
+
     Args:
         data: Template creation data
-    
+
     Returns:
         Created template
     """
@@ -109,12 +113,12 @@ async def create_template(data: TemplateCreate):
         task_templates=data.task_templates,
         playbook_steps=data.playbook_steps,
         applicable_mitre_techniques=data.applicable_mitre_techniques,
-        tags=data.tags
+        tags=data.tags,
     )
-    
+
     if not template:
         raise HTTPException(status_code=500, detail="Failed to create template")
-    
+
     return CaseTemplateSchema.dump(template)
 
 
@@ -122,20 +126,22 @@ async def create_template(data: TemplateCreate):
 async def update_template(template_id: str, data: TemplateUpdate):
     """
     Update a template.
-    
+
     Args:
         template_id: Template ID
         data: Update data
-    
+
     Returns:
         Success status
     """
     updates = {k: v for k, v in data.dict().items() if v is not None}
     success = workflow_service.update_template(template_id, updates)
-    
+
     if not success:
-        raise HTTPException(status_code=404, detail="Template not found or update failed")
-    
+        raise HTTPException(
+            status_code=404, detail="Template not found or update failed"
+        )
+
     return {"success": True}
 
 
@@ -143,18 +149,18 @@ async def update_template(template_id: str, data: TemplateUpdate):
 async def delete_template(template_id: str):
     """
     Delete (deactivate) a template.
-    
+
     Args:
         template_id: Template ID
-    
+
     Returns:
         Success status
     """
     success = workflow_service.delete_template(template_id)
-    
+
     if not success:
         raise HTTPException(status_code=404, detail="Template not found")
-    
+
     return {"success": True}
 
 
@@ -162,11 +168,11 @@ async def delete_template(template_id: str):
 async def create_case_from_template(template_id: str, data: CaseFromTemplate):
     """
     Create a new case from a template.
-    
+
     Args:
         template_id: Template ID
         data: Case creation data
-    
+
     Returns:
         Created case
     """
@@ -176,11 +182,12 @@ async def create_case_from_template(template_id: str, data: CaseFromTemplate):
         description=data.description,
         assignee=data.assignee,
         finding_ids=data.finding_ids,
-        override_priority=data.override_priority
+        override_priority=data.override_priority,
     )
-    
-    if not case:
-        raise HTTPException(status_code=500, detail="Failed to create case from template")
-    
-    return CaseSchema.dump(case)
 
+    if not case:
+        raise HTTPException(
+            status_code=500, detail="Failed to create case from template"
+        )
+
+    return CaseSchema.dump(case)

--- a/core/cases/case_workflow_service.py
+++ b/core/cases/case_workflow_service.py
@@ -8,11 +8,10 @@ and task automation.
 import logging
 from datetime import datetime
 from typing import Dict, List, Optional
+
 from sqlalchemy.orm import Session
 
-from core.storage.models import (
-    Case, CaseTemplate, CaseTask
-)
+from core.storage.models import Case, CaseTask, CaseTemplate
 from core.storage.unit_of_work import unit_of_work
 
 logger = logging.getLogger(__name__)
@@ -20,27 +19,27 @@ logger = logging.getLogger(__name__)
 
 class CaseWorkflowService:
     """Service for managing case workflows and templates."""
-    
+
     def __init__(self):
         """Initialize the workflow service."""
-    
+
     def create_template(
         self,
         name: str,
         template_type: str,
         description: Optional[str] = None,
-        default_priority: str = 'medium',
-        default_status: str = 'open',
+        default_priority: str = "medium",
+        default_status: str = "open",
         default_sla_policy_id: Optional[str] = None,
         task_templates: Optional[List[Dict]] = None,
         playbook_steps: Optional[List[Dict]] = None,
         applicable_mitre_techniques: Optional[List[str]] = None,
         tags: Optional[List[str]] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Optional[CaseTemplate]:
         """
         Create a new case template.
-        
+
         Args:
             name: Template name
             template_type: Type of template
@@ -53,14 +52,14 @@ class CaseWorkflowService:
             applicable_mitre_techniques: List of MITRE technique IDs
             tags: List of tags
             session: Database session (optional)
-        
+
         Returns:
             Created CaseTemplate or None
         """
         try:
             with unit_of_work(session) as session:
                 # Generate template ID
-                timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
+                timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
                 template_id = f"template-{template_type}-{timestamp}"
 
                 template = CaseTemplate(
@@ -76,7 +75,7 @@ class CaseWorkflowService:
                     applicable_mitre_techniques=applicable_mitre_techniques or [],
                     tags=tags or [],
                     is_active=True,
-                    usage_count=0
+                    usage_count=0,
                 )
 
                 session.add(template)
@@ -87,41 +86,41 @@ class CaseWorkflowService:
         except Exception as e:
             logger.error(f"Error creating template: {e}")
             return None
-    
+
     def get_template(
-        self,
-        template_id: str,
-        session: Optional[Session] = None
+        self, template_id: str, session: Optional[Session] = None
     ) -> Optional[CaseTemplate]:
         """
         Get a case template by ID.
-        
+
         Args:
             template_id: Template ID
             session: Database session (optional)
-        
+
         Returns:
             CaseTemplate or None
         """
         with unit_of_work(session) as session:
-            return session.query(CaseTemplate).filter(
-                CaseTemplate.template_id == template_id
-            ).first()
-    
+            return (
+                session.query(CaseTemplate)
+                .filter(CaseTemplate.template_id == template_id)
+                .first()
+            )
+
     def list_templates(
         self,
         template_type: Optional[str] = None,
         active_only: bool = True,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> List[CaseTemplate]:
         """
         List case templates.
-        
+
         Args:
             template_type: Filter by template type
             active_only: Only return active templates
             session: Database session (optional)
-        
+
         Returns:
             List of CaseTemplate objects
         """
@@ -132,10 +131,10 @@ class CaseWorkflowService:
                 query = query.filter(CaseTemplate.template_type == template_type)
 
             if active_only:
-                query = query.filter(CaseTemplate.is_active == True)
+                query = query.filter(CaseTemplate.is_active.is_(True))
 
             return query.order_by(CaseTemplate.usage_count.desc()).all()
-    
+
     def create_case_from_template(
         self,
         template_id: str,
@@ -144,11 +143,11 @@ class CaseWorkflowService:
         assignee: Optional[str] = None,
         finding_ids: Optional[List[str]] = None,
         override_priority: Optional[str] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> Optional[Case]:
         """
         Create a new case from a template.
-        
+
         Args:
             template_id: Template ID
             title: Case title
@@ -157,45 +156,50 @@ class CaseWorkflowService:
             finding_ids: List of finding IDs to attach
             override_priority: Override template's default priority
             session: Database session (optional)
-        
+
         Returns:
             Created Case or None
         """
         try:
             with unit_of_work(session) as session:
                 # Get template
-                template = session.query(CaseTemplate).filter(
-                    CaseTemplate.template_id == template_id
-                ).first()
+                template = (
+                    session.query(CaseTemplate)
+                    .filter(CaseTemplate.template_id == template_id)
+                    .first()
+                )
 
                 if not template or not template.is_active:
                     logger.error(f"Template {template_id} not found or inactive")
                     return None
 
                 # Generate case ID
-                timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
+                timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
                 case_id = f"case-{timestamp}"
 
                 # Create case
                 case = Case(
                     case_id=case_id,
                     title=title,
-                    description=description or template.description or '',
+                    description=description or template.description or "",
                     priority=override_priority or template.default_priority,
                     status=template.default_status,
                     assignee=assignee,
                     tags=template.tags.copy() if template.tags else [],
                     mitre_techniques=(
                         template.applicable_mitre_techniques.copy()
-                        if template.applicable_mitre_techniques else []
+                        if template.applicable_mitre_techniques
+                        else []
                     ),
                     notes=[],
-                    timeline=[{
-                        'timestamp': datetime.utcnow().isoformat(),
-                        'event': f'Case created from template: {template.name}'
-                    }],
+                    timeline=[
+                        {
+                            "timestamp": datetime.utcnow().isoformat(),
+                            "event": f"Case created from template: {template.name}",
+                        }
+                    ],
                     activities=[],
-                    resolution_steps=[]
+                    resolution_steps=[],
                 )
 
                 session.add(case)
@@ -206,23 +210,22 @@ class CaseWorkflowService:
                     for task_tmpl in template.task_templates:
                         task = CaseTask(
                             case_id=case.case_id,
-                            title=task_tmpl.get('title', ''),
-                            description=task_tmpl.get('description', ''),
-                            priority=task_tmpl.get('priority', 'medium'),
-                            status='pending',
-                            task_order=task_tmpl.get('order', 0),
-                            checklist_items=task_tmpl.get('checklist_items', [])
+                            title=task_tmpl.get("title", ""),
+                            description=task_tmpl.get("description", ""),
+                            priority=task_tmpl.get("priority", "medium"),
+                            status="pending",
+                            task_order=task_tmpl.get("order", 0),
+                            checklist_items=task_tmpl.get("checklist_items", []),
                         )
                         session.add(task)
 
                 # Assign SLA if template has one
                 if template.default_sla_policy_id:
                     from core.cases.case_sla_service import CaseSLAService
+
                     sla_service = CaseSLAService()
                     sla_service.assign_sla_to_case(
-                        case.case_id,
-                        template.default_sla_policy_id,
-                        session
+                        case.case_id, template.default_sla_policy_id, session
                     )
 
                 # Increment template usage
@@ -231,10 +234,13 @@ class CaseWorkflowService:
                 # Attach findings if provided
                 if finding_ids:
                     from core.storage.models import Finding
+
                     for finding_id in finding_ids:
-                        finding = session.query(Finding).filter(
-                            Finding.finding_id == finding_id
-                        ).first()
+                        finding = (
+                            session.query(Finding)
+                            .filter(Finding.finding_id == finding_id)
+                            .first()
+                        )
                         if finding:
                             case.findings.append(finding)
 
@@ -244,20 +250,19 @@ class CaseWorkflowService:
         except Exception as e:
             logger.error(f"Error creating case from template: {e}")
             return None
-    
-    
+
     def escalate_case(
         self,
         case_id: str,
         escalated_from: str,
         escalated_to: str,
         reason: str,
-        urgency_level: str = 'high',
-        session: Optional[Session] = None
+        urgency_level: str = "high",
+        session: Optional[Session] = None,
     ) -> bool:
         """
         Escalate a case.
-        
+
         Args:
             case_id: Case ID
             escalated_from: Who escalated the case
@@ -265,7 +270,7 @@ class CaseWorkflowService:
             reason: Escalation reason
             urgency_level: Urgency level
             session: Database session (optional)
-        
+
         Returns:
             True if successful
         """
@@ -285,16 +290,18 @@ class CaseWorkflowService:
                     escalated_to=escalated_to,
                     reason=reason,
                     urgency_level=urgency_level,
-                    status='pending'
+                    status="pending",
                 )
                 session.add(escalation)
 
                 # Update case
                 case.assignee = escalated_to
-                case.timeline.append({
-                    'timestamp': datetime.utcnow().isoformat(),
-                    'event': f'Escalated to {escalated_to}: {reason}'
-                })
+                case.timeline.append(
+                    {
+                        "timestamp": datetime.utcnow().isoformat(),
+                        "event": f"Escalated to {escalated_to}: {reason}",
+                    }
+                )
 
                 logger.info(f"Escalated case {case_id} to {escalated_to}")
                 return True
@@ -302,29 +309,28 @@ class CaseWorkflowService:
         except Exception as e:
             logger.error(f"Error escalating case {case_id}: {e}")
             return False
-    
+
     def update_template(
-        self,
-        template_id: str,
-        updates: Dict,
-        session: Optional[Session] = None
+        self, template_id: str, updates: Dict, session: Optional[Session] = None
     ) -> bool:
         """
         Update a case template.
-        
+
         Args:
             template_id: Template ID
             updates: Dictionary of fields to update
             session: Database session (optional)
-        
+
         Returns:
             True if successful
         """
         try:
             with unit_of_work(session) as session:
-                template = session.query(CaseTemplate).filter(
-                    CaseTemplate.template_id == template_id
-                ).first()
+                template = (
+                    session.query(CaseTemplate)
+                    .filter(CaseTemplate.template_id == template_id)
+                    .first()
+                )
 
                 if not template:
                     logger.error(f"Template {template_id} not found")
@@ -332,9 +338,16 @@ class CaseWorkflowService:
 
                 # Update allowed fields
                 allowed_fields = [
-                    'name', 'description', 'default_priority', 'default_status',
-                    'default_sla_policy_id', 'task_templates', 'playbook_steps',
-                    'applicable_mitre_techniques', 'tags', 'is_active'
+                    "name",
+                    "description",
+                    "default_priority",
+                    "default_status",
+                    "default_sla_policy_id",
+                    "task_templates",
+                    "playbook_steps",
+                    "applicable_mitre_techniques",
+                    "tags",
+                    "is_active",
                 ]
 
                 for field, value in updates.items():
@@ -347,27 +360,27 @@ class CaseWorkflowService:
         except Exception as e:
             logger.error(f"Error updating template {template_id}: {e}")
             return False
-    
+
     def delete_template(
-        self,
-        template_id: str,
-        session: Optional[Session] = None
+        self, template_id: str, session: Optional[Session] = None
     ) -> bool:
         """
         Delete (deactivate) a case template.
-        
+
         Args:
             template_id: Template ID
             session: Database session (optional)
-        
+
         Returns:
             True if successful
         """
         try:
             with unit_of_work(session) as session:
-                template = session.query(CaseTemplate).filter(
-                    CaseTemplate.template_id == template_id
-                ).first()
+                template = (
+                    session.query(CaseTemplate)
+                    .filter(CaseTemplate.template_id == template_id)
+                    .first()
+                )
 
                 if not template:
                     logger.error(f"Template {template_id} not found")
@@ -382,4 +395,3 @@ class CaseWorkflowService:
         except Exception as e:
             logger.error(f"Error deleting template {template_id}: {e}")
             return False
-

--- a/core/cases/sla_policies_router.py
+++ b/core/cases/sla_policies_router.py
@@ -1,13 +1,14 @@
 """SLA Policies API endpoints."""
 
+from datetime import datetime
 from typing import List, Optional
+
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from datetime import datetime
 
+from core.routing import Auth, RouterMeta, UnitOfWorkSession
 from core.storage.models import SLAPolicy
 from core.storage.schemas import CaseSchema, SLAPolicySchema
-from core.routing import Auth, RouterMeta, UnitOfWorkSession
 
 router = APIRouter()
 
@@ -20,6 +21,7 @@ ROUTER_META = RouterMeta(
 
 class SLAPolicyCreate(BaseModel):
     """Create SLA policy request."""
+
     policy_id: str
     name: str
     description: Optional[str] = None
@@ -35,6 +37,7 @@ class SLAPolicyCreate(BaseModel):
 
 class SLAPolicyUpdate(BaseModel):
     """Update SLA policy request."""
+
     name: Optional[str] = None
     description: Optional[str] = None
     response_time_hours: Optional[float] = None
@@ -51,52 +54,47 @@ async def list_sla_policies(
     session: UnitOfWorkSession,
     active_only: bool = False,
     priority_level: Optional[str] = None,
-    default_only: bool = False
+    default_only: bool = False,
 ):
     """
     List all SLA policies.
-    
+
     Args:
         active_only: Only return active policies
         priority_level: Filter by priority level
         default_only: Only return default policies
-    
+
     Returns:
         List of SLA policies
     """
     query = session.query(SLAPolicy)
 
     if active_only:
-        query = query.filter(SLAPolicy.is_active == True)
+        query = query.filter(SLAPolicy.is_active.is_(True))
 
     if priority_level:
         query = query.filter(SLAPolicy.priority_level == priority_level)
 
     if default_only:
-        query = query.filter(SLAPolicy.is_default == True)
+        query = query.filter(SLAPolicy.is_default.is_(True))
 
     policies = query.all()
 
-    return {
-        "policies": SLAPolicySchema.dump_many(policies),
-        "total": len(policies)
-    }
+    return {"policies": SLAPolicySchema.dump_many(policies), "total": len(policies)}
 
 
 @router.get("/{policy_id}")
 async def get_sla_policy(policy_id: str, session: UnitOfWorkSession):
     """
     Get a specific SLA policy by ID.
-    
+
     Args:
         policy_id: The policy ID
-    
+
     Returns:
         SLA policy details
     """
-    policy = session.query(SLAPolicy).filter(
-        SLAPolicy.policy_id == policy_id
-    ).first()
+    policy = session.query(SLAPolicy).filter(SLAPolicy.policy_id == policy_id).first()
 
     if not policy:
         raise HTTPException(status_code=404, detail="SLA policy not found")
@@ -108,59 +106,59 @@ async def get_sla_policy(policy_id: str, session: UnitOfWorkSession):
 async def create_sla_policy(data: SLAPolicyCreate, session: UnitOfWorkSession):
     """
     Create a new SLA policy.
-    
+
     Args:
         data: SLA policy creation data
-    
+
     Returns:
         Created SLA policy
     """
     try:
         # Check if policy ID already exists
-        existing = session.query(SLAPolicy).filter(
-            SLAPolicy.policy_id == data.policy_id
-        ).first()
-        
+        existing = (
+            session.query(SLAPolicy)
+            .filter(SLAPolicy.policy_id == data.policy_id)
+            .first()
+        )
+
         if existing:
             raise HTTPException(
                 status_code=400,
-                detail=f"Policy with ID {data.policy_id} already exists"
+                detail=f"Policy with ID {data.policy_id} already exists",
             )
-        
+
         # Validate priority level
         valid_priorities = ["critical", "high", "medium", "low"]
         if data.priority_level not in valid_priorities:
             raise HTTPException(
                 status_code=400,
-                detail=f"Invalid priority level. Must be one of: {valid_priorities}"
+                detail=f"Invalid priority level. Must be one of: {valid_priorities}",
             )
-        
+
         # Validate time values
         if data.response_time_hours <= 0:
             raise HTTPException(
-                status_code=400,
-                detail="Response time must be greater than 0"
+                status_code=400, detail="Response time must be greater than 0"
             )
-        
+
         if data.resolution_time_hours <= 0:
             raise HTTPException(
-                status_code=400,
-                detail="Resolution time must be greater than 0"
+                status_code=400, detail="Resolution time must be greater than 0"
             )
-        
+
         if data.response_time_hours >= data.resolution_time_hours:
             raise HTTPException(
                 status_code=400,
-                detail="Response time must be less than resolution time"
+                detail="Response time must be less than resolution time",
             )
-        
+
         # If setting as default, unset other defaults for this priority
         if data.is_default:
             session.query(SLAPolicy).filter(
                 SLAPolicy.priority_level == data.priority_level,
-                SLAPolicy.is_default == True
+                SLAPolicy.is_default.is_(True),
             ).update({"is_default": False})
-        
+
         # Create policy
         policy = SLAPolicy(
             policy_id=data.policy_id,
@@ -173,21 +171,23 @@ async def create_sla_policy(data: SLAPolicyCreate, session: UnitOfWorkSession):
             escalation_rules=data.escalation_rules,
             notification_thresholds=data.notification_thresholds or [75, 90, 100],
             is_active=data.is_active,
-            is_default=data.is_default
+            is_default=data.is_default,
         )
-        
+
         session.add(policy)
         # Flush so the read-back sees server defaults; the request's
         # unit of work commits.
         session.flush()
         session.refresh(policy)
-        
+
         return SLAPolicySchema.dump(policy)
-    
+
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to create policy: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to create policy: {str(e)}"
+        )
 
 
 @router.put("/{policy_id}")
@@ -198,87 +198,87 @@ async def update_sla_policy(
 ):
     """
     Update an existing SLA policy.
-    
+
     Args:
         policy_id: The policy ID
         data: SLA policy update data
-    
+
     Returns:
         Updated SLA policy
     """
     try:
-        policy = session.query(SLAPolicy).filter(
-            SLAPolicy.policy_id == policy_id
-        ).first()
-        
+        policy = (
+            session.query(SLAPolicy).filter(SLAPolicy.policy_id == policy_id).first()
+        )
+
         if not policy:
             raise HTTPException(status_code=404, detail="SLA policy not found")
-        
+
         # Update fields if provided
         if data.name is not None:
             policy.name = data.name
-        
+
         if data.description is not None:
             policy.description = data.description
-        
+
         if data.response_time_hours is not None:
             if data.response_time_hours <= 0:
                 raise HTTPException(
-                    status_code=400,
-                    detail="Response time must be greater than 0"
+                    status_code=400, detail="Response time must be greater than 0"
                 )
             policy.response_time_hours = data.response_time_hours
-        
+
         if data.resolution_time_hours is not None:
             if data.resolution_time_hours <= 0:
                 raise HTTPException(
-                    status_code=400,
-                    detail="Resolution time must be greater than 0"
+                    status_code=400, detail="Resolution time must be greater than 0"
                 )
             policy.resolution_time_hours = data.resolution_time_hours
-        
+
         # Validate response < resolution after updates
         if policy.response_time_hours >= policy.resolution_time_hours:
             raise HTTPException(
                 status_code=400,
-                detail="Response time must be less than resolution time"
+                detail="Response time must be less than resolution time",
             )
-        
+
         if data.business_hours_only is not None:
             policy.business_hours_only = data.business_hours_only
-        
+
         if data.escalation_rules is not None:
             policy.escalation_rules = data.escalation_rules
-        
+
         if data.notification_thresholds is not None:
             policy.notification_thresholds = data.notification_thresholds
-        
+
         if data.is_active is not None:
             policy.is_active = data.is_active
-        
+
         if data.is_default is not None:
             # If setting as default, unset other defaults for this priority
             if data.is_default and not policy.is_default:
                 session.query(SLAPolicy).filter(
                     SLAPolicy.priority_level == policy.priority_level,
                     SLAPolicy.policy_id != policy_id,
-                    SLAPolicy.is_default == True
+                    SLAPolicy.is_default.is_(True),
                 ).update({"is_default": False})
-            
+
             policy.is_default = data.is_default
-        
+
         policy.updated_at = datetime.utcnow()
         # Flush so the read-back sees server defaults; the request's
         # unit of work commits.
         session.flush()
         session.refresh(policy)
-        
+
         return SLAPolicySchema.dump(policy)
-    
+
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to update policy: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to update policy: {str(e)}"
+        )
 
 
 @router.delete("/{policy_id}")
@@ -289,74 +289,76 @@ async def delete_sla_policy(
 ):
     """
     Delete an SLA policy.
-    
+
     Args:
         policy_id: The policy ID
         force: Force delete even if policy is in use
-    
+
     Returns:
         Success message
     """
     try:
-        policy = session.query(SLAPolicy).filter(
-            SLAPolicy.policy_id == policy_id
-        ).first()
-        
+        policy = (
+            session.query(SLAPolicy).filter(SLAPolicy.policy_id == policy_id).first()
+        )
+
         if not policy:
             raise HTTPException(status_code=404, detail="SLA policy not found")
-        
+
         # Check if policy is in use
         from core.storage.models import CaseSLA
-        
-        in_use = session.query(CaseSLA).filter(
-            CaseSLA.sla_policy_id == policy_id
-        ).count()
-        
+
+        in_use = (
+            session.query(CaseSLA).filter(CaseSLA.sla_policy_id == policy_id).count()
+        )
+
         if in_use > 0 and not force:
             raise HTTPException(
                 status_code=400,
-                detail=f"Cannot delete policy that is in use by {in_use} case(s). Use force=true to delete anyway."
+                detail=f"Cannot delete policy that is in use by {in_use} case(s). Use force=true to delete anyway.",
             )
-        
+
         session.delete(policy)
-        
+
         return {
             "success": True,
-            "message": f"SLA policy {policy_id} deleted successfully"
+            "message": f"SLA policy {policy_id} deleted successfully",
         }
-    
+
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to delete policy: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to delete policy: {str(e)}"
+        )
 
 
 @router.post("/{policy_id}/set-default")
 async def set_default_policy(policy_id: str, session: UnitOfWorkSession):
     """
     Set a policy as the default for its priority level.
-    
+
     Args:
         policy_id: The policy ID
-    
+
     Returns:
         Updated policy
     """
     try:
-        policy = session.query(SLAPolicy).filter(
-            SLAPolicy.policy_id == policy_id
-        ).first()
-        
+        policy = (
+            session.query(SLAPolicy).filter(SLAPolicy.policy_id == policy_id).first()
+        )
+
         if not policy:
             raise HTTPException(status_code=404, detail="SLA policy not found")
-        
+
         # Unset other defaults for this priority
         session.query(SLAPolicy).filter(
             SLAPolicy.priority_level == policy.priority_level,
             SLAPolicy.policy_id != policy_id,
-            SLAPolicy.is_default == True
+            SLAPolicy.is_default.is_(True),
         ).update({"is_default": False})
-        
+
         # Set this as default
         policy.is_default = True
         policy.updated_at = datetime.utcnow()
@@ -364,52 +366,57 @@ async def set_default_policy(policy_id: str, session: UnitOfWorkSession):
         # unit of work commits.
         session.flush()
         session.refresh(policy)
-        
+
         return SLAPolicySchema.dump(policy)
-    
+
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to set default policy: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to set default policy: {str(e)}"
+        )
 
 
 @router.get("/{policy_id}/usage")
 async def get_policy_usage(policy_id: str, session: UnitOfWorkSession):
     """
     Get usage statistics for an SLA policy.
-    
+
     Args:
         policy_id: The policy ID
-    
+
     Returns:
         Usage statistics
     """
-    policy = session.query(SLAPolicy).filter(
-        SLAPolicy.policy_id == policy_id
-    ).first()
+    policy = session.query(SLAPolicy).filter(SLAPolicy.policy_id == policy_id).first()
 
     if not policy:
         raise HTTPException(status_code=404, detail="SLA policy not found")
 
-    from core.storage.models import CaseSLA, Case
-    from sqlalchemy import func
+    from core.storage.models import Case, CaseSLA
 
     # Total cases using this policy
-    total_cases = session.query(CaseSLA).filter(
-        CaseSLA.sla_policy_id == policy_id
-    ).count()
+    total_cases = (
+        session.query(CaseSLA).filter(CaseSLA.sla_policy_id == policy_id).count()
+    )
 
     # Active cases (not resolved)
-    active_cases = session.query(CaseSLA).join(Case).filter(
-        CaseSLA.sla_policy_id == policy_id,
-        Case.status.notin_(["resolved", "closed"])
-    ).count()
+    active_cases = (
+        session.query(CaseSLA)
+        .join(Case)
+        .filter(
+            CaseSLA.sla_policy_id == policy_id,
+            Case.status.notin_(["resolved", "closed"]),
+        )
+        .count()
+    )
 
     # Breached cases
-    breached_cases = session.query(CaseSLA).filter(
-        CaseSLA.sla_policy_id == policy_id,
-        CaseSLA.breached == True
-    ).count()
+    breached_cases = (
+        session.query(CaseSLA)
+        .filter(CaseSLA.sla_policy_id == policy_id, CaseSLA.breached.is_(True))
+        .count()
+    )
 
     # Compliance rate
     compliance_rate = 0.0
@@ -425,7 +432,7 @@ async def get_policy_usage(policy_id: str, session: UnitOfWorkSession):
         "breached_cases": breached_cases,
         "compliance_rate": round(compliance_rate, 2),
         "is_active": policy.is_active,
-        "is_default": policy.is_default
+        "is_default": policy.is_default,
     }
 
 
@@ -434,43 +441,38 @@ async def get_policy_cases(
     policy_id: str,
     session: UnitOfWorkSession,
     status: Optional[str] = None,
-    breached_only: bool = False
+    breached_only: bool = False,
 ):
     """
     Get all cases using a specific SLA policy.
-    
+
     Args:
         policy_id: The policy ID
         status: Filter by case status
         breached_only: Only return breached cases
-    
+
     Returns:
         List of cases
     """
-    policy = session.query(SLAPolicy).filter(
-        SLAPolicy.policy_id == policy_id
-    ).first()
+    policy = session.query(SLAPolicy).filter(SLAPolicy.policy_id == policy_id).first()
 
     if not policy:
         raise HTTPException(status_code=404, detail="SLA policy not found")
 
-    from core.storage.models import CaseSLA, Case
+    from core.storage.models import Case, CaseSLA
 
-    query = session.query(Case).join(CaseSLA).filter(
-        CaseSLA.sla_policy_id == policy_id
-    )
+    query = session.query(Case).join(CaseSLA).filter(CaseSLA.sla_policy_id == policy_id)
 
     if status:
         query = query.filter(Case.status == status)
 
     if breached_only:
-        query = query.filter(CaseSLA.breached == True)
+        query = query.filter(CaseSLA.breached.is_(True))
 
     cases = query.all()
 
     return {
         "policy_id": policy_id,
         "cases": CaseSchema.dump_many(cases),
-        "total": len(cases)
+        "total": len(cases),
     }
-

--- a/core/chat/context_manager.py
+++ b/core/chat/context_manager.py
@@ -8,6 +8,7 @@ Responsibilities:
 - Prompt-cache control injection (Anthropic cache_control blocks)
 - Tool filtering and per-tool response budgets
 """
+
 from __future__ import annotations
 
 import json
@@ -133,9 +134,7 @@ class ContextManager:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def apply_history_window(
-        messages: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+    def apply_history_window(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         from core.platform.runtime_config import get_ai_operations_setting
 
         window = get_ai_operations_setting("history_window", 20)
@@ -259,7 +258,6 @@ class ContextManager:
         )
         return total_tokens > available_tokens, total_tokens, available_tokens
 
-
     # ------------------------------------------------------------------
     # Rolling summary compression (no LLM call, provider-agnostic)
     # ------------------------------------------------------------------
@@ -279,7 +277,9 @@ class ContextManager:
             _flatten_content_to_text(m.get("content", "")) for m in overflow_messages
         )
 
-        finding_ids = sorted(set(re.findall(r"f-[0-9a-f]{8}-[0-9a-f]{8}", all_text, re.I)))[:10]
+        finding_ids = sorted(
+            set(re.findall(r"f-[0-9a-f]{8}-[0-9a-f]{8}", all_text, re.I))
+        )[:10]
         case_ids = sorted(set(re.findall(r"case-[0-9a-f]{8,}", all_text, re.I)))[:10]
         ips = sorted(set(re.findall(r"\b(?:\d{1,3}\.){3}\d{1,3}\b", all_text)))[:10]
         hashes = list(set(re.findall(r"\b[0-9a-f]{40,64}\b", all_text, re.I)))[:5]
@@ -307,14 +307,18 @@ class ContextManager:
             fold_parts.append("Analysis: " + " | ".join(assistant_snippets))
 
         fold_text = "; ".join(fold_parts)
-        combined = (existing_summary + "\n" + fold_text).lstrip("\n") if existing_summary else fold_text
+        combined = (
+            (existing_summary + "\n" + fold_text).lstrip("\n")
+            if existing_summary
+            else fold_text
+        )
 
         # Cap to avoid unbounded growth; keep the tail (most recent folds).
         if len(combined) > _SUMMARY_MAX_CHARS:
             combined = combined[-_SUMMARY_MAX_CHARS:]
             nl = combined.find("\n")
             if nl > 0:
-                combined = "[...earlier context truncated...]\n" + combined[nl + 1:]
+                combined = "[...earlier context truncated...]\n" + combined[nl + 1 :]
 
         return combined
 
@@ -398,4 +402,3 @@ class ContextManager:
             messages, "", system_prompt, backend_tools, mcp_tools, max_context_tokens
         )
         return prepared, len(overflow)
-

--- a/core/chat/conversation_service.py
+++ b/core/chat/conversation_service.py
@@ -215,9 +215,7 @@ def get_conversation(conversation_id: str, user_id: Optional[str]) -> Optional[d
         return ConversationSchema.dump(conv)
 
 
-def rename(
-    conversation_id: str, user_id: Optional[str], title: str
-) -> Optional[dict]:
+def rename(conversation_id: str, user_id: Optional[str], title: str) -> Optional[dict]:
     """Set a conversation's title; return its summary dict or None."""
     db_manager = get_db_manager()
     with db_manager.session_scope() as session:

--- a/core/chat/session_manager.py
+++ b/core/chat/session_manager.py
@@ -3,6 +3,7 @@
 L1: in-memory dict (fast, per-process).
 L2: MemPalace-backed JSON files (durable across restarts).
 """
+
 from __future__ import annotations
 
 import json

--- a/core/chat/tool_executor.py
+++ b/core/chat/tool_executor.py
@@ -8,6 +8,7 @@ Handles three dispatch paths:
 ``ToolExecutor`` is stateful only in ``skill_tool_index``, which ClaudeService
 refreshes before each request via ``_refresh_skill_tools``.
 """
+
 from __future__ import annotations
 
 import json
@@ -65,7 +66,9 @@ class ToolExecutor:
                             skills_by_tool_name=self.skill_tool_index or None,
                         )
                     except Exception as exc:
-                        logger.warning("Skill tool dispatch failed for %s: %s", tool_name, exc)
+                        logger.warning(
+                            "Skill tool dispatch failed for %s: %s", tool_name, exc
+                        )
                         result = {"error": f"Skill execution failed: {exc}"}
 
                 # Security detection tools
@@ -153,7 +156,9 @@ class ToolExecutor:
                 logger.info("Executed backend tool: %s", tool_name)
 
             except Exception as exc:
-                logger.error("Error calling backend tool %s: %s", tool_name, exc, exc_info=True)
+                logger.error(
+                    "Error calling backend tool %s: %s", tool_name, exc, exc_info=True
+                )
                 from core.llm.security import wrap_tool_result
 
                 err_text = wrap_tool_result(
@@ -214,7 +219,9 @@ class ToolExecutor:
                         server_name, actual_tool_name, arguments, timeout=30.0
                     )
                     if isinstance(raw, dict):
-                        blocks = raw.get("content", [{"type": "text", "text": str(raw)}])
+                        blocks = raw.get(
+                            "content", [{"type": "text", "text": str(raw)}]
+                        )
                     else:
                         blocks = [{"type": "text", "text": str(raw)}]
 
@@ -272,7 +279,9 @@ class ToolExecutor:
 
         for item in content:
             tool_name = (
-                item.get("name") if isinstance(item, dict) else getattr(item, "name", None)
+                item.get("name")
+                if isinstance(item, dict)
+                else getattr(item, "name", None)
             )
             if not tool_name:
                 continue
@@ -290,9 +299,7 @@ class ToolExecutor:
 # ------------------------------------------------------------------
 
 
-async def _dispatch_findings_tool(
-    tool_name: str, arguments: Dict, data_service
-) -> Any:
+async def _dispatch_findings_tool(tool_name: str, arguments: Dict, data_service) -> Any:
     """Handle all findings/cases backend tool calls."""
     if tool_name == "list_findings":
         limit = arguments.get("limit", 20)
@@ -502,9 +509,7 @@ def _dispatch_attack_tool(tool_name: str, arguments: Dict, data_service) -> Any:
     return {"error": f"Unknown ATT&CK tool: {tool_name}"}
 
 
-def _dispatch_approval_tool(
-    tool_name: str, arguments: Dict, approval_service
-) -> Any:
+def _dispatch_approval_tool(tool_name: str, arguments: Dict, approval_service) -> Any:
     from dataclasses import asdict
 
     if tool_name == "list_pending_approvals":
@@ -517,11 +522,19 @@ def _dispatch_approval_tool(
 
     if tool_name == "approve_action":
         action = approval_service.approve_action(**arguments)
-        return asdict(action) if action else {"error": "Action not found or cannot be approved"}
+        return (
+            asdict(action)
+            if action
+            else {"error": "Action not found or cannot be approved"}
+        )
 
     if tool_name == "reject_action":
         action = approval_service.reject_action(**arguments)
-        return asdict(action) if action else {"error": "Action not found or cannot be rejected"}
+        return (
+            asdict(action)
+            if action
+            else {"error": "Action not found or cannot be rejected"}
+        )
 
     if tool_name == "get_approval_stats":
         return approval_service.get_stats()

--- a/core/config.py
+++ b/core/config.py
@@ -9,8 +9,8 @@ from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
 
-_VIGIL_DIRNAME = '.vigil'
-_LEGACY_DIRNAME = '.deeptempo'
+_VIGIL_DIRNAME = ".vigil"
+_LEGACY_DIRNAME = ".deeptempo"
 
 REQUEST_TIMEOUT = 30
 STREAM_TIMEOUT = 120
@@ -261,14 +261,14 @@ def is_demo_mode() -> bool:
     enabled = get_settings().demo_mode
     if enabled is not None:
         return enabled
-    return get_general_config('demo_mode', False)
+    return get_general_config("demo_mode", False)
 
 
 def _load_json_config(path: Path) -> dict:
     if not path.exists():
         return {}
     try:
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             return json.load(f)
     except (json.JSONDecodeError, IOError) as e:
         logger.error(f"Config load error {path}: {e}")
@@ -276,17 +276,17 @@ def _load_json_config(path: Path) -> dict:
 
 
 def get_integration_config(integration_id: str) -> dict[str, Any]:
-    data = _load_json_config(vigil_path('integrations_config.json'))
-    if integration_id not in data.get('enabled_integrations', []):
+    data = _load_json_config(vigil_path("integrations_config.json"))
+    if integration_id not in data.get("enabled_integrations", []):
         return {}
-    return data.get('integrations', {}).get(integration_id, {})
+    return data.get("integrations", {}).get(integration_id, {})
 
 
 def is_integration_enabled(integration_id: str) -> bool:
-    data = _load_json_config(vigil_path('integrations_config.json'))
-    return integration_id in data.get('enabled_integrations', [])
+    data = _load_json_config(vigil_path("integrations_config.json"))
+    return integration_id in data.get("enabled_integrations", [])
 
 
 def get_general_config(key: str, default: Any = None) -> Any:
-    data = _load_json_config(vigil_path('general_config.json'))
+    data = _load_json_config(vigil_path("general_config.json"))
     return data.get(key, default)

--- a/core/detections/detection_rules_service.py
+++ b/core/detections/detection_rules_service.py
@@ -9,10 +9,11 @@ import json
 import logging
 import subprocess
 import uuid
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any
-from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
 from core.config import vigil_path
 
 logger = logging.getLogger(__name__)
@@ -89,7 +90,9 @@ class DetectionRulesService:
                 with open(self.config_path, "r") as f:
                     data = json.load(f)
                     self.sources = data.get("sources", [])
-                    logger.info(f"Loaded {len(self.sources)} detection rule sources from config")
+                    logger.info(
+                        f"Loaded {len(self.sources)} detection rule sources from config"
+                    )
                     return
             except Exception as e:
                 logger.error(f"Error loading detection sources config: {e}")
@@ -121,9 +124,13 @@ class DetectionRulesService:
             # Check if repo already exists on disk
             if clone_dir.exists():
                 source["status"] = "ready"
-                source["rule_count"] = self._count_rules(clone_dir, default["format"], default.get("subdirectory", ""))
+                source["rule_count"] = self._count_rules(
+                    clone_dir, default["format"], default.get("subdirectory", "")
+                )
                 source["last_updated"] = datetime.now().isoformat()
-                logger.info(f"Found existing repo: {default['name']} ({source['rule_count']} rules)")
+                logger.info(
+                    f"Found existing repo: {default['name']} ({source['rule_count']} rules)"
+                )
             else:
                 source["status"] = "not_cloned"
                 logger.info(f"Default source not yet cloned: {default['name']}")
@@ -238,13 +245,17 @@ class DetectionRulesService:
             if clone_dir.exists():
                 # Already cloned, just scan
                 source["status"] = "ready"
-                source["rule_count"] = self._count_rules(clone_dir, format, subdirectory)
+                source["rule_count"] = self._count_rules(
+                    clone_dir, format, subdirectory
+                )
                 source["last_updated"] = datetime.now().isoformat()
             else:
                 try:
                     self._git_clone(url, local_path)
                     source["status"] = "ready"
-                    source["rule_count"] = self._count_rules(clone_dir, format, subdirectory)
+                    source["rule_count"] = self._count_rules(
+                        clone_dir, format, subdirectory
+                    )
                     source["last_updated"] = datetime.now().isoformat()
                 except Exception as e:
                     source["status"] = "error"
@@ -254,7 +265,9 @@ class DetectionRulesService:
             local_dir = Path(local_path)
             if local_dir.exists():
                 source["status"] = "ready"
-                source["rule_count"] = self._count_rules(local_dir, format, subdirectory)
+                source["rule_count"] = self._count_rules(
+                    local_dir, format, subdirectory
+                )
                 source["last_updated"] = datetime.now().isoformat()
             else:
                 source["status"] = "error"
@@ -273,6 +286,7 @@ class DetectionRulesService:
 
         if delete_files and source["type"] == "git":
             import shutil
+
             clone_dir = Path(source["local_path"])
             if clone_dir.exists():
                 try:
@@ -317,9 +331,23 @@ class DetectionRulesService:
         for source in self.sources:
             try:
                 updated = self.update_source(source["id"])
-                results.append({"id": source["id"], "name": source["name"], "success": True, "rule_count": updated["rule_count"]})
+                results.append(
+                    {
+                        "id": source["id"],
+                        "name": source["name"],
+                        "success": True,
+                        "rule_count": updated["rule_count"],
+                    }
+                )
             except Exception as e:
-                results.append({"id": source["id"], "name": source["name"], "success": False, "error": str(e)})
+                results.append(
+                    {
+                        "id": source["id"],
+                        "name": source["name"],
+                        "success": False,
+                        "error": str(e),
+                    }
+                )
                 logger.error(f"Failed to update {source['name']}: {e}")
         return results
 
@@ -333,12 +361,14 @@ class DetectionRulesService:
             count = source.get("rule_count", 0)
             total += count
             by_format[source["format"]] += count
-            by_source.append({
-                "name": source["name"],
-                "format": source["format"],
-                "count": count,
-                "status": source.get("status", "unknown"),
-            })
+            by_source.append(
+                {
+                    "name": source["name"],
+                    "format": source["format"],
+                    "count": count,
+                    "status": source.get("status", "unknown"),
+                }
+            )
 
         return {
             "total_rules": total,

--- a/core/detections/tools.py
+++ b/core/detections/tools.py
@@ -2,45 +2,83 @@
 Security-Detections tool integration - Pure Python implementation
 Provides access to 7,200+ detection rules across Sigma, Splunk, Elastic, and KQL formats
 """
-import re
-import yaml
+
 import os
-from pathlib import Path
-from typing import List, Dict, Optional
+import re
 from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
 
 
 class SecurityDetectionsTools:
     """
     Main class for security detection tools integration.
     Loads and indexes detection rules from multiple formats.
-    
+
     Paths are resolved dynamically from DetectionRulesService when available,
     falling back to environment variables and then default paths.
     """
-    
+
     def __init__(self):
         """Initialize with detection rule paths from dynamic service or environment."""
         # Try to get paths dynamically from DetectionRulesService
         paths = self._get_dynamic_paths()
-        
-        self.sigma_path = Path(paths.get("sigma", os.getenv("SIGMA_PATHS", str(Path.home() / "security-detections/sigma/rules"))))
-        self.splunk_path = Path(paths.get("splunk", os.getenv("SPLUNK_PATHS", str(Path.home() / "security-detections/security_content/detections"))))
-        self.elastic_path = Path(paths.get("elastic", os.getenv("ELASTIC_PATHS", str(Path.home() / "security-detections/detection-rules/rules"))))
-        self.kql_path = Path(paths.get("kql", os.getenv("KQL_PATHS", str(Path.home() / "security-detections/Hunting-Queries-Detection-Rules"))))
-        
+
+        self.sigma_path = Path(
+            paths.get(
+                "sigma",
+                os.getenv(
+                    "SIGMA_PATHS", str(Path.home() / "security-detections/sigma/rules")
+                ),
+            )
+        )
+        self.splunk_path = Path(
+            paths.get(
+                "splunk",
+                os.getenv(
+                    "SPLUNK_PATHS",
+                    str(
+                        Path.home() / "security-detections/security_content/detections"
+                    ),
+                ),
+            )
+        )
+        self.elastic_path = Path(
+            paths.get(
+                "elastic",
+                os.getenv(
+                    "ELASTIC_PATHS",
+                    str(Path.home() / "security-detections/detection-rules/rules"),
+                ),
+            )
+        )
+        self.kql_path = Path(
+            paths.get(
+                "kql",
+                os.getenv(
+                    "KQL_PATHS",
+                    str(
+                        Path.home()
+                        / "security-detections/Hunting-Queries-Detection-Rules"
+                    ),
+                ),
+            )
+        )
+
         self.detections = []
         self.detections_by_technique = defaultdict(list)
         self.detections_by_source = defaultdict(list)
         self._loaded = False
-    
+
     def _get_dynamic_paths(self) -> Dict:
         """Get paths from DetectionRulesService if available."""
         try:
             from core.detections.detection_rules_service import DetectionRulesService
 
             env_vars = DetectionRulesService().get_mcp_env_vars()
-            
+
             paths = {}
             if "SIGMA_PATHS" in env_vars:
                 # Take only the first path if multiple are comma-separated
@@ -51,18 +89,18 @@ class SecurityDetectionsTools:
                 paths["elastic"] = env_vars["ELASTIC_PATHS"].split(",")[0]
             if "KQL_PATHS" in env_vars:
                 paths["kql"] = env_vars["KQL_PATHS"].split(",")[0]
-            
+
             return paths
         except Exception:
             return {}
-    
+
     def reload(self):
         """Reload detection rules (clears cache and re-reads from sources)."""
         self._loaded = False
         self.detections = []
         self.detections_by_technique = defaultdict(list)
         self.detections_by_source = defaultdict(list)
-        
+
         # Refresh paths from dynamic service
         paths = self._get_dynamic_paths()
         if paths.get("sigma"):
@@ -73,234 +111,255 @@ class SecurityDetectionsTools:
             self.elastic_path = Path(paths["elastic"])
         if paths.get("kql"):
             self.kql_path = Path(paths["kql"])
-        
+
         self._load_detections()
-    
+
     def _load_detections(self):
         """Load all detection files (lazy loading)"""
         if self._loaded:
             return
-        
+
         print("Loading detection rules...")
-        
+
         # Load Sigma rules
         if self.sigma_path.exists():
             for file_path in self.sigma_path.rglob("*.yml"):
                 try:
-                    with open(file_path, 'r', encoding='utf-8') as f:
+                    with open(file_path, "r", encoding="utf-8") as f:
                         detection = yaml.safe_load(f)
                         if detection and isinstance(detection, dict):
-                            detection['_source'] = 'sigma'
-                            detection['_file_path'] = str(file_path)
+                            detection["_source"] = "sigma"
+                            detection["_file_path"] = str(file_path)
                             self.detections.append(detection)
-                            self.detections_by_source['sigma'].append(detection)
-                            
+                            self.detections_by_source["sigma"].append(detection)
+
                             # Index by MITRE technique
-                            tags = detection.get('tags', [])
+                            tags = detection.get("tags", [])
                             for tag in tags:
-                                if isinstance(tag, str) and tag.startswith('attack.t'):
-                                    technique = tag.replace('attack.', '').upper()
-                                    self.detections_by_technique[technique].append(detection)
+                                if isinstance(tag, str) and tag.startswith("attack.t"):
+                                    technique = tag.replace("attack.", "").upper()
+                                    self.detections_by_technique[technique].append(
+                                        detection
+                                    )
                 except Exception:
                     pass  # Skip malformed files
-        
+
         # Load Splunk ESCU rules
         if self.splunk_path.exists():
             for file_path in self.splunk_path.rglob("*.yml"):
                 try:
-                    with open(file_path, 'r', encoding='utf-8') as f:
+                    with open(file_path, "r", encoding="utf-8") as f:
                         detection = yaml.safe_load(f)
                         if detection and isinstance(detection, dict):
-                            detection['_source'] = 'splunk'
-                            detection['_file_path'] = str(file_path)
+                            detection["_source"] = "splunk"
+                            detection["_file_path"] = str(file_path)
                             self.detections.append(detection)
-                            self.detections_by_source['splunk'].append(detection)
-                            
+                            self.detections_by_source["splunk"].append(detection)
+
                             # Index by MITRE technique
-                            tags = detection.get('tags', {}).get('mitre_attack_id', [])
+                            tags = detection.get("tags", {}).get("mitre_attack_id", [])
                             if isinstance(tags, list):
                                 for tag in tags:
-                                    self.detections_by_technique[tag.upper()].append(detection)
+                                    self.detections_by_technique[tag.upper()].append(
+                                        detection
+                                    )
                 except Exception:
                     pass
-        
+
         # Load Elastic rules
         if self.elastic_path.exists():
             for file_path in self.elastic_path.rglob("*.toml"):
                 try:
                     # Simple TOML parsing for threat section
-                    with open(file_path, 'r', encoding='utf-8') as f:
+                    with open(file_path, "r", encoding="utf-8") as f:
                         content = f.read()
-                        detection = {'_source': 'elastic', '_file_path': str(file_path), '_content': content}
+                        detection = {
+                            "_source": "elastic",
+                            "_file_path": str(file_path),
+                            "_content": content,
+                        }
                         self.detections.append(detection)
-                        self.detections_by_source['elastic'].append(detection)
-                        
+                        self.detections_by_source["elastic"].append(detection)
+
                         # Extract technique IDs from content
-                        techniques = re.findall(r'technique_id\s*=\s*"(T\d{4}(?:\.\d{3})?)"', content)
+                        techniques = re.findall(
+                            r'technique_id\s*=\s*"(T\d{4}(?:\.\d{3})?)"', content
+                        )
                         for technique in techniques:
-                            self.detections_by_technique[technique.upper()].append(detection)
+                            self.detections_by_technique[technique.upper()].append(
+                                detection
+                            )
                 except Exception:
                     pass
-        
+
         # Load KQL rules (.yaml and .md files)
         if self.kql_path.exists():
             # Load .yaml KQL rules (if any exist)
             for file_path in self.kql_path.rglob("*.yaml"):
                 try:
-                    with open(file_path, 'r', encoding='utf-8') as f:
+                    with open(file_path, "r", encoding="utf-8") as f:
                         detection = yaml.safe_load(f)
                         if detection and isinstance(detection, dict):
-                            detection['_source'] = 'kql'
-                            detection['_file_path'] = str(file_path)
+                            detection["_source"] = "kql"
+                            detection["_file_path"] = str(file_path)
                             self.detections.append(detection)
-                            self.detections_by_source['kql'].append(detection)
-                            
+                            self.detections_by_source["kql"].append(detection)
+
                             # Index by MITRE technique
-                            techniques = detection.get('mitre', [])
+                            techniques = detection.get("mitre", [])
                             if isinstance(techniques, list):
                                 for technique in techniques:
-                                    self.detections_by_technique[technique.upper()].append(detection)
+                                    self.detections_by_technique[
+                                        technique.upper()
+                                    ].append(detection)
                 except Exception:
                     pass
-            
+
             # Load .md KQL rules (Hunting-Queries-Detection-Rules format)
             for file_path in self.kql_path.rglob("*.md"):
                 # Skip README files and templates
-                if file_path.name.lower() in ('readme.md', 'detectiontemplate.md'):
+                if file_path.name.lower() in ("readme.md", "detectiontemplate.md"):
                     continue
                 try:
                     detection = self._parse_kql_markdown(file_path)
                     if detection:
                         self.detections.append(detection)
-                        self.detections_by_source['kql'].append(detection)
-                        
+                        self.detections_by_source["kql"].append(detection)
+
                         # Index by MITRE technique
-                        for technique in detection.get('mitre', []):
-                            self.detections_by_technique[technique.upper()].append(detection)
+                        for technique in detection.get("mitre", []):
+                            self.detections_by_technique[technique.upper()].append(
+                                detection
+                            )
                 except Exception:
                     pass
-        
+
         self._loaded = True
         print(f"Loaded {len(self.detections)} detection rules")
         print(f"  Sigma: {len(self.detections_by_source['sigma'])}")
         print(f"  Splunk: {len(self.detections_by_source['splunk'])}")
         print(f"  Elastic: {len(self.detections_by_source['elastic'])}")
         print(f"  KQL: {len(self.detections_by_source['kql'])}")
-    
+
     async def analyze_coverage(self, techniques: List[str]) -> Dict:
         """
         Analyze detection coverage for MITRE ATT&CK techniques.
-        
+
         Args:
             techniques: List of MITRE technique IDs (e.g., ["T1059.001", "T1071.001"])
-        
+
         Returns:
             Dictionary mapping technique IDs to coverage information
         """
         self._load_detections()
-        
+
         coverage = {}
         for technique in techniques:
             technique_upper = technique.upper()
             matching = self.detections_by_technique.get(technique_upper, [])
-            
+
             # Count by source
             by_source = defaultdict(int)
             for detection in matching:
-                by_source[detection['_source']] += 1
-            
+                by_source[detection["_source"]] += 1
+
             coverage[technique] = {
                 "count": len(matching),
                 "by_source": dict(by_source),
                 "detections": [
                     {
-                        "title": d.get('title') or d.get('name', 'Untitled'),
-                        "source": d['_source'],
-                        "id": d.get('id', ''),
-                        "description": d.get('description', '')[:200]
+                        "title": d.get("title") or d.get("name", "Untitled"),
+                        "source": d["_source"],
+                        "id": d.get("id", ""),
+                        "description": d.get("description", "")[:200],
                     }
                     for d in matching[:5]  # Top 5
-                ]
+                ],
             }
-        
+
         return coverage
-    
-    async def search_detections(self, query: str, source_type: Optional[str] = None, limit: int = 20) -> List[Dict]:
+
+    async def search_detections(
+        self, query: str, source_type: Optional[str] = None, limit: int = 20
+    ) -> List[Dict]:
         """
         Search across all detection rules using keywords.
-        
+
         Args:
             query: Search query (e.g., "powershell base64", "lateral movement")
             source_type: Optional filter by source ("sigma", "splunk", "elastic", "kql")
             limit: Maximum number of results
-        
+
         Returns:
             List of matching detection rules
         """
         self._load_detections()
-        
+
         query_lower = query.lower()
         results = []
-        
+
         detections_to_search = self.detections
         if source_type:
             detections_to_search = self.detections_by_source.get(source_type, [])
-        
+
         for detection in detections_to_search:
             # Search in title, description, tags
             searchable = str(detection).lower()
             if query_lower in searchable:
-                results.append({
-                    "title": detection.get('title') or detection.get('name', 'Untitled'),
-                    "source": detection['_source'],
-                    "id": detection.get('id', ''),
-                    "description": detection.get('description', '')[:300],
-                    "file_path": detection['_file_path']
-                })
-                
+                results.append(
+                    {
+                        "title": detection.get("title")
+                        or detection.get("name", "Untitled"),
+                        "source": detection["_source"],
+                        "id": detection.get("id", ""),
+                        "description": detection.get("description", "")[:300],
+                        "file_path": detection["_file_path"],
+                    }
+                )
+
                 if len(results) >= limit:
                     break
-        
+
         return results
-    
+
     async def get_detection_count(self, source_type: Optional[str] = None) -> Dict:
         """
         Get count of detections by source.
-        
+
         Args:
             source_type: Optional filter by source
-        
+
         Returns:
             Count information
         """
         self._load_detections()
-        
+
         if source_type:
             return {
                 "source": source_type,
-                "count": len(self.detections_by_source.get(source_type, []))
+                "count": len(self.detections_by_source.get(source_type, [])),
             }
-        
+
         return {
             "total": len(self.detections),
             "by_source": {
                 source: len(detections)
                 for source, detections in self.detections_by_source.items()
-            }
+            },
         }
-    
+
     async def identify_gaps(self, context: str) -> Dict:
         """
         Identify detection gaps for a given context (e.g., "ransomware", "APT29").
-        
+
         Args:
             context: Context for gap analysis
-        
+
         Returns:
             Gap analysis results
         """
         self._load_detections()
-        
+
         # Common ransomware techniques
         ransomware_techniques = [
             "T1486",  # Data Encrypted for Impact
@@ -309,73 +368,77 @@ class SecurityDetectionsTools:
             "T1047",  # Windows Management Instrumentation
             "T1059.001",  # PowerShell
         ]
-        
+
         # For demonstration, analyze common techniques
         # In production, this would map context to specific technique sets
-        techniques_to_check = ransomware_techniques if "ransomware" in context.lower() else []
-        
+        techniques_to_check = (
+            ransomware_techniques if "ransomware" in context.lower() else []
+        )
+
         gaps = []
         coverage_map = {}
-        
+
         for technique in techniques_to_check:
             matching = self.detections_by_technique.get(technique, [])
             count = len(matching)
             coverage_map[technique] = count
-            
+
             if count < 3:  # Threshold for "gap"
-                gaps.append({
-                    "technique": technique,
-                    "current_coverage": count,
-                    "priority": "high" if count == 0 else "medium"
-                })
-        
+                gaps.append(
+                    {
+                        "technique": technique,
+                        "current_coverage": count,
+                        "priority": "high" if count == 0 else "medium",
+                    }
+                )
+
         return {
             "context": context,
             "techniques_analyzed": len(techniques_to_check),
             "gaps_identified": len(gaps),
             "gaps": gaps,
-            "coverage_map": coverage_map
+            "coverage_map": coverage_map,
         }
-    
+
     async def get_coverage_stats(self, source_type: Optional[str] = None) -> Dict:
         """
         Get overall coverage statistics.
-        
+
         Args:
             source_type: Optional filter by source
-        
+
         Returns:
             Coverage statistics
         """
         self._load_detections()
-        
+
         stats = {
             "total_detections": len(self.detections),
             "techniques_covered": len(self.detections_by_technique),
             "by_source": {
                 source: {
                     "count": len(detections),
-                    "techniques": len(set(
-                        tech for det in detections
-                        for tech in self._extract_techniques(det)
-                    ))
+                    "techniques": len(
+                        set(
+                            tech
+                            for det in detections
+                            for tech in self._extract_techniques(det)
+                        )
+                    ),
                 }
                 for source, detections in self.detections_by_source.items()
-            }
+            },
         }
-        
+
         if source_type and source_type in self.detections_by_source:
-            return {
-                "source": source_type,
-                **stats["by_source"][source_type]
-            }
-        
+            return {"source": source_type, **stats["by_source"][source_type]}
+
         return stats
-    
+
     def _parse_kql_markdown(self, file_path: Path) -> Optional[Dict]:
         """
         Parse a KQL markdown file from the Hunting-Queries-Detection-Rules repo.
-        
+
         Expected format:
             # Title
             ## Query Information
@@ -390,65 +453,68 @@ class SecurityDetectionsTools:
             ...query...
             ```
         """
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
-        
+
         if not content.strip():
             return None
-        
+
         # Extract title from first markdown heading
-        title_match = re.search(r'^#\s+(.+)', content, re.MULTILINE)
+        title_match = re.search(r"^#\s+(.+)", content, re.MULTILINE)
         title = title_match.group(1).strip() if title_match else file_path.stem
-        
+
         # Extract description from #### Description section
         desc_match = re.search(
-            r'####\s+Description\s*\n(.*?)(?=\n####|\n##|\n```|\Z)',
-            content, re.DOTALL
+            r"####\s+Description\s*\n(.*?)(?=\n####|\n##|\n```|\Z)", content, re.DOTALL
         )
-        description = desc_match.group(1).strip() if desc_match else ''
-        
+        description = desc_match.group(1).strip() if desc_match else ""
+
         # Extract MITRE technique IDs from the table or anywhere in the doc
-        mitre_techniques = list(set(re.findall(r'(T\d{4}(?:\.\d{3})?)', content)))
-        
+        mitre_techniques = list(set(re.findall(r"(T\d{4}(?:\.\d{3})?)", content)))
+
         # Extract KQL queries from code blocks
-        kql_blocks = re.findall(r'```(?:KQL|kql)\s*\n(.*?)```', content, re.DOTALL)
-        query = '\n---\n'.join(block.strip() for block in kql_blocks) if kql_blocks else ''
-        
+        kql_blocks = re.findall(r"```(?:KQL|kql)\s*\n(.*?)```", content, re.DOTALL)
+        query = (
+            "\n---\n".join(block.strip() for block in kql_blocks) if kql_blocks else ""
+        )
+
         # Determine category from parent directory
-        category = file_path.parent.name if file_path.parent != self.kql_path else 'General'
-        
+        category = (
+            file_path.parent.name if file_path.parent != self.kql_path else "General"
+        )
+
         detection = {
-            '_source': 'kql',
-            '_file_path': str(file_path),
-            'title': title,
-            'name': title,
-            'description': description,
-            'query': query,
-            'category': category,
-            'mitre': mitre_techniques,
-            'id': f"kql-{file_path.stem}",
+            "_source": "kql",
+            "_file_path": str(file_path),
+            "title": title,
+            "name": title,
+            "description": description,
+            "query": query,
+            "category": category,
+            "mitre": mitre_techniques,
+            "id": f"kql-{file_path.stem}",
         }
-        
+
         return detection
 
     def _extract_techniques(self, detection: Dict) -> List[str]:
         """Extract MITRE techniques from a detection"""
         techniques = []
-        
-        if detection['_source'] == 'sigma':
-            tags = detection.get('tags', [])
+
+        if detection["_source"] == "sigma":
+            tags = detection.get("tags", [])
             for tag in tags:
-                if isinstance(tag, str) and tag.startswith('attack.t'):
-                    techniques.append(tag.replace('attack.', '').upper())
-        elif detection['_source'] == 'splunk':
-            tags = detection.get('tags', {}).get('mitre_attack_id', [])
+                if isinstance(tag, str) and tag.startswith("attack.t"):
+                    techniques.append(tag.replace("attack.", "").upper())
+        elif detection["_source"] == "splunk":
+            tags = detection.get("tags", {}).get("mitre_attack_id", [])
             if isinstance(tags, list):
                 techniques.extend([t.upper() for t in tags])
-        elif detection['_source'] == 'kql':
-            techs = detection.get('mitre', [])
+        elif detection["_source"] == "kql":
+            techs = detection.get("mitre", [])
             if isinstance(techs, list):
                 techniques.extend([t.upper() for t in techs])
-        
+
         return techniques
 
 
@@ -462,4 +528,3 @@ def get_security_detection_tools() -> SecurityDetectionsTools:
     if _security_detection_tools is None:
         _security_detection_tools = SecurityDetectionsTools()
     return _security_detection_tools
-

--- a/core/federation/registry.py
+++ b/core/federation/registry.py
@@ -46,9 +46,7 @@ def list_adapters() -> List[FederationAdapter]:
         try:
             out.append(factory())
         except Exception as e:
-            logger.warning(
-                "Federation adapter %s failed to construct: %s", name, e
-            )
+            logger.warning("Federation adapter %s failed to construct: %s", name, e)
     return out
 
 
@@ -83,11 +81,19 @@ def _ensure_builtins_loaded() -> None:
     # Every vendor adapter lives in its vertical slice; import the adapter module
     # directly for the module-scope register_adapter() side effect.
     try:
-        from core.integrations.aws_security_hub import adapter as _aws_adapter  # noqa: F401
-        from core.integrations.azure_sentinel import adapter as _azure_adapter  # noqa: F401
-        from core.integrations.crowdstrike import adapter as _crowdstrike_adapter  # noqa: F401
+        from core.integrations.aws_security_hub import (  # noqa: F401
+            adapter as _aws_adapter,
+        )
+        from core.integrations.azure_sentinel import (  # noqa: F401
+            adapter as _azure_adapter,
+        )
+        from core.integrations.crowdstrike import (  # noqa: F401
+            adapter as _crowdstrike_adapter,
+        )
         from core.integrations.elastic import adapter as _elastic_adapter  # noqa: F401
-        from core.integrations.microsoft_defender import adapter as _defender_adapter  # noqa: F401
+        from core.integrations.microsoft_defender import (  # noqa: F401
+            adapter as _defender_adapter,
+        )
         from core.integrations.splunk import adapter as _splunk_adapter  # noqa: F401
     except Exception as e:
         logger.warning("Failed to load builtin federation adapters: %s", e)

--- a/core/federation/runner.py
+++ b/core/federation/runner.py
@@ -26,9 +26,9 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 from core.config import DEFAULT_REDIS_URL, get_settings
-from core.ingestion.dedup import RedisDedupSet
 from core.federation import registry, store
 from core.federation.seed import seed_federation_sources
+from core.ingestion.dedup import RedisDedupSet
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +134,7 @@ class FederationRunner:
 
             interval = int(row.get("interval_seconds") or adapter.default_interval())
             errors = int(row.get("consecutive_errors") or 0)
-            backoff_mult = min(2 ** errors, 8) if errors else 1
+            backoff_mult = min(2**errors, 8) if errors else 1
             sleep_for = max(interval * backoff_mult, 5)
 
             # Honor "poll now" — a redis flag the API sets when the user
@@ -239,7 +239,9 @@ def request_poll_now(source_id: str) -> bool:
 
         url = get_settings().redis_url or DEFAULT_REDIS_URL
         client = redis.from_url(url, decode_responses=True)
-        client.set(f"vigil:federation:trigger:{source_id}", str(int(time.time())), ex=300)
+        client.set(
+            f"vigil:federation:trigger:{source_id}", str(int(time.time())), ex=300
+        )
         return True
     except Exception as e:
         logger.warning("request_poll_now(%s) failed: %s", source_id, e)

--- a/core/findings/enrichment/service.py
+++ b/core/findings/enrichment/service.py
@@ -70,8 +70,8 @@ def _resolve_provider(component: str) -> Tuple[Any, str, Any]:
         NoProviderConfigured: nothing resolved, or no Anthropic API key.
         ProviderUnavailable: the resolved provider id has no spec row.
     """
-    from core.llm.router.router import get_provider_spec
     from core.llm.providers.registry import get_registry
+    from core.llm.router.router import get_provider_spec
 
     resolved_model = get_registry().resolve_model_for_component(component)
     if not resolved_model:
@@ -128,13 +128,13 @@ async def _dispatch(
         "model": model_id,
         "max_tokens": LOCAL_MAX_TOKENS,
     }
-    from core.llm.router.router import LLMRouter
     from core.llm.providers.recovery import (
         is_gateway_connection_error,
         local_bifrost_recovery_enabled,
         local_bifrost_recovery_retry_limit,
         recover_local_bifrost,
     )
+    from core.llm.router.router import LLMRouter
 
     retry_limit = local_bifrost_recovery_retry_limit()
     for attempt in range(retry_limit + 1):

--- a/core/findings/graph_builder_service.py
+++ b/core/findings/graph_builder_service.py
@@ -1,354 +1,371 @@
 """Graph Builder Service - Extracts entity relationships from findings."""
 
-from typing import List, Dict, Any, Set, Tuple
 import logging
+from typing import Any, Dict, List, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
 
 class GraphBuilderService:
     """Service for building graph visualizations from security findings."""
-    
+
     def __init__(self):
-        self.entity_types = ['src_ip', 'dst_ip', 'hostname', 'user', 'query_name', 'uri']
-    
+        self.entity_types = [
+            "src_ip",
+            "dst_ip",
+            "hostname",
+            "user",
+            "query_name",
+            "uri",
+        ]
+
     def build_entity_graph(self, findings: List[Dict[str, Any]]) -> Dict[str, Any]:
         """
         Build entity relationship graph from findings.
-        
+
         Args:
             findings: List of finding dictionaries
-            
+
         Returns:
             Graph data with nodes and links
         """
         nodes_dict: Dict[str, Dict[str, Any]] = {}
         links_dict: Dict[Tuple[str, str], Dict[str, Any]] = {}
-        
+
         for finding in findings:
-            entity_context = finding.get('entity_context', {})
+            entity_context = finding.get("entity_context", {})
             if not entity_context:
                 continue
-            
-            finding_id = finding['finding_id']
-            severity = finding.get('severity', 'unknown')
-            
+
+            finding_id = finding["finding_id"]
+            severity = finding.get("severity", "unknown")
+
             # Extract entities from context
             entities = self._extract_entities(entity_context)
-            
+
             # Add nodes
             for entity_id, entity_data in entities.items():
                 if entity_id not in nodes_dict:
                     nodes_dict[entity_id] = {
-                        'id': entity_id,
-                        'label': entity_data['label'],
-                        'type': entity_data['type'],
-                        'severity': severity,
-                        'findingCount': 1,
-                        'metadata': {'findings': [finding_id]}
+                        "id": entity_id,
+                        "label": entity_data["label"],
+                        "type": entity_data["type"],
+                        "severity": severity,
+                        "findingCount": 1,
+                        "metadata": {"findings": [finding_id]},
                     }
                 else:
                     # Update existing node
-                    nodes_dict[entity_id]['findingCount'] += 1
-                    nodes_dict[entity_id]['metadata']['findings'].append(finding_id)
-                    
+                    nodes_dict[entity_id]["findingCount"] += 1
+                    nodes_dict[entity_id]["metadata"]["findings"].append(finding_id)
+
                     # Update severity to highest
-                    current_severity = nodes_dict[entity_id].get('severity', 'low')
-                    if self._severity_rank(severity) > self._severity_rank(current_severity):
-                        nodes_dict[entity_id]['severity'] = severity
-            
+                    current_severity = nodes_dict[entity_id].get("severity", "low")
+                    if self._severity_rank(severity) > self._severity_rank(
+                        current_severity
+                    ):
+                        nodes_dict[entity_id]["severity"] = severity
+
             # Create links between entities in the same finding
             entity_list = list(entities.keys())
             for i in range(len(entity_list)):
                 for j in range(i + 1, len(entity_list)):
                     source = entity_list[i]
                     target = entity_list[j]
-                    
+
                     # Ensure consistent ordering
                     if source > target:
                         source, target = target, source
-                    
+
                     link_key = (source, target)
-                    
+
                     if link_key not in links_dict:
                         links_dict[link_key] = {
-                            'source': source,
-                            'target': target,
-                            'value': 1,
-                            'techniques': self._extract_techniques(finding)
+                            "source": source,
+                            "target": target,
+                            "value": 1,
+                            "techniques": self._extract_techniques(finding),
                         }
                     else:
-                        links_dict[link_key]['value'] += 1
+                        links_dict[link_key]["value"] += 1
                         # Merge techniques
-                        existing_techniques = set(links_dict[link_key].get('techniques', []))
+                        existing_techniques = set(
+                            links_dict[link_key].get("techniques", [])
+                        )
                         new_techniques = set(self._extract_techniques(finding))
-                        links_dict[link_key]['techniques'] = list(existing_techniques | new_techniques)
-        
+                        links_dict[link_key]["techniques"] = list(
+                            existing_techniques | new_techniques
+                        )
+
         return {
-            'nodes': list(nodes_dict.values()),
-            'links': list(links_dict.values()),
-            'metadata': {
-                'total_findings': len(findings),
-                'unique_entities': len(nodes_dict),
-                'relationships': len(links_dict)
-            }
+            "nodes": list(nodes_dict.values()),
+            "links": list(links_dict.values()),
+            "metadata": {
+                "total_findings": len(findings),
+                "unique_entities": len(nodes_dict),
+                "relationships": len(links_dict),
+            },
         }
-    
-    def build_attack_path(self, findings: List[Dict[str, Any]], case: Dict[str, Any]) -> Dict[str, Any]:
+
+    def build_attack_path(
+        self, findings: List[Dict[str, Any]], case: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
         Build attack path graph showing progression across systems.
-        
+
         Args:
             findings: List of finding dictionaries
             case: Case dictionary
-            
+
         Returns:
             Graph data with nodes and links representing attack progression
         """
         # Sort findings by timestamp
-        sorted_findings = sorted(findings, key=lambda f: f.get('timestamp', ''))
-        
+        sorted_findings = sorted(findings, key=lambda f: f.get("timestamp", ""))
+
         nodes_dict: Dict[str, Dict[str, Any]] = {}
         links_list: List[Dict[str, Any]] = []
-        
+
         prev_entities: Set[str] = set()
-        
+
         for idx, finding in enumerate(sorted_findings):
-            entity_context = finding.get('entity_context', {})
+            entity_context = finding.get("entity_context", {})
             if not entity_context:
                 continue
-            
-            finding_id = finding['finding_id']
-            severity = finding.get('severity', 'unknown')
+
+            finding_id = finding["finding_id"]
+            severity = finding.get("severity", "unknown")
             techniques = self._extract_techniques(finding)
-            
+
             # Extract entities
             entities = self._extract_entities(entity_context)
             current_entities = set(entities.keys())
-            
+
             # Add nodes
             for entity_id, entity_data in entities.items():
                 if entity_id not in nodes_dict:
                     nodes_dict[entity_id] = {
-                        'id': entity_id,
-                        'label': entity_data['label'],
-                        'type': entity_data['type'],
-                        'severity': severity,
-                        'findingCount': 1,
-                        'metadata': {
-                            'findings': [finding_id],
-                            'first_seen': finding.get('timestamp'),
-                            'sequence': idx
-                        }
+                        "id": entity_id,
+                        "label": entity_data["label"],
+                        "type": entity_data["type"],
+                        "severity": severity,
+                        "findingCount": 1,
+                        "metadata": {
+                            "findings": [finding_id],
+                            "first_seen": finding.get("timestamp"),
+                            "sequence": idx,
+                        },
                     }
                 else:
-                    nodes_dict[entity_id]['findingCount'] += 1
-                    nodes_dict[entity_id]['metadata']['findings'].append(finding_id)
-            
+                    nodes_dict[entity_id]["findingCount"] += 1
+                    nodes_dict[entity_id]["metadata"]["findings"].append(finding_id)
+
             # Create temporal links showing attack progression
             if prev_entities:
                 # Link to entities from previous finding (showing progression)
                 for prev_entity in prev_entities:
                     for curr_entity in current_entities:
                         if prev_entity != curr_entity:
-                            links_list.append({
-                                'source': prev_entity,
-                                'target': curr_entity,
-                                'value': 1,
-                                'label': f"Step {idx}",
-                                'techniques': techniques
-                            })
-            
+                            links_list.append(
+                                {
+                                    "source": prev_entity,
+                                    "target": curr_entity,
+                                    "value": 1,
+                                    "label": f"Step {idx}",
+                                    "techniques": techniques,
+                                }
+                            )
+
             prev_entities = current_entities
-        
+
         return {
-            'nodes': list(nodes_dict.values()),
-            'links': links_list,
-            'metadata': {
-                'case_id': case.get('case_id'),
-                'case_title': case.get('title'),
-                'total_findings': len(findings),
-                'attack_steps': len(sorted_findings)
-            }
+            "nodes": list(nodes_dict.values()),
+            "links": links_list,
+            "metadata": {
+                "case_id": case.get("case_id"),
+                "case_title": case.get("title"),
+                "total_findings": len(findings),
+                "attack_steps": len(sorted_findings),
+            },
         }
-    
-    def build_cluster_graph(self, findings: List[Dict[str, Any]], cluster_id: str) -> Dict[str, Any]:
+
+    def build_cluster_graph(
+        self, findings: List[Dict[str, Any]], cluster_id: str
+    ) -> Dict[str, Any]:
         """
         Build graph for a cluster of findings.
-        
+
         Args:
             findings: List of finding dictionaries
             cluster_id: Cluster identifier
-            
+
         Returns:
             Graph data for the cluster
         """
         # Add cluster node at center
         graph_data = self.build_entity_graph(findings)
-        
+
         # Add cluster node
         cluster_node = {
-            'id': f'cluster-{cluster_id}',
-            'label': f'Cluster {cluster_id}',
-            'type': 'cluster',
-            'findingCount': len(findings),
-            'metadata': {
-                'cluster_id': cluster_id,
-                'findings': [f['finding_id'] for f in findings]
-            }
+            "id": f"cluster-{cluster_id}",
+            "label": f"Cluster {cluster_id}",
+            "type": "cluster",
+            "findingCount": len(findings),
+            "metadata": {
+                "cluster_id": cluster_id,
+                "findings": [f["finding_id"] for f in findings],
+            },
         }
-        
-        graph_data['nodes'].append(cluster_node)
-        
+
+        graph_data["nodes"].append(cluster_node)
+
         # Link cluster to all entities
-        entity_nodes = [n for n in graph_data['nodes'] if n['type'] != 'cluster']
+        entity_nodes = [n for n in graph_data["nodes"] if n["type"] != "cluster"]
         for node in entity_nodes[:10]:  # Limit to top 10 to avoid clutter
-            graph_data['links'].append({
-                'source': cluster_node['id'],
-                'target': node['id'],
-                'value': node.get('findingCount', 1),
-                'label': 'member'
-            })
-        
-        graph_data['metadata']['cluster_id'] = cluster_id
-        
+            graph_data["links"].append(
+                {
+                    "source": cluster_node["id"],
+                    "target": node["id"],
+                    "value": node.get("findingCount", 1),
+                    "label": "member",
+                }
+            )
+
+        graph_data["metadata"]["cluster_id"] = cluster_id
+
         return graph_data
-    
-    def build_technique_graph(self, findings: List[Dict[str, Any]], technique_id: str) -> Dict[str, Any]:
+
+    def build_technique_graph(
+        self, findings: List[Dict[str, Any]], technique_id: str
+    ) -> Dict[str, Any]:
         """
         Build graph for a specific MITRE ATT&CK technique.
-        
+
         Args:
             findings: List of finding dictionaries
             technique_id: MITRE ATT&CK technique ID
-            
+
         Returns:
             Graph data for the technique
         """
         graph_data = self.build_entity_graph(findings)
-        
+
         # Add technique node at center
         technique_node = {
-            'id': f'technique-{technique_id}',
-            'label': technique_id,
-            'type': 'technique',
-            'findingCount': len(findings),
-            'metadata': {
-                'technique_id': technique_id,
-                'findings': [f['finding_id'] for f in findings]
-            }
+            "id": f"technique-{technique_id}",
+            "label": technique_id,
+            "type": "technique",
+            "findingCount": len(findings),
+            "metadata": {
+                "technique_id": technique_id,
+                "findings": [f["finding_id"] for f in findings],
+            },
         }
-        
-        graph_data['nodes'].append(technique_node)
-        
+
+        graph_data["nodes"].append(technique_node)
+
         # Link technique to entities involved
-        for node in graph_data['nodes']:
-            if node['type'] != 'technique':
-                graph_data['links'].append({
-                    'source': technique_node['id'],
-                    'target': node['id'],
-                    'value': node.get('findingCount', 1),
-                    'label': 'involves',
-                    'techniques': [technique_id]
-                })
-        
-        graph_data['metadata']['technique_id'] = technique_id
-        
+        for node in graph_data["nodes"]:
+            if node["type"] != "technique":
+                graph_data["links"].append(
+                    {
+                        "source": technique_node["id"],
+                        "target": node["id"],
+                        "value": node.get("findingCount", 1),
+                        "label": "involves",
+                        "techniques": [technique_id],
+                    }
+                )
+
+        graph_data["metadata"]["technique_id"] = technique_id
+
         return graph_data
-    
-    def _extract_entities(self, entity_context: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+
+    def _extract_entities(
+        self, entity_context: Dict[str, Any]
+    ) -> Dict[str, Dict[str, Any]]:
         """
         Extract entities from entity context.
-        
+
         Args:
             entity_context: Entity context dictionary
-            
+
         Returns:
             Dictionary of entity_id -> entity_data
         """
         entities = {}
-        
+
         # Source IP
-        if 'src_ip' in entity_context and entity_context['src_ip']:
+        if "src_ip" in entity_context and entity_context["src_ip"]:
             entity_id = f"ip-{entity_context['src_ip']}"
             entities[entity_id] = {
-                'label': entity_context['src_ip'],
-                'type': 'ip',
-                'role': 'source'
+                "label": entity_context["src_ip"],
+                "type": "ip",
+                "role": "source",
             }
-        
+
         # Destination IP
-        if 'dst_ip' in entity_context and entity_context['dst_ip']:
+        if "dst_ip" in entity_context and entity_context["dst_ip"]:
             entity_id = f"ip-{entity_context['dst_ip']}"
             entities[entity_id] = {
-                'label': entity_context['dst_ip'],
-                'type': 'ip',
-                'role': 'destination'
+                "label": entity_context["dst_ip"],
+                "type": "ip",
+                "role": "destination",
             }
-        
+
         # Hostname
-        if 'hostname' in entity_context and entity_context['hostname']:
+        if "hostname" in entity_context and entity_context["hostname"]:
             entity_id = f"host-{entity_context['hostname']}"
             entities[entity_id] = {
-                'label': entity_context['hostname'],
-                'type': 'hostname'
+                "label": entity_context["hostname"],
+                "type": "hostname",
             }
-        
+
         # User
-        if 'user' in entity_context and entity_context['user']:
+        if "user" in entity_context and entity_context["user"]:
             entity_id = f"user-{entity_context['user']}"
-            entities[entity_id] = {
-                'label': entity_context['user'],
-                'type': 'user'
-            }
-        
+            entities[entity_id] = {"label": entity_context["user"], "type": "user"}
+
         # Domain (from query_name or uri)
-        if 'query_name' in entity_context and entity_context['query_name']:
+        if "query_name" in entity_context and entity_context["query_name"]:
             entity_id = f"domain-{entity_context['query_name']}"
             entities[entity_id] = {
-                'label': entity_context['query_name'],
-                'type': 'domain'
+                "label": entity_context["query_name"],
+                "type": "domain",
             }
-        
+
         # Port
-        if 'dst_port' in entity_context and entity_context['dst_port']:
+        if "dst_port" in entity_context and entity_context["dst_port"]:
             entity_id = f"port-{entity_context['dst_port']}"
             entities[entity_id] = {
-                'label': f"Port {entity_context['dst_port']}",
-                'type': 'port'
+                "label": f"Port {entity_context['dst_port']}",
+                "type": "port",
             }
-        
+
         return entities
-    
+
     def _extract_techniques(self, finding: Dict[str, Any]) -> List[str]:
         """
         Extract MITRE ATT&CK techniques from finding.
-        
+
         Args:
             finding: Finding dictionary
-            
+
         Returns:
             List of technique IDs
         """
-        mitre_predictions = finding.get('mitre_predictions', {})
+        mitre_predictions = finding.get("mitre_predictions", {})
         return list(mitre_predictions.keys())
-    
+
     def _severity_rank(self, severity: str) -> int:
         """
         Get numeric rank for severity.
-        
+
         Args:
             severity: Severity string
-            
+
         Returns:
             Numeric rank (higher = more severe)
         """
-        severity_map = {
-            'critical': 4,
-            'high': 3,
-            'medium': 2,
-            'low': 1,
-            'unknown': 0
-        }
-        return severity_map.get(severity.lower() if severity else 'unknown', 0)
-
+        severity_map = {"critical": 4, "high": 3, "medium": 2, "low": 1, "unknown": 0}
+        return severity_map.get(severity.lower() if severity else "unknown", 0)

--- a/core/findings/source_evidence.py
+++ b/core/findings/source_evidence.py
@@ -14,7 +14,6 @@ from collections.abc import Mapping
 from datetime import date, datetime
 from typing import Any, Dict, Optional
 
-
 SOURCE_EVIDENCE_VERSION = 1
 SOURCE_EVIDENCE_PREVIEW_LIMIT = 100
 SOURCE_EVIDENCE_RAW_TEXT_LIMIT = 65_536

--- a/core/ingestion/ingestion_service.py
+++ b/core/ingestion/ingestion_service.py
@@ -3,7 +3,7 @@ Data Ingestion Service for Vigil SOC
 
 Handles ingestion of findings and cases from various formats:
 - JSON files
-- CSV files  
+- CSV files
 - JSONL (JSON Lines) files
 - Parquet files (DeepTempo LogLM embeddings)
 - Direct JSON data
@@ -11,15 +11,15 @@ Handles ingestion of findings and cases from various formats:
 All data is stored in PostgreSQL when available, with fallback to JSON files.
 """
 
-import json
 import csv
 import hashlib
+import json
 import logging
 import tempfile
-from pathlib import Path
-from typing import List, Dict, Any, Union
 from datetime import datetime
 from io import StringIO
+from pathlib import Path
+from typing import Any, Dict, List, Union
 
 from core.findings.source_evidence import (
     normalize_finding_source_evidence,
@@ -29,10 +29,19 @@ from core.findings.source_evidence import (
 logger = logging.getLogger(__name__)
 
 MITRE_TACTIC_MAP = {
-    0: 'Impact', 1: 'Execution', 2: 'Reconnaissance', 3: 'Credential Access',
-    4: 'Initial Access', 5: 'Persistence', 6: 'Discovery', 7: 'Command and Control',
-    8: 'Lateral Movement', 9: 'Defense Evasion', 10: 'Collection',
-    11: 'Privilege Escalation', 12: 'Exfiltration',
+    0: "Impact",
+    1: "Execution",
+    2: "Reconnaissance",
+    3: "Credential Access",
+    4: "Initial Access",
+    5: "Persistence",
+    6: "Discovery",
+    7: "Command and Control",
+    8: "Lateral Movement",
+    9: "Defense Evasion",
+    10: "Collection",
+    11: "Privilege Escalation",
+    12: "Exfiltration",
 }
 
 # 64 bits. The old 8 chars gave 32, where a 200k-row file is near-certain to
@@ -42,21 +51,30 @@ ID_HASH_WIDTH = 16
 # Columns identifying a row when the source carries no id of its own, ordered
 # most to least selective.
 PARQUET_IDENTITY_COLUMNS = (
-    'embedding', 'event_start_time', 'event_end_time', 'focal_ip', 'engaged_ip',
+    "embedding",
+    "event_start_time",
+    "event_end_time",
+    "focal_ip",
+    "engaged_ip",
 )
 TEMPO_CSV_IDENTITY_COLUMNS = (
-    'event_start', 'event_end', 'IP1', 'IP2', 'mitre_tactic', 'created_at',
+    "event_start",
+    "event_end",
+    "IP1",
+    "IP2",
+    "mitre_tactic",
+    "created_at",
 )
 
 # Column-name aliases for entity_context on schemas ingest doesn't recognize.
 # First match wins; raw row is always kept in raw_features regardless.
 ENTITY_FIELD_ALIASES = {
-    'src_ip': ('src_ip', 'source_ip', 'srcip', 'ip1', 'saddr'),
-    'dst_ip': ('dest_ip', 'dst_ip', 'destination_ip', 'dstip', 'ip2', 'daddr'),
-    'src_port': ('src_port', 'source_port', 'sport', 'srcport'),
-    'dst_port': ('dest_port', 'dst_port', 'destination_port', 'dport', 'dstport'),
-    'proto': ('proto', 'protocol', 'ip_proto'),
-    'timestamp': ('timestamp', 'ts', 'event_time', 'time', 'created_at'),
+    "src_ip": ("src_ip", "source_ip", "srcip", "ip1", "saddr"),
+    "dst_ip": ("dest_ip", "dst_ip", "destination_ip", "dstip", "ip2", "daddr"),
+    "src_port": ("src_port", "source_port", "sport", "srcport"),
+    "dst_port": ("dest_port", "dst_port", "destination_port", "dport", "dstport"),
+    "proto": ("proto", "protocol", "ip_proto"),
+    "timestamp": ("timestamp", "ts", "event_time", "time", "created_at"),
 }
 
 
@@ -75,22 +93,22 @@ def row_identity_key(row: Dict[str, Any], columns: tuple) -> str:
         value = row.get(column)
         if isinstance(value, (list, tuple)):
             value = hashlib.sha256(
-                ','.join(repr(v) for v in value).encode()
+                ",".join(repr(v) for v in value).encode()
             ).hexdigest()
         parts.append(f"{column}={value!r}")
-    return '|'.join(parts)
+    return "|".join(parts)
 
 
 class IngestionService:
     """Service for ingesting data from various formats into the database."""
-    
+
     def __init__(self):
         """Initialize the ingestion service."""
         # Import here to avoid circular dependencies
         try:
-            from core.storage.service import DatabaseService
             from core.storage.connection import get_db_manager
-            
+            from core.storage.service import DatabaseService
+
             db_manager = get_db_manager()
             if db_manager.health_check():
                 self.db_service = DatabaseService()
@@ -104,25 +122,22 @@ class IngestionService:
             logger.warning(f"Database not available: {e}, using JSON fallback")
             self.db_service = None
             self.use_database = False
-        
+
         # Statistics for reporting
         self.stats = {
-            'findings_total': 0,
-            'findings_imported': 0,
-            'findings_skipped': 0,
-            'findings_errors': 0,
-            'cases_total': 0,
-            'cases_imported': 0,
-            'cases_skipped': 0,
-            'cases_errors': 0,
+            "findings_total": 0,
+            "findings_imported": 0,
+            "findings_skipped": 0,
+            "findings_errors": 0,
+            "cases_total": 0,
+            "cases_imported": 0,
+            "cases_skipped": 0,
+            "cases_errors": 0,
         }
         self._identity_warned: set = set()
 
     def _identity_fallback(
-        self,
-        row: Dict[str, Any],
-        columns: tuple,
-        missing_column: str
+        self, row: Dict[str, Any], columns: tuple, missing_column: str
     ) -> str:
         """Content-derived id key for a row whose id column is absent."""
         if missing_column not in self._identity_warned:
@@ -131,7 +146,7 @@ class IngestionService:
                 "No '%s' column in this source; deriving finding ids from row "
                 "content (%s). Rows identical across those columns will dedupe.",
                 missing_column,
-                ', '.join(columns),
+                ", ".join(columns),
             )
         return row_identity_key(row, columns)
 
@@ -139,128 +154,131 @@ class IngestionService:
         """Reset ingestion statistics."""
         for key in self.stats:
             self.stats[key] = 0
-    
+
     def parse_timestamp(self, timestamp_value: Any) -> datetime:
         """
         Parse various timestamp formats to datetime.
-        
+
         Args:
             timestamp_value: Timestamp as string, int, or datetime
-        
+
         Returns:
             datetime object
         """
         if isinstance(timestamp_value, datetime):
             return timestamp_value
-        
+
         if not timestamp_value:
             return datetime.utcnow()
-        
+
         # If it's a Unix timestamp (int or float)
         if isinstance(timestamp_value, (int, float)):
             try:
                 return datetime.fromtimestamp(timestamp_value)
             except (ValueError, OSError):
                 pass
-        
+
         # Try various string formats
         timestamp_str = str(timestamp_value)
         formats = [
-            '%Y-%m-%dT%H:%M:%S.%fZ',
-            '%Y-%m-%dT%H:%M:%S.%f%z',
-            '%Y-%m-%dT%H:%M:%SZ',
-            '%Y-%m-%dT%H:%M:%S%z',
-            '%Y-%m-%dT%H:%M:%S',
-            '%Y-%m-%d %H:%M:%S',
-            '%Y-%m-%d',
+            "%Y-%m-%dT%H:%M:%S.%fZ",
+            "%Y-%m-%dT%H:%M:%S.%f%z",
+            "%Y-%m-%dT%H:%M:%SZ",
+            "%Y-%m-%dT%H:%M:%S%z",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d",
         ]
-        
+
         for fmt in formats:
             try:
-                ts_str = timestamp_str.replace('+00:00', '').replace('Z', '')
-                return datetime.strptime(ts_str, fmt.replace('Z', '').replace('%z', ''))
+                ts_str = timestamp_str.replace("+00:00", "").replace("Z", "")
+                return datetime.strptime(ts_str, fmt.replace("Z", "").replace("%z", ""))
             except ValueError:
                 continue
-        
-        logger.warning(f"Could not parse timestamp: {timestamp_value}, using current time")
+
+        logger.warning(
+            f"Could not parse timestamp: {timestamp_value}, using current time"
+        )
         return datetime.utcnow()
-    
+
     def ingest_finding(self, finding_data: Dict[str, Any]) -> bool:
         """
         Ingest a single finding into the database.
-        
+
         Args:
             finding_data: Finding dictionary
-        
+
         Returns:
             True if successful, False otherwise
         """
-        finding_id = finding_data.get('finding_id')
+        finding_id = finding_data.get("finding_id")
         if not finding_id:
             logger.error("Finding missing finding_id")
-            self.stats['findings_errors'] += 1
+            self.stats["findings_errors"] += 1
             return False
 
         finding_data = normalize_finding_source_evidence(finding_data)
-        
+
         try:
             if self.use_database and self.db_service:
                 # Check if finding already exists
                 existing = self.db_service.get_finding(finding_id)
                 if existing:
                     logger.debug(f"Finding {finding_id} already exists, skipping")
-                    self.stats['findings_skipped'] += 1
+                    self.stats["findings_skipped"] += 1
                     return True
-                
+
                 # Parse timestamp
-                timestamp = self.parse_timestamp(finding_data.get('timestamp'))
-                
+                timestamp = self.parse_timestamp(finding_data.get("timestamp"))
+
                 # Create finding in database
                 finding = self.db_service.create_finding(
                     finding_id=finding_id,
-                    embedding=finding_data.get('embedding', [0.0] * 768),
-                    mitre_predictions=finding_data.get('mitre_predictions', {}),
-                    anomaly_score=float(finding_data.get('anomaly_score', 0.0)),
+                    embedding=finding_data.get("embedding", [0.0] * 768),
+                    mitre_predictions=finding_data.get("mitre_predictions", {}),
+                    anomaly_score=float(finding_data.get("anomaly_score", 0.0)),
                     timestamp=timestamp,
-                    data_source=finding_data.get('data_source', 'imported'),
-                    external_id=finding_data.get('external_id'),
-                    description=finding_data.get('description'),
-                    entity_context=finding_data.get('entity_context'),
-                    evidence_links=finding_data.get('evidence_links'),
-                    cluster_id=finding_data.get('cluster_id'),
-                    severity=finding_data.get('severity'),
-                    status=finding_data.get('status', 'new')
+                    data_source=finding_data.get("data_source", "imported"),
+                    external_id=finding_data.get("external_id"),
+                    description=finding_data.get("description"),
+                    entity_context=finding_data.get("entity_context"),
+                    evidence_links=finding_data.get("evidence_links"),
+                    cluster_id=finding_data.get("cluster_id"),
+                    severity=finding_data.get("severity"),
+                    status=finding_data.get("status", "new"),
                 )
-                
+
                 if finding:
-                    self.stats['findings_imported'] += 1
+                    self.stats["findings_imported"] += 1
                     logger.debug(f"Imported finding: {finding_id}")
                     return True
                 else:
-                    self.stats['findings_errors'] += 1
+                    self.stats["findings_errors"] += 1
                     logger.error(f"Failed to create finding: {finding_id}")
                     return False
             else:
                 # Fallback to JSON file storage
                 from core.storage.database_data_service import DatabaseDataService
+
                 data_service = DatabaseDataService()
                 findings = data_service.get_findings()
-                
+
                 # Check for duplicate
-                if any(f.get('finding_id') == finding_id for f in findings):
-                    self.stats['findings_skipped'] += 1
+                if any(f.get("finding_id") == finding_id for f in findings):
+                    self.stats["findings_skipped"] += 1
                     return True
-                
+
                 findings.append(finding_data)
                 if data_service.save_findings(findings):
-                    self.stats['findings_imported'] += 1
+                    self.stats["findings_imported"] += 1
                     return True
                 else:
-                    self.stats['findings_errors'] += 1
+                    self.stats["findings_errors"] += 1
                     return False
-        
+
         except Exception as e:
-            self.stats['findings_errors'] += 1
+            self.stats["findings_errors"] += 1
             logger.error(f"Error ingesting finding {finding_id}: {e}")
             return False
 
@@ -276,17 +294,23 @@ class IngestionService:
 
         valid = []
         for finding_data in finding_dicts:
-            if not finding_data.get('finding_id'):
+            if not finding_data.get("finding_id"):
                 logger.error("Finding missing finding_id")
-                self.stats['findings_errors'] += 1
+                self.stats["findings_errors"] += 1
                 continue
             try:
                 finding_data = normalize_finding_source_evidence(finding_data)
-                finding_data['timestamp'] = self.parse_timestamp(finding_data.get('timestamp'))
-                finding_data['anomaly_score'] = float(finding_data.get('anomaly_score', 0.0))
+                finding_data["timestamp"] = self.parse_timestamp(
+                    finding_data.get("timestamp")
+                )
+                finding_data["anomaly_score"] = float(
+                    finding_data.get("anomaly_score", 0.0)
+                )
             except Exception as e:
-                logger.error(f"Error preparing finding {finding_data.get('finding_id')}: {e}")
-                self.stats['findings_errors'] += 1
+                logger.error(
+                    f"Error preparing finding {finding_data.get('finding_id')}: {e}"
+                )
+                self.stats["findings_errors"] += 1
                 continue
             valid.append(finding_data)
 
@@ -295,12 +319,12 @@ class IngestionService:
 
         try:
             result = self.db_service.bulk_create_findings(valid)
-            self.stats['findings_imported'] += result['imported']
-            self.stats['findings_skipped'] += result['skipped']
-            self.stats['findings_errors'] += result.get('errors', 0)
+            self.stats["findings_imported"] += result["imported"]
+            self.stats["findings_skipped"] += result["skipped"]
+            self.stats["findings_errors"] += result.get("errors", 0)
         except Exception as e:
             logger.error(f"Error bulk ingesting findings: {e}")
-            self.stats['findings_errors'] += len(valid)
+            self.stats["findings_errors"] += len(valid)
 
     def _ingest_findings_batched(self, findings, batch_size: int = 1000) -> None:
         """Feed an iterable of finding dicts through _ingest_finding_batch in chunks."""
@@ -316,162 +340,174 @@ class IngestionService:
     def ingest_case(self, case_data: Dict[str, Any]) -> bool:
         """
         Ingest a single case into the database.
-        
+
         Args:
             case_data: Case dictionary
-        
+
         Returns:
             True if successful, False otherwise
         """
-        case_id = case_data.get('case_id')
+        case_id = case_data.get("case_id")
         if not case_id:
             logger.error("Case missing case_id")
-            self.stats['cases_errors'] += 1
+            self.stats["cases_errors"] += 1
             return False
-        
+
         try:
             if self.use_database and self.db_service:
                 # Check if case already exists
                 existing = self.db_service.get_case(case_id)
                 if existing:
                     logger.debug(f"Case {case_id} already exists, skipping")
-                    self.stats['cases_skipped'] += 1
+                    self.stats["cases_skipped"] += 1
                     return True
-                
+
                 # Create case in database
                 case = self.db_service.create_case(
                     case_id=case_id,
-                    title=case_data.get('title', 'Imported Case'),
-                    finding_ids=case_data.get('finding_ids', []),
-                    description=case_data.get('description', ''),
-                    status=case_data.get('status', 'new'),
-                    priority=case_data.get('priority', 'medium'),
-                    assignee=case_data.get('assignee'),
-                    tags=case_data.get('tags', []),
-                    notes=case_data.get('notes', []),
-                    timeline=case_data.get('timeline', []),
-                    activities=case_data.get('activities', []),
-                    resolution_steps=case_data.get('resolution_steps', []),
-                    mitre_techniques=case_data.get('mitre_techniques')
+                    title=case_data.get("title", "Imported Case"),
+                    finding_ids=case_data.get("finding_ids", []),
+                    description=case_data.get("description", ""),
+                    status=case_data.get("status", "new"),
+                    priority=case_data.get("priority", "medium"),
+                    assignee=case_data.get("assignee"),
+                    tags=case_data.get("tags", []),
+                    notes=case_data.get("notes", []),
+                    timeline=case_data.get("timeline", []),
+                    activities=case_data.get("activities", []),
+                    resolution_steps=case_data.get("resolution_steps", []),
+                    mitre_techniques=case_data.get("mitre_techniques"),
                 )
-                
+
                 if case:
-                    self.stats['cases_imported'] += 1
+                    self.stats["cases_imported"] += 1
                     logger.debug(f"Imported case: {case_id}")
                     return True
                 else:
-                    self.stats['cases_errors'] += 1
+                    self.stats["cases_errors"] += 1
                     logger.error(f"Failed to create case: {case_id}")
                     return False
             else:
                 # Fallback to JSON file storage
                 from core.storage.database_data_service import DatabaseDataService
+
                 data_service = DatabaseDataService()
                 cases = data_service.get_cases()
-                
+
                 # Check for duplicate
-                if any(c.get('case_id') == case_id for c in cases):
-                    self.stats['cases_skipped'] += 1
+                if any(c.get("case_id") == case_id for c in cases):
+                    self.stats["cases_skipped"] += 1
                     return True
-                
+
                 cases.append(case_data)
                 if data_service.save_cases(cases):
-                    self.stats['cases_imported'] += 1
+                    self.stats["cases_imported"] += 1
                     return True
                 else:
-                    self.stats['cases_errors'] += 1
+                    self.stats["cases_errors"] += 1
                     return False
-        
+
         except Exception as e:
-            self.stats['cases_errors'] += 1
+            self.stats["cases_errors"] += 1
             logger.error(f"Error ingesting case {case_id}: {e}")
             return False
-    
+
     def ingest_json_file(self, file_path: Union[str, Path]) -> Dict[str, Any]:
         """Ingest a JSON file: {findings, cases} dict or a top-level findings/cases array.
         Streams via ijson when available, else falls back to json.load."""
         self.reset_stats()
         file_path = Path(file_path)
-        
+
         if not file_path.exists():
             logger.error(f"File not found: {file_path}")
             return self.stats
-        
+
         try:
             import ijson
+
             self._ingest_json_streaming(file_path, ijson)
         except ImportError:
             logger.info("ijson not available, falling back to full json.load")
             self._ingest_json_full(file_path)
         except Exception as e:
-            logger.warning(f"Streaming JSON parse failed, falling back to json.load: {e}")
+            logger.warning(
+                f"Streaming JSON parse failed, falling back to json.load: {e}"
+            )
             try:
                 self._ingest_json_full(file_path)
             except Exception as e2:
                 logger.error(f"Error ingesting JSON file: {e2}")
-        
+
         logger.info(f"JSON ingestion complete: {self.stats}")
         return self.stats
 
     def _ingest_json_streaming(self, file_path: Path, ijson) -> None:
         """Stream-parse a JSON file item by item to avoid loading it all into memory."""
-        with open(file_path, 'rb') as f:
+        with open(file_path, "rb") as f:
             peek = f.read(1)
             f.seek(0)
-            
-            if peek == b'{':
+
+            if peek == b"{":
+
                 def _findings():
-                    for item in ijson.items(f, 'findings.item'):
-                        self.stats['findings_total'] += 1
+                    for item in ijson.items(f, "findings.item"):
+                        self.stats["findings_total"] += 1
                         yield item
+
                 self._ingest_findings_batched(_findings())
                 f.seek(0)
-                for item in ijson.items(f, 'cases.item'):
-                    self.stats['cases_total'] += 1
+                for item in ijson.items(f, "cases.item"):
+                    self.stats["cases_total"] += 1
                     self.ingest_case(item)
-            elif peek == b'[':
+            elif peek == b"[":
                 first_key = None
                 finding_batch = []
-                for item in ijson.items(f, 'item'):
+                for item in ijson.items(f, "item"):
                     if first_key is None:
-                        first_key = 'finding' if 'finding_id' in item else 'case' if 'case_id' in item else 'finding'
-                    if first_key == 'finding':
-                        self.stats['findings_total'] += 1
+                        first_key = (
+                            "finding"
+                            if "finding_id" in item
+                            else "case" if "case_id" in item else "finding"
+                        )
+                    if first_key == "finding":
+                        self.stats["findings_total"] += 1
                         finding_batch.append(item)
                         if len(finding_batch) >= 1000:
                             self._ingest_finding_batch(finding_batch)
                             finding_batch = []
                     else:
-                        self.stats['cases_total'] += 1
+                        self.stats["cases_total"] += 1
                         self.ingest_case(item)
                 if finding_batch:
                     self._ingest_finding_batch(finding_batch)
 
     def _ingest_json_full(self, file_path: Path) -> None:
         """Fallback: load entire JSON file into memory."""
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             data = json.load(f)
 
         findings = []
         cases = []
 
         if isinstance(data, dict):
-            findings = data.get('findings', [])
-            cases = data.get('cases', [])
+            findings = data.get("findings", [])
+            cases = data.get("cases", [])
         elif isinstance(data, list):
-            if data and 'finding_id' in data[0]:
+            if data and "finding_id" in data[0]:
                 findings = data
-            elif data and 'case_id' in data[0]:
+            elif data and "case_id" in data[0]:
                 cases = data
 
-        self.stats['findings_total'] = len(findings)
-        self.stats['cases_total'] = len(cases)
+        self.stats["findings_total"] = len(findings)
+        self.stats["cases_total"] = len(cases)
 
         self._ingest_findings_batched(findings)
         for case in cases:
             self.ingest_case(case)
-    
-    def ingest_jsonl_file(self, file_path: Union[str, Path], data_type: str = 'finding') -> Dict[str, Any]:
+
+    def ingest_jsonl_file(
+        self, file_path: Union[str, Path], data_type: str = "finding"
+    ) -> Dict[str, Any]:
         """Ingest a JSON Lines file, one finding or case per line."""
         self.reset_stats()
         file_path = Path(file_path)
@@ -482,7 +518,7 @@ class IngestionService:
 
         try:
             finding_batch = []
-            with open(file_path, 'r') as f:
+            with open(file_path, "r") as f:
                 for line_num, line in enumerate(f, 1):
                     line = line.strip()
                     if not line:
@@ -491,33 +527,35 @@ class IngestionService:
                     try:
                         data = json.loads(line)
 
-                        if data_type == 'finding':
-                            self.stats['findings_total'] += 1
+                        if data_type == "finding":
+                            self.stats["findings_total"] += 1
                             finding_batch.append(data)
                             if len(finding_batch) >= 1000:
                                 self._ingest_finding_batch(finding_batch)
                                 finding_batch = []
-                        elif data_type == 'case':
-                            self.stats['cases_total'] += 1
+                        elif data_type == "case":
+                            self.stats["cases_total"] += 1
                             self.ingest_case(data)
 
                     except json.JSONDecodeError as e:
                         logger.error(f"Invalid JSON on line {line_num}: {e}")
-                        if data_type == 'finding':
-                            self.stats['findings_errors'] += 1
+                        if data_type == "finding":
+                            self.stats["findings_errors"] += 1
                         else:
-                            self.stats['cases_errors'] += 1
+                            self.stats["cases_errors"] += 1
             if finding_batch:
                 self._ingest_finding_batch(finding_batch)
 
             logger.info(f"JSONL ingestion complete: {self.stats}")
             return self.stats
-        
+
         except Exception as e:
             logger.error(f"Error ingesting JSONL file: {e}")
             return self.stats
-    
-    def ingest_csv_file(self, file_path: Union[str, Path], data_type: str = 'finding') -> Dict[str, Any]:
+
+    def ingest_csv_file(
+        self, file_path: Union[str, Path], data_type: str = "finding"
+    ) -> Dict[str, Any]:
         """Ingest a CSV file: generic finding/case rows, or the Tempo alert format."""
         self.reset_stats()
         file_path = Path(file_path)
@@ -528,41 +566,41 @@ class IngestionService:
 
         try:
             finding_batch = []
-            with open(file_path, 'r', encoding='utf-8') as f:
+            with open(file_path, "r", encoding="utf-8") as f:
                 reader = csv.DictReader(f)
 
                 for row_num, row in enumerate(reader, 1):
                     try:
-                        if data_type == 'finding':
-                            self.stats['findings_total'] += 1
+                        if data_type == "finding":
+                            self.stats["findings_total"] += 1
                             finding_batch.append(self._csv_row_to_finding(row))
                             if len(finding_batch) >= 1000:
                                 self._ingest_finding_batch(finding_batch)
                                 finding_batch = []
-                        elif data_type == 'case':
-                            self.stats['cases_total'] += 1
+                        elif data_type == "case":
+                            self.stats["cases_total"] += 1
                             case_data = self._csv_row_to_case(row)
                             self.ingest_case(case_data)
 
                     except Exception as e:
                         logger.error(f"Error processing CSV row {row_num}: {e}")
-                        if data_type == 'finding':
-                            self.stats['findings_errors'] += 1
+                        if data_type == "finding":
+                            self.stats["findings_errors"] += 1
                         else:
-                            self.stats['cases_errors'] += 1
+                            self.stats["cases_errors"] += 1
             if finding_batch:
                 self._ingest_finding_batch(finding_batch)
 
             logger.info(f"CSV ingestion complete: {self.stats}")
             return self.stats
-        
+
         except Exception as e:
             logger.error(f"Error ingesting CSV file: {e}")
             return self.stats
-    
+
     def _is_tempo_csv(self, row: Dict[str, str]) -> bool:
         """Detect Tempo alert CSV format by checking for characteristic columns."""
-        tempo_cols = {'sequence_id', 'mitre_tactic', 'incident_confidence'}
+        tempo_cols = {"sequence_id", "mitre_tactic", "incident_confidence"}
         return bool(tempo_cols & set(row.keys()))
 
     def _csv_row_to_finding(self, row: Dict[str, str]) -> Dict[str, Any]:
@@ -570,10 +608,10 @@ class IngestionService:
         Convert CSV row to finding dictionary.
         Handles both the generic finding CSV format and the Tempo alert CSV
         format (sequence_id, IP1, IP2, mitre_tactic, incident_confidence, etc.).
-        
+
         Args:
             row: CSV row as dictionary
-        
+
         Returns:
             Finding dictionary
         """
@@ -581,56 +619,61 @@ class IngestionService:
             return self._tempo_csv_row_to_finding(row)
 
         # Generate finding_id if not present
-        finding_id = row.get('finding_id')
+        finding_id = row.get("finding_id")
         if not finding_id:
             import uuid
+
             finding_id = f"f-{datetime.now().strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
-        
+
         # Parse embedding if present (comma-separated floats)
         embedding = []
-        if 'embedding' in row and row['embedding']:
+        if "embedding" in row and row["embedding"]:
             try:
-                embedding = [float(x.strip()) for x in row['embedding'].split(',')]
+                embedding = [float(x.strip()) for x in row["embedding"].split(",")]
             except ValueError:
-                logger.warning(f"Invalid embedding format for {finding_id}, using empty")
+                logger.warning(
+                    f"Invalid embedding format for {finding_id}, using empty"
+                )
                 embedding = [0.0] * 768
         else:
             embedding = [0.0] * 768
-        
+
         # Parse MITRE predictions (JSON string or comma-separated)
         mitre_predictions = {}
-        if 'mitre_predictions' in row and row['mitre_predictions']:
+        if "mitre_predictions" in row and row["mitre_predictions"]:
             try:
-                mitre_predictions = json.loads(row['mitre_predictions'])
+                mitre_predictions = json.loads(row["mitre_predictions"])
             except json.JSONDecodeError:
                 # Try comma-separated format: T1071.001:0.85,T1048.003:0.72
                 try:
-                    for pair in row['mitre_predictions'].split(','):
-                        technique, score = pair.split(':')
+                    for pair in row["mitre_predictions"].split(","):
+                        technique, score = pair.split(":")
                         mitre_predictions[technique.strip()] = float(score.strip())
                 except Exception as e:
-                    logger.warning(f"Invalid mitre_predictions format for {finding_id}: {e}")
-        
+                    logger.warning(
+                        f"Invalid mitre_predictions format for {finding_id}: {e}"
+                    )
+
         # Parse entity context (JSON string)
         entity_context = None
-        if 'entity_context' in row and row['entity_context']:
+        if "entity_context" in row and row["entity_context"]:
             try:
-                entity_context = json.loads(row['entity_context'])
+                entity_context = json.loads(row["entity_context"])
             except json.JSONDecodeError:
                 logger.warning(f"Invalid entity_context format for {finding_id}")
-        
+
         return {
-            'finding_id': finding_id,
-            'embedding': embedding,
-            'mitre_predictions': mitre_predictions,
-            'anomaly_score': float(row.get('anomaly_score', 0.0)),
-            'timestamp': row.get('timestamp', datetime.utcnow().isoformat()),
-            'data_source': row.get('data_source', 'csv_import'),
-            'entity_context': entity_context,
-            'evidence_links': None,
-            'cluster_id': row.get('cluster_id'),
-            'severity': row.get('severity'),
-            'status': row.get('status', 'new')
+            "finding_id": finding_id,
+            "embedding": embedding,
+            "mitre_predictions": mitre_predictions,
+            "anomaly_score": float(row.get("anomaly_score", 0.0)),
+            "timestamp": row.get("timestamp", datetime.utcnow().isoformat()),
+            "data_source": row.get("data_source", "csv_import"),
+            "entity_context": entity_context,
+            "evidence_links": None,
+            "cluster_id": row.get("cluster_id"),
+            "severity": row.get("severity"),
+            "status": row.get("status", "new"),
         }
 
     def _tempo_csv_row_to_finding(self, row: Dict[str, str]) -> Dict[str, Any]:
@@ -641,120 +684,131 @@ class IngestionService:
             sequence_id, attack_id, IP1, IP2, mitre_tactic,
             incident_confidence, event_start, event_end, created_at, user_feedback
         """
-        sequence_id = str(row.get('sequence_id') or '').strip()
+        sequence_id = str(row.get("sequence_id") or "").strip()
 
         # Parse event_start as timestamp
-        event_start_str = row.get('event_start', '')
-        event_ts = self.parse_timestamp(event_start_str) if event_start_str else datetime.utcnow()
+        event_start_str = row.get("event_start", "")
+        event_ts = (
+            self.parse_timestamp(event_start_str)
+            if event_start_str
+            else datetime.utcnow()
+        )
 
         # sequence_id + attack_id keeps the same sequence distinct across
         # attack clusters; content identity covers rows carrying neither.
-        attack_id = (row.get('attack_id') or '').strip()
+        attack_id = (row.get("attack_id") or "").strip()
         if sequence_id:
             unique_key = f"{sequence_id}_{attack_id}" if attack_id else sequence_id
         else:
             unique_key = self._identity_fallback(
-                row, TEMPO_CSV_IDENTITY_COLUMNS, 'sequence_id'
+                row, TEMPO_CSV_IDENTITY_COLUMNS, "sequence_id"
             )
         id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:ID_HASH_WIDTH]
         finding_id = f"f-{event_ts.strftime('%Y%m%d')}-{id_hash}"
 
         # MITRE tactic comes as a name (e.g. "Command and Control")
         mitre_predictions = {}
-        mitre_tactic = row.get('mitre_tactic', '').strip()
+        mitre_tactic = row.get("mitre_tactic", "").strip()
         if mitre_tactic:
             mitre_predictions[mitre_tactic] = 1.0
 
         # incident_confidence is 0-100 scale; normalise to 0-1
-        raw_confidence = float(row.get('incident_confidence', 0))
-        anomaly_score = raw_confidence / 100.0 if raw_confidence > 1.0 else raw_confidence
+        raw_confidence = float(row.get("incident_confidence", 0))
+        anomaly_score = (
+            raw_confidence / 100.0 if raw_confidence > 1.0 else raw_confidence
+        )
 
         # Derive severity from anomaly score
         if anomaly_score >= 0.9:
-            severity = 'critical'
+            severity = "critical"
         elif anomaly_score >= 0.7:
-            severity = 'high'
+            severity = "high"
         elif anomaly_score >= 0.4:
-            severity = 'medium'
+            severity = "medium"
         else:
-            severity = 'low'
+            severity = "low"
 
         entity_context = {
-            'src_ip': row.get('IP1', '').strip() or None,
-            'dst_ip': row.get('IP2', '').strip() or None,
-            'sequence_id': sequence_id,
-            'confidence_score': anomaly_score,
+            "src_ip": row.get("IP1", "").strip() or None,
+            "dst_ip": row.get("IP2", "").strip() or None,
+            "sequence_id": sequence_id,
+            "confidence_score": anomaly_score,
         }
-        event_end_str = row.get('event_end', '')
+        event_end_str = row.get("event_end", "")
         if event_end_str:
-            entity_context['event_end'] = event_end_str
+            entity_context["event_end"] = event_end_str
 
-        user_feedback = row.get('user_feedback', '').strip()
+        user_feedback = row.get("user_feedback", "").strip()
         if user_feedback:
-            entity_context['user_feedback'] = int(user_feedback) if user_feedback.lstrip('-').isdigit() else user_feedback
+            entity_context["user_feedback"] = (
+                int(user_feedback)
+                if user_feedback.lstrip("-").isdigit()
+                else user_feedback
+            )
 
         cluster_id = attack_id or None
 
         return {
-            'finding_id': finding_id,
-            'embedding': [0.0] * 768,
-            'mitre_predictions': mitre_predictions,
-            'anomaly_score': anomaly_score,
-            'timestamp': event_ts.isoformat(),
-            'data_source': row.get('data_source', 'csv_import'),
-            'entity_context': entity_context,
-            'evidence_links': None,
-            'cluster_id': cluster_id,
-            'severity': severity,
-            'status': 'new',
+            "finding_id": finding_id,
+            "embedding": [0.0] * 768,
+            "mitre_predictions": mitre_predictions,
+            "anomaly_score": anomaly_score,
+            "timestamp": event_ts.isoformat(),
+            "data_source": row.get("data_source", "csv_import"),
+            "entity_context": entity_context,
+            "evidence_links": None,
+            "cluster_id": cluster_id,
+            "severity": severity,
+            "status": "new",
         }
-    
+
     def _csv_row_to_case(self, row: Dict[str, str]) -> Dict[str, Any]:
         """
         Convert CSV row to case dictionary.
-        
+
         Args:
             row: CSV row as dictionary
-        
+
         Returns:
             Case dictionary
         """
         # Generate case_id if not present
-        case_id = row.get('case_id')
+        case_id = row.get("case_id")
         if not case_id:
             import uuid
-            case_id = f"case-{datetime.now().strftime('%Y-%m-%d')}-{uuid.uuid4().hex[:8]}"
-        
+
+            case_id = (
+                f"case-{datetime.now().strftime('%Y-%m-%d')}-{uuid.uuid4().hex[:8]}"
+            )
+
         # Parse finding_ids (comma-separated)
         finding_ids = []
-        if 'finding_ids' in row and row['finding_ids']:
-            finding_ids = [fid.strip() for fid in row['finding_ids'].split(',')]
-        
+        if "finding_ids" in row and row["finding_ids"]:
+            finding_ids = [fid.strip() for fid in row["finding_ids"].split(",")]
+
         # Parse tags (comma-separated)
         tags = []
-        if 'tags' in row and row['tags']:
-            tags = [tag.strip() for tag in row['tags'].split(',')]
-        
+        if "tags" in row and row["tags"]:
+            tags = [tag.strip() for tag in row["tags"].split(",")]
+
         return {
-            'case_id': case_id,
-            'title': row.get('title', 'Imported Case'),
-            'description': row.get('description', ''),
-            'finding_ids': finding_ids,
-            'status': row.get('status', 'new'),
-            'priority': row.get('priority', 'medium'),
-            'assignee': row.get('assignee'),
-            'tags': tags,
-            'notes': [],
-            'timeline': [],
-            'activities': [],
-            'resolution_steps': [],
-            'mitre_techniques': None
+            "case_id": case_id,
+            "title": row.get("title", "Imported Case"),
+            "description": row.get("description", ""),
+            "finding_ids": finding_ids,
+            "status": row.get("status", "new"),
+            "priority": row.get("priority", "medium"),
+            "assignee": row.get("assignee"),
+            "tags": tags,
+            "notes": [],
+            "timeline": [],
+            "activities": [],
+            "resolution_steps": [],
+            "mitre_techniques": None,
         }
-    
+
     def ingest_parquet_file(
-        self,
-        file_path: Union[str, Path],
-        data_source: str = 'flow'
+        self, file_path: Union[str, Path], data_source: str = "flow"
     ) -> Dict[str, Any]:
         """LogLM embedding exports route through _parquet_row_to_finding; anything
         else ingests generically via _generic_row_to_finding."""
@@ -773,7 +827,7 @@ class IngestionService:
             schema_str = str(parquet_file.schema_arrow)
             logger.info(f"Parquet schema: {schema_str}")
             logger.info(f"Parquet columns: {sorted(col_names)}")
-            self.stats['findings_total'] = parquet_file.metadata.num_rows
+            self.stats["findings_total"] = parquet_file.metadata.num_rows
 
             schema_kind = self._detect_parquet_schema(col_names)
             logger.info(f"Detected parquet schema: {schema_kind}")
@@ -786,34 +840,46 @@ class IngestionService:
                 finding_batch = []
                 for i in range(batch_len):
                     try:
-                        row = {col: batch_dict[col][i] for col in col_names if col in batch_dict}
+                        row = {
+                            col: batch_dict[col][i]
+                            for col in col_names
+                            if col in batch_dict
+                        }
                         if not sampled_first_row:
-                            sample = {k: (type(v).__name__, v) for k, v in row.items() if k != 'embedding'}
+                            sample = {
+                                k: (type(v).__name__, v)
+                                for k, v in row.items()
+                                if k != "embedding"
+                            }
                             logger.info(f"Parquet sample row (types+values): {sample}")
                             sampled_first_row = True
-                        if schema_kind == 'loglm':
-                            finding_batch.append(self._parquet_row_to_finding(row, data_source))
+                        if schema_kind == "loglm":
+                            finding_batch.append(
+                                self._parquet_row_to_finding(row, data_source)
+                            )
                         else:
-                            finding_batch.append(self._generic_row_to_finding(row, data_source))
+                            finding_batch.append(
+                                self._generic_row_to_finding(row, data_source)
+                            )
                     except Exception as e:
                         logger.error(f"Error processing parquet row: {e}")
-                        self.stats['findings_errors'] += 1
+                        self.stats["findings_errors"] += 1
                 self._ingest_finding_batch(finding_batch)
 
             logger.info(f"Parquet ingestion complete: {self.stats}")
             return self.stats
 
         except ImportError:
-            logger.error("pyarrow is required for parquet ingestion: pip install pyarrow")
+            logger.error(
+                "pyarrow is required for parquet ingestion: pip install pyarrow"
+            )
             return self.stats
         except Exception as e:
             logger.error(f"Error ingesting parquet file: {e}")
             return self.stats
 
     def _parquet_row_to_finding(
-        self,
-        row: Dict[str, Any],
-        data_source: str = 'flow'
+        self, row: Dict[str, Any], data_source: str = "flow"
     ) -> Dict[str, Any]:
         """
         Transform a row from a DeepTempo LogLM parquet file into a finding dict.
@@ -825,23 +891,23 @@ class IngestionService:
         Returns:
             Finding dictionary ready for ingest_finding()
         """
-        sequence_id = str(row.get('sequence_id') or '')
+        sequence_id = str(row.get("sequence_id") or "")
 
         # Derive event timestamp from event_start_time (epoch milliseconds)
-        event_start_ms = row.get('event_start_time')
+        event_start_ms = row.get("event_start_time")
         if event_start_ms is not None:
             event_ts = datetime.utcfromtimestamp(int(event_start_ms) / 1000.0)
         else:
             event_ts = datetime.utcnow()
 
         unique_key = sequence_id or self._identity_fallback(
-            row, PARQUET_IDENTITY_COLUMNS, 'sequence_id'
+            row, PARQUET_IDENTITY_COLUMNS, "sequence_id"
         )
         id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:ID_HASH_WIDTH]
         finding_id = f"f-{event_ts.strftime('%Y%m%d')}-{id_hash}"
 
         # Embedding: stored as-is regardless of dimension
-        embedding = row.get('embedding')
+        embedding = row.get("embedding")
         if embedding is not None:
             embedding = [float(v) for v in embedding]
         else:
@@ -849,18 +915,19 @@ class IngestionService:
 
         # MITRE predictions from logits (softmax) when available, else from argmax label
         mitre_predictions = {}
-        mitre_logits = row.get('mitre_logits')
+        mitre_logits = row.get("mitre_logits")
         if mitre_logits is not None and len(mitre_logits) > 0:
             import math
+
             max_l = max(mitre_logits)
-            exps = [math.exp(l - max_l) for l in mitre_logits]
+            exps = [math.exp(one - max_l) for one in mitre_logits]
             total = sum(exps)
             for idx, prob in enumerate(exps):
                 p = prob / total
                 if p >= 0.05:
                     tactic = MITRE_TACTIC_MAP.get(idx, f"mitre_class_{idx}")
                     mitre_predictions[tactic] = round(p, 4)
-        elif (mitre_pred := row.get('mitre_pred')) is not None:
+        elif (mitre_pred := row.get("mitre_pred")) is not None:
             tactic = MITRE_TACTIC_MAP.get(int(mitre_pred))
             if tactic:
                 mitre_predictions[tactic] = 1.0
@@ -868,117 +935,116 @@ class IngestionService:
                 mitre_predictions[f"mitre_class_{int(mitre_pred)}"] = 1.0
 
         # Severity from incident_pred (1=attack, 0=benign)
-        incident_pred = int(row.get('incident_pred', 0))
+        incident_pred = int(row.get("incident_pred", 0))
         is_attack = incident_pred == 1
 
         # anomaly_score from confidence_score if available, else derive from incident_pred
-        confidence = row.get('confidence_score')
+        confidence = row.get("confidence_score")
         if confidence is not None:
             anomaly_score = float(confidence)
         else:
             anomaly_score = 0.85 if is_attack else 0.15
 
         if is_attack:
-            severity = 'critical' if anomaly_score >= 0.9 else 'high'
+            severity = "critical" if anomaly_score >= 0.9 else "high"
         else:
-            severity = 'medium' if anomaly_score >= 0.5 else 'low'
+            severity = "medium" if anomaly_score >= 0.5 else "low"
 
         # Build entity_context with all available metadata
         entity_context = {
-            'src_ip': row.get('focal_ip'),
-            'dst_ip': row.get('engaged_ip'),
-            'incident_pred': incident_pred,
-            'confidence_score': anomaly_score,
-            'sequence_id': sequence_id,
+            "src_ip": row.get("focal_ip"),
+            "dst_ip": row.get("engaged_ip"),
+            "incident_pred": incident_pred,
+            "confidence_score": anomaly_score,
+            "sequence_id": sequence_id,
         }
 
-        if row.get('event_start_time') is not None:
-            entity_context['event_start_time'] = int(row['event_start_time'])
-        if row.get('event_end_time') is not None:
-            entity_context['event_end_time'] = int(row['event_end_time'])
-        if row.get('row_count') is not None:
-            entity_context['row_count'] = int(row['row_count'])
-        if row.get('incident_pred') is not None:
-            entity_context['incident_pred'] = int(row['incident_pred'])
+        if row.get("event_start_time") is not None:
+            entity_context["event_start_time"] = int(row["event_start_time"])
+        if row.get("event_end_time") is not None:
+            entity_context["event_end_time"] = int(row["event_end_time"])
+        if row.get("row_count") is not None:
+            entity_context["row_count"] = int(row["row_count"])
+        if row.get("incident_pred") is not None:
+            entity_context["incident_pred"] = int(row["incident_pred"])
 
         source_evidence = source_evidence_from_loglm_row(row)
         if source_evidence is not None:
-            entity_context['source_evidence'] = source_evidence
+            entity_context["source_evidence"] = source_evidence
 
         # cluster_id from attack_id if populated
-        attack_id = row.get('attack_id')
+        attack_id = row.get("attack_id")
         cluster_id = attack_id if attack_id else None
 
         return {
-            'finding_id': finding_id,
-            'embedding': embedding,
-            'mitre_predictions': mitre_predictions,
-            'anomaly_score': anomaly_score,
-            'timestamp': event_ts.isoformat(),
-            'data_source': data_source,
-            'entity_context': entity_context,
-            'evidence_links': None,
-            'cluster_id': cluster_id,
-            'severity': severity,
-            'status': 'new',
+            "finding_id": finding_id,
+            "embedding": embedding,
+            "mitre_predictions": mitre_predictions,
+            "anomaly_score": anomaly_score,
+            "timestamp": event_ts.isoformat(),
+            "data_source": data_source,
+            "entity_context": entity_context,
+            "evidence_links": None,
+            "cluster_id": cluster_id,
+            "severity": severity,
+            "status": "new",
         }
 
     def _detect_parquet_schema(self, col_names: set) -> str:
         """'loglm' for DeepTempo embedding exports, else 'generic'."""
-        if 'embedding' in col_names or 'sequence_id' in col_names:
-            return 'loglm'
-        return 'generic'
+        if "embedding" in col_names or "sequence_id" in col_names:
+            return "loglm"
+        return "generic"
 
     def _generic_row_to_finding(
-        self,
-        row: Dict[str, Any],
-        data_source: str = 'flow'
+        self, row: Dict[str, Any], data_source: str = "flow"
     ) -> Dict[str, Any]:
         """Unscored finding shell for a schema with no known column layout."""
-        timestamp = _first_present(row, ENTITY_FIELD_ALIASES['timestamp'])
-        event_ts = self.parse_timestamp(timestamp) if timestamp is not None else datetime.utcnow()
+        timestamp = _first_present(row, ENTITY_FIELD_ALIASES["timestamp"])
+        event_ts = (
+            self.parse_timestamp(timestamp)
+            if timestamp is not None
+            else datetime.utcnow()
+        )
 
         unique_key = row_identity_key(row, tuple(sorted(row.keys())))
         id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:ID_HASH_WIDTH]
         finding_id = f"f-{event_ts.strftime('%Y%m%d')}-{id_hash}"
 
         entity_context = {
-            'src_ip': _first_present(row, ENTITY_FIELD_ALIASES['src_ip']),
-            'dst_ip': _first_present(row, ENTITY_FIELD_ALIASES['dst_ip']),
-            'src_port': _first_present(row, ENTITY_FIELD_ALIASES['src_port']),
-            'dst_port': _first_present(row, ENTITY_FIELD_ALIASES['dst_port']),
-            'proto': _first_present(row, ENTITY_FIELD_ALIASES['proto']),
-            'raw_features': row,
+            "src_ip": _first_present(row, ENTITY_FIELD_ALIASES["src_ip"]),
+            "dst_ip": _first_present(row, ENTITY_FIELD_ALIASES["dst_ip"]),
+            "src_port": _first_present(row, ENTITY_FIELD_ALIASES["src_port"]),
+            "dst_port": _first_present(row, ENTITY_FIELD_ALIASES["dst_port"]),
+            "proto": _first_present(row, ENTITY_FIELD_ALIASES["proto"]),
+            "raw_features": row,
         }
 
         return {
-            'finding_id': finding_id,
-            'embedding': [0.0] * 768,
-            'mitre_predictions': {},
-            'anomaly_score': 0.0,
-            'timestamp': event_ts.isoformat(),
-            'data_source': data_source,
-            'entity_context': entity_context,
-            'evidence_links': None,
-            'cluster_id': None,
-            'severity': None,
-            'status': 'unscored',
+            "finding_id": finding_id,
+            "embedding": [0.0] * 768,
+            "mitre_predictions": {},
+            "anomaly_score": 0.0,
+            "timestamp": event_ts.isoformat(),
+            "data_source": data_source,
+            "entity_context": entity_context,
+            "evidence_links": None,
+            "cluster_id": None,
+            "severity": None,
+            "status": "unscored",
         }
 
     # Extension -> (ingestion method name, temp file suffix, file mode for write)
     _S3_FORMAT_MAP = {
-        '.parquet': 'parquet',
-        '.csv':     'csv',
-        '.json':    'json',
-        '.jsonl':   'jsonl',
-        '.ndjson':  'jsonl',
+        ".parquet": "parquet",
+        ".csv": "csv",
+        ".json": "json",
+        ".jsonl": "jsonl",
+        ".ndjson": "jsonl",
     }
 
     def ingest_s3_folder(
-        self,
-        s3_service,
-        prefix: str = "",
-        data_source: str = 'flow'
+        self, s3_service, prefix: str = "", data_source: str = "flow"
     ) -> Dict[str, Any]:
         """Discover and ingest all supported files from an S3 prefix, routed by extension."""
         self.reset_stats()
@@ -988,7 +1054,7 @@ class IngestionService:
         all_keys = s3_service.list_files(prefix=prefix)
         if not all_keys:
             logger.warning(f"No files found under S3 prefix '{prefix}'")
-            return {**self.stats, 'files_processed': 0, 'files_skipped': 0}
+            return {**self.stats, "files_processed": 0, "files_skipped": 0}
 
         logger.info(f"Found {len(all_keys)} file(s) under S3 prefix '{prefix}'")
 
@@ -1001,11 +1067,13 @@ class IngestionService:
                 files_skipped += 1
                 continue
 
-            logger.info(f"Downloading s3://{s3_service.bucket_name}/{key} (format: {fmt})")
+            logger.info(
+                f"Downloading s3://{s3_service.bucket_name}/{key} (format: {fmt})"
+            )
             content = s3_service.get_file(key)
             if content is None:
                 logger.error(f"Failed to download {key} from S3")
-                self.stats['findings_errors'] += 1
+                self.stats["findings_errors"] += 1
                 continue
 
             tmp_path = None
@@ -1022,7 +1090,7 @@ class IngestionService:
 
             except Exception as e:
                 logger.error(f"Error processing S3 file {key}: {e}")
-                self.stats['findings_errors'] += 1
+                self.stats["findings_errors"] += 1
             finally:
                 if tmp_path and tmp_path.exists():
                     tmp_path.unlink()
@@ -1031,8 +1099,11 @@ class IngestionService:
             f"S3 folder ingestion complete: {files_processed} processed, "
             f"{files_skipped} skipped, stats={self.stats}"
         )
-        return {**self.stats, 'files_processed': files_processed, 'files_skipped': files_skipped}
-
+        return {
+            **self.stats,
+            "files_processed": files_processed,
+            "files_skipped": files_skipped,
+        }
 
     @staticmethod
     def _s3_key_extension(key: str) -> str:
@@ -1043,95 +1114,92 @@ class IngestionService:
         self,
         file_path: Path,
         fmt: str,
-        data_source: str = 'flow',
-        data_type: str = 'finding'
+        data_source: str = "flow",
+        data_type: str = "finding",
     ) -> Dict[str, Any]:
         """Dispatch a local file to the appropriate ingestion method."""
-        if fmt == 'parquet':
+        if fmt == "parquet":
             return self.ingest_parquet_file(file_path, data_source=data_source)
-        elif fmt == 'csv':
+        elif fmt == "csv":
             return self.ingest_csv_file(file_path, data_type=data_type)
-        elif fmt == 'json':
+        elif fmt == "json":
             return self.ingest_json_file(file_path)
-        elif fmt == 'jsonl':
+        elif fmt == "jsonl":
             return self.ingest_jsonl_file(file_path, data_type=data_type)
         else:
             logger.warning(f"No handler for format '{fmt}', skipping {file_path}")
             return {}
 
     def ingest_from_string(
-        self,
-        data_string: str,
-        format: str = 'json',
-        data_type: str = 'finding'
+        self, data_string: str, format: str = "json", data_type: str = "finding"
     ) -> Dict[str, Any]:
         """Ingest data from a string; format is 'json', 'jsonl', or 'csv'."""
         self.reset_stats()
-        
+
         try:
-            if format == 'json':
+            if format == "json":
                 data = json.loads(data_string)
-                
+
                 findings = []
                 cases = []
-                
+
                 if isinstance(data, dict):
                     # Check if it's a single finding or case based on data_type
-                    if data_type == 'finding' and 'finding_id' in data:
+                    if data_type == "finding" and "finding_id" in data:
                         findings = [data]
-                    elif data_type == 'case' and 'case_id' in data:
+                    elif data_type == "case" and "case_id" in data:
                         cases = [data]
                     else:
                         # Try to get from wrapped arrays
-                        findings = data.get('findings', [])
-                        cases = data.get('cases', [])
+                        findings = data.get("findings", [])
+                        cases = data.get("cases", [])
                 elif isinstance(data, list):
-                    if data and 'finding_id' in data[0]:
+                    if data and "finding_id" in data[0]:
                         findings = data
-                    elif data and 'case_id' in data[0]:
+                    elif data and "case_id" in data[0]:
                         cases = data
-                
-                self.stats['findings_total'] = len(findings)
-                self.stats['cases_total'] = len(cases)
+
+                self.stats["findings_total"] = len(findings)
+                self.stats["cases_total"] = len(cases)
 
                 self._ingest_findings_batched(findings)
                 for case in cases:
                     self.ingest_case(case)
 
-            elif format == 'jsonl':
+            elif format == "jsonl":
                 finding_batch = []
-                for line in data_string.strip().split('\n'):
+                for line in data_string.strip().split("\n"):
                     line = line.strip()
                     if not line:
                         continue
 
                     data = json.loads(line)
 
-                    if data_type == 'finding':
-                        self.stats['findings_total'] += 1
+                    if data_type == "finding":
+                        self.stats["findings_total"] += 1
                         finding_batch.append(data)
-                    elif data_type == 'case':
-                        self.stats['cases_total'] += 1
+                    elif data_type == "case":
+                        self.stats["cases_total"] += 1
                         self.ingest_case(data)
                 self._ingest_findings_batched(finding_batch)
 
-            elif format == 'csv':
+            elif format == "csv":
                 reader = csv.DictReader(StringIO(data_string))
 
                 finding_batch = []
                 for row in reader:
-                    if data_type == 'finding':
-                        self.stats['findings_total'] += 1
+                    if data_type == "finding":
+                        self.stats["findings_total"] += 1
                         finding_batch.append(self._csv_row_to_finding(row))
-                    elif data_type == 'case':
-                        self.stats['cases_total'] += 1
+                    elif data_type == "case":
+                        self.stats["cases_total"] += 1
                         case_data = self._csv_row_to_case(row)
                         self.ingest_case(case_data)
                 self._ingest_findings_batched(finding_batch)
-            
+
             logger.info(f"String ingestion complete: {self.stats}")
             return self.stats
-        
+
         except Exception as e:
             logger.error(f"Error ingesting from string: {e}")
             return self.stats

--- a/core/ingestion/kafka_consumer_service.py
+++ b/core/ingestion/kafka_consumer_service.py
@@ -24,8 +24,8 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-from core.ingestion.kafka_config import KafkaConfig
 from core.ingestion.dedup import RedisDedupSet
+from core.ingestion.kafka_config import KafkaConfig
 
 logger = logging.getLogger(__name__)
 

--- a/core/ingestion/kafka_router.py
+++ b/core/ingestion/kafka_router.py
@@ -20,8 +20,9 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
-from core.routing import Auth, RouterMeta
+
 from core.config import get_settings
+from core.routing import Auth, RouterMeta
 
 # Prefix and tags live in ROUTER_META, not the APIRouter() constructor — one
 # home for mount metadata across all 42 routers. This module was the sole

--- a/core/ingestion/siem_ingestion_service.py
+++ b/core/ingestion/siem_ingestion_service.py
@@ -5,9 +5,9 @@ Provides common functionality for ingesting findings from various SIEM platforms
 """
 
 import logging
-from typing import List, Dict, Any, Optional
-from datetime import datetime
 from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 from core.ingestion.ingestion_service import IngestionService
 
@@ -16,66 +16,68 @@ logger = logging.getLogger(__name__)
 
 class SIEMIngestionService(ABC):
     """Base class for SIEM ingestion services."""
-    
+
     def __init__(self):
         """Initialize the SIEM ingestion service."""
         self.ingestion_service = IngestionService()
         self.siem_name = "Generic SIEM"
-    
+
     @abstractmethod
     async def fetch_alerts(
         self,
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
-        limit: int = 100
+        limit: int = 100,
     ) -> List[Dict[str, Any]]:
         """
         Fetch alerts from the SIEM.
-        
+
         Args:
             start_time: Start time for alert query
             end_time: End time for alert query
             limit: Maximum number of alerts to fetch
-        
+
         Returns:
             List of raw alert dictionaries
         """
-    
+
     @abstractmethod
-    def transform_alert_to_finding(self, alert: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    def transform_alert_to_finding(
+        self, alert: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """
         Transform a SIEM alert into a finding format.
-        
+
         Args:
             alert: Raw alert from SIEM
-        
+
         Returns:
             Finding dictionary or None if transformation fails
         """
-    
+
     def ingest_alerts(
         self,
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
-        limit: int = 100
+        limit: int = 100,
     ) -> Dict[str, Any]:
         """
         Fetch and ingest alerts from SIEM.
-        
+
         Args:
             start_time: Start time for alert query
             end_time: End time for alert query
             limit: Maximum number of alerts to fetch
-        
+
         Returns:
             Ingestion statistics
         """
         import asyncio
-        
+
         try:
             # Fetch alerts
             alerts = asyncio.run(self.fetch_alerts(start_time, end_time, limit))
-            
+
             if not alerts:
                 logger.info(f"No alerts fetched from {self.siem_name}")
                 return {
@@ -84,16 +86,16 @@ class SIEMIngestionService(ABC):
                     "fetched": 0,
                     "ingested": 0,
                     "failed": 0,
-                    "errors": []
+                    "errors": [],
                 }
-            
+
             logger.info(f"Fetched {len(alerts)} alerts from {self.siem_name}")
-            
+
             # Transform and ingest
             ingested = 0
             failed = 0
             errors = []
-            
+
             for alert in alerts:
                 try:
                     finding = self.transform_alert_to_finding(alert)
@@ -103,26 +105,32 @@ class SIEMIngestionService(ABC):
                             ingested += 1
                         else:
                             failed += 1
-                            errors.append(f"Failed to ingest alert: {alert.get('id', 'unknown')}")
+                            errors.append(
+                                f"Failed to ingest alert: {alert.get('id', 'unknown')}"
+                            )
                     else:
                         failed += 1
-                        errors.append(f"Failed to transform alert: {alert.get('id', 'unknown')}")
+                        errors.append(
+                            f"Failed to transform alert: {alert.get('id', 'unknown')}"
+                        )
                 except Exception as e:
                     failed += 1
                     errors.append(f"Error processing alert: {str(e)}")
                     logger.error(f"Error processing alert from {self.siem_name}: {e}")
-            
-            logger.info(f"{self.siem_name} ingestion: {ingested} ingested, {failed} failed")
-            
+
+            logger.info(
+                f"{self.siem_name} ingestion: {ingested} ingested, {failed} failed"
+            )
+
             return {
                 "success": True,
                 "siem": self.siem_name,
                 "fetched": len(alerts),
                 "ingested": ingested,
                 "failed": failed,
-                "errors": errors[:10]  # Limit error messages
+                "errors": errors[:10],  # Limit error messages
             }
-        
+
         except Exception as e:
             logger.error(f"Error ingesting from {self.siem_name}: {e}")
             return {
@@ -131,9 +139,9 @@ class SIEMIngestionService(ABC):
                 "fetched": 0,
                 "ingested": 0,
                 "failed": 0,
-                "errors": [str(e)]
+                "errors": [str(e)],
             }
-    
+
     async def update_upstream_alert_status(
         self,
         alert_id: str,
@@ -152,39 +160,39 @@ class SIEMIngestionService(ABC):
     def normalize_severity(self, severity: Any) -> str:
         """
         Normalize severity to standard values.
-        
+
         Args:
             severity: Raw severity value
-        
+
         Returns:
             Normalized severity: critical, high, medium, low, info
         """
         if not severity:
             return "medium"
-        
+
         severity_str = str(severity).lower()
-        
+
         # Map various severity formats
-        if any(s in severity_str for s in ['critical', 'crit', '5', 'emergency']):
+        if any(s in severity_str for s in ["critical", "crit", "5", "emergency"]):
             return "critical"
-        elif any(s in severity_str for s in ['high', '4', 'error']):
+        elif any(s in severity_str for s in ["high", "4", "error"]):
             return "high"
-        elif any(s in severity_str for s in ['medium', 'med', '3', 'warning', 'warn']):
+        elif any(s in severity_str for s in ["medium", "med", "3", "warning", "warn"]):
             return "medium"
-        elif any(s in severity_str for s in ['low', '2', 'notice']):
+        elif any(s in severity_str for s in ["low", "2", "notice"]):
             return "low"
-        elif any(s in severity_str for s in ['info', 'informational', '1', 'debug']):
+        elif any(s in severity_str for s in ["info", "informational", "1", "debug"]):
             return "info"
         else:
             return "medium"
-    
+
     def extract_entities(self, alert: Dict[str, Any]) -> Dict[str, List[str]]:
         """
         Extract entities (IPs, domains, users, etc.) from alert.
-        
+
         Args:
             alert: Raw alert data
-        
+
         Returns:
             Dictionary of entity types and values
         """
@@ -195,42 +203,48 @@ class SIEMIngestionService(ABC):
             "hostnames": [],
             "file_hashes": [],
         }
-        
+
         # Common field names for entities
-        ip_fields = ['src_ip', 'dst_ip', 'source_ip', 'dest_ip', 'ip', 'ip_address']
-        domain_fields = ['domain', 'hostname', 'dest_domain', 'query']
-        user_fields = ['user', 'username', 'user_name', 'account', 'src_user', 'dst_user']
-        host_fields = ['host', 'hostname', 'computer_name', 'device_name']
-        hash_fields = ['hash', 'file_hash', 'md5', 'sha1', 'sha256']
-        
+        ip_fields = ["src_ip", "dst_ip", "source_ip", "dest_ip", "ip", "ip_address"]
+        domain_fields = ["domain", "hostname", "dest_domain", "query"]
+        user_fields = [
+            "user",
+            "username",
+            "user_name",
+            "account",
+            "src_user",
+            "dst_user",
+        ]
+        host_fields = ["host", "hostname", "computer_name", "device_name"]
+        hash_fields = ["hash", "file_hash", "md5", "sha1", "sha256"]
+
         # Extract IPs
         for field in ip_fields:
             if field in alert and alert[field]:
                 entities["ip_addresses"].append(str(alert[field]))
-        
+
         # Extract domains
         for field in domain_fields:
             if field in alert and alert[field]:
                 entities["domains"].append(str(alert[field]))
-        
+
         # Extract usernames
         for field in user_fields:
             if field in alert and alert[field]:
                 entities["usernames"].append(str(alert[field]))
-        
+
         # Extract hostnames
         for field in host_fields:
             if field in alert and alert[field]:
                 entities["hostnames"].append(str(alert[field]))
-        
+
         # Extract file hashes
         for field in hash_fields:
             if field in alert and alert[field]:
                 entities["file_hashes"].append(str(alert[field]))
-        
+
         # Deduplicate
         for key in entities:
             entities[key] = list(set(entities[key]))
-        
-        return entities
 
+        return entities

--- a/core/integrations/aws_security_hub/ingestion.py
+++ b/core/integrations/aws_security_hub/ingestion.py
@@ -5,95 +5,95 @@ Fetches security findings from AWS Security Hub and converts them to the standar
 """
 
 import logging
-from typing import List, Dict, Any, Optional
-from datetime import datetime, timedelta
 import uuid
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
 
-from core.ingestion.siem_ingestion_service import SIEMIngestionService
 from core.config import get_integration_config
+from core.ingestion.siem_ingestion_service import SIEMIngestionService
 
 logger = logging.getLogger(__name__)
 
 
 class AWSSecurityHubIngestion(SIEMIngestionService):
     """AWS Security Hub ingestion service."""
-    
+
     def __init__(self):
         """Initialize AWS Security Hub ingestion."""
         super().__init__()
         self.siem_name = "AWS Security Hub"
-        self.config = get_integration_config('aws-security-hub')
-    
+        self.config = get_integration_config("aws-security-hub")
+
     async def fetch_alerts(
         self,
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
-        limit: int = 100
+        limit: int = 100,
     ) -> List[Dict[str, Any]]:
         """
         Fetch findings from AWS Security Hub.
-        
+
         Args:
             start_time: Start time for finding query
             end_time: End time for finding query
             limit: Maximum number of findings to fetch
-        
+
         Returns:
             List of raw finding dictionaries
         """
         try:
             import boto3
             from botocore.exceptions import ClientError
-            
+
             # Get config
-            region = self.config.get('region', 'us-east-1')
-            access_key = self.config.get('access_key_id')
-            secret_key = self.config.get('secret_access_key')
-            
+            region = self.config.get("region", "us-east-1")
+            access_key = self.config.get("access_key_id")
+            secret_key = self.config.get("secret_access_key")
+
             # Create client
             if access_key and secret_key:
                 client = boto3.client(
-                    'securityhub',
+                    "securityhub",
                     region_name=region,
                     aws_access_key_id=access_key,
-                    aws_secret_access_key=secret_key
+                    aws_secret_access_key=secret_key,
                 )
             else:
                 # Use default credentials
-                client = boto3.client('securityhub', region_name=region)
-            
+                client = boto3.client("securityhub", region_name=region)
+
             # Set time range
             if not start_time:
                 start_time = datetime.utcnow() - timedelta(hours=24)
             if not end_time:
                 end_time = datetime.utcnow()
-            
+
             # Build filters
             filters = {
-                'RecordState': [{'Value': 'ACTIVE', 'Comparison': 'EQUALS'}],
-                'WorkflowStatus': [{'Value': 'NEW', 'Comparison': 'EQUALS'}],
-                'CreatedAt': [
+                "RecordState": [{"Value": "ACTIVE", "Comparison": "EQUALS"}],
+                "WorkflowStatus": [{"Value": "NEW", "Comparison": "EQUALS"}],
+                "CreatedAt": [
                     {
-                        'Start': start_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
-                        'End': end_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        "Start": start_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                        "End": end_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                     }
-                ]
+                ],
             }
-            
+
             # Fetch findings
             findings = []
-            paginator = client.get_paginator('get_findings')
-            
+            paginator = client.get_paginator("get_findings")
+
             for page in paginator.paginate(Filters=filters, MaxResults=min(limit, 100)):
-                findings.extend(page['Findings'])
+                findings.extend(page["Findings"])
                 if len(findings) >= limit:
                     break
-            
+
             findings = findings[:limit]
-            
+
             logger.info(f"Fetched {len(findings)} findings from AWS Security Hub")
             return findings
-        
+
         except ImportError:
             logger.error("boto3 not installed. Install: pip install boto3")
             return []
@@ -103,31 +103,33 @@ class AWSSecurityHubIngestion(SIEMIngestionService):
         except Exception as e:
             logger.error(f"Error fetching AWS Security Hub findings: {e}")
             return []
-    
-    def transform_alert_to_finding(self, alert: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    def transform_alert_to_finding(
+        self, alert: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """
         Transform AWS Security Hub finding to standard finding format.
-        
+
         Args:
             alert: Raw finding from AWS Security Hub
-        
+
         Returns:
             Finding dictionary
         """
         try:
             # Extract finding ID
             finding_id = f"aws-sh-{alert.get('Id', uuid.uuid4().hex[:12])}"
-            
+
             # Extract severity
-            severity_label = alert.get('Severity', {}).get('Label', 'MEDIUM')
+            severity_label = alert.get("Severity", {}).get("Label", "MEDIUM")
             severity = self.normalize_severity(severity_label)
-            
+
             # Extract resources
-            resources = alert.get('Resources', [])
-            resource_ids = [r.get('Id', '') for r in resources]
-            
+            resources = alert.get("Resources", [])
+            resource_ids = [r.get("Id", "") for r in resources]
+
             # Extract network info
-            network = alert.get('Network', {})
+            network = alert.get("Network", {})
             entities = {
                 "ip_addresses": [],
                 "domains": [],
@@ -135,45 +137,45 @@ class AWSSecurityHubIngestion(SIEMIngestionService):
                 "hostnames": resource_ids,
                 "file_hashes": [],
             }
-            
-            if network.get('SourceIpV4'):
-                entities["ip_addresses"].append(network['SourceIpV4'])
-            if network.get('DestinationIpV4'):
-                entities["ip_addresses"].append(network['DestinationIpV4'])
-            if network.get('SourceDomain'):
-                entities["domains"].append(network['SourceDomain'])
-            if network.get('DestinationDomain'):
-                entities["domains"].append(network['DestinationDomain'])
-            
+
+            if network.get("SourceIpV4"):
+                entities["ip_addresses"].append(network["SourceIpV4"])
+            if network.get("DestinationIpV4"):
+                entities["ip_addresses"].append(network["DestinationIpV4"])
+            if network.get("SourceDomain"):
+                entities["domains"].append(network["SourceDomain"])
+            if network.get("DestinationDomain"):
+                entities["domains"].append(network["DestinationDomain"])
+
             # Extract MITRE ATT&CK info
-            threat_intel = alert.get('ThreatIntelIndicators', [])
+            threat_intel = alert.get("ThreatIntelIndicators", [])
             tactics = []
             techniques = []
-            
+
             for indicator in threat_intel:
-                if 'Category' in indicator:
-                    tactics.append(indicator['Category'])
-            
+                if "Category" in indicator:
+                    tactics.append(indicator["Category"])
+
             # Build finding
             finding = {
                 "finding_id": finding_id,
-                "title": alert.get('Title', 'AWS Security Hub Finding'),
-                "description": alert.get('Description', ''),
+                "title": alert.get("Title", "AWS Security Hub Finding"),
+                "description": alert.get("Description", ""),
                 "severity": severity,
                 "data_source": "aws_security_hub",
-                "timestamp": alert.get('CreatedAt', datetime.utcnow().isoformat()),
+                "timestamp": alert.get("CreatedAt", datetime.utcnow().isoformat()),
                 "raw_data": alert,
                 "metadata": {
-                    "aws_account_id": alert.get('AwsAccountId'),
-                    "generator_id": alert.get('GeneratorId'),
-                    "product_arn": alert.get('ProductArn'),
-                    "product_name": alert.get('ProductName'),
-                    "company_name": alert.get('CompanyName'),
-                    "region": alert.get('Region'),
+                    "aws_account_id": alert.get("AwsAccountId"),
+                    "generator_id": alert.get("GeneratorId"),
+                    "product_arn": alert.get("ProductArn"),
+                    "product_name": alert.get("ProductName"),
+                    "company_name": alert.get("CompanyName"),
+                    "region": alert.get("Region"),
                     "resources": resource_ids,
-                    "compliance": alert.get('Compliance', {}),
-                    "workflow_state": alert.get('WorkflowState'),
-                    "record_state": alert.get('RecordState'),
+                    "compliance": alert.get("Compliance", {}),
+                    "workflow_state": alert.get("WorkflowState"),
+                    "record_state": alert.get("RecordState"),
                 },
                 "entities": entities,
                 "mitre_attack": {
@@ -181,10 +183,9 @@ class AWSSecurityHubIngestion(SIEMIngestionService):
                     "techniques": techniques,
                 },
             }
-            
+
             return finding
-        
+
         except Exception as e:
             logger.error(f"Error transforming AWS Security Hub finding: {e}")
             return None
-

--- a/core/integrations/azure_sentinel/ingestion.py
+++ b/core/integrations/azure_sentinel/ingestion.py
@@ -5,160 +5,194 @@ Fetches security incidents from Microsoft Sentinel (Azure Sentinel) and converts
 """
 
 import logging
-from typing import List, Dict, Any, Optional
-from datetime import datetime, timedelta
 import uuid
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
 
-from core.ingestion.siem_ingestion_service import SIEMIngestionService
 from core.config import get_integration_config
+from core.ingestion.siem_ingestion_service import SIEMIngestionService
 
 logger = logging.getLogger(__name__)
 
 
 class AzureSentinelIngestion(SIEMIngestionService):
     """Azure Sentinel ingestion service."""
-    
+
     def __init__(self):
         """Initialize Azure Sentinel ingestion."""
         super().__init__()
         self.siem_name = "Azure Sentinel"
-        self.config = get_integration_config('azure-sentinel')
-    
+        self.config = get_integration_config("azure-sentinel")
+
     async def fetch_alerts(
         self,
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
-        limit: int = 100
+        limit: int = 100,
     ) -> List[Dict[str, Any]]:
         """
         Fetch incidents from Azure Sentinel.
-        
+
         Args:
             start_time: Start time for incident query
             end_time: End time for incident query
             limit: Maximum number of incidents to fetch
-        
+
         Returns:
             List of raw incident dictionaries
         """
         try:
             from azure.identity import ClientSecretCredential
             from azure.mgmt.securityinsight import SecurityInsights
-            
+
             # Get config
-            tenant_id = self.config.get('tenant_id')
-            client_id = self.config.get('client_id')
-            client_secret = self.config.get('client_secret')
-            subscription_id = self.config.get('subscription_id')
-            resource_group = self.config.get('resource_group')
-            workspace_name = self.config.get('workspace_name')
-            
-            if not all([tenant_id, client_id, client_secret, subscription_id, resource_group, workspace_name]):
+            tenant_id = self.config.get("tenant_id")
+            client_id = self.config.get("client_id")
+            client_secret = self.config.get("client_secret")
+            subscription_id = self.config.get("subscription_id")
+            resource_group = self.config.get("resource_group")
+            workspace_name = self.config.get("workspace_name")
+
+            if not all(
+                [
+                    tenant_id,
+                    client_id,
+                    client_secret,
+                    subscription_id,
+                    resource_group,
+                    workspace_name,
+                ]
+            ):
                 logger.error("Azure Sentinel configuration incomplete")
                 return []
-            
+
             # Authenticate
             credential = ClientSecretCredential(
-                tenant_id=tenant_id,
-                client_id=client_id,
-                client_secret=client_secret
+                tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
             )
-            
+
             # Create client
             client = SecurityInsights(credential, subscription_id)
-            
+
             # Set time range
             if not start_time:
                 start_time = datetime.utcnow() - timedelta(hours=24)
             if not end_time:
                 end_time = datetime.utcnow()
-            
+
             # Fetch incidents
             incidents = []
             incident_list = client.incidents.list(
-                resource_group_name=resource_group,
-                workspace_name=workspace_name
+                resource_group_name=resource_group, workspace_name=workspace_name
             )
-            
+
             for incident in incident_list:
                 # Filter by time
                 if incident.created_time_utc:
-                    if incident.created_time_utc < start_time or incident.created_time_utc > end_time:
+                    if (
+                        incident.created_time_utc < start_time
+                        or incident.created_time_utc > end_time
+                    ):
                         continue
-                
-                incidents.append({
-                    'id': incident.name,
-                    'title': incident.title,
-                    'description': incident.description,
-                    'severity': incident.severity,
-                    'status': incident.status,
-                    'created_time': incident.created_time_utc.isoformat() if incident.created_time_utc else None,
-                    'last_updated_time': incident.last_updated_time_utc.isoformat() if incident.last_updated_time_utc else None,
-                    'owner': incident.owner.email if incident.owner else None,
-                    'labels': [label.label_name for label in incident.labels] if incident.labels else [],
-                    'tactics': incident.additional_data.tactics if incident.additional_data else [],
-                    'alert_count': incident.additional_data.alert_count if incident.additional_data else 0,
-                    'properties': incident.additional_properties or {},
-                })
-                
+
+                incidents.append(
+                    {
+                        "id": incident.name,
+                        "title": incident.title,
+                        "description": incident.description,
+                        "severity": incident.severity,
+                        "status": incident.status,
+                        "created_time": (
+                            incident.created_time_utc.isoformat()
+                            if incident.created_time_utc
+                            else None
+                        ),
+                        "last_updated_time": (
+                            incident.last_updated_time_utc.isoformat()
+                            if incident.last_updated_time_utc
+                            else None
+                        ),
+                        "owner": incident.owner.email if incident.owner else None,
+                        "labels": (
+                            [label.label_name for label in incident.labels]
+                            if incident.labels
+                            else []
+                        ),
+                        "tactics": (
+                            incident.additional_data.tactics
+                            if incident.additional_data
+                            else []
+                        ),
+                        "alert_count": (
+                            incident.additional_data.alert_count
+                            if incident.additional_data
+                            else 0
+                        ),
+                        "properties": incident.additional_properties or {},
+                    }
+                )
+
                 if len(incidents) >= limit:
                     break
-            
+
             logger.info(f"Fetched {len(incidents)} incidents from Azure Sentinel")
             return incidents
-        
+
         except ImportError:
-            logger.error("Azure SDK not installed. Install: pip install azure-mgmt-securityinsight azure-identity")
+            logger.error(
+                "Azure SDK not installed. Install: pip install azure-mgmt-securityinsight azure-identity"
+            )
             return []
         except Exception as e:
             logger.error(f"Error fetching Azure Sentinel incidents: {e}")
             return []
-    
-    def transform_alert_to_finding(self, alert: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    def transform_alert_to_finding(
+        self, alert: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """
         Transform Azure Sentinel incident to finding format.
-        
+
         Args:
             alert: Raw incident from Azure Sentinel
-        
+
         Returns:
             Finding dictionary
         """
         try:
             # Generate finding ID
             finding_id = f"sentinel-{alert.get('id', uuid.uuid4().hex[:12])}"
-            
+
             # Extract entities
-            entities = self.extract_entities(alert.get('properties', {}))
-            
+            entities = self.extract_entities(alert.get("properties", {}))
+
             # Build finding
             finding = {
                 "finding_id": finding_id,
-                "title": alert.get('title', 'Azure Sentinel Incident'),
-                "description": alert.get('description', ''),
-                "severity": self.normalize_severity(alert.get('severity')),
+                "title": alert.get("title", "Azure Sentinel Incident"),
+                "description": alert.get("description", ""),
+                "severity": self.normalize_severity(alert.get("severity")),
                 "data_source": "azure_sentinel",
-                "timestamp": alert.get('created_time', datetime.utcnow().isoformat()),
+                "timestamp": alert.get("created_time", datetime.utcnow().isoformat()),
                 "raw_data": alert,
                 "metadata": {
-                    "incident_id": alert.get('id'),
-                    "status": alert.get('status'),
-                    "owner": alert.get('owner'),
-                    "labels": alert.get('labels', []),
-                    "tactics": alert.get('tactics', []),
-                    "alert_count": alert.get('alert_count', 0),
-                    "last_updated": alert.get('last_updated_time'),
+                    "incident_id": alert.get("id"),
+                    "status": alert.get("status"),
+                    "owner": alert.get("owner"),
+                    "labels": alert.get("labels", []),
+                    "tactics": alert.get("tactics", []),
+                    "alert_count": alert.get("alert_count", 0),
+                    "last_updated": alert.get("last_updated_time"),
                 },
                 "entities": entities,
                 "mitre_attack": {
-                    "tactics": alert.get('tactics', []),
+                    "tactics": alert.get("tactics", []),
                     "techniques": [],
                 },
             }
-            
+
             return finding
-        
+
         except Exception as e:
             logger.error(f"Error transforming Azure Sentinel incident: {e}")
             return None
-

--- a/core/integrations/cloudflare/cloudflare_webhooks_router.py
+++ b/core/integrations/cloudflare/cloudflare_webhooks_router.py
@@ -24,8 +24,9 @@ from hashlib import sha256
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Header, HTTPException, Request, status
-from core.routing import Auth, RouterMeta
+
 from core.config import get_settings
+from core.routing import Auth, RouterMeta
 from core.secrets import get_secret
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,7 @@ router = APIRouter()
 def cloudy_ingestion_enabled() -> bool:
     try:
         from core.storage.config_service import get_config_service
+
         cfg = get_config_service().get_system_config("cloudflare.cloudy.enabled")
         if isinstance(cfg, dict):
             if cfg.get("enabled") is True:

--- a/core/integrations/cloudflare/ingestion.py
+++ b/core/integrations/cloudflare/ingestion.py
@@ -56,9 +56,7 @@ class CloudyIngestionService:
 
         finding_id = str(payload.get("event_id") or payload.get("id") or uuid.uuid4())
         ip = (
-            payload.get("client_ip")
-            or event.get("client_ip")
-            or event.get("source_ip")
+            payload.get("client_ip") or event.get("client_ip") or event.get("source_ip")
         )
         host = payload.get("host") or event.get("host") or event.get("zone_name")
         action = (event.get("action") or event.get("ruleAction") or "").lower()
@@ -91,7 +89,9 @@ class CloudyIngestionService:
         return {
             "finding_id": finding_id,
             "data_source": "cloudflare_cloudy",
-            "timestamp": payload.get("timestamp") or event.get("timestamp") or _utcnow_iso(),
+            "timestamp": payload.get("timestamp")
+            or event.get("timestamp")
+            or _utcnow_iso(),
             "anomaly_score": float(payload.get("anomaly_score", 0.5)),
             "embedding": [0.0],  # ingestion service tolerates a placeholder
             "mitre_predictions": mitre,
@@ -133,7 +133,9 @@ class CloudyIngestionService:
         return "medium"
 
     @staticmethod
-    def _extract_mitre(payload: Dict[str, Any], event: Dict[str, Any]) -> Dict[str, Any]:
+    def _extract_mitre(
+        payload: Dict[str, Any], event: Dict[str, Any]
+    ) -> Dict[str, Any]:
         mitre = payload.get("mitre_predictions") or event.get("mitre_predictions")
         if isinstance(mitre, dict):
             return mitre

--- a/core/integrations/cloudflare/tool.py
+++ b/core/integrations/cloudflare/tool.py
@@ -11,11 +11,11 @@ import json
 import logging
 from typing import Any, Dict, Optional
 
-import requests
-from mcp.server.models import InitializationOptions
-import mcp.types as types
-from mcp.server import NotificationOptions, Server
 import mcp.server.stdio
+import mcp.types as types
+import requests
+from mcp.server import NotificationOptions, Server
+from mcp.server.models import InitializationOptions
 
 from core.config import get_integration_config, is_integration_enabled
 
@@ -58,11 +58,19 @@ async def handle_list_tools():
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "ip": {"type": "string", "description": "IPv4/IPv6 address or CIDR"},
+                    "ip": {
+                        "type": "string",
+                        "description": "IPv4/IPv6 address or CIDR",
+                    },
                     "reason": {"type": "string"},
                     "mode": {
                         "type": "string",
-                        "enum": ["block", "challenge", "js_challenge", "managed_challenge"],
+                        "enum": [
+                            "block",
+                            "challenge",
+                            "js_challenge",
+                            "managed_challenge",
+                        ],
                         "default": "block",
                     },
                 },
@@ -145,13 +153,15 @@ async def handle_list_tools():
 async def handle_call_tool(name: str, arguments: dict | None):
     cfg = _config()
     if cfg is None:
-        return _result({
-            "error": "cloudflare_integration_disabled",
-            "message": (
-                "Cloudflare integration is not configured. Enable it in "
-                "Settings → Integrations and provide an API token."
-            ),
-        })
+        return _result(
+            {
+                "error": "cloudflare_integration_disabled",
+                "message": (
+                    "Cloudflare integration is not configured. Enable it in "
+                    "Settings → Integrations and provide an API token."
+                ),
+            }
+        )
 
     api_token = cfg["api_token"]
     account_id = cfg.get("account_id")
@@ -362,7 +372,11 @@ def _lookup_ip_threat(
     resp = requests.get(
         f"{CF_API_BASE}/accounts/{account_id}/firewall/access_rules/rules",
         headers=_headers(api_token),
-        params={"configuration.target": "ip", "configuration.value": ip, "per_page": 50},
+        params={
+            "configuration.target": "ip",
+            "configuration.value": ip,
+            "per_page": 50,
+        },
         timeout=DEFAULT_TIMEOUT,
     )
     data = resp.json() if resp.content else {}

--- a/core/integrations/crowdstrike/adapter.py
+++ b/core/integrations/crowdstrike/adapter.py
@@ -74,11 +74,14 @@ class CrowdStrikeAdapter:
             cutoff = datetime.utcnow() - timedelta(minutes=1)
 
         try:
-            detections = await asyncio.to_thread(
-                svc.get_detections,
-                filter_query=f"created_timestamp:>='{cutoff.isoformat()}Z'",
-                limit=max_items,
-            ) or []
+            detections = (
+                await asyncio.to_thread(
+                    svc.get_detections,
+                    filter_query=f"created_timestamp:>='{cutoff.isoformat()}Z'",
+                    limit=max_items,
+                )
+                or []
+            )
         except Exception as e:
             logger.debug("CrowdStrike fetch failed: %s", e)
             detections = []
@@ -100,7 +103,9 @@ def _detection_to_finding(detection: Dict[str, Any]) -> Optional[Dict[str, Any]]
     external_id = str(detection_id)[:128]
     finding_id = f"cs-{external_id[:32]}"
 
-    severity = _SEVERITY_MAP.get(detection.get("max_severity_displayname", "Medium"), "medium")
+    severity = _SEVERITY_MAP.get(
+        detection.get("max_severity_displayname", "Medium"), "medium"
+    )
 
     mitre_predictions: Dict[str, float] = {}
     for behavior in detection.get("behaviors", []) or []:
@@ -120,7 +125,8 @@ def _detection_to_finding(detection: Dict[str, Any]) -> Optional[Dict[str, Any]]
         "finding_id": finding_id,
         "data_source": "crowdstrike",
         "external_id": external_id,
-        "timestamp": detection.get("created_timestamp") or datetime.utcnow().isoformat(),
+        "timestamp": detection.get("created_timestamp")
+        or datetime.utcnow().isoformat(),
         "severity": severity,
         "status": "new",
         "title": detection.get("scenario") or "CrowdStrike Detection",

--- a/core/integrations/crowdstrike/client.py
+++ b/core/integrations/crowdstrike/client.py
@@ -1,9 +1,10 @@
 """CrowdStrike Falcon API service for detection polling and host management."""
 
 import logging
-import httpx
-from typing import Optional, List, Dict, Any
 from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -16,47 +17,50 @@ _FOLLOW_REDIRECTS = True
 
 class CrowdStrikeService:
     """Service for interacting with CrowdStrike Falcon API."""
-    
-    def __init__(self, client_id: str, client_secret: str, 
-                 base_url: str = "https://api.crowdstrike.com"):
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        base_url: str = "https://api.crowdstrike.com",
+    ):
         self.client_id = client_id
         self.client_secret = client_secret
-        self.base_url = base_url.rstrip('/')
+        self.base_url = base_url.rstrip("/")
         self.access_token: Optional[str] = None
         self.token_expiry: Optional[datetime] = None
         self.session = httpx.Client(
             timeout=DEFAULT_TIMEOUT,
             follow_redirects=_FOLLOW_REDIRECTS,
         )
-    
+
     def _ensure_authenticated(self) -> bool:
         """Ensure we have a valid access token."""
         if self.access_token and self.token_expiry:
             if datetime.utcnow() < self.token_expiry:
                 return True
         return self._authenticate()
-    
+
     def _authenticate(self) -> bool:
         """Authenticate with CrowdStrike OAuth2."""
         try:
             response = self.session.post(
                 f"{self.base_url}/oauth2/token",
-                data={
-                    "client_id": self.client_id,
-                    "client_secret": self.client_secret
-                },
+                data={"client_id": self.client_id, "client_secret": self.client_secret},
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
-                timeout=30
+                timeout=30,
             )
-            
+
             if response.status_code == 201:
                 data = response.json()
                 self.access_token = data.get("access_token")
                 expires_in = data.get("expires_in", 1800)
-                self.token_expiry = datetime.utcnow() + timedelta(seconds=expires_in - 60)
-                self.session.headers.update({
-                    "Authorization": f"Bearer {self.access_token}"
-                })
+                self.token_expiry = datetime.utcnow() + timedelta(
+                    seconds=expires_in - 60
+                )
+                self.session.headers.update(
+                    {"Authorization": f"Bearer {self.access_token}"}
+                )
                 logger.info("CrowdStrike authentication successful")
                 return True
             else:
@@ -65,97 +69,100 @@ class CrowdStrikeService:
         except Exception as e:
             logger.error(f"CrowdStrike auth error: {e}")
             return False
-    
+
     def test_connection(self) -> tuple[bool, str]:
         """Test connection to CrowdStrike API."""
         try:
             if not self._ensure_authenticated():
                 return False, "Authentication failed"
-            
+
             response = self.session.get(
                 f"{self.base_url}/sensors/queries/sensors/v1",
                 params={"limit": 1},
-                timeout=30
+                timeout=30,
             )
-            
+
             if response.status_code == 200:
                 return True, "Connection successful"
             return False, f"API error: {response.status_code}"
         except Exception as e:
             return False, str(e)
-    
-    def get_detections(self, filter_query: Optional[str] = None, 
-                       limit: int = 100) -> Optional[List[Dict[str, Any]]]:
+
+    def get_detections(
+        self, filter_query: Optional[str] = None, limit: int = 100
+    ) -> Optional[List[Dict[str, Any]]]:
         """
         Get detections from CrowdStrike.
-        
+
         Args:
             filter_query: FQL filter string (e.g., "created_timestamp:>='2024-01-01'")
             limit: Maximum number of detections to return
-        
+
         Returns:
             List of detection details or None on error
         """
         try:
             if not self._ensure_authenticated():
                 return None
-            
+
             # Get detection IDs
             params = {"limit": limit}
             if filter_query:
                 params["filter"] = filter_query
-            
+
             response = self.session.get(
-                f"{self.base_url}/detects/queries/detects/v1",
-                params=params,
-                timeout=30
+                f"{self.base_url}/detects/queries/detects/v1", params=params, timeout=30
             )
-            
+
             if response.status_code != 200:
                 logger.error(f"Failed to query detections: {response.status_code}")
                 return None
-            
+
             data = response.json()
             detection_ids = data.get("resources", [])
-            
+
             if not detection_ids:
                 return []
-            
+
             # Get detection details
             detail_response = self.session.post(
                 f"{self.base_url}/detects/entities/summaries/GET/v1",
                 json={"ids": detection_ids[:100]},
-                timeout=30
+                timeout=30,
             )
-            
+
             if detail_response.status_code != 200:
-                logger.error(f"Failed to get detection details: {detail_response.status_code}")
+                logger.error(
+                    f"Failed to get detection details: {detail_response.status_code}"
+                )
                 return None
-            
+
             details = detail_response.json()
             return details.get("resources", [])
-            
+
         except Exception as e:
             logger.error(f"Error getting detections: {e}")
             return None
-    
-    
-    
+
     def lift_containment(self, host_id: str) -> Dict[str, Any]:
         """Remove containment from a host."""
         try:
             if not self._ensure_authenticated():
                 return {"success": False, "error": "Authentication failed"}
-            
+
             response = self.session.post(
                 f"{self.base_url}/devices/entities/devices-actions/v2",
                 params={"action_name": "lift_containment"},
                 json={"ids": [host_id]},
-                timeout=30
+                timeout=30,
             )
-            
+
             if response.status_code == 202:
-                return {"success": True, "host_id": host_id, "action": "containment_lifted"}
+                return {
+                    "success": True,
+                    "host_id": host_id,
+                    "action": "containment_lifted",
+                }
             return {"success": False, "error": f"API error: {response.status_code}"}
         except Exception as e:
             return {"success": False, "error": str(e)}

--- a/core/integrations/custom_integration_service.py
+++ b/core/integrations/custom_integration_service.py
@@ -4,12 +4,12 @@ import json
 import logging
 import os
 import re
-from pathlib import Path
-from typing import Dict, Any, Optional, List
 from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
-from core.llm.defaults import DEFAULT_MODEL
 from core.config import vigil_path
+from core.llm.defaults import DEFAULT_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -331,9 +331,9 @@ async def handle_call_tool(
     name: str, arguments: dict | None
 ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
     \"\"\"Handle tool execution requests.\"\"\"
-    
+
     config = get_config()
-    
+
     if not config:
         return [types.TextContent(
             type="text",
@@ -342,7 +342,7 @@ async def handle_call_tool(
                 "message": "Please configure in Settings > Integrations"
             }}, indent=2)
         )]
-    
+
     try:
         if name == "tool_name":
             # Implementation here
@@ -351,9 +351,9 @@ async def handle_call_tool(
                 type="text",
                 text=json.dumps(result, indent=2)
             )]
-        
+
         raise ValueError(f"Unknown tool: {{name}}")
-    
+
     except Exception as e:
         logger.error(f"Error in tool {{name}}: {{e}}")
         return [types.TextContent(

--- a/core/integrations/darktrace/darktrace_webhook_router.py
+++ b/core/integrations/darktrace/darktrace_webhook_router.py
@@ -24,9 +24,9 @@ from typing import Any, Callable, Dict, Optional
 
 from fastapi import APIRouter, Header, HTTPException, Request, status
 
+from core.config import get_settings
 from core.integrations.darktrace.ingestion import DarktraceIngestionService
 from core.routing import Auth, RouterMeta
-from core.config import get_settings
 from core.secrets import get_secret
 
 logger = logging.getLogger(__name__)
@@ -66,6 +66,7 @@ def _get_settings() -> Dict[str, Any]:
     """Read darktrace.settings from system_config (DB). Falls back to env vars."""
     try:
         from core.storage.config_service import get_config_service
+
         value = get_config_service().get_system_config("darktrace.settings") or {}
         if value:
             return value

--- a/core/integrations/elastic/client.py
+++ b/core/integrations/elastic/client.py
@@ -53,9 +53,7 @@ class ElasticService:
 
     def _build_kibana_client(self) -> httpx.AsyncClient:
         if not self.kibana_url:
-            raise ValueError(
-                "kibana_url is required for Kibana Security API calls"
-            )
+            raise ValueError("kibana_url is required for Kibana Security API calls")
         headers: Dict[str, str] = {
             "Content-Type": "application/json",
             "kbn-xsrf": "true",
@@ -140,9 +138,7 @@ class ElasticService:
         if sort:
             body["sort"] = sort
         try:
-            resp = await self.es_client.post(
-                f"/{target}/_search", json=body
-            )
+            resp = await self.es_client.post(f"/{target}/_search", json=body)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:
@@ -156,9 +152,7 @@ class ElasticService:
             query={
                 "bool": {
                     "must": [{"multi_match": {"query": ip, "fields": ["*"]}}],
-                    "filter": [
-                        {"range": {"@timestamp": {"gte": f"now-{hours}h"}}}
-                    ],
+                    "filter": [{"range": {"@timestamp": {"gte": f"now-{hours}h"}}}],
                 }
             },
             index=index,
@@ -170,12 +164,8 @@ class ElasticService:
         return await self.search(
             query={
                 "bool": {
-                    "must": [
-                        {"multi_match": {"query": file_hash, "fields": ["*"]}}
-                    ],
-                    "filter": [
-                        {"range": {"@timestamp": {"gte": f"now-{hours}h"}}}
-                    ],
+                    "must": [{"multi_match": {"query": file_hash, "fields": ["*"]}}],
+                    "filter": [{"range": {"@timestamp": {"gte": f"now-{hours}h"}}}],
                 }
             },
             index=index,
@@ -199,9 +189,7 @@ class ElasticService:
                             }
                         }
                     ],
-                    "filter": [
-                        {"range": {"@timestamp": {"gte": f"now-{hours}h"}}}
-                    ],
+                    "filter": [{"range": {"@timestamp": {"gte": f"now-{hours}h"}}}],
                 }
             },
             index=index,
@@ -225,9 +213,7 @@ class ElasticService:
                             }
                         }
                     ],
-                    "filter": [
-                        {"range": {"@timestamp": {"gte": f"now-{hours}h"}}}
-                    ],
+                    "filter": [{"range": {"@timestamp": {"gte": f"now-{hours}h"}}}],
                 }
             },
             index=index,
@@ -285,9 +271,7 @@ class ElasticService:
                 "/api/detection_engine/signals/status", json=body
             )
             resp.raise_for_status()
-            logger.info(
-                f"Updated {len(signal_ids)} alerts to status '{status}'"
-            )
+            logger.info(f"Updated {len(signal_ids)} alerts to status '{status}'")
             return True
         except Exception as exc:
             logger.error(f"Error updating alert status: {exc}")
@@ -300,9 +284,7 @@ class ElasticService:
     async def get_case(self, case_id: str) -> Optional[Dict[str, Any]]:
         """Get a Kibana Security case by ID."""
         try:
-            resp = await self.kibana_client.get(
-                f"/api/cases/{case_id}"
-            )
+            resp = await self.kibana_client.get(f"/api/cases/{case_id}")
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:
@@ -322,15 +304,9 @@ class ElasticService:
             status: One of 'open', 'in-progress', 'closed'.
             version: The case version string (required for optimistic concurrency).
         """
-        body = {
-            "cases": [
-                {"id": case_id, "version": version, "status": status}
-            ]
-        }
+        body = {"cases": [{"id": case_id, "version": version, "status": status}]}
         try:
-            resp = await self.kibana_client.patch(
-                "/api/cases", json=body
-            )
+            resp = await self.kibana_client.patch("/api/cases", json=body)
             resp.raise_for_status()
             logger.info(f"Updated case {case_id} to status '{status}'")
             return True

--- a/core/integrations/elastic/enrichment.py
+++ b/core/integrations/elastic/enrichment.py
@@ -33,9 +33,7 @@ class ElasticEnrichmentService:
     ) -> Dict[str, List[str]]:
         """Extract IOCs from case and findings."""
         ip_pattern = r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
-        hash_pattern = (
-            r"\b[a-fA-F0-9]{32}\b|\b[a-fA-F0-9]{40}\b|\b[a-fA-F0-9]{64}\b"
-        )
+        hash_pattern = r"\b[a-fA-F0-9]{32}\b|\b[a-fA-F0-9]{40}\b|\b[a-fA-F0-9]{64}\b"
 
         indicators: Dict[str, set] = {
             "ips": set(),
@@ -59,9 +57,7 @@ class ElasticEnrichmentService:
                 indicators["hostnames"].add(str(h))
 
         # Filter private IPs
-        indicators["ips"] = {
-            ip for ip in indicators["ips"] if not _is_private_ip(ip)
-        }
+        indicators["ips"] = {ip for ip in indicators["ips"] if not _is_private_ip(ip)}
 
         return {k: sorted(v) for k, v in indicators.items()}
 
@@ -145,6 +141,7 @@ class ElasticEnrichmentService:
 # ------------------------------------------------------------------
 # Helpers
 # ------------------------------------------------------------------
+
 
 def _is_private_ip(ip: str) -> bool:
     try:

--- a/core/integrations/elastic/ingestion.py
+++ b/core/integrations/elastic/ingestion.py
@@ -9,9 +9,9 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
+from core.config import get_integration_config
 from core.ingestion.siem_ingestion_service import SIEMIngestionService
 from core.integrations.elastic.client import ElasticService
-from core.config import get_integration_config
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,9 @@ class ElasticIngestion(SIEMIngestionService):
         try:
             host = self.config.get("elasticsearch_url")
             if not host:
-                logger.error("Elastic configuration incomplete: missing elasticsearch_url")
+                logger.error(
+                    "Elastic configuration incomplete: missing elasticsearch_url"
+                )
                 return None
 
             self._elastic_service = ElasticService(
@@ -84,9 +86,7 @@ class ElasticIngestion(SIEMIngestionService):
                 }
             }
 
-            result = await svc.fetch_detection_alerts(
-                query=time_filter, size=limit
-            )
+            result = await svc.fetch_detection_alerts(query=time_filter, size=limit)
             if not result:
                 return []
 
@@ -159,9 +159,8 @@ class ElasticIngestion(SIEMIngestionService):
 
             # MITRE ATT&CK from rule threat metadata
             mitre_predictions: Dict[str, float] = {}
-            threats = (
-                source.get("kibana.alert.rule.threat", [])
-                or rule.get("threat", [])
+            threats = source.get("kibana.alert.rule.threat", []) or rule.get(
+                "threat", []
             )
             if isinstance(threats, list):
                 for threat in threats:
@@ -188,8 +187,7 @@ class ElasticIngestion(SIEMIngestionService):
                 "metadata": {
                     "elastic_alert_id": alert_id,
                     "rule_id": (
-                        source.get("kibana.alert.rule.uuid")
-                        or rule.get("id", "")
+                        source.get("kibana.alert.rule.uuid") or rule.get("id", "")
                     ),
                     "rule_name": title,
                     "index": alert.get("_index", ""),

--- a/core/integrations/elastic/tool.py
+++ b/core/integrations/elastic/tool.py
@@ -9,13 +9,14 @@ import json
 import logging
 import os
 
-from mcp.server.models import InitializationOptions
+import mcp.server.stdio
 import mcp.types as types
 from mcp.server import NotificationOptions, Server
-import mcp.server.stdio
+from mcp.server.models import InitializationOptions
 
 try:
     from dotenv import load_dotenv
+
     load_dotenv()
 except ImportError:
     pass
@@ -36,6 +37,7 @@ def get_elastic_service():
         return _elastic_service
     try:
         from core.integrations.elastic.client import ElasticService
+
         host = os.environ.get("ELASTIC_HOST")
         if not host:
             return None
@@ -58,6 +60,7 @@ def get_elastic_service():
 # ------------------------------------------------------------------
 # Tool listing
 # ------------------------------------------------------------------
+
 
 @server.list_tools()
 async def handle_list_tools():
@@ -133,13 +136,14 @@ async def handle_list_tools():
 # Tool dispatch
 # ------------------------------------------------------------------
 
+
 @server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     svc = get_elastic_service()
     if svc is None:
-        return result({
-            "error": "Elastic service not configured. Set ELASTIC_HOST in .env."
-        })
+        return result(
+            {"error": "Elastic service not configured. Set ELASTIC_HOST in .env."}
+        )
 
     if name == "elastic_search_logs":
         return await _search_logs(svc, arguments or {})
@@ -178,13 +182,14 @@ async def _search_logs(svc, args: dict):
         return result({"error": "Search failed"})
 
     hits = data.get("hits", {})
-    return result({
-        "total": hits.get("total", {}).get("value", 0),
-        "results": [
-            {"_id": h["_id"], **h.get("_source", {})}
-            for h in hits.get("hits", [])
-        ],
-    })
+    return result(
+        {
+            "total": hits.get("total", {}).get("value", 0),
+            "results": [
+                {"_id": h["_id"], **h.get("_source", {})} for h in hits.get("hits", [])
+            ],
+        }
+    )
 
 
 async def _search_by_ioc(svc, args: dict):
@@ -208,15 +213,16 @@ async def _search_by_ioc(svc, args: dict):
         return result({"error": "Search failed"})
 
     hits = data.get("hits", {})
-    return result({
-        "ioc_type": ioc_type,
-        "ioc_value": ioc_value,
-        "total": hits.get("total", {}).get("value", 0),
-        "results": [
-            {"_id": h["_id"], **h.get("_source", {})}
-            for h in hits.get("hits", [])
-        ],
-    })
+    return result(
+        {
+            "ioc_type": ioc_type,
+            "ioc_value": ioc_value,
+            "total": hits.get("total", {}).get("value", 0),
+            "results": [
+                {"_id": h["_id"], **h.get("_source", {})} for h in hits.get("hits", [])
+            ],
+        }
+    )
 
 
 async def _get_indices(svc):
@@ -240,23 +246,26 @@ async def _get_detection_alerts(svc, args: dict):
         return result({"error": "Failed to fetch detection alerts"})
 
     hits = data.get("hits", {})
-    return result({
-        "total": hits.get("total", {}).get("value", 0),
-        "alerts": [
-            {
-                "_id": h["_id"],
-                "rule": h.get("_source", {}).get("kibana.alert.rule.name", ""),
-                "severity": h.get("_source", {}).get("kibana.alert.severity", ""),
-                "timestamp": h.get("_source", {}).get("@timestamp", ""),
-            }
-            for h in hits.get("hits", [])
-        ],
-    })
+    return result(
+        {
+            "total": hits.get("total", {}).get("value", 0),
+            "alerts": [
+                {
+                    "_id": h["_id"],
+                    "rule": h.get("_source", {}).get("kibana.alert.rule.name", ""),
+                    "severity": h.get("_source", {}).get("kibana.alert.severity", ""),
+                    "timestamp": h.get("_source", {}).get("@timestamp", ""),
+                }
+                for h in hits.get("hits", [])
+            ],
+        }
+    )
 
 
 # ------------------------------------------------------------------
 # Main
 # ------------------------------------------------------------------
+
 
 async def main():
     async with mcp.server.stdio.stdio_server() as (read, write):

--- a/core/integrations/extension/session_service.py
+++ b/core/integrations/extension/session_service.py
@@ -12,10 +12,10 @@ from typing import Any, Dict
 
 import httpx
 
+from core.integrations.extension.trust import is_trusted_connector_url
+from core.integrations.integration_secrets import secret_fields_for
 from core.secrets_manager import get_secret
 from core.storage.config_service import get_config_service
-from core.integrations.integration_secrets import secret_fields_for
-from core.integrations.extension.trust import is_trusted_connector_url
 
 logger = logging.getLogger(__name__)
 

--- a/core/integrations/extension/trust.py
+++ b/core/integrations/extension/trust.py
@@ -10,9 +10,10 @@ app-admin act of configuring a connector URL in Settings.
 
 from __future__ import annotations
 
-from core.config import get_settings
 from typing import Optional
 from urllib.parse import urlsplit
+
+from core.config import get_settings
 
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
 

--- a/core/integrations/integration_bridge_service.py
+++ b/core/integrations/integration_bridge_service.py
@@ -4,8 +4,8 @@ import json
 import logging
 import os
 from typing import Dict, Optional
-from core.config import vigil_path
 
+from core.config import vigil_path
 from core.integrations.aws_security_hub.descriptor import AWS_SECURITY_HUB
 from core.integrations.azure_sentinel.descriptor import AZURE_SENTINEL
 from core.integrations.crowdstrike.descriptor import CROWDSTRIKE
@@ -292,8 +292,8 @@ class IntegrationBridgeService:
             return {}
 
         try:
-            from core.storage.db_proxy import ProxyConfig, child_env_for_proxy
             from core.integrations.integration_secrets import secret_fields_for
+            from core.storage.db_proxy import ProxyConfig, child_env_for_proxy
         except ImportError:  # pragma: no cover - defensive
             return {}
 

--- a/core/integrations/integration_compatibility_service.py
+++ b/core/integrations/integration_compatibility_service.py
@@ -1,10 +1,10 @@
 """Service for checking integration compatibility and managing upgrades."""
 
-import re
-import sys
-import logging
-import subprocess
 import importlib.metadata
+import logging
+import re
+import subprocess
+import sys
 from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)

--- a/core/integrations/mcp/client.py
+++ b/core/integrations/mcp/client.py
@@ -2,18 +2,20 @@
 
 import asyncio
 import logging
-from typing import Optional, Dict, List, Any, TYPE_CHECKING
 import threading
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 try:
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
+
     MCP_AVAILABLE = True
 except ImportError:
     try:
         # Try alternative import path
         from mcp.client import ClientSession
         from mcp.client.stdio import StdioServerParameters, stdio_client
+
         MCP_AVAILABLE = True
     except ImportError:
         MCP_AVAILABLE = False
@@ -25,7 +27,6 @@ except ImportError:
             StdioServerParameters = Any
 
 from core.integrations.mcp.service import MCPService
-
 from core.secrets import get_secret
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 class PersistentServerSession:
     """Manages a persistent connection to an MCP server."""
-    
+
     def __init__(self, server_name: str, server_params):
         self.server_name = server_name
         self.server_params = server_params
@@ -44,39 +45,45 @@ class PersistentServerSession:
         self.session_context = None
         self.is_connected = False
         self.lock = asyncio.Lock()
-    
+
     async def connect(self) -> bool:
         """Establish persistent connection to the server."""
         async with self.lock:
             if self.is_connected and self.session:
                 return True
-            
+
             try:
                 # Create stdio client connection
                 self.stdio_context = stdio_client(self.server_params)
-                self.read_stream, self.write_stream = await self.stdio_context.__aenter__()
-                
+                self.read_stream, self.write_stream = (
+                    await self.stdio_context.__aenter__()
+                )
+
                 # Create session
-                self.session_context = ClientSession(self.read_stream, self.write_stream)
+                self.session_context = ClientSession(
+                    self.read_stream, self.write_stream
+                )
                 self.session = await self.session_context.__aenter__()
-                
+
                 # Initialize session
                 await self.session.initialize()
-                
+
                 self.is_connected = True
-                logger.info(f"✓ Established persistent connection to {self.server_name}")
+                logger.info(
+                    f"✓ Established persistent connection to {self.server_name}"
+                )
                 return True
-                
+
             except Exception as e:
                 logger.error(f"Failed to connect to {self.server_name}: {e}")
                 await self._cleanup()
                 return False
-    
+
     async def disconnect(self):
         """Disconnect from the server."""
         async with self.lock:
             await self._cleanup()
-    
+
     async def _cleanup(self):
         """Internal cleanup method (must be called with lock held)."""
         try:
@@ -85,75 +92,83 @@ class PersistentServerSession:
                     await self.session_context.__aexit__(None, None, None)
                 except Exception:
                     pass
-            
+
             if self.stdio_context:
                 try:
                     await self.stdio_context.__aexit__(None, None, None)
                 except Exception:
                     pass
-            
+
             self.session = None
             self.session_context = None
             self.stdio_context = None
             self.read_stream = None
             self.write_stream = None
             self.is_connected = False
-            
+
         except Exception as e:
             logger.debug(f"Error during cleanup of {self.server_name}: {e}")
-    
-    async def call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+
+    async def call_tool(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Call a tool using the persistent session."""
         async with self.lock:
             if not self.is_connected or not self.session:
                 # Try to reconnect
-                logger.warning(f"Session not connected for {self.server_name}, attempting to reconnect...")
+                logger.warning(
+                    f"Session not connected for {self.server_name}, attempting to reconnect..."
+                )
                 if not await self._reconnect_internal():
                     raise RuntimeError(f"Failed to connect to {self.server_name}")
-            
+
             try:
                 result = await self.session.call_tool(tool_name, arguments)
-                
+
                 # Convert result to dictionary
                 content_list = []
                 for content_item in result.content:
-                    if hasattr(content_item, 'text'):
+                    if hasattr(content_item, "text"):
                         content_list.append({"type": "text", "text": content_item.text})
-                    elif hasattr(content_item, 'type'):
-                        content_list.append({"type": str(content_item.type), "text": str(content_item)})
+                    elif hasattr(content_item, "type"):
+                        content_list.append(
+                            {"type": str(content_item.type), "text": str(content_item)}
+                        )
                     else:
                         content_list.append({"type": "text", "text": str(content_item)})
-                
+
                 return {
-                    "error": result.isError if hasattr(result, 'isError') else False,
-                    "content": content_list
+                    "error": result.isError if hasattr(result, "isError") else False,
+                    "content": content_list,
                 }
-                
+
             except Exception as e:
-                logger.error(f"Tool call failed for {self.server_name}.{tool_name}: {e}")
+                logger.error(
+                    f"Tool call failed for {self.server_name}.{tool_name}: {e}"
+                )
                 # Mark as disconnected and try to reconnect on next call
                 self.is_connected = False
                 raise
-    
+
     async def _reconnect_internal(self) -> bool:
         """Internal reconnect (must be called with lock held)."""
         await self._cleanup()
         return await self._connect_internal()
-    
+
     async def _connect_internal(self) -> bool:
         """Internal connect (must be called with lock held)."""
         try:
             self.stdio_context = stdio_client(self.server_params)
             self.read_stream, self.write_stream = await self.stdio_context.__aenter__()
-            
+
             self.session_context = ClientSession(self.read_stream, self.write_stream)
             self.session = await self.session_context.__aenter__()
-            
+
             await self.session.initialize()
-            
+
             self.is_connected = True
             return True
-            
+
         except Exception as e:
             logger.error(f"Reconnect failed for {self.server_name}: {e}")
             await self._cleanup()
@@ -162,7 +177,7 @@ class PersistentServerSession:
 
 class MCPClient:
     """Client for connecting to MCP servers and using their tools with persistent connections."""
-    
+
     def __init__(self, mcp_service: MCPService):
         """
         Initialize MCP client with persistent connection support.
@@ -173,13 +188,17 @@ class MCPClient:
         self.mcp_service = mcp_service
         self.persistent_sessions: Dict[str, PersistentServerSession] = {}
         self.tools_cache: Dict[str, List[Dict]] = {}
-        self._connection_locks: Dict[str, threading.Lock] = {}  # Locks per server to prevent concurrent connections
+        self._connection_locks: Dict[str, threading.Lock] = (
+            {}
+        )  # Locks per server to prevent concurrent connections
         # Populated by connect_to_server — string reason on failure, and a
         # structured list of env var names when credentials are missing.
         self.last_errors: Dict[str, str] = {}
         self.last_missing_credentials: Dict[str, List[str]] = {}
-    
-    async def connect_to_server(self, server_name: str, persistent: bool = True) -> bool:
+
+    async def connect_to_server(
+        self, server_name: str, persistent: bool = True
+    ) -> bool:
         """
         Connect to an MCP server, cache its tools, and optionally maintain persistent connection.
 
@@ -250,58 +269,60 @@ class MCPClient:
         try:
             # Create stdio server parameters
             server_params = StdioServerParameters(
-                command=server.command,
-                args=server.args,
-                env=server.env
+                command=server.command, args=server.args, env=server.env
             )
-            
+
             if persistent:
                 # Create persistent session
                 if server_name not in self.persistent_sessions:
                     self.persistent_sessions[server_name] = PersistentServerSession(
                         server_name, server_params
                     )
-                
+
                 # Connect
                 if not await self.persistent_sessions[server_name].connect():
                     return False
-                
+
                 # Get tools from the persistent session
                 session = self.persistent_sessions[server_name].session
                 tools_result = await session.list_tools()
-                
+
             else:
                 # Temporary connection just to get tools
                 async with stdio_client(server_params) as (read_stream, write_stream):
                     async with ClientSession(read_stream, write_stream) as session:
                         await session.initialize()
                         tools_result = await session.list_tools()
-            
+
             # Cache tools
             self.tools_cache[server_name] = []
             for tool in tools_result.tools:
                 # Get input schema - handle both dict and object formats
                 input_schema = tool.inputSchema
-                if hasattr(input_schema, 'model_dump'):
+                if hasattr(input_schema, "model_dump"):
                     input_schema = input_schema.model_dump()
-                elif hasattr(input_schema, 'dict'):
+                elif hasattr(input_schema, "dict"):
                     input_schema = input_schema.dict()
                 elif not isinstance(input_schema, dict):
                     input_schema = dict(input_schema) if input_schema else {}
-                
+
                 # Ensure it's a valid JSON schema
                 if not isinstance(input_schema, dict):
                     input_schema = {}
-                
-                self.tools_cache[server_name].append({
-                    "name": tool.name,
-                    "description": tool.description or "",
-                    "inputSchema": input_schema
-                })
-            
-            logger.info(f"Connected to {server_name}, found {len(self.tools_cache[server_name])} tools")
+
+                self.tools_cache[server_name].append(
+                    {
+                        "name": tool.name,
+                        "description": tool.description or "",
+                        "inputSchema": input_schema,
+                    }
+                )
+
+            logger.info(
+                f"Connected to {server_name}, found {len(self.tools_cache[server_name])} tools"
+            )
             return True
-        
+
         except Exception as e:
             # Preserve the exception text so the UI can surface the real
             # reason (e.g. "FileNotFoundError: uvx", "ModuleNotFoundError:
@@ -383,9 +404,7 @@ class MCPClient:
                     server_name, persistent=True
                 )
             except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "Dormant-retry for %s raised: %s", server_name, exc
-                )
+                logger.warning("Dormant-retry for %s raised: %s", server_name, exc)
                 attempted[server_name] = False
         if attempted:
             connected = sum(1 for v in attempted.values() if v)
@@ -396,21 +415,23 @@ class MCPClient:
             )
         return attempted
 
-    async def list_tools(self, server_name: Optional[str] = None) -> Dict[str, List[Dict]]:
+    async def list_tools(
+        self, server_name: Optional[str] = None
+    ) -> Dict[str, List[Dict]]:
         """
         List available tools from MCP servers.
-        
+
         Args:
             server_name: Optional server name to list tools from. If None, lists from all servers.
-            
+
         Returns:
             Dictionary mapping server names to lists of tool definitions
         """
         if not MCP_AVAILABLE:
             return {}
-        
+
         tools = {}
-        
+
         if server_name:
             if server_name in self.tools_cache:
                 tools[server_name] = self.tools_cache[server_name]
@@ -427,10 +448,16 @@ class MCPClient:
                     # Try to connect
                     if await self.connect_to_server(name):
                         tools[name] = self.tools_cache.get(name, [])
-        
+
         return tools
-    
-    async def call_tool(self, server_name: str, tool_name: str, arguments: Dict[str, Any], timeout: float = 30.0) -> Dict[str, Any]:
+
+    async def call_tool(
+        self,
+        server_name: str,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        timeout: float = 30.0,
+    ) -> Dict[str, Any]:
         """
         Call a tool on an MCP server using persistent connection with timeout.
 
@@ -447,17 +474,26 @@ class MCPClient:
         import time as _time
 
         if not MCP_AVAILABLE:
-            return {"error": "MCP SDK not available", "content": [{"type": "text", "text": "MCP SDK not available"}]}
+            return {
+                "error": "MCP SDK not available",
+                "content": [{"type": "text", "text": "MCP SDK not available"}],
+            }
 
         if server_name not in self.mcp_service.servers:
-            return {"error": f"Unknown server: {server_name}", "content": [{"type": "text", "text": f"Unknown server: {server_name}"}]}
+            return {
+                "error": f"Unknown server: {server_name}",
+                "content": [{"type": "text", "text": f"Unknown server: {server_name}"}],
+            }
 
         # OTEL span for transport-level MCP call
         _mcp_span = None
         _mcp_t0 = _time.monotonic()
         try:
+            from opentelemetry.trace import SpanKind
+            from opentelemetry.trace import StatusCode as _SC
+
             from core.telemetry import get_tracer
-            from opentelemetry.trace import SpanKind, StatusCode as _SC
+
             _mcp_tracer = get_tracer("vigil.core.integrations.mcp.client")
             _mcp_span = _mcp_tracer.start_span(
                 "mcp.call_tool",
@@ -478,7 +514,12 @@ class MCPClient:
             if not await self.connect_to_server(server_name, persistent=True):
                 _err = {
                     "error": True,
-                    "content": [{"type": "text", "text": f"Failed to connect to server: {server_name}"}]
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": f"Failed to connect to server: {server_name}",
+                        }
+                    ],
                 }
                 try:
                     if _mcp_span is not None:
@@ -502,16 +543,27 @@ class MCPClient:
             result = await asyncio.wait_for(_call_tool_persistent(), timeout=timeout)
             try:
                 if _mcp_span is not None:
-                    is_err = result.get("error", False) if isinstance(result, dict) else False
+                    is_err = (
+                        result.get("error", False)
+                        if isinstance(result, dict)
+                        else False
+                    )
                     _mcp_span.set_attribute("vigil.tool.success", not is_err)
-                    _mcp_span.set_attribute("vigil.tool.output_size", len(_json.dumps(result, default=str)))
-                    _mcp_span.set_attribute("vigil.tool.duration_ms", round((_time.monotonic() - _mcp_t0) * 1000, 1))
+                    _mcp_span.set_attribute(
+                        "vigil.tool.output_size", len(_json.dumps(result, default=str))
+                    )
+                    _mcp_span.set_attribute(
+                        "vigil.tool.duration_ms",
+                        round((_time.monotonic() - _mcp_t0) * 1000, 1),
+                    )
                     _mcp_span.end()
             except Exception:
                 pass
             return result
         except asyncio.TimeoutError:
-            logger.error(f"Tool call {tool_name} on {server_name} timed out after {timeout}s")
+            logger.error(
+                f"Tool call {tool_name} on {server_name} timed out after {timeout}s"
+            )
             try:
                 if _mcp_span is not None and _SC is not None:
                     _mcp_span.set_attribute("vigil.tool.success", False)
@@ -521,7 +573,12 @@ class MCPClient:
                 pass
             return {
                 "error": True,
-                "content": [{"type": "text", "text": f"Tool call timed out after {timeout} seconds. The MCP server may not be responding."}]
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Tool call timed out after {timeout} seconds. The MCP server may not be responding.",
+                    }
+                ],
             }
         except Exception as e:
             logger.error(f"Error calling tool {tool_name} on {server_name}: {e}")
@@ -531,36 +588,39 @@ class MCPClient:
                     _mcp_span.end()
             except Exception:
                 pass
-            return {"error": True, "content": [{"type": "text", "text": f"Error: {str(e)}"}]}
-    
+            return {
+                "error": True,
+                "content": [{"type": "text", "text": f"Error: {str(e)}"}],
+            }
+
     def get_tools_for_claude(self) -> List[Dict]:
         """
         Get all available tools formatted for Claude's tool use API.
-        
+
         Returns:
             List of tool definitions in Claude's format
         """
         all_tools = []
-        
+
         for server_name, tools in self.tools_cache.items():
             for tool in tools:
                 # Format tool for Claude API
                 claude_tool = {
                     "name": f"{server_name}_{tool['name']}",
                     "description": f"[{server_name}] {tool['description']}",
-                    "input_schema": tool.get("inputSchema", {})
+                    "input_schema": tool.get("inputSchema", {}),
                 }
                 all_tools.append(claude_tool)
-        
+
         return all_tools
-    
+
     async def disconnect_from_server(self, server_name: str) -> bool:
         """
         Disconnect from a specific MCP server.
-        
+
         Args:
             server_name: Name of the server to disconnect from
-            
+
         Returns:
             True if successful, False otherwise
         """
@@ -574,12 +634,11 @@ class MCPClient:
                 logger.error(f"Error disconnecting from {server_name}: {e}")
                 return False
         return True
-    
-    
+
     def get_connection_status(self) -> Dict[str, bool]:
         """
         Get connection status for all servers.
-        
+
         Returns:
             Dictionary mapping server names to connection status
         """
@@ -590,11 +649,11 @@ class MCPClient:
             else:
                 status[server_name] = False
         return status
-    
+
     async def close_all(self):
         """Close all persistent MCP server connections and clear cache."""
         logger.info("Closing all MCP server connections...")
-        
+
         # Disconnect all persistent sessions sequentially to avoid context issues
         for server_name in list(self.persistent_sessions.keys()):
             try:
@@ -602,11 +661,11 @@ class MCPClient:
                 logger.info(f"Disconnected from {server_name}")
             except Exception as e:
                 logger.error(f"Error disconnecting from {server_name}: {e}")
-        
+
         # Clear all state
         self.persistent_sessions.clear()
         self.tools_cache.clear()
-        
+
         logger.info("All MCP connections closed")
 
 
@@ -621,14 +680,13 @@ def build_mcp_client() -> Optional[MCPClient]:
         logger.warning("MCP SDK not available. Install with: pip install mcp")
         return None
     return MCPClient(MCPService())
-    
+
 
 def set_process_mcp_client(client: Optional[MCPClient]) -> None:
     global _process_client
     _process_client = client
-    
+
 
 # None until an owner (the API lifespan, daemon startup) has installed a client.
 def process_mcp_client() -> Optional[MCPClient]:
     return _process_client
-

--- a/core/integrations/mcp/registry.py
+++ b/core/integrations/mcp/registry.py
@@ -6,8 +6,8 @@ whatever MCP servers are currently active, without hardcoding.
 """
 
 import logging
-from typing import Dict, List, Optional, Any
 from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class MCPRegistry:
     """
     Central registry that tracks active MCP servers and their available tools.
-    
+
     Used by ClaudeService and agents to dynamically discover what tools
     are available at runtime, enabling automatic enrichment from active
     MCP integrations (like security-detections, threat intel, etc.)
@@ -26,10 +26,12 @@ class MCPRegistry:
         self._tools_cache: Dict[str, List[Dict]] = {}
         self._last_refresh: Optional[datetime] = None
 
-    def register_server(self, name: str, config: Dict[str, Any], tools: Optional[List[Dict]] = None):
+    def register_server(
+        self, name: str, config: Dict[str, Any], tools: Optional[List[Dict]] = None
+    ):
         """
         Register an MCP server and its tools.
-        
+
         Args:
             name: Server name (e.g., 'security-detections', 'deeptempo-findings')
             config: Server config (command, args, env, etc.)
@@ -45,21 +47,22 @@ class MCPRegistry:
             self._tools_cache[name] = tools
         logger.info(f"Registered MCP server: {name} ({len(tools or [])} tools)")
 
-
     def get_active_servers(self) -> List[str]:
         """Get names of all active servers."""
-        return [name for name, info in self._servers.items() if info.get("active", False)]
+        return [
+            name for name, info in self._servers.items() if info.get("active", False)
+        ]
 
     def get_all_tools(self) -> List[Dict]:
         """
         Get all tools from all active servers, formatted for Claude API.
-        
+
         Returns:
             List of tool definitions with server-prefixed names.
         """
         all_tools = []
         seen = set()
-        
+
         for server_name in self.get_active_servers():
             for tool in self._tools_cache.get(server_name, []):
                 # Prefix tool name with server name (matching ClaudeService convention)
@@ -67,19 +70,26 @@ class MCPRegistry:
                 if tool_name in seen:
                     continue
                 seen.add(tool_name)
-                
-                all_tools.append({
-                    "name": tool_name,
-                    "description": f"[{server_name}] {tool.get('description', '')}",
-                    "input_schema": tool.get("input_schema", tool.get("inputSchema", {
-                        "type": "object",
-                        "properties": {},
-                        "required": [],
-                    })),
-                })
-        
-        return all_tools
 
+                all_tools.append(
+                    {
+                        "name": tool_name,
+                        "description": f"[{server_name}] {tool.get('description', '')}",
+                        "input_schema": tool.get(
+                            "input_schema",
+                            tool.get(
+                                "inputSchema",
+                                {
+                                    "type": "object",
+                                    "properties": {},
+                                    "required": [],
+                                },
+                            ),
+                        ),
+                    }
+                )
+
+        return all_tools
 
     def get_tool_names(self) -> List[str]:
         """Get all tool names (server-prefixed) from active servers."""
@@ -87,9 +97,9 @@ class MCPRegistry:
 
     def get_agent_sdk_configs(self) -> List[Dict]:
         """
-        Get MCP server configurations formatted for Agent SDK's 
+        Get MCP server configurations formatted for Agent SDK's
         ClaudeAgentOptions.mcp_servers parameter.
-        
+
         Returns:
             List of MCP server config dicts with name, command, args, env.
         """
@@ -98,14 +108,15 @@ class MCPRegistry:
             server_info = self._servers.get(name, {})
             config = server_info.get("config", {})
             if config.get("command"):
-                configs.append({
-                    "name": name,
-                    "command": config["command"],
-                    "args": config.get("args", []),
-                    "env": config.get("env", {}),
-                })
+                configs.append(
+                    {
+                        "name": name,
+                        "command": config["command"],
+                        "args": config.get("args", []),
+                        "env": config.get("env", {}),
+                    }
+                )
         return configs
-
 
     def get_summary(self) -> Dict[str, Any]:
         """Get a summary of the registry state."""
@@ -113,7 +124,9 @@ class MCPRegistry:
             "servers": len(self._servers),
             "active_servers": len(self.get_active_servers()),
             "total_tools": sum(len(t) for t in self._tools_cache.values()),
-            "last_refresh": self._last_refresh.isoformat() if self._last_refresh else None,
+            "last_refresh": (
+                self._last_refresh.isoformat() if self._last_refresh else None
+            ),
             "server_details": {
                 name: {
                     "active": info.get("active", False),

--- a/core/integrations/mcp/service.py
+++ b/core/integrations/mcp/service.py
@@ -1,19 +1,19 @@
 """MCP service for managing MCP servers."""
 
-import subprocess
-import platform
-import logging
 import json
-import re
-from pathlib import Path
-from typing import Optional, Dict, List
-from datetime import datetime
+import logging
 import os
+import platform
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
 
-from core.secrets import get_secret
 from core.config import vigil_path
 from core.detections.detection_rules_service import DetectionRulesService
 from core.integrations.integration_bridge_service import IntegrationBridgeService
+from core.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,9 @@ _ENV_PLACEHOLDER_RE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)\}")
 _PLACEHOLDER_BLACKLIST = {"workspaceFolder", "HOME", "PYTHONPATH"}
 
 
-def extract_required_env_vars(raw_env: Dict[str, str], raw_args: List[str]) -> List[str]:
+def extract_required_env_vars(
+    raw_env: Dict[str, str], raw_args: List[str]
+) -> List[str]:
     """Collect every ``${VAR}`` placeholder referenced by a server config.
 
     Scans the raw (pre-substitution) ``env`` values and ``args`` entries
@@ -79,18 +81,18 @@ class MCPServer:
         # Credential placeholders declared in mcp-config.json for this
         # server. Read by mcp_client.connect_to_server at connect time.
         self.required_env_vars: List[str] = list(required_env_vars or [])
-    
+
     def start(self) -> bool:
         """Start the MCP server."""
         if self.process is not None:
             logger.warning(f"Server {self.name} is already running")
             return False
-        
+
         try:
             # Prepare environment
             env = os.environ.copy()  # noqa: ENV001 - MCP child process env
             env.update(self.env)
-            
+
             # Start process
             self.process = subprocess.Popen(
                 [self.command] + self.args,
@@ -98,24 +100,24 @@ class MCPServer:
                 env=env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True
+                text=True,
             )
-            
+
             self.status = "running"
             self.start_time = datetime.now()
             logger.info(f"Started MCP server: {self.name}")
             return True
-        
+
         except Exception as e:
             logger.error(f"Failed to start MCP server {self.name}: {e}")
             self.status = "error"
             return False
-    
+
     def stop(self) -> bool:
         """Stop the MCP server."""
         if self.process is None:
             return True
-        
+
         try:
             self.process.terminate()
             try:
@@ -123,17 +125,17 @@ class MCPServer:
             except subprocess.TimeoutExpired:
                 self.process.kill()
                 self.process.wait()
-            
+
             self.process = None
             self.status = "stopped"
             self.start_time = None
             logger.info(f"Stopped MCP server: {self.name}")
             return True
-        
+
         except Exception as e:
             logger.error(f"Failed to stop MCP server {self.name}: {e}")
             return False
-    
+
     def is_running(self) -> bool:
         """Check if the server is running."""
         # First check if we have a process object and it's still alive
@@ -146,7 +148,7 @@ class MCPServer:
                 self.status = "stopped"
                 self.process = None
                 return False
-        
+
         # If no process object, check if the process is running externally
         # by checking for the process by command line arguments
         try:
@@ -158,7 +160,7 @@ class MCPServer:
                     if len(parts) >= 2:
                         module_name = parts[1]
                     break
-            
+
             if module_name:
                 # On Unix systems (macOS, Linux), use pgrep
                 if platform.system() != "Windows":
@@ -167,7 +169,7 @@ class MCPServer:
                             ["pgrep", "-f", f"tools.*{module_name}"],
                             capture_output=True,
                             text=True,
-                            timeout=2
+                            timeout=2,
                         )
                         if result.returncode == 0 and result.stdout.strip():
                             self.status = "running"
@@ -178,10 +180,16 @@ class MCPServer:
                     # On Windows, use tasklist with findstr
                     try:
                         result = subprocess.run(
-                            ["tasklist", "/FI", f"IMAGENAME eq python.exe", "/FO", "CSV"],
+                            [
+                                "tasklist",
+                                "/FI",
+                                "IMAGENAME eq python.exe",
+                                "/FO",
+                                "CSV",
+                            ],
                             capture_output=True,
                             text=True,
-                            timeout=2
+                            timeout=2,
                         )
                         if result.returncode == 0 and module_name in result.stdout:
                             self.status = "running"
@@ -190,9 +198,9 @@ class MCPServer:
                         pass
         except Exception as e:
             logger.debug(f"Error checking external process status: {e}")
-        
+
         return False
-    
+
     def get_status(self) -> str:
         """Get server status."""
         if self.server_type == "stdio":
@@ -200,7 +208,7 @@ class MCPServer:
         if self.is_running():
             return "running"
         return self.status
-    
+
     def get_log_path(self) -> Path:
         """Get the log file path for this server."""
         # Keep hyphens as servers log to files with hyphens (e.g., deeptempo-findings.log)
@@ -209,11 +217,11 @@ class MCPServer:
 
 class MCPService:
     """Service for managing MCP servers."""
-    
+
     # Path to persist enabled/disabled state for each MCP server
     _STATE_FILE = vigil_path("mcp_server_enabled.json")
     _STATE_WRITE_FILE = vigil_path("mcp_server_enabled.json", write=True)
-    
+
     def __init__(
         self,
         project_root: Optional[Path] = None,
@@ -235,22 +243,22 @@ class MCPService:
         self._detection_rules = detection_rules or DetectionRulesService()
         self.project_root = Path(project_root)
         self.venv_path = self.project_root / "venv"
-        
+
         # Determine Python executable
         if platform.system() == "Windows":
             self.python_exe = self.venv_path / "Scripts" / "python.exe"
         else:
             self.python_exe = self.venv_path / "bin" / "python"
-        
+
         # Load enabled state (servers default to disabled)
         self._enabled_servers: Dict[str, bool] = self._load_enabled_state()
-        
+
         # Initialize servers
         self.servers: Dict[str, MCPServer] = {}
         self._initialize_servers()
-    
+
     # ---- Enabled / Disabled state persistence ----
-    
+
     def _load_enabled_state(self) -> Dict[str, bool]:
         """Load the enabled/disabled state from disk. Returns empty dict if no file."""
         try:
@@ -261,7 +269,7 @@ class MCPService:
         except Exception as e:
             logger.warning(f"Could not load MCP enabled state: {e}")
         return {}
-    
+
     def _save_enabled_state(self) -> None:
         """Persist the enabled/disabled state to disk."""
         try:
@@ -269,9 +277,16 @@ class MCPService:
                 json.dump({"enabled": self._enabled_servers}, f, indent=2)
         except Exception as e:
             logger.error(f"Could not save MCP enabled state: {e}")
-    
+
     # Internal/platform servers that should be on by default
-    _DEFAULT_ENABLED = {"deeptempo-findings", "tempo-flow", "security-detections", "approval", "attack-layer", "mempalace"}
+    _DEFAULT_ENABLED = {
+        "deeptempo-findings",
+        "tempo-flow",
+        "security-detections",
+        "approval",
+        "attack-layer",
+        "mempalace",
+    }
 
     def is_server_enabled(self, server_name: str) -> bool:
         """Check whether a server is enabled. Internal platform servers default to True; all others default to False."""
@@ -279,11 +294,11 @@ class MCPService:
             server_name,
             server_name in self._DEFAULT_ENABLED,
         )
-    
+
     def set_server_enabled(self, server_name: str, enabled: bool) -> bool:
         """
         Enable or disable a server and persist the change.
-        
+
         Returns True if the server exists, False otherwise.
         """
         if server_name not in self.servers:
@@ -292,11 +307,11 @@ class MCPService:
         self._save_enabled_state()
         logger.info(f"Server '{server_name}' {'enabled' if enabled else 'disabled'}")
         return True
-    
+
     def get_all_enabled_states(self) -> Dict[str, bool]:
         """Return a dict of server_name -> enabled for every known server."""
         return {name: self.is_server_enabled(name) for name in self.servers}
-    
+
     def _substitute_env_vars(self, value: str) -> str:
         """
         Substitute environment variables in a string.
@@ -310,7 +325,7 @@ class MCPService:
         """
         import re
 
-        pattern = r'\$\{([^}:]+)(?::-((?:\$\{[^}]+\}|[^{}])*))?\}'
+        pattern = r"\$\{([^}:]+)(?::-((?:\$\{[^}]+\}|[^{}])*))?\}"
 
         def replace_var(match):
             var_name = match.group(1)
@@ -322,7 +337,7 @@ class MCPService:
                 return env_val
             if default is not None:
                 return self._substitute_env_vars(default)
-            return ''
+            return ""
 
         prev = None
         while prev != value:
@@ -330,24 +345,26 @@ class MCPService:
             value = re.sub(pattern, replace_var, value)
 
         return value
-    
+
     def _detect_server_type(self, args: List[str]) -> str:
         """
         Detect if a server is FastMCP or stdio-based by checking the module path.
-        
+
         FastMCP servers: deeptempo_findings
         Stdio servers: All others (designed for advanced MCP integration)
         """
         for arg in args:
             # Check both old tools/ and new mcp-servers/servers/ paths
-            if ("." in arg and arg.startswith("tools")) or "mcp-servers/servers/" in arg:
+            if (
+                "." in arg and arg.startswith("tools")
+            ) or "mcp-servers/servers/" in arg:
                 fastmcp_tools = ["deeptempo_findings"]
                 for fastmcp in fastmcp_tools:
                     if fastmcp in arg:
                         return "fastmcp"
                 return "stdio"
         return "unknown"
-    
+
     def reload_server_configs(self) -> None:
         """Rebuild server configs so a connectorUrl saved after startup is
         re-substituted into the init-time-cached spawn args."""
@@ -356,7 +373,7 @@ class MCPService:
     def _initialize_servers(self):
         """
         Initialize MCP server configurations from mcp-config.json.
-        
+
         Loads server configurations dynamically from the mcp-config.json file
         to ensure consistency with MCP integration workflows.
         Also includes servers for enabled integrations.
@@ -374,29 +391,31 @@ class MCPService:
         # Load servers from mcp-config.json
         mcp_config_path = self.project_root / "mcp-config.json"
         server_configs = []
-        
+
         if mcp_config_path.exists():
             try:
-                with open(mcp_config_path, 'r') as f:
+                with open(mcp_config_path, "r") as f:
                     mcp_config = json.load(f)
-                    
-                for server_name, server_config in mcp_config.get("mcpServers", {}).items():
+
+                for server_name, server_config in mcp_config.get(
+                    "mcpServers", {}
+                ).items():
                     # Skip comment keys
                     if server_name.startswith("_comment"):
                         continue
-                        
+
                     # Convert config format from mcp-config.json to our internal format
                     command = server_config.get("command", "python")
-                    
+
                     # Use venv python if command is just "python" or "python3"
                     if command in ["python", "python3"]:
                         command = python_exe_str
-                    
+
                     # Get cwd, replace ${workspaceFolder} with actual path
                     cwd = server_config.get("cwd", project_path_str)
                     if "${workspaceFolder}" in cwd:
                         cwd = cwd.replace("${workspaceFolder}", project_path_str)
-                    
+
                     # Get environment variables and substitute ${VAR_NAME} patterns
                     raw_env_strs = {
                         k: str(v)
@@ -431,53 +450,63 @@ class MCPService:
                         raw_env_strs, raw_args
                     )
 
-                    server_configs.append({
-                        "name": server_name,
-                        "command": command,
-                        "args": args,
-                        "cwd": cwd,
-                        "env": env,
-                        "server_type": self._detect_server_type(args),
-                        "required_env_vars": required_env_vars,
-                    })
-                    
-                logger.info(f"Loaded {len(server_configs)} servers from mcp-config.json")
+                    server_configs.append(
+                        {
+                            "name": server_name,
+                            "command": command,
+                            "args": args,
+                            "cwd": cwd,
+                            "env": env,
+                            "server_type": self._detect_server_type(args),
+                            "required_env_vars": required_env_vars,
+                        }
+                    )
+
+                logger.info(
+                    f"Loaded {len(server_configs)} servers from mcp-config.json"
+                )
             except Exception as e:
                 logger.error(f"Error loading mcp-config.json: {e}")
                 # Fall back to default servers if config loading fails
-                server_configs = self._get_default_servers(python_exe_str, project_path_str)
+                server_configs = self._get_default_servers(
+                    python_exe_str, project_path_str
+                )
         else:
             logger.warning("mcp-config.json not found, using default servers")
             server_configs = self._get_default_servers(python_exe_str, project_path_str)
-        
+
         # Add servers for enabled integrations using the integration bridge
         try:
             enabled_servers = self._integration_bridge.get_enabled_servers()
-            
+
             # Get list of already loaded server names to avoid duplicates
-            loaded_server_names = [s['name'] for s in server_configs]
-            
+            loaded_server_names = [s["name"] for s in server_configs]
+
             for server_name, server_info in enabled_servers.items():
                 # Skip if already loaded from mcp-config.json
                 if server_name in loaded_server_names:
-                    logger.info(f"Server '{server_name}' already loaded from mcp-config.json, skipping dynamic load")
+                    logger.info(
+                        f"Server '{server_name}' already loaded from mcp-config.json, skipping dynamic load"
+                    )
                     continue
-                
-                integration_id = server_info['integration_id']
-                env_vars = server_info['env_vars']
-                
+
+                integration_id = server_info["integration_id"]
+                env_vars = server_info["env_vars"]
+
                 # Get module path for this integration
                 module_path = self._integration_bridge.get_server_module_path(
                     integration_id
                 )
                 if not module_path:
-                    logger.warning(f"No module path found for integration '{integration_id}'")
+                    logger.warning(
+                        f"No module path found for integration '{integration_id}'"
+                    )
                     continue
-                
+
                 # Prepare environment variables
                 env = env_vars.copy()
                 env["PYTHONPATH"] = project_path_str
-                
+
                 # Create server configuration
                 server_config = {
                     "name": server_name,
@@ -485,24 +514,26 @@ class MCPService:
                     "args": ["-m", module_path],
                     "cwd": project_path_str,
                     "env": env,
-                    "server_type": "stdio"
+                    "server_type": "stdio",
                 }
-                
+
                 server_configs.append(server_config)
-                logger.info(f"Loaded dynamic integration server: {server_name} for '{integration_id}'")
-        
+                logger.info(
+                    f"Loaded dynamic integration server: {server_name} for '{integration_id}'"
+                )
+
         except ImportError as e:
             logger.warning(f"Could not import integration bridge service: {e}")
         except Exception as e:
             logger.warning(f"Error loading dynamic integration servers: {e}")
-        
+
         # Dynamically update security-detections server env vars from DetectionRulesService
         for config in server_configs:
             if config["name"] == "security-detections":
                 config = self._enrich_security_detections_env(config)
             server = MCPServer(**config)
             self.servers[config["name"]] = server
-    
+
     def _enrich_security_detections_env(self, config: Dict) -> Dict:
         """
         Enrich the security-detections MCP server config with dynamic env vars
@@ -511,20 +542,26 @@ class MCPService:
         """
         try:
             dynamic_env = self._detection_rules.get_mcp_env_vars()
-            
+
             if dynamic_env:
                 # Override static env vars with dynamic ones
                 config["env"] = config.get("env", {}).copy()
                 config["env"].update(dynamic_env)
-                logger.info(f"Enriched security-detections env with {len(dynamic_env)} dynamic vars: {list(dynamic_env.keys())}")
+                logger.info(
+                    f"Enriched security-detections env with {len(dynamic_env)} dynamic vars: {list(dynamic_env.keys())}"
+                )
             else:
-                logger.info("No dynamic env vars from DetectionRulesService (no ready sources)")
+                logger.info(
+                    "No dynamic env vars from DetectionRulesService (no ready sources)"
+                )
         except Exception as e:
             logger.warning(f"Could not enrich security-detections env vars: {e}")
-        
+
         return config
-    
-    def _get_default_servers(self, python_exe_str: str, project_path_str: str) -> List[Dict]:
+
+    def _get_default_servers(
+        self, python_exe_str: str, project_path_str: str
+    ) -> List[Dict]:
         """Get default server configurations if mcp-config.json is not available."""
         return [
             {
@@ -533,10 +570,10 @@ class MCPService:
                 "args": ["-m", "tools.deeptempo_findings"],
                 "cwd": project_path_str,
                 "env": {"PYTHONPATH": project_path_str},
-                "server_type": "fastmcp"
+                "server_type": "fastmcp",
             }
         ]
-    
+
     # NOTE: the former `start_server` / `start_all` / `stop_all` methods were
     # removed when the MCP enable toggle became the single runtime lever.
     # They were Popen-subprocess monitors that explicitly refused stdio
@@ -558,26 +595,25 @@ class MCPService:
             return False
         return self.servers[server_name].stop()
 
-
     def get_server_status(self, server_name: str) -> Optional[str]:
         """
         Get the status of an MCP server.
-        
+
         Args:
             server_name: Name of the server.
-        
+
         Returns:
             Status string or None if server not found.
         """
         if server_name not in self.servers:
             return None
-        
+
         return self.servers[server_name].get_status()
-    
+
     def get_all_statuses(self) -> Dict[str, str]:
         """
         Get status of all servers.
-        
+
         Returns:
             Dictionary mapping server names to status strings.
         """
@@ -585,57 +621,56 @@ class MCPService:
         for name, server in self.servers.items():
             statuses[name] = server.get_status()
         return statuses
-    
+
     def get_server_log(self, server_name: str, lines: int = 100) -> str:
         """
         Get log content for a server.
-        
+
         Args:
             server_name: Name of the server.
             lines: Number of lines to retrieve (from end).
-        
+
         Returns:
             Log content as string.
         """
         if server_name not in self.servers:
             return ""
-        
+
         log_path = self.servers[server_name].get_log_path()
-        
+
         if not log_path.exists():
             return f"Log file not yet created. Start the server to generate logs.\n\nExpected log path: {log_path}"
-        
+
         try:
-            with open(log_path, 'r') as f:
+            with open(log_path, "r") as f:
                 all_lines = f.readlines()
                 if not all_lines:
                     return f"Log file is empty. Server may not have started yet.\n\nLog path: {log_path}"
-                return ''.join(all_lines[-lines:])
+                return "".join(all_lines[-lines:])
         except Exception as e:
             return f"Error reading log: {e}"
-    
+
     def test_server(self, server_name: str) -> bool:
         """
         Test if a server is responding.
-        
+
         Args:
             server_name: Name of the server to test.
-        
+
         Returns:
             True if server appears to be running, False otherwise.
         """
         if server_name not in self.servers:
             return False
-        
+
         server = self.servers[server_name]
         return server.is_running()
-    
+
     def list_servers(self) -> List[str]:
         """
         List all available servers.
-        
+
         Returns:
             List of server names.
         """
         return list(self.servers.keys())
-

--- a/core/integrations/mcp/tool_manager.py
+++ b/core/integrations/mcp/tool_manager.py
@@ -298,7 +298,10 @@ async def execute_backend_tool(
     # through so a name that merely *looks* like a skill still tries the rest
     # of the chain.
     try:
-        from core.skills.skill_tools_bridge import execute_skill_tool, is_skill_tool_name
+        from core.skills.skill_tools_bridge import (
+            execute_skill_tool,
+            is_skill_tool_name,
+        )
 
         if is_skill_tool_name(tool_name):
             return (

--- a/core/integrations/microsoft_defender/adapter.py
+++ b/core/integrations/microsoft_defender/adapter.py
@@ -8,7 +8,9 @@ from core.federation.contract import FederationAdapter, register_adapter
 
 def _factory() -> FederationAdapter:
     def make_service():
-        from core.integrations.microsoft_defender.ingestion import MicrosoftDefenderIngestion
+        from core.integrations.microsoft_defender.ingestion import (
+            MicrosoftDefenderIngestion,
+        )
 
         return MicrosoftDefenderIngestion()
 

--- a/core/integrations/microsoft_defender/ingestion.py
+++ b/core/integrations/microsoft_defender/ingestion.py
@@ -6,13 +6,14 @@ Fetches security alerts from Microsoft Defender and converts them to findings.
 
 import asyncio
 import logging
-from typing import List, Dict, Any, Optional
-from datetime import datetime, timedelta
 import uuid
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
 import httpx
 
-from core.ingestion.siem_ingestion_service import SIEMIngestionService
 from core.config import get_integration_config
+from core.ingestion.siem_ingestion_service import SIEMIngestionService
 
 logger = logging.getLogger(__name__)
 
@@ -26,39 +27,41 @@ _FOLLOW_REDIRECTS = True
 
 class MicrosoftDefenderIngestion(SIEMIngestionService):
     """Microsoft Defender ingestion service."""
-    
+
     def __init__(self):
         """Initialize Microsoft Defender ingestion."""
         super().__init__()
         self.siem_name = "Microsoft Defender"
-        self.config = get_integration_config('microsoft-defender')
+        self.config = get_integration_config("microsoft-defender")
         self.access_token = None
-    
+
     def _get_access_token(self) -> Optional[str]:
         """
         Get OAuth2 access token for Microsoft Defender API.
-        
+
         Returns:
             Access token or None
         """
         try:
-            tenant_id = self.config.get('tenant_id')
-            client_id = self.config.get('client_id')
-            client_secret = self.config.get('client_secret')
-            
+            tenant_id = self.config.get("tenant_id")
+            client_id = self.config.get("client_id")
+            client_secret = self.config.get("client_secret")
+
             if not all([tenant_id, client_id, client_secret]):
                 logger.error("Microsoft Defender configuration incomplete")
                 return None
-            
+
             # Get token
-            token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+            token_url = (
+                f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+            )
             token_data = {
-                'client_id': client_id,
-                'client_secret': client_secret,
-                'scope': 'https://api.securitycenter.microsoft.com/.default',
-                'grant_type': 'client_credentials'
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "scope": "https://api.securitycenter.microsoft.com/.default",
+                "grant_type": "client_credentials",
             }
-            
+
             response = httpx.post(
                 token_url,
                 data=token_data,
@@ -66,28 +69,28 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
                 follow_redirects=_FOLLOW_REDIRECTS,
             )
             response.raise_for_status()
-            
-            self.access_token = response.json()['access_token']
+
+            self.access_token = response.json()["access_token"]
             return self.access_token
-        
+
         except Exception as e:
             logger.error(f"Error getting Microsoft Defender access token: {e}")
             return None
-    
+
     async def fetch_alerts(
         self,
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
-        limit: int = 100
+        limit: int = 100,
     ) -> List[Dict[str, Any]]:
         """
         Fetch alerts from Microsoft Defender.
-        
+
         Args:
             start_time: Start time for alert query
             end_time: End time for alert query
             limit: Maximum number of alerts to fetch
-        
+
         Returns:
             List of raw alert dictionaries
         """
@@ -97,27 +100,27 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
             token = await asyncio.to_thread(self._get_access_token)
             if not token:
                 return []
-            
+
             # Set time range
             if not start_time:
                 start_time = datetime.utcnow() - timedelta(hours=24)
             if not end_time:
                 end_time = datetime.utcnow()
-            
+
             # Build API request
             api_url = "https://api.securitycenter.microsoft.com/api/alerts"
             headers = {
-                'Authorization': f'Bearer {token}',
-                'Content-Type': 'application/json'
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
             }
-            
+
             # Filter by time
             params = {
-                '$filter': f"alertCreationTime ge {start_time.isoformat()}Z and alertCreationTime le {end_time.isoformat()}Z",
-                '$top': limit,
-                '$orderby': 'alertCreationTime desc'
+                "$filter": f"alertCreationTime ge {start_time.isoformat()}Z and alertCreationTime le {end_time.isoformat()}Z",
+                "$top": limit,
+                "$orderby": "alertCreationTime desc",
             }
-            
+
             response = await asyncio.to_thread(
                 httpx.get,
                 api_url,
@@ -127,33 +130,35 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
                 follow_redirects=_FOLLOW_REDIRECTS,
             )
             response.raise_for_status()
-            
-            alerts = response.json().get('value', [])
-            
+
+            alerts = response.json().get("value", [])
+
             logger.info(f"Fetched {len(alerts)} alerts from Microsoft Defender")
             return alerts
-        
+
         except (httpx.HTTPError, httpx.InvalidURL) as e:
             logger.error(f"Microsoft Defender API error: {e}")
             return []
         except Exception as e:
             logger.error(f"Error fetching Microsoft Defender alerts: {e}")
             return []
-    
-    def transform_alert_to_finding(self, alert: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    def transform_alert_to_finding(
+        self, alert: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """
         Transform Microsoft Defender alert to finding format.
-        
+
         Args:
             alert: Raw alert from Microsoft Defender
-        
+
         Returns:
             Finding dictionary
         """
         try:
             # Generate finding ID
             finding_id = f"defender-{alert.get('id', uuid.uuid4().hex[:12])}"
-            
+
             # Extract entities
             entities = {
                 "ip_addresses": [],
@@ -162,52 +167,54 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
                 "hostnames": [],
                 "file_hashes": [],
             }
-            
+
             # Extract from evidence
-            evidence = alert.get('evidence', [])
+            evidence = alert.get("evidence", [])
             for item in evidence:
-                entity_type = item.get('entityType', '').lower()
-                
-                if entity_type == 'ip':
-                    entities["ip_addresses"].append(item.get('ipAddress', ''))
-                elif entity_type == 'url':
-                    entities["domains"].append(item.get('url', ''))
-                elif entity_type == 'user':
-                    entities["usernames"].append(item.get('userPrincipalName', ''))
-                elif entity_type == 'machine':
-                    entities["hostnames"].append(item.get('deviceDnsName', ''))
-                elif entity_type == 'file':
-                    if item.get('sha256'):
-                        entities["file_hashes"].append(item['sha256'])
-                    if item.get('sha1'):
-                        entities["file_hashes"].append(item['sha1'])
-                    if item.get('md5'):
-                        entities["file_hashes"].append(item['md5'])
-            
+                entity_type = item.get("entityType", "").lower()
+
+                if entity_type == "ip":
+                    entities["ip_addresses"].append(item.get("ipAddress", ""))
+                elif entity_type == "url":
+                    entities["domains"].append(item.get("url", ""))
+                elif entity_type == "user":
+                    entities["usernames"].append(item.get("userPrincipalName", ""))
+                elif entity_type == "machine":
+                    entities["hostnames"].append(item.get("deviceDnsName", ""))
+                elif entity_type == "file":
+                    if item.get("sha256"):
+                        entities["file_hashes"].append(item["sha256"])
+                    if item.get("sha1"):
+                        entities["file_hashes"].append(item["sha1"])
+                    if item.get("md5"):
+                        entities["file_hashes"].append(item["md5"])
+
             # Extract MITRE ATT&CK
-            mitre_techniques = alert.get('mitreTechniques', [])
-            
+            mitre_techniques = alert.get("mitreTechniques", [])
+
             # Build finding
             finding = {
                 "finding_id": finding_id,
-                "title": alert.get('title', 'Microsoft Defender Alert'),
-                "description": alert.get('description', ''),
-                "severity": self.normalize_severity(alert.get('severity')),
+                "title": alert.get("title", "Microsoft Defender Alert"),
+                "description": alert.get("description", ""),
+                "severity": self.normalize_severity(alert.get("severity")),
                 "data_source": "microsoft_defender",
-                "timestamp": alert.get('alertCreationTime', datetime.utcnow().isoformat()),
+                "timestamp": alert.get(
+                    "alertCreationTime", datetime.utcnow().isoformat()
+                ),
                 "raw_data": alert,
                 "metadata": {
-                    "alert_id": alert.get('id'),
-                    "category": alert.get('category'),
-                    "status": alert.get('status'),
-                    "classification": alert.get('classification'),
-                    "determination": alert.get('determination'),
-                    "assigned_to": alert.get('assignedTo'),
-                    "machine_id": alert.get('machineId'),
-                    "detection_source": alert.get('detectionSource'),
-                    "threat_family_name": alert.get('threatFamilyName'),
-                    "first_activity": alert.get('firstActivityTime'),
-                    "last_activity": alert.get('lastActivityTime'),
+                    "alert_id": alert.get("id"),
+                    "category": alert.get("category"),
+                    "status": alert.get("status"),
+                    "classification": alert.get("classification"),
+                    "determination": alert.get("determination"),
+                    "assigned_to": alert.get("assignedTo"),
+                    "machine_id": alert.get("machineId"),
+                    "detection_source": alert.get("detectionSource"),
+                    "threat_family_name": alert.get("threatFamilyName"),
+                    "first_activity": alert.get("firstActivityTime"),
+                    "last_activity": alert.get("lastActivityTime"),
                 },
                 "entities": entities,
                 "mitre_attack": {
@@ -215,10 +222,9 @@ class MicrosoftDefenderIngestion(SIEMIngestionService):
                     "techniques": mitre_techniques,
                 },
             }
-            
+
             return finding
-        
+
         except Exception as e:
             logger.error(f"Error transforming Microsoft Defender alert: {e}")
             return None
-

--- a/core/integrations/microsoft_defender/tool.py
+++ b/core/integrations/microsoft_defender/tool.py
@@ -1,11 +1,13 @@
 import asyncio
 import json
 import logging
-import requests
-from mcp.server.models import InitializationOptions
-import mcp.types as types
-from mcp.server import NotificationOptions, Server
+
 import mcp.server.stdio
+import mcp.types as types
+import requests
+from mcp.server import NotificationOptions, Server
+from mcp.server.models import InitializationOptions
+
 from core.config import get_integration_config
 
 logger = logging.getLogger(__name__)
@@ -17,18 +19,23 @@ def result(data):
 
 
 def get_token():
-    config = get_integration_config('microsoft-defender')
-    tenant = config.get('tenant_id')
-    client_id = config.get('client_id')
-    client_secret = config.get('client_secret')
+    config = get_integration_config("microsoft-defender")
+    tenant = config.get("tenant_id")
+    client_id = config.get("client_id")
+    client_secret = config.get("client_secret")
     if not all([tenant, client_id, client_secret]):
         return None
     try:
-        resp = requests.post(f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token",
+        resp = requests.post(
+            f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token",
             data={
-                "grant_type": "client_credentials", "client_id": client_id,
-                "client_secret": client_secret, "scope": "https://api.securitycenter.microsoft.com/.default"
-            }, timeout=30)
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "scope": "https://api.securitycenter.microsoft.com/.default",
+            },
+            timeout=30,
+        )
         resp.raise_for_status()
         return resp.json().get("access_token")
     except Exception:
@@ -38,12 +45,36 @@ def get_token():
 @server.list_tools()
 async def handle_list_tools():
     return [
-        types.Tool(name="mde_get_alerts", description="Get Microsoft Defender alerts",
-            inputSchema={"type": "object", "properties": {"limit": {"type": "integer", "default": 20}}, "required": []}),
-        types.Tool(name="mde_get_machine", description="Get machine info",
-            inputSchema={"type": "object", "properties": {"machine_id": {"type": "string"}}, "required": ["machine_id"]}),
-        types.Tool(name="mde_isolate", description="Isolate machine",
-            inputSchema={"type": "object", "properties": {"machine_id": {"type": "string"}, "comment": {"type": "string"}}, "required": ["machine_id", "comment"]}),
+        types.Tool(
+            name="mde_get_alerts",
+            description="Get Microsoft Defender alerts",
+            inputSchema={
+                "type": "object",
+                "properties": {"limit": {"type": "integer", "default": 20}},
+                "required": [],
+            },
+        ),
+        types.Tool(
+            name="mde_get_machine",
+            description="Get machine info",
+            inputSchema={
+                "type": "object",
+                "properties": {"machine_id": {"type": "string"}},
+                "required": ["machine_id"],
+            },
+        ),
+        types.Tool(
+            name="mde_isolate",
+            description="Isolate machine",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "machine_id": {"type": "string"},
+                    "comment": {"type": "string"},
+                },
+                "required": ["machine_id", "comment"],
+            },
+        ),
     ]
 
 
@@ -52,22 +83,31 @@ async def handle_call_tool(name: str, arguments: dict | None):
     token = get_token()
     if not token:
         return result({"error": "Microsoft Defender not configured"})
-    
+
     args = arguments or {}
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
     base = "https://api.securitycenter.microsoft.com/api"
-    
+
     try:
         if name == "mde_get_alerts":
-            resp = requests.get(f"{base}/alerts", headers=headers,
-                params={"$top": args.get("limit", 20)}, timeout=30)
+            resp = requests.get(
+                f"{base}/alerts",
+                headers=headers,
+                params={"$top": args.get("limit", 20)},
+                timeout=30,
+            )
             resp.raise_for_status()
-            alerts = [{
-                "id": a.get("id"), "title": a.get("title"),
-                "severity": a.get("severity"), "status": a.get("status")
-            } for a in resp.json().get("value", [])]
+            alerts = [
+                {
+                    "id": a.get("id"),
+                    "title": a.get("title"),
+                    "severity": a.get("severity"),
+                    "status": a.get("status"),
+                }
+                for a in resp.json().get("value", [])
+            ]
             return result({"count": len(alerts), "alerts": alerts})
-        
+
         elif name == "mde_get_machine":
             mid = args.get("machine_id")
             if not mid:
@@ -75,17 +115,21 @@ async def handle_call_tool(name: str, arguments: dict | None):
             resp = requests.get(f"{base}/machines/{mid}", headers=headers, timeout=30)
             resp.raise_for_status()
             return result({"machine": resp.json()})
-        
+
         elif name == "mde_isolate":
             mid = args.get("machine_id")
             comment = args.get("comment")
             if not mid or not comment:
                 return result({"error": "machine_id and comment required"})
-            resp = requests.post(f"{base}/machines/{mid}/isolate", headers=headers,
-                json={"Comment": comment, "IsolationType": "Full"}, timeout=30)
+            resp = requests.post(
+                f"{base}/machines/{mid}/isolate",
+                headers=headers,
+                json={"Comment": comment, "IsolationType": "Full"},
+                timeout=30,
+            )
             resp.raise_for_status()
             return result({"success": True, "machine_id": mid, "action": "isolated"})
-        
+
         return result({"error": f"Unknown tool: {name}"})
     except Exception as e:
         return result({"error": str(e)})
@@ -93,10 +137,18 @@ async def handle_call_tool(name: str, arguments: dict | None):
 
 async def main():
     async with mcp.server.stdio.stdio_server() as (read, write):
-        await server.run(read, write, InitializationOptions(
-            server_name="microsoft-defender", server_version="0.1.0",
-            capabilities=server.get_capabilities(notification_options=NotificationOptions(), experimental_capabilities={})
-        ))
+        await server.run(
+            read,
+            write,
+            InitializationOptions(
+                server_name="microsoft-defender",
+                server_version="0.1.0",
+                capabilities=server.get_capabilities(
+                    notification_options=NotificationOptions(),
+                    experimental_capabilities={},
+                ),
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/core/integrations/slack/tool.py
+++ b/core/integrations/slack/tool.py
@@ -1,11 +1,13 @@
 import asyncio
 import json
 import logging
-import requests
-from mcp.server.models import InitializationOptions
-import mcp.types as types
-from mcp.server import NotificationOptions, Server
+
 import mcp.server.stdio
+import mcp.types as types
+import requests
+from mcp.server import NotificationOptions, Server
+from mcp.server.models import InitializationOptions
+
 from core.config import get_integration_config
 
 logger = logging.getLogger(__name__)
@@ -17,65 +19,99 @@ def result(data):
 
 
 def get_config():
-    return get_integration_config('slack')
+    return get_integration_config("slack")
 
 
 @server.list_tools()
 async def handle_list_tools():
     return [
-        types.Tool(name="slack_send_alert", description="Send security alert to Slack channel",
-            inputSchema={"type": "object", "properties": {
-                "channel": {"type": "string"}, "message": {"type": "string"},
-                "severity": {"type": "string", "enum": ["low", "medium", "high", "critical"]}
-            }, "required": ["channel", "message"]}),
+        types.Tool(
+            name="slack_send_alert",
+            description="Send security alert to Slack channel",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "channel": {"type": "string"},
+                    "message": {"type": "string"},
+                    "severity": {
+                        "type": "string",
+                        "enum": ["low", "medium", "high", "critical"],
+                    },
+                },
+                "required": ["channel", "message"],
+            },
+        ),
     ]
 
 
 @server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     config = get_config()
-    token = config.get('bot_token')
+    token = config.get("bot_token")
     if not token:
         return result({"error": "Slack not configured"})
-    
+
     args = arguments or {}
-    
+
     if name == "slack_send_alert":
         channel = args.get("channel")
         msg = args.get("message")
         if not channel or not msg:
             return result({"error": "channel and message required"})
-        
+
         sev = args.get("severity", "medium")
-        colors = {"low": "#36a64f", "medium": "#ffcc00", "high": "#ff9900", "critical": "#ff0000"}
-        
+        colors = {
+            "low": "#36a64f",
+            "medium": "#ffcc00",
+            "high": "#ff9900",
+            "critical": "#ff0000",
+        }
+
         try:
-            resp = requests.post("https://slack.com/api/chat.postMessage",
-                headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+            resp = requests.post(
+                "https://slack.com/api/chat.postMessage",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
                 json={
                     "channel": channel,
-                    "attachments": [{
-                        "color": colors.get(sev, "#808080"),
-                        "title": f"Security Alert - {sev.upper()}",
-                        "text": msg
-                    }]
-                }, timeout=30)
+                    "attachments": [
+                        {
+                            "color": colors.get(sev, "#808080"),
+                            "title": f"Security Alert - {sev.upper()}",
+                            "text": msg,
+                        }
+                    ],
+                },
+                timeout=30,
+            )
             data = resp.json()
             if data.get("ok"):
-                return result({"success": True, "channel": channel, "ts": data.get("ts")})
+                return result(
+                    {"success": True, "channel": channel, "ts": data.get("ts")}
+                )
             return result({"error": data.get("error", "Unknown error")})
         except Exception as e:
             return result({"error": str(e)})
-    
+
     return result({"error": f"Unknown tool: {name}"})
 
 
 async def main():
     async with mcp.server.stdio.stdio_server() as (read, write):
-        await server.run(read, write, InitializationOptions(
-            server_name="slack", server_version="0.1.0",
-            capabilities=server.get_capabilities(notification_options=NotificationOptions(), experimental_capabilities={})
-        ))
+        await server.run(
+            read,
+            write,
+            InitializationOptions(
+                server_name="slack",
+                server_version="0.1.0",
+                capabilities=server.get_capabilities(
+                    notification_options=NotificationOptions(),
+                    experimental_capabilities={},
+                ),
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/core/integrations/splunk/adapter.py
+++ b/core/integrations/splunk/adapter.py
@@ -85,7 +85,9 @@ class SplunkAdapter:
         last = parse_cursor_since(cursor) or since
         if last is not None:
             # Convert to relative Splunk earliest_time (rounded up to minute)
-            delta_minutes = max(int((datetime.utcnow() - last).total_seconds() // 60) + 1, 1)
+            delta_minutes = max(
+                int((datetime.utcnow() - last).total_seconds() // 60) + 1, 1
+            )
             earliest_time = f"-{delta_minutes}m"
         else:
             # First run: tiny window so we don't replay history.

--- a/core/integrations/splunk/client.py
+++ b/core/integrations/splunk/client.py
@@ -1,8 +1,9 @@
 """Splunk API service for data enrichment."""
 
 import logging
+from typing import Dict, List, Optional
+
 import httpx
-from typing import Optional, List, Dict
 
 # urllib3.disable_warnings() used to live here to silence
 # InsecureRequestWarning; httpx doesn't use urllib3 and emits no such
@@ -25,19 +26,20 @@ _HTTP_ERRORS = (httpx.HTTPError, httpx.InvalidURL)
 
 class SplunkService:
     """Service for interacting with Splunk API."""
-    
-    def __init__(self, server_url: str, username: str, password: str, 
-                 verify_ssl: bool = False):
+
+    def __init__(
+        self, server_url: str, username: str, password: str, verify_ssl: bool = False
+    ):
         """
         Initialize Splunk service.
-        
+
         Args:
             server_url: Splunk server URL (e.g., "https://splunk.example.com:8089")
             username: Username for authentication
             password: Password for authentication
             verify_ssl: Whether to verify SSL certificates (default: False)
         """
-        self.server_url = server_url.rstrip('/')
+        self.server_url = server_url.rstrip("/")
         self.username = username
         self.password = password
         self.verify_ssl = verify_ssl
@@ -48,37 +50,39 @@ class SplunkService:
             timeout=DEFAULT_TIMEOUT,
             follow_redirects=_FOLLOW_REDIRECTS,
             headers={
-                'Content-Type': 'application/x-www-form-urlencoded',
-                'Accept': 'application/json',
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
             },
         )
         self.session_key: Optional[str] = None
-    
+
     def authenticate(self) -> bool:
         """
         Authenticate with Splunk server and get session key.
-        
+
         Returns:
             True if authentication successful, False otherwise.
         """
         try:
             auth_url = f"{self.server_url}/services/auth/login"
             data = {
-                'username': self.username,
-                'password': self.password,
-                'output_mode': 'json'
+                "username": self.username,
+                "password": self.password,
+                "output_mode": "json",
             }
-            
+
             response = self.session.post(auth_url, data=data)
-            
+
             if response.status_code == 200:
                 result = response.json()
-                self.session_key = result.get('sessionKey')
+                self.session_key = result.get("sessionKey")
                 if self.session_key:
-                    self.session.headers.update({
-                        'Authorization': f'Splunk {self.session_key}'
-                    })
-                    logger.info(f"Successfully authenticated to Splunk as {self.username}")
+                    self.session.headers.update(
+                        {"Authorization": f"Splunk {self.session_key}"}
+                    )
+                    logger.info(
+                        f"Successfully authenticated to Splunk as {self.username}"
+                    )
                     return True
                 else:
                     logger.error("No session key returned from Splunk")
@@ -86,38 +90,43 @@ class SplunkService:
             else:
                 logger.error(f"Authentication failed: HTTP {response.status_code}")
                 return False
-        
+
         except Exception as e:
             logger.error(f"Error during authentication: {e}")
             return False
-    
+
     def test_connection(self) -> tuple[bool, str]:
         """
         Test connection to Splunk server.
-        
+
         Returns:
             Tuple of (success, message)
         """
         try:
             if not self.authenticate():
                 return False, "Authentication failed"
-            
+
             # Try to get server info
             response = self.session.get(
                 f"{self.server_url}/services/server/info",
-                params={'output_mode': 'json'}
+                params={"output_mode": "json"},
             )
-            
+
             if response.status_code == 200:
                 return True, "Connection successful"
             else:
                 return False, f"Connection failed: HTTP {response.status_code}"
-        
+
         except _HTTP_ERRORS as e:
             return False, f"Connection error: {str(e)}"
-    
-    def search(self, query: str, earliest_time: str = "-24h", 
-               latest_time: str = "now", max_count: int = 1000) -> Optional[List[Dict]]:
+
+    def search(
+        self,
+        query: str,
+        earliest_time: str = "-24h",
+        latest_time: str = "now",
+        max_count: int = 1000,
+    ) -> Optional[List[Dict]]:
         """
         Execute a search query in Splunk.
 
@@ -138,144 +147,147 @@ class SplunkService:
             if not self.session_key:
                 if not self.authenticate():
                     return None
-            
+
             # Create search job
             search_url = f"{self.server_url}/services/search/jobs"
             search_data = {
-                'search': f"search {query}",
-                'earliest_time': earliest_time,
-                'latest_time': latest_time,
-                'output_mode': 'json'
+                "search": f"search {query}",
+                "earliest_time": earliest_time,
+                "latest_time": latest_time,
+                "output_mode": "json",
             }
-            
+
             response = self.session.post(search_url, data=search_data)
-            
+
             if response.status_code not in [200, 201]:
-                logger.error(f"Failed to create search job: {response.status_code} - {response.text}")
+                logger.error(
+                    f"Failed to create search job: {response.status_code} - {response.text}"
+                )
                 return None
-            
+
             job_data = response.json()
-            sid = job_data.get('sid')
-            
+            sid = job_data.get("sid")
+
             if not sid:
                 logger.error("No search ID returned")
                 return None
-            
+
             logger.info(f"Created search job: {sid}")
-            
+
             # Poll for job completion
             job_url = f"{self.server_url}/services/search/jobs/{sid}"
             max_attempts = 60  # 60 attempts with 1 second wait = 1 minute max
-            
+
             for attempt in range(max_attempts):
                 status_response = self.session.get(
-                    job_url,
-                    params={'output_mode': 'json'}
+                    job_url, params={"output_mode": "json"}
                 )
-                
+
                 if status_response.status_code == 200:
                     job_status = status_response.json()
-                    entry = job_status.get('entry', [{}])[0]
-                    content = entry.get('content', {})
-                    
-                    is_done = content.get('isDone', False)
-                    
+                    entry = job_status.get("entry", [{}])[0]
+                    content = entry.get("content", {})
+
+                    is_done = content.get("isDone", False)
+
                     if is_done:
                         # Get results
                         results_url = f"{job_url}/results"
                         results_response = self.session.get(
                             results_url,
-                            params={
-                                'output_mode': 'json',
-                                'count': max_count
-                            }
+                            params={"output_mode": "json", "count": max_count},
                         )
-                        
+
                         if results_response.status_code == 200:
                             results_data = results_response.json()
-                            results = results_data.get('results', [])
+                            results = results_data.get("results", [])
                             logger.info(f"Search completed with {len(results)} results")
-                            
+
                             # Clean up job
                             self.session.delete(job_url)
-                            
+
                             return results
                         else:
-                            logger.error(f"Failed to get results: {results_response.status_code}")
+                            logger.error(
+                                f"Failed to get results: {results_response.status_code}"
+                            )
                             return None
-                    
+
                     # Wait before next poll
                     import time
+
                     time.sleep(1)
                 else:
-                    logger.error(f"Failed to check job status: {status_response.status_code}")
+                    logger.error(
+                        f"Failed to check job status: {status_response.status_code}"
+                    )
                     return None
-            
+
             logger.error("Search job timed out")
             # Try to cancel the job
             self.session.delete(job_url)
             return None
-        
+
         except Exception as e:
             logger.error(f"Error executing search: {e}")
             return None
-    
+
     def search_by_ip(self, ip_address: str, hours: int = 24) -> Optional[List[Dict]]:
         """
         Search for events related to an IP address.
-        
+
         Args:
             ip_address: IP address to search for
             hours: Number of hours to look back (default: 24)
-        
+
         Returns:
             List of events or None
         """
         query = f'"{ip_address}" | head 1000'
         return self.search(query, earliest_time=f"-{hours}h")
-    
-    
+
     def search_by_hash(self, file_hash: str, hours: int = 24) -> Optional[List[Dict]]:
         """
         Search for events related to a file hash.
-        
+
         Args:
             file_hash: File hash (MD5, SHA1, or SHA256) to search for
             hours: Number of hours to look back (default: 24)
-        
+
         Returns:
             List of events or None
         """
         query = f'"{file_hash}" | head 1000'
         return self.search(query, earliest_time=f"-{hours}h")
-    
-    def search_by_username(self, username: str, hours: int = 24) -> Optional[List[Dict]]:
+
+    def search_by_username(
+        self, username: str, hours: int = 24
+    ) -> Optional[List[Dict]]:
         """
         Search for events related to a username.
-        
+
         Args:
             username: Username to search for
             hours: Number of hours to look back (default: 24)
-        
+
         Returns:
             List of events or None
         """
         query = f'user="{username}" OR username="{username}" OR account="{username}" | head 1000'
         return self.search(query, earliest_time=f"-{hours}h")
-    
-    def search_by_hostname(self, hostname: str, hours: int = 24) -> Optional[List[Dict]]:
+
+    def search_by_hostname(
+        self, hostname: str, hours: int = 24
+    ) -> Optional[List[Dict]]:
         """
         Search for events related to a hostname.
-        
+
         Args:
             hostname: Hostname to search for
             hours: Number of hours to look back (default: 24)
-        
+
         Returns:
             List of events or None
         """
         query = f'host="{hostname}" OR hostname="{hostname}" OR dest="{hostname}" | head 1000'
         return self.search(query, earliest_time=f"-{hours}h")
-    
-
-

--- a/core/integrations/splunk/enrichment.py
+++ b/core/integrations/splunk/enrichment.py
@@ -1,10 +1,10 @@
 """Splunk enrichment service with Claude AI analysis."""
 
+import json
 import logging
 import re
-from typing import Optional, Dict, List, Any
 from datetime import datetime
-import json
+from typing import Any, Dict, List
 
 from core.integrations.splunk.client import SplunkService
 from core.llm.harness.claude import ClaudeService
@@ -15,11 +15,11 @@ logger = logging.getLogger(__name__)
 
 class SplunkEnrichmentService:
     """Service for enriching cases and findings with Splunk data and Claude analysis."""
-    
-    def __init__(self, splunk_service: SplunkService, claude_service = None):
+
+    def __init__(self, splunk_service: SplunkService, claude_service=None):
         """
         Initialize enrichment service.
-        
+
         Args:
             splunk_service: Configured Splunk service
             claude_service: Optional Claude service for AI analysis (if None, creates one using factory)
@@ -27,96 +27,102 @@ class SplunkEnrichmentService:
         self.splunk_service = splunk_service
         self.claude_service = claude_service or ClaudeService(use_mcp_tools=False)
         self.data_service = DatabaseDataService()
-    
-    def extract_indicators(self, case: Dict, findings: List[Dict]) -> Dict[str, List[str]]:
+
+    def extract_indicators(
+        self, case: Dict, findings: List[Dict]
+    ) -> Dict[str, List[str]]:
         """
         Extract IOCs (Indicators of Compromise) from case and findings.
-        
+
         Args:
             case: Case dictionary
             findings: List of finding dictionaries
-        
+
         Returns:
             Dictionary with indicator types as keys and lists of indicators as values
         """
         indicators = {
-            'ips': set(),
-            'domains': set(),
-            'hashes': set(),
-            'usernames': set(),
-            'hostnames': set(),
-            'emails': set()
+            "ips": set(),
+            "domains": set(),
+            "hashes": set(),
+            "usernames": set(),
+            "hostnames": set(),
+            "emails": set(),
         }
-        
+
         # Patterns for extracting IOCs
-        ip_pattern = r'\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b'
-        domain_pattern = r'\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\b'
-        hash_pattern = r'\b[a-fA-F0-9]{32}\b|\b[a-fA-F0-9]{40}\b|\b[a-fA-F0-9]{64}\b'
-        email_pattern = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'
-        
+        ip_pattern = r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
+        domain_pattern = (
+            r"\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\b"
+        )
+        hash_pattern = r"\b[a-fA-F0-9]{32}\b|\b[a-fA-F0-9]{40}\b|\b[a-fA-F0-9]{64}\b"
+        email_pattern = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
+
         # Extract from case
         case_text = json.dumps(case)
-        indicators['ips'].update(re.findall(ip_pattern, case_text))
-        indicators['domains'].update(re.findall(domain_pattern, case_text))
-        indicators['hashes'].update(re.findall(hash_pattern, case_text))
-        indicators['emails'].update(re.findall(email_pattern, case_text))
-        
+        indicators["ips"].update(re.findall(ip_pattern, case_text))
+        indicators["domains"].update(re.findall(domain_pattern, case_text))
+        indicators["hashes"].update(re.findall(hash_pattern, case_text))
+        indicators["emails"].update(re.findall(email_pattern, case_text))
+
         # Extract from findings
         for finding in findings:
             finding_text = json.dumps(finding)
-            indicators['ips'].update(re.findall(ip_pattern, finding_text))
-            indicators['domains'].update(re.findall(domain_pattern, finding_text))
-            indicators['hashes'].update(re.findall(hash_pattern, finding_text))
-            indicators['emails'].update(re.findall(email_pattern, finding_text))
-            
+            indicators["ips"].update(re.findall(ip_pattern, finding_text))
+            indicators["domains"].update(re.findall(domain_pattern, finding_text))
+            indicators["hashes"].update(re.findall(hash_pattern, finding_text))
+            indicators["emails"].update(re.findall(email_pattern, finding_text))
+
             # Extract entity context
-            entity_context = finding.get('entity_context', {})
-            
+            entity_context = finding.get("entity_context", {})
+
             # IPs
-            if 'src_ip' in entity_context:
-                indicators['ips'].add(entity_context['src_ip'])
-            if 'dest_ip' in entity_context:
-                indicators['ips'].add(entity_context['dest_ip'])
-            
+            if "src_ip" in entity_context:
+                indicators["ips"].add(entity_context["src_ip"])
+            if "dest_ip" in entity_context:
+                indicators["ips"].add(entity_context["dest_ip"])
+
             # Usernames
-            if 'user' in entity_context:
-                indicators['usernames'].add(entity_context['user'])
-            if 'username' in entity_context:
-                indicators['usernames'].add(entity_context['username'])
-            
+            if "user" in entity_context:
+                indicators["usernames"].add(entity_context["user"])
+            if "username" in entity_context:
+                indicators["usernames"].add(entity_context["username"])
+
             # Hostnames
-            if 'host' in entity_context:
-                indicators['hostnames'].add(entity_context['host'])
-            if 'hostname' in entity_context:
-                indicators['hostnames'].add(entity_context['hostname'])
-            if 'src_host' in entity_context:
-                indicators['hostnames'].add(entity_context['src_host'])
-            if 'dest_host' in entity_context:
-                indicators['hostnames'].add(entity_context['dest_host'])
-        
+            if "host" in entity_context:
+                indicators["hostnames"].add(entity_context["host"])
+            if "hostname" in entity_context:
+                indicators["hostnames"].add(entity_context["hostname"])
+            if "src_host" in entity_context:
+                indicators["hostnames"].add(entity_context["src_host"])
+            if "dest_host" in entity_context:
+                indicators["hostnames"].add(entity_context["dest_host"])
+
         # Convert sets to sorted lists and filter out private IPs and common domains
-        indicators['ips'] = sorted([
-            ip for ip in indicators['ips'] 
-            if not self._is_private_ip(ip)
-        ])
-        indicators['domains'] = sorted([
-            domain for domain in indicators['domains']
-            if not self._is_common_domain(domain)
-        ])
-        indicators['hashes'] = sorted(list(indicators['hashes']))
-        indicators['usernames'] = sorted(list(indicators['usernames']))
-        indicators['hostnames'] = sorted(list(indicators['hostnames']))
-        indicators['emails'] = sorted(list(indicators['emails']))
-        
+        indicators["ips"] = sorted(
+            [ip for ip in indicators["ips"] if not self._is_private_ip(ip)]
+        )
+        indicators["domains"] = sorted(
+            [
+                domain
+                for domain in indicators["domains"]
+                if not self._is_common_domain(domain)
+            ]
+        )
+        indicators["hashes"] = sorted(list(indicators["hashes"]))
+        indicators["usernames"] = sorted(list(indicators["usernames"]))
+        indicators["hostnames"] = sorted(list(indicators["hostnames"]))
+        indicators["emails"] = sorted(list(indicators["emails"]))
+
         return indicators
-    
+
     def _is_private_ip(self, ip: str) -> bool:
         """Check if IP is private/internal."""
         try:
-            parts = [int(p) for p in ip.split('.')]
+            parts = [int(p) for p in ip.split(".")]
             if len(parts) != 4:
                 return True
-            
+
             # RFC1918 private ranges
             if parts[0] == 10:
                 return True
@@ -124,127 +130,131 @@ class SplunkEnrichmentService:
                 return True
             if parts[0] == 192 and parts[1] == 168:
                 return True
-            
+
             # Loopback
             if parts[0] == 127:
                 return True
-            
+
             return False
         except Exception as e:
             logger.debug(f"Error checking private IP: {e}")
             return True
-    
+
     def _is_common_domain(self, domain: str) -> bool:
         """Check if domain is a common/benign domain."""
-        common_tlds = ['localhost', 'local', 'internal', 'corp', 'lan']
+        common_tlds = ["localhost", "local", "internal", "corp", "lan"]
         domain_lower = domain.lower()
-        
+
         for tld in common_tlds:
-            if domain_lower.endswith(f'.{tld}'):
+            if domain_lower.endswith(f".{tld}"):
                 return True
-        
+
         return False
-    
-    def query_splunk_for_indicators(self, indicators: Dict[str, List[str]], 
-                                    hours: int = 168) -> Dict[str, Any]:
+
+    def query_splunk_for_indicators(
+        self, indicators: Dict[str, List[str]], hours: int = 168
+    ) -> Dict[str, Any]:
         """
         Query Splunk for each indicator type.
-        
+
         Args:
             indicators: Dictionary of indicator types and values
             hours: Number of hours to look back (default: 168 = 7 days)
-        
+
         Returns:
             Dictionary with enrichment data from Splunk
         """
         enrichment_data = {
-            'query_time': datetime.now().isoformat(),
-            'lookback_hours': hours,
-            'results': {},
-            'summary': {}
+            "query_time": datetime.now().isoformat(),
+            "lookback_hours": hours,
+            "results": {},
+            "summary": {},
         }
-        
+
         total_events = 0
-        
+
         # Query for IPs
-        if indicators.get('ips'):
-            enrichment_data['results']['ips'] = {}
-            for ip in indicators['ips'][:10]:  # Limit to 10 IPs
+        if indicators.get("ips"):
+            enrichment_data["results"]["ips"] = {}
+            for ip in indicators["ips"][:10]:  # Limit to 10 IPs
                 logger.info(f"Querying Splunk for IP: {ip}")
                 results = self.splunk_service.search_by_ip(ip, hours=hours)
                 if results:
-                    enrichment_data['results']['ips'][ip] = results[:100]  # Limit to 100 events per IP
+                    enrichment_data["results"]["ips"][ip] = results[
+                        :100
+                    ]  # Limit to 100 events per IP
                     total_events += len(results[:100])
-        
+
         # Query for domains
-        if indicators.get('domains'):
-            enrichment_data['results']['domains'] = {}
-            for domain in indicators['domains'][:10]:  # Limit to 10 domains
+        if indicators.get("domains"):
+            enrichment_data["results"]["domains"] = {}
+            for domain in indicators["domains"][:10]:  # Limit to 10 domains
                 logger.info(f"Querying Splunk for domain: {domain}")
                 results = self.splunk_service.search_by_domain(domain, hours=hours)
                 if results:
-                    enrichment_data['results']['domains'][domain] = results[:100]
+                    enrichment_data["results"]["domains"][domain] = results[:100]
                     total_events += len(results[:100])
-        
+
         # Query for hashes
-        if indicators.get('hashes'):
-            enrichment_data['results']['hashes'] = {}
-            for file_hash in indicators['hashes'][:10]:  # Limit to 10 hashes
+        if indicators.get("hashes"):
+            enrichment_data["results"]["hashes"] = {}
+            for file_hash in indicators["hashes"][:10]:  # Limit to 10 hashes
                 logger.info(f"Querying Splunk for hash: {file_hash}")
                 results = self.splunk_service.search_by_hash(file_hash, hours=hours)
                 if results:
-                    enrichment_data['results']['hashes'][file_hash] = results[:100]
+                    enrichment_data["results"]["hashes"][file_hash] = results[:100]
                     total_events += len(results[:100])
-        
+
         # Query for usernames
-        if indicators.get('usernames'):
-            enrichment_data['results']['usernames'] = {}
-            for username in indicators['usernames'][:10]:  # Limit to 10 usernames
+        if indicators.get("usernames"):
+            enrichment_data["results"]["usernames"] = {}
+            for username in indicators["usernames"][:10]:  # Limit to 10 usernames
                 logger.info(f"Querying Splunk for username: {username}")
                 results = self.splunk_service.search_by_username(username, hours=hours)
                 if results:
-                    enrichment_data['results']['usernames'][username] = results[:100]
+                    enrichment_data["results"]["usernames"][username] = results[:100]
                     total_events += len(results[:100])
-        
+
         # Query for hostnames
-        if indicators.get('hostnames'):
-            enrichment_data['results']['hostnames'] = {}
-            for hostname in indicators['hostnames'][:10]:  # Limit to 10 hostnames
+        if indicators.get("hostnames"):
+            enrichment_data["results"]["hostnames"] = {}
+            for hostname in indicators["hostnames"][:10]:  # Limit to 10 hostnames
                 logger.info(f"Querying Splunk for hostname: {hostname}")
                 results = self.splunk_service.search_by_hostname(hostname, hours=hours)
                 if results:
-                    enrichment_data['results']['hostnames'][hostname] = results[:100]
+                    enrichment_data["results"]["hostnames"][hostname] = results[:100]
                     total_events += len(results[:100])
-        
+
         # Create summary
-        enrichment_data['summary'] = {
-            'total_events': total_events,
-            'ips_queried': len(indicators.get('ips', [])),
-            'domains_queried': len(indicators.get('domains', [])),
-            'hashes_queried': len(indicators.get('hashes', [])),
-            'usernames_queried': len(indicators.get('usernames', [])),
-            'hostnames_queried': len(indicators.get('hostnames', []))
+        enrichment_data["summary"] = {
+            "total_events": total_events,
+            "ips_queried": len(indicators.get("ips", [])),
+            "domains_queried": len(indicators.get("domains", [])),
+            "hashes_queried": len(indicators.get("hashes", [])),
+            "usernames_queried": len(indicators.get("usernames", [])),
+            "hostnames_queried": len(indicators.get("hostnames", [])),
         }
-        
+
         return enrichment_data
-    
-    def analyze_with_claude(self, case: Dict, findings: List[Dict], 
-                           enrichment_data: Dict[str, Any]) -> str:
+
+    def analyze_with_claude(
+        self, case: Dict, findings: List[Dict], enrichment_data: Dict[str, Any]
+    ) -> str:
         """
         Use Claude to analyze the case with Splunk enrichment data.
-        
+
         Args:
             case: Case dictionary
             findings: List of findings
             enrichment_data: Enrichment data from Splunk
-        
+
         Returns:
             Claude's analysis as a string
         """
         if not self.claude_service.has_api_key():
             logger.warning("Claude API key not available, skipping AI analysis")
             return "AI analysis not available (API key not configured)"
-        
+
         # Build prompt for Claude
         system_prompt = """You are a security analyst helping to enrich and analyze security cases.
 You have access to case data, findings, and additional event data from Splunk.
@@ -257,7 +267,7 @@ Your task is to:
 5. Highlight any critical security concerns
 
 Provide a clear, structured analysis that a SOC analyst can act upon."""
-        
+
         # Prepare case context
         case_summary = f"""
 **Case ID**: {case.get('case_id', 'Unknown')}
@@ -267,21 +277,27 @@ Provide a clear, structured analysis that a SOC analyst can act upon."""
 **Description**: {case.get('description', 'No description')}
 **Number of Findings**: {len(findings)}
 """
-        
+
         # Prepare findings summary (limit to key details)
         findings_summary = "\n\n**Findings Summary**:\n"
         for i, finding in enumerate(findings[:5], 1):  # Limit to 5 findings
             findings_summary += f"\n{i}. **{finding.get('finding_id', 'Unknown')}**\n"
             findings_summary += f"   - Severity: {finding.get('severity', 'unknown')}\n"
-            findings_summary += f"   - Data Source: {finding.get('data_source', 'unknown')}\n"
-            findings_summary += f"   - Timestamp: {finding.get('timestamp', 'unknown')}\n"
-            
-            entity_context = finding.get('entity_context', {})
+            findings_summary += (
+                f"   - Data Source: {finding.get('data_source', 'unknown')}\n"
+            )
+            findings_summary += (
+                f"   - Timestamp: {finding.get('timestamp', 'unknown')}\n"
+            )
+
+            entity_context = finding.get("entity_context", {})
             if entity_context:
-                findings_summary += f"   - Context: {json.dumps(entity_context, indent=6)}\n"
-        
+                findings_summary += (
+                    f"   - Context: {json.dumps(entity_context, indent=6)}\n"
+                )
+
         # Prepare enrichment summary
-        summary = enrichment_data.get('summary', {})
+        summary = enrichment_data.get("summary", {})
         enrichment_summary = f"""
 **Splunk Enrichment Summary**:
 - Total Events Retrieved: {summary.get('total_events', 0)}
@@ -292,40 +308,52 @@ Provide a clear, structured analysis that a SOC analyst can act upon."""
 - Hostnames Queried: {summary.get('hostnames_queried', 0)}
 - Lookback Period: {enrichment_data.get('lookback_hours', 0)} hours
 """
-        
+
         # Sample some Splunk events for context (limit to avoid token overload)
         events_sample = "\n\n**Sample Splunk Events**:\n"
-        results = enrichment_data.get('results', {})
+        results = enrichment_data.get("results", {})
         event_count = 0
         max_events = 20  # Limit total events to show Claude
-        
+
         for indicator_type, indicator_results in results.items():
             if event_count >= max_events:
                 break
-            
+
             events_sample += f"\n**{indicator_type.upper()}**:\n"
             for indicator_value, events in indicator_results.items():
                 if event_count >= max_events:
                     break
-                
+
                 events_sample += f"\n  {indicator_value}:\n"
                 for event in events[:5]:  # Max 5 events per indicator
                     if event_count >= max_events:
                         break
-                    
+
                     # Show key fields from event
                     event_summary = "    - "
-                    key_fields = ['_time', 'sourcetype', 'source', 'host', 'action', 'result', 'user', 'src', 'dest']
+                    key_fields = [
+                        "_time",
+                        "sourcetype",
+                        "source",
+                        "host",
+                        "action",
+                        "result",
+                        "user",
+                        "src",
+                        "dest",
+                    ]
                     event_parts = []
                     for field in key_fields:
                         if field in event and event[field]:
                             event_parts.append(f"{field}={event[field]}")
-                    
+
                     if event_parts:
-                        events_sample += event_summary + ", ".join(event_parts[:5]) + "\n"
-                    
+                        events_sample += (
+                            event_summary + ", ".join(event_parts[:5]) + "\n"
+                        )
+
                     event_count += 1
-        
+
         # Build full prompt
         user_prompt = f"""Analyze the following security case with Splunk enrichment data:
 
@@ -345,69 +373,69 @@ Focus on:
 4. Risk assessment
 5. Recommended next steps for investigation
 """
-        
+
         try:
             logger.info("Requesting Claude analysis of enriched case data")
             analysis = self.claude_service.chat(
-                user_prompt,
-                system_prompt=system_prompt
+                user_prompt, system_prompt=system_prompt
             )
             return analysis or "Analysis failed - no response from Claude"
-        
+
         except Exception as e:
             logger.error(f"Error getting Claude analysis: {e}")
             return f"Error during AI analysis: {str(e)}"
-    
+
     def enrich_case(self, case_id: str, lookback_hours: int = 168) -> Dict[str, Any]:
         """
         Enrich a case with Splunk data and Claude analysis.
-        
+
         Args:
             case_id: Case ID to enrich
             lookback_hours: Hours to look back in Splunk (default: 168 = 7 days)
-        
+
         Returns:
             Dictionary with enrichment results
         """
         logger.info(f"Starting enrichment for case {case_id}")
-        
+
         # Get case and findings
         case = self.data_service.get_case(case_id)
         if not case:
-            return {
-                'success': False,
-                'error': f'Case {case_id} not found'
-            }
-        
-        finding_ids = case.get('finding_ids', [])
+            return {"success": False, "error": f"Case {case_id} not found"}
+
+        finding_ids = case.get("finding_ids", [])
         findings = []
         for finding_id in finding_ids:
             finding = self.data_service.get_finding(finding_id)
             if finding:
                 findings.append(finding)
-        
+
         # Extract indicators
         logger.info("Extracting indicators from case and findings")
         indicators = self.extract_indicators(case, findings)
-        
+
         # Query Splunk
         logger.info("Querying Splunk for indicators")
-        enrichment_data = self.query_splunk_for_indicators(indicators, hours=lookback_hours)
-        
+        enrichment_data = self.query_splunk_for_indicators(
+            indicators, hours=lookback_hours
+        )
+
         # Analyze with Claude
         logger.info("Analyzing with Claude AI")
         analysis = self.analyze_with_claude(case, findings, enrichment_data)
-        
+
         # Prepare enrichment result
         enrichment_result = {
-            'success': True,
-            'case_id': case_id,
-            'enrichment_timestamp': datetime.now().isoformat(),
-            'indicators': {k: v for k, v in indicators.items() if v},  # Only include non-empty
-            'splunk_data': enrichment_data,
-            'claude_analysis': analysis
+            "success": True,
+            "case_id": case_id,
+            "enrichment_timestamp": datetime.now().isoformat(),
+            "indicators": {
+                k: v for k, v in indicators.items() if v
+            },  # Only include non-empty
+            "splunk_data": enrichment_data,
+            "claude_analysis": analysis,
         }
-        
+
         # Update case with enrichment data
         notes_entry = f"""
 === Splunk Enrichment (from {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}) ===
@@ -426,12 +454,10 @@ Focus on:
 
 ---
 """
-        
+
         # Add enrichment note to case
         self.data_service.update_case(case_id, notes=notes_entry)
-        
+
         logger.info(f"Enrichment completed for case {case_id}")
-        
+
         return enrichment_result
-
-

--- a/core/integrations/splunk/ingestion.py
+++ b/core/integrations/splunk/ingestion.py
@@ -5,78 +5,78 @@ Fetches notable events from Splunk ES and converts them to findings.
 """
 
 import logging
-from typing import List, Dict, Any, Optional
-from datetime import datetime, timedelta
 import uuid
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
 
+from core.config import get_integration_config
 from core.ingestion.siem_ingestion_service import SIEMIngestionService
 from core.integrations.splunk.client import SplunkService
-from core.config import get_integration_config
 
 logger = logging.getLogger(__name__)
 
 
 class SplunkIngestion(SIEMIngestionService):
     """Splunk ingestion service."""
-    
+
     def __init__(self):
         """Initialize Splunk ingestion."""
         super().__init__()
         self.siem_name = "Splunk"
-        self.config = get_integration_config('splunk')
+        self.config = get_integration_config("splunk")
         self.splunk_service = None
-    
+
     def _get_splunk_service(self) -> Optional[SplunkService]:
         """
         Get or create Splunk service instance.
-        
+
         Returns:
             SplunkService instance or None
         """
         if self.splunk_service:
             return self.splunk_service
-        
+
         try:
-            server_url = self.config.get('server_url')
-            username = self.config.get('username')
-            password = self.config.get('password')
-            
+            server_url = self.config.get("server_url")
+            username = self.config.get("username")
+            password = self.config.get("password")
+
             if not all([server_url, username, password]):
                 logger.error("Splunk configuration incomplete")
                 return None
-            
+
             self.splunk_service = SplunkService(
                 server_url=server_url,
                 username=username,
                 password=password,
-                verify_ssl=self.config.get('verify_ssl', False)
+                verify_ssl=self.config.get("verify_ssl", False),
             )
-            
+
             # Test authentication
             if not self.splunk_service.authenticate():
                 logger.error("Splunk authentication failed")
                 return None
-            
+
             return self.splunk_service
-        
+
         except Exception as e:
             logger.error(f"Error creating Splunk service: {e}")
             return None
-    
+
     async def fetch_alerts(
         self,
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
-        limit: int = 100
+        limit: int = 100,
     ) -> List[Dict[str, Any]]:
         """
         Fetch notable events from Splunk ES.
-        
+
         Args:
             start_time: Start time for alert query
             end_time: End time for alert query
             limit: Maximum number of alerts to fetch
-        
+
         Returns:
             List of raw alert dictionaries
         """
@@ -84,79 +84,90 @@ class SplunkIngestion(SIEMIngestionService):
             splunk = self._get_splunk_service()
             if not splunk:
                 return []
-            
+
             # Set time range
             if not start_time:
                 start_time = datetime.utcnow() - timedelta(hours=24)
             if not end_time:
                 end_time = datetime.utcnow()
-            
+
             # Calculate relative time
             hours_ago = int((datetime.utcnow() - start_time).total_seconds() / 3600)
             earliest_time = f"-{hours_ago}h"
-            
+
             # Search for notable events (Splunk ES)
-            query = '''
-            search `notable` 
+            query = """
+            search `notable`
             | head {limit}
-            | table _time, rule_name, rule_title, rule_description, severity, urgency, 
-                    src, dest, user, src_user, dest_user, signature, signature_id, 
-                    category, subcategory, mitre_tactic, mitre_technique, 
+            | table _time, rule_name, rule_title, rule_description, severity, urgency,
+                    src, dest, user, src_user, dest_user, signature, signature_id,
+                    category, subcategory, mitre_tactic, mitre_technique,
                     event_id, _raw
-            '''.format(limit=limit)
-            
+            """.format(limit=limit)
+
             results = splunk.search(
                 query=query,
                 earliest_time=earliest_time,
                 latest_time="now",
-                max_count=limit
+                max_count=limit,
             )
-            
+
             if not results:
                 # Fallback: search for any security events
-                query = '''
-                search index=* sourcetype=* (severity=high OR severity=critical OR priority=high) 
+                query = """
+                search index=* sourcetype=* (severity=high OR severity=critical OR priority=high)
                 | head {limit}
-                | table _time, host, source, sourcetype, severity, message, src_ip, dest_ip, 
+                | table _time, host, source, sourcetype, severity, message, src_ip, dest_ip,
                         user, action, signature, _raw
-                '''.format(limit=limit)
-                
+                """.format(limit=limit)
+
                 results = splunk.search(
                     query=query,
                     earliest_time=earliest_time,
                     latest_time="now",
-                    max_count=limit
+                    max_count=limit,
                 )
-            
+
             logger.info(f"Fetched {len(results) if results else 0} events from Splunk")
             return results or []
-        
+
         except Exception as e:
             logger.error(f"Error fetching Splunk alerts: {e}")
             return []
-    
-    def transform_alert_to_finding(self, alert: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    def transform_alert_to_finding(
+        self, alert: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """
         Transform Splunk notable event to finding format.
-        
+
         Args:
             alert: Raw event from Splunk
-        
+
         Returns:
             Finding dictionary
         """
         try:
             # Generate finding ID
-            event_id = alert.get('event_id', alert.get('_cd', uuid.uuid4().hex[:12]))
+            event_id = alert.get("event_id", alert.get("_cd", uuid.uuid4().hex[:12]))
             finding_id = f"splunk-{event_id}"
-            
+
             # Extract title and description
-            title = alert.get('rule_title') or alert.get('rule_name') or alert.get('signature') or 'Splunk Event'
-            description = alert.get('rule_description') or alert.get('message') or alert.get('_raw', '')[:500]
-            
+            title = (
+                alert.get("rule_title")
+                or alert.get("rule_name")
+                or alert.get("signature")
+                or "Splunk Event"
+            )
+            description = (
+                alert.get("rule_description")
+                or alert.get("message")
+                or alert.get("_raw", "")[:500]
+            )
+
             # Extract severity
-            severity = alert.get('severity') or alert.get('urgency') or 'medium'
-            
+            severity = alert.get("severity") or alert.get("urgency") or "medium"
+
             # Extract entities
             entities = {
                 "ip_addresses": [],
@@ -165,30 +176,38 @@ class SplunkIngestion(SIEMIngestionService):
                 "hostnames": [],
                 "file_hashes": [],
             }
-            
+
             # IPs
-            for field in ['src', 'src_ip', 'dest', 'dest_ip', 'clientip']:
+            for field in ["src", "src_ip", "dest", "dest_ip", "clientip"]:
                 if alert.get(field):
                     entities["ip_addresses"].append(str(alert[field]))
-            
+
             # Usernames
-            for field in ['user', 'src_user', 'dest_user', 'username']:
+            for field in ["user", "src_user", "dest_user", "username"]:
                 if alert.get(field):
                     entities["usernames"].append(str(alert[field]))
-            
+
             # Hostnames
-            if alert.get('host'):
-                entities["hostnames"].append(str(alert['host']))
-            
+            if alert.get("host"):
+                entities["hostnames"].append(str(alert["host"]))
+
             # MITRE ATT&CK
             tactics = []
             techniques = []
-            
-            if alert.get('mitre_tactic'):
-                tactics = [alert['mitre_tactic']] if isinstance(alert['mitre_tactic'], str) else alert['mitre_tactic']
-            if alert.get('mitre_technique'):
-                techniques = [alert['mitre_technique']] if isinstance(alert['mitre_technique'], str) else alert['mitre_technique']
-            
+
+            if alert.get("mitre_tactic"):
+                tactics = (
+                    [alert["mitre_tactic"]]
+                    if isinstance(alert["mitre_tactic"], str)
+                    else alert["mitre_tactic"]
+                )
+            if alert.get("mitre_technique"):
+                techniques = (
+                    [alert["mitre_technique"]]
+                    if isinstance(alert["mitre_technique"], str)
+                    else alert["mitre_technique"]
+                )
+
             # Build finding
             finding = {
                 "finding_id": finding_id,
@@ -196,19 +215,19 @@ class SplunkIngestion(SIEMIngestionService):
                 "description": description,
                 "severity": self.normalize_severity(severity),
                 "data_source": "splunk",
-                "timestamp": alert.get('_time', datetime.utcnow().isoformat()),
+                "timestamp": alert.get("_time", datetime.utcnow().isoformat()),
                 "raw_data": alert,
                 "metadata": {
                     "event_id": event_id,
-                    "rule_name": alert.get('rule_name'),
-                    "category": alert.get('category'),
-                    "subcategory": alert.get('subcategory'),
-                    "signature": alert.get('signature'),
-                    "signature_id": alert.get('signature_id'),
-                    "source": alert.get('source'),
-                    "sourcetype": alert.get('sourcetype'),
-                    "host": alert.get('host'),
-                    "action": alert.get('action'),
+                    "rule_name": alert.get("rule_name"),
+                    "category": alert.get("category"),
+                    "subcategory": alert.get("subcategory"),
+                    "signature": alert.get("signature"),
+                    "signature_id": alert.get("signature_id"),
+                    "source": alert.get("source"),
+                    "sourcetype": alert.get("sourcetype"),
+                    "host": alert.get("host"),
+                    "action": alert.get("action"),
                 },
                 "entities": entities,
                 "mitre_attack": {
@@ -216,10 +235,9 @@ class SplunkIngestion(SIEMIngestionService):
                     "techniques": techniques,
                 },
             }
-            
+
             return finding
-        
+
         except Exception as e:
             logger.error(f"Error transforming Splunk event: {e}")
             return None
-

--- a/core/integrations/splunk/tool.py
+++ b/core/integrations/splunk/tool.py
@@ -2,13 +2,15 @@ import asyncio
 import json
 import logging
 import os
-from mcp.server.models import InitializationOptions
+
+import mcp.server.stdio
 import mcp.types as types
 from mcp.server import NotificationOptions, Server
-import mcp.server.stdio
+from mcp.server.models import InitializationOptions
 
 try:
     from dotenv import load_dotenv
+
     load_dotenv()
 except ImportError:
     pass
@@ -36,11 +38,11 @@ logger = logging.getLogger(__name__)
 server = Server("splunk")
 
 SPL_TEMPLATES = {
-    "failed login": 'index=* (failed OR failure) (login OR logon) | stats count by src_ip, user | sort -count',
-    "powershell": 'index=* sourcetype=WinEventLog:Security EventCode=4688 powershell.exe | table _time, Computer, User, CommandLine',
-    "brute force": 'index=* (failed OR failure) login | stats count by src_ip | where count > 10',
-    "c2 beacon": 'index=* sourcetype=firewall action=allowed | stats count by dest_ip, dest_port | where count > 100',
-    "lateral movement": 'index=* (EventCode=4624 OR psexec) Logon_Type=3 | stats dc(dest) as hosts by user | where hosts > 5',
+    "failed login": "index=* (failed OR failure) (login OR logon) | stats count by src_ip, user | sort -count",
+    "powershell": "index=* sourcetype=WinEventLog:Security EventCode=4688 powershell.exe | table _time, Computer, User, CommandLine",
+    "brute force": "index=* (failed OR failure) login | stats count by src_ip | where count > 10",
+    "c2 beacon": "index=* sourcetype=firewall action=allowed | stats count by dest_ip, dest_port | where count > 100",
+    "lateral movement": "index=* (EventCode=4624 OR psexec) Logon_Type=3 | stats dc(dest) as hosts by user | where hosts > 5",
 }
 
 
@@ -51,6 +53,7 @@ def result(data):
 def get_splunk_service():
     try:
         from core.integrations.splunk.client import SplunkService
+
         url = _read_credential("SPLUNK_URL")
         if not url:
             return None
@@ -58,7 +61,10 @@ def get_splunk_service():
             server_url=url,
             username=_read_credential("SPLUNK_USERNAME"),
             password=_read_credential("SPLUNK_PASSWORD"),
-            verify_ssl=(_read_credential("SPLUNK_VERIFY_SSL", "false") or "false").lower() == "true"
+            verify_ssl=(
+                _read_credential("SPLUNK_VERIFY_SSL", "false") or "false"
+            ).lower()
+            == "true",
         )
     except Exception:
         return None
@@ -73,7 +79,7 @@ def generate_spl(query: str, indexes=None):
             break
     if not spl:
         terms = query_lower.replace("show me", "").replace("find", "").strip()
-        spl = f'index=* {terms} | head 100'
+        spl = f"index=* {terms} | head 100"
     if indexes:
         spl = spl.replace("index=*", "index=" + " OR index=".join(indexes))
     return {"spl_query": spl, "pattern": pattern}
@@ -82,41 +88,80 @@ def generate_spl(query: str, indexes=None):
 @server.list_tools()
 async def handle_list_tools():
     return [
-        types.Tool(name="splunk_generate_spl", description="Generate SPL from natural language",
-            inputSchema={"type": "object", "properties": {
-                "query": {"type": "string"}, "indexes": {"type": "array", "items": {"type": "string"}}
-            }, "required": ["query"]}),
-        types.Tool(name="splunk_execute", description="Execute SPL query",
-            inputSchema={"type": "object", "properties": {
-                "spl_query": {"type": "string"},
-                "earliest": {"type": "string", "default": "-24h"},
-                "max_results": {"type": "integer", "default": 100}
-            }, "required": ["spl_query"]}),
-        types.Tool(name="splunk_search_ip", description="Search events for IP",
-            inputSchema={"type": "object", "properties": {
-                "ip_address": {"type": "string"}, "hours": {"type": "integer", "default": 24}
-            }, "required": ["ip_address"]}),
-        types.Tool(name="splunk_search_host", description="Search events for hostname",
-            inputSchema={"type": "object", "properties": {
-                "hostname": {"type": "string"}, "hours": {"type": "integer", "default": 24}
-            }, "required": ["hostname"]}),
-        types.Tool(name="splunk_nl_search", description="Natural language search (generate + execute)",
-            inputSchema={"type": "object", "properties": {
-                "query": {"type": "string"}, "max_results": {"type": "integer", "default": 100}
-            }, "required": ["query"]}),
+        types.Tool(
+            name="splunk_generate_spl",
+            description="Generate SPL from natural language",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "indexes": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["query"],
+            },
+        ),
+        types.Tool(
+            name="splunk_execute",
+            description="Execute SPL query",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "spl_query": {"type": "string"},
+                    "earliest": {"type": "string", "default": "-24h"},
+                    "max_results": {"type": "integer", "default": 100},
+                },
+                "required": ["spl_query"],
+            },
+        ),
+        types.Tool(
+            name="splunk_search_ip",
+            description="Search events for IP",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ip_address": {"type": "string"},
+                    "hours": {"type": "integer", "default": 24},
+                },
+                "required": ["ip_address"],
+            },
+        ),
+        types.Tool(
+            name="splunk_search_host",
+            description="Search events for hostname",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "hostname": {"type": "string"},
+                    "hours": {"type": "integer", "default": 24},
+                },
+                "required": ["hostname"],
+            },
+        ),
+        types.Tool(
+            name="splunk_nl_search",
+            description="Natural language search (generate + execute)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "max_results": {"type": "integer", "default": 100},
+                },
+                "required": ["query"],
+            },
+        ),
     ]
 
 
 @server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     args = arguments or {}
-    
+
     if name == "splunk_generate_spl":
         query = args.get("query")
         if not query:
             return result({"error": "query required"})
         return result(generate_spl(query, args.get("indexes")))
-    
+
     elif name == "splunk_execute":
         spl = args.get("spl_query")
         if not spl:
@@ -125,11 +170,20 @@ async def handle_call_tool(name: str, arguments: dict | None):
         if not splunk:
             return result({"error": "Splunk not configured", "spl": spl})
         try:
-            results = splunk.search(spl, args.get("earliest", "-24h"), "now", args.get("max_results", 100))
-            return result({"success": True, "query": spl, "count": len(results or []), "results": results or []})
+            results = splunk.search(
+                spl, args.get("earliest", "-24h"), "now", args.get("max_results", 100)
+            )
+            return result(
+                {
+                    "success": True,
+                    "query": spl,
+                    "count": len(results or []),
+                    "results": results or [],
+                }
+            )
         except Exception as e:
             return result({"error": str(e), "query": spl})
-    
+
     elif name == "splunk_search_ip":
         ip = args.get("ip_address")
         if not ip:
@@ -139,10 +193,17 @@ async def handle_call_tool(name: str, arguments: dict | None):
             return result({"error": "Splunk not configured"})
         try:
             results = splunk.search_by_ip(ip, args.get("hours", 24))
-            return result({"success": True, "ip": ip, "count": len(results or []), "results": results or []})
+            return result(
+                {
+                    "success": True,
+                    "ip": ip,
+                    "count": len(results or []),
+                    "results": results or [],
+                }
+            )
         except Exception as e:
             return result({"error": str(e)})
-    
+
     elif name == "splunk_search_host":
         host = args.get("hostname")
         if not host:
@@ -152,10 +213,17 @@ async def handle_call_tool(name: str, arguments: dict | None):
             return result({"error": "Splunk not configured"})
         try:
             results = splunk.search_by_hostname(host, args.get("hours", 24))
-            return result({"success": True, "hostname": host, "count": len(results or []), "results": results or []})
+            return result(
+                {
+                    "success": True,
+                    "hostname": host,
+                    "count": len(results or []),
+                    "results": results or [],
+                }
+            )
         except Exception as e:
             return result({"error": str(e)})
-    
+
     elif name == "splunk_nl_search":
         query = args.get("query")
         if not query:
@@ -163,25 +231,43 @@ async def handle_call_tool(name: str, arguments: dict | None):
         spl_result = generate_spl(query)
         splunk = get_splunk_service()
         if not splunk:
-            return result({"error": "Splunk not configured", "generated_spl": spl_result})
+            return result(
+                {"error": "Splunk not configured", "generated_spl": spl_result}
+            )
         try:
-            results = splunk.search(spl_result["spl_query"], "-24h", "now", args.get("max_results", 100))
-            return result({
-                "success": True, "query": query, "spl": spl_result["spl_query"],
-                "pattern": spl_result["pattern"], "count": len(results or []), "results": results or []
-            })
+            results = splunk.search(
+                spl_result["spl_query"], "-24h", "now", args.get("max_results", 100)
+            )
+            return result(
+                {
+                    "success": True,
+                    "query": query,
+                    "spl": spl_result["spl_query"],
+                    "pattern": spl_result["pattern"],
+                    "count": len(results or []),
+                    "results": results or [],
+                }
+            )
         except Exception as e:
             return result({"error": str(e), "spl": spl_result["spl_query"]})
-    
+
     return result({"error": f"Unknown tool: {name}"})
 
 
 async def main():
     async with mcp.server.stdio.stdio_server() as (read, write):
-        await server.run(read, write, InitializationOptions(
-            server_name="splunk", server_version="0.1.0",
-            capabilities=server.get_capabilities(notification_options=NotificationOptions(), experimental_capabilities={})
-        ))
+        await server.run(
+            read,
+            write,
+            InitializationOptions(
+                server_name="splunk",
+                server_version="0.1.0",
+                capabilities=server.get_capabilities(
+                    notification_options=NotificationOptions(),
+                    experimental_capabilities={},
+                ),
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/core/integrations/vstrike/client.py
+++ b/core/integrations/vstrike/client.py
@@ -519,22 +519,17 @@ class VStrikeService:
             try:
                 resp = _post(jwt)
             except _HTTP_ERRORS as e:
-                raise RuntimeError(
-                    f"VStrike MCP tools/list retry failed: {e}"
-                ) from e
+                raise RuntimeError(f"VStrike MCP tools/list retry failed: {e}") from e
 
         if resp.status_code != 200:
             raise RuntimeError(
-                f"VStrike MCP tools/list HTTP {resp.status_code}: "
-                f"{resp.text[:200]}"
+                f"VStrike MCP tools/list HTTP {resp.status_code}: " f"{resp.text[:200]}"
             )
 
         try:
             body = _parse_response_body(resp)
         except ValueError as e:
-            raise RuntimeError(
-                f"VStrike MCP tools/list non-JSON response: {e}"
-            ) from e
+            raise RuntimeError(f"VStrike MCP tools/list non-JSON response: {e}") from e
 
         if isinstance(body, dict) and body.get("error"):
             raise RuntimeError(f"VStrike MCP tools/list error: {body['error']}")

--- a/core/integrations/webhooks_router.py
+++ b/core/integrations/webhooks_router.py
@@ -1,8 +1,10 @@
 """Webhooks API - Configure and manage case event webhooks."""
 
 from typing import List, Optional
+
 from fastapi import APIRouter
 from pydantic import BaseModel
+
 from core.routing import Auth, RouterMeta
 
 router = APIRouter()
@@ -23,6 +25,7 @@ ROUTER_META = RouterMeta(
 
 class WebhookCreate(BaseModel):
     """Create webhook."""
+
     name: str
     url: str
     events: List[str]  # case_created, case_updated, case_closed, sla_breach, etc.
@@ -32,6 +35,7 @@ class WebhookCreate(BaseModel):
 
 class WebhookUpdate(BaseModel):
     """Update webhook."""
+
     name: Optional[str] = None
     url: Optional[str] = None
     events: Optional[List[str]] = None
@@ -43,7 +47,7 @@ class WebhookUpdate(BaseModel):
 async def list_webhooks():
     """
     List all configured webhooks.
-    
+
     Returns:
         List of webhooks
     """
@@ -55,10 +59,10 @@ async def list_webhooks():
 async def create_webhook(data: WebhookCreate):
     """
     Create a new webhook.
-    
+
     Args:
         data: Webhook configuration
-    
+
     Returns:
         Created webhook
     """
@@ -69,7 +73,7 @@ async def create_webhook(data: WebhookCreate):
         "url": data.url,
         "events": data.events,
         "active": data.active,
-        "message": "Webhook management coming soon"
+        "message": "Webhook management coming soon",
     }
 
 
@@ -77,11 +81,11 @@ async def create_webhook(data: WebhookCreate):
 async def update_webhook(webhook_id: str, data: WebhookUpdate):
     """
     Update a webhook.
-    
+
     Args:
         webhook_id: Webhook ID
         data: Update data
-    
+
     Returns:
         Updated webhook
     """
@@ -93,10 +97,10 @@ async def update_webhook(webhook_id: str, data: WebhookUpdate):
 async def delete_webhook(webhook_id: str):
     """
     Delete a webhook.
-    
+
     Args:
         webhook_id: Webhook ID
-    
+
     Returns:
         Success status
     """
@@ -108,10 +112,10 @@ async def delete_webhook(webhook_id: str):
 async def test_webhook(webhook_id: str):
     """
     Test a webhook by sending a test payload.
-    
+
     Args:
         webhook_id: Webhook ID
-    
+
     Returns:
         Test result
     """
@@ -123,14 +127,13 @@ async def test_webhook(webhook_id: str):
 async def get_webhook_deliveries(webhook_id: str, limit: int = 50):
     """
     Get webhook delivery history.
-    
+
     Args:
         webhook_id: Webhook ID
         limit: Maximum deliveries to return
-    
+
     Returns:
         Delivery history
     """
     # TODO: Implement delivery history
     return {"deliveries": [], "message": "Webhook delivery history coming soon"}
-

--- a/core/llm/bifrost/admin.py
+++ b/core/llm/bifrost/admin.py
@@ -393,8 +393,6 @@ async def sync_all_provider_models() -> Dict[str, Any]:
 
 async def _do_sync_all_provider_models() -> Dict[str, Any]:
     # Deferred imports to keep module load cheap.
-    from core.storage.connection import get_db_manager
-    from core.storage.models import LLMProviderConfig
     from core.llm.providers import discovery
     from core.llm.providers.registry import (
         _FALLBACK_MODELS_BY_PROVIDER,
@@ -403,6 +401,8 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
         get_extra_model_ids,
         record_live_meta,
     )
+    from core.storage.connection import get_db_manager
+    from core.storage.models import LLMProviderConfig
 
     db_manager = get_db_manager()
     if db_manager._engine is None:

--- a/core/llm/cost/budget.py
+++ b/core/llm/cost/budget.py
@@ -41,9 +41,13 @@ class BudgetExceeded(Exception):
     for the investigation rather than retrying.
     """
 
-    def __init__(self, *, tier: str, message: str = "", status_code: Optional[int] = None):
+    def __init__(
+        self, *, tier: str, message: str = "", status_code: Optional[int] = None
+    ):
         super().__init__(message or f"LLM budget exceeded ({tier})")
-        self.tier = tier  # "virtual_key" | "team" | "customer" | "rate_limit" | "unknown"
+        self.tier = (
+            tier  # "virtual_key" | "team" | "customer" | "rate_limit" | "unknown"
+        )
         self.status_code = status_code
         self.message = message
 
@@ -102,7 +106,9 @@ def get_settings() -> dict:
     }
 
 
-def set_settings(*, default_vk: str, budget_limit_usd: float, enforcement_mode: str) -> dict:
+def set_settings(
+    *, default_vk: str, budget_limit_usd: float, enforcement_mode: str
+) -> dict:
     """Persist the VK + budget config. Caller (API handler) is admin-gated."""
     if enforcement_mode not in ("warning", "hard_stop"):
         raise ValueError(

--- a/core/llm/cost/estimator.py
+++ b/core/llm/cost/estimator.py
@@ -162,8 +162,7 @@ async def estimate_anthropic(
 
     if api_key:
         try:
-            from core.llm.providers.clients import \
-                create_async_anthropic_client
+            from core.llm.providers.clients import create_async_anthropic_client
 
             client = create_async_anthropic_client(api_key, timeout=30.0)
             kwargs: Dict[str, Any] = {"model": model_id, "messages": messages}

--- a/core/llm/gateway/gateway.py
+++ b/core/llm/gateway/gateway.py
@@ -17,9 +17,8 @@ from arq import create_pool
 from arq.connections import ArqRedis, RedisSettings
 from arq.jobs import DeserializationError
 
-from core.llm.defaults import DEFAULT_MODEL
-
 from core.config import get_settings
+from core.llm.defaults import DEFAULT_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -254,7 +253,9 @@ class LLMGateway:
                 "arq deserialization error for investigation_turn [inv=%s job=%s]: %s — "
                 "likely the worker raised an unserializable exception (e.g. APIStatusError). "
                 "Check llm-worker logs for the real error.",
-                inv_id, getattr(job, "job_id", "?"), exc,
+                inv_id,
+                getattr(job, "job_id", "?"),
+                exc,
                 exc_info=True,
             )
             raise RuntimeError(

--- a/core/llm/harness/claude.py
+++ b/core/llm/harness/claude.py
@@ -9,8 +9,8 @@ from pathlib import Path  # noqa: F401 — patched as ``claude.Path`` in tests
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from core.config import REPO_ROOT, get_settings
-from core.secrets import get_secret
 from core.llm.defaults import DEFAULT_MODEL, build_thinking_kwargs
+from core.secrets import get_secret
 
 # GH #89 — resolve the summarization model via ai_model_configs with a safe
 # fallback to the historical hardcoded default. Defined at module scope so
@@ -36,8 +36,8 @@ def _resolve_summarization_model() -> str:
 
 # Import backend tool support
 try:
-    from core.llm.tool_schemas import ALL_TOOLS as BACKEND_TOOLS
     from core.detections.tools import get_security_detection_tools
+    from core.llm.tool_schemas import ALL_TOOLS as BACKEND_TOOLS
 
     BACKEND_TOOLS_AVAILABLE = True
 except ImportError as e:
@@ -51,6 +51,7 @@ try:
     # `create_anthropic_client` / `create_async_anthropic_client` in
     # core.llm.providers.clients so every Anthropic call flows through Bifrost (GH #84).
     from anthropic import Anthropic, AsyncAnthropic  # noqa: F401
+
     from core.llm.providers.clients import (
         create_anthropic_client,
         create_async_anthropic_client,
@@ -62,8 +63,9 @@ except ImportError:
 
 # OTEL instrumentation (lazy to avoid hard dependency)
 try:
-    from core.telemetry import get_tracer, get_meter, create_genai_metrics
     from opentelemetry.trace import SpanKind
+
+    from core.telemetry import create_genai_metrics, get_meter, get_tracer
 
     _cs_tracer = get_tracer("vigil.services.claude")
     _cs_meter = get_meter("vigil.services.claude")
@@ -82,9 +84,10 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+from core.chat.context_manager import ContextManager  # noqa: E402
+
 # Sub-module imports (lazy to avoid circular deps at module load)
 from core.chat.session_manager import SessionManager  # noqa: E402
-from core.chat.context_manager import ContextManager  # noqa: E402
 from core.chat.tool_executor import ToolExecutor  # noqa: E402
 from core.detections.detection_rules_service import DetectionRulesService  # noqa: E402
 from core.integrations.mcp.client import process_mcp_client  # noqa: E402
@@ -122,7 +125,9 @@ class ClaudeService:
                 Anthropic provider row (GH #88). When set, _load_api_key reads
                 this secret first before the legacy CLAUDE_API_KEY fallback chain.
         """
-        self._mcp_client = mcp_client if mcp_client is not None else process_mcp_client()
+        self._mcp_client = (
+            mcp_client if mcp_client is not None else process_mcp_client()
+        )
         self._mcp_registry = mcp_registry or MCPRegistry()
         self._detection_rules = detection_rules or DetectionRulesService()
 
@@ -213,7 +218,7 @@ When a user mentions an ID or entity (finding, case, IP, hash, domain), ALWAYS u
 Common patterns you should recognize and how to handle them:
 
 - Finding IDs: "f-YYYYMMDD-XXXXXXXX" → Use deeptempo-findings_get_finding tool
-- Case IDs: "case-YYYYMMDD-XXXXXXXX" → Use deeptempo-findings_get_case tool  
+- Case IDs: "case-YYYYMMDD-XXXXXXXX" → Use deeptempo-findings_get_case tool
 - IP addresses: X.X.X.X → Consider using IP geolocation or threat intel tools
 - Domain names: example.com → Consider using URL analysis or threat intel tools
 - File hashes: MD5/SHA1/SHA256 → Consider using malware analysis tools
@@ -881,7 +886,6 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
         except Exception as e:
             logger.debug(f"Could not populate MCP registry: {e}")
 
-
     def has_api_key(self) -> bool:
         """Return True if this ClaudeService can call the Anthropic SDK.
 
@@ -1305,7 +1309,6 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
             max_context_tokens=max_context_tokens,
         )
 
-
     def _prepare_context_sync(
         self,
         messages: List[Dict],
@@ -1352,6 +1355,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
         self, session_id: str, overflow: List[Dict], existing_summary: str
     ) -> None:
         """Fold aged-out messages into the session summary in a daemon thread."""
+
         def _fold() -> None:
             try:
                 new_summary = ContextManager.fold_overflow(overflow, existing_summary)
@@ -1428,7 +1432,9 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                     # of the chain.
                     if tool_name and tool_name.startswith("skill_"):
                         try:
-                            from core.skills.skill_tools_bridge import execute_skill_tool
+                            from core.skills.skill_tools_bridge import (
+                                execute_skill_tool,
+                            )
 
                             result = execute_skill_tool(
                                 tool_name,
@@ -1483,7 +1489,9 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                         "update_case",
                         "add_resolution_step",
                     ]:
-                        from core.storage.database_data_service import DatabaseDataService
+                        from core.storage.database_data_service import (
+                            DatabaseDataService,
+                        )
 
                         data_service = DatabaseDataService()
 
@@ -1667,7 +1675,9 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
 
                     # Attack layer tools
                     elif tool_name in ["get_attack_layer", "get_technique_rollup"]:
-                        from core.storage.database_data_service import DatabaseDataService
+                        from core.storage.database_data_service import (
+                            DatabaseDataService,
+                        )
 
                         data_service = DatabaseDataService()
 
@@ -2028,7 +2038,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
             logger.info(
                 f"🤔 ClaudeService.chat() - Thinking: {use_thinking}, Budget: {thinking_budget or self.thinking_budget}, Model: {model}"
             )
-            logger.info(f"📤 Sending to Claude API:")
+            logger.info("📤 Sending to Claude API:")
             logger.info(f"   - Message type: {type(message).__name__}")
             if isinstance(message, str):
                 logger.info(
@@ -2286,7 +2296,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                 return "I apologize, but I cannot assist with that request."
 
             if response.stop_reason == "tool_use" and response.content:
-                logger.info(f"🔧 Tool use detected - processing tools...")
+                logger.info("🔧 Tool use detected - processing tools...")
                 # Log tool calls
                 for block in response.content:
                     if hasattr(block, "type") and block.type == "tool_use":
@@ -2341,9 +2351,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                     messages.append(
                         {
                             "role": "assistant",
-                            "content": self._clean_blocks_for_resend(
-                                assistant_content
-                            ),
+                            "content": self._clean_blocks_for_resend(assistant_content),
                         }
                     )
                     # Tool results need to be wrapped in a user message
@@ -2549,7 +2557,6 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
         # Simple text message
         return message
 
-
     async def chat_stream(
         self,
         message: Union[str, List[Dict]],
@@ -2604,7 +2611,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
             logger.info(
                 f"🌊 ClaudeService.chat_stream() - Thinking: {use_thinking}, Budget: {thinking_budget or self.thinking_budget}, Model: {model}"
             )
-            logger.info(f"📤 Streaming to Claude API:")
+            logger.info("📤 Streaming to Claude API:")
             logger.info(f"   - Message type: {type(message).__name__}")
             if isinstance(message, str):
                 logger.info(
@@ -2897,7 +2904,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
 
                 # Check if tool use is needed
                 if stop_reason == "tool_use" and accumulated_content:
-                    logger.info(f"🔧 Tool use in stream - processing...")
+                    logger.info("🔧 Tool use in stream - processing...")
 
                     # Check for infinite loop detection
                     current_tool_calls = []
@@ -2914,7 +2921,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
                         and current_tool_calls in last_tool_calls[-3:]
                     ):
                         logger.warning(
-                            f"⚠️ Infinite loop detected - same tool calls repeated"
+                            "⚠️ Infinite loop detected - same tool calls repeated"
                         )
                         yield {
                             "type": "text",
@@ -2988,10 +2995,7 @@ Your goal is to help SOC analysts work more efficiently by leveraging all availa
 
         message = f"Analyze this security finding:\n\n{finding_text}\n\nProvide a detailed analysis."
 
-        return self.chat(
-            message, system_prompt=system_prompt, model=DEFAULT_MODEL
-        )
-
+        return self.chat(message, system_prompt=system_prompt, model=DEFAULT_MODEL)
 
     async def generate_event_analysis(
         self,

--- a/core/llm/harness/openai.py
+++ b/core/llm/harness/openai.py
@@ -11,8 +11,8 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Set
 from core.integrations.mcp import tool_manager
 from core.integrations.mcp.client import process_mcp_client
 from core.llm.router.format import anthropic_tools_to_openai
-from core.response.approval_service import ApprovalService
 from core.llm.router.router import LLMRouter, ProviderSpec
+from core.response.approval_service import ApprovalService
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +94,9 @@ class OpenAIAgentService:
         approvals: Optional[ApprovalService] = None,
     ):
         # mcp_client defaults to the process owner's; None when no owner started.
-        self._mcp_client = mcp_client if mcp_client is not None else process_mcp_client()
+        self._mcp_client = (
+            mcp_client if mcp_client is not None else process_mcp_client()
+        )
         self._approvals = approvals or ApprovalService()
         self._backend_tools = backend_tools or self._load_backend_tools()
         self._include_mcp_tools = include_mcp_tools
@@ -804,7 +806,6 @@ class OpenAIAgentService:
         """Persist an LLMInteractionLog row (non-fatal, fire-and-forget)."""
         try:
             from core.storage.models import LLMInteractionLog
-
             from core.storage.unit_of_work import unit_of_work
 
             try:

--- a/core/llm/providers/clients.py
+++ b/core/llm/providers/clients.py
@@ -51,8 +51,7 @@ def _bifrost_anthropic_base_url() -> str:
 
 def create_anthropic_client(api_key: str, *, timeout: float = _DEFAULT_TIMEOUT):
     """Synchronous Anthropic client routed through Bifrost."""
-    from anthropic import \
-        Anthropic  # lazy so tests without the SDK still import
+    from anthropic import Anthropic  # lazy so tests without the SDK still import
 
     return Anthropic(
         api_key=api_key,

--- a/core/llm/providers/recovery.py
+++ b/core/llm/providers/recovery.py
@@ -58,14 +58,21 @@ def local_bifrost_recovery_retry_limit() -> int:
 
 
 def local_bifrost_restart_enabled() -> bool:
-    return bool(get_ai_operations_setting("local_ollama_recovery_restart_gateway", True))
+    return bool(
+        get_ai_operations_setting("local_ollama_recovery_restart_gateway", True)
+    )
 
 
 def is_gateway_connection_error(error: Exception) -> bool:
     """Recognize network errors without retrying provider or model errors."""
     if isinstance(
         error,
-        (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout, httpx.NetworkError),
+        (
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.ReadTimeout,
+            httpx.NetworkError,
+        ),
     ):
         return True
     try:
@@ -132,13 +139,19 @@ async def recover_local_bifrost() -> RecoveryResult:
 
     async with _RECOVERY_LOCK:
         if await _bifrost_healthy():
-            return RecoveryResult(True, False, "gateway is reachable; retrying the request")
+            return RecoveryResult(
+                True, False, "gateway is reachable; retrying the request"
+            )
         if not local_bifrost_restart_enabled():
-            return RecoveryResult(False, False, "gateway is unavailable and automatic restart is disabled")
+            return RecoveryResult(
+                False, False, "gateway is unavailable and automatic restart is disabled"
+            )
 
         logger.warning("Local Bifrost is unavailable; restarting its container")
         if not await _restart_bifrost():
             return RecoveryResult(False, True, "could not restart the local gateway")
         if await _wait_for_bifrost():
             return RecoveryResult(True, True, "local gateway restarted and is healthy")
-        return RecoveryResult(False, True, "local gateway did not become healthy in time")
+        return RecoveryResult(
+            False, True, "local gateway did not become healthy in time"
+        )

--- a/core/llm/providers/registry.py
+++ b/core/llm/providers/registry.py
@@ -22,7 +22,6 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -60,7 +59,10 @@ def _record_pricing_unknown(provider_type: str, model_id: str) -> None:
             )
         _pricing_unknown_counter.add(
             1,
-            {"provider_type": provider_type or "unknown", "model_id": model_id or "unknown"},
+            {
+                "provider_type": provider_type or "unknown",
+                "model_id": model_id or "unknown",
+            },
         )
     except Exception:
         # Telemetry must never break cost math.
@@ -715,7 +717,6 @@ class ModelRegistry:
 
     # ---- assignments -----------------------------------------------------
 
-
     def get_all_assignments(self) -> Dict[str, ComponentAssignment]:
         """Return every configured assignment keyed by component."""
         try:
@@ -996,5 +997,3 @@ def invalidate_model_cache(provider_id: Optional[str] = None) -> None:
     except Exception:  # noqa: BLE001
         pass
     clear_live_meta()
-
-

--- a/core/llm/router/format.py
+++ b/core/llm/router/format.py
@@ -146,10 +146,12 @@ def _user_block_messages(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             if isinstance(source, dict) and source.get("type") == "base64":
                 media_type = source.get("media_type", "image/jpeg")
                 data = source.get("data", "")
-                user_parts.append({
-                    "type": "image_url",
-                    "image_url": {"url": f"data:{media_type};base64,{data}"}
-                })
+                user_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{media_type};base64,{data}"},
+                    }
+                )
             else:
                 user_parts.append(block)
         else:

--- a/core/llm/router/router.py
+++ b/core/llm/router/router.py
@@ -521,8 +521,8 @@ class LLMRouter:
         thinking_budget: int,
         extra_headers: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
-        from core.llm.providers.clients import create_async_anthropic_client
         from core.llm.defaults import build_thinking_kwargs
+        from core.llm.providers.clients import create_async_anthropic_client
 
         api_key: Optional[str] = None
         if provider.api_key_ref:

--- a/core/llm/tool_schemas.py
+++ b/core/llm/tool_schemas.py
@@ -14,11 +14,11 @@ SECURITY_DETECTION_TOOLS = [
                 "techniques": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of MITRE technique IDs (e.g., ['T1059.001', 'T1071.001'])"
+                    "description": "List of MITRE technique IDs (e.g., ['T1059.001', 'T1071.001'])",
                 }
             },
-            "required": ["techniques"]
-        }
+            "required": ["techniques"],
+        },
     },
     {
         "name": "search_detections",
@@ -28,21 +28,21 @@ SECURITY_DETECTION_TOOLS = [
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Search query - keywords or phrases (e.g., 'powershell base64', 'lateral movement', 'mimikatz')"
+                    "description": "Search query - keywords or phrases (e.g., 'powershell base64', 'lateral movement', 'mimikatz')",
                 },
                 "source_type": {
                     "type": "string",
                     "enum": ["sigma", "splunk", "elastic", "kql"],
-                    "description": "Optional: Filter by detection format. Omit to search all formats."
+                    "description": "Optional: Filter by detection format. Omit to search all formats.",
                 },
                 "limit": {
                     "type": "integer",
                     "description": "Maximum number of results to return (default: 20)",
-                    "default": 20
-                }
+                    "default": 20,
+                },
             },
-            "required": ["query"]
-        }
+            "required": ["query"],
+        },
     },
     {
         "name": "identify_gaps",
@@ -52,11 +52,11 @@ SECURITY_DETECTION_TOOLS = [
             "properties": {
                 "context": {
                     "type": "string",
-                    "description": "Context for gap analysis (e.g., 'ransomware', 'APT29', 'initial access', 'lateral movement')"
+                    "description": "Context for gap analysis (e.g., 'ransomware', 'APT29', 'initial access', 'lateral movement')",
                 }
             },
-            "required": ["context"]
-        }
+            "required": ["context"],
+        },
     },
     {
         "name": "get_coverage_stats",
@@ -67,10 +67,10 @@ SECURITY_DETECTION_TOOLS = [
                 "source_type": {
                     "type": "string",
                     "enum": ["sigma", "splunk", "elastic", "kql"],
-                    "description": "Optional: Get stats for specific source format only"
+                    "description": "Optional: Get stats for specific source format only",
                 }
-            }
-        }
+            },
+        },
     },
     {
         "name": "get_detection_count",
@@ -81,11 +81,11 @@ SECURITY_DETECTION_TOOLS = [
                 "source_type": {
                     "type": "string",
                     "enum": ["sigma", "splunk", "elastic", "kql"],
-                    "description": "Optional: Count for specific source format"
+                    "description": "Optional: Count for specific source format",
                 }
-            }
-        }
-    }
+            },
+        },
+    },
 ]
 
 # DeepTempo Findings Tools (Already implemented in backend)
@@ -99,40 +99,40 @@ DEEPTEMPO_FINDING_TOOLS = [
                 "severity": {
                     "type": "string",
                     "enum": ["low", "medium", "high", "critical"],
-                    "description": "Filter by severity level"
+                    "description": "Filter by severity level",
                 },
                 "data_source": {
                     "type": "string",
-                    "description": "Filter by data source (e.g., 'sysmon', 'cloudtrail')"
+                    "description": "Filter by data source (e.g., 'sysmon', 'cloudtrail')",
                 },
                 "status": {
                     "type": "string",
-                    "description": "Filter by status (e.g., 'new', 'investigating', 'resolved')"
+                    "description": "Filter by status (e.g., 'new', 'investigating', 'resolved')",
                 },
                 "sort_by": {
                     "type": "string",
                     "enum": ["timestamp", "anomaly_score", "severity"],
                     "description": "Column to sort by",
-                    "default": "timestamp"
+                    "default": "timestamp",
                 },
                 "sort_order": {
                     "type": "string",
                     "enum": ["asc", "desc"],
                     "description": "Sort direction",
-                    "default": "desc"
+                    "default": "desc",
                 },
                 "offset": {
                     "type": "integer",
                     "description": "Pagination offset (0-based)",
-                    "default": 0
+                    "default": 0,
                 },
                 "limit": {
                     "type": "integer",
                     "description": "Maximum number of findings to return",
-                    "default": 20
-                }
-            }
-        }
+                    "default": 20,
+                },
+            },
+        },
     },
     {
         "name": "search_findings",
@@ -142,50 +142,38 @@ DEEPTEMPO_FINDING_TOOLS = [
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Text search query (searches finding IDs, descriptions, entity context)"
+                    "description": "Text search query (searches finding IDs, descriptions, entity context)",
                 },
                 "severity": {
                     "type": "string",
                     "enum": ["low", "medium", "high", "critical"],
-                    "description": "Filter by severity level"
+                    "description": "Filter by severity level",
                 },
                 "data_source": {
                     "type": "string",
-                    "description": "Filter by data source"
+                    "description": "Filter by data source",
                 },
-                "status": {
-                    "type": "string",
-                    "description": "Filter by status"
-                },
+                "status": {"type": "string", "description": "Filter by status"},
                 "sort_by": {
                     "type": "string",
                     "enum": ["timestamp", "anomaly_score", "severity"],
-                    "default": "anomaly_score"
+                    "default": "anomaly_score",
                 },
                 "sort_order": {
                     "type": "string",
                     "enum": ["asc", "desc"],
-                    "default": "desc"
+                    "default": "desc",
                 },
-                "offset": {
-                    "type": "integer",
-                    "default": 0
-                },
-                "limit": {
-                    "type": "integer",
-                    "default": 20
-                }
+                "offset": {"type": "integer", "default": 0},
+                "limit": {"type": "integer", "default": 20},
             },
-            "required": ["query"]
-        }
+            "required": ["query"],
+        },
     },
     {
         "name": "get_findings_stats",
         "description": "Get aggregate statistics about all findings without returning individual finding data. Returns counts by severity, data source, status, and top MITRE techniques. Use this to get an overview before drilling into specific findings.",
-        "input_schema": {
-            "type": "object",
-            "properties": {}
-        }
+        "input_schema": {"type": "object", "properties": {}},
     },
     {
         "name": "get_finding",
@@ -195,11 +183,11 @@ DEEPTEMPO_FINDING_TOOLS = [
             "properties": {
                 "finding_id": {
                     "type": "string",
-                    "description": "The finding ID (e.g., 'f-20260209-001')"
+                    "description": "The finding ID (e.g., 'f-20260209-001')",
                 }
             },
-            "required": ["finding_id"]
-        }
+            "required": ["finding_id"],
+        },
     },
     {
         "name": "nearest_neighbors",
@@ -209,16 +197,16 @@ DEEPTEMPO_FINDING_TOOLS = [
             "properties": {
                 "finding_id": {
                     "type": "string",
-                    "description": "Reference finding ID to find neighbors for"
+                    "description": "Reference finding ID to find neighbors for",
                 },
                 "limit": {
                     "type": "integer",
                     "description": "Number of similar findings to return",
-                    "default": 10
-                }
+                    "default": 10,
+                },
             },
-            "required": ["finding_id"]
-        }
+            "required": ["finding_id"],
+        },
     },
     {
         "name": "list_cases",
@@ -229,33 +217,25 @@ DEEPTEMPO_FINDING_TOOLS = [
                 "status": {
                     "type": "string",
                     "enum": ["open", "in_progress", "closed"],
-                    "description": "Filter by case status"
+                    "description": "Filter by case status",
                 },
                 "severity": {
                     "type": "string",
                     "enum": ["low", "medium", "high", "critical"],
-                    "description": "Filter by severity"
+                    "description": "Filter by severity",
                 },
-                "limit": {
-                    "type": "integer",
-                    "default": 50
-                }
-            }
-        }
+                "limit": {"type": "integer", "default": 50},
+            },
+        },
     },
     {
         "name": "get_case",
         "description": "Get detailed information about a specific case including all findings, timeline, activities, and MITRE techniques.",
         "input_schema": {
             "type": "object",
-            "properties": {
-                "case_id": {
-                    "type": "string",
-                    "description": "The case ID"
-                }
-            },
-            "required": ["case_id"]
-        }
+            "properties": {"case_id": {"type": "string", "description": "The case ID"}},
+            "required": ["case_id"],
+        },
     },
     {
         "name": "create_case",
@@ -263,27 +243,24 @@ DEEPTEMPO_FINDING_TOOLS = [
         "input_schema": {
             "type": "object",
             "properties": {
-                "title": {
-                    "type": "string",
-                    "description": "Case title/summary"
-                },
+                "title": {"type": "string", "description": "Case title/summary"},
                 "description": {
                     "type": "string",
-                    "description": "Detailed case description"
+                    "description": "Detailed case description",
                 },
                 "severity": {
                     "type": "string",
                     "enum": ["low", "medium", "high", "critical"],
-                    "description": "Case severity"
+                    "description": "Case severity",
                 },
                 "finding_ids": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Optional: Initial findings to add to case"
-                }
+                    "description": "Optional: Initial findings to add to case",
+                },
             },
-            "required": ["title", "severity"]
-        }
+            "required": ["title", "severity"],
+        },
     },
     {
         "name": "add_finding_to_case",
@@ -292,10 +269,10 @@ DEEPTEMPO_FINDING_TOOLS = [
             "type": "object",
             "properties": {
                 "case_id": {"type": "string"},
-                "finding_id": {"type": "string"}
+                "finding_id": {"type": "string"},
             },
-            "required": ["case_id", "finding_id"]
-        }
+            "required": ["case_id", "finding_id"],
+        },
     },
     {
         "name": "update_case",
@@ -305,12 +282,21 @@ DEEPTEMPO_FINDING_TOOLS = [
             "properties": {
                 "case_id": {"type": "string", "description": "The case ID to update"},
                 "title": {"type": "string", "description": "New title"},
-                "description": {"type": "string", "description": "New description or executive summary"},
-                "status": {"type": "string", "enum": ["open", "investigating", "resolved", "closed"]},
-                "priority": {"type": "string", "enum": ["low", "medium", "high", "critical"]}
+                "description": {
+                    "type": "string",
+                    "description": "New description or executive summary",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["open", "investigating", "resolved", "closed"],
+                },
+                "priority": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high", "critical"],
+                },
             },
-            "required": ["case_id"]
-        }
+            "required": ["case_id"],
+        },
     },
     {
         "name": "add_resolution_step",
@@ -319,13 +305,22 @@ DEEPTEMPO_FINDING_TOOLS = [
             "type": "object",
             "properties": {
                 "case_id": {"type": "string", "description": "The case ID"},
-                "description": {"type": "string", "description": "What needs to be done or was done"},
-                "action_taken": {"type": "string", "description": "The specific action taken or recommended"},
-                "result": {"type": "string", "description": "Outcome or expected outcome of the action"}
+                "description": {
+                    "type": "string",
+                    "description": "What needs to be done or was done",
+                },
+                "action_taken": {
+                    "type": "string",
+                    "description": "The specific action taken or recommended",
+                },
+                "result": {
+                    "type": "string",
+                    "description": "Outcome or expected outcome of the action",
+                },
             },
-            "required": ["case_id", "description", "action_taken"]
-        }
-    }
+            "required": ["case_id", "description", "action_taken"],
+        },
+    },
 ]
 
 # Attack Layer Tools
@@ -340,10 +335,10 @@ ATTACK_LAYER_TOOLS = [
                     "type": "string",
                     "enum": ["coverage", "findings", "detections"],
                     "description": "Type of layer to generate",
-                    "default": "coverage"
+                    "default": "coverage",
                 }
-            }
-        }
+            },
+        },
     },
     {
         "name": "get_technique_rollup",
@@ -353,11 +348,11 @@ ATTACK_LAYER_TOOLS = [
             "properties": {
                 "tactic": {
                     "type": "string",
-                    "description": "Optional: Filter by MITRE tactic (e.g., 'initial-access', 'execution')"
+                    "description": "Optional: Filter by MITRE tactic (e.g., 'initial-access', 'execution')",
                 }
-            }
-        }
-    }
+            },
+        },
+    },
 ]
 
 # Approval Tools
@@ -371,10 +366,10 @@ APPROVAL_TOOLS = [
                 "limit": {
                     "type": "integer",
                     "description": "Maximum number of pending actions to return",
-                    "default": 50
+                    "default": 50,
                 }
-            }
-        }
+            },
+        },
     },
     {
         "name": "get_approval_action",
@@ -384,11 +379,11 @@ APPROVAL_TOOLS = [
             "properties": {
                 "action_id": {
                     "type": "string",
-                    "description": "The action ID (e.g., 'action-20260209-001')"
+                    "description": "The action ID (e.g., 'action-20260209-001')",
                 }
             },
-            "required": ["action_id"]
-        }
+            "required": ["action_id"],
+        },
     },
     {
         "name": "approve_action",
@@ -398,16 +393,16 @@ APPROVAL_TOOLS = [
             "properties": {
                 "action_id": {
                     "type": "string",
-                    "description": "The action ID to approve"
+                    "description": "The action ID to approve",
                 },
                 "approved_by": {
                     "type": "string",
                     "description": "Name of approver (e.g., 'analyst_name', 'auto_approved')",
-                    "default": "analyst"
-                }
+                    "default": "analyst",
+                },
             },
-            "required": ["action_id"]
-        }
+            "required": ["action_id"],
+        },
     },
     {
         "name": "reject_action",
@@ -417,36 +412,29 @@ APPROVAL_TOOLS = [
             "properties": {
                 "action_id": {
                     "type": "string",
-                    "description": "The action ID to reject"
+                    "description": "The action ID to reject",
                 },
-                "reason": {
-                    "type": "string",
-                    "description": "Reason for rejection"
-                },
+                "reason": {"type": "string", "description": "Reason for rejection"},
                 "rejected_by": {
                     "type": "string",
                     "description": "Name of person rejecting",
-                    "default": "analyst"
-                }
+                    "default": "analyst",
+                },
             },
-            "required": ["action_id", "reason"]
-        }
+            "required": ["action_id", "reason"],
+        },
     },
     {
         "name": "get_approval_stats",
         "description": "Get statistics about approval actions including total, pending, approved, rejected, and executed counts.",
-        "input_schema": {
-            "type": "object",
-            "properties": {}
-        }
-    }
+        "input_schema": {"type": "object", "properties": {}},
+    },
 ]
 
 # Combine all tools
 ALL_TOOLS = (
-    SECURITY_DETECTION_TOOLS +
-    DEEPTEMPO_FINDING_TOOLS +
-    ATTACK_LAYER_TOOLS +
-    APPROVAL_TOOLS
+    SECURITY_DETECTION_TOOLS
+    + DEEPTEMPO_FINDING_TOOLS
+    + ATTACK_LAYER_TOOLS
+    + APPROVAL_TOOLS
 )
-

--- a/core/platform/autostart_config.py
+++ b/core/platform/autostart_config.py
@@ -27,7 +27,6 @@ from typing import List
 
 from core.config import get_settings
 from core.platform.service_manager import REQUIRED_SERVICES, SERVICES
-from core.config import get_settings
 
 logger = logging.getLogger(__name__)
 

--- a/core/platform/demo_data_service.py
+++ b/core/platform/demo_data_service.py
@@ -1,10 +1,10 @@
 """Demo data service for Vigil SOC demo mode."""
 
+import logging
 import random
 import uuid
-import logging
 from datetime import datetime, timedelta, timezone
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -37,9 +37,14 @@ MITRE_TECHNIQUES = {
 
 DATA_SOURCES = ["flow", "edr", "siem", "dns", "proxy", "firewall", "email", "endpoint"]
 CLUSTERS = [
-    "c-beaconing-001", "c-lateral-movement-002", "c-exfiltration-003",
-    "c-credential-theft-004", "c-ransomware-005", "c-phishing-006",
-    "c-c2-communication-007", "c-persistence-008",
+    "c-beaconing-001",
+    "c-lateral-movement-002",
+    "c-exfiltration-003",
+    "c-credential-theft-004",
+    "c-ransomware-005",
+    "c-phishing-006",
+    "c-c2-communication-007",
+    "c-persistence-008",
 ]
 SEVERITIES = ["critical", "high", "medium", "low"]
 SEVERITY_WEIGHTS = [0.1, 0.25, 0.4, 0.25]
@@ -47,85 +52,101 @@ SEVERITY_WEIGHTS = [0.1, 0.25, 0.4, 0.25]
 
 class DemoDataService:
     """Service that provides demo/sample data for demo mode."""
-    
+
     _instance = None
     _findings: List[Dict] = []
     _cases: List[Dict] = []
     _initialized = False
-    
+
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
-    
+
     def __init__(self):
         if not DemoDataService._initialized:
             self._generate_demo_data()
             DemoDataService._initialized = True
-    
+
     def _generate_embedding(self, dim: int = 768) -> List[float]:
         vec = [random.gauss(0, 1) for _ in range(dim)]
         norm = sum(x**2 for x in vec) ** 0.5
         return [x / norm for x in vec]
-    
+
     def _generate_ip(self) -> str:
         if random.random() < 0.6:
             return f"192.168.{random.randint(1, 254)}.{random.randint(1, 254)}"
         return f"{random.randint(1, 223)}.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(1, 254)}"
-    
+
     def _generate_hostname(self) -> str:
         prefixes = ["ws", "srv", "dc", "web", "db", "app", "dev", "prod"]
         return f"{random.choice(prefixes)}-{random.randint(1, 999):03d}"
-    
+
     def _generate_username(self) -> str:
         names = ["john", "jane", "bob", "alice", "admin", "service", "backup"]
         return f"{random.choice(names)}{random.randint(1, 99)}"
-    
+
     def _generate_mitre_predictions(self) -> Dict[str, float]:
         num_techniques = random.randint(1, 4)
         techniques = random.sample(list(MITRE_TECHNIQUES.keys()), num_techniques)
         return {tech: round(random.uniform(0.5, 0.99), 3) for tech in techniques}
-    
+
     def _generate_entity_context(self) -> Dict[str, Any]:
         context = {}
         if random.random() < 0.8:
-            context["src_ips"] = [self._generate_ip() for _ in range(random.randint(1, 3))]
+            context["src_ips"] = [
+                self._generate_ip() for _ in range(random.randint(1, 3))
+            ]
         if random.random() < 0.6:
-            context["dest_ips"] = [self._generate_ip() for _ in range(random.randint(1, 2))]
+            context["dest_ips"] = [
+                self._generate_ip() for _ in range(random.randint(1, 2))
+            ]
         if random.random() < 0.7:
-            context["hostnames"] = [self._generate_hostname() for _ in range(random.randint(1, 2))]
+            context["hostnames"] = [
+                self._generate_hostname() for _ in range(random.randint(1, 2))
+            ]
         if random.random() < 0.5:
             context["usernames"] = [self._generate_username()]
         if random.random() < 0.3:
-            context["file_hashes"] = [uuid.uuid4().hex for _ in range(random.randint(1, 2))]
+            context["file_hashes"] = [
+                uuid.uuid4().hex for _ in range(random.randint(1, 2))
+            ]
         return context
-    
+
     def _generate_finding(self, days_back: int = 30) -> Dict[str, Any]:
         timestamp = datetime.now(timezone.utc) - timedelta(
             days=random.randint(0, days_back),
             hours=random.randint(0, 23),
-            minutes=random.randint(0, 59)
+            minutes=random.randint(0, 59),
         )
         severity = random.choices(SEVERITIES, weights=SEVERITY_WEIGHTS)[0]
         mitre_preds = self._generate_mitre_predictions()
-        
+
         techniques = list(mitre_preds.keys())
         if techniques:
             primary = techniques[0]
             desc = f"Detected {MITRE_TECHNIQUES.get(primary, 'Unknown')} ({primary}) activity"
         else:
             desc = "Anomalous activity detected"
-        
+
         return {
             "finding_id": f"f-{timestamp.strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}",
             "timestamp": timestamp.isoformat(),
             "data_source": random.choice(DATA_SOURCES),
             "anomaly_score": round(random.uniform(0.3, 0.99), 3),
             "severity": severity,
-            "status": random.choice(["new", "investigating", "resolved"]) if random.random() > 0.3 else "new",
+            "status": (
+                random.choice(["new", "investigating", "resolved"])
+                if random.random() > 0.3
+                else "new"
+            ),
             "mitre_predictions": mitre_preds,
             "predicted_techniques": [
-                {"technique_id": t, "confidence": c, "technique_name": MITRE_TECHNIQUES.get(t, "")}
+                {
+                    "technique_id": t,
+                    "confidence": c,
+                    "technique_name": MITRE_TECHNIQUES.get(t, ""),
+                }
                 for t, c in mitre_preds.items()
             ],
             "entity_context": self._generate_entity_context(),
@@ -133,13 +154,13 @@ class DemoDataService:
             "embedding": self._generate_embedding(),
             "description": desc,
         }
-    
+
     def _generate_case(self, findings: List[Dict]) -> Dict[str, Any]:
         now = datetime.now(timezone.utc)
         num_findings = min(random.randint(2, 5), len(findings))
         selected = random.sample(findings, num_findings)
         finding_ids = [f["finding_id"] for f in selected]
-        
+
         severities = [f["severity"] for f in selected]
         if "critical" in severities:
             priority = "critical"
@@ -147,10 +168,10 @@ class DemoDataService:
             priority = "high"
         else:
             priority = "medium"
-        
+
         clusters = [f.get("cluster_id") for f in selected if f.get("cluster_id")]
         title_cluster = clusters[0] if clusters else "suspicious-activity"
-        
+
         return {
             "case_id": f"case-{now.strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}",
             "title": f"Investigation: {title_cluster.replace('c-', '').replace('-', ' ').title()}",
@@ -158,85 +179,108 @@ class DemoDataService:
             "finding_ids": finding_ids,
             "status": random.choice(["open", "investigating", "closed"]),
             "priority": priority,
-            "assignee": self._generate_username() + "@company.com" if random.random() < 0.5 else "",
-            "tags": ["demo", random.choice(["malware", "lateral-movement", "exfiltration", "phishing"])],
+            "assignee": (
+                self._generate_username() + "@company.com"
+                if random.random() < 0.5
+                else ""
+            ),
+            "tags": [
+                "demo",
+                random.choice(
+                    ["malware", "lateral-movement", "exfiltration", "phishing"]
+                ),
+            ],
             "notes": [],
-            "timeline": [{"timestamp": now.isoformat(), "event": "Case created (demo mode)"}],
+            "timeline": [
+                {"timestamp": now.isoformat(), "event": "Case created (demo mode)"}
+            ],
             "activities": [],
             "resolution_steps": [],
             "created_at": now.isoformat(),
             "updated_at": now.isoformat(),
         }
-    
+
     def _generate_demo_data(self, num_findings: int = 25, num_cases: int = 5):
         """Generate demo findings and cases."""
         logger.info(f"Generating demo data: {num_findings} findings, {num_cases} cases")
         random.seed(42)  # Consistent demo data
-        DemoDataService._findings = [self._generate_finding() for _ in range(num_findings)]
-        DemoDataService._cases = [self._generate_case(DemoDataService._findings) for _ in range(num_cases)]
+        DemoDataService._findings = [
+            self._generate_finding() for _ in range(num_findings)
+        ]
+        DemoDataService._cases = [
+            self._generate_case(DemoDataService._findings) for _ in range(num_cases)
+        ]
         logger.info("Demo data generated successfully")
-    
+
     def get_findings(self, limit: int = 10000) -> List[Dict]:
         return DemoDataService._findings[:limit]
-    
+
     def get_finding(self, finding_id: str) -> Optional[Dict]:
         for f in DemoDataService._findings:
             if f.get("finding_id") == finding_id:
                 return f
         return None
-    
+
     def get_nearest_neighbors(self, finding_id: str, limit: int = 10) -> Dict:
         """Find similar findings using embedding-based cosine similarity.
-        
+
         Args:
             finding_id: Reference finding ID to find neighbors for
             limit: Maximum number of neighbors to return
-            
+
         Returns:
             Dict with seed_finding and neighbors list
         """
         seed = self.get_finding(finding_id)
-        if not seed or 'embedding' not in seed:
+        if not seed or "embedding" not in seed:
             return {"error": f"Finding {finding_id} not found or has no embedding"}
-        
-        seed_emb = seed['embedding']
+
+        seed_emb = seed["embedding"]
         sims = []
         for f in DemoDataService._findings:
-            if f.get('finding_id') != finding_id and 'embedding' in f:
+            if f.get("finding_id") != finding_id and "embedding" in f:
                 # Cosine similarity
-                a = f['embedding']
+                a = f["embedding"]
                 dot = sum(x * y for x, y in zip(seed_emb, a))
-                norm_a = sum(x ** 2 for x in seed_emb) ** 0.5
-                norm_b = sum(x ** 2 for x in a) ** 0.5
+                norm_a = sum(x**2 for x in seed_emb) ** 0.5
+                norm_b = sum(x**2 for x in a) ** 0.5
                 denom = norm_a * norm_b
                 sim = dot / denom if denom > 0 else 0.0
-                sims.append({
-                    "finding_id": f['finding_id'],
-                    "similarity": round(sim, 4),
-                    "cluster_id": f.get('cluster_id'),
-                    "severity": f.get('severity'),
-                    "data_source": f.get('data_source'),
-                    "anomaly_score": float(f.get('anomaly_score', 0)),
-                })
-        
-        sims.sort(key=lambda x: x['similarity'], reverse=True)
+                sims.append(
+                    {
+                        "finding_id": f["finding_id"],
+                        "similarity": round(sim, 4),
+                        "cluster_id": f.get("cluster_id"),
+                        "severity": f.get("severity"),
+                        "data_source": f.get("data_source"),
+                        "anomaly_score": float(f.get("anomaly_score", 0)),
+                    }
+                )
+
+        sims.sort(key=lambda x: x["similarity"], reverse=True)
         return {"seed_finding": finding_id, "neighbors": sims[:limit]}
-    
+
     def get_cases(self, limit: int = 10000) -> List[Dict]:
         return DemoDataService._cases[:limit]
-    
+
     def get_case(self, case_id: str) -> Optional[Dict]:
         for c in DemoDataService._cases:
             if c.get("case_id") == case_id:
                 return c
         return None
-    
+
     def create_finding(self, finding_data: Dict) -> Optional[Dict]:
         DemoDataService._findings.append(finding_data)
         return finding_data
-    
-    def create_case(self, title: str, finding_ids: List[str], priority: str = "medium",
-                    description: str = "", status: str = "open") -> Optional[Dict]:
+
+    def create_case(
+        self,
+        title: str,
+        finding_ids: List[str],
+        priority: str = "medium",
+        description: str = "",
+        status: str = "open",
+    ) -> Optional[Dict]:
         now = datetime.now(timezone.utc)
         case = {
             "case_id": f"case-{now.strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}",
@@ -255,14 +299,14 @@ class DemoDataService:
         }
         DemoDataService._cases.append(case)
         return case
-    
+
     def update_finding(self, finding_id: str, **updates) -> bool:
         for f in DemoDataService._findings:
             if f.get("finding_id") == finding_id:
                 f.update(updates)
                 return True
         return False
-    
+
     def update_case(self, case_id: str, **updates) -> bool:
         for c in DemoDataService._cases:
             if c.get("case_id") == case_id:
@@ -270,26 +314,26 @@ class DemoDataService:
                 c["updated_at"] = datetime.now(timezone.utc).isoformat()
                 return True
         return False
-    
+
     def add_finding_to_case(self, case_id: str, finding_id: str) -> bool:
         """Add a finding to an existing case."""
         for c in DemoDataService._cases:
             if c.get("case_id") == case_id:
-                if 'finding_ids' not in c:
-                    c['finding_ids'] = []
-                if finding_id not in c['finding_ids']:
-                    c['finding_ids'].append(finding_id)
-                    c['updated_at'] = datetime.now(timezone.utc).isoformat()
+                if "finding_ids" not in c:
+                    c["finding_ids"] = []
+                if finding_id not in c["finding_ids"]:
+                    c["finding_ids"].append(finding_id)
+                    c["updated_at"] = datetime.now(timezone.utc).isoformat()
                 return True
         return False
-    
+
     def delete_case(self, case_id: str) -> bool:
         for i, c in enumerate(DemoDataService._cases):
             if c.get("case_id") == case_id:
                 DemoDataService._cases.pop(i)
                 return True
         return False
-    
+
     def reset(self):
         """Regenerate demo data."""
         DemoDataService._initialized = False

--- a/core/platform/email_service.py
+++ b/core/platform/email_service.py
@@ -29,8 +29,9 @@ logger = logging.getLogger(__name__)
 
 class EmailBackend(ABC):
     @abstractmethod
-    def send(self, *, to: str, subject: str, body: str, from_addr: Optional[str] = None) -> None:
-        ...
+    def send(
+        self, *, to: str, subject: str, body: str, from_addr: Optional[str] = None
+    ) -> None: ...
 
 
 class ConsoleBackend(EmailBackend):
@@ -113,7 +114,8 @@ def get_email_backend() -> EmailBackend:
     else:
         if choice != "console":
             logger.warning(
-                "Unknown VIGIL_EMAIL_BACKEND=%r; falling back to console backend", choice
+                "Unknown VIGIL_EMAIL_BACKEND=%r; falling back to console backend",
+                choice,
             )
         _backend = ConsoleBackend()
     return _backend
@@ -130,8 +132,6 @@ def send_email(
     outage does not turn into a user-facing 500. Callers that need the
     error (e.g. admin ops) can call the backend directly."""
     try:
-        get_email_backend().send(
-            to=to, subject=subject, body=body, from_addr=from_addr
-        )
+        get_email_backend().send(to=to, subject=subject, body=body, from_addr=from_addr)
     except Exception as exc:
         logger.error("Email send failed: to=%s subject=%r error=%s", to, subject, exc)

--- a/core/platform/mempalace_paths.py
+++ b/core/platform/mempalace_paths.py
@@ -24,6 +24,7 @@ import logging
 from pathlib import Path
 
 from core.config import get_settings
+
 logger = logging.getLogger(__name__)
 
 # Matches mcp-config.json's default for the mempalace server. Keep in
@@ -40,7 +41,9 @@ def get_palace_path(*, ensure_exists: bool = True) -> Path:
         try:
             palace.mkdir(parents=True, exist_ok=True)
         except OSError as e:
-            logger.warning("Could not create palace dir %s: %s", palace, e)  # survivable
+            logger.warning(
+                "Could not create palace dir %s: %s", palace, e
+            )  # survivable
     return palace
 
 

--- a/core/platform/monitoring.py
+++ b/core/platform/monitoring.py
@@ -8,15 +8,15 @@ The SentrySpanProcessor bridges OTEL error spans to Sentry breadcrumbs so
 both systems remain useful without creating duplicate transaction records.
 """
 
-import time
 import logging
-
+import time
 from typing import Any, Optional
 
 import sentry_sdk
 from sentry_sdk.integrations.fastapi import FastApiIntegration
-from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+
 from core.config import get_settings
 
 logger = logging.getLogger(__name__)
@@ -44,9 +44,7 @@ try:
             try:
                 ctx = span.get_span_context()
                 if ctx and ctx.is_valid:
-                    sentry_sdk.set_tag(
-                        "otel.trace_id", format(ctx.trace_id, "032x")
-                    )
+                    sentry_sdk.set_tag("otel.trace_id", format(ctx.trace_id, "032x"))
             except Exception:
                 pass
 
@@ -59,9 +57,7 @@ try:
                     category="otel.span",
                     level="error",
                     data={
-                        "span_id": format(
-                            span.get_span_context().span_id, "016x"
-                        ),
+                        "span_id": format(span.get_span_context().span_id, "016x"),
                     },
                 )
             except Exception:
@@ -106,14 +102,12 @@ def init_sentry() -> None:
         logger.info("Sentry DSN not configured, skipping initialization")
         return
 
-
     # When OTEL is active, disable Sentry's own distributed tracing to prevent
     # double-tracing. Sentry still captures errors — tracing is OTEL's job.
     otel_active = get_settings().vigil_otel_enabled
-    traces_sample_rate = 0.0 if otel_active else (
-        0.1 if environment == "production" else 1.0
+    traces_sample_rate = (
+        0.0 if otel_active else (0.1 if environment == "production" else 1.0)
     )
-
 
     sentry_sdk.init(
         dsn=sentry_dsn,
@@ -144,7 +138,6 @@ def init_sentry() -> None:
     )
 
 
-
 def before_send_filter(event, hint):
     """Filter events before sending to Sentry."""
 
@@ -168,14 +161,16 @@ def capture_exception(error: Exception, context: Optional[dict] = None) -> None:
     sentry_sdk.capture_exception(error)
 
 
-def add_breadcrumb(message: str, category: str = "default", level: str = "info", data: Optional[dict] = None) -> None:
+def add_breadcrumb(
+    message: str,
+    category: str = "default",
+    level: str = "info",
+    data: Optional[dict] = None,
+) -> None:
     """Add a breadcrumb for debugging."""
 
     sentry_sdk.add_breadcrumb(
-        message=message,
-        category=category,
-        level=level,
-        data=data or {}
+        message=message, category=category, level=level, data=data or {}
     )
 
 
@@ -186,28 +181,27 @@ def add_breadcrumb(message: str, category: str = "default", level: str = "info",
 PROMETHEUS_AVAILABLE = False
 
 try:
-    from prometheus_client import Counter, Histogram, Gauge, generate_latest, CONTENT_TYPE_LATEST
+    from prometheus_client import (
+        CONTENT_TYPE_LATEST,
+        Counter,
+        Gauge,
+        Histogram,
+        generate_latest,
+    )
     from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.requests import Request as StarletteRequest
 
     http_requests_total = Counter(
-        'http_requests_total',
-        'Total HTTP requests',
-        ['method', 'endpoint', 'status']
+        "http_requests_total", "Total HTTP requests", ["method", "endpoint", "status"]
     )
     http_request_duration_seconds = Histogram(
-        'http_request_duration_seconds',
-        'HTTP request duration in seconds',
-        ['method', 'endpoint']
+        "http_request_duration_seconds",
+        "HTTP request duration in seconds",
+        ["method", "endpoint"],
     )
-    active_cases_total = Gauge(
-        'active_cases_total',
-        'Number of active cases'
-    )
+    active_cases_total = Gauge("active_cases_total", "Number of active cases")
     findings_processed_total = Counter(
-        'findings_processed_total',
-        'Total findings processed',
-        ['source', 'severity']
+        "findings_processed_total", "Total findings processed", ["source", "severity"]
     )
 
     PROMETHEUS_AVAILABLE = True

--- a/core/platform/ollama_supervisor.py
+++ b/core/platform/ollama_supervisor.py
@@ -79,11 +79,7 @@ def ollama_ping(base_url: Optional[str] = None, timeout: float = 2.0) -> bool:
     for a spawned ``ollama serve`` to come up, which rules out
     :func:`fetch_ollama_models` (async, plus an ``/api/show`` per model).
     """
-    base = (
-        (base_url or get_settings().ollama_url)
-        .strip()
-        .rstrip("/")
-    )
+    base = (base_url or get_settings().ollama_url).strip().rstrip("/")
     try:
         with httpx.Client(timeout=timeout, follow_redirects=False) as client:
             return client.get(f"{base}/api/tags").status_code == 200

--- a/core/platform/service_manager.py
+++ b/core/platform/service_manager.py
@@ -26,8 +26,8 @@ import subprocess
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
-from core.platform.ollama_supervisor import container_base_url
 from core.platform import ollama_supervisor as ollama_process
+from core.platform.ollama_supervisor import container_base_url
 from core.platform.service_contract import (  # re-exported for existing callers
     ActionResult,
     ServiceSpec,

--- a/core/rate_limit.py
+++ b/core/rate_limit.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
 import time
-from fastapi import Request, HTTPException
+
+from fastapi import HTTPException, Request
 
 logger = logging.getLogger(__name__)
 

--- a/core/reporting/ai_decisions_router.py
+++ b/core/reporting/ai_decisions_router.py
@@ -6,13 +6,14 @@ Enables continuous improvement of AI agents through human oversight.
 """
 
 import logging
-from typing import Optional, List
+from typing import List, Optional
+
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from core.storage.service import DatabaseService
-from core.storage.schemas import AIDecisionLogSchema
 from core.routing import Auth, RouterMeta
+from core.storage.schemas import AIDecisionLogSchema
+from core.storage.service import DatabaseService
 
 logger = logging.getLogger(__name__)
 
@@ -27,12 +28,18 @@ ROUTER_META = RouterMeta(
 
 # ========== Request/Response Models ==========
 
+
 class CreateAIDecisionRequest(BaseModel):
     """Request model for creating an AI decision log."""
+
     decision_id: str = Field(..., description="Unique decision identifier")
     agent_id: str = Field(..., description="ID of the agent making the decision")
-    decision_type: str = Field(..., description="Type of decision (e.g., 'triage', 'escalate', 'isolate')")
-    confidence_score: float = Field(..., ge=0, le=1, description="AI's confidence (0-1)")
+    decision_type: str = Field(
+        ..., description="Type of decision (e.g., 'triage', 'escalate', 'isolate')"
+    )
+    confidence_score: float = Field(
+        ..., ge=0, le=1, description="AI's confidence (0-1)"
+    )
     reasoning: str = Field(..., description="AI's reasoning for the decision")
     recommended_action: str = Field(..., description="Recommended action")
     finding_id: Optional[str] = Field(None, description="Associated finding ID")
@@ -43,18 +50,34 @@ class CreateAIDecisionRequest(BaseModel):
 
 class SubmitFeedbackRequest(BaseModel):
     """Request model for submitting feedback on an AI decision."""
+
     human_reviewer: str = Field(..., description="Name/ID of reviewer")
-    human_decision: str = Field(..., description="Human's decision: 'agree', 'disagree', or 'partial'")
-    feedback_comment: Optional[str] = Field(None, description="Optional feedback comment")
-    accuracy_grade: Optional[float] = Field(None, ge=0, le=1, description="Accuracy grade (0-1)")
-    reasoning_grade: Optional[float] = Field(None, ge=0, le=1, description="Reasoning quality grade (0-1)")
-    action_appropriateness: Optional[float] = Field(None, ge=0, le=1, description="Action appropriateness (0-1)")
-    actual_outcome: Optional[str] = Field(None, description="Actual outcome: 'true_positive', 'false_positive', etc.")
-    time_saved_minutes: Optional[int] = Field(None, description="Estimated time saved by AI")
+    human_decision: str = Field(
+        ..., description="Human's decision: 'agree', 'disagree', or 'partial'"
+    )
+    feedback_comment: Optional[str] = Field(
+        None, description="Optional feedback comment"
+    )
+    accuracy_grade: Optional[float] = Field(
+        None, ge=0, le=1, description="Accuracy grade (0-1)"
+    )
+    reasoning_grade: Optional[float] = Field(
+        None, ge=0, le=1, description="Reasoning quality grade (0-1)"
+    )
+    action_appropriateness: Optional[float] = Field(
+        None, ge=0, le=1, description="Action appropriateness (0-1)"
+    )
+    actual_outcome: Optional[str] = Field(
+        None, description="Actual outcome: 'true_positive', 'false_positive', etc."
+    )
+    time_saved_minutes: Optional[int] = Field(
+        None, description="Estimated time saved by AI"
+    )
 
 
 class AIDecisionResponse(BaseModel):
     """Response model for AI decision."""
+
     id: int
     decision_id: str
     agent_id: str
@@ -80,6 +103,7 @@ class AIDecisionResponse(BaseModel):
 
 class AIDecisionStatsResponse(BaseModel):
     """Response model for AI decision statistics."""
+
     total_decisions: int
     total_with_feedback: int
     feedback_rate: float
@@ -93,17 +117,18 @@ class AIDecisionStatsResponse(BaseModel):
 
 # ========== API Endpoints ==========
 
+
 @router.post("/decisions", response_model=AIDecisionResponse, status_code=201)
 async def create_ai_decision(request: CreateAIDecisionRequest):
     """
     Log an AI decision for tracking and feedback.
-    
+
     This endpoint should be called by AI agents whenever they make a decision
     that could benefit from human review and feedback.
     """
     try:
         db_service = DatabaseService()
-        
+
         decision = db_service.create_ai_decision(
             decision_id=request.decision_id,
             agent_id=request.agent_id,
@@ -114,14 +139,16 @@ async def create_ai_decision(request: CreateAIDecisionRequest):
             finding_id=request.finding_id,
             case_id=request.case_id,
             workflow_id=request.workflow_id,
-            decision_metadata=request.decision_metadata
+            decision_metadata=request.decision_metadata,
         )
-        
+
         if not decision:
-            raise HTTPException(status_code=500, detail="Failed to create AI decision log")
-        
+            raise HTTPException(
+                status_code=500, detail="Failed to create AI decision log"
+            )
+
         return AIDecisionResponse(**AIDecisionLogSchema.dump(decision))
-        
+
     except Exception as e:
         logger.error(f"Error creating AI decision: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -131,13 +158,13 @@ async def create_ai_decision(request: CreateAIDecisionRequest):
 async def submit_feedback(decision_id: str, request: SubmitFeedbackRequest):
     """
     Submit human feedback on an AI decision.
-    
+
     This allows SOC analysts to grade AI decisions and provide feedback
     for continuous improvement.
     """
     try:
         db_service = DatabaseService()
-        
+
         decision = db_service.submit_ai_decision_feedback(
             decision_id=decision_id,
             human_reviewer=request.human_reviewer,
@@ -147,14 +174,16 @@ async def submit_feedback(decision_id: str, request: SubmitFeedbackRequest):
             reasoning_grade=request.reasoning_grade,
             action_appropriateness=request.action_appropriateness,
             actual_outcome=request.actual_outcome,
-            time_saved_minutes=request.time_saved_minutes
+            time_saved_minutes=request.time_saved_minutes,
         )
-        
+
         if not decision:
-            raise HTTPException(status_code=404, detail=f"AI decision not found: {decision_id}")
-        
+            raise HTTPException(
+                status_code=404, detail=f"AI decision not found: {decision_id}"
+            )
+
         return AIDecisionResponse(**AIDecisionLogSchema.dump(decision))
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -165,7 +194,7 @@ async def submit_feedback(decision_id: str, request: SubmitFeedbackRequest):
 @router.get("/decisions/stats", response_model=AIDecisionStatsResponse)
 async def get_ai_decision_stats(
     agent_id: Optional[str] = Query(None, description="Filter by agent ID"),
-    days: int = Query(30, ge=1, le=365, description="Number of days to analyze")
+    days: int = Query(30, ge=1, le=365, description="Number of days to analyze"),
 ):
     """
     Get statistics on AI decisions and feedback.
@@ -184,9 +213,7 @@ async def get_ai_decision_stats(
 
 
 @router.get("/decisions/pending-feedback")
-async def get_pending_feedback_decisions(
-    limit: int = Query(50, ge=1, le=100)
-):
+async def get_pending_feedback_decisions(limit: int = Query(50, ge=1, le=100)):
     """
     Get decisions that are awaiting human feedback.
 
@@ -196,15 +223,14 @@ async def get_pending_feedback_decisions(
     try:
         db_service = DatabaseService()
 
-        decisions = db_service.list_ai_decisions(
-            has_feedback=False,
-            limit=limit
-        )
+        decisions = db_service.list_ai_decisions(has_feedback=False, limit=limit)
 
         # Sort by confidence score (lowest first)
         decisions_sorted = sorted(decisions, key=lambda d: d.confidence_score)
 
-        return [AIDecisionResponse(**AIDecisionLogSchema.dump(d)) for d in decisions_sorted]
+        return [
+            AIDecisionResponse(**AIDecisionLogSchema.dump(d)) for d in decisions_sorted
+        ]
 
     except Exception as e:
         logger.error(f"Error getting pending feedback decisions: {e}")
@@ -219,7 +245,7 @@ async def list_ai_decisions(
     workflow_id: Optional[str] = Query(None, description="Filter by workflow ID"),
     has_feedback: Optional[bool] = Query(None, description="Filter by feedback status"),
     limit: int = Query(100, ge=1, le=500, description="Maximum results"),
-    offset: int = Query(0, ge=0, description="Offset for pagination")
+    offset: int = Query(0, ge=0, description="Offset for pagination"),
 ):
     """
     List AI decisions with optional filters.
@@ -235,7 +261,7 @@ async def list_ai_decisions(
             case_id=case_id,
             has_feedback=has_feedback,
             limit=limit,
-            offset=offset
+            offset=offset,
         )
 
         if workflow_id:
@@ -256,7 +282,9 @@ async def get_ai_decision(decision_id: str):
         decision = db_service.get_ai_decision(decision_id)
 
         if not decision:
-            raise HTTPException(status_code=404, detail=f"AI decision not found: {decision_id}")
+            raise HTTPException(
+                status_code=404, detail=f"AI decision not found: {decision_id}"
+            )
 
         return AIDecisionResponse(**AIDecisionLogSchema.dump(decision))
 
@@ -265,4 +293,3 @@ async def get_ai_decision(decision_id: str):
     except Exception as e:
         logger.error(f"Error getting AI decision: {e}")
         raise HTTPException(status_code=500, detail=str(e))
-

--- a/core/reporting/ai_insights_service.py
+++ b/core/reporting/ai_insights_service.py
@@ -8,16 +8,17 @@ This service analyzes SOC metrics and patterns to generate:
 - Performance optimization suggestions
 """
 
+import asyncio
 import json
 import logging
-from typing import List, Dict, Any
 from datetime import datetime, timezone
-import asyncio
+from typing import Any, Dict, List
+
 from sqlalchemy.orm import Session
 
-from core.secrets_manager import get_secret
 from core.llm.defaults import DEFAULT_MODEL
 from core.llm.providers.clients import create_anthropic_client
+from core.secrets_manager import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +32,15 @@ class AIInsightsService:
 
     def __init__(self):
         """Initialize the AI insights service with Claude API client."""
-        api_key = (get_secret("ANTHROPIC_API_KEY") or
-                   get_secret("CLAUDE_API_KEY") or
-                   get_secret("anthropic_api_key"))
+        api_key = (
+            get_secret("ANTHROPIC_API_KEY")
+            or get_secret("CLAUDE_API_KEY")
+            or get_secret("anthropic_api_key")
+        )
         if not api_key:
-            logger.warning("No Anthropic API key found - AI insights will use fallback mode")
+            logger.warning(
+                "No Anthropic API key found - AI insights will use fallback mode"
+            )
             self.client = None
         else:
             self.client = create_anthropic_client(api_key)
@@ -129,23 +134,23 @@ class AIInsightsService:
                 if time_range in self._cache:
                     self._cache[time_range]["generating"] = False
             return False
-    
+
     async def generate_insights(
         self,
         db: Session,
         metrics: Dict[str, Any],
         time_series: List[Dict[str, Any]],
-        time_range: str
+        time_range: str,
     ) -> List[Dict[str, Any]]:
         """
         Generate AI-powered insights from analytics data.
-        
+
         Args:
             db: Database session
             metrics: Key SOC metrics
             time_series: Time series data for trends
             time_range: Time range for the analysis
-            
+
         Returns:
             List of insights with recommendations, warnings, and anomalies
         """
@@ -154,31 +159,31 @@ class AIInsightsService:
             if not self.client:
                 logger.info("No Claude API client - using fallback insights")
                 return self._get_fallback_insights(metrics)
-            
+
             # Prepare context for Claude
             context = self._prepare_context(metrics, time_series, time_range)
-            
+
             # Generate insights using Claude
             insights_text = await self._call_claude(context)
-            
+
             # Parse insights from Claude's response
             insights = self._parse_insights(insights_text)
-            
+
             return insights
-        
+
         except Exception as e:
             logger.error(f"Error generating AI insights: {str(e)}")
             # Return fallback insights
             return self._get_fallback_insights(metrics)
-    
+
     def _prepare_context(
         self,
         metrics: Dict[str, Any],
         time_series: List[Dict[str, Any]],
-        time_range: str
+        time_range: str,
     ) -> str:
         """Prepare context for Claude to analyze."""
-        
+
         context = f"""You are an expert Security Operations Center (SOC) analyst AI assistant. Analyze the following SOC metrics and provide actionable insights.
 
 Time Range: {time_range}
@@ -219,11 +224,12 @@ Format your response as a JSON array of insights. Example:
 Provide ONLY the JSON array, no other text."""
 
         return context
-    
+
     async def _call_claude(self, context: str) -> str:
         """Call Claude API via the LLM queue for global rate limiting."""
         try:
             from core.llm.gateway.gateway import get_llm_gateway
+
             gateway = await get_llm_gateway()
             result = await gateway.submit_insights(
                 prompt=context,
@@ -246,43 +252,45 @@ Provide ONLY the JSON array, no other text."""
                     model=self.model,
                     max_tokens=2000,
                     temperature=0.3,
-                    messages=[{"role": "user", "content": context}]
-                )
+                    messages=[{"role": "user", "content": context}],
+                ),
             )
             return message.content[0].text
         except Exception as e:
             logger.error(f"Error calling Claude API: {str(e)}")
             raise
-    
+
     def _parse_insights(self, insights_text: str) -> List[Dict[str, Any]]:
         """Parse insights from Claude's JSON response."""
         try:
             # Extract JSON from response (in case there's extra text)
-            start = insights_text.find('[')
-            end = insights_text.rfind(']') + 1
-            
+            start = insights_text.find("[")
+            end = insights_text.rfind("]") + 1
+
             if start == -1 or end == 0:
                 logger.warning("No JSON array found in Claude response")
                 return []
-            
+
             json_text = insights_text[start:end]
             insights_raw = json.loads(json_text)
-            
+
             # Add timestamps and IDs
             insights = []
             for i, insight in enumerate(insights_raw):
-                insights.append({
-                    "id": f"insight-{datetime.utcnow().timestamp()}-{i}",
-                    "type": insight.get("type", "info"),
-                    "title": insight.get("title", "Insight"),
-                    "description": insight.get("description", ""),
-                    "confidence": insight.get("confidence", 0.7),
-                    "actionable": insight.get("actionable", False),
-                    "timestamp": datetime.utcnow().isoformat(),
-                })
-            
+                insights.append(
+                    {
+                        "id": f"insight-{datetime.utcnow().timestamp()}-{i}",
+                        "type": insight.get("type", "info"),
+                        "title": insight.get("title", "Insight"),
+                        "description": insight.get("description", ""),
+                        "confidence": insight.get("confidence", 0.7),
+                        "actionable": insight.get("actionable", False),
+                        "timestamp": datetime.utcnow().isoformat(),
+                    }
+                )
+
             return insights
-        
+
         except json.JSONDecodeError as e:
             logger.error(f"Error parsing insights JSON: {str(e)}")
             logger.debug(f"Raw response: {insights_text}")
@@ -290,69 +298,80 @@ Provide ONLY the JSON array, no other text."""
         except Exception as e:
             logger.error(f"Error processing insights: {str(e)}")
             return []
-    
+
     def _get_fallback_insights(self, metrics: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Generate fallback insights when AI service is unavailable."""
         insights = []
         timestamp = datetime.utcnow().isoformat()
-        
-        # Findings trend insight
-        if abs(metrics['findingsChange']) > 20:
-            insights.append({
-                "id": f"fallback-findings-{datetime.utcnow().timestamp()}",
-                "type": "warning" if metrics['findingsChange'] > 0 else "info",
-                "title": f"Findings {'increased' if metrics['findingsChange'] > 0 else 'decreased'} significantly",
-                "description": f"Findings changed by {metrics['findingsChange']:+.1f}% compared to previous period.",
-                "confidence": 0.9,
-                "actionable": metrics['findingsChange'] > 0,
-                "timestamp": timestamp,
-            })
-        
-        # Response time insight
-        if metrics['avgResponseTime'] > 60:
-            insights.append({
-                "id": f"fallback-response-{datetime.utcnow().timestamp()}",
-                "type": "warning",
-                "title": "Response time exceeds target",
-                "description": f"Average response time is {metrics['avgResponseTime']} minutes. Consider workload optimization.",
-                "confidence": 0.85,
-                "actionable": True,
-                "timestamp": timestamp,
-            })
-        
-        # False positive insight
-        if metrics['falsePositiveRate'] > 30:
-            insights.append({
-                "id": f"fallback-fp-{datetime.utcnow().timestamp()}",
-                "type": "recommendation",
-                "title": "High false positive rate detected",
-                "description": f"False positive rate is {metrics['falsePositiveRate']}%. Review detection rules for tuning.",
-                "confidence": 0.9,
-                "actionable": True,
-                "timestamp": timestamp,
-            })
-        
-        # Positive performance insight
-        if metrics['responseTimeChange'] < -10:
-            insights.append({
-                "id": f"fallback-performance-{datetime.utcnow().timestamp()}",
-                "type": "info",
-                "title": "Response time improvement",
-                "description": f"Response time improved by {abs(metrics['responseTimeChange']):.1f}%. Great work!",
-                "confidence": 0.95,
-                "actionable": False,
-                "timestamp": timestamp,
-            })
-        
-        return insights if insights else [{
-            "id": f"fallback-default-{datetime.utcnow().timestamp()}",
-            "type": "info",
-            "title": "SOC operations stable",
-            "description": "All metrics are within normal ranges. Continue monitoring for changes.",
-            "confidence": 0.8,
-            "actionable": False,
-            "timestamp": timestamp,
-        }]
-    
-    
 
+        # Findings trend insight
+        if abs(metrics["findingsChange"]) > 20:
+            insights.append(
+                {
+                    "id": f"fallback-findings-{datetime.utcnow().timestamp()}",
+                    "type": "warning" if metrics["findingsChange"] > 0 else "info",
+                    "title": f"Findings {'increased' if metrics['findingsChange'] > 0 else 'decreased'} significantly",
+                    "description": f"Findings changed by {metrics['findingsChange']:+.1f}% compared to previous period.",
+                    "confidence": 0.9,
+                    "actionable": metrics["findingsChange"] > 0,
+                    "timestamp": timestamp,
+                }
+            )
+
+        # Response time insight
+        if metrics["avgResponseTime"] > 60:
+            insights.append(
+                {
+                    "id": f"fallback-response-{datetime.utcnow().timestamp()}",
+                    "type": "warning",
+                    "title": "Response time exceeds target",
+                    "description": f"Average response time is {metrics['avgResponseTime']} minutes. Consider workload optimization.",
+                    "confidence": 0.85,
+                    "actionable": True,
+                    "timestamp": timestamp,
+                }
+            )
+
+        # False positive insight
+        if metrics["falsePositiveRate"] > 30:
+            insights.append(
+                {
+                    "id": f"fallback-fp-{datetime.utcnow().timestamp()}",
+                    "type": "recommendation",
+                    "title": "High false positive rate detected",
+                    "description": f"False positive rate is {metrics['falsePositiveRate']}%. Review detection rules for tuning.",
+                    "confidence": 0.9,
+                    "actionable": True,
+                    "timestamp": timestamp,
+                }
+            )
+
+        # Positive performance insight
+        if metrics["responseTimeChange"] < -10:
+            insights.append(
+                {
+                    "id": f"fallback-performance-{datetime.utcnow().timestamp()}",
+                    "type": "info",
+                    "title": "Response time improvement",
+                    "description": f"Response time improved by {abs(metrics['responseTimeChange']):.1f}%. Great work!",
+                    "confidence": 0.95,
+                    "actionable": False,
+                    "timestamp": timestamp,
+                }
+            )
+
+        return (
+            insights
+            if insights
+            else [
+                {
+                    "id": f"fallback-default-{datetime.utcnow().timestamp()}",
+                    "type": "info",
+                    "title": "SOC operations stable",
+                    "description": "All metrics are within normal ranges. Continue monitoring for changes.",
+                    "confidence": 0.8,
+                    "actionable": False,
+                    "timestamp": timestamp,
+                }
+            ]
+        )

--- a/core/reporting/logs_router.py
+++ b/core/reporting/logs_router.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 
 from fastapi import APIRouter
 from pydantic import BaseModel
+
 from core.routing import Auth, RouterMeta
 
 router = APIRouter()
@@ -17,7 +18,7 @@ ROUTER_META = RouterMeta(
 )
 
 # Create dedicated logger for frontend logs
-frontend_logger = logging.getLogger('frontend')
+frontend_logger = logging.getLogger("frontend")
 frontend_logger.setLevel(logging.DEBUG)
 
 # Resolve the frontend log file path.
@@ -30,8 +31,7 @@ log_file = Path("logs") / "frontend-app.log"
 # console handler if the log file cannot be created.
 if not frontend_logger.handlers:
     formatter = logging.Formatter(
-        '%(asctime)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        "%(asctime)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
 
     try:
@@ -56,6 +56,7 @@ if not frontend_logger.handlers:
 
 class FrontendLogEntry(BaseModel):
     """Frontend log entry model."""
+
     level: str
     message: str
     component: str
@@ -67,38 +68,38 @@ class FrontendLogEntry(BaseModel):
 async def log_frontend(entry: FrontendLogEntry):
     """
     Receive logs from frontend and write to file.
-    
+
     Args:
         entry: Log entry with level, message, component, and optional extra data
-    
+
     Returns:
         Status confirmation
     """
     try:
         # Build log message
         log_message = f"[{entry.component}] {entry.message}"
-        
+
         # Append extra data if present
         if entry.extra:
             # Format extra data nicely
             extra_str = ", ".join([f"{k}={v}" for k, v in entry.extra.items()])
             log_message += f" ({extra_str})"
-        
+
         # Log at appropriate level
         level = entry.level.upper()
-        if level == 'DEBUG':
+        if level == "DEBUG":
             frontend_logger.debug(log_message)
-        elif level == 'INFO':
+        elif level == "INFO":
             frontend_logger.info(log_message)
-        elif level == 'WARN' or level == 'WARNING':
+        elif level == "WARN" or level == "WARNING":
             frontend_logger.warning(log_message)
-        elif level == 'ERROR':
+        elif level == "ERROR":
             frontend_logger.error(log_message)
         else:
             frontend_logger.info(log_message)
-        
+
         return {"status": "ok"}
-    
+
     except Exception as e:
         # Don't fail the request if logging fails
         logging.error(f"Error processing frontend log: {e}")
@@ -112,6 +113,5 @@ async def get_frontend_log_status():
         "enabled": True,
         "log_file": str(log_file),
         "exists": log_file.exists(),
-        "size": log_file.stat().st_size if log_file.exists() else 0
+        "size": log_file.stat().st_size if log_file.exists() else 0,
     }
-

--- a/core/reporting/report_service.py
+++ b/core/reporting/report_service.py
@@ -1,17 +1,25 @@
 """PDF report generation service."""
 
 import logging
-from pathlib import Path
 from datetime import datetime
-from typing import List, Dict
+from pathlib import Path
+from typing import Dict, List
 
 try:
     from reportlab.lib import colors
-    from reportlab.lib.pagesizes import letter
-    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-    from reportlab.lib.units import inch
-    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Spacer, PageBreak
     from reportlab.lib.enums import TA_CENTER
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+    from reportlab.lib.units import inch
+    from reportlab.platypus import (
+        PageBreak,
+        Paragraph,
+        SimpleDocTemplate,
+        Spacer,
+        Table,
+        TableStyle,
+    )
+
     REPORTLAB_AVAILABLE = True
 except ImportError:
     REPORTLAB_AVAILABLE = False
@@ -21,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 class ReportService:
     """Service for generating PDF reports."""
-    
+
     def __init__(self):
         """Initialize the report service."""
         if not REPORTLAB_AVAILABLE:
@@ -30,333 +38,462 @@ class ReportService:
             )
         self.styles = getSampleStyleSheet()
         self._setup_custom_styles()
-    
+
     def _setup_custom_styles(self):
         """Set up custom paragraph styles."""
         # Title style
-        self.styles.add(ParagraphStyle(
-            name='CustomTitle',
-            parent=self.styles['Heading1'],
-            fontSize=24,
-            textColor=colors.HexColor('#1a1a1a'),
-            spaceAfter=30,
-            alignment=TA_CENTER
-        ))
-        
+        self.styles.add(
+            ParagraphStyle(
+                name="CustomTitle",
+                parent=self.styles["Heading1"],
+                fontSize=24,
+                textColor=colors.HexColor("#1a1a1a"),
+                spaceAfter=30,
+                alignment=TA_CENTER,
+            )
+        )
+
         # Heading style
-        self.styles.add(ParagraphStyle(
-            name='CustomHeading',
-            parent=self.styles['Heading2'],
-            fontSize=16,
-            textColor=colors.HexColor('#2c3e50'),
-            spaceAfter=12,
-            spaceBefore=12
-        ))
-        
+        self.styles.add(
+            ParagraphStyle(
+                name="CustomHeading",
+                parent=self.styles["Heading2"],
+                fontSize=16,
+                textColor=colors.HexColor("#2c3e50"),
+                spaceAfter=12,
+                spaceBefore=12,
+            )
+        )
+
         # Subheading style
-        self.styles.add(ParagraphStyle(
-            name='CustomSubheading',
-            parent=self.styles['Heading3'],
-            fontSize=12,
-            textColor=colors.HexColor('#34495e'),
-            spaceAfter=8,
-            spaceBefore=8
-        ))
-        
+        self.styles.add(
+            ParagraphStyle(
+                name="CustomSubheading",
+                parent=self.styles["Heading3"],
+                fontSize=12,
+                textColor=colors.HexColor("#34495e"),
+                spaceAfter=8,
+                spaceBefore=8,
+            )
+        )
+
         # Body text style
-        self.styles.add(ParagraphStyle(
-            name='CustomBody',
-            parent=self.styles['Normal'],
-            fontSize=10,
-            textColor=colors.HexColor('#333333'),
-            spaceAfter=6
-        ))
-    
-    
-    def generate_case_report(self, output_path: Path, case: Dict, findings: List[Dict]) -> bool:
+        self.styles.add(
+            ParagraphStyle(
+                name="CustomBody",
+                parent=self.styles["Normal"],
+                fontSize=10,
+                textColor=colors.HexColor("#333333"),
+                spaceAfter=6,
+            )
+        )
+
+    def generate_case_report(
+        self, output_path: Path, case: Dict, findings: List[Dict]
+    ) -> bool:
         """
         Generate a PDF report for a specific case.
-        
+
         Args:
             output_path: Path to save the PDF file.
             case: Case dictionary.
             findings: List of findings related to the case.
-        
+
         Returns:
             True if successful, False otherwise.
         """
         try:
-            doc = SimpleDocTemplate(str(output_path), pagesize=letter,
-                                   rightMargin=72, leftMargin=72,
-                                   topMargin=72, bottomMargin=18)
+            doc = SimpleDocTemplate(
+                str(output_path),
+                pagesize=letter,
+                rightMargin=72,
+                leftMargin=72,
+                topMargin=72,
+                bottomMargin=18,
+            )
             story = []
-            
+
             # Title
-            title = case.get('title', 'Investigation Case')
-            story.append(Paragraph(f"Case Report: {title}", self.styles['CustomTitle']))
-            story.append(Spacer(1, 0.2*inch))
-            
+            title = case.get("title", "Investigation Case")
+            story.append(Paragraph(f"Case Report: {title}", self.styles["CustomTitle"]))
+            story.append(Spacer(1, 0.2 * inch))
+
             # Case metadata
-            case_id = case.get('case_id', 'N/A')
-            created = case.get('created_at', 'N/A')
-            updated = case.get('updated_at', 'N/A')
-            status = case.get('status', 'N/A')
-            priority = case.get('priority', 'N/A')
-            assignee = case.get('assignee', 'Unassigned')
-            
+            case_id = case.get("case_id", "N/A")
+            created = case.get("created_at", "N/A")
+            updated = case.get("updated_at", "N/A")
+            status = case.get("status", "N/A")
+            priority = case.get("priority", "N/A")
+            assignee = case.get("assignee", "Unassigned")
+
             metadata = [
                 ["Case ID:", case_id],
                 ["Status:", status.capitalize()],
                 ["Priority:", priority.capitalize()],
                 ["Assignee:", assignee],
-                ["Created:", created.split('T')[0] if 'T' in created else created],
-                ["Last Updated:", updated.split('T')[0] if 'T' in updated else updated],
+                ["Created:", created.split("T")[0] if "T" in created else created],
+                ["Last Updated:", updated.split("T")[0] if "T" in updated else updated],
             ]
-            
-            metadata_table = Table(metadata, colWidths=[2*inch, 4*inch])
-            metadata_table.setStyle(TableStyle([
-                ('BACKGROUND', (0, 0), (0, -1), colors.HexColor('#ecf0f1')),
-                ('TEXTCOLOR', (0, 0), (-1, -1), colors.black),
-                ('ALIGN', (0, 0), (0, -1), 'LEFT'),
-                ('ALIGN', (1, 0), (1, -1), 'LEFT'),
-                ('FONTNAME', (0, 0), (0, -1), 'Helvetica-Bold'),
-                ('FONTNAME', (1, 0), (1, -1), 'Helvetica'),
-                ('FONTSIZE', (0, 0), (-1, -1), 10),
-                ('BOTTOMPADDING', (0, 0), (-1, -1), 6),
-                ('TOPPADDING', (0, 0), (-1, -1), 6),
-                ('GRID', (0, 0), (-1, -1), 1, colors.grey),
-            ]))
+
+            metadata_table = Table(metadata, colWidths=[2 * inch, 4 * inch])
+            metadata_table.setStyle(
+                TableStyle(
+                    [
+                        ("BACKGROUND", (0, 0), (0, -1), colors.HexColor("#ecf0f1")),
+                        ("TEXTCOLOR", (0, 0), (-1, -1), colors.black),
+                        ("ALIGN", (0, 0), (0, -1), "LEFT"),
+                        ("ALIGN", (1, 0), (1, -1), "LEFT"),
+                        ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
+                        ("FONTNAME", (1, 0), (1, -1), "Helvetica"),
+                        ("FONTSIZE", (0, 0), (-1, -1), 10),
+                        ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                        ("TOPPADDING", (0, 0), (-1, -1), 6),
+                        ("GRID", (0, 0), (-1, -1), 1, colors.grey),
+                    ]
+                )
+            )
             story.append(metadata_table)
-            story.append(Spacer(1, 0.3*inch))
-            
+            story.append(Spacer(1, 0.3 * inch))
+
             # Description
-            description = case.get('description', 'No description provided.')
-            story.append(Paragraph("Description", self.styles['CustomHeading']))
-            story.append(Paragraph(description, self.styles['CustomBody']))
-            story.append(Spacer(1, 0.2*inch))
-            
+            description = case.get("description", "No description provided.")
+            story.append(Paragraph("Description", self.styles["CustomHeading"]))
+            story.append(Paragraph(description, self.styles["CustomBody"]))
+            story.append(Spacer(1, 0.2 * inch))
+
             # Tags
-            tags = case.get('tags', [])
+            tags = case.get("tags", [])
             if tags:
-                story.append(Paragraph("Tags", self.styles['CustomHeading']))
+                story.append(Paragraph("Tags", self.styles["CustomHeading"]))
                 tags_text = ", ".join(tags)
-                story.append(Paragraph(tags_text, self.styles['CustomBody']))
-                story.append(Spacer(1, 0.2*inch))
-            
+                story.append(Paragraph(tags_text, self.styles["CustomBody"]))
+                story.append(Spacer(1, 0.2 * inch))
+
             # Timeline
-            timeline = case.get('timeline', [])
+            timeline = case.get("timeline", [])
             if timeline:
-                story.append(Paragraph("Timeline", self.styles['CustomHeading']))
+                story.append(Paragraph("Timeline", self.styles["CustomHeading"]))
                 timeline_data = [["Timestamp", "Event"]]
                 for event in timeline:
-                    timestamp = event.get('timestamp', 'N/A')
-                    if 'T' in timestamp:
-                        timestamp = timestamp.split('T')[0] + ' ' + timestamp.split('T')[1].split('.')[0]
-                    timeline_data.append([timestamp, event.get('event', 'N/A')])
-                
-                timeline_table = Table(timeline_data, colWidths=[2.5*inch, 3.5*inch])
-                timeline_table.setStyle(TableStyle([
-                    ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#3498db')),
-                    ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-                    ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
-                    ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-                    ('FONTSIZE', (0, 0), (-1, 0), 10),
-                    ('BACKGROUND', (0, 1), (-1, -1), colors.white),
-                    ('GRID', (0, 0), (-1, -1), 1, colors.grey),
-                ]))
+                    timestamp = event.get("timestamp", "N/A")
+                    if "T" in timestamp:
+                        timestamp = (
+                            timestamp.split("T")[0]
+                            + " "
+                            + timestamp.split("T")[1].split(".")[0]
+                        )
+                    timeline_data.append([timestamp, event.get("event", "N/A")])
+
+                timeline_table = Table(
+                    timeline_data, colWidths=[2.5 * inch, 3.5 * inch]
+                )
+                timeline_table.setStyle(
+                    TableStyle(
+                        [
+                            ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#3498db")),
+                            ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                            ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                            ("FONTSIZE", (0, 0), (-1, 0), 10),
+                            ("BACKGROUND", (0, 1), (-1, -1), colors.white),
+                            ("GRID", (0, 0), (-1, -1), 1, colors.grey),
+                        ]
+                    )
+                )
                 story.append(timeline_table)
-                story.append(Spacer(1, 0.2*inch))
-            
+                story.append(Spacer(1, 0.2 * inch))
+
             # Notes
-            notes = case.get('notes', [])
+            notes = case.get("notes", [])
             if notes:
-                story.append(Paragraph("Investigation Notes", self.styles['CustomHeading']))
+                story.append(
+                    Paragraph("Investigation Notes", self.styles["CustomHeading"])
+                )
                 for note in notes:
-                    note_text = note.get('text', note.get('content', 'N/A'))
-                    note_timestamp = note.get('timestamp', 'N/A')
-                    if 'T' in note_timestamp:
-                        note_timestamp = note_timestamp.split('T')[0]
-                    story.append(Paragraph(f"<b>{note_timestamp}:</b> {note_text}", self.styles['CustomBody']))
-                    story.append(Spacer(1, 0.1*inch))
-                story.append(Spacer(1, 0.2*inch))
-            
+                    note_text = note.get("text", note.get("content", "N/A"))
+                    note_timestamp = note.get("timestamp", "N/A")
+                    if "T" in note_timestamp:
+                        note_timestamp = note_timestamp.split("T")[0]
+                    story.append(
+                        Paragraph(
+                            f"<b>{note_timestamp}:</b> {note_text}",
+                            self.styles["CustomBody"],
+                        )
+                    )
+                    story.append(Spacer(1, 0.1 * inch))
+                story.append(Spacer(1, 0.2 * inch))
+
             # Activities
-            activities = case.get('activities', [])
+            activities = case.get("activities", [])
             if activities:
-                story.append(Paragraph("Case Activities", self.styles['CustomHeading']))
+                story.append(Paragraph("Case Activities", self.styles["CustomHeading"]))
                 activities_data = [["Timestamp", "Type", "Description"]]
                 for activity in activities:
-                    timestamp = activity.get('timestamp', 'N/A')
-                    if 'T' in timestamp:
-                        timestamp = timestamp.split('T')[0] + ' ' + timestamp.split('T')[1].split('.')[0]
-                    activity_type = activity.get('activity_type', 'N/A').replace('_', ' ').title()
-                    description = activity.get('description', 'N/A')[:100]
+                    timestamp = activity.get("timestamp", "N/A")
+                    if "T" in timestamp:
+                        timestamp = (
+                            timestamp.split("T")[0]
+                            + " "
+                            + timestamp.split("T")[1].split(".")[0]
+                        )
+                    activity_type = (
+                        activity.get("activity_type", "N/A").replace("_", " ").title()
+                    )
+                    description = activity.get("description", "N/A")[:100]
                     activities_data.append([timestamp, activity_type, description])
-                
-                activities_table = Table(activities_data, colWidths=[2*inch, 1.5*inch, 2.5*inch])
-                activities_table.setStyle(TableStyle([
-                    ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#9b59b6')),
-                    ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-                    ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
-                    ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-                    ('FONTSIZE', (0, 0), (-1, 0), 10),
-                    ('BACKGROUND', (0, 1), (-1, -1), colors.white),
-                    ('GRID', (0, 0), (-1, -1), 1, colors.grey),
-                    ('FONTSIZE', (0, 1), (-1, -1), 9),
-                ]))
+
+                activities_table = Table(
+                    activities_data, colWidths=[2 * inch, 1.5 * inch, 2.5 * inch]
+                )
+                activities_table.setStyle(
+                    TableStyle(
+                        [
+                            ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#9b59b6")),
+                            ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                            ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                            ("FONTSIZE", (0, 0), (-1, 0), 10),
+                            ("BACKGROUND", (0, 1), (-1, -1), colors.white),
+                            ("GRID", (0, 0), (-1, -1), 1, colors.grey),
+                            ("FONTSIZE", (0, 1), (-1, -1), 9),
+                        ]
+                    )
+                )
                 story.append(activities_table)
-                story.append(Spacer(1, 0.2*inch))
-            
+                story.append(Spacer(1, 0.2 * inch))
+
             # Resolution Steps
-            resolution_steps = case.get('resolution_steps', [])
+            resolution_steps = case.get("resolution_steps", [])
             if resolution_steps:
-                story.append(Paragraph("Resolution Steps", self.styles['CustomHeading']))
+                story.append(
+                    Paragraph("Resolution Steps", self.styles["CustomHeading"])
+                )
                 for i, step in enumerate(resolution_steps, 1):
-                    story.append(Paragraph(f"Step {i}: {step.get('description', 'N/A')}", 
-                                          self.styles['CustomSubheading']))
-                    
+                    story.append(
+                        Paragraph(
+                            f"Step {i}: {step.get('description', 'N/A')}",
+                            self.styles["CustomSubheading"],
+                        )
+                    )
+
                     step_info = [
                         ["Field", "Value"],
-                        ["Timestamp", step.get('timestamp', 'N/A')],
-                        ["Action Taken", step.get('action_taken', 'N/A')],
+                        ["Timestamp", step.get("timestamp", "N/A")],
+                        ["Action Taken", step.get("action_taken", "N/A")],
                     ]
-                    
-                    result = step.get('result', '')
+
+                    result = step.get("result", "")
                     if result:
                         step_info.append(["Result", result])
-                    
-                    step_table = Table(step_info, colWidths=[2*inch, 4*inch])
-                    step_table.setStyle(TableStyle([
-                        ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#27ae60')),
-                        ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-                        ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
-                        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-                        ('FONTSIZE', (0, 0), (-1, 0), 10),
-                        ('BACKGROUND', (0, 1), (-1, -1), colors.white),
-                        ('GRID', (0, 0), (-1, -1), 1, colors.grey),
-                        ('FONTSIZE', (0, 1), (-1, -1), 9),
-                    ]))
+
+                    step_table = Table(step_info, colWidths=[2 * inch, 4 * inch])
+                    step_table.setStyle(
+                        TableStyle(
+                            [
+                                (
+                                    "BACKGROUND",
+                                    (0, 0),
+                                    (-1, 0),
+                                    colors.HexColor("#27ae60"),
+                                ),
+                                ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                                ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                                ("FONTSIZE", (0, 0), (-1, 0), 10),
+                                ("BACKGROUND", (0, 1), (-1, -1), colors.white),
+                                ("GRID", (0, 0), (-1, -1), 1, colors.grey),
+                                ("FONTSIZE", (0, 1), (-1, -1), 9),
+                            ]
+                        )
+                    )
                     story.append(step_table)
-                    story.append(Spacer(1, 0.15*inch))
-                story.append(Spacer(1, 0.2*inch))
-            
+                    story.append(Spacer(1, 0.15 * inch))
+                story.append(Spacer(1, 0.2 * inch))
+
             # Findings
-            story.append(Paragraph(f"Related Findings ({len(findings)})", self.styles['CustomHeading']))
-            
+            story.append(
+                Paragraph(
+                    f"Related Findings ({len(findings)})", self.styles["CustomHeading"]
+                )
+            )
+
             if findings:
-                findings_data = [["Finding ID", "Severity", "Data Source", "Anomaly Score", "MITRE Techniques"]]
+                findings_data = [
+                    [
+                        "Finding ID",
+                        "Severity",
+                        "Data Source",
+                        "Anomaly Score",
+                        "MITRE Techniques",
+                    ]
+                ]
                 for finding in findings:
-                    finding_id = finding.get('finding_id', 'N/A')
-                    severity = finding.get('severity', 'N/A')
-                    data_source = finding.get('data_source', 'N/A')
+                    finding_id = finding.get("finding_id", "N/A")
+                    severity = finding.get("severity", "N/A")
+                    data_source = finding.get("data_source", "N/A")
                     anomaly_score = f"{float(finding.get('anomaly_score') or 0):.3f}"
-                    
+
                     # Get top MITRE techniques
-                    mitre_preds = finding.get('mitre_predictions') or {}
+                    mitre_preds = finding.get("mitre_predictions") or {}
                     if mitre_preds:
-                        top_techs = sorted(mitre_preds.items(), key=lambda x: float(x[1] or 0), reverse=True)[:3]
+                        top_techs = sorted(
+                            mitre_preds.items(),
+                            key=lambda x: float(x[1] or 0),
+                            reverse=True,
+                        )[:3]
                         tech_str = ", ".join([t[0] for t in top_techs])
                     else:
                         tech_str = "None"
-                    
-                    findings_data.append([finding_id, severity, data_source, anomaly_score, tech_str])
-                
-                findings_table = Table(findings_data, colWidths=[1.5*inch, 1*inch, 1*inch, 1*inch, 1.5*inch])
-                findings_table.setStyle(TableStyle([
-                    ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#e74c3c')),
-                    ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-                    ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
-                    ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-                    ('FONTSIZE', (0, 0), (-1, 0), 9),
-                    ('BACKGROUND', (0, 1), (-1, -1), colors.white),
-                    ('GRID', (0, 0), (-1, -1), 1, colors.grey),
-                    ('FONTSIZE', (0, 1), (-1, -1), 8),
-                    ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.white, colors.HexColor('#f8f9fa')]),
-                ]))
+
+                    findings_data.append(
+                        [finding_id, severity, data_source, anomaly_score, tech_str]
+                    )
+
+                findings_table = Table(
+                    findings_data,
+                    colWidths=[1.5 * inch, 1 * inch, 1 * inch, 1 * inch, 1.5 * inch],
+                )
+                findings_table.setStyle(
+                    TableStyle(
+                        [
+                            ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e74c3c")),
+                            ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                            ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                            ("FONTSIZE", (0, 0), (-1, 0), 9),
+                            ("BACKGROUND", (0, 1), (-1, -1), colors.white),
+                            ("GRID", (0, 0), (-1, -1), 1, colors.grey),
+                            ("FONTSIZE", (0, 1), (-1, -1), 8),
+                            (
+                                "ROWBACKGROUNDS",
+                                (0, 1),
+                                (-1, -1),
+                                [colors.white, colors.HexColor("#f8f9fa")],
+                            ),
+                        ]
+                    )
+                )
                 story.append(findings_table)
                 story.append(PageBreak())
-                
+
                 # Detailed findings
-                story.append(Paragraph("Finding Details", self.styles['CustomHeading']))
-                
+                story.append(Paragraph("Finding Details", self.styles["CustomHeading"]))
+
                 for i, finding in enumerate(findings, 1):
-                    story.append(Paragraph(f"Finding {i}: {finding.get('finding_id', 'N/A')}", 
-                                          self.styles['CustomSubheading']))
-                    
+                    story.append(
+                        Paragraph(
+                            f"Finding {i}: {finding.get('finding_id', 'N/A')}",
+                            self.styles["CustomSubheading"],
+                        )
+                    )
+
                     finding_info = [
                         ["Field", "Value"],
-                        ["Finding ID", finding.get('finding_id', 'N/A')],
-                        ["Timestamp", finding.get('timestamp', 'N/A')],
-                        ["Severity", finding.get('severity', 'N/A')],
-                        ["Data Source", finding.get('data_source', 'N/A')],
+                        ["Finding ID", finding.get("finding_id", "N/A")],
+                        ["Timestamp", finding.get("timestamp", "N/A")],
+                        ["Severity", finding.get("severity", "N/A")],
+                        ["Data Source", finding.get("data_source", "N/A")],
                         ["Anomaly Score", f"{finding.get('anomaly_score', 0):.3f}"],
-                        ["Cluster ID", finding.get('cluster_id', 'None')],
+                        ["Cluster ID", finding.get("cluster_id", "None")],
                     ]
-                    
+
                     # Entity context
-                    entity_context = finding.get('entity_context') or {}
+                    entity_context = finding.get("entity_context") or {}
                     if entity_context:
                         for key, value in entity_context.items():
                             finding_info.append([f"Entity: {key}", str(value)])
-                    
+
                     # MITRE techniques
-                    mitre_preds = finding.get('mitre_predictions') or {}
+                    mitre_preds = finding.get("mitre_predictions") or {}
                     if mitre_preds:
-                        for tech_id, confidence in sorted(mitre_preds.items(), key=lambda x: float(x[1] or 0), reverse=True)[:10]:
-                            finding_info.append([f"MITRE: {tech_id}", f"{float(confidence or 0):.3f}"])
-                    
-                    finding_table = Table(finding_info, colWidths=[2*inch, 4*inch])
-                    finding_table.setStyle(TableStyle([
-                        ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#95a5a6')),
-                        ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-                        ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
-                        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-                        ('FONTSIZE', (0, 0), (-1, 0), 9),
-                        ('BACKGROUND', (0, 1), (-1, -1), colors.white),
-                        ('GRID', (0, 0), (-1, -1), 1, colors.grey),
-                        ('FONTSIZE', (0, 1), (-1, -1), 8),
-                    ]))
+                        for tech_id, confidence in sorted(
+                            mitre_preds.items(),
+                            key=lambda x: float(x[1] or 0),
+                            reverse=True,
+                        )[:10]:
+                            finding_info.append(
+                                [f"MITRE: {tech_id}", f"{float(confidence or 0):.3f}"]
+                            )
+
+                    finding_table = Table(finding_info, colWidths=[2 * inch, 4 * inch])
+                    finding_table.setStyle(
+                        TableStyle(
+                            [
+                                (
+                                    "BACKGROUND",
+                                    (0, 0),
+                                    (-1, 0),
+                                    colors.HexColor("#95a5a6"),
+                                ),
+                                ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                                ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                                ("FONTSIZE", (0, 0), (-1, 0), 9),
+                                ("BACKGROUND", (0, 1), (-1, -1), colors.white),
+                                ("GRID", (0, 0), (-1, -1), 1, colors.grey),
+                                ("FONTSIZE", (0, 1), (-1, -1), 8),
+                            ]
+                        )
+                    )
                     story.append(finding_table)
-                    story.append(Spacer(1, 0.1*inch))
+                    story.append(Spacer(1, 0.1 * inch))
             else:
-                story.append(Paragraph("No findings associated with this case.", self.styles['CustomBody']))
-            
+                story.append(
+                    Paragraph(
+                        "No findings associated with this case.",
+                        self.styles["CustomBody"],
+                    )
+                )
+
             # Build PDF
             doc.build(story)
             logger.info(f"Generated case report: {output_path}")
             return True
-        
+
         except Exception as e:
             logger.error(f"Error generating case report: {e}", exc_info=True)
             return False
-    
-    def generate_investigation_chat_report(self, output_path: Path, tab_title: str,
-                                          conversation_history: List[Dict], 
-                                          focused_findings: List[Dict] = None,
-                                          notes: str = None) -> bool:
+
+    def generate_investigation_chat_report(
+        self,
+        output_path: Path,
+        tab_title: str,
+        conversation_history: List[Dict],
+        focused_findings: List[Dict] = None,
+        notes: str = None,
+    ) -> bool:
         """
         Generate a PDF report for an investigation chat/conversation.
-        
+
         Args:
             output_path: Path to save the PDF file.
             tab_title: Title of the investigation tab.
             conversation_history: List of conversation messages (role, content).
             focused_findings: Optional list of findings being investigated.
             notes: Optional investigation notes.
-        
+
         Returns:
             True if successful, False otherwise.
         """
         try:
-            doc = SimpleDocTemplate(str(output_path), pagesize=letter,
-                                   rightMargin=72, leftMargin=72,
-                                   topMargin=72, bottomMargin=18)
+            doc = SimpleDocTemplate(
+                str(output_path),
+                pagesize=letter,
+                rightMargin=72,
+                leftMargin=72,
+                topMargin=72,
+                bottomMargin=18,
+            )
             story = []
-            
+
             # Title
-            story.append(Paragraph(f"Investigation Report: {tab_title}", self.styles['CustomTitle']))
-            story.append(Spacer(1, 0.2*inch))
-            
+            story.append(
+                Paragraph(
+                    f"Investigation Report: {tab_title}", self.styles["CustomTitle"]
+                )
+            )
+            story.append(Spacer(1, 0.2 * inch))
+
             # Report metadata
             report_date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             metadata = [
@@ -364,112 +501,147 @@ class ReportService:
                 ["Investigation:", tab_title],
                 ["Total Messages:", str(len(conversation_history))],
             ]
-            
+
             if focused_findings:
                 metadata.append(["Focused Findings:", str(len(focused_findings))])
-            
-            metadata_table = Table(metadata, colWidths=[2*inch, 4*inch])
-            metadata_table.setStyle(TableStyle([
-                ('BACKGROUND', (0, 0), (0, -1), colors.HexColor('#ecf0f1')),
-                ('TEXTCOLOR', (0, 0), (-1, -1), colors.black),
-                ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
-                ('FONTNAME', (0, 0), (0, -1), 'Helvetica-Bold'),
-                ('FONTSIZE', (0, 0), (-1, -1), 10),
-                ('BOTTOMPADDING', (0, 0), (-1, -1), 6),
-                ('TOPPADDING', (0, 0), (-1, -1), 6),
-                ('GRID', (0, 0), (-1, -1), 1, colors.grey),
-            ]))
+
+            metadata_table = Table(metadata, colWidths=[2 * inch, 4 * inch])
+            metadata_table.setStyle(
+                TableStyle(
+                    [
+                        ("BACKGROUND", (0, 0), (0, -1), colors.HexColor("#ecf0f1")),
+                        ("TEXTCOLOR", (0, 0), (-1, -1), colors.black),
+                        ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                        ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
+                        ("FONTSIZE", (0, 0), (-1, -1), 10),
+                        ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                        ("TOPPADDING", (0, 0), (-1, -1), 6),
+                        ("GRID", (0, 0), (-1, -1), 1, colors.grey),
+                    ]
+                )
+            )
             story.append(metadata_table)
-            story.append(Spacer(1, 0.3*inch))
-            
+            story.append(Spacer(1, 0.3 * inch))
+
             # Investigation Notes
             if notes and notes.strip():
-                story.append(Paragraph("Investigation Notes", self.styles['CustomHeading']))
+                story.append(
+                    Paragraph("Investigation Notes", self.styles["CustomHeading"])
+                )
                 # Escape HTML entities in notes
-                notes_escaped = notes.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
-                story.append(Paragraph(notes_escaped, self.styles['CustomBody']))
-                story.append(Spacer(1, 0.2*inch))
-            
+                notes_escaped = (
+                    notes.replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;")
+                )
+                story.append(Paragraph(notes_escaped, self.styles["CustomBody"]))
+                story.append(Spacer(1, 0.2 * inch))
+
             # Focused Findings Summary
             if focused_findings:
-                story.append(Paragraph(f"Focused Findings ({len(focused_findings)})", 
-                                      self.styles['CustomHeading']))
-                
-                findings_data = [["Finding ID", "Severity", "Data Source", "Anomaly Score"]]
+                story.append(
+                    Paragraph(
+                        f"Focused Findings ({len(focused_findings)})",
+                        self.styles["CustomHeading"],
+                    )
+                )
+
+                findings_data = [
+                    ["Finding ID", "Severity", "Data Source", "Anomaly Score"]
+                ]
                 for finding in focused_findings:
-                    findings_data.append([
-                        finding.get('finding_id', 'N/A'),
-                        finding.get('severity', 'N/A'),
-                        finding.get('data_source', 'N/A'),
-                        f"{finding.get('anomaly_score', 0):.3f}"
-                    ])
-                
-                findings_table = Table(findings_data, colWidths=[2*inch, 1.5*inch, 1.5*inch, 1*inch])
-                findings_table.setStyle(TableStyle([
-                    ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#e74c3c')),
-                    ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-                    ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
-                    ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-                    ('FONTSIZE', (0, 0), (-1, 0), 10),
-                    ('BACKGROUND', (0, 1), (-1, -1), colors.white),
-                    ('GRID', (0, 0), (-1, -1), 1, colors.grey),
-                    ('FONTSIZE', (0, 1), (-1, -1), 9),
-                ]))
+                    findings_data.append(
+                        [
+                            finding.get("finding_id", "N/A"),
+                            finding.get("severity", "N/A"),
+                            finding.get("data_source", "N/A"),
+                            f"{finding.get('anomaly_score', 0):.3f}",
+                        ]
+                    )
+
+                findings_table = Table(
+                    findings_data,
+                    colWidths=[2 * inch, 1.5 * inch, 1.5 * inch, 1 * inch],
+                )
+                findings_table.setStyle(
+                    TableStyle(
+                        [
+                            ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e74c3c")),
+                            ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                            ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                            ("FONTSIZE", (0, 0), (-1, 0), 10),
+                            ("BACKGROUND", (0, 1), (-1, -1), colors.white),
+                            ("GRID", (0, 0), (-1, -1), 1, colors.grey),
+                            ("FONTSIZE", (0, 1), (-1, -1), 9),
+                        ]
+                    )
+                )
                 story.append(findings_table)
-                story.append(Spacer(1, 0.2*inch))
-            
+                story.append(Spacer(1, 0.2 * inch))
+
             # Chat Conversation
-            story.append(Paragraph("Chat Conversation", self.styles['CustomHeading']))
-            story.append(Spacer(1, 0.1*inch))
-            
+            story.append(Paragraph("Chat Conversation", self.styles["CustomHeading"]))
+            story.append(Spacer(1, 0.1 * inch))
+
             for i, message in enumerate(conversation_history, 1):
-                role = message.get('role', 'unknown')
-                content = message.get('content', '')
-                
+                role = message.get("role", "unknown")
+                content = message.get("content", "")
+
                 # Escape HTML entities in content
-                content_escaped = content.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
-                
+                content_escaped = (
+                    content.replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;")
+                )
+
                 # Truncate very long messages
                 if len(content_escaped) > 5000:
-                    content_escaped = content_escaped[:5000] + "\n\n[... message truncated for PDF ...]"
-                
+                    content_escaped = (
+                        content_escaped[:5000]
+                        + "\n\n[... message truncated for PDF ...]"
+                    )
+
                 # Style by role
-                if role == 'user':
-                    role_color = '#2196F3'
-                    role_label = '👤 User'
-                elif role == 'assistant':
-                    role_color = '#4CAF50'
-                    role_label = '🤖 Assistant'
+                if role == "user":
+                    role_color = "#2196F3"
+                    role_label = "👤 User"
+                elif role == "assistant":
+                    role_color = "#4CAF50"
+                    role_label = "🤖 Assistant"
                 else:
-                    role_color = '#9E9E9E'
+                    role_color = "#9E9E9E"
                     role_label = role.capitalize()
-                
+
                 # Message header
-                story.append(Paragraph(
-                    f"<b><font color='{role_color}'>{role_label} (Message {i})</font></b>",
-                    self.styles['CustomSubheading']
-                ))
-                
+                story.append(
+                    Paragraph(
+                        f"<b><font color='{role_color}'>{role_label} (Message {i})</font></b>",
+                        self.styles["CustomSubheading"],
+                    )
+                )
+
                 # Message content - split into paragraphs for better formatting
-                paragraphs = content_escaped.split('\n\n')
+                paragraphs = content_escaped.split("\n\n")
                 for para in paragraphs:
                     if para.strip():
                         # Replace single newlines with spaces
-                        para_clean = para.replace('\n', ' ').strip()
-                        story.append(Paragraph(para_clean, self.styles['CustomBody']))
-                
-                story.append(Spacer(1, 0.15*inch))
-                
+                        para_clean = para.replace("\n", " ").strip()
+                        story.append(Paragraph(para_clean, self.styles["CustomBody"]))
+
+                story.append(Spacer(1, 0.15 * inch))
+
                 # Page break every 5 messages to avoid overly long pages
                 if i % 5 == 0 and i < len(conversation_history):
                     story.append(PageBreak())
-            
+
             # Build PDF
             doc.build(story)
             logger.info(f"Generated investigation chat report: {output_path}")
             return True
-        
-        except Exception as e:
-            logger.error(f"Error generating investigation chat report: {e}", exc_info=True)
-            return False
 
+        except Exception as e:
+            logger.error(
+                f"Error generating investigation chat report: {e}", exc_info=True
+            )
+            return False

--- a/core/response/approvals_router.py
+++ b/core/response/approvals_router.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
+
 from core.deps import provide_approvals, provide_workflows
 from core.response.approval_service import ApprovalService
 from core.routing import Auth, RouterMeta

--- a/core/response/autonomous_response_service.py
+++ b/core/response/autonomous_response_service.py
@@ -2,8 +2,8 @@
 
 import asyncio
 import logging
-from typing import Dict, List, Optional, Callable, Any
 from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
 
 from core.agents.builtins import AgentId
 from core.response.approval_service import ActionType, ApprovalService
@@ -17,7 +17,7 @@ EscalationCallback = Callable[[Dict[str, Any], str, str], None]
 
 class AutonomousResponseService:
     """Service for managing autonomous threat response with approval workflow."""
-    
+
     def __init__(self, approvals: Optional[ApprovalService] = None):
         """Initialize autonomous response service."""
         self.approval_service = approvals or ApprovalService()
@@ -27,56 +27,66 @@ class AutonomousResponseService:
         """Register a callback for escalation events."""
         self._escalation_callbacks.append(callback)
         logger.info(f"Registered escalation callback: {callback.__name__}")
-    
+
     def unregister_escalation_callback(self, callback: EscalationCallback):
         """Unregister an escalation callback."""
         if callback in self._escalation_callbacks:
             self._escalation_callbacks.remove(callback)
             logger.info(f"Unregistered escalation callback: {callback.__name__}")
-    
-    def _trigger_escalation(self, data: Dict[str, Any], severity: str, action_type: str):
+
+    def _trigger_escalation(
+        self, data: Dict[str, Any], severity: str, action_type: str
+    ):
         """Trigger all registered escalation callbacks."""
         for callback in self._escalation_callbacks:
             try:
                 callback(data, severity, action_type)
             except Exception as e:
                 logger.error(f"Escalation callback error: {e}")
-    
-    async def escalate_to_slack(self, message: str, severity: str, channel: Optional[str] = None):
+
+    async def escalate_to_slack(
+        self, message: str, severity: str, channel: Optional[str] = None
+    ):
         """Send escalation to Slack channel."""
         try:
-            from core.config import get_integration_config
             import httpx
 
-            config = get_integration_config('slack')
-            token = config.get('bot_token')
-            
+            from core.config import get_integration_config
+
+            config = get_integration_config("slack")
+            token = config.get("bot_token")
+
             if not token:
                 logger.warning("Slack not configured for escalation")
                 return False
-            
-            target_channel = channel or config.get('default_channel', '#soc-alerts')
+
+            target_channel = channel or config.get("default_channel", "#soc-alerts")
             color_map = {
                 "critical": "#ff0000",
                 "high": "#ff9900",
                 "medium": "#ffcc00",
-                "low": "#36a64f"
+                "low": "#36a64f",
             }
-            
+
             # Blocking POST inside an async method — offload it.
             response = await asyncio.to_thread(
                 httpx.post,
                 "https://slack.com/api/chat.postMessage",
-                headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
                 json={
                     "channel": target_channel,
-                    "attachments": [{
-                        "color": color_map.get(severity.lower(), "#808080"),
-                        "title": f"🚨 SOC Alert - {severity.upper()}",
-                        "text": message,
-                        "footer": "AI-SOC Autonomous Response",
-                        "ts": datetime.utcnow().timestamp()
-                    }]
+                    "attachments": [
+                        {
+                            "color": color_map.get(severity.lower(), "#808080"),
+                            "title": f"🚨 SOC Alert - {severity.upper()}",
+                            "text": message,
+                            "footer": "AI-SOC Autonomous Response",
+                            "ts": datetime.utcnow().timestamp(),
+                        }
+                    ],
                 },
                 timeout=30,
                 # requests followed redirects by default; httpx does not.
@@ -89,31 +99,32 @@ class AutonomousResponseService:
             else:
                 logger.warning(f"Slack escalation failed: {response.text}")
                 return False
-                
+
         except Exception as e:
             logger.error(f"Slack escalation error: {e}")
             return False
-    
+
     async def escalate_to_pagerduty(self, title: str, details: str, severity: str):
         """Send escalation to PagerDuty."""
         try:
-            from core.config import get_integration_config
             import httpx
 
-            config = get_integration_config('pagerduty')
-            routing_key = config.get('routing_key') or config.get('integration_key')
-            
+            from core.config import get_integration_config
+
+            config = get_integration_config("pagerduty")
+            routing_key = config.get("routing_key") or config.get("integration_key")
+
             if not routing_key:
                 logger.warning("PagerDuty not configured for escalation")
                 return False
-            
+
             severity_map = {
                 "critical": "critical",
                 "high": "error",
                 "medium": "warning",
-                "low": "info"
+                "low": "info",
             }
-            
+
             # Blocking POST inside an async method — offload it.
             response = await asyncio.to_thread(
                 httpx.post,
@@ -125,14 +136,14 @@ class AutonomousResponseService:
                         "summary": title,
                         "source": "ai-soc-autonomous-response",
                         "severity": severity_map.get(severity.lower(), "warning"),
-                        "custom_details": {"details": details}
-                    }
+                        "custom_details": {"details": details},
+                    },
                 },
                 timeout=30,
                 # requests followed redirects by default; httpx does not.
                 follow_redirects=True,
             )
-            
+
             data = response.json()
             if data.get("status") == "success":
                 logger.info(f"PagerDuty alert triggered: {data.get('dedup_key')}")
@@ -140,25 +151,25 @@ class AutonomousResponseService:
             else:
                 logger.warning(f"PagerDuty escalation failed: {data}")
                 return False
-                
+
         except Exception as e:
             logger.error(f"PagerDuty escalation error: {e}")
             return False
-    
+
     async def escalate_action(
         self,
         action_data: Dict[str, Any],
         severity: str,
-        channels: Optional[List[str]] = None
+        channels: Optional[List[str]] = None,
     ):
         """Escalate an action through configured channels."""
         channels = channels or ["slack", "pagerduty"]
-        
+
         title = action_data.get("title", "Autonomous Response Action")
         description = action_data.get("description", "")
         target = action_data.get("target", "unknown")
         confidence = action_data.get("confidence", 0)
-        
+
         message = f"""
 **Action Required:** {title}
 **Target:** {target}
@@ -169,35 +180,37 @@ class AutonomousResponseService:
 
 Please review and approve/reject in the SOC dashboard.
 """.strip()
-        
+
         results = {}
-        
+
         if "slack" in channels:
             results["slack"] = await self.escalate_to_slack(message, severity)
-        
+
         if "pagerduty" in channels and severity in ["critical", "high"]:
-            results["pagerduty"] = await self.escalate_to_pagerduty(title, message, severity)
-        
+            results["pagerduty"] = await self.escalate_to_pagerduty(
+                title, message, severity
+            )
+
         # Trigger callbacks
         self._trigger_escalation(action_data, severity, "escalate_action")
-        
+
         logger.info(f"Escalation results for {target}: {results}")
         return results
-    
+
     def correlate_alerts(
         self,
         tempo_flow_alert: Optional[Dict] = None,
         crowdstrike_alert: Optional[Dict] = None,
-        splunk_results: Optional[List[Dict]] = None
+        splunk_results: Optional[List[Dict]] = None,
     ) -> Dict:
         """
         Correlate alerts from multiple sources and calculate confidence score.
-        
+
         Args:
             tempo_flow_alert: Alert from Tempo Flow
             crowdstrike_alert: Alert from CrowdStrike
             splunk_results: Results from Splunk queries
-        
+
         Returns:
             Correlation result with confidence score and reasoning
         """
@@ -205,81 +218,87 @@ Please review and approve/reject in the SOC dashboard.
         evidence = []
         indicators = []
         reasoning = []
-        
+
         # Correlate Tempo Flow alerts
         if tempo_flow_alert:
-            evidence.append(f"Tempo Flow: {tempo_flow_alert.get('finding_id', 'unknown')}")
-            
-            severity = tempo_flow_alert.get('severity', '').lower()
-            if severity in ['high', 'critical']:
+            evidence.append(
+                f"Tempo Flow: {tempo_flow_alert.get('finding_id', 'unknown')}"
+            )
+
+            severity = tempo_flow_alert.get("severity", "").lower()
+            if severity in ["high", "critical"]:
                 confidence += 0.15
                 reasoning.append(f"High severity detection in Tempo Flow ({severity})")
-            
+
             # Check for specific attack patterns
-            mitre_predictions = tempo_flow_alert.get('mitre_predictions', {})
-            if any(t.startswith('T1486') for t in mitre_predictions):  # Ransomware
+            mitre_predictions = tempo_flow_alert.get("mitre_predictions", {})
+            if any(t.startswith("T1486") for t in mitre_predictions):  # Ransomware
                 confidence += 0.25
                 reasoning.append("Ransomware behavior detected (T1486)")
                 indicators.append("ransomware")
-            
-            if any(t.startswith('T1071') for t in mitre_predictions):  # C2
+
+            if any(t.startswith("T1071") for t in mitre_predictions):  # C2
                 confidence += 0.20
                 reasoning.append("C2 communication detected (T1071)")
                 indicators.append("c2_communication")
-            
-            if any(t.startswith('T1021') for t in mitre_predictions):  # Lateral movement
+
+            if any(
+                t.startswith("T1021") for t in mitre_predictions
+            ):  # Lateral movement
                 confidence += 0.15
                 reasoning.append("Lateral movement detected (T1021)")
                 indicators.append("lateral_movement")
-        
+
         # Correlate CrowdStrike alerts
         if crowdstrike_alert:
-            cs_alerts = crowdstrike_alert.get('alerts', [])
+            cs_alerts = crowdstrike_alert.get("alerts", [])
             if cs_alerts:
                 evidence.append(f"CrowdStrike: {len(cs_alerts)} alert(s)")
-                
+
                 for alert in cs_alerts:
-                    severity = alert.get('severity', '').lower()
-                    if severity == 'critical':
+                    severity = alert.get("severity", "").lower()
+                    if severity == "critical":
                         confidence += 0.15
                         reasoning.append("Critical severity in CrowdStrike")
-                    
-                    detection_type = alert.get('detection_type', '').lower()
-                    if detection_type == 'malware':
+
+                    detection_type = alert.get("detection_type", "").lower()
+                    if detection_type == "malware":
                         confidence += 0.20
-                        reasoning.append(f"Malware detected: {alert.get('description', '')}")
+                        reasoning.append(
+                            f"Malware detected: {alert.get('description', '')}"
+                        )
                         indicators.append("malware")
-                    
+
                     # Check if already isolated
-                    if alert.get('isolated', False):
+                    if alert.get("isolated", False):
                         reasoning.append("Host already isolated in CrowdStrike")
-        
+
         # Correlate Splunk results
         if splunk_results and len(splunk_results) > 0:
             evidence.append(f"Splunk: {len(splunk_results)} event(s)")
-            
+
             # High volume of events indicates active threat
             if len(splunk_results) > 50:
                 confidence += 0.10
                 reasoning.append(f"High volume of events ({len(splunk_results)})")
-        
+
         # Time correlation bonus
         if tempo_flow_alert and crowdstrike_alert:
             # If alerts are within 5 minutes, add correlation bonus
             confidence += 0.10
             reasoning.append("Temporal correlation between multiple sources")
-        
+
         # Cap confidence at 1.0
         confidence = min(confidence, 1.0)
-        
+
         return {
             "confidence": confidence,
             "indicators": indicators,
             "evidence": evidence,
             "reasoning": reasoning,
-            "recommendation": self._get_recommendation(confidence, indicators)
+            "recommendation": self._get_recommendation(confidence, indicators),
         }
-    
+
     def _get_recommendation(self, confidence: float, indicators: List[str]) -> str:
         """Get recommendation based on confidence and indicators."""
         if confidence >= 0.90:
@@ -290,7 +309,7 @@ Please review and approve/reject in the SOC dashboard.
             return "MANUAL REVIEW: Moderate confidence, requires analyst review"
         else:
             return "MONITOR: Low confidence, continue monitoring"
-    
+
     def create_isolation_action(
         self,
         ip_address: str,
@@ -298,11 +317,11 @@ Please review and approve/reject in the SOC dashboard.
         confidence: float,
         reason: str,
         evidence: List[str],
-        correlation_data: Dict
+        correlation_data: Dict,
     ) -> Optional[Dict]:
         """
         Create an isolation action (auto-execute if confidence >= 0.90).
-        
+
         Args:
             ip_address: Target IP address
             hostname: Target hostname (optional)
@@ -310,7 +329,7 @@ Please review and approve/reject in the SOC dashboard.
             reason: Reason for isolation
             evidence: List of evidence IDs
             correlation_data: Data from correlation analysis
-        
+
         Returns:
             Action result
         """
@@ -320,41 +339,46 @@ Please review and approve/reject in the SOC dashboard.
                 action_type=ActionType.ISOLATE_HOST,
                 title=f"Isolate Host: {hostname or ip_address}",
                 description=f"Network isolation of compromised host based on correlated detections.\n\n"
-                           f"Indicators: {', '.join(correlation_data.get('indicators', []))}\n"
-                           f"Reasoning: {' | '.join(correlation_data.get('reasoning', []))}",
+                f"Indicators: {', '.join(correlation_data.get('indicators', []))}\n"
+                f"Reasoning: {' | '.join(correlation_data.get('reasoning', []))}",
                 target=ip_address,
                 confidence=confidence,
                 reason=reason,
                 evidence=evidence,
                 created_by=AgentId.AUTO_RESPONDER.value,
-                parameters={
-                    "hostname": hostname,
-                    "correlation": correlation_data
-                }
+                parameters={"hostname": hostname, "correlation": correlation_data},
             )
-            
+
             # Check if auto-approved (confidence >= 0.90)
             if action.status == "approved":
-                logger.info(f"Action {action.action_id} auto-approved (confidence: {confidence:.2%})")
-                
+                logger.info(
+                    f"Action {action.action_id} auto-approved (confidence: {confidence:.2%})"
+                )
+
                 # Execute isolation (would call actual CrowdStrike API in production)
-                execution_result = self._execute_isolation(ip_address, hostname, reason, confidence)
-                
+                execution_result = self._execute_isolation(
+                    ip_address, hostname, reason, confidence
+                )
+
                 # Mark as executed
                 self.approval_service.mark_executed(action.action_id, execution_result)
-                
+
                 return {
                     "status": "executed",
                     "action_id": action.action_id,
                     "message": f"Host {hostname or ip_address} isolated automatically",
                     "confidence": confidence,
-                    "result": execution_result
+                    "result": execution_result,
                 }
             else:
-                logger.info(f"Action {action.action_id} pending approval (confidence: {confidence:.2%})")
-                
+                logger.info(
+                    f"Action {action.action_id} pending approval (confidence: {confidence:.2%})"
+                )
+
                 # Trigger escalation for pending actions
-                severity = self._determine_severity_from_confidence(confidence, correlation_data)
+                severity = self._determine_severity_from_confidence(
+                    confidence, correlation_data
+                )
                 escalation_data = {
                     "action_id": action.action_id,
                     "title": action.title,
@@ -363,35 +387,39 @@ Please review and approve/reject in the SOC dashboard.
                     "hostname": hostname,
                     "confidence": confidence,
                     "indicators": correlation_data.get("indicators", []),
-                    "evidence": evidence
+                    "evidence": evidence,
                 }
                 self._trigger_escalation(escalation_data, severity, "pending_approval")
-                
+
                 return {
                     "status": "pending_approval",
                     "action_id": action.action_id,
-                    "message": f"Isolation action created, awaiting analyst approval",
+                    "message": "Isolation action created, awaiting analyst approval",
                     "confidence": confidence,
                     "requires_approval": True,
-                    "escalation_triggered": True
+                    "escalation_triggered": True,
                 }
-        
+
         except Exception as e:
             logger.error(f"Error creating isolation action: {e}")
             return {"error": str(e)}
-    
-    def _determine_severity_from_confidence(self, confidence: float, correlation_data: Dict) -> str:
+
+    def _determine_severity_from_confidence(
+        self, confidence: float, correlation_data: Dict
+    ) -> str:
         """Determine severity level from confidence and indicators."""
         indicators = correlation_data.get("indicators", [])
-        
+
         # Critical indicators
         if any(ind in indicators for ind in ["ransomware", "malware"]):
             return "critical"
-        
+
         # High confidence + C2 or lateral movement
-        if confidence >= 0.8 and any(ind in indicators for ind in ["c2_communication", "lateral_movement"]):
+        if confidence >= 0.8 and any(
+            ind in indicators for ind in ["c2_communication", "lateral_movement"]
+        ):
             return "high"
-        
+
         # Based on confidence
         if confidence >= 0.85:
             return "high"
@@ -399,22 +427,20 @@ Please review and approve/reject in the SOC dashboard.
             return "medium"
         else:
             return "low"
-    
+
     def _execute_isolation(
-        self,
-        ip_address: str,
-        hostname: Optional[str],
-        reason: str,
-        confidence: float
+        self, ip_address: str, hostname: Optional[str], reason: str, confidence: float
     ) -> Dict:
         """
         Execute host isolation via CrowdStrike.
-        
+
         In production, this would call the actual CrowdStrike API.
         For now, it returns a mock result.
         """
-        logger.info(f"Executing isolation: {hostname or ip_address} (confidence: {confidence:.2%})")
-        
+        logger.info(
+            f"Executing isolation: {hostname or ip_address} (confidence: {confidence:.2%})"
+        )
+
         # Mock execution result
         return {
             "success": True,
@@ -430,24 +456,26 @@ Please review and approve/reject in the SOC dashboard.
                 "Verify threat containment",
                 "Conduct forensic analysis",
                 "Remediate threat",
-                "Consider unisolation after remediation"
-            ]
+                "Consider unisolation after remediation",
+            ],
         }
-    
+
     def execute_approved_actions(self) -> List[Dict]:
         """
         Execute all approved actions that haven't been executed yet.
-        
+
         Returns:
             List of execution results
         """
         try:
             from core.response.approval_service import ActionStatus
-            
+
             # Get approved but not executed actions
-            approved_actions = self.approval_service.list_actions(status=ActionStatus.APPROVED)
+            approved_actions = self.approval_service.list_actions(
+                status=ActionStatus.APPROVED
+            )
             results = []
-            
+
             for action in approved_actions:
                 # Skip if already executed
                 if action.executed_at:
@@ -459,11 +487,15 @@ Please review and approve/reject in the SOC dashboard.
                 if action.action_type == "isolate_host":
                     result = self._execute_isolation(
                         ip_address=action.target,
-                        hostname=params.get('hostname'),
+                        hostname=params.get("hostname"),
                         reason=action.reason,
-                        confidence=action.confidence
+                        confidence=action.confidence,
                     )
-                elif action.action_type in ("waf_block", "gateway_block", "access_revoke"):
+                elif action.action_type in (
+                    "waf_block",
+                    "gateway_block",
+                    "access_revoke",
+                ):
                     result = self._execute_cloudflare_action(
                         action_type=action.action_type,
                         target=action.target,
@@ -475,69 +507,72 @@ Please review and approve/reject in the SOC dashboard.
                     # Unknown action type — leave for another executor or manual handling.
                     continue
 
-                if result.get('success'):
+                if result.get("success"):
                     self.approval_service.mark_executed(action.action_id, result)
                 else:
-                    self.approval_service.mark_failed(action.action_id, result.get('error', 'Unknown error'))
+                    self.approval_service.mark_failed(
+                        action.action_id, result.get("error", "Unknown error")
+                    )
 
-                results.append({
-                    "action_id": action.action_id,
-                    "action_type": action.action_type,
-                    "target": action.target,
-                    "result": result
-                })
+                results.append(
+                    {
+                        "action_id": action.action_id,
+                        "action_type": action.action_type,
+                        "target": action.target,
+                        "result": result,
+                    }
+                )
 
             return results
-        
+
         except Exception as e:
             logger.error(f"Error executing approved actions: {e}")
             return []
-    
+
     def investigate_and_respond(
-        self,
-        finding_id: str,
-        auto_execute: bool = True
+        self, finding_id: str, auto_execute: bool = True
     ) -> Dict:
         """
         Full investigation and response workflow for a finding.
-        
+
         Args:
             finding_id: Finding ID to investigate
             auto_execute: Whether to auto-execute high-confidence actions
-        
+
         Returns:
             Investigation and response result
         """
         try:
             # Load finding
             from core.storage.database_data_service import DatabaseDataService
+
             data_service = DatabaseDataService()
             finding = data_service.get_finding(finding_id)
-            
+
             if not finding:
                 return {"error": f"Finding {finding_id} not found"}
-            
+
             # Extract entity information
-            entity_context = finding.get('entity_context', {})
-            src_ips = entity_context.get('src_ips', [])
-            hostnames = entity_context.get('hostnames', [])
-            
+            entity_context = finding.get("entity_context", {})
+            src_ips = entity_context.get("src_ips", [])
+            hostnames = entity_context.get("hostnames", [])
+
             if not src_ips:
                 return {"error": "No source IPs found in finding"}
-            
+
             target_ip = src_ips[0]
             target_hostname = hostnames[0] if hostnames else None
-            
+
             # Correlate with multiple sources
             correlation = self.correlate_alerts(
                 tempo_flow_alert=finding,
                 crowdstrike_alert=None,  # Would fetch from CrowdStrike in production
-                splunk_results=None  # Would fetch from Splunk in production
+                splunk_results=None,  # Would fetch from Splunk in production
             )
-            
+
             # Determine action
-            confidence = correlation['confidence']
-            
+            confidence = correlation["confidence"]
+
             if confidence >= 0.85 and auto_execute:
                 # Create isolation action
                 action_result = self.create_isolation_action(
@@ -546,14 +581,14 @@ Please review and approve/reject in the SOC dashboard.
                     confidence=confidence,
                     reason=f"Automated response to finding {finding_id}",
                     evidence=[finding_id],
-                    correlation_data=correlation
+                    correlation_data=correlation,
                 )
-                
+
                 return {
                     "finding_id": finding_id,
                     "target": target_ip,
                     "correlation": correlation,
-                    "action": action_result
+                    "action": action_result,
                 }
             else:
                 # Just report findings
@@ -563,10 +598,10 @@ Please review and approve/reject in the SOC dashboard.
                     "correlation": correlation,
                     "action": {
                         "status": "no_action",
-                        "reason": f"Confidence below threshold ({confidence:.2%} < 0.85)"
-                    }
+                        "reason": f"Confidence below threshold ({confidence:.2%} < 0.85)",
+                    },
                 }
-        
+
         except Exception as e:
             logger.error(f"Error in investigate_and_respond: {e}")
             return {"error": str(e)}
@@ -574,7 +609,6 @@ Please review and approve/reject in the SOC dashboard.
     # ------------------------------------------------------------------
     # Cloudflare action factories + executor
     # ------------------------------------------------------------------
-
 
     def _execute_cloudflare_action(
         self,
@@ -636,11 +670,13 @@ Please review and approve/reject in the SOC dashboard.
                     email=parameters.get("email") or target,
                     reason=reason,
                 )
-            return {"success": False, "error": f"unknown cloudflare action {action_type}"}
+            return {
+                "success": False,
+                "error": f"unknown cloudflare action {action_type}",
+            }
         except Exception as e:  # noqa: BLE001
             logger.exception("Cloudflare action %s failed", action_type)
             return {"success": False, "error": str(e)}
 
 
 # Singleton instance
-

--- a/core/routing.py
+++ b/core/routing.py
@@ -122,6 +122,7 @@ class RouterMeta:
     def is_enabled(self) -> bool:
         return True if self.enabled is None else bool(self.enabled())
 
+
 def request_unit_of_work() -> Generator[Session, None, None]:
     """Yield a session whose transaction spans the whole request.
 

--- a/core/secrets_manager.py
+++ b/core/secrets_manager.py
@@ -15,11 +15,12 @@ Usage:
 """
 
 import json
-import os
 import logging
-from pathlib import Path
-from typing import Optional, Dict, Any
+import os
 from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Dict, Optional
+
 from core.config import vigil_path
 
 logger = logging.getLogger(__name__)

--- a/core/storage/config_service.py
+++ b/core/storage/config_service.py
@@ -6,13 +6,14 @@ and integration configurations with automatic audit logging.
 """
 
 import logging
-from typing import Optional, Dict, Any, List, Set
 from contextlib import contextmanager
+from typing import Any, Dict, List, Optional, Set
+
+from sqlalchemy.orm import Session
 
 from core.storage.connection import get_db_manager
-from core.storage.models import SystemConfig, IntegrationConfig, ConfigAuditLog
+from core.storage.models import ConfigAuditLog, IntegrationConfig, SystemConfig
 from core.storage.schemas import IntegrationConfigSchema
-from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
@@ -21,16 +22,16 @@ logger = logging.getLogger(__name__)
 def get_session():
     """
     Context manager for database sessions.
-    
+
     Yields:
         SQLAlchemy session
     """
     db_manager = get_db_manager()
-    
+
     # Initialize database if not already done
     if db_manager._engine is None:
         db_manager.initialize()
-    
+
     # Use session_scope for automatic commit/rollback
     with db_manager.session_scope() as session:
         yield session
@@ -38,28 +39,30 @@ def get_session():
 
 class ConfigService:
     """Service for managing configurations in the database."""
-    
-    def __init__(self, user_id: str = 'system'):
+
+    def __init__(self, user_id: str = "system"):
         """
         Initialize config service.
-        
+
         Args:
             user_id: ID of the user making changes (for audit trail)
         """
         self.user_id = user_id
-    
+
     # =========================================================================
     # System Configuration Methods
     # =========================================================================
-    
-    def get_system_config(self, key: str, default: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+
+    def get_system_config(
+        self, key: str, default: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
         """
         Get a system configuration value.
-        
+
         Args:
             key: Configuration key (e.g., 'general.settings', 'approval.force_manual_approval')
             default: Default value if not found
-            
+
         Returns:
             Configuration value or default
         """
@@ -72,109 +75,106 @@ class ConfigService:
         except Exception as e:
             logger.error(f"Error getting system config '{key}': {e}")
             return default
-    
+
     def set_system_config(
-        self, 
-        key: str, 
-        value: Dict[str, Any], 
+        self,
+        key: str,
+        value: Dict[str, Any],
         description: Optional[str] = None,
-        config_type: str = 'general',
-        change_reason: Optional[str] = None
+        config_type: str = "general",
+        change_reason: Optional[str] = None,
     ) -> bool:
         """
         Set a system configuration value.
-        
+
         Args:
             key: Configuration key
             value: Configuration value (will be stored as JSONB)
             description: Optional description of this config
             config_type: Type/category of config (general, approval, theme, etc.)
             change_reason: Reason for the change (for audit)
-            
+
         Returns:
             True if successful
         """
         try:
             with get_session() as session:
                 config = session.query(SystemConfig).filter_by(key=key).first()
-                
+
                 old_value = None
-                action = 'create'
-                
+                action = "create"
+
                 if config:
                     old_value = config.value
                     config.value = value
                     config.updated_by = self.user_id
                     if description:
                         config.description = description
-                    action = 'update'
+                    action = "update"
                 else:
                     config = SystemConfig(
                         key=key,
                         value=value,
                         description=description,
                         config_type=config_type,
-                        updated_by=self.user_id
+                        updated_by=self.user_id,
                     )
                     session.add(config)
-                
+
                 # Create audit log
                 self._create_audit_log(
-                    session, 
+                    session,
                     config_type=config_type,
                     config_key=key,
                     action=action,
                     old_value=old_value,
                     new_value=value,
-                    change_reason=change_reason
+                    change_reason=change_reason,
                 )
-                
+
                 session.commit()
                 logger.info(f"System config '{key}' {action}d by {self.user_id}")
                 return True
-                
+
         except Exception as e:
             logger.error(f"Error setting system config '{key}': {e}")
             return False
-    
-    
-    
+
     # =========================================================================
     # User Preferences Methods
     # =========================================================================
-    
-    
-    
-    
+
     # =========================================================================
     # Integration Configuration Methods
     # =========================================================================
-    
+
     def get_integration_config(self, integration_id: str) -> Optional[Dict[str, Any]]:
         """
         Get integration configuration.
-        
+
         Args:
             integration_id: Integration identifier
-            
+
         Returns:
             Integration configuration or None
         """
         try:
             with get_session() as session:
-                integration = session.query(IntegrationConfig).filter_by(
-                    integration_id=integration_id
-                ).first()
-                
+                integration = (
+                    session.query(IntegrationConfig)
+                    .filter_by(integration_id=integration_id)
+                    .first()
+                )
+
                 if integration:
                     return IntegrationConfigSchema.dump(integration)
-                
+
                 return None
-                
+
         except Exception as e:
             logger.error(f"Error getting integration config '{integration_id}': {e}")
             return None
-    
+
     def set_integration_config(
         self,
         integration_id: str,
@@ -183,11 +183,11 @@ class ConfigService:
         integration_name: Optional[str] = None,
         integration_type: Optional[str] = None,
         description: Optional[str] = None,
-        change_reason: Optional[str] = None
+        change_reason: Optional[str] = None,
     ) -> bool:
         """
         Set integration configuration.
-        
+
         Args:
             integration_id: Integration identifier
             config: Configuration dictionary (non-sensitive data only)
@@ -196,19 +196,21 @@ class ConfigService:
             integration_type: Type/category of integration
             description: Optional description
             change_reason: Reason for change (for audit)
-            
+
         Returns:
             True if successful
         """
         try:
             with get_session() as session:
-                integration = session.query(IntegrationConfig).filter_by(
-                    integration_id=integration_id
-                ).first()
-                
+                integration = (
+                    session.query(IntegrationConfig)
+                    .filter_by(integration_id=integration_id)
+                    .first()
+                )
+
                 old_value = None
-                action = 'create'
-                
+                action = "create"
+
                 if integration:
                     old_value = integration.config
                     integration.config = config
@@ -220,7 +222,7 @@ class ConfigService:
                         integration.integration_type = integration_type
                     if description:
                         integration.description = description
-                    action = 'update'
+                    action = "update"
                 else:
                     integration = IntegrationConfig(
                         integration_id=integration_id,
@@ -229,55 +231,54 @@ class ConfigService:
                         integration_name=integration_name,
                         integration_type=integration_type,
                         description=description,
-                        updated_by=self.user_id
+                        updated_by=self.user_id,
                     )
                     session.add(integration)
-                
+
                 # Create audit log
                 self._create_audit_log(
                     session,
-                    config_type='integration',
+                    config_type="integration",
                     config_key=integration_id,
                     action=action,
                     old_value=old_value,
                     new_value=config,
-                    change_reason=change_reason
+                    change_reason=change_reason,
                 )
-                
+
                 session.commit()
-                logger.info(f"Integration '{integration_id}' {action}d by {self.user_id}")
+                logger.info(
+                    f"Integration '{integration_id}' {action}d by {self.user_id}"
+                )
                 return True
-                
+
         except Exception as e:
             logger.error(f"Error setting integration config '{integration_id}': {e}")
             return False
-    
-    
-    
+
     def list_integrations(self, enabled_only: bool = False) -> List[Dict[str, Any]]:
         """
         List all integrations.
-        
+
         Args:
             enabled_only: If True, only return enabled integrations
-            
+
         Returns:
             List of integration configuration dictionaries
         """
         try:
             with get_session() as session:
                 query = session.query(IntegrationConfig)
-                
+
                 if enabled_only:
                     query = query.filter_by(enabled=True)
-                
+
                 integrations = query.all()
                 return IntegrationConfigSchema.dump_many(integrations)
-                
+
         except Exception as e:
             logger.error(f"Error listing integrations: {e}")
             return []
-    
 
     def get_disabled_integration_ids(self) -> Set[str]:
         """Registered-but-disabled integration IDs. Sources with no config row
@@ -285,16 +286,18 @@ class ConfigService:
         so a lookup blip can't silently drop ingestion."""
         try:
             with get_session() as session:
-                integrations = session.query(IntegrationConfig).filter_by(enabled=False).all()
+                integrations = (
+                    session.query(IntegrationConfig).filter_by(enabled=False).all()
+                )
                 return {i.integration_id for i in integrations}
         except Exception as e:
             logger.error(f"Error getting disabled integrations: {e}")
             return set()
-    
+
     # =========================================================================
     # Audit Methods
     # =========================================================================
-    
+
     def _create_audit_log(
         self,
         session: Session,
@@ -303,7 +306,7 @@ class ConfigService:
         action: str,
         old_value: Optional[Dict[str, Any]],
         new_value: Optional[Dict[str, Any]],
-        change_reason: Optional[str] = None
+        change_reason: Optional[str] = None,
     ):
         """Create an audit log entry."""
         try:
@@ -314,12 +317,12 @@ class ConfigService:
                 old_value=old_value,
                 new_value=new_value,
                 changed_by=self.user_id,
-                change_reason=change_reason
+                change_reason=change_reason,
             )
             session.add(audit_entry)
         except Exception as e:
             logger.error(f"Error creating audit log: {e}")
-    
+
     def record_audit(
         self,
         config_type: str,
@@ -332,8 +335,13 @@ class ConfigService:
         """Write a standalone audit entry (no SystemConfig row touched)."""
         with get_session() as session:
             self._create_audit_log(
-                session, config_type, config_key, action,
-                old_value, new_value, change_reason,
+                session,
+                config_type,
+                config_key,
+                action,
+                old_value,
+                new_value,
+                change_reason,
             )
 
 
@@ -341,20 +349,19 @@ class ConfigService:
 _config_service: Optional[ConfigService] = None
 
 
-def get_config_service(user_id: str = 'system') -> ConfigService:
+def get_config_service(user_id: str = "system") -> ConfigService:
     """
     Get or create the global config service instance.
-    
+
     Args:
         user_id: ID of the user (for audit trail)
-        
+
     Returns:
         ConfigService instance
     """
     global _config_service
-    
+
     if _config_service is None or _config_service.user_id != user_id:
         _config_service = ConfigService(user_id=user_id)
-    
-    return _config_service
 
+    return _config_service

--- a/core/storage/connection.py
+++ b/core/storage/connection.py
@@ -8,61 +8,61 @@ import asyncio
 import logging
 import threading
 import time
-from dataclasses import astuple, dataclass, field
-from typing import Any, Dict, Optional, Generator, TYPE_CHECKING
-from urllib.parse import parse_qsl, quote, unquote, urlsplit
 from contextlib import contextmanager
+from dataclasses import astuple, dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional
+from urllib.parse import parse_qsl, quote, unquote, urlsplit
+
 from sqlalchemy import create_engine, inspect, text
-from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
 
 if TYPE_CHECKING:
     from core.storage.db_proxy import ProxyConfig
 
-from core.storage.models import Base
+from core.config import get_settings
+from core.secrets import get_secret
 
 # Import all models to register them with Base.metadata before create_all()
-from core.storage.models import (
-    Finding,
-    Case,
-    SketchMapping,
-    AttackLayer,
+from core.storage.models import (  # noqa: F401
     AIDecisionLog,
-    SystemConfig,
-    UserPreference,
-    IntegrationConfig,
-    ConfigAuditLog,
-    SLAPolicy,
-    CaseSLA,
+    AttackLayer,
+    Base,
+    Case,
+    CaseAttachment,
+    CaseAuditLog,
+    CaseClosureInfo,
     CaseComment,
-    CaseWatcher,
+    CaseEscalation,
     CaseEvidence,
     CaseIOC,
+    CaseMetrics,
+    CaseNotification,
+    CaseRelationship,
+    CaseSLA,
     CaseTask,
     CaseTemplate,
-    CaseRelationship,
-    CaseMetrics,
-    CaseAttachment,
-    CaseClosureInfo,
-    CaseEscalation,
-    CaseAuditLog,
-    User,
-    Role,
+    CaseWatcher,
+    ChatMessage,
+    ConfigAuditLog,
+    Conversation,
+    CustomAgent,
+    CustomWorkflow,
+    Finding,
+    IntegrationConfig,
     Investigation,
     InvestigationLog,
     LLMInteractionLog,
-    SharedIOC,
-    CaseNotification,
-    CustomAgent,
-    CustomWorkflow,
-    Skill,
     LLMProviderConfig,
-    Conversation,
-    ChatMessage,
+    Role,
+    SharedIOC,
+    SketchMapping,
+    Skill,
+    SLAPolicy,
+    SystemConfig,
+    User,
+    UserPreference,
 )
-
-from core.config import get_settings
-from core.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -91,8 +91,8 @@ def _load_platform_db_proxy() -> "ProxyConfig":
     configured.
     """
     try:
-        from core.storage.db_proxy import ProxyConfig
         from core.secrets_manager import get_secret
+        from core.storage.db_proxy import ProxyConfig
     except ImportError:
         # If the secrets manager isn't importable yet skip proxy support gracefully.
         from core.storage.db_proxy import ProxyConfig

--- a/core/storage/database_data_service.py
+++ b/core/storage/database_data_service.py
@@ -1,19 +1,18 @@
 import json
 import logging
 import time
-from pathlib import Path
-from typing import Optional, List, Dict, Tuple
-from datetime import datetime
 import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
-from core.storage.connection import get_db_manager, init_database
-from core.storage.service import DatabaseService
-from core.storage.schemas import CaseSchema, FindingSchema
+from core.config import is_demo_mode, vigil_path
 from core.exceptions import DatabaseError
-from core.config import is_demo_mode
-from core.config import vigil_path
+from core.storage.connection import get_db_manager, init_database
+from core.storage.schemas import CaseSchema, FindingSchema
+from core.storage.service import DatabaseService
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +23,7 @@ CASES_FILE = DATA_DIR / "cases.json"
 
 def _cosine_sim(a, b):
     """Compute cosine similarity between two vectors.
-    
+
     Returns None if the vectors have incompatible dimensions.
     """
     a, b = np.array(a), np.array(b)
@@ -99,66 +98,76 @@ class DatabaseDataService:
         self._last_reconnect_attempt = now
         self._init_database(require_db=False)
         return self._db_connected
-    
+
     def is_using_database(self) -> bool:
         return self._db_available and self._db_service is not None
-    
+
     def is_demo_mode(self) -> bool:
         return self._demo_mode
-    
+
     def get_backend_info(self) -> dict:
         if self._demo_mode:
-            return {'backend': 'demo', 'database_available': False, 'demo_mode': True}
+            return {"backend": "demo", "database_available": False, "demo_mode": True}
         if self._db_available:
-            return {'backend': 'postgresql', 'database_available': True, 'demo_mode': False}
+            return {
+                "backend": "postgresql",
+                "database_available": True,
+                "demo_mode": False,
+            }
         elif self._use_json_fallback:
-            return {'backend': 'json', 'database_available': False, 'demo_mode': False}
-        return {'backend': 'none', 'database_available': False, 'demo_mode': False}
-    
+            return {"backend": "json", "database_available": False, "demo_mode": False}
+        return {"backend": "none", "database_available": False, "demo_mode": False}
+
     def _load_findings_json(self) -> List[Dict]:
         if FINDINGS_FILE.exists():
             try:
                 with open(FINDINGS_FILE) as f:
                     data = json.load(f)
-                    return data.get('findings', []) if isinstance(data, dict) else data
+                    return data.get("findings", []) if isinstance(data, dict) else data
             except Exception as e:
                 logger.error(f"Error loading findings JSON: {e}")
         return []
-    
+
     def _save_findings_json(self, findings: List[Dict]) -> bool:
         try:
-            with open(FINDINGS_FILE, 'w') as f:
-                json.dump({'findings': findings}, f, indent=2, default=str)
+            with open(FINDINGS_FILE, "w") as f:
+                json.dump({"findings": findings}, f, indent=2, default=str)
             return True
         except Exception as e:
             logger.error(f"Error saving findings JSON: {e}")
             return False
-    
+
     def _load_cases_json(self) -> List[Dict]:
         if CASES_FILE.exists():
             try:
                 with open(CASES_FILE) as f:
                     data = json.load(f)
-                    return data.get('cases', []) if isinstance(data, dict) else data
+                    return data.get("cases", []) if isinstance(data, dict) else data
             except Exception as e:
                 logger.error(f"Error loading cases JSON: {e}")
         return []
-    
+
     def _save_cases_json(self, cases: List[Dict]) -> bool:
         try:
-            with open(CASES_FILE, 'w') as f:
-                json.dump({'cases': cases}, f, indent=2, default=str)
+            with open(CASES_FILE, "w") as f:
+                json.dump({"cases": cases}, f, indent=2, default=str)
             return True
         except Exception as e:
             logger.error(f"Error saving cases JSON: {e}")
             return False
-    
+
     def get_findings(
-        self, limit: int = 10000, offset: int = 0,
-        severity: Optional[str] = None, data_source: Optional[str] = None,
-        cluster_id: Optional[str] = None, min_anomaly_score: Optional[float] = None,
-        status: Optional[str] = None, search_query: Optional[str] = None,
-        sort_by: str = "timestamp", sort_order: str = "desc",
+        self,
+        limit: int = 10000,
+        offset: int = 0,
+        severity: Optional[str] = None,
+        data_source: Optional[str] = None,
+        cluster_id: Optional[str] = None,
+        min_anomaly_score: Optional[float] = None,
+        status: Optional[str] = None,
+        search_query: Optional[str] = None,
+        sort_by: str = "timestamp",
+        sort_order: str = "desc",
         include_embedding: bool = True,
     ) -> List[Dict]:
         # Callers that only render/aggregate findings pass include_embedding=False
@@ -173,11 +182,16 @@ class DatabaseDataService:
         if self._db_available:
             try:
                 findings = self._db_service.get_findings(
-                    severity=severity, data_source=data_source,
-                    cluster_id=cluster_id, min_anomaly_score=min_anomaly_score,
-                    status=status, search_query=search_query,
-                    limit=limit, offset=offset,
-                    sort_by=sort_by, sort_order=sort_order,
+                    severity=severity,
+                    data_source=data_source,
+                    cluster_id=cluster_id,
+                    min_anomaly_score=min_anomaly_score,
+                    status=status,
+                    search_query=search_query,
+                    limit=limit,
+                    offset=offset,
+                    sort_by=sort_by,
+                    sort_order=sort_order,
                 )
                 if include_embedding:
                     return FindingSchema.dump_many(findings)
@@ -188,25 +202,33 @@ class DatabaseDataService:
         elif self._use_json_fallback:
             findings = self._load_findings_json()
             if severity:
-                findings = [f for f in findings if f.get('severity') == severity]
+                findings = [f for f in findings if f.get("severity") == severity]
             if data_source:
-                findings = [f for f in findings if f.get('data_source') == data_source]
+                findings = [f for f in findings if f.get("data_source") == data_source]
             if cluster_id is not None:
-                findings = [f for f in findings if f.get('cluster_id') == cluster_id]
+                findings = [f for f in findings if f.get("cluster_id") == cluster_id]
             if min_anomaly_score is not None:
-                findings = [f for f in findings if f.get('anomaly_score', 0) >= min_anomaly_score]
+                findings = [
+                    f
+                    for f in findings
+                    if f.get("anomaly_score", 0) >= min_anomaly_score
+                ]
             if status:
-                findings = [f for f in findings if f.get('status') == status]
+                findings = [f for f in findings if f.get("status") == status]
             if search_query:
                 q = search_query.lower()
-                findings = [f for f in findings if (
-                    q in f.get('finding_id', '').lower()
-                    or q in str(f.get('entity_context', '')).lower()
-                    or q in f.get('description', '').lower()
-                )]
+                findings = [
+                    f
+                    for f in findings
+                    if (
+                        q in f.get("finding_id", "").lower()
+                        or q in str(f.get("entity_context", "")).lower()
+                        or q in f.get("description", "").lower()
+                    )
+                ]
             reverse = sort_order == "desc"
-            findings.sort(key=lambda f: f.get(sort_by, ''), reverse=reverse)
-            return _strip(findings[offset:offset + limit])
+            findings.sort(key=lambda f: f.get(sort_by, ""), reverse=reverse)
+            return _strip(findings[offset : offset + limit])
         return []
 
     def get_findings_missing_enrichment(
@@ -225,18 +247,25 @@ class DatabaseDataService:
             return []
 
     def count_findings(
-        self, severity: Optional[str] = None, data_source: Optional[str] = None,
-        cluster_id: Optional[str] = None, min_anomaly_score: Optional[float] = None,
-        status: Optional[str] = None, search_query: Optional[str] = None,
+        self,
+        severity: Optional[str] = None,
+        data_source: Optional[str] = None,
+        cluster_id: Optional[str] = None,
+        min_anomaly_score: Optional[float] = None,
+        status: Optional[str] = None,
+        search_query: Optional[str] = None,
     ) -> int:
         if self._demo_mode and self._demo_service:
             return len(self._demo_service.get_findings(10000))
         if self._db_available:
             try:
                 return self._db_service.count_findings(
-                    severity=severity, data_source=data_source,
-                    cluster_id=cluster_id, min_anomaly_score=min_anomaly_score,
-                    status=status, search_query=search_query,
+                    severity=severity,
+                    data_source=data_source,
+                    cluster_id=cluster_id,
+                    min_anomaly_score=min_anomaly_score,
+                    status=status,
+                    search_query=search_query,
                 )
             except Exception as e:
                 logger.error(f"Error counting findings from DB: {e}")
@@ -244,25 +273,33 @@ class DatabaseDataService:
         elif self._use_json_fallback:
             findings = self._load_findings_json()
             if severity:
-                findings = [f for f in findings if f.get('severity') == severity]
+                findings = [f for f in findings if f.get("severity") == severity]
             if data_source:
-                findings = [f for f in findings if f.get('data_source') == data_source]
+                findings = [f for f in findings if f.get("data_source") == data_source]
             if cluster_id is not None:
-                findings = [f for f in findings if f.get('cluster_id') == cluster_id]
+                findings = [f for f in findings if f.get("cluster_id") == cluster_id]
             if min_anomaly_score is not None:
-                findings = [f for f in findings if f.get('anomaly_score', 0) >= min_anomaly_score]
+                findings = [
+                    f
+                    for f in findings
+                    if f.get("anomaly_score", 0) >= min_anomaly_score
+                ]
             if status:
-                findings = [f for f in findings if f.get('status') == status]
+                findings = [f for f in findings if f.get("status") == status]
             if search_query:
                 q = search_query.lower()
-                findings = [f for f in findings if (
-                    q in f.get('finding_id', '').lower()
-                    or q in str(f.get('entity_context', '')).lower()
-                    or q in f.get('description', '').lower()
-                )]
+                findings = [
+                    f
+                    for f in findings
+                    if (
+                        q in f.get("finding_id", "").lower()
+                        or q in str(f.get("entity_context", "")).lower()
+                        or q in f.get("description", "").lower()
+                    )
+                ]
             return len(findings)
         return 0
-    
+
     def get_finding(self, finding_id: str) -> Optional[Dict]:
         if self._demo_mode and self._demo_service:
             return self._demo_service.get_finding(finding_id)
@@ -276,17 +313,17 @@ class DatabaseDataService:
         elif self._use_json_fallback:
             findings = self._load_findings_json()
             for f in findings:
-                if f.get('finding_id') == finding_id:
+                if f.get("finding_id") == finding_id:
                     return f
         return None
-    
+
     def get_nearest_neighbors(self, finding_id: str, limit: int = 10) -> Dict:
         """Find similar findings using embedding-based cosine similarity.
-        
+
         Args:
             finding_id: Reference finding ID to find neighbors for
             limit: Maximum number of neighbors to return
-            
+
         Returns:
             Dict with seed_finding and neighbors list
         """
@@ -321,7 +358,9 @@ class DatabaseDataService:
                 findings_objs = self._db_service.get_findings(limit=10000)
                 findings = FindingSchema.dump_many(findings_objs)
             except Exception as e:
-                logger.error(f"Error getting findings from DB for nearest_neighbors: {e}")
+                logger.error(
+                    f"Error getting findings from DB for nearest_neighbors: {e}"
+                )
                 return {"error": str(e)}
         elif self._use_json_fallback:
             findings = self._load_findings_json()
@@ -329,51 +368,55 @@ class DatabaseDataService:
             return {"error": "No data backend available"}
 
         # Find the seed finding
-        seed = next((f for f in findings if f.get('finding_id') == finding_id), None)
-        if not seed or 'embedding' not in seed:
+        seed = next((f for f in findings if f.get("finding_id") == finding_id), None)
+        if not seed or "embedding" not in seed:
             return {"error": f"Finding {finding_id} not found or has no embedding"}
 
         # Compute cosine similarity against all other findings with embeddings
         sims = []
         skipped = 0
         for f in findings:
-            if f.get('finding_id') != finding_id and 'embedding' in f:
-                sim = _cosine_sim(seed['embedding'], f['embedding'])
+            if f.get("finding_id") != finding_id and "embedding" in f:
+                sim = _cosine_sim(seed["embedding"], f["embedding"])
                 if sim is None:
                     skipped += 1
                     continue
-                sims.append({
-                    "finding_id": f['finding_id'],
-                    "similarity": round(sim, 4),
-                    "cluster_id": f.get('cluster_id'),
-                    "severity": f.get('severity'),
-                    "data_source": f.get('data_source'),
-                    "anomaly_score": float(f.get('anomaly_score', 0)),
-                })
+                sims.append(
+                    {
+                        "finding_id": f["finding_id"],
+                        "similarity": round(sim, 4),
+                        "cluster_id": f.get("cluster_id"),
+                        "severity": f.get("severity"),
+                        "data_source": f.get("data_source"),
+                        "anomaly_score": float(f.get("anomaly_score", 0)),
+                    }
+                )
         if skipped:
-            logger.warning(f"Skipped {skipped} findings with incompatible embedding dimensions")
+            logger.warning(
+                f"Skipped {skipped} findings with incompatible embedding dimensions"
+            )
 
-        sims.sort(key=lambda x: x['similarity'], reverse=True)
+        sims.sort(key=lambda x: x["similarity"], reverse=True)
         return {"seed_finding": finding_id, "neighbors": sims[:limit]}
-    
+
     def create_finding(self, finding_data: Dict) -> Optional[Dict]:
         if self._demo_mode and self._demo_service:
             return self._demo_service.create_finding(finding_data)
         if self._db_available:
             try:
                 finding = self._db_service.create_finding(
-                    finding_id=finding_data.get('finding_id'),
-                    embedding=finding_data.get('embedding', [0.0] * 768),
-                    mitre_predictions=finding_data.get('mitre_predictions', {}),
-                    anomaly_score=float(finding_data.get('anomaly_score', 0.0)),
-                    timestamp=finding_data.get('timestamp', datetime.utcnow()),
-                    data_source=finding_data.get('data_source', 'imported'),
-                    description=finding_data.get('description'),
-                    entity_context=finding_data.get('entity_context'),
-                    evidence_links=finding_data.get('evidence_links'),
-                    cluster_id=finding_data.get('cluster_id'),
-                    severity=finding_data.get('severity'),
-                    status=finding_data.get('status', 'new')
+                    finding_id=finding_data.get("finding_id"),
+                    embedding=finding_data.get("embedding", [0.0] * 768),
+                    mitre_predictions=finding_data.get("mitre_predictions", {}),
+                    anomaly_score=float(finding_data.get("anomaly_score", 0.0)),
+                    timestamp=finding_data.get("timestamp", datetime.utcnow()),
+                    data_source=finding_data.get("data_source", "imported"),
+                    description=finding_data.get("description"),
+                    entity_context=finding_data.get("entity_context"),
+                    evidence_links=finding_data.get("evidence_links"),
+                    cluster_id=finding_data.get("cluster_id"),
+                    severity=finding_data.get("severity"),
+                    status=finding_data.get("status", "new"),
                 )
                 return FindingSchema.dump(finding) if finding else None
             except Exception as e:
@@ -385,7 +428,7 @@ class DatabaseDataService:
             if self._save_findings_json(findings):
                 return finding_data
         return None
-    
+
     def update_finding(self, finding_id: str, **updates) -> bool:
         if self._demo_mode and self._demo_service:
             return self._demo_service.update_finding(finding_id, **updates)
@@ -398,16 +441,16 @@ class DatabaseDataService:
         elif self._use_json_fallback:
             findings = self._load_findings_json()
             for f in findings:
-                if f.get('finding_id') == finding_id:
+                if f.get("finding_id") == finding_id:
                     f.update(updates)
                     return self._save_findings_json(findings)
         return False
-    
+
     def save_findings(self, findings: List[Dict]) -> bool:
         if self._use_json_fallback:
             return self._save_findings_json(findings)
         return False
-    
+
     def get_cases(self, limit: int = 10000) -> List[Dict]:
         if self._demo_mode and self._demo_service:
             return self._demo_service.get_cases(limit)
@@ -422,7 +465,7 @@ class DatabaseDataService:
             cases = self._load_cases_json()
             return cases[:limit]
         return []
-    
+
     def get_case(self, case_id: str) -> Optional[Dict]:
         if self._demo_mode and self._demo_service:
             return self._demo_service.get_case(case_id)
@@ -436,22 +479,34 @@ class DatabaseDataService:
         elif self._use_json_fallback:
             cases = self._load_cases_json()
             for c in cases:
-                if c.get('case_id') == case_id:
+                if c.get("case_id") == case_id:
                     return c
         return None
-    
-    def create_case(self, title: str, finding_ids: List[str], priority: str = "medium",
-                    description: str = "", status: str = "open") -> Optional[Dict]:
+
+    def create_case(
+        self,
+        title: str,
+        finding_ids: List[str],
+        priority: str = "medium",
+        description: str = "",
+        status: str = "open",
+    ) -> Optional[Dict]:
         if self._demo_mode and self._demo_service:
-            return self._demo_service.create_case(title, finding_ids, priority, description, status)
-        
+            return self._demo_service.create_case(
+                title, finding_ids, priority, description, status
+            )
+
         case_id = f"case-{datetime.now().strftime('%Y-%m-%d')}-{uuid.uuid4().hex[:8]}"
-        
+
         if self._db_available:
             try:
                 case = self._db_service.create_case(
-                    case_id=case_id, title=title, finding_ids=finding_ids,
-                    description=description, status=status, priority=priority
+                    case_id=case_id,
+                    title=title,
+                    finding_ids=finding_ids,
+                    description=description,
+                    status=status,
+                    priority=priority,
                 )
                 return CaseSchema.dump(case) if case else None
             except Exception as e:
@@ -460,24 +515,23 @@ class DatabaseDataService:
         elif self._use_json_fallback:
             now = datetime.utcnow().isoformat()
             case_data = {
-                'case_id': case_id,
-                'title': title,
-                'description': description,
-                'finding_ids': finding_ids,
-                'status': status,
-                'priority': priority,
-                'created_at': now,
-                'updated_at': now,
-                'notes': [],
-                'timeline': [{'timestamp': now, 'event': 'Case created'}]
+                "case_id": case_id,
+                "title": title,
+                "description": description,
+                "finding_ids": finding_ids,
+                "status": status,
+                "priority": priority,
+                "created_at": now,
+                "updated_at": now,
+                "notes": [],
+                "timeline": [{"timestamp": now, "event": "Case created"}],
             }
             cases = self._load_cases_json()
             cases.append(case_data)
             if self._save_cases_json(cases):
                 return case_data
         return None
-    
-    
+
     def update_case(self, case_id: str, **updates) -> bool:
         if self._demo_mode and self._demo_service:
             return self._demo_service.update_case(case_id, **updates)
@@ -490,12 +544,12 @@ class DatabaseDataService:
         elif self._use_json_fallback:
             cases = self._load_cases_json()
             for c in cases:
-                if c.get('case_id') == case_id:
+                if c.get("case_id") == case_id:
                     c.update(updates)
-                    c['updated_at'] = datetime.utcnow().isoformat()
+                    c["updated_at"] = datetime.utcnow().isoformat()
                     return self._save_cases_json(cases)
         return False
-    
+
     def delete_case(self, case_id: str) -> bool:
         if self._demo_mode and self._demo_service:
             return self._demo_service.delete_case(case_id)
@@ -507,31 +561,31 @@ class DatabaseDataService:
                 return False
         elif self._use_json_fallback:
             cases = self._load_cases_json()
-            cases = [c for c in cases if c.get('case_id') != case_id]
+            cases = [c for c in cases if c.get("case_id") != case_id]
             return self._save_cases_json(cases)
         return False
-    
+
     def get_findings_by_case(self, case_id: str) -> List[Dict]:
         """Get all findings associated with a case.
-        
+
         Args:
             case_id: ID of the case
-            
+
         Returns:
             List of finding dictionaries
         """
         if self._demo_mode and self._demo_service:
             # Get case and extract finding IDs
             case = self._demo_service.get_case(case_id)
-            if case and 'finding_ids' in case:
+            if case and "finding_ids" in case:
                 findings = []
-                for fid in case['finding_ids']:
+                for fid in case["finding_ids"]:
                     finding = self._demo_service.get_finding(fid)
                     if finding:
                         findings.append(finding)
                 return findings
             return []
-        
+
         if self._db_available:
             try:
                 # Get case with findings
@@ -545,24 +599,26 @@ class DatabaseDataService:
         elif self._use_json_fallback:
             # Get case and lookup findings
             case = self.get_case(case_id)
-            if case and 'finding_ids' in case:
+            if case and "finding_ids" in case:
                 findings = self._load_findings_json()
-                return [f for f in findings if f.get('finding_id') in case['finding_ids']]
+                return [
+                    f for f in findings if f.get("finding_id") in case["finding_ids"]
+                ]
         return []
-    
+
     def add_finding_to_case(self, case_id: str, finding_id: str) -> bool:
         """Add a finding to an existing case.
-        
+
         Args:
             case_id: The case ID
             finding_id: The finding ID to add
-            
+
         Returns:
             True if successful, False otherwise
         """
         if self._demo_mode and self._demo_service:
             return self._demo_service.add_finding_to_case(case_id, finding_id)
-        
+
         if self._db_available:
             try:
                 return self._db_service.add_finding_to_case(case_id, finding_id)
@@ -572,80 +628,80 @@ class DatabaseDataService:
         elif self._use_json_fallback:
             cases = self._load_cases_json()
             for c in cases:
-                if c.get('case_id') == case_id:
-                    if 'finding_ids' not in c:
-                        c['finding_ids'] = []
-                    if finding_id not in c['finding_ids']:
-                        c['finding_ids'].append(finding_id)
-                        c['updated_at'] = datetime.utcnow().isoformat()
+                if c.get("case_id") == case_id:
+                    if "finding_ids" not in c:
+                        c["finding_ids"] = []
+                    if finding_id not in c["finding_ids"]:
+                        c["finding_ids"].append(finding_id)
+                        c["updated_at"] = datetime.utcnow().isoformat()
                     return self._save_cases_json(cases)
             return False
         return False
-    
+
     def save_cases(self, cases: List[Dict]) -> bool:
         if self._use_json_fallback:
             return self._save_cases_json(cases)
         return False
-    
+
     def export_findings(self, output_path: Path, fmt: str = "json") -> bool:
         findings = self.get_findings()
         try:
-            with open(output_path, 'w') as f:
+            with open(output_path, "w") as f:
                 if fmt == "jsonl":
                     for finding in findings:
-                        f.write(json.dumps(finding) + '\n')
+                        f.write(json.dumps(finding) + "\n")
                 else:
                     json.dump({"findings": findings}, f, indent=2)
             return True
         except Exception as e:
             logger.error(f"Error exporting findings: {e}")
             return False
-    
+
     def _init_s3_service(self) -> bool:
         """
         Initialize S3 service from configuration.
-        
+
         Returns:
             True if S3 is configured and initialized, False otherwise
         """
         try:
             # Load S3 config from database
-            from core.storage.config_service import get_config_service
             from core.secrets_manager import get_secret
-            
+            from core.storage.config_service import get_config_service
+
             config_service = get_config_service()
-            s3_config = config_service.get_integration_config('s3')
-            
+            s3_config = config_service.get_integration_config("s3")
+
             if not s3_config:
                 # Fallback to file-based config
-                config_file = vigil_path('s3_config.json')
+                config_file = vigil_path("s3_config.json")
                 if config_file.exists():
-                    with open(config_file, 'r') as f:
+                    with open(config_file, "r") as f:
                         s3_config = json.load(f)
                 else:
                     return False
-            
+
             # Unwrap nested config if present (DB stores config under 'config' key)
-            if 'config' in s3_config and isinstance(s3_config['config'], dict):
-                s3_config = s3_config['config']
+            if "config" in s3_config and isinstance(s3_config["config"], dict):
+                s3_config = s3_config["config"]
 
             # Parse bucket name -- handle full S3 URIs like s3://bucket/path
-            raw_bucket = s3_config.get('bucket_name', '')
-            if raw_bucket.startswith('s3://'):
-                parts = raw_bucket[5:].split('/', 1)
+            raw_bucket = s3_config.get("bucket_name", "")
+            if raw_bucket.startswith("s3://"):
+                parts = raw_bucket[5:].split("/", 1)
                 bucket_name = parts[0]
             else:
                 bucket_name = raw_bucket
 
             from core.storage.s3_service import S3Service
 
-            auth_method = s3_config.get('auth_method', 'credentials')
-            aws_profile = s3_config.get('aws_profile', '')
+            auth_method = s3_config.get("auth_method", "credentials")
+            aws_profile = s3_config.get("aws_profile", "")
 
-            if auth_method == 'profile' and aws_profile:
+            if auth_method == "profile" and aws_profile:
                 self._s3_service = S3Service(
                     bucket_name=bucket_name,
-                    region_name=s3_config.get('region', 'us-east-1'),
+                    region_name=s3_config.get("region", "us-east-1"),
                     aws_profile=aws_profile,
                 )
             else:
@@ -659,12 +715,12 @@ class DatabaseDataService:
 
                 self._s3_service = S3Service(
                     bucket_name=bucket_name,
-                    region_name=s3_config.get('region', 'us-east-1'),
+                    region_name=s3_config.get("region", "us-east-1"),
                     aws_access_key_id=access_key_id,
                     aws_secret_access_key=secret_access_key,
                     aws_session_token=session_token or None,
                 )
-            
+
             # Test connection
             success, message = self._s3_service.test_connection()
             if success:
@@ -674,91 +730,106 @@ class DatabaseDataService:
                 logger.warning(f"S3 connection test failed: {message}")
                 self._s3_service = None
                 return False
-                
+
         except Exception as e:
             logger.error(f"Error initializing S3 service: {e}")
             self._s3_service = None
             return False
-    
+
     def is_s3_configured(self) -> bool:
         """Check if S3 is configured and available."""
         if self._s3_service is None:
             self._init_s3_service()
         return self._s3_service is not None
-    
+
     def sync_from_s3(self) -> Tuple[bool, str, Dict]:
         """
         Sync findings and cases from S3 to local storage.
-        
+
         Returns:
             Tuple of (success, message, stats)
         """
         if self._demo_mode:
             return False, "Cannot sync from S3 in demo mode", {}
-        
+
         # Initialize S3 if not already done
         if self._s3_service is None:
             if not self._init_s3_service():
                 return False, "S3 not configured or connection failed", {}
-        
+
         try:
             # Load S3 config to get file paths
             from core.storage.config_service import get_config_service
+
             config_service = get_config_service()
-            s3_config = config_service.get_integration_config('s3')
-            
+            s3_config = config_service.get_integration_config("s3")
+
             if not s3_config:
-                config_file = vigil_path('s3_config.json')
+                config_file = vigil_path("s3_config.json")
                 if config_file.exists():
-                    with open(config_file, 'r') as f:
+                    with open(config_file, "r") as f:
                         s3_config = json.load(f)
                 else:
                     s3_config = {}
-            
-            findings_path = s3_config.get('findings_path', 'findings.json')
-            cases_path = s3_config.get('cases_path', 'cases.json')
-            
+
+            findings_path = s3_config.get("findings_path", "findings.json")
+            cases_path = s3_config.get("cases_path", "cases.json")
+
             findings_synced = 0
             cases_synced = 0
             errors = []
-            
+
             # Sync findings
             logger.info(f"Fetching findings from S3: {findings_path}")
             s3_findings = self._s3_service.get_findings(key=findings_path)
-            
+
             if s3_findings:
                 logger.info(f"Retrieved {len(s3_findings)} findings from S3")
-                
+
                 if self._db_available:
                     # Sync to PostgreSQL
                     for finding in s3_findings:
                         try:
                             # Check if finding exists
-                            existing = self._db_service.get_finding(finding.get('finding_id'))
-                            
+                            existing = self._db_service.get_finding(
+                                finding.get("finding_id")
+                            )
+
                             if existing:
                                 # Update existing finding
-                                self._db_service.update_finding(finding.get('finding_id'), **finding)
+                                self._db_service.update_finding(
+                                    finding.get("finding_id"), **finding
+                                )
                             else:
                                 # Create new finding
                                 self._db_service.create_finding(
-                                    finding_id=finding.get('finding_id'),
-                                    embedding=finding.get('embedding', [0.0] * 768),
-                                    mitre_predictions=finding.get('mitre_predictions', {}),
-                                    anomaly_score=float(finding.get('anomaly_score', 0.0)),
-                                    timestamp=finding.get('timestamp', datetime.utcnow()),
-                                    data_source=finding.get('data_source', 's3_import'),
-                                    entity_context=finding.get('entity_context'),
-                                    evidence_links=finding.get('evidence_links'),
-                                    cluster_id=finding.get('cluster_id'),
-                                    severity=finding.get('severity'),
-                                    status=finding.get('status', 'new')
+                                    finding_id=finding.get("finding_id"),
+                                    embedding=finding.get("embedding", [0.0] * 768),
+                                    mitre_predictions=finding.get(
+                                        "mitre_predictions", {}
+                                    ),
+                                    anomaly_score=float(
+                                        finding.get("anomaly_score", 0.0)
+                                    ),
+                                    timestamp=finding.get(
+                                        "timestamp", datetime.utcnow()
+                                    ),
+                                    data_source=finding.get("data_source", "s3_import"),
+                                    entity_context=finding.get("entity_context"),
+                                    evidence_links=finding.get("evidence_links"),
+                                    cluster_id=finding.get("cluster_id"),
+                                    severity=finding.get("severity"),
+                                    status=finding.get("status", "new"),
                                 )
                             findings_synced += 1
                         except Exception as e:
-                            logger.error(f"Error syncing finding {finding.get('finding_id')}: {e}")
-                            errors.append(f"Finding {finding.get('finding_id')}: {str(e)}")
-                
+                            logger.error(
+                                f"Error syncing finding {finding.get('finding_id')}: {e}"
+                            )
+                            errors.append(
+                                f"Finding {finding.get('finding_id')}: {str(e)}"
+                            )
+
                 elif self._use_json_fallback:
                     # Sync to JSON file
                     if self._save_findings_json(s3_findings):
@@ -767,39 +838,45 @@ class DatabaseDataService:
                         errors.append("Failed to save findings to JSON file")
             else:
                 logger.warning(f"No findings found in S3 at {findings_path}")
-            
+
             # Sync cases
             logger.info(f"Fetching cases from S3: {cases_path}")
             s3_cases = self._s3_service.get_cases(key=cases_path)
-            
+
             if s3_cases:
                 logger.info(f"Retrieved {len(s3_cases)} cases from S3")
-                
+
                 if self._db_available:
                     # Sync to PostgreSQL
                     for case in s3_cases:
                         try:
                             # Check if case exists
-                            existing = self._db_service.get_case(case.get('case_id'), include_findings=False)
-                            
+                            existing = self._db_service.get_case(
+                                case.get("case_id"), include_findings=False
+                            )
+
                             if existing:
                                 # Update existing case
-                                self._db_service.update_case(case.get('case_id'), **case)
+                                self._db_service.update_case(
+                                    case.get("case_id"), **case
+                                )
                             else:
                                 # Create new case
                                 self._db_service.create_case(
-                                    case_id=case.get('case_id'),
-                                    title=case.get('title', ''),
-                                    finding_ids=case.get('finding_ids', []),
-                                    description=case.get('description', ''),
-                                    status=case.get('status', 'open'),
-                                    priority=case.get('priority', 'medium')
+                                    case_id=case.get("case_id"),
+                                    title=case.get("title", ""),
+                                    finding_ids=case.get("finding_ids", []),
+                                    description=case.get("description", ""),
+                                    status=case.get("status", "open"),
+                                    priority=case.get("priority", "medium"),
                                 )
                             cases_synced += 1
                         except Exception as e:
-                            logger.error(f"Error syncing case {case.get('case_id')}: {e}")
+                            logger.error(
+                                f"Error syncing case {case.get('case_id')}: {e}"
+                            )
                             errors.append(f"Case {case.get('case_id')}: {str(e)}")
-                
+
                 elif self._use_json_fallback:
                     # Sync to JSON file
                     if self._save_cases_json(s3_cases):
@@ -808,14 +885,14 @@ class DatabaseDataService:
                         errors.append("Failed to save cases to JSON file")
             else:
                 logger.warning(f"No cases found in S3 at {cases_path}")
-            
+
             # Build result message
             stats = {
                 "findings_synced": findings_synced,
                 "cases_synced": cases_synced,
-                "errors": errors
+                "errors": errors,
             }
-            
+
             if findings_synced > 0 or cases_synced > 0:
                 message = f"Successfully synced {findings_synced} findings and {cases_synced} cases from S3"
                 if errors:
@@ -827,8 +904,12 @@ class DatabaseDataService:
                 if errors:
                     message += f": {'; '.join(errors)}"
                 return False, message, stats
-                
+
         except Exception as e:
             error_msg = f"Error syncing from S3: {str(e)}"
             logger.error(error_msg)
-            return False, error_msg, {"findings_synced": 0, "cases_synced": 0, "errors": [error_msg]}
+            return (
+                False,
+                error_msg,
+                {"findings_synced": 0, "cases_synced": 0, "errors": [error_msg]},
+            )

--- a/core/storage/models.py
+++ b/core/storage/models.py
@@ -4,28 +4,29 @@ SQLAlchemy Database Models for Vigil SOC
 Defines the database schema for cases, findings, and related entities.
 """
 
+import uuid
 from datetime import datetime
-from typing import Optional, List
+from typing import List, Optional
+
+from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
-    Column,
-    String,
-    Integer,
-    Float,
-    DateTime,
-    Text,
-    ForeignKey,
-    Table,
-    Index,
-    Boolean,
     ARRAY,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
     Numeric,
+    String,
+    Table,
+    Text,
     UniqueConstraint,
     text,
 )
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.dialects.postgresql import JSONB
-from pgvector.sqlalchemy import Vector
-import uuid
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 # Fixed width for the findings vector column; sources of other dimensions
 # (LogLM 512) are zero-padded/truncated to this before storage.
@@ -34,7 +35,6 @@ EMBEDDING_DIM = 768
 
 class Base(DeclarativeBase):
     """Base class for all database models."""
-
 
 
 # Association table for case-finding many-to-many relationship
@@ -65,7 +65,9 @@ class Finding(Base):
     # Primary key
     finding_id: Mapped[str] = mapped_column(String(50), primary_key=True)
 
-    embedding: Mapped[List[float]] = mapped_column(Vector(EMBEDDING_DIM), nullable=False)
+    embedding: Mapped[List[float]] = mapped_column(
+        Vector(EMBEDDING_DIM), nullable=False
+    )
     mitre_predictions: Mapped[dict] = mapped_column(JSONB, nullable=False)
     anomaly_score: Mapped[float] = mapped_column(Float, nullable=False)
 
@@ -525,9 +527,7 @@ class FederationSource(Base):
 
     # Health
     last_poll_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
-    last_success_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime, nullable=True
-    )
+    last_success_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     consecutive_errors: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0"
@@ -1412,7 +1412,9 @@ class User(Base):
     # MFA
     mfa_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     mfa_secret: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    mfa_recovery_codes: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    mfa_recovery_codes: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list
+    )
 
     # Session tracking
     last_login: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
@@ -2188,9 +2190,7 @@ class Conversation(Base):
         server_default="now()",
     )
     # Sort key for the history list; null until the first message lands.
-    last_message_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime, nullable=True
-    )
+    last_message_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
     messages: Mapped[List["ChatMessage"]] = relationship(
         "ChatMessage",

--- a/core/storage/s3_service.py
+++ b/core/storage/s3_service.py
@@ -3,7 +3,8 @@
 import json
 import logging
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional
+
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 
@@ -12,15 +13,19 @@ logger = logging.getLogger(__name__)
 
 class S3Service:
     """Service for accessing data from AWS S3 buckets."""
-    
-    def __init__(self, bucket_name: str, region_name: str = "us-east-1",
-                 aws_access_key_id: Optional[str] = None,
-                 aws_secret_access_key: Optional[str] = None,
-                 aws_session_token: Optional[str] = None,
-                 aws_profile: Optional[str] = None):
+
+    def __init__(
+        self,
+        bucket_name: str,
+        region_name: str = "us-east-1",
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
+        aws_profile: Optional[str] = None,
+    ):
         """
         Initialize S3 service.
-        
+
         Args:
             bucket_name: S3 bucket name
             region_name: AWS region (default: us-east-1)
@@ -31,81 +36,86 @@ class S3Service:
         """
         self.bucket_name = bucket_name
         self.region_name = region_name
-        
+
         try:
             if aws_profile:
-                session = boto3.Session(profile_name=aws_profile, region_name=region_name)
-                self.s3_client = session.client('s3')
+                session = boto3.Session(
+                    profile_name=aws_profile, region_name=region_name
+                )
+                self.s3_client = session.client("s3")
                 logger.info(f"S3 client initialized using AWS profile '{aws_profile}'")
             elif aws_access_key_id and aws_secret_access_key:
                 kwargs: Dict[str, Any] = {
-                    'region_name': region_name,
-                    'aws_access_key_id': aws_access_key_id,
-                    'aws_secret_access_key': aws_secret_access_key,
+                    "region_name": region_name,
+                    "aws_access_key_id": aws_access_key_id,
+                    "aws_secret_access_key": aws_secret_access_key,
                 }
                 if aws_session_token:
-                    kwargs['aws_session_token'] = aws_session_token
-                self.s3_client = boto3.client('s3', **kwargs)
+                    kwargs["aws_session_token"] = aws_session_token
+                self.s3_client = boto3.client("s3", **kwargs)
             else:
-                self.s3_client = boto3.client('s3', region_name=region_name)
+                self.s3_client = boto3.client("s3", region_name=region_name)
         except Exception as e:
             logger.error(f"Failed to initialize S3 client: {e}")
             self.s3_client = None
-    
+
     def test_connection(self) -> tuple[bool, str]:
         """
         Test S3 connection.
-        
+
         Returns:
             Tuple of (success, message)
         """
         if not self.s3_client:
             return False, "S3 client not initialized"
-        
+
         try:
             # Try to list bucket contents (head_bucket is lighter but list_objects_v2 gives better error)
             self.s3_client.head_bucket(Bucket=self.bucket_name)
             return True, f"Successfully connected to bucket: {self.bucket_name}"
         except ClientError as e:
-            error_code = e.response.get('Error', {}).get('Code', 'Unknown')
-            if error_code == '404':
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            if error_code == "404":
                 return False, f"Bucket '{self.bucket_name}' not found"
-            elif error_code == '403':
-                return False, f"Access denied to bucket '{self.bucket_name}'. Check your credentials and permissions."
+            elif error_code == "403":
+                return (
+                    False,
+                    f"Access denied to bucket '{self.bucket_name}'. Check your credentials and permissions.",
+                )
             else:
                 return False, f"Error connecting to S3: {error_code} - {str(e)}"
         except NoCredentialsError:
             return False, "AWS credentials not found. Please configure credentials."
         except Exception as e:
             return False, f"Unexpected error: {str(e)}"
-    
+
     def list_files(self, prefix: str = "") -> List[str]:
         """
         List files in the bucket with optional prefix.
-        
+
         Args:
             prefix: Prefix to filter files (e.g., "findings/" or "data/")
-        
+
         Returns:
             List of file keys
         """
         if not self.s3_client:
             return []
-        
+
         try:
             files = []
-            paginator = self.s3_client.get_paginator('list_objects_v2')
-            
+            paginator = self.s3_client.get_paginator("list_objects_v2")
+
             for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix):
-                if 'Contents' in page:
-                    for obj in page['Contents']:
-                        files.append(obj['Key'])
-            
+                if "Contents" in page:
+                    for obj in page["Contents"]:
+                        files.append(obj["Key"])
+
             return files
         except Exception as e:
             logger.error(f"Error listing S3 files: {e}")
             return []
-    
+
     def list_files_detailed(self, prefix: str = "") -> List[Dict[str, Any]]:
         """
         List files in the bucket with metadata (size, last modified).
@@ -121,18 +131,20 @@ class S3Service:
 
         try:
             files = []
-            paginator = self.s3_client.get_paginator('list_objects_v2')
+            paginator = self.s3_client.get_paginator("list_objects_v2")
 
             for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix):
-                if 'Contents' in page:
-                    for obj in page['Contents']:
-                        if obj['Key'].endswith('/'):
+                if "Contents" in page:
+                    for obj in page["Contents"]:
+                        if obj["Key"].endswith("/"):
                             continue
-                        files.append({
-                            'key': obj['Key'],
-                            'size': obj['Size'],
-                            'last_modified': obj['LastModified'].isoformat(),
-                        })
+                        files.append(
+                            {
+                                "key": obj["Key"],
+                                "size": obj["Size"],
+                                "last_modified": obj["LastModified"].isoformat(),
+                            }
+                        )
 
             return files
         except Exception as e:
@@ -142,33 +154,33 @@ class S3Service:
     def get_findings(self, key: str = "findings.json") -> List[Dict]:
         """
         Get findings from S3.
-        
+
         Args:
             key: S3 object key (default: "findings.json")
-        
+
         Returns:
             List of finding dictionaries
         """
         if not self.s3_client:
             return []
-        
+
         try:
             response = self.s3_client.get_object(Bucket=self.bucket_name, Key=key)
-            content = response['Body'].read().decode('utf-8')
+            content = response["Body"].read().decode("utf-8")
             data = json.loads(content)
-            
+
             # Handle both formats: {"findings": [...]} or [...]
-            if isinstance(data, dict) and 'findings' in data:
-                return data['findings']
+            if isinstance(data, dict) and "findings" in data:
+                return data["findings"]
             elif isinstance(data, list):
                 return data
             else:
                 logger.error(f"Unexpected findings format in S3: {type(data)}")
                 return []
-        
+
         except ClientError as e:
-            error_code = e.response.get('Error', {}).get('Code', 'Unknown')
-            if error_code == 'NoSuchKey':
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            if error_code == "NoSuchKey":
                 logger.warning(f"Findings file not found in S3: {key}")
             else:
                 logger.error(f"Error reading findings from S3: {e}")
@@ -176,37 +188,37 @@ class S3Service:
         except Exception as e:
             logger.error(f"Error reading findings from S3: {e}")
             return []
-    
+
     def get_cases(self, key: str = "cases.json") -> List[Dict]:
         """
         Get cases from S3.
-        
+
         Args:
             key: S3 object key (default: "cases.json")
-        
+
         Returns:
             List of case dictionaries
         """
         if not self.s3_client:
             return []
-        
+
         try:
             response = self.s3_client.get_object(Bucket=self.bucket_name, Key=key)
-            content = response['Body'].read().decode('utf-8')
+            content = response["Body"].read().decode("utf-8")
             data = json.loads(content)
-            
+
             # Handle both formats: {"cases": [...]} or [...]
-            if isinstance(data, dict) and 'cases' in data:
-                return data['cases']
+            if isinstance(data, dict) and "cases" in data:
+                return data["cases"]
             elif isinstance(data, list):
                 return data
             else:
                 logger.error(f"Unexpected cases format in S3: {type(data)}")
                 return []
-        
+
         except ClientError as e:
-            error_code = e.response.get('Error', {}).get('Code', 'Unknown')
-            if error_code == 'NoSuchKey':
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            if error_code == "NoSuchKey":
                 logger.warning(f"Cases file not found in S3: {key}")
             else:
                 logger.error(f"Error reading cases from S3: {e}")
@@ -214,42 +226,41 @@ class S3Service:
         except Exception as e:
             logger.error(f"Error reading cases from S3: {e}")
             return []
-    
+
     def get_file(self, key: str) -> Optional[bytes]:
         """
         Get any file from S3 as bytes.
-        
+
         Args:
             key: S3 object key
-        
+
         Returns:
             File content as bytes, or None if error
         """
         if not self.s3_client:
             return None
-        
+
         try:
             response = self.s3_client.get_object(Bucket=self.bucket_name, Key=key)
-            return response['Body'].read()
+            return response["Body"].read()
         except Exception as e:
             logger.error(f"Error reading file from S3: {e}")
             return None
-    
 
     def upload_file(self, local_path: Path, s3_key: str) -> bool:
         """
         Upload a file to S3.
-        
+
         Args:
             local_path: Local file path
             s3_key: S3 object key
-        
+
         Returns:
             True if successful, False otherwise
         """
         if not self.s3_client:
             return False
-        
+
         try:
             self.s3_client.upload_file(str(local_path), self.bucket_name, s3_key)
             logger.info(f"Uploaded {local_path} to s3://{self.bucket_name}/{s3_key}")
@@ -257,4 +268,3 @@ class S3Service:
         except Exception as e:
             logger.error(f"Error uploading file to S3: {e}")
             return False
-

--- a/core/storage/service.py
+++ b/core/storage/service.py
@@ -5,18 +5,19 @@ Provides high-level database operations for cases, findings, and related entitie
 """
 
 import logging
-from typing import Optional, List, Dict, Any
 from datetime import datetime, timedelta
-from sqlalchemy import select, func, or_, and_
+from typing import Any, Dict, List, Optional
 
+from sqlalchemy import and_, func, or_, select
+
+from core.storage.case_repository import CaseRepository
+from core.storage.connection import get_db_manager
 from core.storage.models import (
+    EMBEDDING_DIM,
+    AIDecisionLog,
     Case,
     Finding,
-    AIDecisionLog,
-    EMBEDDING_DIM,
 )
-from core.storage.connection import get_db_manager
-from core.storage.case_repository import CaseRepository
 from core.storage.schemas import FindingSchema
 
 logger = logging.getLogger(__name__)
@@ -37,13 +38,13 @@ def _normalize_embedding(embedding: Optional[List[float]]) -> List[float]:
 
 class DatabaseService:
     """Service layer for database operations."""
-    
+
     def __init__(self):
         """Initialize the database service."""
         self.db_manager = get_db_manager()
-    
+
     # ========== Finding Operations ==========
-    
+
     def create_finding(
         self,
         finding_id: str,
@@ -52,11 +53,11 @@ class DatabaseService:
         anomaly_score: float,
         timestamp: datetime,
         data_source: str,
-        **kwargs
+        **kwargs,
     ) -> Optional[Finding]:
         """
         Create a new finding.
-        
+
         Args:
             finding_id: Unique finding ID
             embedding: embedding vector (padded/truncated to EMBEDDING_DIM)
@@ -65,7 +66,7 @@ class DatabaseService:
             timestamp: Finding timestamp
             data_source: Data source type
             **kwargs: Additional fields (entity_context, evidence_links, cluster_id, severity, status)
-        
+
         Returns:
             Created Finding object or None if failed
         """
@@ -78,13 +79,13 @@ class DatabaseService:
                     anomaly_score=anomaly_score,
                     timestamp=timestamp,
                     data_source=data_source,
-                    external_id=kwargs.get('external_id'),
-                    description=kwargs.get('description'),
-                    entity_context=kwargs.get('entity_context'),
-                    evidence_links=kwargs.get('evidence_links'),
-                    cluster_id=kwargs.get('cluster_id'),
-                    severity=kwargs.get('severity'),
-                    status=kwargs.get('status', 'new')
+                    external_id=kwargs.get("external_id"),
+                    description=kwargs.get("description"),
+                    entity_context=kwargs.get("entity_context"),
+                    evidence_links=kwargs.get("evidence_links"),
+                    cluster_id=kwargs.get("cluster_id"),
+                    severity=kwargs.get("severity"),
+                    status=kwargs.get("status", "new"),
                 )
                 session.add(finding)
                 session.flush()
@@ -99,48 +100,51 @@ class DatabaseService:
         """Dedup + insert many findings in one transaction; per-row create_finding
         doesn't scale to hundred-thousand-row parquet files."""
         if not rows:
-            return {'imported': 0, 'skipped': 0}
+            return {"imported": 0, "skipped": 0}
 
-        by_id = {r['finding_id']: r for r in rows}
+        by_id = {r["finding_id"]: r for r in rows}
         ids = list(by_id.keys())
         try:
             with self.db_manager.session_scope() as session:
                 existing = {
-                    row_id for (row_id,) in session.execute(
+                    row_id
+                    for (row_id,) in session.execute(
                         select(Finding.finding_id).where(Finding.finding_id.in_(ids))
                     )
                 }
                 new_ids = [i for i in ids if i not in existing]
                 for finding_id in new_ids:
                     r = by_id[finding_id]
-                    session.add(Finding(
-                        finding_id=finding_id,
-                        embedding=_normalize_embedding(r.get('embedding')),
-                        mitre_predictions=r.get('mitre_predictions') or {},
-                        anomaly_score=r.get('anomaly_score', 0.0),
-                        timestamp=r['timestamp'],
-                        data_source=r.get('data_source', 'imported'),
-                        external_id=r.get('external_id'),
-                        description=r.get('description'),
-                        entity_context=r.get('entity_context'),
-                        evidence_links=r.get('evidence_links'),
-                        cluster_id=r.get('cluster_id'),
-                        severity=r.get('severity'),
-                        status=r.get('status', 'new'),
-                    ))
+                    session.add(
+                        Finding(
+                            finding_id=finding_id,
+                            embedding=_normalize_embedding(r.get("embedding")),
+                            mitre_predictions=r.get("mitre_predictions") or {},
+                            anomaly_score=r.get("anomaly_score", 0.0),
+                            timestamp=r["timestamp"],
+                            data_source=r.get("data_source", "imported"),
+                            external_id=r.get("external_id"),
+                            description=r.get("description"),
+                            entity_context=r.get("entity_context"),
+                            evidence_links=r.get("evidence_links"),
+                            cluster_id=r.get("cluster_id"),
+                            severity=r.get("severity"),
+                            status=r.get("status", "new"),
+                        )
+                    )
                 session.flush()
-                return {'imported': len(new_ids), 'skipped': len(rows) - len(new_ids)}
+                return {"imported": len(new_ids), "skipped": len(rows) - len(new_ids)}
         except Exception as e:
             logger.error(f"Error bulk-creating findings: {e}")
-            return {'imported': 0, 'skipped': 0, 'errors': len(rows)}
+            return {"imported": 0, "skipped": 0, "errors": len(rows)}
 
     def get_finding(self, finding_id: str) -> Optional[Finding]:
         """
         Get a finding by ID.
-        
+
         Args:
             finding_id: Finding ID
-        
+
         Returns:
             Finding object or None if not found
         """
@@ -154,7 +158,7 @@ class DatabaseService:
         except Exception as e:
             logger.error(f"Error getting finding {finding_id}: {e}")
             return None
-    
+
     def get_findings(
         self,
         severity: Optional[str] = None,
@@ -170,7 +174,7 @@ class DatabaseService:
     ) -> List[Finding]:
         """
         Get findings with optional filters, search, and pagination.
-        
+
         Args:
             severity: Filter by severity
             data_source: Filter by data source
@@ -182,14 +186,14 @@ class DatabaseService:
             offset: Offset for pagination
             sort_by: Column to sort by (timestamp, anomaly_score, severity)
             sort_order: Sort direction (asc, desc)
-        
+
         Returns:
             List of Finding objects
         """
         try:
             with self.db_manager.session_scope() as session:
                 query = select(Finding)
-                
+
                 filters = []
                 if severity:
                     filters.append(Finding.severity == severity)
@@ -202,18 +206,21 @@ class DatabaseService:
                 if status:
                     filters.append(Finding.status == status)
                 if search_query:
-                    from sqlalchemy import cast, String
+                    from sqlalchemy import String, cast
+
                     search_clauses = [
                         Finding.finding_id.ilike(f"%{search_query}%"),
                         cast(Finding.entity_context, String).ilike(f"%{search_query}%"),
                     ]
-                    if hasattr(Finding, 'description'):
-                        search_clauses.append(Finding.description.ilike(f"%{search_query}%"))
+                    if hasattr(Finding, "description"):
+                        search_clauses.append(
+                            Finding.description.ilike(f"%{search_query}%")
+                        )
                     filters.append(or_(*search_clauses))
-                
+
                 if filters:
                     query = query.where(and_(*filters))
-                
+
                 sort_column_map = {
                     "timestamp": Finding.timestamp,
                     "anomaly_score": Finding.anomaly_score,
@@ -228,17 +235,17 @@ class DatabaseService:
                     query = query.order_by(sort_col.desc())
 
                 query = query.limit(limit).offset(offset)
-                
+
                 findings = session.execute(query).scalars().all()
-                
+
                 for finding in findings:
                     session.expunge(finding)
-                
+
                 return findings
         except Exception as e:
             logger.error(f"Error getting findings: {e}")
             return []
-    
+
     def find_similar_findings(
         self,
         finding_id: str,
@@ -334,12 +341,19 @@ class DatabaseService:
                 if status:
                     filters.append(Finding.status == status)
                 if search_query:
-                    from sqlalchemy import cast, String
+                    from sqlalchemy import String, cast
+
                     filters.append(
                         or_(
                             Finding.finding_id.ilike(f"%{search_query}%"),
-                            Finding.description.ilike(f"%{search_query}%") if hasattr(Finding, 'description') else Finding.finding_id.ilike(f"%{search_query}%"),
-                            cast(Finding.entity_context, String).ilike(f"%{search_query}%"),
+                            (
+                                Finding.description.ilike(f"%{search_query}%")
+                                if hasattr(Finding, "description")
+                                else Finding.finding_id.ilike(f"%{search_query}%")
+                            ),
+                            cast(Finding.entity_context, String).ilike(
+                                f"%{search_query}%"
+                            ),
                         )
                     )
 
@@ -354,11 +368,11 @@ class DatabaseService:
     def update_finding(self, finding_id: str, **updates) -> bool:
         """
         Update a finding.
-        
+
         Args:
             finding_id: Finding ID
             **updates: Fields to update
-        
+
         Returns:
             True if successful, False otherwise
         """
@@ -368,12 +382,12 @@ class DatabaseService:
                 if not finding:
                     logger.warning(f"Finding not found: {finding_id}")
                     return False
-                
+
                 # Update allowed fields
                 for key, value in updates.items():
                     if hasattr(finding, key):
                         setattr(finding, key, value)
-                
+
                 finding.updated_at = datetime.utcnow()
                 session.flush()
                 logger.info(f"Updated finding: {finding_id}")
@@ -381,14 +395,14 @@ class DatabaseService:
         except Exception as e:
             logger.error(f"Error updating finding {finding_id}: {e}")
             return False
-    
+
     def delete_finding(self, finding_id: str) -> bool:
         """
         Delete a finding.
-        
+
         Args:
             finding_id: Finding ID
-        
+
         Returns:
             True if successful, False otherwise
         """
@@ -398,32 +412,28 @@ class DatabaseService:
                 if not finding:
                     logger.warning(f"Finding not found: {finding_id}")
                     return False
-                
+
                 session.delete(finding)
                 logger.info(f"Deleted finding: {finding_id}")
                 return True
         except Exception as e:
             logger.error(f"Error deleting finding {finding_id}: {e}")
             return False
-    
+
     # ========== Case Operations ==========
-    
+
     def create_case(
-        self,
-        case_id: str,
-        title: str,
-        finding_ids: List[str],
-        **kwargs
+        self, case_id: str, title: str, finding_ids: List[str], **kwargs
     ) -> Optional[Case]:
         """
         Create a new case.
-        
+
         Args:
             case_id: Unique case ID
             title: Case title
             finding_ids: List of finding IDs to link
             **kwargs: Additional fields (description, status, priority, assignee, tags, etc.)
-        
+
         Returns:
             Created Case object or None if failed
         """
@@ -434,43 +444,50 @@ class DatabaseService:
                 case = Case(
                     case_id=case_id,
                     title=title,
-                    description=kwargs.get('description', ''),
-                    status=kwargs.get('status', 'new'),
-                    priority=kwargs.get('priority', 'medium'),
-                    assignee=kwargs.get('assignee'),
-                    tags=kwargs.get('tags', []),
-                    notes=kwargs.get('notes', []),
-                    timeline=kwargs.get('timeline', [{'timestamp': now.isoformat() + 'Z', 'event': 'Case created'}]),
-                    activities=kwargs.get('activities', []),
-                    resolution_steps=kwargs.get('resolution_steps', []),
-                    mitre_techniques=kwargs.get('mitre_techniques'),
+                    description=kwargs.get("description", ""),
+                    status=kwargs.get("status", "new"),
+                    priority=kwargs.get("priority", "medium"),
+                    assignee=kwargs.get("assignee"),
+                    tags=kwargs.get("tags", []),
+                    notes=kwargs.get("notes", []),
+                    timeline=kwargs.get(
+                        "timeline",
+                        [{"timestamp": now.isoformat() + "Z", "event": "Case created"}],
+                    ),
+                    activities=kwargs.get("activities", []),
+                    resolution_steps=kwargs.get("resolution_steps", []),
+                    mitre_techniques=kwargs.get("mitre_techniques"),
                 )
                 session.add(case)
                 session.flush()
-                
+
                 # Link findings
                 if finding_ids:
-                    findings = session.execute(
-                        select(Finding).where(Finding.finding_id.in_(finding_ids))
-                    ).scalars().all()
+                    findings = (
+                        session.execute(
+                            select(Finding).where(Finding.finding_id.in_(finding_ids))
+                        )
+                        .scalars()
+                        .all()
+                    )
                     case.findings.extend(findings)
                     session.flush()
-                
+
                 session.refresh(case)
                 logger.info(f"Created case: {case_id} with {len(finding_ids)} findings")
                 return case
         except Exception as e:
             logger.error(f"Error creating case {case_id}: {e}")
             return None
-    
+
     def get_case(self, case_id: str, include_findings: bool = False) -> Optional[Case]:
         """
         Get a case by ID.
-        
+
         Args:
             case_id: Case ID
             include_findings: If True, include full finding objects
-        
+
         Returns:
             Case object or None if not found
         """
@@ -486,25 +503,25 @@ class DatabaseService:
         except Exception as e:
             logger.error(f"Error getting case {case_id}: {e}")
             return None
-    
+
     def get_cases(
         self,
         status: Optional[str] = None,
         priority: Optional[str] = None,
         assignee: Optional[str] = None,
         limit: int = 1000,
-        offset: int = 0
+        offset: int = 0,
     ) -> List[Case]:
         """
         Get cases with optional filters.
-        
+
         Args:
             status: Filter by status
             priority: Filter by priority
             assignee: Filter by assignee
             limit: Maximum number of results
             offset: Offset for pagination
-        
+
         Returns:
             List of Case objects
         """
@@ -527,15 +544,15 @@ class DatabaseService:
         except Exception as e:
             logger.error(f"Error getting cases: {e}")
             return []
-    
+
     def update_case(self, case_id: str, **updates) -> bool:
         """
         Update a case.
-        
+
         Args:
             case_id: Case ID
             **updates: Fields to update
-        
+
         Returns:
             True if successful, False otherwise
         """
@@ -565,14 +582,14 @@ class DatabaseService:
         except Exception as e:
             logger.error(f"Error updating case {case_id}: {e}")
             return False
-    
+
     def delete_case(self, case_id: str) -> bool:
         """
         Delete a case.
-        
+
         Args:
             case_id: Case ID
-        
+
         Returns:
             True if successful, False otherwise
         """
@@ -582,22 +599,22 @@ class DatabaseService:
                 if not case:
                     logger.warning(f"Case not found: {case_id}")
                     return False
-                
+
                 session.delete(case)
                 logger.info(f"Deleted case: {case_id}")
                 return True
         except Exception as e:
             logger.error(f"Error deleting case {case_id}: {e}")
             return False
-    
+
     def add_finding_to_case(self, case_id: str, finding_id: str) -> bool:
         """
         Add a finding to a case.
-        
+
         Args:
             case_id: Case ID
             finding_id: Finding ID
-        
+
         Returns:
             True if successful, False otherwise
         """
@@ -605,30 +622,32 @@ class DatabaseService:
             with self.db_manager.session_scope() as session:
                 case = session.get(Case, case_id)
                 finding = session.get(Finding, finding_id)
-                
+
                 if not case or not finding:
-                    logger.warning(f"Case or finding not found: {case_id}, {finding_id}")
+                    logger.warning(
+                        f"Case or finding not found: {case_id}, {finding_id}"
+                    )
                     return False
-                
+
                 if finding not in case.findings:
                     case.findings.append(finding)
                     case.updated_at = datetime.utcnow()
                     session.flush()
                     logger.info(f"Added finding {finding_id} to case {case_id}")
-                
+
                 return True
         except Exception as e:
             logger.error(f"Error adding finding to case: {e}")
             return False
-    
+
     def remove_finding_from_case(self, case_id: str, finding_id: str) -> bool:
         """
         Remove a finding from a case.
-        
+
         Args:
             case_id: Case ID
             finding_id: Finding ID
-        
+
         Returns:
             True if successful, False otherwise
         """
@@ -636,28 +655,28 @@ class DatabaseService:
             with self.db_manager.session_scope() as session:
                 case = session.get(Case, case_id)
                 finding = session.get(Finding, finding_id)
-                
+
                 if not case or not finding:
-                    logger.warning(f"Case or finding not found: {case_id}, {finding_id}")
+                    logger.warning(
+                        f"Case or finding not found: {case_id}, {finding_id}"
+                    )
                     return False
-                
+
                 if finding in case.findings:
                     case.findings.remove(finding)
                     case.updated_at = datetime.utcnow()
                     session.flush()
                     logger.info(f"Removed finding {finding_id} from case {case_id}")
-                
+
                 return True
         except Exception as e:
             logger.error(f"Error removing finding from case: {e}")
             return False
-    
+
     # ========== Statistics ==========
-    
-    
-    
+
     # ========== AI Decision Log Operations ==========
-    
+
     def create_ai_decision(
         self,
         decision_id: str,
@@ -669,11 +688,11 @@ class DatabaseService:
         finding_id: Optional[str] = None,
         case_id: Optional[str] = None,
         workflow_id: Optional[str] = None,
-        decision_metadata: Optional[dict] = None
+        decision_metadata: Optional[dict] = None,
     ) -> Optional[AIDecisionLog]:
         """
         Log an AI decision for tracking and feedback.
-        
+
         Args:
             decision_id: Unique decision identifier
             agent_id: ID of the agent making the decision
@@ -685,7 +704,7 @@ class DatabaseService:
             case_id: Optional associated case ID
             workflow_id: Optional workflow ID
             decision_metadata: Optional additional metadata
-        
+
         Returns:
             Created AIDecisionLog or None if failed
         """
@@ -702,18 +721,18 @@ class DatabaseService:
                     case_id=case_id,
                     workflow_id=workflow_id,
                     decision_metadata=decision_metadata,
-                    timestamp=datetime.utcnow()
+                    timestamp=datetime.utcnow(),
                 )
-                
+
                 session.add(decision)
                 session.flush()
-                
+
                 logger.info(f"Created AI decision log: {decision_id} by {agent_id}")
                 return decision
         except Exception as e:
             logger.error(f"Error creating AI decision log: {e}")
             return None
-    
+
     def submit_ai_decision_feedback(
         self,
         decision_id: str,
@@ -724,11 +743,11 @@ class DatabaseService:
         reasoning_grade: Optional[float] = None,
         action_appropriateness: Optional[float] = None,
         actual_outcome: Optional[str] = None,
-        time_saved_minutes: Optional[int] = None
+        time_saved_minutes: Optional[int] = None,
     ) -> Optional[AIDecisionLog]:
         """
         Submit human feedback on an AI decision.
-        
+
         Args:
             decision_id: Decision to provide feedback on
             human_reviewer: Name/ID of reviewer
@@ -739,20 +758,22 @@ class DatabaseService:
             action_appropriateness: Grade for action appropriateness (0-1)
             actual_outcome: Actual outcome ('true_positive', 'false_positive', etc.)
             time_saved_minutes: Estimated time saved by AI
-        
+
         Returns:
             Updated AIDecisionLog or None if failed
         """
         try:
             with self.db_manager.session_scope() as session:
-                decision = session.query(AIDecisionLog).filter(
-                    AIDecisionLog.decision_id == decision_id
-                ).first()
-                
+                decision = (
+                    session.query(AIDecisionLog)
+                    .filter(AIDecisionLog.decision_id == decision_id)
+                    .first()
+                )
+
                 if not decision:
                     logger.error(f"AI decision not found: {decision_id}")
                     return None
-                
+
                 # Update feedback fields
                 decision.human_reviewer = human_reviewer
                 decision.human_decision = human_decision
@@ -763,34 +784,38 @@ class DatabaseService:
                 decision.actual_outcome = actual_outcome
                 decision.time_saved_minutes = time_saved_minutes
                 decision.feedback_timestamp = datetime.utcnow()
-                
+
                 session.flush()
-                
-                logger.info(f"Updated AI decision feedback: {decision_id} by {human_reviewer}")
+
+                logger.info(
+                    f"Updated AI decision feedback: {decision_id} by {human_reviewer}"
+                )
                 return decision
         except Exception as e:
             logger.error(f"Error submitting AI decision feedback: {e}")
             return None
-    
+
     def get_ai_decision(self, decision_id: str) -> Optional[AIDecisionLog]:
         """
         Get an AI decision by ID.
-        
+
         Args:
             decision_id: Decision ID
-        
+
         Returns:
             AIDecisionLog or None if not found
         """
         try:
             with self.db_manager.session_scope() as session:
-                return session.query(AIDecisionLog).filter(
-                    AIDecisionLog.decision_id == decision_id
-                ).first()
+                return (
+                    session.query(AIDecisionLog)
+                    .filter(AIDecisionLog.decision_id == decision_id)
+                    .first()
+                )
         except Exception as e:
             logger.error(f"Error getting AI decision: {e}")
             return None
-    
+
     def list_ai_decisions(
         self,
         agent_id: Optional[str] = None,
@@ -798,11 +823,11 @@ class DatabaseService:
         case_id: Optional[str] = None,
         has_feedback: Optional[bool] = None,
         limit: int = 100,
-        offset: int = 0
+        offset: int = 0,
     ) -> List[AIDecisionLog]:
         """
         List AI decisions with optional filters.
-        
+
         Args:
             agent_id: Filter by agent ID
             finding_id: Filter by finding ID
@@ -810,137 +835,153 @@ class DatabaseService:
             has_feedback: Filter by whether feedback exists
             limit: Maximum number of results
             offset: Offset for pagination
-        
+
         Returns:
             List of AIDecisionLog objects
         """
         try:
             with self.db_manager.session_scope() as session:
                 query = session.query(AIDecisionLog)
-                
+
                 if agent_id:
                     query = query.filter(AIDecisionLog.agent_id == agent_id)
-                
+
                 if finding_id:
                     query = query.filter(AIDecisionLog.finding_id == finding_id)
-                
+
                 if case_id:
                     query = query.filter(AIDecisionLog.case_id == case_id)
-                
+
                 if has_feedback is not None:
                     if has_feedback:
                         query = query.filter(AIDecisionLog.human_decision.isnot(None))
                     else:
                         query = query.filter(AIDecisionLog.human_decision.is_(None))
-                
-                decisions = query.order_by(
-                    AIDecisionLog.timestamp.desc()
-                ).limit(limit).offset(offset).all()
-                
+
+                decisions = (
+                    query.order_by(AIDecisionLog.timestamp.desc())
+                    .limit(limit)
+                    .offset(offset)
+                    .all()
+                )
+
                 return decisions
         except Exception as e:
             logger.error(f"Error listing AI decisions: {e}")
             return []
-    
+
     def get_ai_decision_stats(
-        self,
-        agent_id: Optional[str] = None,
-        days: int = 30
+        self, agent_id: Optional[str] = None, days: int = 30
     ) -> dict:
         """
         Get statistics on AI decisions and feedback.
-        
+
         Args:
             agent_id: Optional filter by agent ID
             days: Number of days to look back
-        
+
         Returns:
             Dictionary with statistics
         """
         try:
             from datetime import timedelta
-            
+
             with self.db_manager.session_scope() as session:
                 since = datetime.utcnow() - timedelta(days=days)
-                
+
                 query = session.query(AIDecisionLog).filter(
                     AIDecisionLog.timestamp >= since
                 )
-                
+
                 if agent_id:
                     query = query.filter(AIDecisionLog.agent_id == agent_id)
-                
+
                 # Total decisions
                 total_decisions = query.count()
-                
+
                 # Decisions with feedback
                 feedback_query = query.filter(AIDecisionLog.human_decision.isnot(None))
                 total_with_feedback = feedback_query.count()
-                
+
                 # Agreement rate
                 agree_count = feedback_query.filter(
-                    AIDecisionLog.human_decision == 'agree'
+                    AIDecisionLog.human_decision == "agree"
                 ).count()
-                
+
                 # Average grades
                 avg_accuracy = session.query(
                     func.avg(AIDecisionLog.accuracy_grade)
                 ).filter(
                     AIDecisionLog.timestamp >= since,
-                    AIDecisionLog.accuracy_grade.isnot(None)
+                    AIDecisionLog.accuracy_grade.isnot(None),
                 )
-                
+
                 if agent_id:
-                    avg_accuracy = avg_accuracy.filter(AIDecisionLog.agent_id == agent_id)
-                
+                    avg_accuracy = avg_accuracy.filter(
+                        AIDecisionLog.agent_id == agent_id
+                    )
+
                 avg_accuracy = avg_accuracy.scalar() or 0
-                
+
                 # Outcome counts
                 outcomes = {}
-                for outcome, count in session.query(
-                    AIDecisionLog.actual_outcome,
-                    func.count(AIDecisionLog.id)
-                ).filter(
-                    AIDecisionLog.timestamp >= since,
-                    AIDecisionLog.actual_outcome.isnot(None)
-                ).group_by(AIDecisionLog.actual_outcome).all():
+                for outcome, count in (
+                    session.query(
+                        AIDecisionLog.actual_outcome, func.count(AIDecisionLog.id)
+                    )
+                    .filter(
+                        AIDecisionLog.timestamp >= since,
+                        AIDecisionLog.actual_outcome.isnot(None),
+                    )
+                    .group_by(AIDecisionLog.actual_outcome)
+                    .all()
+                ):
                     outcomes[outcome] = count
-                
+
                 # Time saved
                 total_time_saved = session.query(
                     func.sum(AIDecisionLog.time_saved_minutes)
                 ).filter(
                     AIDecisionLog.timestamp >= since,
-                    AIDecisionLog.time_saved_minutes.isnot(None)
+                    AIDecisionLog.time_saved_minutes.isnot(None),
                 )
-                
+
                 if agent_id:
-                    total_time_saved = total_time_saved.filter(AIDecisionLog.agent_id == agent_id)
-                
+                    total_time_saved = total_time_saved.filter(
+                        AIDecisionLog.agent_id == agent_id
+                    )
+
                 total_time_saved = total_time_saved.scalar() or 0
-                
+
                 return {
-                    'total_decisions': total_decisions,
-                    'total_with_feedback': total_with_feedback,
-                    'feedback_rate': round(total_with_feedback / total_decisions, 3) if total_decisions > 0 else 0,
-                    'agreement_rate': round(agree_count / total_with_feedback, 3) if total_with_feedback > 0 else 0,
-                    'avg_accuracy_grade': round(avg_accuracy, 3),
-                    'outcomes': outcomes,
-                    'total_time_saved_minutes': int(total_time_saved),
-                    'total_time_saved_hours': round(total_time_saved / 60, 1),
-                    'period_days': days
+                    "total_decisions": total_decisions,
+                    "total_with_feedback": total_with_feedback,
+                    "feedback_rate": (
+                        round(total_with_feedback / total_decisions, 3)
+                        if total_decisions > 0
+                        else 0
+                    ),
+                    "agreement_rate": (
+                        round(agree_count / total_with_feedback, 3)
+                        if total_with_feedback > 0
+                        else 0
+                    ),
+                    "avg_accuracy_grade": round(avg_accuracy, 3),
+                    "outcomes": outcomes,
+                    "total_time_saved_minutes": int(total_time_saved),
+                    "total_time_saved_hours": round(total_time_saved / 60, 1),
+                    "period_days": days,
                 }
         except Exception as e:
             logger.error(f"Error getting AI decision statistics: {e}")
             return {
-                'total_decisions': 0,
-                'total_with_feedback': 0,
-                'feedback_rate': 0,
-                'agreement_rate': 0,
-                'avg_accuracy_grade': 0,
-                'outcomes': {},
-                'total_time_saved_minutes': 0,
-                'total_time_saved_hours': 0,
-                'period_days': days
+                "total_decisions": 0,
+                "total_with_feedback": 0,
+                "feedback_rate": 0,
+                "agreement_rate": 0,
+                "avg_accuracy_grade": 0,
+                "outcomes": {},
+                "total_time_saved_minutes": 0,
+                "total_time_saved_hours": 0,
+                "period_days": days,
             }
-

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -13,6 +13,7 @@ Environment variables:
     ENVIRONMENT                     Deployment environment label (default "development")
     RELEASE_VERSION                 Service version label (default "unknown")
 """
+
 from __future__ import annotations
 
 import json
@@ -41,6 +42,7 @@ _investigation_id_var: ContextVar[Optional[str]] = ContextVar(
 # Context helpers
 # ---------------------------------------------------------------------------
 
+
 def set_investigation_id(investigation_id: Optional[str]) -> None:
     """Attach an investigation ID to the current async context."""
     _investigation_id_var.set(investigation_id)
@@ -55,6 +57,7 @@ def get_investigation_id() -> Optional[str]:
 # Configuration helpers
 # ---------------------------------------------------------------------------
 
+
 def _is_otel_enabled() -> bool:
     return get_settings().vigil_otel_enabled
 
@@ -62,15 +65,15 @@ def _is_otel_enabled() -> bool:
 # Opt-in flag helpers live in core.telemetry_config so the sanitizer can
 # read them without importing this module (breaks the import cycle).
 # Re-exported here for backwards compatibility with existing callers/tests.
-from core.telemetry_config import (  # noqa: E402
+from core.telemetry_config import (  # noqa: E402,F401
     _should_record_ioc_values,
     _should_record_llm_content,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fallback no-op classes (used when OTEL is disabled or SDK missing)
 # ---------------------------------------------------------------------------
+
 
 class _NoOpSpan:
     """No-op span satisfying the OpenTelemetry Span interface."""
@@ -160,13 +163,14 @@ class _FallbackNoOpMeter:
 # Internal initialization
 # ---------------------------------------------------------------------------
 
+
 def _do_init(service_name: str) -> None:
     """Actually initialize OTEL providers. Raises on any failure."""
-    from opentelemetry import trace, metrics
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry import metrics, trace
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
     global _tracer_provider, _meter_provider
 
@@ -189,11 +193,13 @@ def _do_init(service_name: str) -> None:
         from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
             OTLPSpanExporter,
         )
+
         span_exporter = OTLPSpanExporter(endpoint=endpoint, insecure=True)
     except Exception:
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
             OTLPSpanExporter as OTLPSpanExporterHTTP,
         )
+
         span_exporter = OTLPSpanExporterHTTP(endpoint=endpoint)
 
     batch_processor = BatchSpanProcessor(
@@ -215,6 +221,7 @@ def _do_init(service_name: str) -> None:
     if sentry_dsn:
         try:
             from core.platform.monitoring import SentrySpanProcessor
+
             tracer_provider.add_span_processor(SentrySpanProcessor())
         except Exception:
             pass  # core.platform.monitoring may not be importable in daemon context
@@ -225,6 +232,7 @@ def _do_init(service_name: str) -> None:
     # --- MeterProvider ---
     try:
         from opentelemetry.exporter.prometheus import PrometheusMetricReader
+
         metric_reader = PrometheusMetricReader()
         logger.debug("Using PrometheusMetricReader on port 9090")
     except Exception:
@@ -233,6 +241,7 @@ def _do_init(service_name: str) -> None:
                 OTLPMetricExporter,
             )
             from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
             metric_reader = PeriodicExportingMetricReader(
                 OTLPMetricExporter(endpoint=endpoint, insecure=True)
             )
@@ -256,6 +265,7 @@ def _do_init(service_name: str) -> None:
 # Public API
 # ---------------------------------------------------------------------------
 
+
 def init_telemetry(service_name: str) -> bool:
     """
     Bootstrap tracing and metrics for a process.
@@ -278,9 +288,7 @@ def init_telemetry(service_name: str) -> bool:
         _install_json_logging()
         return True
     except Exception as exc:
-        logger.warning(
-            "OpenTelemetry initialization failed (non-fatal): %s", exc
-        )
+        logger.warning("OpenTelemetry initialization failed (non-fatal): %s", exc)
         return False
 
 
@@ -401,6 +409,7 @@ shutdown_telemetry = shutdown
 # ---------------------------------------------------------------------------
 # Structured JSON logging with OTEL trace correlation (#59)
 # ---------------------------------------------------------------------------
+
 
 def _install_json_logging() -> None:
     """

--- a/core/telemetry_config.py
+++ b/core/telemetry_config.py
@@ -5,6 +5,7 @@ Extracted so both ``core.telemetry`` and ``core.telemetry_sanitizer`` can
 read operator opt-in flags without importing each other (avoids an import
 cycle between the bootstrap and the span-scrubbing processor).
 """
+
 from __future__ import annotations
 
 from core.config import get_settings

--- a/core/telemetry_sanitizer.py
+++ b/core/telemetry_sanitizer.py
@@ -13,10 +13,11 @@ Note: LLM content (prompts/responses) and raw finding/IOC values are always
 redacted unless the operator has explicitly opted in via environment variables
 VIGIL_OTEL_RECORD_LLM_CONTENT and VIGIL_OTEL_RECORD_IOC_VALUES respectively.
 """
+
 from __future__ import annotations
 
-import re
 import logging
+import re
 from types import MappingProxyType
 from typing import Any, Optional
 
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 try:
     from opentelemetry.sdk.trace import SpanProcessor
+
     _SDK_AVAILABLE = True
 except ImportError:
     SpanProcessor = object  # type: ignore[assignment,misc]
@@ -196,8 +198,13 @@ class SensitiveAttributeScrubber(SpanProcessor):  # type: ignore[misc]
                     continue
 
                 # Raw finding / IOC values: redact unless operator opted in
-                if not record_ioc and "finding." in key_lower and any(
-                    k in key_lower for k in ("raw", "payload", "description", "entity")
+                if (
+                    not record_ioc
+                    and "finding." in key_lower
+                    and any(
+                        k in key_lower
+                        for k in ("raw", "payload", "description", "entity")
+                    )
                 ):
                     new_attrs[key] = "[REDACTED]"
                     modified = True

--- a/core/threat_intel/attack_router.py
+++ b/core/threat_intel/attack_router.py
@@ -1,13 +1,18 @@
 """ATT&CK framework API endpoints."""
 
+import logging
 from datetime import datetime
 from typing import Optional
-from fastapi import APIRouter, Query
-import logging
 
-from core.storage.database_data_service import DatabaseDataService
-from core.threat_intel.mitre_lookup import get_time_range, iter_techniques, resolve_technique
+from fastapi import APIRouter, Query
+
 from core.routing import Auth, RouterMeta
+from core.storage.database_data_service import DatabaseDataService
+from core.threat_intel.mitre_lookup import (
+    get_time_range,
+    iter_techniques,
+    resolve_technique,
+)
 
 router = APIRouter()
 

--- a/core/threat_intel/mitre_lookup.py
+++ b/core/threat_intel/mitre_lookup.py
@@ -36,6 +36,7 @@ def get_time_range(time_range: str) -> tuple[datetime, datetime]:
 
     return start_time, end_time
 
+
 # {technique_id: (name, tactic)} — extend as ATT&CK coverage grows.
 TECHNIQUE_NAME_FALLBACKS: dict[str, tuple[str, str]] = {
     "T1071.001": ("Web Protocols", "Command and Control"),

--- a/core/threat_intel/threat_feed_service.py
+++ b/core/threat_intel/threat_feed_service.py
@@ -120,7 +120,9 @@ def _parse_dt(value: Any) -> Optional[datetime]:
         return value.replace(tzinfo=None)
     if isinstance(value, str):
         try:
-            return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(
+                tzinfo=None
+            )
         except ValueError:
             return None
     return None
@@ -186,16 +188,24 @@ def fetch_taxii_collection(
         params: Dict[str, Any] = {}
         if since:
             params["added_after"] = since.isoformat() + "Z"
-        envelope = collection.get_objects(**params) if params else collection.get_objects()
+        envelope = (
+            collection.get_objects(**params) if params else collection.get_objects()
+        )
     except Exception as e:  # noqa: BLE001
         logger.error("TAXII fetch failed (%s/%s): %s", server_url, collection_id, e)
         return []
 
-    objects = envelope.get("objects") if isinstance(envelope, dict) else getattr(envelope, "objects", [])
+    objects = (
+        envelope.get("objects")
+        if isinstance(envelope, dict)
+        else getattr(envelope, "objects", [])
+    )
     out: List[NormalizedIndicator] = []
     for obj in objects or []:
         try:
-            out.extend(parse_stix_indicator(obj, source=source, collection_id=collection_id))
+            out.extend(
+                parse_stix_indicator(obj, source=source, collection_id=collection_id)
+            )
         except Exception as e:  # noqa: BLE001
             logger.debug("Skipping malformed STIX object: %s", e)
     return out
@@ -270,7 +280,12 @@ def upsert_indicators(indicators: List[NormalizedIndicator]) -> Dict[str, int]:
                         existing.raw_stix = ind.raw_stix
                     updated += 1
             except Exception as e:  # noqa: BLE001
-                logger.debug("Failed to upsert indicator %s/%s: %s", ind.indicator_type, ind.indicator_value, e)
+                logger.debug(
+                    "Failed to upsert indicator %s/%s: %s",
+                    ind.indicator_type,
+                    ind.indicator_value,
+                    e,
+                )
                 skipped += 1
     return {"inserted": inserted, "updated": updated, "skipped": skipped}
 

--- a/core/workflows/workflows_router.py
+++ b/core/workflows/workflows_router.py
@@ -1,10 +1,11 @@
 """Workflows API endpoints for SOC workflow management and execution."""
 
+import logging
 from typing import Any, Dict, List, Optional
 
-import logging
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+
 from core.deps import (
     provide_approvals,
     provide_custom_workflows,

--- a/core/workflows/workflows_service.py
+++ b/core/workflows/workflows_service.py
@@ -611,8 +611,8 @@ For each phase:
         Any failure degrades to ``(None, DEFAULT_MODEL)`` (legacy behavior).
         """
         try:
-            from core.llm.router.router import get_provider_spec
             from core.llm.providers.registry import get_registry
+            from core.llm.router.router import get_provider_spec
 
             pick = get_registry().resolve_model_for_component(component)
             if not pick:
@@ -681,8 +681,8 @@ For each phase:
         """Legacy composite-prompt path for file-based workflows that
         don't have structured phases. No approval gating possible —
         there's no phase_id to attach an approval to."""
-        from core.llm.harness.claude import ClaudeService
         from core.agents.manager import SOCAgentLibrary
+        from core.llm.harness.claude import ClaudeService
 
         target_context = self._build_target_context(parameters)
         all_agents = SOCAgentLibrary.get_all_agents()
@@ -852,8 +852,8 @@ For each phase:
         """Shared phase-loop body used by both initial execute and
         resume. Walks phases from ``start_index``; pauses or completes
         the run as appropriate."""
-        from core.llm.harness.claude import ClaudeService
         from core.agents.manager import SOCAgentLibrary
+        from core.llm.harness.claude import ClaudeService
 
         run_service = self._workflow_runs
         approval_service = self._approvals
@@ -1255,16 +1255,14 @@ You have access to SOC tools and must ground every conclusion in tool output.
                         if techniques
                         else "None"
                     )
-                    parts.append(
-                        f"""**Target Finding:**
+                    parts.append(f"""**Target Finding:**
 - Finding ID: {finding.get('finding_id')}
 - Severity: {finding.get('severity')}
 - Data Source: {finding.get('data_source')}
 - Timestamp: {finding.get('timestamp')}
 - Anomaly Score: {finding.get('anomaly_score', 'N/A')}
 - Description: {finding.get('description', 'N/A')}
-- MITRE ATT&CK Techniques: {technique_str}"""
-                    )
+- MITRE ATT&CK Techniques: {technique_str}""")
                 else:
                     parts.append(
                         f"**Target Finding ID:** {finding_id} (details will be retrieved during execution)"
@@ -1281,15 +1279,13 @@ You have access to SOC tools and must ground every conclusion in tool output.
                 data_service = DatabaseDataService()
                 case = data_service.get_case(case_id)
                 if case:
-                    parts.append(
-                        f"""**Target Case:**
+                    parts.append(f"""**Target Case:**
 - Case ID: {case.get('case_id')}
 - Title: {case.get('title')}
 - Status: {case.get('status')}
 - Priority: {case.get('priority')}
 - Description: {case.get('description', 'N/A')}
-- Finding Count: {len(case.get('finding_ids', []))}"""
-                    )
+- Finding Count: {len(case.get('finding_ids', []))}""")
                 else:
                     parts.append(
                         f"**Target Case ID:** {case_id} (details will be retrieved during execution)"

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -19,21 +19,24 @@ project_root = str(_repo_root)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from fastapi import FastAPI, Depends
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from slowapi.errors import RateLimitExceeded
 from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
 
+from core.config import get_settings
+from core.platform.monitoring import (
+    PROMETHEUS_AVAILABLE,
+    get_metrics_response,
+    init_sentry,
+)
 from core.version import __version__
+from services.api.discovery import mount_routers
+from services.api.middleware.auth import get_current_active_user
 from services.api.middleware.csrf import CSRFMiddleware
 from services.api.middleware.rate_limit import limiter
 from services.api.middleware.security_headers import SecurityHeadersMiddleware
-
-from services.api.discovery import mount_routers
-from services.api.middleware.auth import get_current_active_user
-from core.config import get_settings
-from core.platform.monitoring import init_sentry, PROMETHEUS_AVAILABLE, get_metrics_response
 
 # Single source of truth for the "require an authenticated active user"
 # dependency. Applied to every non-public /api/* router below so that any
@@ -481,8 +484,8 @@ async def _startup(app: FastAPI):
     # Initialize data storage backend
     logger.info("Initializing data storage...")
     try:
-        from core.storage.database_data_service import DatabaseDataService
         from core.config import is_demo_mode
+        from core.storage.database_data_service import DatabaseDataService
 
         # Defense-in-depth: ensure the SQLAlchemy-managed schema exists before
         # any endpoint tries to query it. start.sh runs scripts/init_schema.py
@@ -648,8 +651,8 @@ async def metrics():
 async def health_check():
     """Health check endpoint with storage backend info."""
     try:
-        from core.storage.database_data_service import DatabaseDataService
         from core.config import is_demo_mode
+        from core.storage.database_data_service import DatabaseDataService
 
         service = DatabaseDataService()
         backend_info = service.get_backend_info()
@@ -682,7 +685,9 @@ static_dir = frontend_build_dir / "static"
 # This prevents errors during development when frontend hasn't been built
 if frontend_build_dir.exists() and static_dir.exists():
     try:
-        app.mount(f"{_CONTEXT_PATH}/static", StaticFiles(directory=static_dir), name="static")
+        app.mount(
+            f"{_CONTEXT_PATH}/static", StaticFiles(directory=static_dir), name="static"
+        )
         logger.info(f"Serving static files from: {static_dir}")
     except Exception as e:
         logger.warning(f"Failed to mount static files: {e}")
@@ -700,7 +705,9 @@ else:
 assets_dir = frontend_build_dir / "assets"
 if frontend_build_dir.exists() and assets_dir.exists():
     try:
-        app.mount(f"{_CONTEXT_PATH}/assets", StaticFiles(directory=assets_dir), name="assets")
+        app.mount(
+            f"{_CONTEXT_PATH}/assets", StaticFiles(directory=assets_dir), name="assets"
+        )
         logger.info(f"Serving frontend assets from: {assets_dir}")
     except Exception as e:
         logger.warning(f"Failed to mount frontend assets: {e}")
@@ -725,7 +732,9 @@ if frontend_build_dir.exists() and (frontend_build_dir / "index.html").exists():
             # SSRF guard). A <meta>, not an inline <script>, because CSP is
             # script-src 'self'.
             try:
-                from core.integrations.extension.trust import connector_allowlist_origins
+                from core.integrations.extension.trust import (
+                    connector_allowlist_origins,
+                )
 
                 origins = connector_allowlist_origins()
                 if origins:
@@ -762,5 +771,9 @@ if __name__ == "__main__":
 
     logger.info("Starting Vigil SOC API server...")
     uvicorn.run(
-        "services.api.main:app", host="0.0.0.0", port=6987, reload=True, log_level="info"
+        "services.api.main:app",
+        host="0.0.0.0",
+        port=6987,
+        reload=True,
+        log_level="info",
     )

--- a/services/api/middleware/auth.py
+++ b/services/api/middleware/auth.py
@@ -5,18 +5,18 @@ Provides middleware for FastAPI to validate JWT tokens and check permissions.
 Supports DEV_MODE for bypassing authentication during development.
 """
 
-from core.routing import UnitOfWorkSession
 import logging
 from typing import Optional
-from fastapi import HTTPException, Header, Depends, Request, status
+
+from fastapi import Depends, Header, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from core.auth.auth_cookies import ACCESS_COOKIE_NAME
 from core.auth.auth_service import AuthService
 from core.auth.token_blacklist import is_token_revoked
-from core.storage.models import User
-
 from core.config import get_settings
+from core.routing import UnitOfWorkSession
+from core.storage.models import User
 
 logger = logging.getLogger(__name__)
 
@@ -49,8 +49,9 @@ def _get_dev_user(session: Session) -> User:
 
         # If no admin, create a mock user object (won't be persisted)
         if _dev_user is None:
-            from core.storage.models import Role
             import uuid
+
+            from core.storage.models import Role
 
             # Try to get admin role
             admin_role = session.query(Role).filter(Role.name == "admin").first()

--- a/services/api/middleware/csrf.py
+++ b/services/api/middleware/csrf.py
@@ -35,6 +35,7 @@ from typing import Callable, Iterable, Optional
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
+
 from core.config import get_settings
 
 logger = logging.getLogger(__name__)
@@ -64,9 +65,7 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         cookie_secure: Optional[bool] = None,
     ):
         super().__init__(app)
-        self.enabled = (
-            get_settings().vigil_csrf_enabled if enabled is None else enabled
-        )
+        self.enabled = get_settings().vigil_csrf_enabled if enabled is None else enabled
         self.report_only = (
             get_settings().vigil_csrf_report_only
             if report_only is None

--- a/services/api/middleware/security_headers.py
+++ b/services/api/middleware/security_headers.py
@@ -17,6 +17,7 @@ from typing import Callable, Optional
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+
 from core.config import get_settings
 
 logger = logging.getLogger(__name__)
@@ -84,9 +85,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     ):
         super().__init__(app)
         self.hsts_enabled = (
-            get_settings().vigil_hsts_enabled
-            if hsts_enabled is None
-            else hsts_enabled
+            get_settings().vigil_hsts_enabled if hsts_enabled is None else hsts_enabled
         )
         self.frame_options_enabled = (
             get_settings().vigil_frame_options_enabled
@@ -104,9 +103,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             else referrer_policy_enabled
         )
         self.csp_enabled = (
-            get_settings().vigil_csp_enabled
-            if csp_enabled is None
-            else csp_enabled
+            get_settings().vigil_csp_enabled if csp_enabled is None else csp_enabled
         )
         self.csp_policy = csp_policy or get_settings().vigil_csp_policy or DEFAULT_CSP
         # Admit allowlisted connector origins so the browser may import their
@@ -133,9 +130,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
                     connector_origins,
                 )
         self.hsts_max_age = (
-            get_settings().vigil_hsts_max_age
-            if hsts_max_age is None
-            else hsts_max_age
+            get_settings().vigil_hsts_max_age if hsts_max_age is None else hsts_max_age
         )
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:

--- a/services/api/routers/agents.py
+++ b/services/api/routers/agents.py
@@ -1,15 +1,16 @@
 """Agents API endpoints for SOC agent management."""
 
+import logging
 from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-import logging
 
+from core.agents.builtins import DEFAULT_AGENT_ID
+from core.agents.manager import CUSTOM_AGENT_ID_PREFIX, AgentManager
 from core.deps import provide_mcp_registry
 from core.integrations.mcp.registry import MCPRegistry
 from core.llm.defaults import DEFAULT_MODEL
-from core.agents.builtins import DEFAULT_AGENT_ID
-from core.agents.manager import AgentManager, CUSTOM_AGENT_ID_PREFIX
 from core.routing import Auth, RouterMeta
 
 router = APIRouter()
@@ -42,6 +43,7 @@ def _resolve_agent(agent_id: str):
 
 class InvestigationRequest(BaseModel):
     """Request to start an investigation with an agent."""
+
     finding_id: str
     agent_id: Optional[str] = DEFAULT_AGENT_ID
     additional_context: Optional[str] = None
@@ -61,10 +63,7 @@ async def list_agents():
         # place — you'd still get the built-in list back.
         agent_manager.refresh_custom_agents()
         agents = agent_manager.get_agent_list()
-        return {
-            "agents": agents,
-            "current_agent": agent_manager.current_agent_id
-        }
+        return {"agents": agents, "current_agent": agent_manager.current_agent_id}
     except Exception as e:
         logger.error(f"Error listing agents: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -74,10 +73,10 @@ async def list_agents():
 async def get_agent(agent_id: str):
     """
     Get details for a specific agent.
-    
+
     Args:
         agent_id: The agent ID
-    
+
     Returns:
         Agent details
     """
@@ -95,7 +94,7 @@ async def get_agent(agent_id: str):
             "specialization": agent.specialization,
             "recommended_tools": agent.recommended_tools,
             "max_tokens": agent.max_tokens,
-            "enable_thinking": agent.enable_thinking
+            "enable_thinking": agent.enable_thinking,
         }
     except HTTPException:
         raise
@@ -108,10 +107,10 @@ async def get_agent(agent_id: str):
 async def set_current_agent(agent_id: str):
     """
     Set the current active agent.
-    
+
     Args:
         agent_id: The agent ID to set as current
-    
+
     Returns:
         Success status
     """
@@ -119,11 +118,8 @@ async def set_current_agent(agent_id: str):
         success = agent_manager.set_current_agent(agent_id)
         if not success:
             raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
-        
-        return {
-            "success": True,
-            "current_agent": agent_manager.current_agent_id
-        }
+
+        return {"success": True, "current_agent": agent_manager.current_agent_id}
     except HTTPException:
         raise
     except Exception as e:
@@ -135,32 +131,40 @@ async def set_current_agent(agent_id: str):
 async def start_investigation(request: InvestigationRequest):
     """
     Start an investigation on a finding with a specific agent.
-    
+
     Args:
         request: Investigation request with finding ID and agent
-    
+
     Returns:
         Investigation prompt and agent details
     """
     from core.storage.database_data_service import DatabaseDataService
-    
+
     try:
         # Get the finding
         data_service = DatabaseDataService()
         finding = data_service.get_finding(request.finding_id)
-        
+
         if not finding:
-            raise HTTPException(status_code=404, detail=f"Finding not found: {request.finding_id}")
-        
+            raise HTTPException(
+                status_code=404, detail=f"Finding not found: {request.finding_id}"
+            )
+
         # Get the agent
         agent = _resolve_agent(request.agent_id)
         if not agent:
-            raise HTTPException(status_code=404, detail=f"Agent not found: {request.agent_id}")
-        
+            raise HTTPException(
+                status_code=404, detail=f"Agent not found: {request.agent_id}"
+            )
+
         # Construct investigation prompt
-        techniques = finding.get('predicted_techniques', [])
-        technique_str = ', '.join([t.get('technique_id', '') for t in techniques]) if techniques else 'None'
-        
+        techniques = finding.get("predicted_techniques", [])
+        technique_str = (
+            ", ".join([t.get("technique_id", "") for t in techniques])
+            if techniques
+            else "None"
+        )
+
         prompt = f"""Please investigate this security finding:
 
 **Finding ID:** {finding.get('finding_id')}
@@ -174,7 +178,7 @@ async def start_investigation(request: InvestigationRequest):
 {f'**Additional Context:** {request.additional_context}' if request.additional_context else ''}
 
 Please conduct a thorough investigation of this finding. Use your available tools to gather more information, correlate with other findings, and provide your analysis."""
-        
+
         return {
             "prompt": prompt,
             "agent": {
@@ -182,11 +186,11 @@ Please conduct a thorough investigation of this finding. Use your available tool
                 "name": agent.name,
                 "icon": agent.icon,
                 "color": agent.color,
-                "system_prompt": agent.system_prompt
+                "system_prompt": agent.system_prompt,
             },
-            "finding": finding
+            "finding": finding,
         }
-    
+
     except HTTPException:
         raise
     except Exception as e:
@@ -196,6 +200,7 @@ Please conduct a thorough investigation of this finding. Use your available tool
 
 class AgentRunRequest(BaseModel):
     """Request to run an agent task with Agent SDK."""
+
     finding_id: Optional[str] = None
     case_id: Optional[str] = None
     task: Optional[str] = None
@@ -210,37 +215,45 @@ async def run_agent(
 ):
     """
     Run an agent task using Claude Agent SDK.
-    
+
     This endpoint leverages the Agent SDK for autonomous tool execution,
     allowing the agent to investigate findings, cases, or perform custom tasks.
-    
+
     Args:
         request: Agent run request
-    
+
     Returns:
         Agent execution result with tool calls and analysis
     """
-    from core.storage.database_data_service import DatabaseDataService
     from core.llm.harness.claude import ClaudeService
-    
+    from core.storage.database_data_service import DatabaseDataService
+
     try:
         agent = _resolve_agent(request.agent_id)
         if not agent:
-            raise HTTPException(status_code=404, detail=f"Agent not found: {request.agent_id}")
+            raise HTTPException(
+                status_code=404, detail=f"Agent not found: {request.agent_id}"
+            )
 
         # Build task from finding/case if not explicitly provided
         task = request.task
         context_data = {}
-        
+
         if request.finding_id and not task:
             data_service = DatabaseDataService()
             finding = data_service.get_finding(request.finding_id)
             if not finding:
-                raise HTTPException(status_code=404, detail=f"Finding not found: {request.finding_id}")
-            
-            techniques = finding.get('predicted_techniques', [])
-            technique_str = ', '.join([t.get('technique_id', '') for t in techniques]) if techniques else 'None'
-            
+                raise HTTPException(
+                    status_code=404, detail=f"Finding not found: {request.finding_id}"
+                )
+
+            techniques = finding.get("predicted_techniques", [])
+            technique_str = (
+                ", ".join([t.get("technique_id", "") for t in techniques])
+                if techniques
+                else "None"
+            )
+
             task = f"""Investigate security finding {finding.get('finding_id')}.
 
 Finding Details:
@@ -252,14 +265,16 @@ Finding Details:
 - MITRE ATT&CK Techniques: {technique_str}
 
 Use the get_finding tool first to retrieve full details, then investigate thoroughly."""
-            context_data['finding'] = finding
-            
+            context_data["finding"] = finding
+
         elif request.case_id and not task:
             data_service = DatabaseDataService()
             case = data_service.get_case(request.case_id)
             if not case:
-                raise HTTPException(status_code=404, detail=f"Case not found: {request.case_id}")
-            
+                raise HTTPException(
+                    status_code=404, detail=f"Case not found: {request.case_id}"
+                )
+
             task = f"""Investigate case {case.get('case_id')}.
 
 Case Details:
@@ -270,11 +285,13 @@ Case Details:
 - Finding Count: {len(case.get('finding_ids', []))}
 
 Use the get_case tool first to retrieve full details, then investigate all associated findings."""
-            context_data['case'] = case
-        
+            context_data["case"] = case
+
         if not task:
-            raise HTTPException(status_code=400, detail="No task, finding_id, or case_id provided")
-        
+            raise HTTPException(
+                status_code=400, detail="No task, finding_id, or case_id provided"
+            )
+
         claude_service = ClaudeService(
             use_backend_tools=True,
             use_mcp_tools=True,  # Enable MCP tools for dynamic enrichment
@@ -282,12 +299,12 @@ Use the get_case tool first to retrieve full details, then investigate all assoc
             enable_thinking=agent.enable_thinking,
             mcp_registry=registry,
         )
-        
+
         if not claude_service.has_api_key():
             from services.api.routers.claude import NO_PROVIDER_DETAIL
 
             raise HTTPException(status_code=503, detail=NO_PROVIDER_DETAIL)
-        
+
         # Build allowed tools: combine agent's recommended tools with
         # dynamically discovered MCP tools from the registry
         allowed_tools = list(agent.recommended_tools) if agent.recommended_tools else []
@@ -295,39 +312,40 @@ Use the get_case tool first to retrieve full details, then investigate all assoc
             mcp_tool_names = registry.get_tool_names()
             if mcp_tool_names:
                 allowed_tools.extend(mcp_tool_names)
-                logger.info(f"Agent '{agent.id}' enriched with {len(mcp_tool_names)} MCP tools")
+                logger.info(
+                    f"Agent '{agent.id}' enriched with {len(mcp_tool_names)} MCP tools"
+                )
         except Exception as e:
             logger.debug(f"Could not get MCP tools from registry: {e}")
-        
+
         result = await claude_service.run_agent_task(
             task=task,
             agent_config={
                 "system_prompt": agent.system_prompt,
                 "allowed_tools": allowed_tools if allowed_tools else None,
                 "max_turns": 15,
-                "model": DEFAULT_MODEL
-            }
+                "model": DEFAULT_MODEL,
+            },
         )
-        
+
         return {
             "success": result.get("success", False),
             "agent": {
                 "id": agent.id,
                 "name": agent.name,
                 "icon": agent.icon,
-                "color": agent.color
+                "color": agent.color,
             },
             "task": task,
             "result": result.get("final_result", ""),
             "tool_calls": result.get("tool_calls", []),
             "error": result.get("error"),
             "context": context_data,
-            "agent_sdk_used": request.use_agent_sdk
+            "agent_sdk_used": request.use_agent_sdk,
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error running agent: {e}")
         raise HTTPException(status_code=500, detail=str(e))
-

--- a/services/api/routers/ai_config.py
+++ b/services/api/routers/ai_config.py
@@ -15,15 +15,15 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import Session
-from core.routing import Auth, RouterMeta, UnitOfWorkSession
-from core.storage.models import AIModelConfig, LLMProviderConfig
+
 from core.llm.providers.registry import (
     COMPONENTS,
     ModelInfo,
     get_registry,
     is_valid_component,
 )
+from core.routing import Auth, RouterMeta, UnitOfWorkSession
+from core.storage.models import AIModelConfig, LLMProviderConfig
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/services/api/routers/analytics.py
+++ b/services/api/routers/analytics.py
@@ -18,10 +18,13 @@ from pydantic import BaseModel, Field
 from sqlalchemy import and_, func
 from sqlalchemy.orm import Session
 
-from core.storage.models import Finding, Case, CaseClosureInfo, LLMInteractionLog
 from core.reporting.ai_insights_service import AIInsightsService
-from core.threat_intel.mitre_lookup import get_time_range, resolve_technique  # noqa: F401
 from core.routing import Auth, RouterMeta, UnitOfWorkSession
+from core.storage.models import Case, CaseClosureInfo, Finding, LLMInteractionLog
+from core.threat_intel.mitre_lookup import (  # noqa: F401
+    get_time_range,
+    resolve_technique,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/services/api/routers/auth.py
+++ b/services/api/routers/auth.py
@@ -7,7 +7,8 @@ Handles login, logout, token refresh, password management, and MFA.
 import logging
 from datetime import datetime
 from typing import Annotated, List, Optional
-from fastapi import APIRouter, HTTPException, Depends, Header, Request, Response, status
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -19,12 +20,11 @@ from core.auth.auth_cookies import (
     set_auth_cookies,
 )
 from core.auth.auth_service import (
+    PASSWORD_HISTORY_LIMIT,
     AccountLockedError,
     AuthService,
-    PASSWORD_HISTORY_LIMIT,
     password_matches_any,
 )
-from core.platform.email_service import send_email
 from core.auth.password_reset import (
     generate_reset_token,
     verify_reset_token,
@@ -38,12 +38,13 @@ from core.auth.token_blacklist import (
     is_token_revoked,
     revoke_all_for_user,
 )
-from services.api.middleware.auth import get_current_active_user
-from services.api.middleware.rate_limit import limiter
+from core.config import get_settings
+from core.platform.email_service import send_email
+from core.routing import Auth, RouterMeta, UnitOfWorkSession
 from core.storage.models import User
 from core.storage.schemas import UserSchema
-from core.routing import Auth, RouterMeta, UnitOfWorkSession
-from core.config import get_settings
+from services.api.middleware.auth import get_current_active_user
+from services.api.middleware.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 

--- a/services/api/routers/budgets.py
+++ b/services/api/routers/budgets.py
@@ -22,6 +22,7 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
+
 from core.routing import Auth, RouterMeta
 
 router = APIRouter()

--- a/services/api/routers/cases.py
+++ b/services/api/routers/cases.py
@@ -1,13 +1,16 @@
 """Cases API endpoints."""
 
-from typing import List, Optional, Dict, Any
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
-from services.api.middleware.auth import get_current_user
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
 from core.auth.auth_service import AuthService
+from core.reporting.report_service import REPORTLAB_AVAILABLE, ReportService
+from core.routing import Auth, RouterMeta, UnitOfWorkSession
+from core.storage.database_data_service import DatabaseDataService
 from core.storage.models import User
 from core.storage.schemas import (
     CaseClosureInfoSchema,
@@ -20,9 +23,7 @@ from core.storage.schemas import (
     CaseTaskSchema,
     CaseWatcherSchema,
 )
-from core.storage.database_data_service import DatabaseDataService
-from core.reporting.report_service import ReportService, REPORTLAB_AVAILABLE
-from core.routing import Auth, RouterMeta, UnitOfWorkSession
+from services.api.middleware.auth import get_current_user
 
 router = APIRouter()
 
@@ -41,6 +42,7 @@ else:
 
 class CaseCreate(BaseModel):
     """Case creation request."""
+
     title: str
     description: str = ""
     finding_ids: List[str]
@@ -50,6 +52,7 @@ class CaseCreate(BaseModel):
 
 class CaseUpdate(BaseModel):
     """Case update request."""
+
     title: Optional[str] = None
     description: Optional[str] = None
     status: Optional[str] = None
@@ -60,6 +63,7 @@ class CaseUpdate(BaseModel):
 
 class ActivityAdd(BaseModel):
     """Add activity to case."""
+
     activity_type: str  # e.g., "note", "status_change", "finding_added", "action_taken"
     description: str
     details: Optional[Dict[str, Any]] = None
@@ -67,34 +71,32 @@ class ActivityAdd(BaseModel):
 
 class ResolutionStepAdd(BaseModel):
     """Add resolution step to case."""
+
     description: str
     action_taken: str
     result: Optional[str] = None
 
 
 @router.get("/")
-async def get_cases(
-    status: Optional[str] = None,
-    priority: Optional[str] = None
-):
+async def get_cases(status: Optional[str] = None, priority: Optional[str] = None):
     """
     Get all cases with optional filters.
-    
+
     Args:
         status: Filter by status
         priority: Filter by priority
-    
+
     Returns:
         List of cases
     """
     cases = data_service.get_cases()
-    
+
     # Apply filters
     if status:
-        cases = [c for c in cases if c.get('status') == status]
+        cases = [c for c in cases if c.get("status") == status]
     if priority:
-        cases = [c for c in cases if c.get('priority') == priority]
-    
+        cases = [c for c in cases if c.get("priority") == priority]
+
     return {"cases": cases, "total": len(cases)}
 
 
@@ -180,10 +182,10 @@ async def clear_all_cases(
 async def get_case(case_id: str):
     """
     Get a specific case by ID.
-    
+
     Args:
         case_id: The case ID
-    
+
     Returns:
         Case details
     """
@@ -197,10 +199,10 @@ async def get_case(case_id: str):
 async def create_case(case_data: CaseCreate):
     """
     Create a new case.
-    
+
     Args:
         case_data: Case creation data
-    
+
     Returns:
         Created case
     """
@@ -209,37 +211,41 @@ async def create_case(case_data: CaseCreate):
         finding_ids=case_data.finding_ids,
         priority=case_data.priority,
         description=case_data.description,
-        status=case_data.status
+        status=case_data.status,
     )
-    
+
     if not case:
         raise HTTPException(status_code=500, detail="Failed to create case")
-    
+
     # Automatically assign SLA policy based on priority
     try:
         from core.cases.case_sla_service import CaseSLAService
+
         sla_service = CaseSLAService()
-        
-        case_id = case.get('case_id')
+
+        case_id = case.get("case_id")
         if case_id:
             # This will auto-select the default policy for the case priority
             sla_result = sla_service.assign_sla_to_case(case_id, sla_policy_id=None)
             if sla_result:
                 import logging
+
                 logger = logging.getLogger(__name__)
                 logger.info(f"Auto-assigned SLA policy to case {case_id}")
     except Exception as e:
         # Don't fail case creation if SLA assignment fails
         import logging
+
         logger = logging.getLogger(__name__)
         logger.warning(f"Failed to auto-assign SLA to case {case.get('case_id')}: {e}")
-    
+
     return case
 
 
 async def _sync_upstream_status(case_id: str, new_status: str) -> None:
     """Best-effort sync of case status to the upstream SIEM."""
     import logging
+
     _logger = logging.getLogger(__name__)
     try:
         case = data_service.get_case(case_id)
@@ -252,9 +258,9 @@ async def _sync_upstream_status(case_id: str, new_status: str) -> None:
             if not finding:
                 continue
             source = finding.get("data_source", "")
-            alert_id = (finding.get("metadata") or {}).get(
-                f"{source}_alert_id"
-            ) or (finding.get("metadata") or {}).get("elastic_alert_id")
+            alert_id = (finding.get("metadata") or {}).get(f"{source}_alert_id") or (
+                finding.get("metadata") or {}
+            ).get("elastic_alert_id")
             if not alert_id:
                 continue
             # Lazy-load the right ingestion service
@@ -274,6 +280,7 @@ async def _sync_upstream_status(case_id: str, new_status: str) -> None:
                 )
     except Exception as exc:
         import logging
+
         logging.getLogger(__name__).warning(
             f"Upstream status sync error for case {case_id}: {exc}"
         )
@@ -284,6 +291,7 @@ def _get_ingestion_service(source: str):
     if source == "elastic":
         try:
             from core.integrations.elastic.ingestion import ElasticIngestion
+
             return ElasticIngestion()
         except Exception:
             return None
@@ -295,27 +303,27 @@ def _get_ingestion_service(source: str):
 async def update_case(case_id: str, case_data: CaseUpdate):
     """
     Update an existing case.
-    
+
     Args:
         case_id: The case ID
         case_data: Case update data
-    
+
     Returns:
         Success status
     """
     # Build updates dict
     updates = {}
     if case_data.title is not None:
-        updates['title'] = case_data.title
+        updates["title"] = case_data.title
     if case_data.description is not None:
-        updates['description'] = case_data.description
+        updates["description"] = case_data.description
     if case_data.status is not None:
-        updates['status'] = case_data.status
+        updates["status"] = case_data.status
     if case_data.priority is not None:
-        updates['priority'] = case_data.priority
+        updates["priority"] = case_data.priority
     if case_data.notes is not None:
-        updates['notes'] = case_data.notes
-    
+        updates["notes"] = case_data.notes
+
     success = data_service.update_case(case_id, **updates)
 
     if not success:
@@ -324,9 +332,8 @@ async def update_case(case_id: str, case_data: CaseUpdate):
     # Fire upstream SIEM status sync when status changes
     if case_data.status is not None:
         import asyncio
-        asyncio.ensure_future(
-            _sync_upstream_status(case_id, case_data.status)
-        )
+
+        asyncio.ensure_future(_sync_upstream_status(case_id, case_data.status))
 
     return {"success": True}
 
@@ -335,36 +342,36 @@ async def update_case(case_id: str, case_data: CaseUpdate):
 async def add_case_activity(case_id: str, activity: ActivityAdd):
     """
     Add an activity/action to a case.
-    
+
     Args:
         case_id: The case ID
         activity: Activity data
-    
+
     Returns:
         Updated case
     """
     case = data_service.get_case(case_id)
     if not case:
         raise HTTPException(status_code=404, detail="Case not found")
-    
+
     # Get or initialize activities list
-    activities = case.get('activities', [])
-    
+    activities = case.get("activities", [])
+
     # Add new activity
     new_activity = {
-        'timestamp': datetime.utcnow().isoformat() + 'Z',
-        'activity_type': activity.activity_type,
-        'description': activity.description,
-        'details': activity.details or {}
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "activity_type": activity.activity_type,
+        "description": activity.description,
+        "details": activity.details or {},
     }
     activities.append(new_activity)
-    
+
     # Update case
     success = data_service.update_case(case_id, activities=activities)
-    
+
     if not success:
         raise HTTPException(status_code=500, detail="Failed to add activity")
-    
+
     return data_service.get_case(case_id)
 
 
@@ -372,36 +379,36 @@ async def add_case_activity(case_id: str, activity: ActivityAdd):
 async def add_resolution_step(case_id: str, step: ResolutionStepAdd):
     """
     Add a resolution step to a case.
-    
+
     Args:
         case_id: The case ID
         step: Resolution step data
-    
+
     Returns:
         Updated case
     """
     case = data_service.get_case(case_id)
     if not case:
         raise HTTPException(status_code=404, detail="Case not found")
-    
+
     # Get or initialize resolution steps list
-    resolution_steps = case.get('resolution_steps', [])
-    
+    resolution_steps = case.get("resolution_steps", [])
+
     # Add new step
     new_step = {
-        'timestamp': datetime.utcnow().isoformat() + 'Z',
-        'description': step.description,
-        'action_taken': step.action_taken,
-        'result': step.result
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "description": step.description,
+        "action_taken": step.action_taken,
+        "result": step.result,
     }
     resolution_steps.append(new_step)
-    
+
     # Update case
     success = data_service.update_case(case_id, resolution_steps=resolution_steps)
-    
+
     if not success:
         raise HTTPException(status_code=500, detail="Failed to add resolution step")
-    
+
     return data_service.get_case(case_id)
 
 
@@ -409,25 +416,25 @@ async def add_resolution_step(case_id: str, step: ResolutionStepAdd):
 async def add_finding_to_case(case_id: str, finding_id: str):
     """
     Add a finding to a case.
-    
+
     Args:
         case_id: The case ID
         finding_id: The finding ID to add
-    
+
     Returns:
         Updated case
     """
     case = data_service.get_case(case_id)
     if not case:
         raise HTTPException(status_code=404, detail="Case not found")
-    
-    finding_ids = case.get('finding_ids', [])
+
+    finding_ids = case.get("finding_ids", [])
     if finding_id not in finding_ids:
         finding_ids.append(finding_id)
         success = data_service.update_case(case_id, finding_ids=finding_ids)
         if not success:
             raise HTTPException(status_code=500, detail="Failed to add finding")
-    
+
     return data_service.get_case(case_id)
 
 
@@ -435,25 +442,25 @@ async def add_finding_to_case(case_id: str, finding_id: str):
 async def remove_finding_from_case(case_id: str, finding_id: str):
     """
     Remove a finding from a case.
-    
+
     Args:
         case_id: The case ID
         finding_id: The finding ID to remove
-    
+
     Returns:
         Updated case
     """
     case = data_service.get_case(case_id)
     if not case:
         raise HTTPException(status_code=404, detail="Case not found")
-    
-    finding_ids = case.get('finding_ids', [])
+
+    finding_ids = case.get("finding_ids", [])
     if finding_id in finding_ids:
         finding_ids.remove(finding_id)
         success = data_service.update_case(case_id, finding_ids=finding_ids)
         if not success:
             raise HTTPException(status_code=500, detail="Failed to remove finding")
-    
+
     return data_service.get_case(case_id)
 
 
@@ -461,45 +468,45 @@ async def remove_finding_from_case(case_id: str, finding_id: str):
 async def generate_case_report(case_id: str):
     """
     Generate a PDF report for a case.
-    
+
     Args:
         case_id: The case ID
-    
+
     Returns:
         Report file information
     """
     if not report_service:
         raise HTTPException(
             status_code=501,
-            detail="Report generation requires reportlab. Install with: pip install reportlab"
+            detail="Report generation requires reportlab. Install with: pip install reportlab",
         )
-    
+
     case = data_service.get_case(case_id)
     if not case:
         raise HTTPException(status_code=404, detail="Case not found")
-    
+
     # Get associated findings
-    finding_ids = case.get('finding_ids', [])
+    finding_ids = case.get("finding_ids", [])
     findings = [data_service.get_finding(fid) for fid in finding_ids]
     findings = [f for f in findings if f]  # Filter out None values
-    
+
     # Generate report filename
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     filename = f"{case_id}_report_{timestamp}.pdf"
     output_path = Path("TestOutputs") / filename
     output_path.parent.mkdir(exist_ok=True)
-    
+
     # Generate the report
     success = report_service.generate_case_report(output_path, case, findings)
-    
+
     if not success:
         raise HTTPException(status_code=500, detail="Failed to generate report")
-    
+
     return {
         "success": True,
         "filename": filename,
         "path": str(output_path),
-        "case_id": case_id
+        "case_id": case_id,
     }
 
 
@@ -507,22 +514,22 @@ async def generate_case_report(case_id: str):
 async def delete_case(case_id: str):
     """
     Delete a case.
-    
+
     Args:
         case_id: The case ID
-    
+
     Returns:
         Success status
     """
     case = data_service.get_case(case_id)
     if not case:
         raise HTTPException(status_code=404, detail="Case not found")
-    
+
     success = data_service.delete_case(case_id)
-    
+
     if not success:
         raise HTTPException(status_code=500, detail="Failed to delete case")
-    
+
     return {"success": True}
 
 
@@ -530,28 +537,28 @@ async def delete_case(case_id: str):
 async def get_cases_summary():
     """
     Get summary statistics for cases.
-    
+
     Returns:
         Summary statistics
     """
     cases = data_service.get_cases()
-    
+
     # Calculate statistics
     status_counts = {}
     priority_counts = {}
     total_count = len(cases)
-    
+
     for case in cases:
-        status = case.get('status', 'unknown')
+        status = case.get("status", "unknown")
         status_counts[status] = status_counts.get(status, 0) + 1
-        
-        priority = case.get('priority', 'unknown')
+
+        priority = case.get("priority", "unknown")
         priority_counts[priority] = priority_counts.get(priority, 0) + 1
-    
+
     return {
         "total": total_count,
         "by_status": status_counts,
-        "by_priority": priority_counts
+        "by_priority": priority_counts,
     }
 
 
@@ -559,9 +566,11 @@ async def get_cases_summary():
 # Enhanced Case Management Endpoints
 # =============================================================================
 
+
 # SLA Management
 class SLAAssign(BaseModel):
     """Assign SLA to case."""
+
     sla_policy_id: Optional[str] = None
 
 
@@ -569,6 +578,7 @@ class SLAAssign(BaseModel):
 async def assign_sla(case_id: str, data: SLAAssign):
     """Assign SLA policy to case."""
     from core.cases.case_sla_service import CaseSLAService
+
     sla_service = CaseSLAService()
     result = sla_service.assign_sla_to_case(case_id, data.sla_policy_id)
     if not result:
@@ -580,6 +590,7 @@ async def assign_sla(case_id: str, data: SLAAssign):
 async def get_case_sla(case_id: str):
     """Get SLA status for case."""
     from core.cases.case_sla_service import CaseSLAService
+
     sla_service = CaseSLAService()
     status = sla_service.get_sla_status(case_id)
     if not status:
@@ -591,6 +602,7 @@ async def get_case_sla(case_id: str):
 async def pause_sla(case_id: str):
     """Pause SLA timer."""
     from core.cases.case_sla_service import CaseSLAService
+
     sla_service = CaseSLAService()
     success = sla_service.pause_sla(case_id)
     if not success:
@@ -602,6 +614,7 @@ async def pause_sla(case_id: str):
 async def resume_sla(case_id: str):
     """Resume SLA timer."""
     from core.cases.case_sla_service import CaseSLAService
+
     sla_service = CaseSLAService()
     success = sla_service.resume_sla(case_id)
     if not success:
@@ -612,6 +625,7 @@ async def resume_sla(case_id: str):
 # Comments and Collaboration
 class CommentAdd(BaseModel):
     """Add comment to case."""
+
     author: str
     content: str
     parent_comment_id: Optional[int] = None
@@ -621,6 +635,7 @@ class CommentAdd(BaseModel):
 async def get_comments(case_id: str):
     """Get all comments for case."""
     from core.cases.case_collaboration_service import CaseCollaborationService
+
     collab_service = CaseCollaborationService()
     comments = collab_service.get_case_comments(case_id)
     return {"comments": CaseCommentSchema.dump_many(comments)}
@@ -630,6 +645,7 @@ async def get_comments(case_id: str):
 async def add_comment(case_id: str, data: CommentAdd):
     """Add comment to case."""
     from core.cases.case_collaboration_service import CaseCollaborationService
+
     collab_service = CaseCollaborationService()
     comment = collab_service.add_comment(
         case_id, data.author, data.content, data.parent_comment_id
@@ -641,6 +657,7 @@ async def add_comment(case_id: str, data: CommentAdd):
 
 class CommentUpdate(BaseModel):
     """Update comment."""
+
     content: str
 
 
@@ -648,6 +665,7 @@ class CommentUpdate(BaseModel):
 async def update_comment(case_id: str, comment_id: int, data: CommentUpdate):
     """Update comment."""
     from core.cases.case_collaboration_service import CaseCollaborationService
+
     collab_service = CaseCollaborationService()
     success = collab_service.update_comment(comment_id, data.content)
     if not success:
@@ -659,6 +677,7 @@ async def update_comment(case_id: str, comment_id: int, data: CommentUpdate):
 async def delete_comment(case_id: str, comment_id: int):
     """Delete comment."""
     from core.cases.case_collaboration_service import CaseCollaborationService
+
     collab_service = CaseCollaborationService()
     success = collab_service.delete_comment(comment_id)
     if not success:
@@ -669,6 +688,7 @@ async def delete_comment(case_id: str, comment_id: int):
 # Watchers
 class WatcherAdd(BaseModel):
     """Add watcher to case."""
+
     user_id: str
     notification_preferences: Optional[Dict] = None
 
@@ -677,6 +697,7 @@ class WatcherAdd(BaseModel):
 async def add_watcher(case_id: str, data: WatcherAdd):
     """Add watcher to case."""
     from core.cases.case_collaboration_service import CaseCollaborationService
+
     collab_service = CaseCollaborationService()
     watcher = collab_service.add_watcher(
         case_id, data.user_id, data.notification_preferences
@@ -690,6 +711,7 @@ async def add_watcher(case_id: str, data: WatcherAdd):
 async def remove_watcher(case_id: str, user_id: str):
     """Remove watcher from case."""
     from core.cases.case_collaboration_service import CaseCollaborationService
+
     collab_service = CaseCollaborationService()
     success = collab_service.remove_watcher(case_id, user_id)
     if not success:
@@ -701,6 +723,7 @@ async def remove_watcher(case_id: str, user_id: str):
 async def get_watchers(case_id: str):
     """Get all watchers for case."""
     from core.cases.case_collaboration_service import CaseCollaborationService
+
     collab_service = CaseCollaborationService()
     watchers = collab_service.get_case_watchers(case_id)
     return {"watchers": CaseWatcherSchema.dump_many(watchers)}
@@ -709,6 +732,7 @@ async def get_watchers(case_id: str):
 # Evidence Management
 class EvidenceAdd(BaseModel):
     """Add evidence to case."""
+
     evidence_type: str
     name: str
     collected_by: str
@@ -722,6 +746,7 @@ class EvidenceAdd(BaseModel):
 async def add_evidence(case_id: str, data: EvidenceAdd):
     """Add evidence to case."""
     from core.cases.case_evidence_service import CaseEvidenceService
+
     evidence_service = CaseEvidenceService()
     evidence = evidence_service.add_evidence(
         case_id=case_id,
@@ -731,7 +756,7 @@ async def add_evidence(case_id: str, data: EvidenceAdd):
         description=data.description,
         file_path=data.file_path,
         source=data.source,
-        tags=data.tags
+        tags=data.tags,
     )
     if not evidence:
         raise HTTPException(status_code=500, detail="Failed to add evidence")
@@ -742,6 +767,7 @@ async def add_evidence(case_id: str, data: EvidenceAdd):
 async def get_evidence(case_id: str, evidence_type: Optional[str] = None):
     """Get all evidence for case."""
     from core.cases.case_evidence_service import CaseEvidenceService
+
     evidence_service = CaseEvidenceService()
     evidence_list = evidence_service.get_case_evidence(case_id, evidence_type)
     return {"evidence": CaseEvidenceSchema.dump_many(evidence_list)}
@@ -749,6 +775,7 @@ async def get_evidence(case_id: str, evidence_type: Optional[str] = None):
 
 class ChainOfCustodyAdd(BaseModel):
     """Add chain of custody entry."""
+
     action: str
     user: str
     notes: Optional[str] = None
@@ -758,6 +785,7 @@ class ChainOfCustodyAdd(BaseModel):
 async def add_custody_entry(case_id: str, evidence_id: int, data: ChainOfCustodyAdd):
     """Add chain of custody entry."""
     from core.cases.case_evidence_service import CaseEvidenceService
+
     evidence_service = CaseEvidenceService()
     success = evidence_service.add_chain_of_custody_entry(
         evidence_id, data.action, data.user, data.notes
@@ -770,6 +798,7 @@ async def add_custody_entry(case_id: str, evidence_id: int, data: ChainOfCustody
 # IOC Management
 class IOCAdd(BaseModel):
     """Add IOC to case."""
+
     ioc_type: str
     value: str
     threat_level: Optional[str] = None
@@ -783,6 +812,7 @@ class IOCAdd(BaseModel):
 async def add_ioc(case_id: str, data: IOCAdd):
     """Add IOC to case."""
     from core.cases.case_ioc_service import CaseIOCService
+
     ioc_service = CaseIOCService()
     ioc = ioc_service.add_ioc(
         case_id=case_id,
@@ -792,7 +822,7 @@ async def add_ioc(case_id: str, data: IOCAdd):
         confidence=data.confidence,
         source=data.source,
         tags=data.tags,
-        context=data.context
+        context=data.context,
     )
     if not ioc:
         raise HTTPException(status_code=500, detail="Failed to add IOC")
@@ -803,6 +833,7 @@ async def add_ioc(case_id: str, data: IOCAdd):
 async def get_iocs(case_id: str, ioc_type: Optional[str] = None):
     """Get all IOCs for case."""
     from core.cases.case_ioc_service import CaseIOCService
+
     ioc_service = CaseIOCService()
     iocs = ioc_service.get_case_iocs(case_id, ioc_type)
     return {"iocs": CaseIOCSchema.dump_many(iocs)}
@@ -810,6 +841,7 @@ async def get_iocs(case_id: str, ioc_type: Optional[str] = None):
 
 class IOCBulkAdd(BaseModel):
     """Bulk add IOCs."""
+
     iocs: List[Dict]
 
 
@@ -817,6 +849,7 @@ class IOCBulkAdd(BaseModel):
 async def bulk_add_iocs(case_id: str, data: IOCBulkAdd):
     """Bulk add IOCs to case."""
     from core.cases.case_ioc_service import CaseIOCService
+
     ioc_service = CaseIOCService()
     count = ioc_service.bulk_add_iocs(case_id, data.iocs)
     return {"added": count}
@@ -826,8 +859,9 @@ async def bulk_add_iocs(case_id: str, data: IOCBulkAdd):
 async def export_iocs(case_id: str, format: str = "json"):
     """Export IOCs (json, csv, or stix)."""
     from core.cases.case_ioc_service import CaseIOCService
+
     ioc_service = CaseIOCService()
-    
+
     if format == "csv":
         content = ioc_service.export_iocs_csv(case_id)
         return {"format": "csv", "content": content}
@@ -842,6 +876,7 @@ async def export_iocs(case_id: str, format: str = "json"):
 # Task Management
 class TaskAdd(BaseModel):
     """Add task to case."""
+
     title: str
     description: Optional[str] = None
     assignee: Optional[str] = None
@@ -862,9 +897,9 @@ async def add_task(case_id: str, data: TaskAdd, session: UnitOfWorkSession):
             description=data.description,
             assignee=data.assignee,
             priority=data.priority,
-            status='pending',
+            status="pending",
             due_date=data.due_date,
-            checklist_items=data.checklist_items or []
+            checklist_items=data.checklist_items or [],
         )
         session.add(task)
         # Flush so the read-back sees server defaults; the request's
@@ -894,6 +929,7 @@ async def get_tasks(case_id: str):
 
 class TaskUpdate(BaseModel):
     """Update task."""
+
     title: Optional[str] = None
     description: Optional[str] = None
     status: Optional[str] = None
@@ -915,7 +951,7 @@ async def update_task(
         task = session.query(CaseTask).filter(CaseTask.task_id == task_id).first()
         if not task:
             raise HTTPException(status_code=404, detail="Task not found")
-        
+
         if data.title is not None:
             task.title = data.title
         if data.description is not None:
@@ -932,7 +968,7 @@ async def update_task(
             task.completed_at = data.completed_at
         if data.actual_hours is not None:
             task.actual_hours = data.actual_hours
-        
+
         # Flush so the read-back sees server defaults; the request's
         # unit of work commits.
         session.flush()
@@ -944,6 +980,7 @@ async def update_task(
 # Case Relationships
 class RelationshipAdd(BaseModel):
     """Add case relationship."""
+
     related_case_id: str
     relationship_type: str
     created_by: str
@@ -963,7 +1000,7 @@ async def add_relationship(
             related_case_id=data.related_case_id,
             relationship_type=data.relationship_type,
             created_by=data.created_by,
-            notes=data.notes
+            notes=data.notes,
         )
         session.add(rel)
         # Flush so the read-back sees server defaults; the request's
@@ -971,7 +1008,9 @@ async def add_relationship(
         session.flush()
         return CaseRelationshipSchema.dump(rel)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to add relationship: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to add relationship: {str(e)}"
+        )
 
 
 @router.get("/{case_id}/relationships")
@@ -990,6 +1029,7 @@ async def get_relationships(case_id: str, session: UnitOfWorkSession):
 # Case Closure
 class ClosureInfo(BaseModel):
     """Close case with metadata."""
+
     closure_category: str
     closed_by: str
     root_cause: Optional[str] = None
@@ -1001,16 +1041,16 @@ class ClosureInfo(BaseModel):
 @router.post("/{case_id}/close")
 async def close_case(case_id: str, data: ClosureInfo, session: UnitOfWorkSession):
     """Close case with closure metadata."""
-    from core.storage.models import CaseClosureInfo, Case
+    from core.storage.models import Case, CaseClosureInfo
 
     try:
         # Update case status
         case = session.query(Case).filter(Case.case_id == case_id).first()
         if not case:
             raise HTTPException(status_code=404, detail="Case not found")
-        
-        case.status = 'closed'
-        
+
+        case.status = "closed"
+
         # Add closure info
         closure = CaseClosureInfo(
             case_id=case_id,
@@ -1019,15 +1059,16 @@ async def close_case(case_id: str, data: ClosureInfo, session: UnitOfWorkSession
             root_cause=data.root_cause,
             lessons_learned=data.lessons_learned,
             recommendations=data.recommendations,
-            executive_summary=data.executive_summary
+            executive_summary=data.executive_summary,
         )
         session.add(closure)
-        
+
         # Mark SLA resolution complete
         from core.cases.case_sla_service import CaseSLAService
+
         sla_service = CaseSLAService()
         sla_service.mark_resolution_complete(case_id, session)
-        
+
         # Flush so the read-back sees server defaults; the request's
         # unit of work commits.
         session.flush()
@@ -1039,6 +1080,7 @@ async def close_case(case_id: str, data: ClosureInfo, session: UnitOfWorkSession
 # Case Escalation
 class EscalationAdd(BaseModel):
     """Escalate case."""
+
     escalated_from: str
     escalated_to: str
     reason: str
@@ -1049,10 +1091,10 @@ class EscalationAdd(BaseModel):
 async def escalate_case(case_id: str, data: EscalationAdd):
     """Escalate case."""
     from core.cases.case_workflow_service import CaseWorkflowService
+
     workflow_service = CaseWorkflowService()
     success = workflow_service.escalate_case(
-        case_id, data.escalated_from, data.escalated_to, 
-        data.reason, data.urgency_level
+        case_id, data.escalated_from, data.escalated_to, data.reason, data.urgency_level
     )
     if not success:
         raise HTTPException(status_code=500, detail="Failed to escalate case")
@@ -1073,6 +1115,7 @@ async def get_escalations(case_id: str, session: UnitOfWorkSession):
 # Case Merge
 class MergeRequest(BaseModel):
     """Merge another case into this one."""
+
     source_case_id: str
     merged_by: str = "system"
 
@@ -1089,18 +1132,20 @@ async def merge_cases(case_id: str, data: MergeRequest):
         raise HTTPException(status_code=400, detail="Cannot merge a case into itself")
 
     from core.storage.connection import get_db_manager
-    from core.storage.models import (
-        Case, case_findings, CaseRelationship,
-    )
+    from core.storage.models import Case, CaseRelationship
 
     with get_db_manager().session_scope() as session:
         target = session.query(Case).filter_by(case_id=case_id).first()
         source = session.query(Case).filter_by(case_id=data.source_case_id).first()
 
         if not target:
-            raise HTTPException(status_code=404, detail=f"Target case {case_id} not found")
+            raise HTTPException(
+                status_code=404, detail=f"Target case {case_id} not found"
+            )
         if not source:
-            raise HTTPException(status_code=404, detail=f"Source case {data.source_case_id} not found")
+            raise HTTPException(
+                status_code=404, detail=f"Source case {data.source_case_id} not found"
+            )
 
         target_finding_ids = {f.finding_id for f in target.findings}
         moved_findings = 0
@@ -1112,7 +1157,9 @@ async def merge_cases(case_id: str, data: MergeRequest):
 
         target.timeline = (target.timeline or []) + (source.timeline or [])
         target.activities = (target.activities or []) + (source.activities or [])
-        target.resolution_steps = (target.resolution_steps or []) + (source.resolution_steps or [])
+        target.resolution_steps = (target.resolution_steps or []) + (
+            source.resolution_steps or []
+        )
 
         source_techniques = source.mitre_techniques or []
         target_techniques = target.mitre_techniques or []
@@ -1141,12 +1188,17 @@ async def merge_cases(case_id: str, data: MergeRequest):
 
         if target.priority and source.priority:
             priority_order = ["low", "medium", "high", "critical"]
-            if priority_order.index(source.priority) > priority_order.index(target.priority):
+            if priority_order.index(source.priority) > priority_order.index(
+                target.priority
+            ):
                 target.priority = source.priority
 
         try:
             from core.storage.models import CaseIOC
-            source_iocs = session.query(CaseIOC).filter_by(case_id=data.source_case_id).all()
+
+            source_iocs = (
+                session.query(CaseIOC).filter_by(case_id=data.source_case_id).all()
+            )
             for ioc in source_iocs:
                 ioc.case_id = case_id
         except Exception:
@@ -1154,7 +1206,10 @@ async def merge_cases(case_id: str, data: MergeRequest):
 
         try:
             from core.storage.models import CaseEvidence
-            source_evidence = session.query(CaseEvidence).filter_by(case_id=data.source_case_id).all()
+
+            source_evidence = (
+                session.query(CaseEvidence).filter_by(case_id=data.source_case_id).all()
+            )
             for ev in source_evidence:
                 ev.case_id = case_id
         except Exception:
@@ -1162,7 +1217,10 @@ async def merge_cases(case_id: str, data: MergeRequest):
 
         try:
             from core.storage.models import CaseTask
-            source_tasks = session.query(CaseTask).filter_by(case_id=data.source_case_id).all()
+
+            source_tasks = (
+                session.query(CaseTask).filter_by(case_id=data.source_case_id).all()
+            )
             for task in source_tasks:
                 task.case_id = case_id
         except Exception:
@@ -1170,7 +1228,10 @@ async def merge_cases(case_id: str, data: MergeRequest):
 
         try:
             from core.storage.models import CaseComment
-            source_comments = session.query(CaseComment).filter_by(case_id=data.source_case_id).all()
+
+            source_comments = (
+                session.query(CaseComment).filter_by(case_id=data.source_case_id).all()
+            )
             for comment in source_comments:
                 comment.case_id = case_id
         except Exception:
@@ -1186,7 +1247,10 @@ async def merge_cases(case_id: str, data: MergeRequest):
         session.add(rel)
 
         source.status = "closed"
-        source.description = (source.description or "") + f"\n\n[MERGED] This case was merged into {case_id} by {data.merged_by} on {now.isoformat()}Z"
+        source.description = (
+            (source.description or "")
+            + f"\n\n[MERGED] This case was merged into {case_id} by {data.merged_by} on {now.isoformat()}Z"
+        )
 
     result_case = data_service.get_case(case_id)
     return {
@@ -1201,6 +1265,7 @@ async def merge_cases(case_id: str, data: MergeRequest):
 # Advanced Search
 class SearchRequest(BaseModel):
     """Advanced search request."""
+
     query_text: Optional[str] = None
     status: Optional[List[str]] = None
     priority: Optional[List[str]] = None
@@ -1217,8 +1282,9 @@ class SearchRequest(BaseModel):
 async def search_cases(data: SearchRequest):
     """Advanced case search."""
     from core.cases.case_search_service import CaseSearchService
+
     search_service = CaseSearchService()
-    
+
     results = search_service.search_cases(
         query_text=data.query_text,
         status=data.status,
@@ -1229,6 +1295,6 @@ async def search_cases(data: SearchRequest):
         created_after=data.created_after,
         created_before=data.created_before,
         limit=data.limit,
-        offset=data.offset
+        offset=data.offset,
     )
     return results

--- a/services/api/routers/claude.py
+++ b/services/api/routers/claude.py
@@ -1,30 +1,31 @@
 """Claude API endpoints for chat, streaming, and Agent SDK workflows."""
 
-from typing import List, Optional, Dict, Union, Any, Tuple
+import asyncio
+import base64
+import json
+import logging
+from typing import Any, Dict, List, Optional, Tuple, Union
+
 from fastapi import (
     APIRouter,
     Depends,
+    File,
     HTTPException,
+    UploadFile,
     WebSocket,
     WebSocketDisconnect,
-    File,
-    UploadFile,
 )
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, field_validator
-import asyncio
-import json
-import logging
-import base64
 
-from services.api.middleware.auth import get_current_user
-from core.llm.system_prompt import validate_system_prompt
-from core.storage.models import User
-from core.llm.harness.claude import ClaudeService
 from core.llm.defaults import DEFAULT_MODEL
+from core.llm.harness.claude import ClaudeService
 from core.llm.providers.registry import get_registry
-from core.routing import Auth, RouterMeta
+from core.llm.system_prompt import validate_system_prompt
 from core.rate_limit import rate_limit_dependency
+from core.routing import Auth, RouterMeta
+from core.storage.models import User
+from services.api.middleware.auth import get_current_user
 
 router = APIRouter()
 
@@ -101,6 +102,8 @@ def _persist_chat_turn(
         )
     except Exception as exc:  # noqa: BLE001 — fail-open, never break the chat
         logger.warning("chat history write-through failed (non-fatal): %s", exc)
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -340,9 +343,10 @@ async def chat(request: ChatRequest):
     Returns:
         Claude's response
     """
-    from core.agents.manager import AgentManager
-    import uuid
     import time
+    import uuid
+
+    from core.agents.manager import AgentManager
 
     # Generate unique request ID for tracking
     request_id = str(uuid.uuid4())[:8]
@@ -653,8 +657,8 @@ async def chat_stream(
     Returns:
         Streaming response
     """
-    import uuid
     import time
+    import uuid
 
     # Generate unique request ID for tracking
     request_id = str(uuid.uuid4())[:8]
@@ -1031,9 +1035,7 @@ async def chat_stream(
                         complete=history_reached_end,
                     )
                 except Exception as exc:  # noqa: BLE001 — fail-open
-                    logger.warning(
-                        "chat history persist failed (non-fatal): %s", exc
-                    )
+                    logger.warning("chat history persist failed (non-fatal): %s", exc)
 
     return StreamingResponse(
         generate(),
@@ -1253,7 +1255,7 @@ async def summarize_conversation(request: SummarizeRequest):
             full_text[:max_chars] + "\n\n[... earlier conversation truncated ...]"
         )
 
-    summary_prompt = f"""Summarize the following conversation between a user and an AI assistant (Vigil SOC platform). 
+    summary_prompt = f"""Summarize the following conversation between a user and an AI assistant (Vigil SOC platform).
 Preserve ALL important context including:
 - Key findings, case IDs, IOCs, and entity references discussed
 - Decisions made and actions taken
@@ -1660,9 +1662,10 @@ async def generate_chat_report(request: ChatReportRequest):
     Returns:
         Report file information
     """
-    from core.reporting.report_service import ReportService, REPORTLAB_AVAILABLE
-    from pathlib import Path
     from datetime import datetime
+    from pathlib import Path
+
+    from core.reporting.report_service import REPORTLAB_AVAILABLE, ReportService
 
     if not REPORTLAB_AVAILABLE:
         raise HTTPException(

--- a/services/api/routers/config.py
+++ b/services/api/routers/config.py
@@ -1,25 +1,30 @@
 """Configuration API endpoints."""
 
-from typing import Any, Dict, Optional, List
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
-from pathlib import Path
 import json
 import logging
 import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from core.config import get_settings, vigil_path
 from core.deps import (
     provide_demo_data,
     provide_integration_bridge,
     provide_mcp_client,
 )
 from core.integrations.integration_bridge_service import IntegrationBridgeService
+from core.integrations.integration_secrets import (
+    redact_secrets,
+    secret_fields_for,
+    split_secrets,
+)
+from core.llm.defaults import DEFAULT_MODEL
 from core.routing import Auth, RouterMeta
 from core.secrets import get_secret, set_secret
 from core.storage.config_service import get_config_service
-from core.llm.defaults import DEFAULT_MODEL
-from core.integrations.integration_secrets import redact_secrets, secret_fields_for, split_secrets
-from core.config import get_settings, vigil_path
 
 router = APIRouter()
 
@@ -254,7 +259,6 @@ async def set_claude_config(config: ClaudeConfig):
         # commit) must NOT block the secret write that already succeeded, so
         # this runs in its own transaction rather than the request's.
         try:
-            from core.storage.connection import get_db_session
             from core.storage.models import LLMProviderConfig
             from core.storage.unit_of_work import unit_of_work
 
@@ -709,7 +713,9 @@ def _secrets_set_map(integrations: dict) -> dict:
     for iid in integrations:
         fields = secret_fields_for(iid)
         if fields:
-            result[iid] = {field: bool(get_secret(env)) for field, env in fields.items()}
+            result[iid] = {
+                field: bool(get_secret(env)) for field, env in fields.items()
+            }
     return result
 
 
@@ -1018,10 +1024,9 @@ async def set_general_config(config: GeneralConfig):
 
         # Update the global secrets manager if keyring setting changed
         try:
-            from core.secrets_manager import get_secrets_manager
-
             # Force reinitialize with new setting
             from core import secrets_manager as sm_module
+            from core.secrets_manager import get_secrets_manager
 
             sm_module._secrets_manager = None  # Reset global instance
             get_secrets_manager(enable_keyring=config.enable_keyring)

--- a/services/api/routers/conversations.py
+++ b/services/api/routers/conversations.py
@@ -16,10 +16,10 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
-from services.api.middleware.auth import get_current_user
-from core.storage.models import User
 from core.chat import conversation_service
 from core.routing import Auth, RouterMeta
+from core.storage.models import User
+from services.api.middleware.auth import get_current_user
 
 logger = logging.getLogger(__name__)
 
@@ -81,9 +81,7 @@ async def get_conversation(
     current_user: User = Depends(get_current_user),
 ):
     """Fetch a single conversation with its ordered messages."""
-    conv = conversation_service.get_conversation(
-        conversation_id, current_user.user_id
-    )
+    conv = conversation_service.get_conversation(conversation_id, current_user.user_id)
     if conv is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
     return conv

--- a/services/api/routers/custom_agents.py
+++ b/services/api/routers/custom_agents.py
@@ -11,15 +11,15 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
 from core.agents.agent_ai_generator import AgentAIGenerator
-from core.deps import provide_agent_ai, provide_mcp_registry
-from core.integrations.mcp.registry import MCPRegistry
-from core.llm.system_prompt import validate_system_prompt
 from core.agents.custom_agent_service import (
     CustomAgentAlreadyExists,
     CustomAgentNotFound,
     CustomAgentService,
 )
 from core.agents.manager import CUSTOM_AGENT_ID_PREFIX
+from core.deps import provide_agent_ai, provide_mcp_registry
+from core.integrations.mcp.registry import MCPRegistry
+from core.llm.system_prompt import validate_system_prompt
 from core.routing import Auth, RouterMeta
 
 logger = logging.getLogger(__name__)
@@ -245,7 +245,7 @@ async def fork_agent(
     without affecting the source.
     """
     try:
-        from services.api.routers.agents import agent_manager, _resolve_agent
+        from services.api.routers.agents import _resolve_agent, agent_manager
 
         source = _resolve_agent(source_agent_id)
         if source is None:

--- a/services/api/routers/custom_integrations.py
+++ b/services/api/routers/custom_integrations.py
@@ -6,18 +6,20 @@ only — the previous query-string-based shape allowed traversal payloads
 to be smuggled through ``--url-query`` (see 2026-05 disclosure).
 """
 
-from typing import Optional
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
-from pydantic import BaseModel
 import logging
-from core.routing import Auth, RouterMeta
-from services.api.middleware.auth import get_current_active_user
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel
+
 from core.auth.auth_service import AuthService
-from core.storage.models import User
 from core.integrations.custom_integration_service import (
     CustomIntegrationService,
     InvalidIntegrationIdError,
 )
+from core.routing import Auth, RouterMeta
+from core.storage.models import User
+from services.api.middleware.auth import get_current_active_user
 
 router = APIRouter()
 

--- a/services/api/routers/detection_rules.py
+++ b/services/api/routers/detection_rules.py
@@ -2,8 +2,10 @@
 
 import logging
 from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+
 from core.deps import provide_detection_rules, provide_mcp_client
 from core.detections.detection_rules_service import DetectionRulesService
 from core.routing import Auth, RouterMeta
@@ -21,6 +23,7 @@ ROUTER_META = RouterMeta(
 
 class AddSourceRequest(BaseModel):
     """Request to add a new detection rule source."""
+
     name: str
     source_type: str  # 'git' or 'local'
     format: str  # 'sigma', 'splunk', 'elastic', 'kql', 'auto'
@@ -36,7 +39,7 @@ async def list_sources(
 ):
     """
     List all registered detection rule sources.
-    
+
     Returns:
         List of sources with metadata (name, format, rule count, status, etc.)
     """
@@ -55,17 +58,19 @@ async def get_source(
 ):
     """
     Get details for a specific detection rule source.
-    
+
     Args:
         source_id: The source ID
-    
+
     Returns:
         Source details
     """
     try:
         source = service.get_source(source_id)
         if not source:
-            raise HTTPException(status_code=404, detail=f"Source not found: {source_id}")
+            raise HTTPException(
+                status_code=404, detail=f"Source not found: {source_id}"
+            )
         return source
     except HTTPException:
         raise
@@ -81,10 +86,10 @@ async def add_source(
 ):
     """
     Add a new detection rule source (git repo or local directory).
-    
+
     Args:
         request: Source configuration (name, type, format, url/path, etc.)
-    
+
     Returns:
         The newly created source
     """
@@ -114,18 +119,20 @@ async def remove_source(
 ):
     """
     Remove a detection rule source.
-    
+
     Args:
         source_id: The source ID to remove
         delete_files: Whether to delete the cloned files on disk
-    
+
     Returns:
         Success status
     """
     try:
         success = service.remove_source(source_id, delete_files=delete_files)
         if not success:
-            raise HTTPException(status_code=404, detail=f"Source not found: {source_id}")
+            raise HTTPException(
+                status_code=404, detail=f"Source not found: {source_id}"
+            )
         return {"success": True}
     except HTTPException:
         raise
@@ -142,19 +149,19 @@ async def update_source(
 ):
     """
     Update a single detection rule source (git pull or rescan).
-    
+
     Args:
         source_id: The source ID to update
-    
+
     Returns:
         Updated source details
     """
     try:
         source = service.update_source(source_id)
-        
+
         # After updating, restart the security-detections MCP server to rebuild index
         await _restart_security_detections_mcp(mcp_client, service)
-        
+
         return {"success": True, "source": source}
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
@@ -170,16 +177,16 @@ async def update_all_sources(
 ):
     """
     Update all detection rule sources (git pull all repos).
-    
+
     Returns:
         Results for each source update
     """
     try:
         results = service.update_all()
-        
+
         # After updating all, restart the security-detections MCP server
         await _restart_security_detections_mcp(mcp_client, service)
-        
+
         return {"success": True, "results": results}
     except Exception as e:
         logger.error(f"Error updating all sources: {e}")
@@ -192,7 +199,7 @@ async def get_stats(
 ):
     """
     Get aggregate detection rule statistics.
-    
+
     Returns:
         Statistics including total rules, breakdown by format, and per-source counts
     """
@@ -210,7 +217,7 @@ async def get_mcp_env(
 ):
     """
     Get the environment variables that would be passed to the Security-Detections-MCP server.
-    
+
     Returns:
         Dictionary of environment variable names to their values
     """
@@ -230,28 +237,31 @@ async def reload_service(
     """
     Reload the detection rules service (re-reads config and rescans all sources).
     Also restarts the security-detections MCP server.
-    
+
     Returns:
         Success status with updated stats
     """
     try:
-        
+
         # Re-read config
         service._load_config()
-        
+
         # Rescan all sources
         for source in service.sources:
             from pathlib import Path
+
             source["rule_count"] = service._count_rules(
-                Path(source["local_path"]), source["format"], source.get("subdirectory", "")
+                Path(source["local_path"]),
+                source["format"],
+                source.get("subdirectory", ""),
             )
             if Path(source["local_path"]).exists():
                 source["status"] = "ready"
         service._save_config()
-        
+
         # Restart the MCP server
         await _restart_security_detections_mcp(mcp_client, service)
-        
+
         stats = service.get_stats()
         return {"success": True, "stats": stats}
     except Exception as e:
@@ -268,21 +278,21 @@ async def _restart_security_detections_mcp(mcp_client, service: DetectionRulesSe
         if mcp_client and mcp_client.mcp_service:
             mcp_service = mcp_client.mcp_service
             server_name = "security-detections"
-            
+
             if server_name in mcp_service.servers:
                 # Update the server's env vars with latest paths from detection_rules_service
                 env_vars = service.get_mcp_env_vars()
-                
+
                 server = mcp_service.servers[server_name]
                 server.env.update(env_vars)
-                
+
                 # Stop and restart
                 mcp_service.stop_server(server_name)
-                
+
                 # Disconnect and reconnect MCP client
                 await mcp_client.disconnect_from_server(server_name)
                 await mcp_client.connect_to_server(server_name, persistent=True)
-                
+
                 logger.info(f"Restarted {server_name} MCP server with updated env vars")
             else:
                 logger.warning(f"MCP server '{server_name}' not found in service")

--- a/services/api/routers/extensions.py
+++ b/services/api/routers/extensions.py
@@ -9,11 +9,11 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from services.api.middleware.auth import get_current_active_user
 from core.auth.auth_service import AuthService
-from core.storage.models import User
 from core.integrations.extension import session_service as ext_session
 from core.routing import Auth, RouterMeta
+from core.storage.models import User
+from services.api.middleware.auth import get_current_active_user
 
 logger = logging.getLogger(__name__)
 

--- a/services/api/routers/federation.py
+++ b/services/api/routers/federation.py
@@ -131,7 +131,9 @@ async def list_sources() -> Dict[str, Any]:
 
 
 @router.patch("/sources/{source_id}")
-async def patch_source(source_id: str, payload: FederationSourcePatch) -> Dict[str, Any]:
+async def patch_source(
+    source_id: str, payload: FederationSourcePatch
+) -> Dict[str, Any]:
     if fed_registry.get_adapter(source_id) is None:
         raise HTTPException(status_code=404, detail=f"Unknown source: {source_id}")
 

--- a/services/api/routers/findings.py
+++ b/services/api/routers/findings.py
@@ -1,11 +1,11 @@
 """Findings API endpoints."""
 
-from typing import List, Optional, Dict, Any
+import logging
+from typing import Any, Dict, List, Optional
+
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
-import logging
 
-from core.storage.database_data_service import DatabaseDataService
 from core.config import vigil_path
 from core.findings.enrichment import (
     FindingNotFound,
@@ -18,6 +18,7 @@ from core.findings.source_evidence import (
     project_finding_source_evidence_for_list,
 )
 from core.routing import Auth, RouterMeta, UnitOfWorkSession
+from core.storage.database_data_service import DatabaseDataService
 
 router = APIRouter()
 
@@ -38,16 +39,18 @@ def get_findings(
     cluster_id: Optional[int] = Query(None),
     min_anomaly_score: Optional[float] = Query(None),
     status: Optional[str] = Query(None),
-    search: Optional[str] = Query(None, description="Text search across finding IDs, descriptions, entity context"),
+    search: Optional[str] = Query(
+        None, description="Text search across finding IDs, descriptions, entity context"
+    ),
     offset: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     sort_by: str = Query("timestamp"),
     sort_order: str = Query("desc"),
-    force_refresh: bool = Query(False)
+    force_refresh: bool = Query(False),
 ):
     """
     Get findings with optional filters, search, and server-side pagination.
-    
+
     Returns:
         Paginated list of findings with total count and has_more flag.
     """
@@ -62,16 +65,24 @@ def get_findings(
     cluster_id_str = str(cluster_id) if cluster_id is not None else None
 
     total = data_service.count_findings(
-        severity=severity, data_source=data_source,
-        cluster_id=cluster_id_str, min_anomaly_score=min_anomaly_score,
-        status=status, search_query=search,
+        severity=severity,
+        data_source=data_source,
+        cluster_id=cluster_id_str,
+        min_anomaly_score=min_anomaly_score,
+        status=status,
+        search_query=search,
     )
     findings = data_service.get_findings(
-        limit=limit, offset=offset,
-        severity=severity, data_source=data_source,
-        cluster_id=cluster_id_str, min_anomaly_score=min_anomaly_score,
-        status=status, search_query=search,
-        sort_by=sort_by, sort_order=sort_order,
+        limit=limit,
+        offset=offset,
+        severity=severity,
+        data_source=data_source,
+        cluster_id=cluster_id_str,
+        min_anomaly_score=min_anomaly_score,
+        status=status,
+        search_query=search,
+        sort_by=sort_by,
+        sort_order=sort_order,
         # The list view never uses the 768-float embedding — omit it so a
         # 1000-row page (polled every 10s) isn't several MB of vectors.
         include_embedding=False,
@@ -92,10 +103,10 @@ def get_findings(
 def get_finding(finding_id: str):
     """
     Get a specific finding by ID.
-    
+
     Args:
         finding_id: The finding ID
-    
+
     Returns:
         Finding details
     """
@@ -109,7 +120,7 @@ def get_finding(finding_id: str):
 def get_findings_summary():
     """
     Get summary statistics for findings.
-    
+
     Returns:
         Summary statistics
     """
@@ -119,33 +130,33 @@ def get_findings_summary():
     severity_counts = {}
     data_source_counts = {}
     total_count = len(findings)
-    
+
     for finding in findings:
-        severity = finding.get('severity', 'unknown')
+        severity = finding.get("severity", "unknown")
         severity_counts[severity] = severity_counts.get(severity, 0) + 1
-        
-        data_source = finding.get('data_source', 'unknown')
+
+        data_source = finding.get("data_source", "unknown")
         data_source_counts[data_source] = data_source_counts.get(data_source, 0) + 1
-    
+
     return {
         "total": total_count,
         "by_severity": severity_counts,
-        "by_data_source": data_source_counts
+        "by_data_source": data_source_counts,
     }
 
 
 @router.post("/export")
 def export_findings(output_format: str = "json"):
     from datetime import datetime
-    
+
     output_dir = vigil_path("exports", write=True)
     output_dir.mkdir(parents=True, exist_ok=True)
-    
+
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_path = output_dir / f"findings_export_{timestamp}.{output_format}"
-    
+
     success = data_service.export_findings(output_path, format=output_format)
-    
+
     if success:
         return {"success": True, "file_path": str(output_path)}
     else:
@@ -154,6 +165,7 @@ def export_findings(output_format: str = "json"):
 
 class FindingUpdate(BaseModel):
     """Schema for updating a finding."""
+
     mitre_predictions: Optional[Dict[str, float]] = None
     predicted_techniques: Optional[List[Dict[str, Any]]] = None
     severity: Optional[str] = None
@@ -166,6 +178,7 @@ class FindingUpdate(BaseModel):
 
 class BulkEnrichmentRequest(BaseModel):
     """Schema for bulk enrichment request."""
+
     finding_ids: List[str]
     enrichment_data: Dict[str, FindingUpdate]
 
@@ -174,17 +187,17 @@ class BulkEnrichmentRequest(BaseModel):
 def update_finding(finding_id: str, update: FindingUpdate):
     """
     Update/enrich an existing finding.
-    
+
     This endpoint allows you to add or update information on a finding,
     including MITRE ATT&CK technique mappings, severity, and other metadata.
-    
+
     Args:
         finding_id: The finding ID to update
         update: Fields to update
-    
+
     Returns:
         Updated finding
-    
+
     Example:
         PATCH /api/findings/f-20260114-abc123
         {
@@ -200,29 +213,29 @@ def update_finding(finding_id: str, update: FindingUpdate):
     finding = data_service.get_finding(finding_id)
     if not finding:
         raise HTTPException(status_code=404, detail="Finding not found")
-    
+
     # Prepare updates (exclude None values)
     updates = {}
     for key, value in update.model_dump(exclude_none=True).items():
         updates[key] = value
-    
+
     if not updates:
         raise HTTPException(status_code=400, detail="No updates provided")
-    
+
     # Update the finding
     success = data_service.update_finding(finding_id, **updates)
-    
+
     if not success:
         raise HTTPException(status_code=500, detail="Failed to update finding")
-    
+
     # Return updated finding
     updated_finding = data_service.get_finding(finding_id)
     logger.info(f"Updated finding {finding_id} with {len(updates)} fields")
-    
+
     return {
         "success": True,
         "finding": updated_finding,
-        "updated_fields": list(updates.keys())
+        "updated_fields": list(updates.keys()),
     }
 
 
@@ -230,16 +243,16 @@ def update_finding(finding_id: str, update: FindingUpdate):
 def bulk_enrich_findings(request: BulkEnrichmentRequest):
     """
     Bulk enrich multiple findings with MITRE ATT&CK and other data.
-    
+
     This endpoint allows you to enrich multiple findings at once,
     useful for batch processing or adding threat intelligence data.
-    
+
     Args:
         request: Bulk enrichment request with finding IDs and enrichment data
-    
+
     Returns:
         Summary of enrichment results
-    
+
     Example:
         POST /api/findings/bulk-enrich
         {
@@ -261,9 +274,9 @@ def bulk_enrich_findings(request: BulkEnrichmentRequest):
         "updated": 0,
         "failed": 0,
         "not_found": 0,
-        "errors": []
+        "errors": [],
     }
-    
+
     for finding_id in request.finding_ids:
         try:
             # Check if finding exists
@@ -272,56 +285,58 @@ def bulk_enrich_findings(request: BulkEnrichmentRequest):
                 results["not_found"] += 1
                 results["errors"].append(f"{finding_id}: Not found")
                 continue
-            
+
             # Get enrichment data for this finding
             enrichment = request.enrichment_data.get(finding_id)
             if not enrichment:
                 continue
-            
+
             # Prepare updates
             updates = enrichment.model_dump(exclude_none=True)
             if not updates:
                 continue
-            
+
             # Update the finding
             success = data_service.update_finding(finding_id, **updates)
-            
+
             if success:
                 results["updated"] += 1
                 logger.info(f"Enriched finding {finding_id}")
             else:
                 results["failed"] += 1
                 results["errors"].append(f"{finding_id}: Update failed")
-                
+
         except Exception as e:
             results["failed"] += 1
             results["errors"].append(f"{finding_id}: {str(e)}")
             logger.error(f"Error enriching finding {finding_id}: {e}")
-    
+
     return {
         "success": results["updated"] > 0,
         "message": f"Updated {results['updated']} of {results['total']} findings",
-        "results": results
+        "results": results,
     }
 
 
 @router.post("/{finding_id}/enrich")
-async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Query(False)):
+async def get_or_generate_enrichment(
+    finding_id: str, force_regenerate: bool = Query(False)
+):
     """
     Get or generate AI enrichment for a finding.
-    
+
     This endpoint checks if AI enrichment already exists for the finding.
     If it exists, returns the cached enrichment immediately.
     If not, generates new enrichment using the configured reporting model,
     caches it, and returns it.
-    
+
     Args:
         finding_id: The finding ID to enrich
         force_regenerate: Force regeneration even if enrichment exists
-    
+
     Returns:
         AI enrichment data with threat analysis, impact, recommendations, etc.
-    
+
     Example Response:
         {
             "finding_id": "f-20260114-001",
@@ -347,13 +362,13 @@ async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Q
     # Check if enrichment already exists. Caching is HTTP policy — the shared
     # enrich() seam deliberately doesn't do this check, since `force_regenerate`
     # is a query param and the daemon has its own freshness rules.
-    existing_enrichment = finding.get('ai_enrichment')
+    existing_enrichment = finding.get("ai_enrichment")
     if existing_enrichment and not force_regenerate:
         logger.info(f"Returning cached enrichment for {finding_id}")
         return {
             "finding_id": finding_id,
             "cached": True,
-            "enrichment": existing_enrichment
+            "enrichment": existing_enrichment,
         }
 
     # Generate new enrichment using the configured reporting provider. The flow
@@ -380,15 +395,10 @@ async def get_or_generate_enrichment(finding_id: str, force_regenerate: bool = Q
     except Exception as e:
         logger.error(f"Error generating enrichment for {finding_id}: {e}")
         raise HTTPException(
-            status_code=500,
-            detail=f"Failed to generate enrichment: {str(e)}"
+            status_code=500, detail=f"Failed to generate enrichment: {str(e)}"
         )
 
-    return {
-        "finding_id": finding_id,
-        "cached": False,
-        "enrichment": enrichment
-    }
+    return {"finding_id": finding_id, "cached": False, "enrichment": enrichment}
 
 
 @router.delete("/all")
@@ -401,7 +411,13 @@ def clear_all_findings(session: UnitOfWorkSession):
         session.query(Finding).delete()
 
         logger.info(f"Cleared {count} findings")
-        return {"success": True, "deleted": count, "message": f"Deleted {count} findings"}
+        return {
+            "success": True,
+            "deleted": count,
+            "message": f"Deleted {count} findings",
+        }
     except Exception as e:
         logger.error(f"Error clearing findings: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to clear findings: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to clear findings: {str(e)}"
+        )

--- a/services/api/routers/graph.py
+++ b/services/api/routers/graph.py
@@ -1,12 +1,13 @@
 """Graph API endpoints for visualizing entity relationships and attack paths."""
 
-from typing import List, Optional, Dict, Any
+import logging
+from typing import Any, Dict, List, Optional
+
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
-import logging
 
-from core.storage.database_data_service import DatabaseDataService
 from core.routing import Auth, RouterMeta
+from core.storage.database_data_service import DatabaseDataService
 
 router = APIRouter()
 
@@ -20,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 class GraphNode(BaseModel):
     """Graph node model."""
+
     id: str
     label: str
     type: str  # ip, hostname, user, domain, port, cluster
@@ -30,6 +32,7 @@ class GraphNode(BaseModel):
 
 class GraphLink(BaseModel):
     """Graph link model."""
+
     source: str
     target: str
     value: Optional[int] = None
@@ -39,6 +42,7 @@ class GraphLink(BaseModel):
 
 class GraphData(BaseModel):
     """Graph data model."""
+
     nodes: List[GraphNode]
     links: List[GraphLink]
     metadata: Optional[Dict[str, Any]] = None
@@ -49,30 +53,30 @@ async def get_entity_graph(
     finding_ids: Optional[str] = Query(None, description="Comma-separated finding IDs"),
     case_id: Optional[str] = Query(None, description="Case ID"),
     cluster_id: Optional[str] = Query(None, description="Cluster ID"),
-    limit: int = Query(default=100, ge=1, le=1000)
+    limit: int = Query(default=100, ge=1, le=1000),
 ):
     """
     Get entity relationship graph.
-    
+
     Builds a graph of entities (IPs, hosts, users, domains) and their relationships
     based on findings.
-    
+
     Args:
         finding_ids: Comma-separated list of finding IDs
         case_id: Case ID to get entities from
         cluster_id: Cluster ID to get entities from
         limit: Maximum number of findings to process
-        
+
     Returns:
         Graph data with nodes and links
     """
     try:
         data_service = DatabaseDataService()
         findings = []
-        
+
         # Get findings based on filters
         if finding_ids:
-            ids = [fid.strip() for fid in finding_ids.split(',')]
+            ids = [fid.strip() for fid in finding_ids.split(",")]
             for fid in ids:
                 finding = data_service.get_finding(fid)
                 if finding:
@@ -81,25 +85,30 @@ async def get_entity_graph(
             findings = data_service.get_findings_by_case(case_id)
         elif cluster_id:
             all_findings = data_service.get_findings(limit=limit * 2)
-            findings = [f for f in all_findings if f.get('cluster_id') == cluster_id][:limit]
+            findings = [f for f in all_findings if f.get("cluster_id") == cluster_id][
+                :limit
+            ]
         else:
             # Get recent findings
             findings = data_service.get_findings(limit=limit)
-        
+
         if not findings:
-            return GraphData(nodes=[], links=[], metadata={"message": "No findings found"})
-        
+            return GraphData(
+                nodes=[], links=[], metadata={"message": "No findings found"}
+            )
+
         # Build graph from findings
         from core.findings.graph_builder_service import GraphBuilderService
+
         graph_builder = GraphBuilderService()
         graph_data = graph_builder.build_entity_graph(findings)
-        
+
         return GraphData(
-            nodes=[GraphNode(**node) for node in graph_data['nodes']],
-            links=[GraphLink(**link) for link in graph_data['links']],
-            metadata=graph_data.get('metadata', {})
+            nodes=[GraphNode(**node) for node in graph_data["nodes"]],
+            links=[GraphLink(**link) for link in graph_data["links"]],
+            metadata=graph_data.get("metadata", {}),
         )
-        
+
     except Exception as e:
         logger.error(f"Error building entity graph: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -109,40 +118,43 @@ async def get_entity_graph(
 async def get_attack_path(case_id: str):
     """
     Get attack path visualization for a case.
-    
+
     Shows the progression of an attack across systems, highlighting
     lateral movement and compromise chains.
-    
+
     Args:
         case_id: Case identifier
-        
+
     Returns:
         Graph data showing attack progression
     """
     try:
         data_service = DatabaseDataService()
         case = data_service.get_case(case_id)
-        
+
         if not case:
             raise HTTPException(status_code=404, detail="Case not found")
-        
+
         # Get findings for the case
         findings = data_service.get_findings_by_case(case_id)
-        
+
         if not findings:
-            return GraphData(nodes=[], links=[], metadata={"message": "No findings in case"})
-        
+            return GraphData(
+                nodes=[], links=[], metadata={"message": "No findings in case"}
+            )
+
         # Build attack path graph
         from core.findings.graph_builder_service import GraphBuilderService
+
         graph_builder = GraphBuilderService()
         graph_data = graph_builder.build_attack_path(findings, case)
-        
+
         return GraphData(
-            nodes=[GraphNode(**node) for node in graph_data['nodes']],
-            links=[GraphLink(**link) for link in graph_data['links']],
-            metadata=graph_data.get('metadata', {})
+            nodes=[GraphNode(**node) for node in graph_data["nodes"]],
+            links=[GraphLink(**link) for link in graph_data["links"]],
+            metadata=graph_data.get("metadata", {}),
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -154,36 +166,39 @@ async def get_attack_path(case_id: str):
 async def get_cluster_graph(cluster_id: str):
     """
     Get graph visualization for a cluster of findings.
-    
+
     Shows how findings in a cluster are related through shared entities.
-    
+
     Args:
         cluster_id: Cluster identifier
-        
+
     Returns:
         Graph data for the cluster
     """
     try:
         data_service = DatabaseDataService()
-        
+
         # Get findings in cluster
         all_findings = data_service.get_findings(limit=10000)
-        findings = [f for f in all_findings if f.get('cluster_id') == cluster_id]
-        
+        findings = [f for f in all_findings if f.get("cluster_id") == cluster_id]
+
         if not findings:
-            raise HTTPException(status_code=404, detail="Cluster not found or has no findings")
-        
+            raise HTTPException(
+                status_code=404, detail="Cluster not found or has no findings"
+            )
+
         # Build cluster graph
         from core.findings.graph_builder_service import GraphBuilderService
+
         graph_builder = GraphBuilderService()
         graph_data = graph_builder.build_cluster_graph(findings, cluster_id)
-        
+
         return GraphData(
-            nodes=[GraphNode(**node) for node in graph_data['nodes']],
-            links=[GraphLink(**link) for link in graph_data['links']],
-            metadata=graph_data.get('metadata', {})
+            nodes=[GraphNode(**node) for node in graph_data["nodes"]],
+            links=[GraphLink(**link) for link in graph_data["links"]],
+            metadata=graph_data.get("metadata", {}),
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -193,104 +208,107 @@ async def get_cluster_graph(cluster_id: str):
 
 @router.get("/technique/{technique_id}", response_model=GraphData)
 async def get_technique_graph(
-    technique_id: str,
-    limit: int = Query(default=100, ge=1, le=500)
+    technique_id: str, limit: int = Query(default=100, ge=1, le=500)
 ):
     """
     Get graph of entities involved in a specific MITRE ATT&CK technique.
-    
+
     Args:
         technique_id: MITRE ATT&CK technique ID (e.g., T1071.001)
         limit: Maximum number of findings to process
-        
+
     Returns:
         Graph data for the technique
     """
     try:
         data_service = DatabaseDataService()
-        
+
         # Get findings with this technique
         all_findings = data_service.get_findings(limit=limit * 2)
         findings = []
-        
+
         for finding in all_findings:
-            mitre_predictions = finding.get('mitre_predictions', {})
+            mitre_predictions = finding.get("mitre_predictions", {})
             if technique_id in mitre_predictions:
                 findings.append(finding)
                 if len(findings) >= limit:
                     break
-        
+
         if not findings:
             return GraphData(
                 nodes=[],
                 links=[],
-                metadata={"message": f"No findings with technique {technique_id}"}
+                metadata={"message": f"No findings with technique {technique_id}"},
             )
-        
+
         # Build technique graph
         from core.findings.graph_builder_service import GraphBuilderService
+
         graph_builder = GraphBuilderService()
         graph_data = graph_builder.build_technique_graph(findings, technique_id)
-        
+
         return GraphData(
-            nodes=[GraphNode(**node) for node in graph_data['nodes']],
-            links=[GraphLink(**link) for link in graph_data['links']],
-            metadata=graph_data.get('metadata', {})
+            nodes=[GraphNode(**node) for node in graph_data["nodes"]],
+            links=[GraphLink(**link) for link in graph_data["links"]],
+            metadata=graph_data.get("metadata", {}),
         )
-        
+
     except Exception as e:
         logger.error(f"Error building technique graph: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.get("/summary", response_model=Dict[str, Any])
-async def get_graph_summary(
-    limit: int = Query(default=100, ge=1, le=1000)
-):
+async def get_graph_summary(limit: int = Query(default=100, ge=1, le=1000)):
     """
     Get summary statistics about the entity graph.
-    
+
     Args:
         limit: Maximum number of findings to analyze
-        
+
     Returns:
         Summary statistics
     """
     try:
         data_service = DatabaseDataService()
         findings = data_service.get_findings(limit=limit)
-        
+
         # Build graph and calculate metrics
         from core.findings.graph_builder_service import GraphBuilderService
+
         graph_builder = GraphBuilderService()
         graph_data = graph_builder.build_entity_graph(findings)
-        
+
         # Calculate summary metrics
         nodes_by_type = {}
-        for node in graph_data['nodes']:
-            node_type = node['type']
+        for node in graph_data["nodes"]:
+            node_type = node["type"]
             nodes_by_type[node_type] = nodes_by_type.get(node_type, 0) + 1
-        
+
         # Find most connected nodes
         node_connections = {}
-        for link in graph_data['links']:
-            node_connections[link['source']] = node_connections.get(link['source'], 0) + 1
-            node_connections[link['target']] = node_connections.get(link['target'], 0) + 1
-        
-        top_nodes = sorted(node_connections.items(), key=lambda x: x[1], reverse=True)[:10]
-        
+        for link in graph_data["links"]:
+            node_connections[link["source"]] = (
+                node_connections.get(link["source"], 0) + 1
+            )
+            node_connections[link["target"]] = (
+                node_connections.get(link["target"], 0) + 1
+            )
+
+        top_nodes = sorted(node_connections.items(), key=lambda x: x[1], reverse=True)[
+            :10
+        ]
+
         return {
-            "total_nodes": len(graph_data['nodes']),
-            "total_links": len(graph_data['links']),
+            "total_nodes": len(graph_data["nodes"]),
+            "total_links": len(graph_data["links"]),
             "nodes_by_type": nodes_by_type,
             "top_connected_nodes": [
-                {"id": node_id, "connections": count}
-                for node_id, count in top_nodes
+                {"id": node_id, "connections": count} for node_id, count in top_nodes
             ],
-            "findings_analyzed": len(findings)
+            "findings_analyzed": len(findings),
         }
-        
+
     except Exception as e:
         logger.error(f"Error getting graph summary: {e}")
         raise HTTPException(status_code=500, detail=str(e))
-

--- a/services/api/routers/ingestion.py
+++ b/services/api/routers/ingestion.py
@@ -11,15 +11,16 @@ Handles uploading and ingesting findings/cases from various file formats:
 
 import asyncio
 import logging
-from datetime import datetime
-from typing import Dict, Optional, List
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException, Query
-from pydantic import BaseModel
-from pathlib import Path
-from starlette.concurrency import run_in_threadpool
 import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
 
-from core.ingestion.ingestion_service import IngestionService
+from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
+from pydantic import BaseModel
+from starlette.concurrency import run_in_threadpool
+
+from core.config import get_settings
 from core.ingestion.ingestion_jobs import (
     IngestionJob,
     IngestionJobConflict,
@@ -27,9 +28,9 @@ from core.ingestion.ingestion_jobs import (
     run_job,
     summarize_stats,
 )
-from core.storage.database_data_service import DatabaseDataService
+from core.ingestion.ingestion_service import IngestionService
 from core.routing import Auth, RouterMeta
-from core.config import get_settings
+from core.storage.database_data_service import DatabaseDataService
 
 logger = logging.getLogger(__name__)
 
@@ -44,11 +45,11 @@ ROUTER_META = RouterMeta(
 MAX_UPLOAD_SIZE_BYTES = get_settings().max_upload_size_mb * 1024 * 1024
 
 EXTENSION_FORMATS = {
-    '.json': 'json',
-    '.csv': 'csv',
-    '.jsonl': 'jsonl',
-    '.ndjson': 'jsonl',
-    '.parquet': 'parquet',
+    ".json": "json",
+    ".csv": "csv",
+    ".jsonl": "jsonl",
+    ".ndjson": "jsonl",
+    ".parquet": "parquet",
 }
 
 _running_tasks: set = set()  # asyncio only weak-refs tasks; unheld ones get GC'd
@@ -56,6 +57,7 @@ _running_tasks: set = set()  # asyncio only weak-refs tasks; unheld ones get GC'
 
 class IngestionStats(BaseModel):
     """Ingestion statistics response."""
+
     findings_total: int
     findings_imported: int
     findings_skipped: int
@@ -70,6 +72,7 @@ class IngestionStats(BaseModel):
 
 class IngestionJobStatus(BaseModel):
     """Snapshot of a background ingestion job."""
+
     job_id: str
     filename: str
     format: str
@@ -88,7 +91,9 @@ class IngestionJobStatus(BaseModel):
 async def _spool_upload(file: UploadFile, suffix: str) -> Path:
     """Stream an upload to a temp file, enforcing the size cap as it goes."""
 
-    with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix=suffix) as temp_file:
+    with tempfile.NamedTemporaryFile(
+        mode="wb", delete=False, suffix=suffix
+    ) as temp_file:
         temp_path = Path(temp_file.name)
         total_size = 0
         while True:
@@ -101,7 +106,7 @@ async def _spool_upload(file: UploadFile, suffix: str) -> Path:
                 temp_path.unlink(missing_ok=True)
                 raise HTTPException(
                     status_code=413,
-                    detail=f"File too large. Maximum upload size is {MAX_UPLOAD_SIZE_BYTES // (1024*1024)}MB."
+                    detail=f"File too large. Maximum upload size is {MAX_UPLOAD_SIZE_BYTES // (1024*1024)}MB.",
                 )
             temp_file.write(chunk)
     return temp_path
@@ -111,25 +116,30 @@ async def _spool_upload(file: UploadFile, suffix: str) -> Path:
 async def upload_and_ingest_file(
     file: UploadFile = File(...),
     data_type: str = Form("finding"),
-    format: Optional[str] = Form(None)
+    format: Optional[str] = Form(None),
 ):
     """Accept a file and ingest it as a background job; poll /ingest/jobs/{id}."""
-    if data_type not in ['finding', 'case']:
-        raise HTTPException(status_code=400, detail="data_type must be 'finding' or 'case'")
+    if data_type not in ["finding", "case"]:
+        raise HTTPException(
+            status_code=400, detail="data_type must be 'finding' or 'case'"
+        )
 
-    filename = file.filename or 'upload'
+    filename = file.filename or "upload"
     if not format:
         format = EXTENSION_FORMATS.get(Path(filename).suffix.lower())
         if format is None:
             raise HTTPException(
                 status_code=400,
-                detail="Unable to detect file format. Please specify format parameter or use .json, .csv, .jsonl, or .parquet extension"
+                detail="Unable to detect file format. Please specify format parameter or use .json, .csv, .jsonl, or .parquet extension",
             )
 
-    if format not in ['json', 'csv', 'jsonl', 'parquet']:
-        raise HTTPException(status_code=400, detail="format must be 'json', 'csv', 'jsonl', or 'parquet'")
+    if format not in ["json", "csv", "jsonl", "parquet"]:
+        raise HTTPException(
+            status_code=400,
+            detail="format must be 'json', 'csv', 'jsonl', or 'parquet'",
+        )
 
-    temp_path = await _spool_upload(file, f'.{format}')
+    temp_path = await _spool_upload(file, f".{format}")
 
     job = IngestionJob(filename=filename, fmt=format, data_type=data_type)
     try:
@@ -138,7 +148,7 @@ async def upload_and_ingest_file(
         temp_path.unlink(missing_ok=True)
         raise HTTPException(
             status_code=409,
-            detail=f"Already ingesting '{conflict.active.filename}'. Wait for it to finish."
+            detail=f"Already ingesting '{conflict.active.filename}'. Wait for it to finish.",
         )
 
     task = asyncio.create_task(run_in_threadpool(run_job, job, temp_path))
@@ -165,20 +175,24 @@ async def get_ingestion_job(job_id: str):
 
 @router.post("/ingest-string", response_model=IngestionStats)
 async def ingest_from_string(
-    data: str = Form(...),
-    format: str = Form("json"),
-    data_type: str = Form("finding")
+    data: str = Form(...), format: str = Form("json"), data_type: str = Form("finding")
 ):
     """Ingest data from a string; format is 'json', 'csv', or 'jsonl'."""
-    if data_type not in ['finding', 'case']:
-        raise HTTPException(status_code=400, detail="data_type must be 'finding' or 'case'")
+    if data_type not in ["finding", "case"]:
+        raise HTTPException(
+            status_code=400, detail="data_type must be 'finding' or 'case'"
+        )
 
-    if format not in ['json', 'csv', 'jsonl']:
-        raise HTTPException(status_code=400, detail="format must be 'json', 'csv', or 'jsonl'")
+    if format not in ["json", "csv", "jsonl"]:
+        raise HTTPException(
+            status_code=400, detail="format must be 'json', 'csv', or 'jsonl'"
+        )
 
     try:
         ingestion_service = IngestionService()
-        stats = ingestion_service.ingest_from_string(data, format=format, data_type=data_type)
+        stats = ingestion_service.ingest_from_string(
+            data, format=format, data_type=data_type
+        )
         success, message = summarize_stats(stats)
         return IngestionStats(**stats, success=success, message=message)
 
@@ -191,7 +205,7 @@ async def ingest_from_string(
 async def get_supported_formats():
     """
     Get information about supported file formats.
-    
+
     Returns:
         Dictionary of supported formats and their specifications
     """
@@ -211,7 +225,7 @@ async def get_supported_formats():
                             "timestamp": "2026-01-14T10:00:00Z",
                             "data_source": "flow",
                             "severity": "high",
-                            "status": "new"
+                            "status": "new",
                         }
                     ],
                     "cases": [
@@ -220,16 +234,16 @@ async def get_supported_formats():
                             "title": "Investigation",
                             "finding_ids": ["f-20260114-abc123"],
                             "status": "open",
-                            "priority": "high"
+                            "priority": "high",
                         }
-                    ]
-                }
+                    ],
+                },
             },
             "jsonl": {
                 "name": "JSON Lines",
                 "extensions": [".jsonl", ".ndjson"],
                 "description": "One JSON object per line",
-                "example": '{"finding_id": "f-123", "anomaly_score": 0.8}\n{"finding_id": "f-456", "anomaly_score": 0.9}'
+                "example": '{"finding_id": "f-123", "anomaly_score": 0.8}\n{"finding_id": "f-456", "anomaly_score": 0.9}',
             },
             "csv": {
                 "name": "CSV",
@@ -245,7 +259,7 @@ async def get_supported_formats():
                     "cluster_id",
                     "embedding (comma-separated floats)",
                     "mitre_predictions (JSON string or technique:score pairs)",
-                    "entity_context (JSON string)"
+                    "entity_context (JSON string)",
                 ],
                 "case_columns": [
                     "case_id",
@@ -255,8 +269,8 @@ async def get_supported_formats():
                     "status",
                     "priority",
                     "assignee",
-                    "tags (comma-separated)"
-                ]
+                    "tags (comma-separated)",
+                ],
             },
             "parquet": {
                 "name": "Parquet",
@@ -271,21 +285,21 @@ async def get_supported_formats():
                     "event_start_time (epoch ms -> timestamp)",
                     "event_end_time (epoch ms -> entity_context)",
                     "malicious (bool -> severity + anomaly_score)",
-                    "row_count, incident_pred, attack_id, created_at (metadata)"
-                ]
-            }
+                    "row_count, incident_pred, attack_id, created_at (metadata)",
+                ],
+            },
         },
         "data_types": {
             "finding": "Security findings with embeddings and MITRE predictions",
-            "case": "Investigation cases grouping related findings"
+            "case": "Investigation cases grouping related findings",
         },
         "notes": [
             "finding_id and case_id are auto-generated if not provided",
             "Duplicate IDs are automatically skipped",
             "All data is stored in PostgreSQL when available, falls back to JSON files",
             "Embeddings default to 768-dimensional zero vector if not provided",
-            "Timestamps are parsed from various formats or default to current time"
-        ]
+            "Timestamps are parsed from various formats or default to current time",
+        ],
     }
 
 
@@ -293,62 +307,64 @@ async def get_supported_formats():
 async def get_csv_template(data_type: str):
     """
     Get a CSV template for the specified data type.
-    
+
     Args:
         data_type: Type of data ('finding' or 'case')
-    
+
     Returns:
         CSV template string
     """
-    if data_type == 'finding':
+    if data_type == "finding":
         return {
-            "template": "finding_id,anomaly_score,timestamp,data_source,severity,status,cluster_id,mitre_predictions,entity_context\n" +
-                       "f-20260114-example,0.85,2026-01-14T10:00:00Z,flow,high,new,c-beaconing-001,\"{\"\"T1071.001\"\": 0.85}\",\"{\"\"src_ip\"\": \"\"192.168.1.100\"\"}\"\n",
-            "description": "CSV template for findings. Note: embedding column omitted for brevity (768 values)"
+            "template": "finding_id,anomaly_score,timestamp,data_source,severity,status,cluster_id,mitre_predictions,entity_context\n"
+            + 'f-20260114-example,0.85,2026-01-14T10:00:00Z,flow,high,new,c-beaconing-001,"{""T1071.001"": 0.85}","{""src_ip"": ""192.168.1.100""}"\n',
+            "description": "CSV template for findings. Note: embedding column omitted for brevity (768 values)",
         }
-    elif data_type == 'case':
+    elif data_type == "case":
         return {
-            "template": "case_id,title,description,finding_ids,status,priority,assignee,tags\n" +
-                       "case-2026-01-14-example,Suspicious Activity,Investigation of unusual network traffic,\"f-123,f-456\",open,high,analyst@example.com,\"lateral-movement,investigation\"\n",
-            "description": "CSV template for cases"
+            "template": "case_id,title,description,finding_ids,status,priority,assignee,tags\n"
+            + 'case-2026-01-14-example,Suspicious Activity,Investigation of unusual network traffic,"f-123,f-456",open,high,analyst@example.com,"lateral-movement,investigation"\n',
+            "description": "CSV template for cases",
         }
     else:
-        raise HTTPException(status_code=400, detail="data_type must be 'finding' or 'case'")
+        raise HTTPException(
+            status_code=400, detail="data_type must be 'finding' or 'case'"
+        )
 
 
 @router.post("/sync-s3")
 def sync_from_s3():
     """
     Sync findings and cases from AWS S3.
-    
+
     Requires S3 to be configured in settings.
     Fetches data from the configured S3 bucket and syncs to local storage.
-    
+
     Returns:
         Sync status and statistics
     """
     try:
         data_service = DatabaseDataService()
-        
+
         # Check if S3 is configured
         if not data_service.is_s3_configured():
             raise HTTPException(
                 status_code=400,
-                detail="S3 is not configured. Please configure S3 in Settings first."
+                detail="S3 is not configured. Please configure S3 in Settings first.",
             )
-        
+
         # Perform sync
         logger.info("Starting S3 sync via API endpoint")
         success, message, stats = data_service.sync_from_s3()
-        
+
         return {
             "success": success,
             "message": message,
             "findings_synced": stats.get("findings_synced", 0),
             "cases_synced": stats.get("cases_synced", 0),
-            "errors": stats.get("errors", [])
+            "errors": stats.get("errors", []),
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -384,28 +400,28 @@ def sync_s3_folder(prefix: Optional[str] = Query(None)):
         if not data_service.is_s3_configured():
             raise HTTPException(
                 status_code=400,
-                detail="S3 is not configured. Please configure S3 in Settings first."
+                detail="S3 is not configured. Please configure S3 in Settings first.",
             )
 
         if prefix is None:
             from core.storage.config_service import get_config_service
+
             config_service = get_config_service()
-            s3_config = config_service.get_integration_config('s3') or {}
-            prefix = s3_config.get('parquet_prefix', '')
+            s3_config = config_service.get_integration_config("s3") or {}
+            prefix = s3_config.get("parquet_prefix", "")
 
         logger.info(f"Starting S3 folder sync with prefix='{prefix}'")
 
         ingestion_service = IngestionService()
         stats = ingestion_service.ingest_s3_folder(
-            s3_service=data_service._s3_service,
-            prefix=prefix
+            s3_service=data_service._s3_service, prefix=prefix
         )
 
         success, summary = summarize_stats(stats)
 
         prefix = []
-        fp = stats.get('files_processed', 0)
-        fs = stats.get('files_skipped', 0)
+        fp = stats.get("files_processed", 0)
+        fs = stats.get("files_skipped", 0)
         if fp > 0:
             prefix.append(f"Processed {fp} file(s)")
         if fs > 0:
@@ -417,16 +433,16 @@ def sync_s3_folder(prefix: Optional[str] = Query(None)):
             message = ". ".join(prefix + [summary])
 
         return IngestionStats(
-            findings_total=stats.get('findings_total', 0),
-            findings_imported=stats.get('findings_imported', 0),
-            findings_skipped=stats.get('findings_skipped', 0),
-            findings_errors=stats.get('findings_errors', 0),
-            cases_total=stats.get('cases_total', 0),
-            cases_imported=stats.get('cases_imported', 0),
-            cases_skipped=stats.get('cases_skipped', 0),
-            cases_errors=stats.get('cases_errors', 0),
+            findings_total=stats.get("findings_total", 0),
+            findings_imported=stats.get("findings_imported", 0),
+            findings_skipped=stats.get("findings_skipped", 0),
+            findings_errors=stats.get("findings_errors", 0),
+            cases_total=stats.get("cases_total", 0),
+            cases_imported=stats.get("cases_imported", 0),
+            cases_skipped=stats.get("cases_skipped", 0),
+            cases_errors=stats.get("cases_errors", 0),
             success=success,
-            message=message
+            message=message,
         )
 
     except HTTPException:
@@ -443,33 +459,37 @@ def _get_s3_service():
     Unlike DatabaseDataService.is_s3_configured() this skips the head_bucket
     test so it works with IAM policies that only grant list/get permissions.
     """
-    from core.storage.config_service import get_config_service
     from core.secrets_manager import get_secret
+    from core.storage.config_service import get_config_service
     from core.storage.s3_service import S3Service
 
     config_service = get_config_service()
-    s3_integration = config_service.get_integration_config('s3')
+    s3_integration = config_service.get_integration_config("s3")
     if not s3_integration:
         return None
 
-    cfg = s3_integration.get('config') if isinstance(s3_integration.get('config'), dict) else s3_integration
+    cfg = (
+        s3_integration.get("config")
+        if isinstance(s3_integration.get("config"), dict)
+        else s3_integration
+    )
 
-    raw_bucket = cfg.get('bucket_name', '')
-    if raw_bucket.startswith('s3://'):
-        bucket_name = raw_bucket[5:].split('/', 1)[0]
+    raw_bucket = cfg.get("bucket_name", "")
+    if raw_bucket.startswith("s3://"):
+        bucket_name = raw_bucket[5:].split("/", 1)[0]
     else:
         bucket_name = raw_bucket
 
     if not bucket_name:
         return None
 
-    auth_method = cfg.get('auth_method', 'credentials')
-    aws_profile = cfg.get('aws_profile', '')
+    auth_method = cfg.get("auth_method", "credentials")
+    aws_profile = cfg.get("aws_profile", "")
 
-    if auth_method == 'profile' and aws_profile:
+    if auth_method == "profile" and aws_profile:
         return S3Service(
             bucket_name=bucket_name,
-            region_name=cfg.get('region', 'us-east-1'),
+            region_name=cfg.get("region", "us-east-1"),
             aws_profile=aws_profile,
         )
 
@@ -479,7 +499,7 @@ def _get_s3_service():
 
     return S3Service(
         bucket_name=bucket_name,
-        region_name=cfg.get('region', 'us-east-1'),
+        region_name=cfg.get("region", "us-east-1"),
         aws_access_key_id=access_key or None,
         aws_secret_access_key=secret_key or None,
         aws_session_token=session_token or None,
@@ -502,7 +522,7 @@ def list_s3_files(prefix: Optional[str] = Query("")):
         if s3 is None:
             raise HTTPException(
                 status_code=400,
-                detail="S3 is not configured. Please configure S3 in Settings first."
+                detail="S3 is not configured. Please configure S3 in Settings first.",
             )
 
         files = s3.list_files_detailed(prefix=prefix or "")
@@ -512,7 +532,9 @@ def list_s3_files(prefix: Optional[str] = Query("")):
         raise
     except Exception as e:
         logger.error(f"Error listing S3 files: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to list S3 files: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to list S3 files: {str(e)}"
+        )
 
 
 class S3FileIngestRequest(BaseModel):
@@ -538,7 +560,7 @@ def ingest_s3_file(request: S3FileIngestRequest):
     if fmt is None:
         raise HTTPException(
             status_code=400,
-            detail=f"Unsupported file extension '{ext}'. Supported: {', '.join(EXTENSION_FORMATS.keys())}"
+            detail=f"Unsupported file extension '{ext}'. Supported: {', '.join(EXTENSION_FORMATS.keys())}",
         )
 
     try:
@@ -546,12 +568,14 @@ def ingest_s3_file(request: S3FileIngestRequest):
         if s3 is None:
             raise HTTPException(
                 status_code=400,
-                detail="S3 is not configured. Please configure S3 in Settings first."
+                detail="S3 is not configured. Please configure S3 in Settings first.",
             )
 
         content = s3.get_file(key)
         if content is None:
-            raise HTTPException(status_code=404, detail=f"Failed to download '{key}' from S3")
+            raise HTTPException(
+                status_code=404, detail=f"Failed to download '{key}' from S3"
+            )
 
         tmp_path = None
         try:
@@ -568,14 +592,14 @@ def ingest_s3_file(request: S3FileIngestRequest):
         success, message = summarize_stats(stats)
 
         return IngestionStats(
-            findings_total=stats.get('findings_total', 0),
-            findings_imported=stats.get('findings_imported', 0),
-            findings_skipped=stats.get('findings_skipped', 0),
-            findings_errors=stats.get('findings_errors', 0),
-            cases_total=stats.get('cases_total', 0),
-            cases_imported=stats.get('cases_imported', 0),
-            cases_skipped=stats.get('cases_skipped', 0),
-            cases_errors=stats.get('cases_errors', 0),
+            findings_total=stats.get("findings_total", 0),
+            findings_imported=stats.get("findings_imported", 0),
+            findings_skipped=stats.get("findings_skipped", 0),
+            findings_errors=stats.get("findings_errors", 0),
+            cases_total=stats.get("cases_total", 0),
+            cases_imported=stats.get("cases_imported", 0),
+            cases_skipped=stats.get("cases_skipped", 0),
+            cases_errors=stats.get("cases_errors", 0),
             success=success,
             message=message,
         )
@@ -584,42 +608,36 @@ def ingest_s3_file(request: S3FileIngestRequest):
         raise
     except Exception as e:
         logger.error(f"Error ingesting S3 file '{key}': {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"S3 file ingestion failed: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"S3 file ingestion failed: {str(e)}"
+        )
 
 
 @router.get("/s3-status")
 def get_s3_status():
     """
     Get S3 connection status.
-    
+
     Returns:
         S3 configuration and connection status
     """
     try:
         data_service = DatabaseDataService()
-        
+
         # Check if S3 is configured
         is_configured = data_service.is_s3_configured()
-        
+
         if is_configured:
             # Test connection
             success, message = data_service._s3_service.test_connection()
-            return {
-                "configured": True,
-                "connected": success,
-                "message": message
-            }
+            return {"configured": True, "connected": success, "message": message}
         else:
             return {
                 "configured": False,
                 "connected": False,
-                "message": "S3 is not configured. Configure in Settings to enable S3 sync."
+                "message": "S3 is not configured. Configure in Settings to enable S3 sync.",
             }
-        
+
     except Exception as e:
         logger.error(f"Error checking S3 status: {e}")
-        return {
-            "configured": False,
-            "connected": False,
-            "error": str(e)
-        }
+        return {"configured": False, "connected": False, "error": str(e)}

--- a/services/api/routers/integrations_compatibility.py
+++ b/services/api/routers/integrations_compatibility.py
@@ -9,18 +9,19 @@ All mutating endpoints require an authenticated admin
 (``integrations.write`` permission).
 """
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 import logging
 
-from services.api.middleware.auth import get_current_active_user
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
 from core.auth.auth_service import AuthService
-from core.storage.models import User
 from core.deps import provide_integration_compat
 from core.integrations.integration_compatibility_service import (
     IntegrationCompatibilityService,
 )
 from core.routing import Auth, RouterMeta
+from core.storage.models import User
+from services.api.middleware.auth import get_current_active_user
 
 router = APIRouter()
 

--- a/services/api/routers/jira_export.py
+++ b/services/api/routers/jira_export.py
@@ -6,15 +6,16 @@ Provides endpoints to export case reports and remediation steps to JIRA.
 
 import logging
 from typing import Annotated, Optional
-from fastapi import APIRouter, HTTPException, Depends, status
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
-from services.api.middleware.auth import get_current_user
 from core.auth.auth_service import AuthService
-from core.storage.models import User, Case, Finding
 from core.config import get_integration_config
-import httpx
 from core.routing import Auth, RouterMeta, UnitOfWorkSession
+from core.storage.models import Case, Finding, User
+from services.api.middleware.auth import get_current_user
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,7 @@ ROUTER_META = RouterMeta(
 # Request/Response Models
 class JiraExportRequest(BaseModel):
     """JIRA export request."""
+
     project_key: str
     include_findings: bool = True
     include_timeline: bool = True
@@ -41,12 +43,14 @@ class JiraExportRequest(BaseModel):
 
 class JiraRemediationExportRequest(BaseModel):
     """JIRA remediation export request."""
+
     parent_issue_key: str
     assign_to: Optional[str] = None
 
 
 class JiraExportResponse(BaseModel):
     """JIRA export response."""
+
     success: bool
     issue_key: Optional[str] = None
     subtasks_created: int = 0
@@ -63,13 +67,13 @@ def export_case_to_jira(
 ):
     """
     Export a case to JIRA as a ticket with findings as subtasks.
-    
+
     Args:
         case_id: Case ID to export
         request: Export configuration
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         Export result with JIRA issue key
     """
@@ -77,40 +81,42 @@ def export_case_to_jira(
     if not AuthService.check_permission(current_user.user_id, "cases.read"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied: cases.read required"
+            detail="Permission denied: cases.read required",
         )
-    
+
     # Get JIRA config
-    jira_config = get_integration_config('jira')
-    url = jira_config.get('url')
-    email = jira_config.get('email')
-    token = jira_config.get('api_token')
-    
+    jira_config = get_integration_config("jira")
+    url = jira_config.get("url")
+    email = jira_config.get("email")
+    token = jira_config.get("api_token")
+
     if not all([url, email, token]):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="JIRA not configured. Set JIRA_URL, JIRA_EMAIL, JIRA_API_TOKEN in environment."
+            detail="JIRA not configured. Set JIRA_URL, JIRA_EMAIL, JIRA_API_TOKEN in environment.",
         )
-    
+
     try:
         # Get case
         case = session.query(Case).filter(Case.case_id == case_id).first()
         if not case:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Case {case_id} not found"
+                detail=f"Case {case_id} not found",
             )
-        
+
         # Build description
         description = f"*Case Report: {case.title}*\n\n"
         description += f"*Priority:* {case.priority}\n"
         description += f"*Status:* {case.status}\n"
-        description += f"*Created:* {case.created_at.isoformat() if case.created_at else 'N/A'}\n"
+        description += (
+            f"*Created:* {case.created_at.isoformat() if case.created_at else 'N/A'}\n"
+        )
         description += f"*Assigned To:* {case.assignee or 'Unassigned'}\n\n"
-        
+
         if case.description:
             description += f"*Description:*\n{case.description}\n\n"
-        
+
         # Get findings
         findings = session.query(Finding).filter(Finding.case_id == case_id).all()
         if findings:
@@ -120,31 +126,33 @@ def export_case_to_jira(
             if len(findings) > 10:
                 description += f"- ... and {len(findings) - 10} more\n"
             description += "\n"
-        
+
         # Get resolution steps
-        if case.metadata and case.metadata.get('resolution_steps'):
+        if case.metadata and case.metadata.get("resolution_steps"):
             description += "*Resolution Steps:*\n"
-            for i, step in enumerate(case.metadata['resolution_steps'][:5], 1):
+            for i, step in enumerate(case.metadata["resolution_steps"][:5], 1):
                 description += f"{i}. {step.get('description', 'N/A')}\n"
             description += "\n"
-        
+
         # Add link
         description += f"*Full report available in AI SOC (Case ID: {case_id})*\n"
-        description += f"*Exported by: {current_user.full_name} ({current_user.email})*\n"
-        
+        description += (
+            f"*Exported by: {current_user.full_name} ({current_user.email})*\n"
+        )
+
         # Map priority
         priority_map = {
             "critical": "Highest",
             "high": "High",
             "medium": "Medium",
-            "low": "Low"
+            "low": "Low",
         }
         jira_priority = priority_map.get(case.priority.lower(), "Medium")
-        
+
         # Create main issue
         auth = (email, token)
         headers = {"Content-Type": "application/json"}
-        
+
         issue_data = {
             "fields": {
                 "project": {"key": request.project_key},
@@ -152,10 +160,10 @@ def export_case_to_jira(
                 "description": description,
                 "issuetype": {"name": "Task"},
                 "priority": {"name": jira_priority},
-                "labels": ["security", "ai-soc", f"case-{case_id}"]
+                "labels": ["security", "ai-soc", f"case-{case_id}"],
             }
         }
-        
+
         response = httpx.post(
             f"{url}/rest/api/2/issue",
             auth=auth,
@@ -167,7 +175,7 @@ def export_case_to_jira(
         response.raise_for_status()
         result_data = response.json()
         issue_key = result_data.get("key")
-        
+
         # Create subtasks for findings if requested
         subtasks_created = 0
         if request.include_findings and findings:
@@ -177,11 +185,15 @@ def export_case_to_jira(
                         "project": {"key": request.project_key},
                         "parent": {"key": issue_key},
                         "summary": f"[{(finding.severity or 'unknown').upper()}] {finding.title}",
-                        "description": finding.description[:500] if finding.description else "See parent issue",
-                        "issuetype": {"name": "Sub-task"}
+                        "description": (
+                            finding.description[:500]
+                            if finding.description
+                            else "See parent issue"
+                        ),
+                        "issuetype": {"name": "Sub-task"},
                     }
                 }
-                
+
                 try:
                     sub_response = httpx.post(
                         f"{url}/rest/api/2/issue",
@@ -194,32 +206,30 @@ def export_case_to_jira(
                     sub_response.raise_for_status()
                     subtasks_created += 1
                 except Exception as e:
-                    logger.warning(f"Failed to create subtask for finding {finding.finding_id}: {e}")
+                    logger.warning(
+                        f"Failed to create subtask for finding {finding.finding_id}: {e}"
+                    )
                     continue
-        
-        logger.info(f"Case {case_id} exported to JIRA: {issue_key} by {current_user.username}")
-        
+
+        logger.info(
+            f"Case {case_id} exported to JIRA: {issue_key} by {current_user.username}"
+        )
+
         return JiraExportResponse(
             success=True,
             issue_key=issue_key,
             subtasks_created=subtasks_created,
-            url=f"{url}/browse/{issue_key}"
+            url=f"{url}/browse/{issue_key}",
         )
-    
+
     except HTTPException:
         raise
     except (httpx.HTTPError, httpx.InvalidURL) as e:
         logger.error(f"JIRA API error: {e}")
-        return JiraExportResponse(
-            success=False,
-            error=f"JIRA API error: {str(e)}"
-        )
+        return JiraExportResponse(success=False, error=f"JIRA API error: {str(e)}")
     except Exception as e:
         logger.error(f"Export error: {e}")
-        return JiraExportResponse(
-            success=False,
-            error=str(e)
-        )
+        return JiraExportResponse(success=False, error=str(e))
 
 
 @router.post("/cases/{case_id}/remediation/jira", response_model=JiraExportResponse)
@@ -231,13 +241,13 @@ def export_remediation_to_jira(
 ):
     """
     Export remediation steps to JIRA as subtasks.
-    
+
     Args:
         case_id: Case ID
         request: Export configuration with parent issue key
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         Export result with created subtask keys
     """
@@ -245,42 +255,42 @@ def export_remediation_to_jira(
     if not AuthService.check_permission(current_user.user_id, "cases.read"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied: cases.read required"
+            detail="Permission denied: cases.read required",
         )
-    
+
     # Get JIRA config
-    jira_config = get_integration_config('jira')
-    url = jira_config.get('url')
-    email = jira_config.get('email')
-    token = jira_config.get('api_token')
-    
+    jira_config = get_integration_config("jira")
+    url = jira_config.get("url")
+    email = jira_config.get("email")
+    token = jira_config.get("api_token")
+
     if not all([url, email, token]):
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="JIRA not configured"
+            status_code=status.HTTP_400_BAD_REQUEST, detail="JIRA not configured"
         )
-    
+
     try:
         # Get case
         case = session.query(Case).filter(Case.case_id == case_id).first()
         if not case:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Case {case_id} not found"
+                detail=f"Case {case_id} not found",
             )
-        
+
         # Get resolution steps
-        resolution_steps = case.metadata.get('resolution_steps', []) if case.metadata else []
+        resolution_steps = (
+            case.metadata.get("resolution_steps", []) if case.metadata else []
+        )
         if not resolution_steps:
             return JiraExportResponse(
-                success=False,
-                error=f"No resolution steps found for case {case_id}"
+                success=False, error=f"No resolution steps found for case {case_id}"
             )
-        
+
         # Get parent issue to determine project
         auth = (email, token)
         headers = {"Content-Type": "application/json"}
-        
+
         parent_response = httpx.get(
             f"{url}/rest/api/2/issue/{request.parent_issue_key}",
             auth=auth,
@@ -291,7 +301,7 @@ def export_remediation_to_jira(
         parent_response.raise_for_status()
         parent_data = parent_response.json()
         project_key = parent_data["fields"]["project"]["key"]
-        
+
         # Create subtasks for each remediation step
         created_subtasks = 0
         for i, step in enumerate(resolution_steps, 1):
@@ -301,10 +311,10 @@ def export_remediation_to_jira(
                     "parent": {"key": request.parent_issue_key},
                     "summary": f"Remediation Step {i}: {step.get('description', 'N/A')[:80]}",
                     "description": f"*Action:* {step.get('action_taken', 'N/A')}\n\n*Result:* {step.get('result', 'N/A')}",
-                    "issuetype": {"name": "Sub-task"}
+                    "issuetype": {"name": "Sub-task"},
                 }
             }
-            
+
             if request.assign_to:
                 # Try to find user by email
                 user_response = httpx.get(
@@ -316,8 +326,10 @@ def export_remediation_to_jira(
                     follow_redirects=_FOLLOW_REDIRECTS,
                 )
                 if user_response.is_success and user_response.json():
-                    subtask_data["fields"]["assignee"] = {"name": user_response.json()[0]["name"]}
-            
+                    subtask_data["fields"]["assignee"] = {
+                        "name": user_response.json()[0]["name"]
+                    }
+
             try:
                 response = httpx.post(
                     f"{url}/rest/api/2/issue",
@@ -332,27 +344,22 @@ def export_remediation_to_jira(
             except Exception as e:
                 logger.warning(f"Failed to create remediation subtask {i}: {e}")
                 continue
-        
-        logger.info(f"Exported {created_subtasks} remediation steps for case {case_id} by {current_user.username}")
-        
+
+        logger.info(
+            f"Exported {created_subtasks} remediation steps for case {case_id} by {current_user.username}"
+        )
+
         return JiraExportResponse(
             success=True,
             subtasks_created=created_subtasks,
-            url=f"{url}/browse/{request.parent_issue_key}"
+            url=f"{url}/browse/{request.parent_issue_key}",
         )
-    
+
     except HTTPException:
         raise
     except (httpx.HTTPError, httpx.InvalidURL) as e:
         logger.error(f"JIRA API error: {e}")
-        return JiraExportResponse(
-            success=False,
-            error=f"JIRA API error: {str(e)}"
-        )
+        return JiraExportResponse(success=False, error=f"JIRA API error: {str(e)}")
     except Exception as e:
         logger.error(f"Export error: {e}")
-        return JiraExportResponse(
-            success=False,
-            error=str(e)
-        )
-
+        return JiraExportResponse(success=False, error=str(e))

--- a/services/api/routers/llm_providers.py
+++ b/services/api/routers/llm_providers.py
@@ -9,27 +9,26 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Dict, List, Optional
-import sys
-from pathlib import Path
 from typing import Annotated, Any, Dict, List, Optional
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy import delete as sa_delete, update
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import update
 from sqlalchemy.orm import Session
-from core.routing import Auth, RouterMeta, UnitOfWorkSession
-from core.secrets import delete_secret, get_secret, set_secret
-from services.api.middleware.auth import get_current_active_user
+
 from core.auth.auth_service import AuthService
-from core.storage.models import AIModelConfig, LLMProviderConfig, User
-from core.storage.schemas import LLMProviderConfigSchema
 from core.llm.bifrost.admin import push_provider_key
 from core.platform.url_safety import (
     UrlSafetyError,
     validate_provider_url,
 )
+from core.routing import Auth, RouterMeta, UnitOfWorkSession
+from core.secrets import delete_secret, get_secret, set_secret
+from core.storage.models import AIModelConfig, LLMProviderConfig, User
+from core.storage.schemas import LLMProviderConfigSchema
+from services.api.middleware.auth import get_current_active_user
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/services/api/routers/local_services.py
+++ b/services/api/routers/local_services.py
@@ -17,13 +17,16 @@ from typing import Callable, List
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
-from services.api.middleware.auth import get_current_active_user, require_settings_admin
-from core.storage.models import User
-from core.platform import service_manager
-from core.platform.autostart_config import get_autostart_services, set_autostart_services
 from core.llm.bifrost.admin import sync_after_ollama_start
+from core.platform import service_manager
+from core.platform.autostart_config import (
+    get_autostart_services,
+    set_autostart_services,
+)
 from core.platform.service_manager import SERVICES, ActionResult, ServiceStatus
 from core.routing import Auth, RouterMeta
+from core.storage.models import User
+from services.api.middleware.auth import get_current_active_user, require_settings_admin
 
 router = APIRouter()
 
@@ -208,9 +211,7 @@ def service_start(
     _resolve(name)
     # Composition root: the API may depend on both tiers, so it hands the LLM
     # catalog refresh to the platform supervisor, which must not import it.
-    r = service_manager.start(
-        name, wait=wait, post_start_sync=sync_after_ollama_start
-    )
+    r = service_manager.start(name, wait=wait, post_start_sync=sync_after_ollama_start)
     if not r.success:
         code = 409 if r.code in ("not_startable", "not_installed") else 500
         raise HTTPException(status_code=code, detail=r.message)

--- a/services/api/routers/mcp.py
+++ b/services/api/routers/mcp.py
@@ -8,15 +8,16 @@ an MCP server can spawn subprocesses and surface tools to agents.
 
 import logging
 from typing import Dict, List, Optional
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from services.api.middleware.auth import get_current_active_user
 from core.auth.auth_service import AuthService
 from core.deps import provide_mcp_client
-from core.storage.models import User
 from core.integrations.mcp.service import MCPService
 from core.routing import Auth, RouterMeta
+from core.storage.models import User
+from services.api.middleware.auth import get_current_active_user
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/services/api/routers/orchestrator.py
+++ b/services/api/routers/orchestrator.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+
 from core.routing import Auth, RouterMeta
 
 router = APIRouter()
@@ -34,8 +35,8 @@ def _get_orchestrator():
     if _cached_orchestrator is not None:
         return _cached_orchestrator
     try:
-        from services.daemon.orchestrator import Orchestrator
         from services.daemon.config import OrchestratorConfig
+        from services.daemon.orchestrator import Orchestrator
 
         config = OrchestratorConfig()
         orch = Orchestrator(config)
@@ -57,16 +58,17 @@ class InvestigationCreateRequest(BaseModel):
 
 # ---- Status & Control ----
 
+
 @router.get("/status")
 async def get_orchestrator_status():
     """Get orchestrator status: enabled state, active agents, stats, cost."""
     try:
         orch = _get_orchestrator()
-        
+
         investigations = []
         cost_summary = {}
         stats = {}
-        
+
         if orch:
             investigations = orch.get_all_investigations()
             cost_summary = orch.get_cost_summary()
@@ -77,24 +79,28 @@ async def get_orchestrator_status():
         enabled = False
         try:
             from core.storage.config_service import get_config_service
-            settings = get_config_service().get_system_config('orchestrator.settings')
+
+            settings = get_config_service().get_system_config("orchestrator.settings")
             if isinstance(settings, dict):
                 enabled = bool(settings.get("enabled", False))
         except Exception:
             enabled = orch.enabled if orch else False
-        
-        active = [i for i in investigations if i.get("status") in ("assigned", "executing")]
+
+        active = [
+            i for i in investigations if i.get("status") in ("assigned", "executing")
+        ]
         queued = [i for i in investigations if i.get("status") == "queued"]
         completed = [i for i in investigations if i.get("status") == "completed"]
         failed = [i for i in investigations if i.get("status") == "failed"]
         review = [i for i in investigations if i.get("status") == "review_submitted"]
-        
+
         max_agents = 3
         try:
             from core.storage.config_service import get_config_service
-            orch_cfg = get_config_service().get_system_config('orchestrator.settings')
+
+            orch_cfg = get_config_service().get_system_config("orchestrator.settings")
             if orch_cfg and isinstance(orch_cfg, dict):
-                max_agents = int(orch_cfg.get('max_concurrent_agents', 3))
+                max_agents = int(orch_cfg.get("max_concurrent_agents", 3))
         except Exception:
             if orch:
                 max_agents = orch.config.max_concurrent_agents
@@ -127,15 +133,17 @@ def _persist_orchestrator_enabled(enabled: bool) -> None:
         from core.storage.config_service import get_config_service
         from services.api.routers.config import ORCHESTRATOR_DEFAULTS
 
-        svc = get_config_service(user_id='web_ui')
-        current = svc.get_system_config('orchestrator.settings')
-        base = dict(current) if isinstance(current, dict) else dict(ORCHESTRATOR_DEFAULTS)
+        svc = get_config_service(user_id="web_ui")
+        current = svc.get_system_config("orchestrator.settings")
+        base = (
+            dict(current) if isinstance(current, dict) else dict(ORCHESTRATOR_DEFAULTS)
+        )
         base["enabled"] = bool(enabled)
         svc.set_system_config(
-            key='orchestrator.settings',
+            key="orchestrator.settings",
             value=base,
-            description='Autonomous orchestrator settings',
-            config_type='orchestrator',
+            description="Autonomous orchestrator settings",
+            config_type="orchestrator",
             change_reason=f'Orchestrator {"enabled" if enabled else "disabled"} via API',
         )
     except Exception as e:
@@ -163,7 +171,11 @@ async def disable_orchestrator():
         if orch:
             orch.disable()
         _persist_orchestrator_enabled(False)
-        return {"success": True, "enabled": False, "message": "Orchestrator disabled (graceful)"}
+        return {
+            "success": True,
+            "enabled": False,
+            "message": "Orchestrator disabled (graceful)",
+        }
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -191,9 +203,7 @@ async def purge_investigations():
     try:
         orch = _get_orchestrator()
         if not orch:
-            raise HTTPException(
-                status_code=503, detail="Orchestrator not available"
-            )
+            raise HTTPException(status_code=503, detail="Orchestrator not available")
         result = await orch.purge_all_investigations()
         return {
             "success": True,
@@ -209,6 +219,7 @@ async def purge_investigations():
 
 # ---- Investigations ----
 
+
 @router.get("/investigations")
 async def list_investigations(status: Optional[str] = Query(None)):
     """List all investigations with optional status filter."""
@@ -216,7 +227,7 @@ async def list_investigations(status: Optional[str] = Query(None)):
         orch = _get_orchestrator()
         if not orch:
             return {"investigations": [], "count": 0}
-        
+
         investigations = orch.get_all_investigations(status=status)
         return {
             "investigations": investigations,
@@ -233,16 +244,18 @@ async def get_investigation(investigation_id: str):
         orch = _get_orchestrator()
         if not orch:
             raise HTTPException(status_code=404, detail="Orchestrator not available")
-        
+
         inv = orch.get_investigation(investigation_id)
         if not inv:
-            raise HTTPException(status_code=404, detail=f"Investigation not found: {investigation_id}")
-        
+            raise HTTPException(
+                status_code=404, detail=f"Investigation not found: {investigation_id}"
+            )
+
         files = orch.workdir.list_files(investigation_id)
         log = orch.workdir.get_log(investigation_id, tail=20)
         state = orch.workdir.read_state(investigation_id)
         disk_usage = orch.workdir.get_disk_usage(investigation_id)
-        
+
         return {
             **inv,
             "files": files,
@@ -263,13 +276,15 @@ async def get_investigation_file(investigation_id: str, filename: str):
         orch = _get_orchestrator()
         if not orch:
             raise HTTPException(status_code=404, detail="Orchestrator not available")
-        
+
         content = orch.workdir.read_file(investigation_id, filename)
         if not content and not orch.workdir.exists(investigation_id):
-            raise HTTPException(status_code=404, detail=f"Investigation not found: {investigation_id}")
-        
+            raise HTTPException(
+                status_code=404, detail=f"Investigation not found: {investigation_id}"
+            )
+
         is_json = filename.endswith(".json") or filename.endswith(".jsonl")
-        
+
         return {
             "filename": filename,
             "investigation_id": investigation_id,
@@ -289,25 +304,30 @@ async def wake_investigation(investigation_id: str):
         orch = _get_orchestrator()
         if not orch:
             raise HTTPException(status_code=404, detail="Orchestrator not available")
-        
+
         inv = orch.get_investigation(investigation_id)
         if not inv:
-            raise HTTPException(status_code=404, detail=f"Investigation not found: {investigation_id}")
-        
+            raise HTTPException(
+                status_code=404, detail=f"Investigation not found: {investigation_id}"
+            )
+
         if inv.get("status") not in ("sleeping", "needs_rework", "completed", "failed"):
             raise HTTPException(
                 status_code=400,
-                detail=f"Cannot wake investigation in status '{inv.get('status')}'"
+                detail=f"Cannot wake investigation in status '{inv.get('status')}'",
             )
-        
+
         state = orch.workdir.read_state(investigation_id)
         state["status"] = "executing"
         state.pop("failure_reason", None)
         state["error_count"] = 0
         orch.workdir.write_state(investigation_id, state)
         orch._update_investigation_status(investigation_id, "assigned")
-        
-        return {"success": True, "message": f"Investigation {investigation_id} woken up"}
+
+        return {
+            "success": True,
+            "message": f"Investigation {investigation_id} woken up",
+        }
     except HTTPException:
         raise
     except Exception as e:
@@ -321,15 +341,17 @@ async def kill_investigation(investigation_id: str):
         orch = _get_orchestrator()
         if not orch:
             raise HTTPException(status_code=404, detail="Orchestrator not available")
-        
+
         await orch.agent_runner.stop_agent(investigation_id)
-        orch._update_investigation_status(investigation_id, "failed", "Manually killed by user")
-        
+        orch._update_investigation_status(
+            investigation_id, "failed", "Manually killed by user"
+        )
+
         state = orch.workdir.read_state(investigation_id)
         state["status"] = "failed"
         state["failure_reason"] = "Manually killed by user"
         orch.workdir.write_state(investigation_id, state)
-        
+
         return {"success": True, "message": f"Investigation {investigation_id} killed"}
     except HTTPException:
         raise
@@ -346,7 +368,9 @@ class ReviewRequest(BaseModel):
 async def review_investigation(investigation_id: str, request: ReviewRequest):
     """Human review of an investigation: approve or request rework."""
     if request.action not in ("approve", "rework"):
-        raise HTTPException(status_code=400, detail="action must be 'approve' or 'rework'")
+        raise HTTPException(
+            status_code=400, detail="action must be 'approve' or 'rework'"
+        )
 
     try:
         orch = _get_orchestrator()
@@ -355,7 +379,9 @@ async def review_investigation(investigation_id: str, request: ReviewRequest):
 
         inv = orch.get_investigation(investigation_id)
         if not inv:
-            raise HTTPException(status_code=404, detail=f"Investigation not found: {investigation_id}")
+            raise HTTPException(
+                status_code=404, detail=f"Investigation not found: {investigation_id}"
+            )
 
         if inv.get("status") != "review_submitted":
             raise HTTPException(
@@ -370,10 +396,16 @@ async def review_investigation(investigation_id: str, request: ReviewRequest):
         from core.storage.models import Investigation as InvestigationModel
 
         with get_db_manager().session_scope() as session:
-            db_inv = session.query(InvestigationModel).filter_by(investigation_id=investigation_id).first()
+            db_inv = (
+                session.query(InvestigationModel)
+                .filter_by(investigation_id=investigation_id)
+                .first()
+            )
             if db_inv:
                 db_inv.master_review_notes = request.notes or (
-                    "Approved by human reviewer" if request.action == "approve" else "Rework requested by human reviewer"
+                    "Approved by human reviewer"
+                    if request.action == "approve"
+                    else "Rework requested by human reviewer"
                 )
 
         if request.action == "rework":
@@ -403,16 +435,18 @@ async def create_investigation(request: InvestigationCreateRequest):
         orch = _get_orchestrator()
         if not orch:
             raise HTTPException(status_code=503, detail="Orchestrator not available")
-        
-        orch.investigation_queue.put_nowait({
-            "type": "manual",
-            "workflow_id": request.workflow_id,
-            "finding_ids": request.finding_ids,
-            "case_id": request.case_id,
-            "hypothesis": request.hypothesis,
-            "priority": request.priority,
-        })
-        
+
+        orch.investigation_queue.put_nowait(
+            {
+                "type": "manual",
+                "workflow_id": request.workflow_id,
+                "finding_ids": request.finding_ids,
+                "case_id": request.case_id,
+                "hypothesis": request.hypothesis,
+                "priority": request.priority,
+            }
+        )
+
         return {
             "success": True,
             "message": "Investigation queued for creation",
@@ -423,6 +457,7 @@ async def create_investigation(request: InvestigationCreateRequest):
 
 
 # ---- Scan Existing Findings ----
+
 
 class ScanFindingsRequest(BaseModel):
     severities: list = ["critical", "high"]
@@ -445,7 +480,7 @@ async def scan_existing_findings(request: ScanFindingsRequest):
         with get_db_manager().session_scope() as session:
             already_investigated = set()
             for inv in session.query(Investigation).all():
-                for tid in (inv.trigger_ids or []):
+                for tid in inv.trigger_ids or []:
                     already_investigated.add(tid)
 
             findings = (
@@ -461,12 +496,14 @@ async def scan_existing_findings(request: ScanFindingsRequest):
                 if fid in already_investigated:
                     skipped_existing += 1
                     continue
-                to_investigate.append({
-                    "finding_id": fid,
-                    "severity": f.severity,
-                    "title": f.description[:200] if f.description else "",
-                    "data_source": f.data_source,
-                })
+                to_investigate.append(
+                    {
+                        "finding_id": fid,
+                        "severity": f.severity,
+                        "title": f.description[:200] if f.description else "",
+                        "data_source": f.data_source,
+                    }
+                )
 
         orch = _get_orchestrator()
         created = 0
@@ -482,7 +519,9 @@ async def scan_existing_findings(request: ScanFindingsRequest):
                     )
                     created += 1
                 except Exception as e:
-                    logger.warning(f"Failed to create investigation for {finding_data.get('finding_id')}: {e}")
+                    logger.warning(
+                        f"Failed to create investigation for {finding_data.get('finding_id')}: {e}"
+                    )
 
         return {
             "success": True,
@@ -490,7 +529,9 @@ async def scan_existing_findings(request: ScanFindingsRequest):
             "skipped_already_investigated": skipped_existing,
             "total_matching": created + skipped_existing,
             "message": f"Queued {created} investigations (will run up to max_concurrent_agents at a time)"
-                       + (f", {skipped_existing} already investigated" if skipped_existing else ""),
+            + (
+                f", {skipped_existing} already investigated" if skipped_existing else ""
+            ),
         }
     except Exception as e:
         logger.error(f"Error scanning findings: {e}")
@@ -498,6 +539,7 @@ async def scan_existing_findings(request: ScanFindingsRequest):
 
 
 # ---- Cost ----
+
 
 @router.get("/cost")
 async def get_cost_summary():

--- a/services/api/routers/reasoning.py
+++ b/services/api/routers/reasoning.py
@@ -3,12 +3,12 @@
 import logging
 
 from fastapi import APIRouter, HTTPException, Query
-from sqlalchemy import select, func
+from sqlalchemy import func, select
 
+from core.routing import Auth, RouterMeta
 from core.storage.connection import get_db_manager
 from core.storage.models import LLMInteractionLog
 from core.storage.schemas import LLMInteractionLogSchema
-from core.routing import Auth, RouterMeta
 
 logger = logging.getLogger(__name__)
 

--- a/services/api/routers/skills.py
+++ b/services/api/routers/skills.py
@@ -8,6 +8,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
+
 from core.routing import Auth, RouterMeta
 from core.skills.schemas import (
     SkillCreate,

--- a/services/api/routers/storage_status.py
+++ b/services/api/routers/storage_status.py
@@ -9,9 +9,9 @@ import threading
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from services.api.middleware.auth import get_current_active_user, require_settings_admin
-from core.storage.models import User
 from core.routing import Auth, RouterMeta
+from core.storage.models import User
+from services.api.middleware.auth import get_current_active_user, require_settings_admin
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +36,8 @@ async def get_storage_status():
         Dictionary with storage backend information
     """
     try:
-        from core.storage.database_data_service import DatabaseDataService
         from core.config import is_demo_mode
+        from core.storage.database_data_service import DatabaseDataService
 
         test_service = DatabaseDataService()
         backend_info = test_service.get_backend_info()
@@ -114,8 +114,8 @@ async def check_storage_health():
         Health status of the storage backend
     """
     try:
-        from core.storage.database_data_service import DatabaseDataService
         from core.config import is_demo_mode
+        from core.storage.database_data_service import DatabaseDataService
 
         service = DatabaseDataService()
         is_healthy = True
@@ -139,9 +139,11 @@ async def check_storage_health():
                 "demo_mode": demo_mode,
                 "findings_count": len(findings),
                 "cases_count": len(cases),
-                "message": "Demo mode active with sample data"
-                if demo_mode
-                else "Storage backend is functioning normally",
+                "message": (
+                    "Demo mode active with sample data"
+                    if demo_mode
+                    else "Storage backend is functioning normally"
+                ),
             }
 
         except Exception as e:
@@ -259,7 +261,9 @@ def _audit_retarget(previous, current, user: User) -> None:
         from core.storage.config_service import get_config_service
 
         def _target(t):
-            return {"host": t.host, "port": t.port, "database": t.database} if t else None
+            return (
+                {"host": t.host, "port": t.port, "database": t.database} if t else None
+            )
 
         # config_type is NOT NULL and old_value/new_value are JSONB, so they
         # take dicts, not text; the service commits via its session_scope.

--- a/services/api/routers/timeline.py
+++ b/services/api/routers/timeline.py
@@ -1,13 +1,14 @@
 """Timeline API endpoints for visualizing temporal security events."""
 
-from typing import List, Optional, Dict, Any
+import logging
 from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
-import logging
 
-from core.storage.database_data_service import DatabaseDataService
 from core.routing import Auth, RouterMeta
+from core.storage.database_data_service import DatabaseDataService
 
 router = APIRouter()
 
@@ -22,28 +23,29 @@ logger = logging.getLogger(__name__)
 def normalize_timestamp(timestamp_str: str) -> datetime:
     """
     Normalize a timestamp string to a timezone-aware datetime object.
-    
+
     Args:
         timestamp_str: ISO format timestamp string
-        
+
     Returns:
         Timezone-aware datetime object
     """
     # Remove 'Z' and replace with '+00:00' for proper ISO parsing
-    timestamp_str = timestamp_str.replace('Z', '+00:00')
-    
+    timestamp_str = timestamp_str.replace("Z", "+00:00")
+
     # Parse the timestamp
     dt = datetime.fromisoformat(timestamp_str)
-    
+
     # If timezone-naive, assume UTC
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    
+
     return dt
 
 
 class TimelineEvent(BaseModel):
     """Timeline event model."""
+
     id: str
     content: str
     start: datetime
@@ -55,6 +57,7 @@ class TimelineEvent(BaseModel):
 
 class TimelineResponse(BaseModel):
     """Timeline response model."""
+
     events: List[TimelineEvent]
     total: int
     start_time: Optional[datetime] = None
@@ -65,100 +68,115 @@ class TimelineResponse(BaseModel):
 async def get_case_timeline(case_id: str):
     """
     Get timeline events for a specific case.
-    
+
     Includes:
     - Case timeline events
     - Associated findings
     - Activities
     - Status changes
     - Notes
-    
+
     Args:
         case_id: Case identifier
-        
+
     Returns:
         Timeline events for the case
     """
     try:
         data_service = DatabaseDataService()
         case = data_service.get_case(case_id)
-        
+
         if not case:
             raise HTTPException(status_code=404, detail="Case not found")
-        
+
         events: List[TimelineEvent] = []
-        
+
         # Add case creation event
-        events.append(TimelineEvent(
-            id=f"case-created-{case_id}",
-            content=f"Case created: {case.get('title', 'Untitled')}",
-            start=normalize_timestamp(case['created_at']),
-            type="status",
-            severity=case.get('priority'),
-            metadata={"case_id": case_id, "action": "created"}
-        ))
-        
+        events.append(
+            TimelineEvent(
+                id=f"case-created-{case_id}",
+                content=f"Case created: {case.get('title', 'Untitled')}",
+                start=normalize_timestamp(case["created_at"]),
+                type="status",
+                severity=case.get("priority"),
+                metadata={"case_id": case_id, "action": "created"},
+            )
+        )
+
         # Add timeline events from case
-        for idx, timeline_event in enumerate(case.get('timeline', [])):
-            events.append(TimelineEvent(
-                id=f"timeline-{case_id}-{idx}",
-                content=timeline_event.get('event', 'Event'),
-                start=normalize_timestamp(timeline_event['timestamp']),
-                type="activity",
-                metadata={"case_id": case_id, **timeline_event}
-            ))
-        
+        for idx, timeline_event in enumerate(case.get("timeline", [])):
+            events.append(
+                TimelineEvent(
+                    id=f"timeline-{case_id}-{idx}",
+                    content=timeline_event.get("event", "Event"),
+                    start=normalize_timestamp(timeline_event["timestamp"]),
+                    type="activity",
+                    metadata={"case_id": case_id, **timeline_event},
+                )
+            )
+
         # Add activities
-        for idx, activity in enumerate(case.get('activities', [])):
-            events.append(TimelineEvent(
-                id=f"activity-{case_id}-{idx}",
-                content=activity.get('description', 'Activity'),
-                start=normalize_timestamp(activity.get('timestamp', case['created_at'])),
-                type="activity",
-                metadata={"case_id": case_id, **activity}
-            ))
-        
+        for idx, activity in enumerate(case.get("activities", [])):
+            events.append(
+                TimelineEvent(
+                    id=f"activity-{case_id}-{idx}",
+                    content=activity.get("description", "Activity"),
+                    start=normalize_timestamp(
+                        activity.get("timestamp", case["created_at"])
+                    ),
+                    type="activity",
+                    metadata={"case_id": case_id, **activity},
+                )
+            )
+
         # Add notes as events
-        for idx, note in enumerate(case.get('notes', [])):
-            events.append(TimelineEvent(
-                id=f"note-{case_id}-{idx}",
-                content=f"Note: {note.get('content', '')[:100]}",
-                start=normalize_timestamp(note.get('timestamp', case['created_at'])),
-                type="note",
-                metadata={"case_id": case_id, "author": note.get('author'), "full_content": note.get('content')}
-            ))
-        
+        for idx, note in enumerate(case.get("notes", [])):
+            events.append(
+                TimelineEvent(
+                    id=f"note-{case_id}-{idx}",
+                    content=f"Note: {note.get('content', '')[:100]}",
+                    start=normalize_timestamp(
+                        note.get("timestamp", case["created_at"])
+                    ),
+                    type="note",
+                    metadata={
+                        "case_id": case_id,
+                        "author": note.get("author"),
+                        "full_content": note.get("content"),
+                    },
+                )
+            )
+
         # Add findings as events
         findings = data_service.get_findings_by_case(case_id)
         for finding in findings:
-            events.append(TimelineEvent(
-                id=f"finding-{finding['finding_id']}",
-                content=f"Finding: {finding['finding_id']} - {finding.get('severity', 'unknown')}",
-                start=normalize_timestamp(finding['timestamp']),
-                type="finding",
-                severity=finding.get('severity'),
-                metadata={
-                    "finding_id": finding['finding_id'],
-                    "data_source": finding.get('data_source'),
-                    "anomaly_score": finding.get('anomaly_score'),
-                    "entity_context": finding.get('entity_context')
-                }
-            ))
-        
+            events.append(
+                TimelineEvent(
+                    id=f"finding-{finding['finding_id']}",
+                    content=f"Finding: {finding['finding_id']} - {finding.get('severity', 'unknown')}",
+                    start=normalize_timestamp(finding["timestamp"]),
+                    type="finding",
+                    severity=finding.get("severity"),
+                    metadata={
+                        "finding_id": finding["finding_id"],
+                        "data_source": finding.get("data_source"),
+                        "anomaly_score": finding.get("anomaly_score"),
+                        "entity_context": finding.get("entity_context"),
+                    },
+                )
+            )
+
         # Sort events by timestamp
         events.sort(key=lambda e: e.start)
-        
+
         # Calculate time range
         start_time = min(e.start for e in events) if events else None
         end_time = max(e.start for e in events) if events else None
-        
+
         return TimelineResponse(
-            events=events,
-            total=len(events),
-            start_time=start_time,
-            end_time=end_time
+            events=events, total=len(events), start_time=start_time, end_time=end_time
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -168,66 +186,64 @@ async def get_case_timeline(case_id: str):
 
 @router.get("/finding/{finding_id}/context", response_model=TimelineResponse)
 async def get_finding_context_timeline(
-    finding_id: str,
-    time_window_minutes: int = Query(default=60, ge=1, le=1440)
+    finding_id: str, time_window_minutes: int = Query(default=60, ge=1, le=1440)
 ):
     """
     Get timeline context around a specific finding.
-    
+
     Shows related findings within a time window before and after the finding.
-    
+
     Args:
         finding_id: Finding identifier
         time_window_minutes: Minutes before/after to include (default 60)
-        
+
     Returns:
         Timeline events around the finding
     """
     try:
         data_service = DatabaseDataService()
         finding = data_service.get_finding(finding_id)
-        
+
         if not finding:
             raise HTTPException(status_code=404, detail="Finding not found")
-        
-        finding_time = normalize_timestamp(finding['timestamp'])
+
+        finding_time = normalize_timestamp(finding["timestamp"])
         start_time = finding_time - timedelta(minutes=time_window_minutes)
         end_time = finding_time + timedelta(minutes=time_window_minutes)
-        
+
         # Get findings in time window
         all_findings = data_service.get_findings(limit=1000)
-        
+
         events: List[TimelineEvent] = []
-        
+
         for f in all_findings:
-            f_time = normalize_timestamp(f['timestamp'])
+            f_time = normalize_timestamp(f["timestamp"])
             if start_time <= f_time <= end_time:
-                is_target = f['finding_id'] == finding_id
-                events.append(TimelineEvent(
-                    id=f"finding-{f['finding_id']}",
-                    content=f"{'🎯 ' if is_target else ''}Finding: {f['finding_id']} - {f.get('severity', 'unknown')}",
-                    start=f_time,
-                    type="finding",
-                    severity=f.get('severity'),
-                    metadata={
-                        "finding_id": f['finding_id'],
-                        "data_source": f.get('data_source'),
-                        "anomaly_score": f.get('anomaly_score'),
-                        "entity_context": f.get('entity_context'),
-                        "is_target": is_target
-                    }
-                ))
-        
+                is_target = f["finding_id"] == finding_id
+                events.append(
+                    TimelineEvent(
+                        id=f"finding-{f['finding_id']}",
+                        content=f"{'🎯 ' if is_target else ''}Finding: {f['finding_id']} - {f.get('severity', 'unknown')}",
+                        start=f_time,
+                        type="finding",
+                        severity=f.get("severity"),
+                        metadata={
+                            "finding_id": f["finding_id"],
+                            "data_source": f.get("data_source"),
+                            "anomaly_score": f.get("anomaly_score"),
+                            "entity_context": f.get("entity_context"),
+                            "is_target": is_target,
+                        },
+                    )
+                )
+
         # Sort events by timestamp
         events.sort(key=lambda e: e.start)
-        
+
         return TimelineResponse(
-            events=events,
-            total=len(events),
-            start_time=start_time,
-            end_time=end_time
+            events=events, total=len(events), start_time=start_time, end_time=end_time
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -241,78 +257,80 @@ async def get_timeline_range(
     end: Optional[str] = Query(None, description="End time (ISO format)"),
     severity: Optional[str] = Query(None, description="Filter by severity"),
     data_source: Optional[str] = Query(None, description="Filter by data source"),
-    limit: int = Query(default=500, ge=1, le=5000)
+    limit: int = Query(default=500, ge=1, le=5000),
 ):
     """
     Get timeline events for a specific time range.
-    
+
     Args:
         start: Start time (ISO format)
         end: End time (ISO format)
         severity: Filter by severity
         data_source: Filter by data source
         limit: Maximum number of events
-        
+
     Returns:
         Timeline events in the specified range
     """
     try:
         data_service = DatabaseDataService()
-        
+
         # Parse time range
         start_time = normalize_timestamp(start) if start else None
         end_time = normalize_timestamp(end) if end else None
-        
+
         # Get findings
         all_findings = data_service.get_findings(limit=limit)
-        
+
         events: List[TimelineEvent] = []
-        
+
         for finding in all_findings:
-            f_time = normalize_timestamp(finding['timestamp'])
-            
+            f_time = normalize_timestamp(finding["timestamp"])
+
             # Filter by time range if specified
             if start_time and f_time < start_time:
                 continue
             if end_time and f_time > end_time:
                 continue
-            
+
             # Filter by severity if specified
-            if severity and finding.get('severity') != severity:
+            if severity and finding.get("severity") != severity:
                 continue
-            
+
             # Filter by data source if specified
-            if data_source and finding.get('data_source') != data_source:
+            if data_source and finding.get("data_source") != data_source:
                 continue
-            
-            events.append(TimelineEvent(
-                id=f"finding-{finding['finding_id']}",
-                content=f"Finding: {finding['finding_id']} - {finding.get('severity', 'unknown')}",
-                start=f_time,
-                type="finding",
-                severity=finding.get('severity'),
-                metadata={
-                    "finding_id": finding['finding_id'],
-                    "data_source": finding.get('data_source'),
-                    "anomaly_score": finding.get('anomaly_score'),
-                    "entity_context": finding.get('entity_context')
-                }
-            ))
-        
+
+            events.append(
+                TimelineEvent(
+                    id=f"finding-{finding['finding_id']}",
+                    content=f"Finding: {finding['finding_id']} - {finding.get('severity', 'unknown')}",
+                    start=f_time,
+                    type="finding",
+                    severity=finding.get("severity"),
+                    metadata={
+                        "finding_id": finding["finding_id"],
+                        "data_source": finding.get("data_source"),
+                        "anomaly_score": finding.get("anomaly_score"),
+                        "entity_context": finding.get("entity_context"),
+                    },
+                )
+            )
+
         # Sort events by timestamp
         events.sort(key=lambda e: e.start)
-        
+
         # Calculate actual time range from events
         actual_start = min(e.start for e in events) if events else start_time
         actual_end = max(e.start for e in events) if events else end_time
-        
+
         return TimelineResponse(
             events=events,
             total=len(events),
             start_time=actual_start,
-            end_time=actual_end
+            end_time=actual_end,
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -324,57 +342,58 @@ async def get_timeline_range(
 async def get_cluster_timeline(cluster_id: str):
     """
     Get timeline events for findings in a specific cluster.
-    
+
     Args:
         cluster_id: Cluster identifier
-        
+
     Returns:
         Timeline events for the cluster
     """
     try:
         data_service = DatabaseDataService()
-        
+
         # Get findings in cluster
         all_findings = data_service.get_findings(limit=1000)
-        
+
         # Filter by cluster_id
-        findings = [f for f in all_findings if f.get('cluster_id') == cluster_id]
-        
+        findings = [f for f in all_findings if f.get("cluster_id") == cluster_id]
+
         if not findings:
-            raise HTTPException(status_code=404, detail="Cluster not found or has no findings")
-        
+            raise HTTPException(
+                status_code=404, detail="Cluster not found or has no findings"
+            )
+
         events: List[TimelineEvent] = []
-        
+
         for finding in findings:
-            events.append(TimelineEvent(
-                id=f"finding-{finding['finding_id']}",
-                content=f"Finding: {finding['finding_id']} - {finding.get('severity', 'unknown')}",
-                start=normalize_timestamp(finding['timestamp']),
-                type="finding",
-                severity=finding.get('severity'),
-                metadata={
-                    "finding_id": finding['finding_id'],
-                    "data_source": finding.get('data_source'),
-                    "anomaly_score": finding.get('anomaly_score'),
-                    "entity_context": finding.get('entity_context'),
-                    "cluster_id": cluster_id
-                }
-            ))
-        
+            events.append(
+                TimelineEvent(
+                    id=f"finding-{finding['finding_id']}",
+                    content=f"Finding: {finding['finding_id']} - {finding.get('severity', 'unknown')}",
+                    start=normalize_timestamp(finding["timestamp"]),
+                    type="finding",
+                    severity=finding.get("severity"),
+                    metadata={
+                        "finding_id": finding["finding_id"],
+                        "data_source": finding.get("data_source"),
+                        "anomaly_score": finding.get("anomaly_score"),
+                        "entity_context": finding.get("entity_context"),
+                        "cluster_id": cluster_id,
+                    },
+                )
+            )
+
         # Sort events by timestamp
         events.sort(key=lambda e: e.start)
-        
+
         # Calculate time range
         start_time = min(e.start for e in events) if events else None
         end_time = max(e.start for e in events) if events else None
-        
+
         return TimelineResponse(
-            events=events,
-            total=len(events),
-            start_time=start_time,
-            end_time=end_time
+            events=events, total=len(events), start_time=start_time, end_time=end_time
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -384,6 +403,7 @@ async def get_cluster_timeline(cluster_id: str):
 
 class EventVisualizationResponse(BaseModel):
     """Event visualization data model."""
+
     event: TimelineEvent
     finding: Optional[Dict[str, Any]] = None
     related_events: List[TimelineEvent] = []
@@ -397,11 +417,11 @@ class EventVisualizationResponse(BaseModel):
 async def get_event_visualization(
     event_id: str,
     time_window_minutes: int = Query(default=30, ge=5, le=240),
-    include_ai_analysis: bool = Query(default=True)
+    include_ai_analysis: bool = Query(default=True),
 ):
     """
     Get comprehensive visualization data for a timeline event.
-    
+
     This endpoint provides all data needed for incident visualization:
     - Event details and metadata
     - Associated finding (if applicable)
@@ -409,160 +429,173 @@ async def get_event_visualization(
     - Entity relationship graph
     - MITRE ATT&CK techniques
     - AI-generated incident analysis
-    
+
     Args:
         event_id: Event identifier (format: {type}-{id})
         time_window_minutes: Minutes before/after to include related events
         include_ai_analysis: Whether to generate AI analysis (requires Claude API)
-        
+
     Returns:
         Comprehensive event visualization data
     """
     try:
         data_service = DatabaseDataService()
-        
+
         # Parse event ID to determine type and actual ID
         # Format: finding-{finding_id}, activity-{case_id}-{idx}, note-{case_id}-{idx}
-        event_parts = event_id.split('-', 1)
+        event_parts = event_id.split("-", 1)
         if len(event_parts) < 2:
             raise HTTPException(status_code=400, detail="Invalid event ID format")
-        
+
         event_type = event_parts[0]
         actual_id = event_parts[1]
-        
+
         # Get the main event data
         event_data = None
         finding_data = None
         case_data = None
-        
+
         if event_type == "finding":
             # This is a finding event
             finding_data = data_service.get_finding(actual_id)
             if not finding_data:
                 raise HTTPException(status_code=404, detail="Finding not found")
-            
+
             event_data = TimelineEvent(
                 id=event_id,
                 content=f"Finding: {finding_data['finding_id']} - {finding_data.get('severity', 'unknown')}",
-                start=normalize_timestamp(finding_data['timestamp']),
+                start=normalize_timestamp(finding_data["timestamp"]),
                 type="finding",
-                severity=finding_data.get('severity'),
+                severity=finding_data.get("severity"),
                 metadata={
-                    "finding_id": finding_data['finding_id'],
-                    "data_source": finding_data.get('data_source'),
-                    "anomaly_score": finding_data.get('anomaly_score'),
-                    "entity_context": finding_data.get('entity_context'),
-                    "description": finding_data.get('description')
-                }
+                    "finding_id": finding_data["finding_id"],
+                    "data_source": finding_data.get("data_source"),
+                    "anomaly_score": finding_data.get("anomaly_score"),
+                    "entity_context": finding_data.get("entity_context"),
+                    "description": finding_data.get("description"),
+                },
             )
         elif event_type in ["activity", "note", "timeline"]:
             # This is a case-related event
-            case_id_parts = actual_id.split('-')
+            case_id_parts = actual_id.split("-")
             if len(case_id_parts) >= 2:
                 case_id = f"{case_id_parts[0]}-{case_id_parts[1]}"
                 case_data = data_service.get_case(case_id)
                 if not case_data:
                     raise HTTPException(status_code=404, detail="Case not found")
-                
+
                 # Try to find the specific event in the case data
                 # This is a simplified version - in production you'd want to store events with IDs
                 event_data = TimelineEvent(
                     id=event_id,
                     content=f"{event_type.capitalize()} event",
-                    start=normalize_timestamp(case_data['created_at']),
+                    start=normalize_timestamp(case_data["created_at"]),
                     type=event_type,
-                    metadata={"case_id": case_id}
+                    metadata={"case_id": case_id},
                 )
         else:
             raise HTTPException(status_code=400, detail="Unknown event type")
-        
+
         if not event_data:
             raise HTTPException(status_code=404, detail="Event not found")
-        
+
         # Get related events in time window
         event_time = event_data.start
         start_time = event_time - timedelta(minutes=time_window_minutes)
         end_time = event_time + timedelta(minutes=time_window_minutes)
-        
+
         related_events: List[TimelineEvent] = []
         all_findings = data_service.get_findings(limit=1000)
-        
+
         for f in all_findings:
-            f_time = normalize_timestamp(f['timestamp'])
-            if start_time <= f_time <= end_time and f['finding_id'] != finding_data.get('finding_id') if finding_data else True:
-                related_events.append(TimelineEvent(
-                    id=f"finding-{f['finding_id']}",
-                    content=f"Finding: {f['finding_id']} - {f.get('severity', 'unknown')}",
-                    start=f_time,
-                    type="finding",
-                    severity=f.get('severity'),
-                    metadata={
-                        "finding_id": f['finding_id'],
-                        "data_source": f.get('data_source'),
-                        "anomaly_score": f.get('anomaly_score'),
-                        "entity_context": f.get('entity_context')
-                    }
-                ))
-        
+            f_time = normalize_timestamp(f["timestamp"])
+            if (
+                start_time <= f_time <= end_time
+                and f["finding_id"] != finding_data.get("finding_id")
+                if finding_data
+                else True
+            ):
+                related_events.append(
+                    TimelineEvent(
+                        id=f"finding-{f['finding_id']}",
+                        content=f"Finding: {f['finding_id']} - {f.get('severity', 'unknown')}",
+                        start=f_time,
+                        type="finding",
+                        severity=f.get("severity"),
+                        metadata={
+                            "finding_id": f["finding_id"],
+                            "data_source": f.get("data_source"),
+                            "anomaly_score": f.get("anomaly_score"),
+                            "entity_context": f.get("entity_context"),
+                        },
+                    )
+                )
+
         # Sort related events by time
         related_events.sort(key=lambda e: e.start)
-        
+
         # Build entity graph for this event and related events
         from core.findings.graph_builder_service import GraphBuilderService
+
         graph_builder = GraphBuilderService()
-        
+
         findings_for_graph = []
         if finding_data:
             findings_for_graph.append(finding_data)
         # Add related findings
         for re in related_events[:10]:  # Limit to 10 related events for graph
-            if re.metadata and re.metadata.get('finding_id'):
-                rf = data_service.get_finding(re.metadata['finding_id'])
+            if re.metadata and re.metadata.get("finding_id"):
+                rf = data_service.get_finding(re.metadata["finding_id"])
                 if rf:
                     findings_for_graph.append(rf)
-        
+
         entity_graph = {}
         if findings_for_graph:
             entity_graph = graph_builder.build_entity_graph(findings_for_graph)
-        
+
         # Extract MITRE ATT&CK techniques
         mitre_techniques = []
         if finding_data:
-            mitre_preds = finding_data.get('mitre_predictions', {})
-            predicted_techniques = finding_data.get('predicted_techniques', [])
-            
+            mitre_preds = finding_data.get("mitre_predictions", {})
+            predicted_techniques = finding_data.get("predicted_techniques", [])
+
             if mitre_preds:
-                for technique_id, confidence in sorted(mitre_preds.items(), key=lambda x: x[1], reverse=True)[:5]:
-                    mitre_techniques.append({
-                        "technique_id": technique_id,
-                        "confidence": confidence,
-                        "name": technique_id  # In production, look up technique name
-                    })
+                for technique_id, confidence in sorted(
+                    mitre_preds.items(), key=lambda x: x[1], reverse=True
+                )[:5]:
+                    mitre_techniques.append(
+                        {
+                            "technique_id": technique_id,
+                            "confidence": confidence,
+                            "name": technique_id,  # In production, look up technique name
+                        }
+                    )
             elif predicted_techniques:
                 for tech in predicted_techniques[:5]:
-                    mitre_techniques.append({
-                        "technique_id": tech,
-                        "confidence": 0.0,
-                        "name": tech
-                    })
-        
+                    mitre_techniques.append(
+                        {"technique_id": tech, "confidence": 0.0, "name": tech}
+                    )
+
         # Generate AI analysis if requested
         ai_analysis = None
         if include_ai_analysis and finding_data:
             try:
                 from core.llm.harness.claude import ClaudeService
-                claude_service = ClaudeService(use_backend_tools=True, use_mcp_tools=False)
-                
+
+                claude_service = ClaudeService(
+                    use_backend_tools=True, use_mcp_tools=False
+                )
+
                 if claude_service.has_api_key():
                     ai_analysis = await claude_service.generate_event_analysis(
                         event_data.model_dump(),
                         [e.model_dump() for e in related_events],
-                        finding_data
+                        finding_data,
                     )
             except Exception as e:
                 logger.warning(f"Failed to generate AI analysis: {e}")
                 ai_analysis = {"error": "AI analysis unavailable"}
-        
+
         # Build response
         return EventVisualizationResponse(
             event=event_data,
@@ -574,14 +607,13 @@ async def get_event_visualization(
             metadata={
                 "time_window_minutes": time_window_minutes,
                 "related_events_count": len(related_events),
-                "entities_count": len(entity_graph.get('nodes', [])),
-                "mitre_techniques_count": len(mitre_techniques)
-            }
+                "entities_count": len(entity_graph.get("nodes", [])),
+                "mitre_techniques_count": len(mitre_techniques),
+            },
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error getting event visualization: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
-

--- a/services/api/routers/users.py
+++ b/services/api/routers/users.py
@@ -5,18 +5,19 @@ Handles user CRUD operations, role assignment, and user administration.
 """
 
 import logging
-from typing import Annotated, List, Optional
-from fastapi import APIRouter, HTTPException, Depends, status, Query
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 from core.auth.auth_service import AuthService
-from services.api.middleware.auth import get_current_user
 from core.auth.password_validator import PasswordPolicyError, validate_password_strength
 from core.auth.token_blacklist import revoke_all_for_user
-from core.storage.models import User, Role
-from core.storage.schemas import RoleSchema, UserSchema
 from core.routing import Auth, RouterMeta, UnitOfWorkSession
+from core.storage.models import Role, User
+from core.storage.schemas import RoleSchema, UserSchema
+from services.api.middleware.auth import get_current_user
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ ROUTER_META = RouterMeta(
 # Request/Response Models
 class CreateUserRequest(BaseModel):
     """Create user request."""
+
     username: str
     email: EmailStr
     password: str
@@ -41,6 +43,7 @@ class CreateUserRequest(BaseModel):
 
 class UpdateUserRequest(BaseModel):
     """Update user request."""
+
     full_name: Optional[str] = None
     email: Optional[EmailStr] = None
     role_id: Optional[str] = None
@@ -49,6 +52,7 @@ class UpdateUserRequest(BaseModel):
 
 class ChangeUserRoleRequest(BaseModel):
     """Change user role request."""
+
     role_id: str
 
 
@@ -78,7 +82,7 @@ async def list_users(
 ):
     """
     List all users (requires users.read permission).
-    
+
     Args:
         skip: Number of users to skip
         limit: Maximum number of users to return
@@ -87,7 +91,7 @@ async def list_users(
         search: Search in username, email, or full name
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         List of users
     """
@@ -95,45 +99,45 @@ async def list_users(
     if not AuthService.check_permission(current_user.user_id, "users.read"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied: users.read required"
+            detail="Permission denied: users.read required",
         )
-    
+
     try:
         query = session.query(User)
-        
+
         # Apply filters
         if role_id:
             query = query.filter(User.role_id == role_id)
-        
+
         if is_active is not None:
             query = query.filter(User.is_active == is_active)
-        
+
         if search:
             search_pattern = f"%{search}%"
             query = query.filter(
-                (User.username.ilike(search_pattern)) |
-                (User.email.ilike(search_pattern)) |
-                (User.full_name.ilike(search_pattern))
+                (User.username.ilike(search_pattern))
+                | (User.email.ilike(search_pattern))
+                | (User.full_name.ilike(search_pattern))
             )
-        
+
         # Get total count
         total = query.count()
-        
+
         # Apply pagination
         users = query.offset(skip).limit(limit).all()
-        
+
         return {
             "total": total,
             "skip": skip,
             "limit": limit,
-            "users": UserSchema.dump_many(users)
+            "users": UserSchema.dump_many(users),
         }
-    
+
     except Exception as e:
         logger.error(f"List users error: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list users"
+            detail="Failed to list users",
         )
 
 
@@ -145,12 +149,12 @@ async def get_user(
 ):
     """
     Get user by ID (requires users.read permission).
-    
+
     Args:
         user_id: User ID
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         User information
     """
@@ -159,26 +163,25 @@ async def get_user(
         if not AuthService.check_permission(current_user.user_id, "users.read"):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail="Permission denied: users.read required"
+                detail="Permission denied: users.read required",
             )
-    
+
     user = session.query(User).filter(User.user_id == user_id).first()
     if not user:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found"
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
-    
+
     user_dict = UserSchema.dump(user)
-    
+
     # Add role information
     role = session.query(Role).filter(Role.role_id == user.role_id).first()
     if role:
         user_dict["role"] = RoleSchema.dump(role)
-    
+
     # Add permissions
     user_dict["permissions"] = AuthService.get_user_permissions(user_id)
-    
+
     return user_dict
 
 
@@ -190,12 +193,12 @@ async def create_user(
 ):
     """
     Create a new user (requires users.write permission).
-    
+
     Args:
         request: User creation details
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         Created user information
     """
@@ -203,9 +206,9 @@ async def create_user(
     if not AuthService.check_permission(current_user.user_id, "users.write"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied: users.write required"
+            detail="Permission denied: users.write required",
         )
-    
+
     # Validate password against the full strength policy. Penalize passwords
     # built from the new account's own identifiers.
     try:
@@ -223,8 +226,7 @@ async def create_user(
     role = session.query(Role).filter(Role.role_id == request.role_id).first()
     if not role:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid role ID"
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid role ID"
         )
 
     if not _can_assign_role(current_user, role, session):
@@ -232,7 +234,7 @@ async def create_user(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot assign a role with more privileges than your own",
         )
-    
+
     # Create user
     user = AuthService.create_user(
         username=request.username,
@@ -240,15 +242,15 @@ async def create_user(
         password=request.password,
         full_name=request.full_name,
         role_id=request.role_id,
-        session=session
+        session=session,
     )
-    
+
     if not user:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Username or email already exists"
+            detail="Username or email already exists",
         )
-    
+
     logger.info(f"User created by {current_user.username}: {user.username}")
     return UserSchema.dump(user)
 
@@ -262,13 +264,13 @@ async def update_user(
 ):
     """
     Update user information (requires users.write permission).
-    
+
     Args:
         user_id: User ID to update
         request: Update details
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         Updated user information
     """
@@ -276,17 +278,16 @@ async def update_user(
     if not AuthService.check_permission(current_user.user_id, "users.write"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied: users.write required"
+            detail="Permission denied: users.write required",
         )
-    
+
     # Get user
     user = session.query(User).filter(User.user_id == user_id).first()
     if not user:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found"
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
-    
+
     try:
         # Update fields
         email_changed = False
@@ -295,15 +296,16 @@ async def update_user(
 
         if request.email is not None:
             # Check if email is already taken
-            existing = session.query(User).filter(
-                User.email == request.email,
-                User.user_id != user_id
-            ).first()
+            existing = (
+                session.query(User)
+                .filter(User.email == request.email, User.user_id != user_id)
+                .first()
+            )
 
             if existing:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Email already in use"
+                    detail="Email already in use",
                 )
 
             user.email = request.email
@@ -315,8 +317,7 @@ async def update_user(
             role = session.query(Role).filter(Role.role_id == request.role_id).first()
             if not role:
                 raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Invalid role ID"
+                    status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid role ID"
                 )
             if not _can_assign_role(current_user, role, session):
                 raise HTTPException(
@@ -352,7 +353,7 @@ async def update_user(
         logger.error(f"Update user error: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to update user"
+            detail="Failed to update user",
         )
 
 
@@ -364,12 +365,12 @@ async def delete_user(
 ):
     """
     Delete a user (requires users.delete permission).
-    
+
     Args:
         user_id: User ID to delete
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         Success message
     """
@@ -377,36 +378,35 @@ async def delete_user(
     if not AuthService.check_permission(current_user.user_id, "users.delete"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied: users.delete required"
+            detail="Permission denied: users.delete required",
         )
-    
+
     # Prevent self-deletion
     if user_id == current_user.user_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cannot delete your own account"
+            detail="Cannot delete your own account",
         )
-    
+
     # Get user
     user = session.query(User).filter(User.user_id == user_id).first()
     if not user:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found"
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
-    
+
     try:
         username = user.username
         session.delete(user)
 
         logger.info(f"User deleted by {current_user.username}: {username}")
         return {"message": "User deleted successfully"}
-    
+
     except Exception as e:
         logger.error(f"Delete user error: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to delete user"
+            detail="Failed to delete user",
         )
 
 
@@ -419,13 +419,13 @@ async def change_user_role(
 ):
     """
     Change user role (requires users.write permission).
-    
+
     Args:
         user_id: User ID
         request: New role ID
         current_user: Current authenticated user
         session: Database session
-    
+
     Returns:
         Updated user information
     """
@@ -433,23 +433,21 @@ async def change_user_role(
     if not AuthService.check_permission(current_user.user_id, "users.write"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied: users.write required"
+            detail="Permission denied: users.write required",
         )
-    
+
     # Get user
     user = session.query(User).filter(User.user_id == user_id).first()
     if not user:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found"
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
-    
+
     # Verify role exists
     role = session.query(Role).filter(Role.role_id == request.role_id).first()
     if not role:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid role ID"
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid role ID"
         )
 
     if not _can_assign_role(current_user, role, session):
@@ -471,6 +469,7 @@ async def change_user_role(
         # cached token happens to expire.
         try:
             from core.auth.token_blacklist import revoke_all_for_user
+
             await revoke_all_for_user(user.user_id)
         except Exception as exc:
             logger.error(
@@ -480,14 +479,16 @@ async def change_user_role(
                 exc,
             )
 
-        logger.info(f"User role changed by {current_user.username}: {user.username} from {old_role_id} to {request.role_id}")
+        logger.info(
+            f"User role changed by {current_user.username}: {user.username} from {old_role_id} to {request.role_id}"
+        )
         return UserSchema.dump(user)
-    
+
     except Exception as e:
         logger.error(f"Change role error: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to change user role"
+            detail="Failed to change user role",
         )
 
 
@@ -513,14 +514,11 @@ async def list_roles(
         )
     try:
         roles = session.query(Role).all()
-        return {
-            "roles": RoleSchema.dump_many(roles)
-        }
-    
+        return {"roles": RoleSchema.dump_many(roles)}
+
     except Exception as e:
         logger.error(f"List roles error: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list roles"
+            detail="Failed to list roles",
         )
-

--- a/services/api/routers/vstrike.py
+++ b/services/api/routers/vstrike.py
@@ -19,18 +19,21 @@ from typing import Optional
 from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
 
+from core.config import get_settings
+from core.integrations.vstrike.client import (
+    VStrikeToolNotImplemented,
+    get_vstrike_service,
+)
 from core.integrations.vstrike.schemas import (
     VStrikeFindingResult,
     VStrikeHealthResponse,
     VStrikePushRequest,
     VStrikePushResponse,
 )
-from services.api.middleware.auth import get_current_active_user
-from core.storage.database_data_service import DatabaseDataService
-from core.integrations.vstrike.client import VStrikeToolNotImplemented, get_vstrike_service
 from core.routing import Auth, RouterMeta
-from core.config import get_settings
 from core.secrets import get_secret
+from core.storage.database_data_service import DatabaseDataService
+from services.api.middleware.auth import get_current_active_user
 
 
 class VStrikeLoadNetworkRequest(BaseModel):

--- a/services/daemon/agent_runner.py
+++ b/services/daemon/agent_runner.py
@@ -64,7 +64,6 @@ except Exception:
 
 from core.llm.cost.calls import compute_call_cost
 
-
 WORKDIR_TOOLS = [
     {
         "name": "read_investigation_file",

--- a/services/daemon/config.py
+++ b/services/daemon/config.py
@@ -1,12 +1,11 @@
 import logging
 from dataclasses import dataclass, field
-
-from core.ingestion.kafka_config import KafkaConfig  # re-exported for DaemonConfig
 from typing import List, Optional
 
 from core.config import DEFAULT_REDIS_URL, get_settings
-from core.secrets import get_secret
+from core.ingestion.kafka_config import KafkaConfig  # re-exported for DaemonConfig
 from core.llm.defaults import DEFAULT_MODEL
+from core.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +27,15 @@ class ProcessingConfig:
     batch_size: int = 10
     max_concurrent_tasks: int = 5
     triage_timeout: int = 60  # seconds
-    enrich_max_inflight: int = 50          # cap on pending background enrich tasks (backpressure)
-    enrich_backfill_enabled: bool = True   # sweep for stored-but-never-enriched findings
-    enrich_backfill_interval: int = 300    # seconds between sweeps
-    enrich_backfill_batch: int = 50        # findings re-queued per sweep
-    enrich_backfill_max_age_hours: int = 168  # only backfill findings newer than this (7d)
+    enrich_max_inflight: int = (
+        50  # cap on pending background enrich tasks (backpressure)
+    )
+    enrich_backfill_enabled: bool = True  # sweep for stored-but-never-enriched findings
+    enrich_backfill_interval: int = 300  # seconds between sweeps
+    enrich_backfill_batch: int = 50  # findings re-queued per sweep
+    enrich_backfill_max_age_hours: int = (
+        168  # only backfill findings newer than this (7d)
+    )
 
 
 @dataclass
@@ -50,12 +53,14 @@ class EscalationConfig:
     slack_enabled: bool = True
     slack_channel: str = "#soc-alerts"
     pagerduty_enabled: bool = False
-    pagerduty_severity_map: dict = field(default_factory=lambda: {
-        "critical": "critical",
-        "high": "error",
-        "medium": "warning",
-        "low": "info"
-    })
+    pagerduty_severity_map: dict = field(
+        default_factory=lambda: {
+            "critical": "critical",
+            "high": "error",
+            "medium": "warning",
+            "low": "info",
+        }
+    )
 
 
 @dataclass
@@ -89,7 +94,9 @@ class OrchestratorConfig:
     stale_threshold: int = 300
     workdir_base: str = "data/investigations"
     auto_assign_findings: bool = True
-    auto_assign_severities: List[str] = field(default_factory=lambda: ["critical", "high"])
+    auto_assign_severities: List[str] = field(
+        default_factory=lambda: ["critical", "high"]
+    )
     dry_run: bool = False
     dedup_window_minutes: int = 30
     agent_loop_delay: int = 2
@@ -152,9 +159,13 @@ class DaemonConfig:
         config.processing.batch_size = settings.daemon_batch_size
         config.processing.enrich_max_inflight = settings.daemon_enrich_max_inflight
         config.processing.enrich_backfill_enabled = settings.daemon_enrich_backfill
-        config.processing.enrich_backfill_interval = settings.daemon_enrich_backfill_interval
+        config.processing.enrich_backfill_interval = (
+            settings.daemon_enrich_backfill_interval
+        )
         config.processing.enrich_backfill_batch = settings.daemon_enrich_backfill_batch
-        config.processing.enrich_backfill_max_age_hours = settings.daemon_enrich_backfill_max_age_hours
+        config.processing.enrich_backfill_max_age_hours = (
+            settings.daemon_enrich_backfill_max_age_hours
+        )
 
         config.response.auto_response_enabled = settings.daemon_auto_response
         config.response.confidence_threshold = settings.daemon_confidence_threshold
@@ -163,11 +174,15 @@ class DaemonConfig:
 
         config.escalation.enabled = settings.daemon_escalation_enabled
         config.escalation.slack_enabled = (
-            True if settings.daemon_slack_enabled is None else settings.daemon_slack_enabled
+            True
+            if settings.daemon_slack_enabled is None
+            else settings.daemon_slack_enabled
         )
         config.escalation.slack_channel = settings.daemon_slack_channel
         config.escalation.pagerduty_enabled = settings.daemon_pagerduty_enabled
-        config.escalation.escalate_severities = list(settings.daemon_escalate_severities)
+        config.escalation.escalate_severities = list(
+            settings.daemon_escalate_severities
+        )
 
         config.scheduler.threat_hunt_enabled = settings.daemon_threat_hunt_enabled
         config.scheduler.threat_hunt_interval = settings.daemon_threat_hunt_interval
@@ -179,11 +194,17 @@ class DaemonConfig:
         config.orchestrator.enabled = settings.orchestrator_enabled
         config.orchestrator.loop_interval = settings.orchestrator_loop_interval
         config.orchestrator.max_concurrent_agents = settings.orchestrator_max_agents
-        config.orchestrator.max_iterations_per_agent = settings.orchestrator_max_iterations
+        config.orchestrator.max_iterations_per_agent = (
+            settings.orchestrator_max_iterations
+        )
         config.orchestrator.max_cost_per_investigation = settings.orchestrator_max_cost
-        config.orchestrator.max_total_hourly_cost = settings.orchestrator_max_hourly_cost
+        config.orchestrator.max_total_hourly_cost = (
+            settings.orchestrator_max_hourly_cost
+        )
         config.orchestrator.max_total_daily_cost = settings.orchestrator_max_daily_cost
-        config.orchestrator.max_runtime_per_investigation = settings.orchestrator_max_runtime
+        config.orchestrator.max_runtime_per_investigation = (
+            settings.orchestrator_max_runtime
+        )
         config.orchestrator.stale_threshold = settings.orchestrator_stale_threshold
         config.orchestrator.workdir_base = settings.orchestrator_workdir
         config.orchestrator.auto_assign_findings = settings.orchestrator_auto_assign
@@ -191,7 +212,9 @@ class DaemonConfig:
         config.orchestrator.dedup_window_minutes = settings.orchestrator_dedup_window
         config.orchestrator.agent_loop_delay = settings.orchestrator_agent_loop_delay
         config.orchestrator.context_max_chars = settings.orchestrator_context_max_chars
-        config.orchestrator.auto_assign_severities = list(settings.orchestrator_auto_severities)
+        config.orchestrator.auto_assign_severities = list(
+            settings.orchestrator_auto_severities
+        )
 
         config.llm_queue.redis_url = settings.redis_url or DEFAULT_REDIS_URL
         config.llm_queue.max_concurrent_llm_calls = settings.llm_max_concurrent
@@ -212,47 +235,51 @@ class DaemonConfig:
         # Override with DB-persisted settings (set via Settings UI)
         try:
             from core.storage.config_service import get_config_service
+
             config_service = get_config_service()
-            db_config = config_service.get_system_config('orchestrator.settings')
+            db_config = config_service.get_system_config("orchestrator.settings")
             if db_config and isinstance(db_config, dict):
                 field_map = {
-                    'enabled': bool,
-                    'loop_interval': int,
-                    'max_concurrent_agents': int,
-                    'max_iterations_per_agent': int,
-                    'max_cost_per_investigation': float,
-                    'max_total_hourly_cost': float,
-                    'max_total_daily_cost': float,
-                    'max_runtime_per_investigation': int,
-                    'stale_threshold': int,
-                    'workdir_base': str,
-                    'auto_assign_findings': bool,
-                    'dry_run': bool,
-                    'dedup_window_minutes': int,
-                    'agent_loop_delay': int,
-                    'context_max_chars': int,
-                    'plan_model': str,
-                    'review_model': str,
+                    "enabled": bool,
+                    "loop_interval": int,
+                    "max_concurrent_agents": int,
+                    "max_iterations_per_agent": int,
+                    "max_cost_per_investigation": float,
+                    "max_total_hourly_cost": float,
+                    "max_total_daily_cost": float,
+                    "max_runtime_per_investigation": int,
+                    "stale_threshold": int,
+                    "workdir_base": str,
+                    "auto_assign_findings": bool,
+                    "dry_run": bool,
+                    "dedup_window_minutes": int,
+                    "agent_loop_delay": int,
+                    "context_max_chars": int,
+                    "plan_model": str,
+                    "review_model": str,
                 }
                 for key, cast in field_map.items():
                     if key in db_config:
                         setattr(config.orchestrator, key, cast(db_config[key]))
-                if 'auto_assign_severities' in db_config:
-                    val = db_config['auto_assign_severities']
+                if "auto_assign_severities" in db_config:
+                    val = db_config["auto_assign_severities"]
                     if isinstance(val, list):
                         config.orchestrator.auto_assign_severities = val
                 logger.info("Orchestrator config overridden from database settings")
         except Exception as e:
-            logger.debug(f"Could not load orchestrator config from DB (using env/defaults): {e}")
+            logger.debug(
+                f"Could not load orchestrator config from DB (using env/defaults): {e}"
+            )
 
         # GH #89 — ai_model_configs takes precedence over orchestrator.settings
         # for plan_model/review_model. This is the same override layer that
         # powers the "Model Assignment" section of the AI Config tab.
         try:
             from core.llm.providers.registry import get_registry
+
             registry = get_registry()
-            plan_pick = registry.resolve_model_for_component('orchestrator_plan')
-            review_pick = registry.resolve_model_for_component('orchestrator_review')
+            plan_pick = registry.resolve_model_for_component("orchestrator_plan")
+            review_pick = registry.resolve_model_for_component("orchestrator_review")
             # resolve_model_for_component returns (provider_id, model_id). Keep
             # BOTH: the provider_id is what lets the daemon route a non-Anthropic
             # model through Bifrost instead of silently assuming Anthropic.
@@ -275,38 +302,42 @@ class DaemonConfig:
         # Kafka: merge non-secret DB settings on top of env defaults
         try:
             from core.storage.config_service import get_config_service
+
             config_service = get_config_service()
-            kafka_db = config_service.get_system_config('kafka.settings')
+            kafka_db = config_service.get_system_config("kafka.settings")
             if kafka_db and isinstance(kafka_db, dict):
-                if 'enabled' in kafka_db:
-                    config.kafka.enabled = bool(kafka_db['enabled'])
-                if 'bootstrap_servers' in kafka_db:
-                    config.kafka.bootstrap_servers = str(kafka_db['bootstrap_servers'])
-                if 'consumer_group' in kafka_db:
-                    config.kafka.consumer_group = str(kafka_db['consumer_group'])
-                if 'topics' in kafka_db and isinstance(kafka_db['topics'], list):
-                    config.kafka.topics = [str(t) for t in kafka_db['topics']]
-                if 'auto_offset_reset' in kafka_db:
-                    config.kafka.auto_offset_reset = str(kafka_db['auto_offset_reset'])
-                if 'security_protocol' in kafka_db:
-                    config.kafka.security_protocol = str(kafka_db['security_protocol'])
-                if 'sasl_mechanism' in kafka_db:
-                    config.kafka.sasl_mechanism = kafka_db['sasl_mechanism'] or None
-                if 'sasl_username' in kafka_db:
-                    config.kafka.sasl_username = kafka_db['sasl_username'] or None
-                if 'max_poll_records' in kafka_db:
-                    config.kafka.max_poll_records = int(kafka_db['max_poll_records'])
-                if 'session_timeout_ms' in kafka_db:
-                    config.kafka.session_timeout_ms = int(kafka_db['session_timeout_ms'])
+                if "enabled" in kafka_db:
+                    config.kafka.enabled = bool(kafka_db["enabled"])
+                if "bootstrap_servers" in kafka_db:
+                    config.kafka.bootstrap_servers = str(kafka_db["bootstrap_servers"])
+                if "consumer_group" in kafka_db:
+                    config.kafka.consumer_group = str(kafka_db["consumer_group"])
+                if "topics" in kafka_db and isinstance(kafka_db["topics"], list):
+                    config.kafka.topics = [str(t) for t in kafka_db["topics"]]
+                if "auto_offset_reset" in kafka_db:
+                    config.kafka.auto_offset_reset = str(kafka_db["auto_offset_reset"])
+                if "security_protocol" in kafka_db:
+                    config.kafka.security_protocol = str(kafka_db["security_protocol"])
+                if "sasl_mechanism" in kafka_db:
+                    config.kafka.sasl_mechanism = kafka_db["sasl_mechanism"] or None
+                if "sasl_username" in kafka_db:
+                    config.kafka.sasl_username = kafka_db["sasl_username"] or None
+                if "max_poll_records" in kafka_db:
+                    config.kafka.max_poll_records = int(kafka_db["max_poll_records"])
+                if "session_timeout_ms" in kafka_db:
+                    config.kafka.session_timeout_ms = int(
+                        kafka_db["session_timeout_ms"]
+                    )
                 logger.info("Kafka config overridden from database settings")
         except Exception as e:
-            logger.debug(f"Could not load Kafka config from DB (using env/defaults): {e}")
+            logger.debug(
+                f"Could not load Kafka config from DB (using env/defaults): {e}"
+            )
 
         return config
 
     def setup_logging(self):
         logging.basicConfig(
-            level=getattr(logging, self.log_level.upper()),
-            format=self.log_format
+            level=getattr(logging, self.log_level.upper()), format=self.log_format
         )
         logger.info(f"Logging configured at {self.log_level} level")

--- a/services/daemon/kafka_ingestor.py
+++ b/services/daemon/kafka_ingestor.py
@@ -15,8 +15,8 @@ import asyncio
 import logging
 from typing import Any, Dict, Optional
 
-from core.ingestion.kafka_config import KafkaConfig
 from core.ingestion.dedup import RedisDedupSet
+from core.ingestion.kafka_config import KafkaConfig
 from core.ingestion.kafka_consumer_service import KafkaConsumerService
 
 logger = logging.getLogger(__name__)

--- a/services/daemon/main.py
+++ b/services/daemon/main.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class SOCDaemon:
     """Main daemon orchestrator for autonomous SOC operations."""
-    
+
     def __init__(self, config: Optional[DaemonConfig] = None):
         self.config = config or DaemonConfig.from_env()
         self.config.setup_logging()
@@ -25,13 +25,14 @@ class SOCDaemon:
         # Initialize OTEL telemetry after logging is set up
         try:
             from core.telemetry import init_telemetry
+
             init_telemetry("vigil-daemon")
         except Exception as _tel_err:
             logger.warning("Telemetry init failed (non-fatal): %s", _tel_err)
 
         self._running = False
         self._shutdown_event = asyncio.Event()
-        
+
         # Components (lazy loaded)
         self._poller = None
         self._kafka_ingestor = None
@@ -42,39 +43,40 @@ class SOCDaemon:
         self._llm_worker_manager = None
         self._metrics_server = None
         self._mcp_client = None
-        
+
         logger.info("SOC Daemon initialized")
-    
+
     def _setup_signal_handlers(self):
         """Setup graceful shutdown handlers."""
         loop = asyncio.get_event_loop()
-        
+
         for sig in (signal.SIGTERM, signal.SIGINT):
             loop.add_signal_handler(sig, self._handle_shutdown)
-    
+
     def _handle_shutdown(self):
         """Handle shutdown signal."""
         logger.info("Shutdown signal received")
         self._shutdown_event.set()
-    
+
     async def _init_components(self):
         """Initialize all daemon components."""
         logger.info("Initializing daemon components...")
-        
+
         # Import here to avoid circular imports
-        from core.integrations.mcp.client import (build_mcp_client,
-                                                  set_process_mcp_client)
+        from core.integrations.mcp.client import (
+            build_mcp_client,
+            set_process_mcp_client,
+        )
         from core.response.approval_service import ApprovalService
-        from core.response.autonomous_response_service import \
-            AutonomousResponseService
+        from core.response.autonomous_response_service import AutonomousResponseService
+        from services.daemon.kafka_ingestor import KafkaIngestor
+        from services.daemon.llm_worker_manager import LLMWorkerManager
+        from services.daemon.metrics import MetricsServer
+        from services.daemon.orchestrator import Orchestrator
         from services.daemon.poller import DataPoller
         from services.daemon.processor import FindingProcessor
         from services.daemon.responder import AutonomousResponder
         from services.daemon.scheduler import TaskScheduler
-        from services.daemon.metrics import MetricsServer
-        from services.daemon.orchestrator import Orchestrator
-        from services.daemon.llm_worker_manager import LLMWorkerManager
-        from services.daemon.kafka_ingestor import KafkaIngestor
 
         self._poller = DataPoller(self.config.polling)
         self._kafka_ingestor = KafkaIngestor(self.config.kafka)
@@ -116,85 +118,98 @@ class SOCDaemon:
             self._metrics_server.responder = self._responder
             self._metrics_server.scheduler = self._scheduler
             self._metrics_server.orchestrator = self._orchestrator
-        
+
         logger.info("All components initialized")
-    
+
     async def run(self):
         """Run the daemon."""
         logger.info("Starting SOC Daemon...")
         self._running = True
-        
+
         try:
             self._setup_signal_handlers()
         except NotImplementedError:
             # Windows doesn't support add_signal_handler
             logger.warning("Signal handlers not supported on this platform")
-        
+
         await self._init_components()
-        
+
         # Start all component tasks
         tasks = []
-        
+
         if self._poller:
             tasks.append(asyncio.create_task(self._poller.run(self._shutdown_event)))
             logger.info("Data poller started")
 
         if self._kafka_ingestor:
-            tasks.append(asyncio.create_task(self._kafka_ingestor.run(self._shutdown_event)))
-            logger.info("Kafka ingestor started (controlled by kafka.settings enabled flag)")
+            tasks.append(
+                asyncio.create_task(self._kafka_ingestor.run(self._shutdown_event))
+            )
+            logger.info(
+                "Kafka ingestor started (controlled by kafka.settings enabled flag)"
+            )
 
         if self._processor:
             tasks.append(asyncio.create_task(self._processor.run(self._shutdown_event)))
             logger.info("Finding processor started")
-        
+
         if self._responder:
             tasks.append(asyncio.create_task(self._responder.run(self._shutdown_event)))
             logger.info("Autonomous responder started")
-        
+
         if self._scheduler:
             tasks.append(asyncio.create_task(self._scheduler.run(self._shutdown_event)))
             logger.info("Task scheduler started")
-        
+
         if self._orchestrator:
-            tasks.append(asyncio.create_task(self._orchestrator.run(self._shutdown_event)))
+            tasks.append(
+                asyncio.create_task(self._orchestrator.run(self._shutdown_event))
+            )
             if self.config.orchestrator.enabled:
                 logger.info("Autonomous orchestrator started")
             else:
                 logger.info("Autonomous orchestrator loaded (disabled)")
 
         if self._llm_worker_manager:
-            tasks.append(asyncio.create_task(self._llm_worker_manager.run(self._shutdown_event)))
-            logger.info("LLM Worker Manager started (controls worker subprocess via DB toggle)")
+            tasks.append(
+                asyncio.create_task(self._llm_worker_manager.run(self._shutdown_event))
+            )
+            logger.info(
+                "LLM Worker Manager started (controls worker subprocess via DB toggle)"
+            )
 
         if self._metrics_server:
-            tasks.append(asyncio.create_task(self._metrics_server.run(self._shutdown_event)))
+            tasks.append(
+                asyncio.create_task(self._metrics_server.run(self._shutdown_event))
+            )
             logger.info(f"Metrics server started on port {self.config.metrics.port}")
-        
+
         logger.info("SOC Daemon fully operational")
-        
+
         # Wait for shutdown signal
         await self._shutdown_event.wait()
-        
+
         logger.info("Shutting down daemon components...")
-        
+
         # Cancel all tasks
         for task in tasks:
             task.cancel()
-        
+
         # Wait for tasks to complete
         await asyncio.gather(*tasks, return_exceptions=True)
-        
+
         self._running = False
 
         # Flush and shut down OTEL providers
         try:
             from core.telemetry import shutdown_telemetry
+
             shutdown_telemetry()
         except Exception as e:
             logger.warning("Telemetry shutdown error (non-fatal): %s", e)
 
         logger.info("SOC Daemon shutdown complete")
-    
+
     async def stop(self):
         """Stop the daemon gracefully."""
         self._shutdown_event.set()
@@ -204,7 +219,7 @@ def main():
     """Entry point for the daemon."""
     config = DaemonConfig.from_env()
     daemon = SOCDaemon(config)
-    
+
     try:
         asyncio.run(daemon.run())
     except KeyboardInterrupt:

--- a/services/daemon/metrics.py
+++ b/services/daemon/metrics.py
@@ -32,6 +32,7 @@ DAEMON_HEALTH_PORT = get_settings().daemon_health_port
 # DaemonMetrics — OTEL-backed, public interface unchanged
 # ---------------------------------------------------------------------------
 
+
 class DaemonMetrics:
     """Metrics tracking backed by OpenTelemetry instruments.
 
@@ -59,6 +60,7 @@ class DaemonMetrics:
 
         try:
             from core.telemetry import get_meter
+
             meter = get_meter("vigil.daemon")
 
             self._polls_counter = meter.create_counter(
@@ -113,7 +115,9 @@ class DaemonMetrics:
         except Exception as _err:
             logger.debug("OTEL record_poll failed (non-fatal): %s", _err)
 
-        logger.debug("Recorded poll for %s: %d events in %.2fs", source, events_count, duration)
+        logger.debug(
+            "Recorded poll for %s: %d events in %.2fs", source, events_count, duration
+        )
 
     def get_poll_count(self, source: str) -> int:
         """Get total poll count for a source."""
@@ -132,7 +136,9 @@ class DaemonMetrics:
         except Exception as _err:
             logger.debug("OTEL record_processing failed (non-fatal): %s", _err)
 
-        logger.debug("Recorded processing: %d findings in %.2fs", findings_count, duration)
+        logger.debug(
+            "Recorded processing: %d findings in %.2fs", findings_count, duration
+        )
 
     def get_total_processed(self) -> int:
         """Get total number of findings processed."""
@@ -185,6 +191,7 @@ class DaemonMetrics:
 # MetricsServer — health/status only on DAEMON_HEALTH_PORT
 # Prometheus /metrics is served by core/telemetry PrometheusMetricReader on 9090
 # ---------------------------------------------------------------------------
+
 
 class MetricsServer:
     """Health and status HTTP server for the daemon.
@@ -259,7 +266,9 @@ class MetricsServer:
             components["scheduler"] = "not_initialized"
 
         if self.orchestrator:
-            components["orchestrator"] = "running" if self.orchestrator.enabled else "disabled"
+            components["orchestrator"] = (
+                "running" if self.orchestrator.enabled else "disabled"
+            )
         else:
             components["orchestrator"] = "not_initialized"
 
@@ -282,7 +291,9 @@ class MetricsServer:
         status = {
             "daemon": {
                 "start_time": self._start_time.isoformat(),
-                "uptime_seconds": (datetime.utcnow() - self._start_time).total_seconds(),
+                "uptime_seconds": (
+                    datetime.utcnow() - self._start_time
+                ).total_seconds(),
             },
             "poller": metrics.get("poller", {}),
             "kafka": metrics.get("kafka", {}),

--- a/services/daemon/orchestrator.py
+++ b/services/daemon/orchestrator.py
@@ -23,8 +23,9 @@ from services.daemon.agent_runner import AgentRunner
 from services.daemon.config import OrchestratorConfig
 
 try:
-    from core.telemetry import get_meter, get_tracer, inject_traceparent
     from opentelemetry.trace import SpanKind
+
+    from core.telemetry import get_meter, get_tracer, inject_traceparent
 
     _tracer = get_tracer("vigil.daemon.orchestrator")
     _orch_meter = get_meter("vigil.daemon.orchestrator")
@@ -56,6 +57,8 @@ try:
 except Exception:
     _tracer = None  # type: ignore[assignment]
     _inv_created = _inv_completed = _inv_failed = _dedup_prevented = _stuck_agents = None  # type: ignore[assignment]
+from core.integrations.mcp.client import process_mcp_client
+from core.response.approval_service import ApprovalService
 from services.daemon.plan_generator import (
     count_steps,
     generate_case_review_context,
@@ -67,8 +70,6 @@ from services.daemon.plan_generator import (
 )
 from services.daemon.shared_intel import SharedIntelligence
 from services.daemon.workdir import WorkdirManager
-from core.integrations.mcp.client import process_mcp_client
-from core.response.approval_service import ApprovalService
 
 logger = logging.getLogger(__name__)
 
@@ -877,7 +878,10 @@ class Orchestrator:
         try:
             # Route through the single helper (#129) so the daemon,
             # MCP server, and ClaudeService all resolve the same path.
-            from core.platform.mempalace_paths import get_closed_cases_dir, get_palace_path
+            from core.platform.mempalace_paths import (
+                get_closed_cases_dir,
+                get_palace_path,
+            )
 
             data_dir = get_palace_path()
             get_closed_cases_dir()  # mkdir side-effect for investigation snapshots
@@ -1314,9 +1318,7 @@ class Orchestrator:
             from core.storage.models import Investigation
 
             with get_db_manager().session_scope() as session:
-                deleted = session.query(Investigation).delete(
-                    synchronize_session=False
-                )
+                deleted = session.query(Investigation).delete(synchronize_session=False)
         except Exception as e:
             logger.error(f"Failed to delete investigations from DB: {e}")
             raise

--- a/services/daemon/plan_generator.py
+++ b/services/daemon/plan_generator.py
@@ -12,56 +12,164 @@ logger = logging.getLogger(__name__)
 
 WORKFLOW_STEP_MAP = {
     "incident-response": [
-        {"title": "Initial Triage", "description": "Retrieve finding details, assess severity, determine if false positive"},
-        {"title": "Deep Investigation", "description": "Gather evidence, correlate related findings, build entity timeline"},
-        {"title": "Correlate & Enrich", "description": "Search for related activity, enrich IOCs with threat intel"},
-        {"title": "Map to MITRE ATT&CK", "description": "Map discovered TTPs, create ATT&CK Navigator layer"},
-        {"title": "Containment & Response", "description": "Assess blast radius, propose containment actions, create approval requests"},
-        {"title": "Case Management", "description": "Check existing cases via list_cases; add findings to matching case or create new case; log IOCs, timeline, and MITRE techniques to the case"},
-        {"title": "Document & Report", "description": "Write investigation summary, submit for review"},
+        {
+            "title": "Initial Triage",
+            "description": "Retrieve finding details, assess severity, determine if false positive",
+        },
+        {
+            "title": "Deep Investigation",
+            "description": "Gather evidence, correlate related findings, build entity timeline",
+        },
+        {
+            "title": "Correlate & Enrich",
+            "description": "Search for related activity, enrich IOCs with threat intel",
+        },
+        {
+            "title": "Map to MITRE ATT&CK",
+            "description": "Map discovered TTPs, create ATT&CK Navigator layer",
+        },
+        {
+            "title": "Containment & Response",
+            "description": "Assess blast radius, propose containment actions, create approval requests",
+        },
+        {
+            "title": "Case Management",
+            "description": "Check existing cases via list_cases; add findings to matching case or create new case; log IOCs, timeline, and MITRE techniques to the case",
+        },
+        {
+            "title": "Document & Report",
+            "description": "Write investigation summary, submit for review",
+        },
     ],
     "full-investigation": [
-        {"title": "Evidence Gathering", "description": "Retrieve all related findings, entity context, and evidence"},
-        {"title": "Deep Analysis", "description": "Analyze patterns, identify root cause, build hypotheses"},
-        {"title": "ATT&CK Mapping", "description": "Map all TTPs to MITRE ATT&CK, identify technique chains"},
-        {"title": "Cross-Signal Correlation", "description": "Correlate across data sources, find related campaigns"},
-        {"title": "Response Planning", "description": "Determine response actions, assess risk, create approval requests"},
-        {"title": "Case Management", "description": "Check existing cases via list_cases; add findings to matching case or create new case; log IOCs, timeline, and MITRE techniques to the case"},
-        {"title": "Final Report", "description": "Comprehensive report with findings, timeline, and recommendations"},
+        {
+            "title": "Evidence Gathering",
+            "description": "Retrieve all related findings, entity context, and evidence",
+        },
+        {
+            "title": "Deep Analysis",
+            "description": "Analyze patterns, identify root cause, build hypotheses",
+        },
+        {
+            "title": "ATT&CK Mapping",
+            "description": "Map all TTPs to MITRE ATT&CK, identify technique chains",
+        },
+        {
+            "title": "Cross-Signal Correlation",
+            "description": "Correlate across data sources, find related campaigns",
+        },
+        {
+            "title": "Response Planning",
+            "description": "Determine response actions, assess risk, create approval requests",
+        },
+        {
+            "title": "Case Management",
+            "description": "Check existing cases via list_cases; add findings to matching case or create new case; log IOCs, timeline, and MITRE techniques to the case",
+        },
+        {
+            "title": "Final Report",
+            "description": "Comprehensive report with findings, timeline, and recommendations",
+        },
     ],
     "threat-hunt": [
-        {"title": "Hypothesis Formation", "description": "Form hunt hypothesis based on available intelligence"},
-        {"title": "Data Collection", "description": "Gather relevant findings, search for matching patterns"},
-        {"title": "Network Analysis", "description": "Analyze network flows, identify anomalous connections"},
-        {"title": "Artifact Analysis", "description": "Examine suspicious artifacts, file hashes, processes"},
-        {"title": "Intelligence Enrichment", "description": "Enrich discovered IOCs, check threat intel feeds"},
-        {"title": "Case Management", "description": "Check existing cases via list_cases; add findings to matching case or create new case; log IOCs, timeline, and MITRE techniques to the case"},
-        {"title": "Hunt Report", "description": "Document findings, update detections, submit report"},
+        {
+            "title": "Hypothesis Formation",
+            "description": "Form hunt hypothesis based on available intelligence",
+        },
+        {
+            "title": "Data Collection",
+            "description": "Gather relevant findings, search for matching patterns",
+        },
+        {
+            "title": "Network Analysis",
+            "description": "Analyze network flows, identify anomalous connections",
+        },
+        {
+            "title": "Artifact Analysis",
+            "description": "Examine suspicious artifacts, file hashes, processes",
+        },
+        {
+            "title": "Intelligence Enrichment",
+            "description": "Enrich discovered IOCs, check threat intel feeds",
+        },
+        {
+            "title": "Case Management",
+            "description": "Check existing cases via list_cases; add findings to matching case or create new case; log IOCs, timeline, and MITRE techniques to the case",
+        },
+        {
+            "title": "Hunt Report",
+            "description": "Document findings, update detections, submit report",
+        },
     ],
     "forensic-analysis": [
-        {"title": "Evidence Acquisition", "description": "Identify and preserve digital evidence, establish chain of custody"},
-        {"title": "Initial Assessment", "description": "Preliminary analysis of evidence scope and key artifacts"},
-        {"title": "Malware Analysis", "description": "Analyze suspicious files, executables, and scripts"},
-        {"title": "Network Forensics", "description": "Examine network traffic, DNS logs, connection patterns"},
-        {"title": "Timeline Reconstruction", "description": "Build comprehensive event timeline from all sources"},
-        {"title": "Case Management", "description": "Check existing cases via list_cases; add findings to matching case or create new case; log IOCs, timeline, and MITRE techniques to the case"},
-        {"title": "Forensic Report", "description": "Detailed forensic report with evidence chain and conclusions"},
+        {
+            "title": "Evidence Acquisition",
+            "description": "Identify and preserve digital evidence, establish chain of custody",
+        },
+        {
+            "title": "Initial Assessment",
+            "description": "Preliminary analysis of evidence scope and key artifacts",
+        },
+        {
+            "title": "Malware Analysis",
+            "description": "Analyze suspicious files, executables, and scripts",
+        },
+        {
+            "title": "Network Forensics",
+            "description": "Examine network traffic, DNS logs, connection patterns",
+        },
+        {
+            "title": "Timeline Reconstruction",
+            "description": "Build comprehensive event timeline from all sources",
+        },
+        {
+            "title": "Case Management",
+            "description": "Check existing cases via list_cases; add findings to matching case or create new case; log IOCs, timeline, and MITRE techniques to the case",
+        },
+        {
+            "title": "Forensic Report",
+            "description": "Detailed forensic report with evidence chain and conclusions",
+        },
     ],
     "case-review": [
-        {"title": "Review Findings", "description": "Use get_case to load the case, then get_finding for each finding; review IOCs, timeline, and activities already logged"},
-        {"title": "Root Cause Analysis", "description": "Determine root cause from aggregated evidence across all findings; identify the initial access vector and attack chain"},
-        {"title": "Resolution Planning", "description": "Generate concrete resolution steps using add_resolution_step for containment, eradication, and recovery actions"},
-        {"title": "Recommendations", "description": "Write preventive recommendations, lessons learned, and update case description with executive summary using update_case"},
-        {"title": "Finalize Case", "description": "Ensure all resolution steps are recorded, case description updated, and signal_complete"},
+        {
+            "title": "Review Findings",
+            "description": "Use get_case to load the case, then get_finding for each finding; review IOCs, timeline, and activities already logged",
+        },
+        {
+            "title": "Root Cause Analysis",
+            "description": "Determine root cause from aggregated evidence across all findings; identify the initial access vector and attack chain",
+        },
+        {
+            "title": "Resolution Planning",
+            "description": "Generate concrete resolution steps using add_resolution_step for containment, eradication, and recovery actions",
+        },
+        {
+            "title": "Recommendations",
+            "description": "Write preventive recommendations, lessons learned, and update case description with executive summary using update_case",
+        },
+        {
+            "title": "Finalize Case",
+            "description": "Ensure all resolution steps are recorded, case description updated, and signal_complete",
+        },
     ],
 }
 
 DEFAULT_STEPS = [
-    {"title": "Initial Assessment", "description": "Retrieve and assess the triggering finding(s)"},
-    {"title": "Investigation", "description": "Gather evidence, correlate related activity"},
+    {
+        "title": "Initial Assessment",
+        "description": "Retrieve and assess the triggering finding(s)",
+    },
+    {
+        "title": "Investigation",
+        "description": "Gather evidence, correlate related activity",
+    },
     {"title": "Analysis", "description": "Analyze patterns, enrich IOCs, map TTPs"},
     {"title": "Response", "description": "Propose containment and response actions"},
-    {"title": "Case Management", "description": "Check existing cases via list_cases; add findings to matching case or create new case; log IOCs, timeline, and MITRE techniques to the case"},
+    {
+        "title": "Case Management",
+        "description": "Check existing cases via list_cases; add findings to matching case or create new case; log IOCs, timeline, and MITRE techniques to the case",
+    },
     {"title": "Report", "description": "Document findings and submit for review"},
 ]
 
@@ -72,19 +180,19 @@ def select_workflow(finding: Dict[str, Any]) -> str:
     recommended = (finding.get("recommended_action") or "").lower()
     category = (finding.get("category") or "").lower()
     mitre = finding.get("mitre_predictions") or {}
-    
+
     if recommended in ("isolate", "block") or severity == "critical":
         return "incident-response"
-    
+
     if category in ("malware", "ransomware"):
         return "forensic-analysis"
-    
+
     if len(mitre) >= 3:
         return "full-investigation"
-    
+
     if severity == "high":
         return "full-investigation"
-    
+
     return "incident-response"
 
 
@@ -92,14 +200,24 @@ def _build_entity_section(finding: Dict[str, Any]) -> str:
     """Build the entity context section from a finding."""
     ctx = finding.get("entity_context") or {}
     parts = []
-    
+
     src_ips = ctx.get("src_ips") or ([ctx["src_ip"]] if ctx.get("src_ip") else [])
-    dst_ips = ctx.get("dest_ips") or ctx.get("dst_ips") or ([ctx["dst_ip"]] if ctx.get("dst_ip") else [])
-    hostnames = ctx.get("hostnames") or ([ctx["hostname"]] if ctx.get("hostname") else [])
-    users = ctx.get("usernames") or ctx.get("users") or ([ctx["user"]] if ctx.get("user") else [])
+    dst_ips = (
+        ctx.get("dest_ips")
+        or ctx.get("dst_ips")
+        or ([ctx["dst_ip"]] if ctx.get("dst_ip") else [])
+    )
+    hostnames = ctx.get("hostnames") or (
+        [ctx["hostname"]] if ctx.get("hostname") else []
+    )
+    users = (
+        ctx.get("usernames")
+        or ctx.get("users")
+        or ([ctx["user"]] if ctx.get("user") else [])
+    )
     domains = ctx.get("domains") or []
     hashes = ctx.get("file_hashes") or []
-    
+
     if src_ips:
         parts.append(f"- Source IPs: {', '.join(src_ips[:5])}")
     if dst_ips:
@@ -112,7 +230,7 @@ def _build_entity_section(finding: Dict[str, Any]) -> str:
         parts.append(f"- Domains: {', '.join(domains[:5])}")
     if hashes:
         parts.append(f"- File Hashes: {', '.join(hashes[:3])}")
-    
+
     return "\n".join(parts) if parts else "- No entity context available"
 
 
@@ -147,18 +265,18 @@ def generate_plan(
         f"priority: {primary.get('severity', 'medium')}",
         f"created: {datetime.utcnow().isoformat()}Z",
         "status: planning",
-        f"current_step: 1",
+        "current_step: 1",
         "---",
         "",
         f"# Investigation Plan: {title}",
         "",
         "## Objective",
     ]
-    
+
     if hypothesis:
         lines.append(f"Hunt hypothesis: {hypothesis}")
         lines.append("")
-    
+
     if primary:
         fid = primary.get("finding_id", "unknown")
         desc = (primary.get("description") or "No description")[:300]
@@ -167,33 +285,35 @@ def generate_plan(
         lines.append("### Entity Context")
         lines.append(_build_entity_section(primary))
         lines.append("")
-        lines.append(f"### MITRE ATT&CK Predictions")
+        lines.append("### MITRE ATT&CK Predictions")
         lines.append(f"- {_format_mitre(primary)}")
         lines.append(f"- Anomaly Score: {primary.get('anomaly_score', 'N/A')}")
     else:
         lines.append("Investigate based on provided context.")
-    
+
     if len(findings) > 1:
         lines.append("")
         lines.append(f"### Additional Trigger Findings ({len(findings) - 1})")
         for f in findings[1:5]:
-            lines.append(f"- {f.get('finding_id', '?')}: {(f.get('description') or 'N/A')[:100]}")
-    
+            lines.append(
+                f"- {f.get('finding_id', '?')}: {(f.get('description') or 'N/A')[:100]}"
+            )
+
     lines.append("")
     lines.append("## Steps")
     lines.append("")
-    
+
     for i, step in enumerate(steps, 1):
         lines.append(f"### Step {i}: {step['title']} [pending]")
         lines.append(f"- {step['description']}")
         lines.append("")
-    
+
     lines.append("## Blockers")
     lines.append("(none)")
     lines.append("")
     lines.append("## Notes")
     lines.append("")
-    
+
     return "\n".join(lines)
 
 
@@ -250,7 +370,9 @@ def generate_case_review_plan(
     return "\n".join(lines)
 
 
-def generate_case_review_context(case_id: str, case_title: str, finding_ids: List[str]) -> str:
+def generate_case_review_context(
+    case_id: str, case_title: str, finding_ids: List[str]
+) -> str:
     """Generate the initial context.md for a case-review investigation."""
     lines = [
         "# Case Review Context",
@@ -277,7 +399,9 @@ def _infer_title(finding: Dict[str, Any], workflow_id: str) -> str:
     ctx = finding.get("entity_context") or {}
 
     subject_parts = []
-    hostnames = ctx.get("hostnames") or ([ctx["hostname"]] if ctx.get("hostname") else [])
+    hostnames = ctx.get("hostnames") or (
+        [ctx["hostname"]] if ctx.get("hostname") else []
+    )
     if hostnames:
         subject_parts.append(hostnames[0])
 
@@ -321,7 +445,9 @@ def generate_initial_state(
         "status": "executing",
         "current_step": 1,
         "total_steps": total_steps,
-        "trigger_finding_ids": [f.get("finding_id") for f in findings if f.get("finding_id")],
+        "trigger_finding_ids": [
+            f.get("finding_id") for f in findings if f.get("finding_id")
+        ],
         "created_at": datetime.utcnow().isoformat(),
         "completed_steps": [],
         "discovered_iocs": {},
@@ -334,7 +460,7 @@ def generate_initial_state(
 def generate_initial_context(findings: List[Dict[str, Any]]) -> str:
     """Generate the initial context.md with trigger finding summaries."""
     lines = ["# Investigation Context", "", "## Trigger Findings", ""]
-    
+
     for f in findings[:5]:
         fid = f.get("finding_id", "unknown")
         sev = f.get("severity", "unknown")
@@ -342,10 +468,10 @@ def generate_initial_context(findings: List[Dict[str, Any]]) -> str:
         lines.append(f"### {fid} (Severity: {sev})")
         lines.append(desc)
         lines.append("")
-    
+
     lines.append("## Progress Notes")
     lines.append("")
-    
+
     return "\n".join(lines)
 
 

--- a/services/daemon/poller.py
+++ b/services/daemon/poller.py
@@ -18,13 +18,13 @@ delete the legacy loops in a follow-up.
 import asyncio
 import hmac
 import logging
-from datetime import datetime, timedelta
-from typing import Optional, Dict, Any
 from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
 
-from services.daemon.config import PollingConfig
-from core.ingestion.dedup import RedisDedupSet
 from core.federation.runner import FederationRunner
+from core.ingestion.dedup import RedisDedupSet
+from services.daemon.config import PollingConfig
 
 logger = logging.getLogger(__name__)
 
@@ -37,12 +37,13 @@ class PollState:
     this dataclass tracks only the last-poll timestamp used to compute
     query windows.
     """
+
     last_poll_time: Optional[datetime] = None
 
 
 class DataPoller:
     """Polls various data sources for new security findings."""
-    
+
     def __init__(self, config: PollingConfig):
         self.config = config
         self._output_queue: Optional[asyncio.Queue] = None
@@ -94,91 +95,112 @@ class DataPoller:
             "elastic_polls": 0,
             "elastic_findings": 0,
             "webhook_findings": 0,
-            "errors": 0
+            "errors": 0,
         }
-    
+
     def set_output_queue(self, queue: asyncio.Queue):
         """Set the output queue for processed findings."""
         self._output_queue = queue
         self._federation.set_output_queue(queue)
-    
+
     def _init_services(self):
         """Initialize data source services."""
         try:
             from core.config import get_integration_config, is_integration_enabled
-            
+
             # Initialize Splunk service if configured
-            if is_integration_enabled('splunk'):
+            if is_integration_enabled("splunk"):
                 try:
                     from core.integrations.splunk.client import SplunkService
-                    splunk_config = get_integration_config('splunk')
+
+                    splunk_config = get_integration_config("splunk")
                     self._splunk_service = SplunkService(
-                        server_url=splunk_config.get('server_url', ''),
-                        username=splunk_config.get('username', ''),
-                        password=splunk_config.get('password', ''),
-                        verify_ssl=splunk_config.get('verify_ssl', False)
+                        server_url=splunk_config.get("server_url", ""),
+                        username=splunk_config.get("username", ""),
+                        password=splunk_config.get("password", ""),
+                        verify_ssl=splunk_config.get("verify_ssl", False),
                     )
                     logger.info("Splunk service initialized")
                 except Exception as e:
                     logger.warning(f"Failed to initialize Splunk service: {e}")
-            
+
             # Initialize CrowdStrike service if configured
-            if is_integration_enabled('crowdstrike'):
+            if is_integration_enabled("crowdstrike"):
                 try:
                     from core.integrations.crowdstrike.client import CrowdStrikeService
-                    cs_config = get_integration_config('crowdstrike')
+
+                    cs_config = get_integration_config("crowdstrike")
                     self._crowdstrike_service = CrowdStrikeService(
-                        client_id=cs_config.get('client_id', ''),
-                        client_secret=cs_config.get('client_secret', ''),
-                        base_url=cs_config.get('base_url', 'https://api.crowdstrike.com')
+                        client_id=cs_config.get("client_id", ""),
+                        client_secret=cs_config.get("client_secret", ""),
+                        base_url=cs_config.get(
+                            "base_url", "https://api.crowdstrike.com"
+                        ),
                     )
                     logger.info("CrowdStrike service initialized")
                 except Exception as e:
                     logger.warning(f"Failed to initialize CrowdStrike service: {e}")
-            
+
             # Initialize Azure Sentinel service if configured
-            if is_integration_enabled('azure-sentinel'):
+            if is_integration_enabled("azure-sentinel"):
                 try:
-                    from core.integrations.azure_sentinel.ingestion import AzureSentinelIngestion
+                    from core.integrations.azure_sentinel.ingestion import (
+                        AzureSentinelIngestion,
+                    )
+
                     self._azure_sentinel_service = AzureSentinelIngestion()
                     logger.info("Azure Sentinel service initialized")
                 except Exception as e:
                     logger.warning(f"Failed to initialize Azure Sentinel service: {e}")
-            
+
             # Initialize AWS Security Hub service if configured
-            if is_integration_enabled('aws-security-hub'):
+            if is_integration_enabled("aws-security-hub"):
                 try:
-                    from core.integrations.aws_security_hub.ingestion import AWSSecurityHubIngestion
+                    from core.integrations.aws_security_hub.ingestion import (
+                        AWSSecurityHubIngestion,
+                    )
+
                     self._aws_security_hub_service = AWSSecurityHubIngestion()
                     logger.info("AWS Security Hub service initialized")
                 except Exception as e:
-                    logger.warning(f"Failed to initialize AWS Security Hub service: {e}")
-            
+                    logger.warning(
+                        f"Failed to initialize AWS Security Hub service: {e}"
+                    )
+
             # Initialize Microsoft Defender service if configured
-            if is_integration_enabled('microsoft-defender'):
+            if is_integration_enabled("microsoft-defender"):
                 try:
-                    from core.integrations.microsoft_defender.ingestion import MicrosoftDefenderIngestion
+                    from core.integrations.microsoft_defender.ingestion import (
+                        MicrosoftDefenderIngestion,
+                    )
+
                     self._microsoft_defender_service = MicrosoftDefenderIngestion()
                     logger.info("Microsoft Defender service initialized")
                 except Exception as e:
-                    logger.warning(f"Failed to initialize Microsoft Defender service: {e}")
+                    logger.warning(
+                        f"Failed to initialize Microsoft Defender service: {e}"
+                    )
 
             # Initialize Elastic Security service if configured
-            if is_integration_enabled('elastic-siem'):
+            if is_integration_enabled("elastic-siem"):
                 try:
                     from core.integrations.elastic.ingestion import ElasticIngestion
+
                     self._elastic_service = ElasticIngestion()
                     logger.info("Elastic Security service initialized")
                 except Exception as e:
-                    logger.warning(f"Failed to initialize Elastic Security service: {e}")
+                    logger.warning(
+                        f"Failed to initialize Elastic Security service: {e}"
+                    )
 
             # Initialize data service for database access
             from core.storage.database_data_service import DatabaseDataService
+
             self._data_service = DatabaseDataService()
-            
+
         except Exception as e:
             logger.error(f"Error initializing services: {e}")
-    
+
     async def run(self, shutdown_event: asyncio.Event):
         """Run the polling loop."""
         logger.info("Data poller starting...")
@@ -192,56 +214,52 @@ class DataPoller:
         tasks.append(asyncio.create_task(self._federation.run(shutdown_event)))
 
         if self._splunk_service:
-            tasks.append(asyncio.create_task(
-                self._poll_splunk_loop(shutdown_event)
-            ))
-        
+            tasks.append(asyncio.create_task(self._poll_splunk_loop(shutdown_event)))
+
         if self._crowdstrike_service:
-            tasks.append(asyncio.create_task(
-                self._poll_crowdstrike_loop(shutdown_event)
-            ))
-        
+            tasks.append(
+                asyncio.create_task(self._poll_crowdstrike_loop(shutdown_event))
+            )
+
         if self._azure_sentinel_service:
-            tasks.append(asyncio.create_task(
-                self._poll_azure_sentinel_loop(shutdown_event)
-            ))
-        
+            tasks.append(
+                asyncio.create_task(self._poll_azure_sentinel_loop(shutdown_event))
+            )
+
         if self._aws_security_hub_service:
-            tasks.append(asyncio.create_task(
-                self._poll_aws_security_hub_loop(shutdown_event)
-            ))
-        
+            tasks.append(
+                asyncio.create_task(self._poll_aws_security_hub_loop(shutdown_event))
+            )
+
         if self._microsoft_defender_service:
-            tasks.append(asyncio.create_task(
-                self._poll_microsoft_defender_loop(shutdown_event)
-            ))
+            tasks.append(
+                asyncio.create_task(self._poll_microsoft_defender_loop(shutdown_event))
+            )
 
         if self._elastic_service:
-            tasks.append(asyncio.create_task(
-                self._poll_elastic_loop(shutdown_event)
-            ))
+            tasks.append(asyncio.create_task(self._poll_elastic_loop(shutdown_event)))
 
         if self.config.webhook_enabled:
-            tasks.append(asyncio.create_task(
-                self._run_webhook_server(shutdown_event)
-            ))
-        
+            tasks.append(asyncio.create_task(self._run_webhook_server(shutdown_event)))
+
         if not tasks:
             logger.warning("No data sources configured for polling")
             # Just wait for shutdown
             await shutdown_event.wait()
             return
-        
+
         # Wait for all tasks or shutdown
         try:
             await asyncio.gather(*tasks)
         except asyncio.CancelledError:
             logger.info("Polling tasks cancelled")
-    
+
     async def _poll_splunk_loop(self, shutdown_event: asyncio.Event):
         """Poll Splunk for new alerts on interval."""
-        logger.info(f"Splunk polling loop started (interval: {self.config.splunk_interval}s)")
-        
+        logger.info(
+            f"Splunk polling loop started (interval: {self.config.splunk_interval}s)"
+        )
+
         while not shutdown_event.is_set():
             try:
                 await self._poll_splunk()
@@ -249,38 +267,37 @@ class DataPoller:
             except Exception as e:
                 logger.error(f"Splunk polling error: {e}")
                 self.stats["errors"] += 1
-            
+
             # Wait for interval or shutdown
             try:
                 await asyncio.wait_for(
-                    shutdown_event.wait(),
-                    timeout=self.config.splunk_interval
+                    shutdown_event.wait(), timeout=self.config.splunk_interval
                 )
                 break  # Shutdown requested
             except asyncio.TimeoutError:
                 pass  # Continue polling
-    
+
     async def _poll_splunk(self):
         """Poll Splunk for new security alerts."""
         if not self._splunk_service:
             return
         if self._federation.is_active_for("splunk"):
             return  # Federation owns this source while globally + per-source enabled
-        
+
         self.stats["splunk_polls"] += 1
         logger.debug("Polling Splunk for new alerts...")
-        
+
         # Calculate time range
         lookback_minutes = max(self.config.splunk_interval // 60 + 1, 5)
         earliest_time = f"-{lookback_minutes}m"
-        
+
         # Query for notable events / security alerts
         queries = [
-            'index=notable | head 100',
-            'index=security sourcetype=*:alert* | head 100',
-            '`notable` | head 100'
+            "index=notable | head 100",
+            "index=security sourcetype=*:alert* | head 100",
+            "`notable` | head 100",
         ]
-        
+
         findings = []
         for query in queries:
             try:
@@ -291,7 +308,7 @@ class DataPoller:
                     query=query,
                     earliest_time=earliest_time,
                     latest_time="now",
-                    max_count=100
+                    max_count=100,
                 )
                 if results:
                     findings.extend(results)
@@ -299,79 +316,91 @@ class DataPoller:
             except Exception as e:
                 logger.debug(f"Splunk query failed: {query} - {e}")
                 continue
-        
+
         # Process findings
         new_count = 0
         for event in findings:
             finding = self._splunk_event_to_finding(event)
-            if finding and not await self._splunk_dedup.is_processed(finding['finding_id']):
+            if finding and not await self._splunk_dedup.is_processed(
+                finding["finding_id"]
+            ):
                 await self._enqueue_finding(finding, "splunk")
-                await self._splunk_dedup.mark_processed(finding['finding_id'])
+                await self._splunk_dedup.mark_processed(finding["finding_id"])
                 new_count += 1
-        
+
         if new_count > 0:
             logger.info(f"Polled {new_count} new findings from Splunk")
             self.stats["splunk_findings"] += new_count
-    
-    def _splunk_event_to_finding(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    def _splunk_event_to_finding(
+        self, event: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """Convert Splunk event to finding format."""
         import uuid
-        
+
         # Extract key fields
-        event_id = event.get('_cd') or event.get('event_id') or str(uuid.uuid4())
+        event_id = event.get("_cd") or event.get("event_id") or str(uuid.uuid4())
         finding_id = f"splunk-{event_id[:32]}"
-        
+
         # Determine severity
-        severity_raw = event.get('urgency') or event.get('severity') or 'medium'
+        severity_raw = event.get("urgency") or event.get("severity") or "medium"
         severity_map = {
-            'critical': 'critical', 'high': 'high', 'medium': 'medium',
-            'low': 'low', 'info': 'low', 'informational': 'low'
+            "critical": "critical",
+            "high": "high",
+            "medium": "medium",
+            "low": "low",
+            "info": "low",
+            "informational": "low",
         }
-        severity = severity_map.get(severity_raw.lower(), 'medium')
-        
+        severity = severity_map.get(severity_raw.lower(), "medium")
+
         # Extract entity context
         entity_context = {
-            'src_ips': [],
-            'dest_ips': [],
-            'hostnames': [],
-            'usernames': []
+            "src_ips": [],
+            "dest_ips": [],
+            "hostnames": [],
+            "usernames": [],
         }
-        
-        for ip_field in ['src_ip', 'src', 'source_ip']:
+
+        for ip_field in ["src_ip", "src", "source_ip"]:
             if event.get(ip_field):
-                entity_context['src_ips'].append(event[ip_field])
-        
-        for ip_field in ['dest_ip', 'dest', 'destination_ip']:
+                entity_context["src_ips"].append(event[ip_field])
+
+        for ip_field in ["dest_ip", "dest", "destination_ip"]:
             if event.get(ip_field):
-                entity_context['dest_ips'].append(event[ip_field])
-        
-        for host_field in ['host', 'hostname', 'src_host', 'dest_host']:
+                entity_context["dest_ips"].append(event[ip_field])
+
+        for host_field in ["host", "hostname", "src_host", "dest_host"]:
             if event.get(host_field):
-                entity_context['hostnames'].append(event[host_field])
-        
-        for user_field in ['user', 'username', 'src_user']:
+                entity_context["hostnames"].append(event[host_field])
+
+        for user_field in ["user", "username", "src_user"]:
             if event.get(user_field):
-                entity_context['usernames'].append(event[user_field])
-        
+                entity_context["usernames"].append(event[user_field])
+
         return {
-            'finding_id': finding_id,
-            'data_source': 'splunk',
-            'timestamp': event.get('_time') or datetime.utcnow().isoformat(),
-            'severity': severity,
-            'status': 'new',
-            'title': event.get('search_name') or event.get('rule_name') or 'Splunk Alert',
-            'description': event.get('description') or event.get('_raw', '')[:500],
-            'entity_context': entity_context,
-            'raw_event': event,
-            'anomaly_score': 0.5,  # Default score
-            'mitre_predictions': {},
-            'embedding': []
+            "finding_id": finding_id,
+            "data_source": "splunk",
+            "timestamp": event.get("_time") or datetime.utcnow().isoformat(),
+            "severity": severity,
+            "status": "new",
+            "title": event.get("search_name")
+            or event.get("rule_name")
+            or "Splunk Alert",
+            "description": event.get("description") or event.get("_raw", "")[:500],
+            "entity_context": entity_context,
+            "raw_event": event,
+            "anomaly_score": 0.5,  # Default score
+            "mitre_predictions": {},
+            "embedding": [],
         }
-    
+
     async def _poll_crowdstrike_loop(self, shutdown_event: asyncio.Event):
         """Poll CrowdStrike for new detections on interval."""
-        logger.info(f"CrowdStrike polling loop started (interval: {self.config.crowdstrike_interval}s)")
-        
+        logger.info(
+            f"CrowdStrike polling loop started (interval: {self.config.crowdstrike_interval}s)"
+        )
+
         while not shutdown_event.is_set():
             try:
                 await self._poll_crowdstrike()
@@ -379,108 +408,117 @@ class DataPoller:
             except Exception as e:
                 logger.error(f"CrowdStrike polling error: {e}")
                 self.stats["errors"] += 1
-            
+
             try:
                 await asyncio.wait_for(
-                    shutdown_event.wait(),
-                    timeout=self.config.crowdstrike_interval
+                    shutdown_event.wait(), timeout=self.config.crowdstrike_interval
                 )
                 break
             except asyncio.TimeoutError:
                 pass
-    
+
     async def _poll_crowdstrike(self):
         """Poll CrowdStrike for new detections."""
         if not self._crowdstrike_service:
             return
         if self._federation.is_active_for("crowdstrike"):
             return
-        
+
         self.stats["crowdstrike_polls"] += 1
         logger.debug("Polling CrowdStrike for new detections...")
-        
+
         try:
             # Get recent detections
             lookback_minutes = max(self.config.crowdstrike_interval // 60 + 1, 5)
             since = datetime.utcnow() - timedelta(minutes=lookback_minutes)
-            
+
             detections = await asyncio.to_thread(
                 self._crowdstrike_service.get_detections,
                 filter_query=f"created_timestamp:>='{since.isoformat()}Z'",
-                limit=100
+                limit=100,
             )
-            
+
             if not detections:
                 return
-            
+
             new_count = 0
             for detection in detections:
                 finding = self._crowdstrike_detection_to_finding(detection)
-                if finding and not await self._crowdstrike_dedup.is_processed(finding['finding_id']):
+                if finding and not await self._crowdstrike_dedup.is_processed(
+                    finding["finding_id"]
+                ):
                     await self._enqueue_finding(finding, "crowdstrike")
-                    await self._crowdstrike_dedup.mark_processed(finding['finding_id'])
+                    await self._crowdstrike_dedup.mark_processed(finding["finding_id"])
                     new_count += 1
-            
+
             if new_count > 0:
                 logger.info(f"Polled {new_count} new detections from CrowdStrike")
                 self.stats["crowdstrike_findings"] += new_count
-                
+
         except Exception as e:
             logger.error(f"CrowdStrike API error: {e}")
             raise
-    
-    def _crowdstrike_detection_to_finding(self, detection: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    def _crowdstrike_detection_to_finding(
+        self, detection: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """Convert CrowdStrike detection to finding format."""
-        detection_id = detection.get('detection_id', '')
+        detection_id = detection.get("detection_id", "")
         if not detection_id:
             return None
-        
+
         finding_id = f"cs-{detection_id[:32]}"
-        
+
         # Map severity
-        severity_raw = detection.get('max_severity_displayname', 'Medium')
+        severity_raw = detection.get("max_severity_displayname", "Medium")
         severity_map = {
-            'Critical': 'critical', 'High': 'high', 'Medium': 'medium',
-            'Low': 'low', 'Informational': 'low'
+            "Critical": "critical",
+            "High": "high",
+            "Medium": "medium",
+            "Low": "low",
+            "Informational": "low",
         }
-        severity = severity_map.get(severity_raw, 'medium')
-        
+        severity = severity_map.get(severity_raw, "medium")
+
         # Extract behaviors and tactics
-        behaviors = detection.get('behaviors', [])
+        behaviors = detection.get("behaviors", [])
         mitre_predictions = {}
         for behavior in behaviors:
-            technique = behavior.get('technique')
+            technique = behavior.get("technique")
             if technique:
                 mitre_predictions[technique] = 0.9  # High confidence from EDR
-        
+
         # Entity context
-        device = detection.get('device', {})
+        device = detection.get("device", {})
         entity_context = {
-            'src_ips': [device.get('local_ip')] if device.get('local_ip') else [],
-            'hostnames': [device.get('hostname')] if device.get('hostname') else [],
-            'usernames': [detection.get('user_name')] if detection.get('user_name') else [],
-            'device_id': device.get('device_id')
+            "src_ips": [device.get("local_ip")] if device.get("local_ip") else [],
+            "hostnames": [device.get("hostname")] if device.get("hostname") else [],
+            "usernames": (
+                [detection.get("user_name")] if detection.get("user_name") else []
+            ),
+            "device_id": device.get("device_id"),
         }
-        
+
         return {
-            'finding_id': finding_id,
-            'data_source': 'crowdstrike',
-            'timestamp': detection.get('created_timestamp') or datetime.utcnow().isoformat(),
-            'severity': severity,
-            'status': 'new',
-            'title': detection.get('scenario') or 'CrowdStrike Detection',
-            'description': detection.get('description', ''),
-            'entity_context': entity_context,
-            'raw_event': detection,
-            'anomaly_score': detection.get('max_confidence', 50) / 100.0,
-            'mitre_predictions': mitre_predictions,
-            'embedding': []
+            "finding_id": finding_id,
+            "data_source": "crowdstrike",
+            "timestamp": detection.get("created_timestamp")
+            or datetime.utcnow().isoformat(),
+            "severity": severity,
+            "status": "new",
+            "title": detection.get("scenario") or "CrowdStrike Detection",
+            "description": detection.get("description", ""),
+            "entity_context": entity_context,
+            "raw_event": detection,
+            "anomaly_score": detection.get("max_confidence", 50) / 100.0,
+            "mitre_predictions": mitre_predictions,
+            "embedding": [],
         }
-    
+
     async def _run_webhook_server(self, shutdown_event: asyncio.Event):
         """Run a simple webhook server for external ingestion."""
         from aiohttp import web
-        
+
         async def handle_webhook(request: web.Request) -> web.Response:
             """Handle incoming webhook data."""
             # Fail closed: no token configured => ingestion is disabled, and every
@@ -495,7 +533,9 @@ class DataPoller:
                     {"error": "ingest disabled: server missing DAEMON_WEBHOOK_TOKEN"},
                     status=503,
                 )
-            presented = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
+            presented = (
+                request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
+            )
             if not hmac.compare_digest(presented, token):
                 return web.json_response({"error": "unauthorized"}, status=401)
             try:
@@ -509,6 +549,7 @@ class DataPoller:
                 # resumes on re-enable). Only registered-but-disabled sources are
                 # blocked, so generic 'webhook'/'flow' pushes are unaffected.
                 from core.storage.config_service import get_config_service
+
                 # Run the sync SQLAlchemy lookup off the event loop so a slow or
                 # locked DB can't freeze the whole daemon on the ingest hot path.
                 disabled = await asyncio.to_thread(
@@ -519,78 +560,86 @@ class DataPoller:
                 }
                 if blocked:
                     return web.json_response(
-                        {"error": f"ingestion disabled for source(s): {sorted(blocked)}"},
+                        {
+                            "error": f"ingestion disabled for source(s): {sorted(blocked)}"
+                        },
                         status=503,
                     )
 
                 count = 0
                 for finding_data in findings:
-                    finding_id = finding_data.get('finding_id')
+                    finding_id = finding_data.get("finding_id")
                     if not finding_id:
                         import uuid
+
                         finding_id = f"webhook-{uuid.uuid4().hex[:16]}"
-                        finding_data['finding_id'] = finding_id
-                    
+                        finding_data["finding_id"] = finding_id
+
                     if not await self._webhook_dedup.is_processed(finding_id):
-                        finding_data['data_source'] = finding_data.get('data_source', 'webhook')
+                        finding_data["data_source"] = finding_data.get(
+                            "data_source", "webhook"
+                        )
                         await self._enqueue_finding(finding_data, "webhook")
                         await self._webhook_dedup.mark_processed(finding_id)
                         count += 1
-                
+
                 self.stats["webhook_findings"] += count
                 return web.json_response({"status": "ok", "ingested": count})
-            
+
             except Exception as e:
                 logger.error(f"Webhook error: {e}")
                 return web.json_response({"error": str(e)}, status=400)
-        
+
         async def health_check(request: web.Request) -> web.Response:
             """Health check endpoint."""
             return web.json_response({"status": "healthy", "stats": self.stats})
-        
+
         app = web.Application()
-        app.router.add_post('/ingest', handle_webhook)
-        app.router.add_post('/webhook', handle_webhook)
-        app.router.add_get('/health', health_check)
-        
+        app.router.add_post("/ingest", handle_webhook)
+        app.router.add_post("/webhook", handle_webhook)
+        app.router.add_get("/health", health_check)
+
         runner = web.AppRunner(app)
         await runner.setup()
-        site = web.TCPSite(runner, '0.0.0.0', self.config.webhook_port)
-        
+        site = web.TCPSite(runner, "0.0.0.0", self.config.webhook_port)
+
         logger.info(f"Webhook server starting on port {self.config.webhook_port}")
         await site.start()
-        
+
         # Wait for shutdown
         await shutdown_event.wait()
-        
+
         await runner.cleanup()
         logger.info("Webhook server stopped")
-    
+
     async def _enqueue_finding(self, finding: Dict[str, Any], source: str):
         """Add finding to output queue for processing."""
         if self._output_queue:
-            await self._output_queue.put({
-                "type": "finding",
-                "source": source,
-                "data": finding,
-                "timestamp": datetime.utcnow().isoformat()
-            })
+            await self._output_queue.put(
+                {
+                    "type": "finding",
+                    "source": source,
+                    "data": finding,
+                    "timestamp": datetime.utcnow().isoformat(),
+                }
+            )
             logger.debug(f"Enqueued finding {finding.get('finding_id')} from {source}")
         else:
             # No queue, store directly
             if self._data_service:
                 try:
                     from core.ingestion.ingestion_service import IngestionService
+
                     ingestion = IngestionService()
                     ingestion.ingest_finding(finding)
                 except Exception as e:
                     logger.error(f"Failed to store finding: {e}")
-    
+
     async def _poll_azure_sentinel_loop(self, shutdown_event: asyncio.Event):
         """Poll Azure Sentinel for new incidents on interval."""
         interval = self.config.splunk_interval  # Use same interval as Splunk
         logger.info(f"Azure Sentinel polling loop started (interval: {interval}s)")
-        
+
         while not shutdown_event.is_set():
             try:
                 await self._poll_azure_sentinel()
@@ -598,28 +647,28 @@ class DataPoller:
             except Exception as e:
                 logger.error(f"Azure Sentinel polling error: {e}")
                 self.stats["errors"] += 1
-            
+
             # Wait for interval or shutdown
             try:
                 await asyncio.wait_for(shutdown_event.wait(), timeout=interval)
                 break  # Shutdown requested
             except asyncio.TimeoutError:
                 pass  # Continue polling
-    
+
     async def _poll_azure_sentinel(self):
         """Poll Azure Sentinel for new incidents."""
         if not self._azure_sentinel_service:
             return
         if self._federation.is_active_for("azure_sentinel"):
             return
-        
+
         self.stats["azure_sentinel_polls"] += 1
         logger.debug("Polling Azure Sentinel for new incidents...")
-        
+
         try:
             # Use ingestion service
             result = self._azure_sentinel_service.ingest_alerts(limit=100)
-            
+
             if result.get("success"):
                 ingested = result.get("ingested", 0)
                 self.stats["azure_sentinel_findings"] += ingested
@@ -628,12 +677,12 @@ class DataPoller:
                 logger.error(f"Azure Sentinel ingestion failed: {result.get('errors')}")
         except Exception as e:
             logger.error(f"Error polling Azure Sentinel: {e}")
-    
+
     async def _poll_aws_security_hub_loop(self, shutdown_event: asyncio.Event):
         """Poll AWS Security Hub for new findings on interval."""
         interval = self.config.splunk_interval  # Use same interval as Splunk
         logger.info(f"AWS Security Hub polling loop started (interval: {interval}s)")
-        
+
         while not shutdown_event.is_set():
             try:
                 await self._poll_aws_security_hub()
@@ -641,42 +690,44 @@ class DataPoller:
             except Exception as e:
                 logger.error(f"AWS Security Hub polling error: {e}")
                 self.stats["errors"] += 1
-            
+
             # Wait for interval or shutdown
             try:
                 await asyncio.wait_for(shutdown_event.wait(), timeout=interval)
                 break  # Shutdown requested
             except asyncio.TimeoutError:
                 pass  # Continue polling
-    
+
     async def _poll_aws_security_hub(self):
         """Poll AWS Security Hub for new findings."""
         if not self._aws_security_hub_service:
             return
         if self._federation.is_active_for("aws_security_hub"):
             return
-        
+
         self.stats["aws_security_hub_polls"] += 1
         logger.debug("Polling AWS Security Hub for new findings...")
-        
+
         try:
             # Use ingestion service
             result = self._aws_security_hub_service.ingest_alerts(limit=100)
-            
+
             if result.get("success"):
                 ingested = result.get("ingested", 0)
                 self.stats["aws_security_hub_findings"] += ingested
                 logger.info(f"AWS Security Hub: ingested {ingested} findings")
             else:
-                logger.error(f"AWS Security Hub ingestion failed: {result.get('errors')}")
+                logger.error(
+                    f"AWS Security Hub ingestion failed: {result.get('errors')}"
+                )
         except Exception as e:
             logger.error(f"Error polling AWS Security Hub: {e}")
-    
+
     async def _poll_microsoft_defender_loop(self, shutdown_event: asyncio.Event):
         """Poll Microsoft Defender for new alerts on interval."""
         interval = self.config.splunk_interval  # Use same interval as Splunk
         logger.info(f"Microsoft Defender polling loop started (interval: {interval}s)")
-        
+
         while not shutdown_event.is_set():
             try:
                 await self._poll_microsoft_defender()
@@ -684,34 +735,36 @@ class DataPoller:
             except Exception as e:
                 logger.error(f"Microsoft Defender polling error: {e}")
                 self.stats["errors"] += 1
-            
+
             # Wait for interval or shutdown
             try:
                 await asyncio.wait_for(shutdown_event.wait(), timeout=interval)
                 break  # Shutdown requested
             except asyncio.TimeoutError:
                 pass  # Continue polling
-    
+
     async def _poll_microsoft_defender(self):
         """Poll Microsoft Defender for new alerts."""
         if not self._microsoft_defender_service:
             return
         if self._federation.is_active_for("microsoft_defender"):
             return
-        
+
         self.stats["microsoft_defender_polls"] += 1
         logger.debug("Polling Microsoft Defender for new alerts...")
-        
+
         try:
             # Use ingestion service
             result = self._microsoft_defender_service.ingest_alerts(limit=100)
-            
+
             if result.get("success"):
                 ingested = result.get("ingested", 0)
                 self.stats["microsoft_defender_findings"] += ingested
                 logger.info(f"Microsoft Defender: ingested {ingested} alerts")
             else:
-                logger.error(f"Microsoft Defender ingestion failed: {result.get('errors')}")
+                logger.error(
+                    f"Microsoft Defender ingestion failed: {result.get('errors')}"
+                )
         except Exception as e:
             logger.error(f"Error polling Microsoft Defender: {e}")
 
@@ -755,7 +808,9 @@ class DataPoller:
             new_count = 0
             for alert in alerts:
                 finding = self._elastic_service.transform_alert_to_finding(alert)
-                if finding and not await self._elastic_dedup.is_processed(finding["finding_id"]):
+                if finding and not await self._elastic_dedup.is_processed(
+                    finding["finding_id"]
+                ):
                     await self._enqueue_finding(finding, "elastic")
                     await self._elastic_dedup.mark_processed(finding["finding_id"])
                     new_count += 1

--- a/services/daemon/processor.py
+++ b/services/daemon/processor.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from datetime import datetime
-from typing import Optional, Dict, List, Any
+from typing import Any, Dict, List, Optional
 
 from services.daemon.config import ProcessingConfig
 
@@ -130,7 +130,7 @@ class FindingProcessor:
 
     def _init_enrichment_services(self):
         """Initialize threat intelligence enrichment services."""
-        from core.config import is_integration_enabled, get_integration_config
+        from core.config import get_integration_config, is_integration_enabled
 
         # VirusTotal
         if is_integration_enabled("virustotal"):
@@ -289,7 +289,9 @@ class FindingProcessor:
             logger.error(f"Error processing finding {finding_id}: {e}")
             self.stats["errors"] += 1
 
-    async def _spawn_enrich(self, finding: Dict[str, Any], source: Optional[str] = None):
+    async def _spawn_enrich(
+        self, finding: Dict[str, Any], source: Optional[str] = None
+    ):
         """Acquire an in-flight slot (blocks when the cap is reached → backpressure),
         then run enrichment in the background. Bounds pending enrich tasks so a burst
         or backfill can't pile up unbounded coroutines. Single choke point shared by
@@ -675,10 +677,14 @@ REASONING: [Brief explanation]
         hits: Dict[str, Any] = {}
         try:
             if ips:
-                hits.update(self._wrap_hits("ip", lookup_indicators("ip", list(set(ips)))))
+                hits.update(
+                    self._wrap_hits("ip", lookup_indicators("ip", list(set(ips))))
+                )
             if domains:
                 hits.update(
-                    self._wrap_hits("domain", lookup_indicators("domain", list(set(domains))))
+                    self._wrap_hits(
+                        "domain", lookup_indicators("domain", list(set(domains)))
+                    )
                 )
             if hashes:
                 for hash_type in ("hash_sha256", "hash_sha1", "hash_md5"):
@@ -692,9 +698,7 @@ REASONING: [Brief explanation]
 
     @staticmethod
     def _wrap_hits(indicator_type: str, rows: Dict[str, Any]) -> Dict[str, Any]:
-        return {
-            f"{indicator_type}:{value}": data for value, data in rows.items()
-        }
+        return {f"{indicator_type}:{value}": data for value, data in rows.items()}
 
     async def _enrich_ip(self, ip: str) -> Optional[Dict[str, Any]]:
         """Enrich IP address with threat intel."""

--- a/services/daemon/responder.py
+++ b/services/daemon/responder.py
@@ -3,11 +3,11 @@
 import asyncio
 import logging
 from datetime import datetime
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 from core.response.approval_service import ApprovalService
 from core.response.autonomous_response_service import AutonomousResponseService
-from services.daemon.config import ResponseConfig, EscalationConfig
+from services.daemon.config import EscalationConfig, ResponseConfig
 
 logger = logging.getLogger(__name__)
 
@@ -37,9 +37,9 @@ class AutonomousResponder:
             "auto_executed": 0,
             "pending_approval": 0,
             "escalated": 0,
-            "errors": 0
+            "errors": 0,
         }
-    
+
     async def run(self, shutdown_event: asyncio.Event):
         """Run the response handler loop."""
         logger.info("Autonomous responder starting...")
@@ -47,38 +47,35 @@ class AutonomousResponder:
         # Start worker tasks
         workers = [
             asyncio.create_task(self._response_worker(shutdown_event)),
-            asyncio.create_task(self._approved_action_executor(shutdown_event))
+            asyncio.create_task(self._approved_action_executor(shutdown_event)),
         ]
-        
+
         await shutdown_event.wait()
-        
+
         for worker in workers:
             worker.cancel()
-        
+
         await asyncio.gather(*workers, return_exceptions=True)
         logger.info("Autonomous responder stopped")
-    
+
     async def _response_worker(self, shutdown_event: asyncio.Event):
         """Process response candidates from queue."""
         while not shutdown_event.is_set():
             try:
                 try:
-                    item = await asyncio.wait_for(
-                        self.input_queue.get(),
-                        timeout=1.0
-                    )
+                    item = await asyncio.wait_for(self.input_queue.get(), timeout=1.0)
                 except asyncio.TimeoutError:
                     continue
-                
+
                 if item.get("type") == "response_candidate":
                     await self._evaluate_response(item["finding"])
-                    
+
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 logger.error(f"Response worker error: {e}")
                 self.stats["errors"] += 1
-    
+
     async def _approved_action_executor(self, shutdown_event: asyncio.Event):
         """Periodically execute approved actions."""
         while not shutdown_event.is_set():
@@ -86,105 +83,114 @@ class AutonomousResponder:
                 if self.response_config.auto_response_enabled:
                     # Execute approved actions
                     results = self._response_service.execute_approved_actions()
-                    
+
                     for result in results:
                         if result.get("result", {}).get("success"):
                             self.stats["auto_executed"] += 1
-                            logger.info(f"Executed approved action: {result.get('action_id')}")
+                            logger.info(
+                                f"Executed approved action: {result.get('action_id')}"
+                            )
                         else:
                             logger.warning(f"Action execution failed: {result}")
-                
+
             except Exception as e:
                 logger.error(f"Action executor error: {e}")
-            
+
             # Check every 30 seconds
             try:
                 await asyncio.wait_for(shutdown_event.wait(), timeout=30)
                 break
             except asyncio.TimeoutError:
                 pass
-    
+
     async def _evaluate_response(self, finding: Dict[str, Any]):
         """Evaluate finding and determine response action."""
         finding_id = finding.get("finding_id", "unknown")
         self.stats["evaluated"] += 1
-        
+
         logger.debug(f"Evaluating response for finding {finding_id}")
-        
+
         if not self.response_config.auto_response_enabled:
             logger.debug("Auto-response disabled, skipping")
             return
-        
+
         # Extract relevant data
         severity = finding.get("severity", "medium").lower()
         confidence = finding.get("triage_confidence", 0.5)
         recommended_action = finding.get("recommended_action", "").lower()
         entity_context = finding.get("entity_context", {})
-        
+
         # Determine if response is needed
-        response_action = self._determine_action(severity, confidence, recommended_action)
-        
+        response_action = self._determine_action(
+            severity, confidence, recommended_action
+        )
+
         if not response_action:
             logger.debug(f"No response action needed for {finding_id}")
             return
-        
+
         # Check if escalation is needed
         should_escalate = self._should_escalate(severity, confidence)
-        
+
         if should_escalate:
             await self._escalate_finding(finding, response_action)
-        
+
         # Create response action
         if response_action in ["isolate", "block"]:
             await self._create_response_action(finding, response_action, entity_context)
-    
-    def _determine_action(self, severity: str, confidence: float, recommended: str) -> Optional[str]:
+
+    def _determine_action(
+        self, severity: str, confidence: float, recommended: str
+    ) -> Optional[str]:
         """Determine what response action to take."""
         # High confidence + recommended isolation/block
         if confidence >= self.response_config.confidence_threshold:
             if recommended in ["isolate", "block"]:
                 return recommended
-        
+
         # Critical severity always warrants action
         if severity == "critical" and confidence >= 0.7:
             return "isolate"
-        
+
         # High severity with good confidence
         if severity == "high" and confidence >= 0.8:
             return "investigate"
-        
+
         return None
-    
+
     def _should_escalate(self, severity: str, confidence: float) -> bool:
         """Determine if finding should be escalated."""
         if not self.escalation_config.enabled:
             return False
-        
+
         return severity in self.escalation_config.escalate_severities
-    
+
     async def _escalate_finding(self, finding: Dict[str, Any], action: str):
         """Escalate finding via configured channels."""
         finding_id = finding.get("finding_id")
         severity = finding.get("severity", "unknown")
         title = finding.get("title", "Security Alert")
-        
+
         message = self._build_escalation_message(finding, action)
-        
+
         # Slack escalation
         if self.escalation_config.slack_enabled:
             await self._send_slack_alert(message, severity)
-        
+
         # PagerDuty escalation
-        if self.escalation_config.pagerduty_enabled and severity in ["critical", "high"]:
+        if self.escalation_config.pagerduty_enabled and severity in [
+            "critical",
+            "high",
+        ]:
             await self._send_pagerduty_alert(title, message, severity)
-        
+
         self.stats["escalated"] += 1
         logger.info(f"Escalated finding {finding_id} (severity: {severity})")
-    
+
     def _build_escalation_message(self, finding: Dict[str, Any], action: str) -> str:
         """Build escalation message."""
         entity_context = finding.get("entity_context", {})
-        
+
         parts = [
             f"**Finding ID:** {finding.get('finding_id')}",
             f"**Severity:** {finding.get('severity', 'unknown').upper()}",
@@ -194,80 +200,89 @@ class AutonomousResponder:
             "",
             "**Affected Entities:**",
         ]
-        
+
         if entity_context.get("src_ips"):
             parts.append(f"- IPs: {', '.join(entity_context['src_ips'][:5])}")
         if entity_context.get("hostnames"):
             parts.append(f"- Hosts: {', '.join(entity_context['hostnames'][:5])}")
         if entity_context.get("usernames"):
             parts.append(f"- Users: {', '.join(entity_context['usernames'][:5])}")
-        
+
         if finding.get("triage_reasoning"):
             parts.extend(["", f"**AI Assessment:** {finding['triage_reasoning']}"])
-        
+
         return "\n".join(parts)
-    
+
     async def _send_slack_alert(self, message: str, severity: str):
         """Send alert to Slack."""
         try:
             from core.config import get_integration_config
-            config = get_integration_config('slack')
-            token = config.get('bot_token')
-            
+
+            config = get_integration_config("slack")
+            token = config.get("bot_token")
+
             if not token:
                 logger.warning("Slack not configured, skipping escalation")
                 return
-            
+
             import httpx
-            
+
             color_map = {
                 "critical": "#ff0000",
                 "high": "#ff9900",
                 "medium": "#ffcc00",
-                "low": "#36a64f"
+                "low": "#36a64f",
             }
-            
+
             response = await asyncio.to_thread(
                 httpx.post,
                 "https://slack.com/api/chat.postMessage",
-                headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
                 json={
                     "channel": self.escalation_config.slack_channel,
-                    "attachments": [{
-                        "color": color_map.get(severity, "#808080"),
-                        "title": f"🚨 SOC Alert - {severity.upper()}",
-                        "text": message,
-                        "footer": "AI-SOC Daemon",
-                        "ts": datetime.utcnow().timestamp()
-                    }]
+                    "attachments": [
+                        {
+                            "color": color_map.get(severity, "#808080"),
+                            "title": f"🚨 SOC Alert - {severity.upper()}",
+                            "text": message,
+                            "footer": "AI-SOC Daemon",
+                            "ts": datetime.utcnow().timestamp(),
+                        }
+                    ],
                 },
                 timeout=30,
                 follow_redirects=True,
             )
-            
+
             if response.status_code == 200 and response.json().get("ok"):
                 logger.debug("Slack alert sent successfully")
             else:
                 logger.warning(f"Slack alert failed: {response.text}")
-                
+
         except Exception as e:
             logger.error(f"Slack escalation error: {e}")
-    
+
     async def _send_pagerduty_alert(self, title: str, details: str, severity: str):
         """Send alert to PagerDuty."""
         try:
             from core.config import get_integration_config
-            config = get_integration_config('pagerduty')
-            routing_key = config.get('routing_key') or config.get('integration_key')
-            
+
+            config = get_integration_config("pagerduty")
+            routing_key = config.get("routing_key") or config.get("integration_key")
+
             if not routing_key:
                 logger.warning("PagerDuty not configured, skipping escalation")
                 return
-            
+
             import httpx
-            
-            pd_severity = self.escalation_config.pagerduty_severity_map.get(severity, "warning")
-            
+
+            pd_severity = self.escalation_config.pagerduty_severity_map.get(
+                severity, "warning"
+            )
+
             response = await asyncio.to_thread(
                 httpx.post,
                 "https://events.pagerduty.com/v2/enqueue",
@@ -278,54 +293,53 @@ class AutonomousResponder:
                         "summary": title,
                         "source": "ai-soc-daemon",
                         "severity": pd_severity,
-                        "custom_details": {"details": details}
-                    }
+                        "custom_details": {"details": details},
+                    },
                 },
                 timeout=30,
                 follow_redirects=True,
             )
-            
+
             data = response.json()
             if data.get("status") == "success":
                 logger.debug(f"PagerDuty alert triggered: {data.get('dedup_key')}")
             else:
                 logger.warning(f"PagerDuty alert failed: {data}")
-                
+
         except Exception as e:
             logger.error(f"PagerDuty escalation error: {e}")
-    
+
     async def _create_response_action(
-        self,
-        finding: Dict[str, Any],
-        action_type: str,
-        entity_context: Dict[str, Any]
+        self, finding: Dict[str, Any], action_type: str, entity_context: Dict[str, Any]
     ):
         """Create a response action (pending or auto-approved)."""
         if self.response_config.dry_run:
-            logger.info(f"[DRY RUN] Would create {action_type} action for finding {finding.get('finding_id')}")
+            logger.info(
+                f"[DRY RUN] Would create {action_type} action for finding {finding.get('finding_id')}"
+            )
             return
-        
+
         finding_id = finding.get("finding_id")
         confidence = finding.get("triage_confidence", 0.5)
-        
+
         # Get target
         target_ip = None
         hostname = None
-        
+
         if entity_context.get("src_ips"):
             target_ip = entity_context["src_ips"][0]
         if entity_context.get("hostnames"):
             hostname = entity_context["hostnames"][0]
-        
+
         if not target_ip and not hostname:
             logger.warning(f"No target available for response action on {finding_id}")
             return
-        
+
         # Build correlation data
         correlation_data = self._response_service.correlate_alerts(
             tempo_flow_alert=finding
         )
-        
+
         # Create the action
         result = self._response_service.create_isolation_action(
             ip_address=target_ip or "unknown",
@@ -333,9 +347,9 @@ class AutonomousResponder:
             confidence=confidence,
             reason=f"Automated response to {finding_id}",
             evidence=[finding_id],
-            correlation_data=correlation_data
+            correlation_data=correlation_data,
         )
-        
+
         if result:
             if result.get("status") == "executed":
                 self.stats["auto_executed"] += 1

--- a/services/daemon/sandbox_submitter.py
+++ b/services/daemon/sandbox_submitter.py
@@ -24,10 +24,11 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional
-from core.config import get_settings
-from core.secrets import get_secret
 
 import httpx
+
+from core.config import get_settings
+from core.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 

--- a/services/daemon/scheduler.py
+++ b/services/daemon/scheduler.py
@@ -2,9 +2,9 @@
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
-from typing import Optional, Dict, List, Any, Callable
 from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Callable, Dict, List, Optional
 
 from core.config import get_settings
 from services.daemon.config import SchedulerConfig
@@ -23,6 +23,7 @@ def _sandbox_poll_interval() -> int:
 @dataclass
 class ScheduledTask:
     """Represents a scheduled task."""
+
     name: str
     func: Callable
     interval: int  # seconds
@@ -33,110 +34,125 @@ class ScheduledTask:
 
 class TaskScheduler:
     """Manages periodic tasks for the SOC daemon."""
-    
+
     def __init__(self, config: SchedulerConfig):
         self.config = config
         self._tasks: List[ScheduledTask] = []
-        
+
         # Services (lazy loaded)
         self._data_service = None
         self._claude_service = None
-        
+
         # Stats
         self.stats = {
             "tasks_run": 0,
             "threat_hunts": 0,
             "reports_generated": 0,
             "cleanups_run": 0,
-            "errors": 0
+            "errors": 0,
         }
-        
+
         # Register default tasks
         self._register_default_tasks()
-    
+
     def _register_default_tasks(self):
         """Register default scheduled tasks."""
         if self.config.threat_hunt_enabled:
-            self._tasks.append(ScheduledTask(
-                name="threat_hunt",
-                func=self._run_threat_hunt,
-                interval=self.config.threat_hunt_interval,
-                enabled=True,
-                run_on_start=False
-            ))
-        
+            self._tasks.append(
+                ScheduledTask(
+                    name="threat_hunt",
+                    func=self._run_threat_hunt,
+                    interval=self.config.threat_hunt_interval,
+                    enabled=True,
+                    run_on_start=False,
+                )
+            )
+
         if self.config.report_generation_enabled:
-            self._tasks.append(ScheduledTask(
-                name="weekly_report",
-                func=self._generate_report,
-                interval=self.config.report_interval,
-                enabled=True,
-                run_on_start=False
-            ))
-        
+            self._tasks.append(
+                ScheduledTask(
+                    name="weekly_report",
+                    func=self._generate_report,
+                    interval=self.config.report_interval,
+                    enabled=True,
+                    run_on_start=False,
+                )
+            )
+
         if self.config.cleanup_enabled:
-            self._tasks.append(ScheduledTask(
-                name="cleanup",
-                func=self._run_cleanup,
-                interval=self.config.cleanup_interval,
-                enabled=True,
-                run_on_start=False
-            ))
-        
+            self._tasks.append(
+                ScheduledTask(
+                    name="cleanup",
+                    func=self._run_cleanup,
+                    interval=self.config.cleanup_interval,
+                    enabled=True,
+                    run_on_start=False,
+                )
+            )
+
         # Health check task (every 5 minutes)
-        self._tasks.append(ScheduledTask(
-            name="health_check",
-            func=self._run_health_check,
-            interval=300,
-            enabled=True,
-            run_on_start=True
-        ))
+        self._tasks.append(
+            ScheduledTask(
+                name="health_check",
+                func=self._run_health_check,
+                interval=300,
+                enabled=True,
+                run_on_start=True,
+            )
+        )
 
         # Sandbox poller — only runs when auto-submit is enabled
         if _sandbox_poll_enabled():
-            self._tasks.append(ScheduledTask(
-                name="sandbox_poll",
-                func=self._run_sandbox_poll,
-                interval=_sandbox_poll_interval(),
-                enabled=True,
-                run_on_start=False,
-            ))
+            self._tasks.append(
+                ScheduledTask(
+                    name="sandbox_poll",
+                    func=self._run_sandbox_poll,
+                    interval=_sandbox_poll_interval(),
+                    enabled=True,
+                    run_on_start=False,
+                )
+            )
 
         # Threat-feed poller — only runs when the Cloudforce One integration is enabled.
         try:
             from services.daemon.threat_feed_poller import ThreatFeedPoller
+
             if ThreatFeedPoller.is_enabled():
-                self._tasks.append(ScheduledTask(
-                    name="threat_feed_poll",
-                    func=self._run_threat_feed_poll,
-                    interval=ThreatFeedPoller.poll_interval_seconds(),
-                    enabled=True,
-                    run_on_start=True,
-                ))
+                self._tasks.append(
+                    ScheduledTask(
+                        name="threat_feed_poll",
+                        func=self._run_threat_feed_poll,
+                        interval=ThreatFeedPoller.poll_interval_seconds(),
+                        enabled=True,
+                        run_on_start=True,
+                    )
+                )
         except Exception as e:  # noqa: BLE001
             logger.warning(f"Threat feed poller unavailable: {e}")
-    
+
     def _init_services(self):
         """Initialize required services."""
         try:
             from core.storage.database_data_service import DatabaseDataService
+
             self._data_service = DatabaseDataService()
             logger.info("Database service initialized for scheduler")
         except Exception as e:
             logger.error(f"Failed to initialize database service: {e}")
-        
+
         try:
             from core.llm.harness.claude import ClaudeService
+
             self._claude_service = ClaudeService()
             logger.info("Claude service initialized for scheduler")
         except Exception as e:
             logger.warning(f"Failed to initialize Claude service: {e}")
-    
+
     async def run(self, shutdown_event: asyncio.Event):
         """Run the scheduler loop."""
         logger.info("Task scheduler starting...")
         self._init_services()
-        
+
         # Run startup tasks
         for task in self._tasks:
             if task.run_on_start and task.enabled:
@@ -145,21 +161,21 @@ class TaskScheduler:
                     task.last_run = datetime.utcnow()
                 except Exception as e:
                     logger.error(f"Startup task {task.name} failed: {e}")
-        
+
         # Main scheduling loop
         while not shutdown_event.is_set():
             now = datetime.utcnow()
-            
+
             for task in self._tasks:
                 if not task.enabled:
                     continue
-                
+
                 # Check if task should run
                 should_run = (
-                    task.last_run is None or
-                    (now - task.last_run).total_seconds() >= task.interval
+                    task.last_run is None
+                    or (now - task.last_run).total_seconds() >= task.interval
                 )
-                
+
                 if should_run:
                     try:
                         logger.info(f"Running scheduled task: {task.name}")
@@ -169,158 +185,158 @@ class TaskScheduler:
                     except Exception as e:
                         logger.error(f"Scheduled task {task.name} failed: {e}")
                         self.stats["errors"] += 1
-            
+
             # Check every minute
             try:
                 await asyncio.wait_for(shutdown_event.wait(), timeout=60)
                 break
             except asyncio.TimeoutError:
                 pass
-        
+
         logger.info("Task scheduler stopped")
-    
+
     async def _run_threat_hunt(self):
         """Execute periodic threat hunting queries."""
         logger.info("Starting scheduled threat hunt...")
         self.stats["threat_hunts"] += 1
-        
+
         if not self._data_service:
             logger.warning("Data service not available for threat hunt")
             return
-        
+
         # Get recent findings for analysis
         findings = self._data_service.get_findings()
         if not findings:
             logger.info("No findings to analyze for threat hunt")
             return
-        
+
         # Analyze patterns in recent findings
         analysis = await self._analyze_finding_patterns(findings)
-        
+
         # Look for indicators of compromise across data
         iocs = self._extract_iocs(findings)
-        
+
         # Query for related activity (if Splunk is available)
         await self._hunt_for_iocs(iocs)
-        
+
         # Generate threat hunt summary
         summary = {
             "timestamp": datetime.utcnow().isoformat(),
             "findings_analyzed": len(findings),
             "patterns_detected": analysis.get("patterns", []),
             "iocs_found": len(iocs),
-            "recommendations": analysis.get("recommendations", [])
+            "recommendations": analysis.get("recommendations", []),
         }
-        
+
         logger.info(f"Threat hunt complete: {summary}")
         return summary
-    
+
     async def _analyze_finding_patterns(self, findings: List[Dict]) -> Dict[str, Any]:
         """Analyze patterns in findings."""
         patterns = []
         recommendations = []
-        
+
         # Group by MITRE technique
         technique_counts = {}
         for finding in findings:
             mitre = finding.get("mitre_predictions", {})
             for technique in mitre.keys():
                 technique_counts[technique] = technique_counts.get(technique, 0) + 1
-        
+
         # Identify common techniques
-        for technique, count in sorted(technique_counts.items(), key=lambda x: -x[1])[:5]:
+        for technique, count in sorted(technique_counts.items(), key=lambda x: -x[1])[
+            :5
+        ]:
             if count >= 3:
-                patterns.append({
-                    "type": "common_technique",
-                    "technique": technique,
-                    "count": count
-                })
-                recommendations.append(f"Review defenses for {technique} (seen {count} times)")
-        
+                patterns.append(
+                    {"type": "common_technique", "technique": technique, "count": count}
+                )
+                recommendations.append(
+                    f"Review defenses for {technique} (seen {count} times)"
+                )
+
         # Group by severity
         severity_counts = {}
         for finding in findings:
             sev = finding.get("severity", "unknown")
             severity_counts[sev] = severity_counts.get(sev, 0) + 1
-        
+
         critical_count = severity_counts.get("critical", 0)
-        
+
         if critical_count > 5:
-            patterns.append({
-                "type": "severity_spike",
-                "severity": "critical",
-                "count": critical_count
-            })
-            recommendations.append(f"Investigate spike in critical findings ({critical_count})")
-        
+            patterns.append(
+                {
+                    "type": "severity_spike",
+                    "severity": "critical",
+                    "count": critical_count,
+                }
+            )
+            recommendations.append(
+                f"Investigate spike in critical findings ({critical_count})"
+            )
+
         return {
             "patterns": patterns,
             "severity_distribution": severity_counts,
             "technique_distribution": technique_counts,
-            "recommendations": recommendations
+            "recommendations": recommendations,
         }
-    
+
     def _extract_iocs(self, findings: List[Dict]) -> Dict[str, List[str]]:
         """Extract IOCs from findings."""
-        iocs = {
-            "ips": set(),
-            "domains": set(),
-            "hashes": set(),
-            "users": set()
-        }
-        
+        iocs = {"ips": set(), "domains": set(), "hashes": set(), "users": set()}
+
         for finding in findings:
             context = finding.get("entity_context", {})
-            
+
             for ip in context.get("src_ips", []):
                 if ip and not ip.startswith(("10.", "192.168.", "172.")):
                     iocs["ips"].add(ip)
-            
+
             for ip in context.get("dest_ips", []):
                 if ip and not ip.startswith(("10.", "192.168.", "172.")):
                     iocs["ips"].add(ip)
-            
+
             for domain in context.get("domains", []):
                 iocs["domains"].add(domain)
-            
+
             for hash_val in context.get("file_hashes", []):
                 iocs["hashes"].add(hash_val)
-            
+
             for user in context.get("usernames", []):
                 iocs["users"].add(user)
-        
+
         return {k: list(v) for k, v in iocs.items()}
-    
+
     async def _hunt_for_iocs(self, iocs: Dict[str, List[str]]):
         """Hunt for IOCs in connected systems."""
         # This would query Splunk/SIEM for IOC matches
         # For now, just log
         total_iocs = sum(len(v) for v in iocs.values())
         logger.info(f"Hunting for {total_iocs} IOCs across systems")
-    
+
     async def _generate_report(self):
         """Generate periodic summary report."""
         logger.info("Generating scheduled report...")
         self.stats["reports_generated"] += 1
-        
+
         if not self._data_service:
             logger.warning("Data service not available for report generation")
             return
-        
+
         # Gather data for report
         findings = self._data_service.get_findings()
         cases = self._data_service.get_cases()
-        
+
         # Calculate time range (last week)
         now = datetime.utcnow()
         week_ago = now - timedelta(days=7)
-        
+
         # Filter to recent findings
         recent_findings = [
-            f for f in findings
-            if self._parse_timestamp(f.get("timestamp")) >= week_ago
+            f for f in findings if self._parse_timestamp(f.get("timestamp")) >= week_ago
         ]
-        
+
         # Build report
         report = {
             "generated_at": now.isoformat(),
@@ -329,29 +345,35 @@ class TaskScheduler:
             "summary": {
                 "total_findings": len(recent_findings),
                 "total_cases": len(cases),
-                "critical_findings": len([f for f in recent_findings if f.get("severity") == "critical"]),
-                "high_findings": len([f for f in recent_findings if f.get("severity") == "high"]),
+                "critical_findings": len(
+                    [f for f in recent_findings if f.get("severity") == "critical"]
+                ),
+                "high_findings": len(
+                    [f for f in recent_findings if f.get("severity") == "high"]
+                ),
             },
             "top_techniques": self._get_top_techniques(recent_findings, 5),
-            "data_sources": self._get_data_source_breakdown(recent_findings)
+            "data_sources": self._get_data_source_breakdown(recent_findings),
         }
-        
+
         logger.info(f"Report generated: {report['summary']}")
-        
+
         # Could send report via email/Slack here
         return report
-    
+
     def _parse_timestamp(self, ts: Any) -> datetime:
         """Parse timestamp to datetime."""
         if isinstance(ts, datetime):
             return ts
         if isinstance(ts, str):
             try:
-                return datetime.fromisoformat(ts.replace("Z", "+00:00").replace("+00:00", ""))
+                return datetime.fromisoformat(
+                    ts.replace("Z", "+00:00").replace("+00:00", "")
+                )
             except ValueError:
                 pass
         return datetime.min
-    
+
     def _get_top_techniques(self, findings: List[Dict], limit: int) -> List[Dict]:
         """Get top MITRE techniques from findings."""
         technique_counts = {}
@@ -359,10 +381,12 @@ class TaskScheduler:
             mitre = finding.get("mitre_predictions", {})
             for technique in mitre.keys():
                 technique_counts[technique] = technique_counts.get(technique, 0) + 1
-        
-        sorted_techniques = sorted(technique_counts.items(), key=lambda x: -x[1])[:limit]
+
+        sorted_techniques = sorted(technique_counts.items(), key=lambda x: -x[1])[
+            :limit
+        ]
         return [{"technique": t, "count": c} for t, c in sorted_techniques]
-    
+
     def _get_data_source_breakdown(self, findings: List[Dict]) -> Dict[str, int]:
         """Get finding counts by data source."""
         source_counts = {}
@@ -370,23 +394,23 @@ class TaskScheduler:
             source = finding.get("data_source", "unknown")
             source_counts[source] = source_counts.get(source, 0) + 1
         return source_counts
-    
+
     async def _run_cleanup(self):
         """Clean up old data."""
         logger.info("Running scheduled cleanup...")
         self.stats["cleanups_run"] += 1
-        
+
         # Calculate cutoff date
         cutoff = datetime.utcnow() - timedelta(days=self.config.cleanup_retention_days)
-        
+
         # For now, just log what would be cleaned
         # In production, would delete old findings/processed events
         logger.info(f"Cleanup would remove data older than {cutoff.isoformat()}")
-        
+
         # Dedup sets are pruned by RedisDedupSet itself (TTL + size cap)
 
         return {"cutoff_date": cutoff.isoformat()}
-    
+
     async def _run_sandbox_poll(self):
         """Advance pending sandbox submissions to completed reports."""
         try:
@@ -416,27 +440,27 @@ class TaskScheduler:
     async def _run_health_check(self):
         """Run system health check."""
         logger.info("Running health check...")
-        
+
         health = {
             "timestamp": datetime.utcnow().isoformat(),
             "status": "healthy",
-            "components": {}
+            "components": {},
         }
-        
+
         # Check database
         try:
             if self._data_service:
                 findings = self._data_service.get_findings()
                 health["components"]["database"] = {
                     "status": "healthy",
-                    "findings_count": len(findings) if findings else 0
+                    "findings_count": len(findings) if findings else 0,
                 }
             else:
                 health["components"]["database"] = {"status": "unavailable"}
         except Exception as e:
             health["components"]["database"] = {"status": "error", "error": str(e)}
             health["status"] = "degraded"
-        
+
         # Check Claude service
         try:
             if self._claude_service:
@@ -445,6 +469,6 @@ class TaskScheduler:
                 health["components"]["claude"] = {"status": "unavailable"}
         except Exception as e:
             health["components"]["claude"] = {"status": "error", "error": str(e)}
-        
+
         logger.info(f"Health check: {health['status']}")
         return health

--- a/services/daemon/shared_intel.py
+++ b/services/daemon/shared_intel.py
@@ -18,6 +18,7 @@ def _get_mempalace_searcher():
         return None
     try:
         from mempalace.searcher import search_memories
+
         from core.platform.mempalace_paths import get_palace_path
 
         data_dir = get_palace_path()

--- a/services/daemon/threat_feed_poller.py
+++ b/services/daemon/threat_feed_poller.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
+
 from core.config import get_settings
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,13 @@ class ThreatFeedPoller:
     """Pull STIX 2.1 indicators from configured TAXII collections."""
 
     def __init__(self) -> None:
-        self.stats = {"runs": 0, "indicators_seen": 0, "inserted": 0, "updated": 0, "errors": 0}
+        self.stats = {
+            "runs": 0,
+            "indicators_seen": 0,
+            "inserted": 0,
+            "updated": 0,
+            "errors": 0,
+        }
 
     @staticmethod
     def is_enabled() -> bool:
@@ -41,6 +48,7 @@ class ThreatFeedPoller:
 
         try:
             from core.config import get_integration_config
+
             cfg = get_integration_config("cloudforce_one") or {}
             raw = cfg.get("poll_interval_seconds")
         except Exception:  # noqa: BLE001
@@ -72,7 +80,9 @@ class ThreatFeedPoller:
         collection_ids_raw = cfg.get("collection_ids") or ""
 
         if not api_token or not server_url or not collection_ids_raw:
-            logger.info("Cloudforce One configured but missing token/url/collections; skipping")
+            logger.info(
+                "Cloudforce One configured but missing token/url/collections; skipping"
+            )
             return {"skipped": "incomplete_config"}
 
         collection_ids: List[str] = [

--- a/services/daemon/workdir.py
+++ b/services/daemon/workdir.py
@@ -12,11 +12,11 @@ logger = logging.getLogger(__name__)
 
 class WorkdirManager:
     """Manages working directories for sub-agent investigations.
-    
+
     Each investigation gets an isolated directory with structured files
     that the agent reads/writes during its execution loop.
     """
-    
+
     REQUIRED_FILES = {
         "plan.md": "",
         "state.json": "{}",
@@ -27,36 +27,35 @@ class WorkdirManager:
         "log.jsonl": "",
         "review.md": "",
     }
-    
+
     def __init__(self, base_dir: str = "data/investigations"):
         self.base_dir = Path(base_dir)
         self.base_dir.mkdir(parents=True, exist_ok=True)
-    
+
     def create(self, investigation_id: str) -> Path:
         workdir = self.base_dir / investigation_id
         workdir.mkdir(parents=True, exist_ok=True)
         (workdir / "evidence").mkdir(exist_ok=True)
         (workdir / "evidence" / "query_results").mkdir(exist_ok=True)
         (workdir / "evidence" / "enrichments").mkdir(exist_ok=True)
-        
+
         for filename, default_content in self.REQUIRED_FILES.items():
             filepath = workdir / filename
             if not filepath.exists():
                 filepath.write_text(default_content, encoding="utf-8")
-        
+
         logger.info(f"Created working directory: {workdir}")
         return workdir
-    
+
     def exists(self, investigation_id: str) -> bool:
         return (self.base_dir / investigation_id).is_dir()
-    
-    
+
     def read_file(self, investigation_id: str, filename: str) -> str:
         filepath = self._safe_path(investigation_id, filename)
         if filepath and filepath.exists():
             return filepath.read_text(encoding="utf-8")
         return ""
-    
+
     def write_file(self, investigation_id: str, filename: str, content: str) -> bool:
         filepath = self._safe_path(investigation_id, filename)
         if not filepath:
@@ -64,7 +63,7 @@ class WorkdirManager:
         filepath.parent.mkdir(parents=True, exist_ok=True)
         filepath.write_text(content, encoding="utf-8")
         return True
-    
+
     def append_file(self, investigation_id: str, filename: str, content: str) -> bool:
         filepath = self._safe_path(investigation_id, filename)
         if not filepath:
@@ -72,7 +71,7 @@ class WorkdirManager:
         with open(filepath, "a", encoding="utf-8") as f:
             f.write(content)
         return True
-    
+
     def list_files(self, investigation_id: str) -> List[str]:
         workdir = self.base_dir / investigation_id
         if not workdir.is_dir():
@@ -82,7 +81,7 @@ class WorkdirManager:
             if p.is_file():
                 result.append(str(p.relative_to(workdir)))
         return result
-    
+
     def read_state(self, investigation_id: str) -> Dict[str, Any]:
         raw = self.read_file(investigation_id, "state.json")
         if not raw.strip():
@@ -92,18 +91,19 @@ class WorkdirManager:
         except json.JSONDecodeError:
             logger.warning(f"Corrupt state.json for {investigation_id}")
             return {}
-    
+
     def write_state(self, investigation_id: str, state: Dict[str, Any]):
-        self.write_file(investigation_id, "state.json", json.dumps(state, indent=2, default=str))
-    
-    
-    
+        self.write_file(
+            investigation_id, "state.json", json.dumps(state, indent=2, default=str)
+        )
+
     def append_log(self, investigation_id: str, event: Dict[str, Any]):
         event.setdefault("ts", datetime.utcnow().isoformat())
         event.setdefault("vigil.investigation.id", investigation_id)
         # Embed current OTEL trace context so log lines are correlatable in Jaeger/Grafana
         try:
             from opentelemetry import trace
+
             span = trace.get_current_span()
             ctx = span.get_span_context()
             if ctx and ctx.is_valid:
@@ -113,7 +113,7 @@ class WorkdirManager:
             pass
         line = json.dumps(event, default=str) + "\n"
         self.append_file(investigation_id, "log.jsonl", line)
-    
+
     def get_log(self, investigation_id: str, tail: int = 50) -> List[Dict]:
         raw = self.read_file(investigation_id, "log.jsonl")
         if not raw.strip():
@@ -126,7 +126,7 @@ class WorkdirManager:
             except json.JSONDecodeError:
                 continue
         return entries
-    
+
     def get_disk_usage(self, investigation_id: str) -> int:
         """Return total bytes used by investigation directory."""
         workdir = self.base_dir / investigation_id
@@ -137,7 +137,7 @@ class WorkdirManager:
             if p.is_file():
                 total += p.stat().st_size
         return total
-    
+
     def archive(self, investigation_id: str) -> Optional[Path]:
         workdir = self.base_dir / investigation_id
         if not workdir.is_dir():
@@ -148,7 +148,7 @@ class WorkdirManager:
         shutil.move(str(workdir), str(dest))
         logger.info(f"Archived investigation {investigation_id}")
         return dest
-    
+
     def _safe_path(self, investigation_id: str, filename: str) -> Optional[Path]:
         """Prevent path traversal attacks."""
         workdir = self.base_dir / investigation_id

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,27 @@
 [flake8]
-max-line-length = 88
+max-line-length = 120
+# Black owns line length: it wraps code at 88, and E501 then only ever fires on
+# a string it cannot split, where the rule says nothing. E203 contradicts black's
+# slice spacing and W503 its operator wrapping.
+extend-ignore = E203, W503, E501
 exclude =
     .git,
     __pycache__,
     build,
-    dist
+    dist,
+    venv,
+    node_modules
+per-file-ignores =
+    # The sanctioned sys.path entry has to run before core.* resolves.
+    services/api/main.py:E402
+    services/daemon/main.py:E402
+    # Imports placed after a tracer try/except; moving them risks a cycle.
+    services/daemon/agent_runner.py:E402
+
+[isort]
+# Without this isort produces grid-style wrapping and black immediately undoes
+# it, so --check-only could never pass for both at once.
+profile = black
+line_length = 88
 
 [mypy]


### PR DESCRIPTION
Stacked on #665, which carries the uv migration and the nightly fix. This is the half that touches source, held separately because **merging it is a scheduling decision, not a review one**.

## Merge this when the queue is quiet

161 files. It overlaps six open PRs:

| PR | Overlapping files |
|---|---|
| #655 refactor/collapse-error-handling | **48** |
| #638 agent-refactor | **27** |
| #658 exact sequence evidence | 6 |
| #663 tools httpx | 3 |
| #569 schema drift startup | 2 |
| #533 security tests in PR CI | 1 |

Whoever merges this should expect to tell those authors to rebase. Nothing in #665 waits on it.

## What was actually wrong

`flake8`, `black` and `isort` have carried `continue-on-error: true` since they were added, so only `lint-imports` could ever fail the build. The tree drifted to **2383 flake8 violations and 124 files black would rewrite**. They gate from here, which means the cleanup lands in the same change.

Black and isort account for all but 207 of it and change no behaviour. `setup.cfg` becomes the one config both agree on — without `profile = black` they undo each other and neither can pass — and **E501 leaves the selection**: black caps code at 88, so E501 only ever fired on a long string black cannot split, where the rule says nothing.

## The 207 that were real

- **20 SQLAlchemy `== True/False/None` filters → `.is_()`.** These build SQL, so `is None` would have evaluated in Python and silently changed the query. Three of the twenty turned out to be **fetched rows, not columns** — `case_metrics_service` compares instance attributes, where `.is_()` is wrong and plain truthiness is right. flake8 flags both identically, which is why these went one at a time rather than by regex.
- **10 unused imports** removed. The 36 model imports in `core/storage/connection.py` stay with `# noqa: F401` — importing them *is* the `Base.metadata` registration.
- 9 f-strings with no placeholders, 13 trailing-whitespace lines inside string literals, one `l` as a variable name.

`mypy` and `eslint` stay advisory. An annotation backlog is real work, not a formatting pass.

## Verification

`flake8`, `black --check` and `isort --check-only` all clean on `services/` and `core/`. 1483 unit + security passed; 84 integration passed against real Postgres and Redis. The `.is_()` conversions are the only behavioural risk and the SLA/case suites cover them.