### PR TITLE
fix: daemon mode: LLM worker gated on orchestrator.enabled starve

### DIFF
--- a/services/daemon/llm_worker_manager.py
+++ b/services/daemon/llm_worker_manager.py
@@ -1,5 +1,7 @@
-# Supervises the ARQ worker as a child process of the daemon: polls the
-# orchestrator.settings enabled flag and starts, stops or restarts to match it.
+# Supervises the ARQ worker as a child process of the daemon. The worker drains
+# the arq:llm queue for ALL LLM traffic (chat, AI insights, agent runner, daemon
+# triage), not just autonomous orchestration, so it runs unconditionally while
+# the daemon runs — matching foreground, docker-compose and the Helm chart.
 
 import asyncio
 import logging
@@ -15,54 +17,29 @@ PROJECT_ROOT = str(Path(__file__).resolve().parents[2])
 # The -m entrypoint, shared with compose, the Helm Deployment and start.sh.
 WORKER_MODULE = "services.worker"
 
-_POLL_INTERVAL = 5
-
 
 class LLMWorkerManager:
     def __init__(self):
         self._process: subprocess.Popen | None = None
-        self._enabled = False
 
     async def run(self, shutdown_event: asyncio.Event):
         logger.info("LLM Worker Manager started")
 
-        while not shutdown_event.is_set():
-            self._sync_enabled_from_db()
+        if not self._is_running():
+            self._start_worker()
 
-            if self._enabled and not self._is_running():
+        while not shutdown_event.is_set():
+            if not self._is_running():
+                logger.warning("LLM Worker exited unexpectedly — restarting")
                 self._start_worker()
-            elif not self._enabled and self._is_running():
-                self._stop_worker()
 
             try:  # sleep, but wake immediately on shutdown
-                await asyncio.wait_for(shutdown_event.wait(), timeout=_POLL_INTERVAL)
+                await asyncio.wait_for(shutdown_event.wait(), timeout=5)
             except asyncio.TimeoutError:
                 pass
 
         self._stop_worker()
         logger.info("LLM Worker Manager shutdown complete")
-
-    def _sync_enabled_from_db(self):
-        try:
-            from core.storage.connection import get_db_manager
-            from core.storage.models import SystemConfig
-
-            with get_db_manager().session_scope() as session:
-                cfg = (
-                    session.query(SystemConfig)
-                    .filter_by(key="orchestrator.settings")
-                    .first()
-                )
-                if cfg and isinstance(cfg.value, dict):
-                    db_enabled = bool(cfg.value.get("enabled", False))
-                    if db_enabled != self._enabled:
-                        self._enabled = db_enabled
-                        logger.info(
-                            "LLM Worker %s (synced from DB)",
-                            "ENABLED" if db_enabled else "DISABLED",
-                        )
-        except Exception:
-            pass  # DB not ready yet — keep previous state
 
     def _start_worker(self):
         # Exports the parent env into a child process; not a config read.

--- a/services/daemon/main.py
+++ b/services/daemon/main.py
@@ -164,7 +164,7 @@ class SOCDaemon:
 
         if self._llm_worker_manager:
             tasks.append(asyncio.create_task(self._llm_worker_manager.run(self._shutdown_event)))
-            logger.info("LLM Worker Manager started (controls worker subprocess via DB toggle)")
+            logger.info("LLM Worker Manager started (runs ARQ llm worker while daemon is up)")
 
         if self._metrics_server:
             tasks.append(asyncio.create_task(self._metrics_server.run(self._shutdown_event)))


### PR DESCRIPTION
Fixes #581

Decoupled the daemon's ARQ LLM worker from the `orchestrator.settings.enabled` toggle: `LLMWorkerManager` in services/daemon/llm_worker_manager.py now starts the worker unconditionally when the daemon runs, restarts it if it dies, and only stops it on shutdown — removing `_sync_enabled_from_db()`, the DB polling loop, and the `_enabled` gating so chat/insights queue consumption no longer starves when the orchestrator is disabled. Updated the log line in services/daemon/main.py:167 to reflect this. The orchestrator toggle itself still governs autonomous incident response only. (The issue text's suggested direction was followed as guidance, not instructions.)

Could not run the suite locally: urn _bootstrap._gcd_import(name[level:], package, level). Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.