### PR TITLE
chore(ci): surface refactor and chore in changelog

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,6 +6,21 @@
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
   "prerelease": false,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "feature", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "refactor", "section": "Code Refactoring" },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "chore", "section": "Miscellaneous Chores" },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true }
+  ],
   "packages": {
     ".": {
       "package-name": "vigil",


### PR DESCRIPTION
Merging #682 did not open a release PR. That was release-please working as designed, not a failure — the [run](https://github.com/Vigil-SOC/vigil/actions/runs/31869661460) ended with:

```
✔ Considering: 2 commits
✔ No user facing commits found since 45939ce7 - skipping
```

Only `feat`, `fix`, `perf` and `revert` count as user-facing by default. `refactor`, `chore`, `docs`, `test`, `ci`, `build` and `style` are hidden, so they neither render in the changelog nor trigger a release. A stretch of pure-refactor merges therefore accumulates on `main` unreleased until something else lands — and during a restructure that stretch can get long. The commits still ship under the eventual tag; they are just invisible in `CHANGELOG.md`, which makes the release PR a lagging indicator of what is actually being released.

## Change

Adds `changelog-sections` to `.github/release-please-config.json`, un-hiding four types:

| Type | Section | Before | After |
|---|---|---|---|
| `refactor` | Code Refactoring | hidden | visible |
| `docs` | Documentation | hidden | visible |
| `chore` | Miscellaneous Chores | hidden | visible |
| `deps` | Dependencies | hidden | visible |

`build`, `ci`, `style` and `test` stay hidden.

## Notes

**The section list is replaced, not extended.** Setting this key discards release-please's built-in defaults, so `feat` / `feature` / `fix` / `perf` / `revert` are restated verbatim. Dropping them from the array would silently remove Features and Bug Fixes from the changelog.

**Version math is unchanged.** Un-hiding a type makes it count toward opening a release PR, but does not change the bump size. Only `feat` and breaking changes move the minor; everything else is a patch. At pre-1.0 with `bump-minor-pre-major: true`, that means `feat` or breaking → 0.6.0, and these newly-visible types → 0.5.1.

**Dependabot becomes visible.** Its commits are `chore(deps): …`, so they will now appear under Miscellaneous Chores. If that proves noisy, setting `"hidden": true` on the `chore` entry alone reverts just that behaviour.

## Expected effect

Merging this is itself a push to `main`, which re-runs the workflow over a range that now holds `refactor(integrations): the descriptor is the registry` (#682) and `chore(deps): update python-multipart requirement` (#676). Both are user-facing under the new config, so a `chore(main): release 0.5.1` PR should open shortly after merge — worth checking that first run to confirm the sections render as intended.