### PR TITLE
fix(config): report invalid startup settings cleanly

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -1,10 +1,12 @@
 import json
 import logging
+import os
+import sys
 from functools import lru_cache
 from pathlib import Path
 from typing import Annotated, Any, List, Optional
 
-from pydantic import field_validator
+from pydantic import ValidationError, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -258,6 +260,23 @@ class Settings(BaseSettings):
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:
     return Settings()
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    details = []
+    for error in exc.errors():
+        loc = ".".join(str(part) for part in error.get("loc", ()))
+        msg = error.get("msg", "invalid value")
+        details.append(f"{loc}: {msg}" if loc else msg)
+    return "; ".join(details) or str(exc).replace("\n", " ")
+
+
+def validate_settings_or_exit() -> Settings:
+    try:
+        return get_settings()
+    except ValidationError as exc:
+        print(f"configuration error: {_format_validation_error(exc)}", file=sys.stderr)
+        sys.exit(os.EX_CONFIG)
 
 
 def is_demo_mode() -> bool:

--- a/core/config.py
+++ b/core/config.py
@@ -268,7 +268,7 @@ def _format_validation_error(exc: ValidationError) -> str:
         loc = ".".join(str(part) for part in error.get("loc", ()))
         msg = error.get("msg", "invalid value")
         details.append(f"{loc}: {msg}" if loc else msg)
-    return "; ".join(details) or str(exc).replace("\n", " ")
+    return "; ".join(details) or "invalid settings"
 
 
 def validate_settings_or_exit() -> Settings:

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -19,6 +19,10 @@ project_root = str(_repo_root)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
+from core.config import get_settings, validate_settings_or_exit
+
+validate_settings_or_exit()
+
 from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -32,7 +36,6 @@ from services.api.middleware.security_headers import SecurityHeadersMiddleware
 
 from services.api.discovery import mount_routers
 from services.api.middleware.auth import get_current_active_user
-from core.config import get_settings
 from core.platform.monitoring import init_sentry, PROMETHEUS_AVAILABLE, get_metrics_response
 
 # Single source of truth for the "require an authenticated active user"

--- a/services/daemon/__init__.py
+++ b/services/daemon/__init__.py
@@ -1,6 +1,22 @@
 """SOC Daemon - Headless autonomous security operations service."""
 
-from services.daemon.config import DaemonConfig
-from services.daemon.main import SOCDaemon
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from services.daemon.config import DaemonConfig
+    from services.daemon.main import SOCDaemon
+
+
+def __getattr__(name: str):
+    if name == "DaemonConfig":
+        from services.daemon.config import DaemonConfig
+
+        return DaemonConfig
+    if name == "SOCDaemon":
+        from services.daemon.main import SOCDaemon
+
+        return SOCDaemon
+    raise AttributeError(name)
+
 
 __all__ = ["DaemonConfig", "SOCDaemon"]

--- a/services/daemon/main.py
+++ b/services/daemon/main.py
@@ -1,16 +1,21 @@
 """SOC Daemon - Main entry point and orchestration."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import signal
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 # Add the repo root to sys.path (this file is services/daemon/main.py).
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from services.daemon.config import DaemonConfig
+from core.config import validate_settings_or_exit
+
+if TYPE_CHECKING:
+    from services.daemon.config import DaemonConfig
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +24,11 @@ class SOCDaemon:
     """Main daemon orchestrator for autonomous SOC operations."""
     
     def __init__(self, config: Optional[DaemonConfig] = None):
-        self.config = config or DaemonConfig.from_env()
+        if config is None:
+            from services.daemon.config import DaemonConfig
+
+            config = DaemonConfig.from_env()
+        self.config = config
         self.config.setup_logging()
 
         # Initialize OTEL telemetry after logging is set up
@@ -202,6 +211,9 @@ class SOCDaemon:
 
 def main():
     """Entry point for the daemon."""
+    validate_settings_or_exit()
+    from services.daemon.config import DaemonConfig
+
     config = DaemonConfig.from_env()
     daemon = SOCDaemon(config)
     

--- a/tests/unit/test_startup_config_validation.py
+++ b/tests/unit/test_startup_config_validation.py
@@ -2,8 +2,18 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import cast
+
+from pydantic import ValidationError
+
+from core.config import _format_validation_error
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _EmptyValidationError:
+    def errors(self) -> list[object]:
+        return []
 
 
 def _run_startup(command: str) -> subprocess.CompletedProcess[str]:
@@ -43,3 +53,9 @@ def test_daemon_entrypoint_reports_labeled_configuration_error():
     assert "daemon_health_port" in result.stderr
     assert "Traceback" not in result.stderr
     assert "ValidationError" not in result.stderr
+
+
+def test_validation_error_formatting_never_falls_back_to_exception_text():
+    error = cast(ValidationError, _EmptyValidationError())
+
+    assert _format_validation_error(error) == "invalid settings"

--- a/tests/unit/test_startup_config_validation.py
+++ b/tests/unit/test_startup_config_validation.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_startup(command: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DAEMON_HEALTH_PORT"] = "not-an-int"
+    env["DEV_MODE"] = "true"
+    env["PYTHONPATH"] = (
+        f"{REPO_ROOT}{os.pathsep}{env['PYTHONPATH']}"
+        if env.get("PYTHONPATH")
+        else str(REPO_ROOT)
+    )
+    return subprocess.run(
+        [sys.executable, "-c", command],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_api_startup_reports_labeled_configuration_error():
+    result = _run_startup("import services.api.main")
+
+    assert result.returncode == os.EX_CONFIG
+    assert result.stderr.count("configuration error:") == 1
+    assert "daemon_health_port" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert "ValidationError" not in result.stderr
+
+
+def test_daemon_entrypoint_reports_labeled_configuration_error():
+    result = _run_startup("from services.daemon.main import main; main()")
+
+    assert result.returncode == os.EX_CONFIG
+    assert result.stderr.count("configuration error:") == 1
+    assert "daemon_health_port" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert "ValidationError" not in result.stderr


### PR DESCRIPTION
## Summary
- validate `Settings` at the daemon and API process boundaries and emit one `configuration error: …` line before configuration-dependent imports proceed
- exit invalid daemon and direct API startup with `os.EX_CONFIG` (78); the API validation lives above its existing import-time settings users so Uvicorn's lifespan handler cannot rewrite the exit code
- make daemon package exports lazy so importing the daemon entry module does not construct settings before its boundary validation
- add subprocess regression coverage for malformed `DAEMON_HEALTH_PORT`

Closes #643.

## Verification
- `uv run --with-requirements <(grep -v '^-e ./mempalace' requirements.txt) python -m pytest tests/unit/api/test_local_startup.py tests/unit/test_startup_config_validation.py -c tests/pytest.ini` — 4 passed
- `uv run --with-requirements <(grep -v '^-e ./mempalace' requirements.txt) python -m pytest tests/unit -c tests/pytest.ini` — 1495 passed, 53 skipped, 2 xfailed; 6 existing approval-workflow tests fail because PostgreSQL is unavailable. The same six tests fail on unmodified `main` with the same connection-refused error.
- `uv run --with-requirements <(grep -v '^-e ./mempalace' requirements.txt) --with import-linter lint-imports` — 3 contracts kept
- `git diff --check` — passed

The repository's standard requirements install is currently blocked in this checkout by `-e ./mempalace`: that directory has neither `pyproject.toml` nor `setup.py`; validation used the identical requirement set with only that unusable editable line excluded.
