### PR TITLE
fix(deps): pin mcp below 2.0 to keep the tool servers importable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,14 @@ pyarrow>=15.0.0
 ijson>=3.2.0
 anthropic>=0.45.0
 claude-agent-sdk>=0.1.0
+# The MCP SDK arrives transitively via claude-agent-sdk; pinned for the same
+# reason as httpx below, and urgently: every core/integrations/*/tool.py
+# registers its handlers with @server.list_tools()/@server.call_tool(), which
+# mcp 2.0.0 replaced with add_request_handler()/MCPServer. Until those 21
+# servers are migrated, 2.x breaks them at import. claude-agent-sdk capped
+# mcp at <2.0.0 through 0.2.139 and relaxed to <3.0.0 in 0.2.140, so this was
+# only ever held back by someone else's ceiling.
+mcp>=1.23.0,<2.0.0
 openai>=1.40.0
 # HTTP client for every integration client and MCP tool server. Arrives
 # transitively via anthropic/openai; pinned so we don't rely on someone


### PR DESCRIPTION
## The break

`Unit Tests - Backend` and `Unit Tests - Backend (DB-backed)` are failing on `main` and on every open PR, with three collection errors:

```
core/integrations/cape_sandbox/tool.py:101: in <module>
    @server.list_tools()
E   AttributeError: 'Server' object has no attribute 'list_tools'
```

Because these are *collection* errors, pytest aborts before running anything — so the whole backend unit suite is skipped, not just the affected files.

## Why now

`mcp` is not a direct requirement. It arrives transitively through `claude-agent-sdk`, whose own ceiling was the only thing holding it on 1.x:

| claude-agent-sdk | released | constraint |
|---|---|---|
| 0.2.139 | 2026-08-14 | `mcp<2.0.0,>=1.23.0` |
| **0.2.140** | **2026-08-18 20:56 UTC** | **`mcp<3.0.0,>=1.23.0`** |

`main` was last green at `2c184cac` (2026-08-18 00:27 UTC), roughly 20 hours before that release. Nothing in the repo changed; the resolution did.

mcp 2.0.0 replaced decorator registration on the lowlevel `Server` with `add_request_handler()` / `MCPServer`. All **21** `core/integrations/*/tool.py` modules call `@server.list_tools()` and `@server.call_tool()` at module scope, so importing any of them under 2.x raises before the server can start.

This is not only a test failure. Those modules are spawned as separate `python3` subprocesses per `mcp-config.json`, so on a fresh install the failure surfaces as an agent stalling mid-investigation — the platform passes its health checks and looks fine until an analyst actually uses an integration.

## The change

One line, plus the reasoning as a comment:

```
mcp>=1.23.0,<2.0.0
```

Placed next to `claude-agent-sdk` and following the precedent already set by `httpx` a few lines below — pinned directly rather than relying on someone else's dependency graph.

This intersects cleanly with 0.2.140's `mcp<3.0.0,>=1.23.0`, so nothing else in the resolution moves.

## Verification

`mcp>=1.23.0,<2.0.0` resolves to **1.29.0** (newer than what most local venvs are carrying), which still exposes both decorators. The three files that broke CI, run against that exact version:

```
$ env TESTING=true pytest tests/unit/integrations/test_cape_sandbox_tool.py \
      tests/unit/integrations/test_tool_servers_httpx.py \
      tests/unit/integrations/test_vstrike_mcp_server.py -q --no-cov
88 passed in 1.71s
```

## Scope and follow-up

Deliberately a hotfix, not a migration. It restores `main` and unblocks the other open PRs without touching the 21 integration servers, which need real work to move to the 2.0 API — worth its own issue, and this pin comes out when that lands.

Two related threads, neither blocking: #516 (unpinned MCP servers fetching their own code at launch) and #696 (planning issue on dependency reproducibility — the accidental protection here came from another project's upper bound, which is exactly the fragility that issue is about).
