### PR TITLE
fix(state): one way to locate the state directory

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -151,6 +151,23 @@ if it's runtime plumbing with no owning capability. The cut against a capability
 domain is **mechanism vs. knowledge**: supervising a process, or resolving a
 setting, is `platform`; knowing what the setting *means* is the domain's.
 
+**State Directory**:
+The one per-install directory outside the repo holding everything a Vigil
+install accumulates that the metadata DB does not — credentials, integration
+config, MCP enable flags, detection sources, theme, exports. Defaults to
+`~/.vigil`; `VIGIL_DIR` names it explicitly and is the **only** override.
+Resolved by `vigil_path()` — a mechanism, so it is `platform` by the cut above.
+_Avoid_: config dir, state dir, `.vigil`, "where secrets live", VIGIL_HOME.
+
+**Mirror** vs **Original** (State Directory contents):
+A **Mirror** is a State Directory file the DB is authoritative for — the router
+reads "database first" and writes the file only "for backward compatibility"
+(`theme_config.json`, `s3_config.json`, `integrations_config.json`,
+`general_config.json`). Losing one costs nothing. An **Original** has no DB home,
+so losing the file loses the data: the secrets store, `mcp_server_enabled.json`,
+`detection_sources.json`, `custom_integrations/`. Only Originals constrain where
+the State Directory can live.
+
 ### Agent layer
 
 Vocabulary of `services/agent/` — TypeScript, outside `core/`, but the terms

--- a/clients/desktop/standalone/docker-compose.yml
+++ b/clients/desktop/standalone/docker-compose.yml
@@ -88,18 +88,14 @@ services:
     ports:
       - "127.0.0.1:6987:6987"
     volumes:
-      # HOME is /home/vigil in the image (set beside the uid-1000 user in
-      # Dockerfile.backend, #701), so the encrypted secret store resolves to
-      # /home/vigil/.vigil. Without this volume every UI-configured key dies on
-      # restart. The image pre-creates the dir owned by 1000:1000, so the named
-      # volume inherits that ownership on first mount.
+      # Must track HOME in Dockerfile.backend, or every UI-configured key dies
+      # on restart. The image pre-creates the dir owned by 1000:1000 so a fresh
+      # named volume inherits that; a volume from before #701 does not, and has
+      # to be recreated.
       - vigil_home:/home/vigil/.vigil
-    # core/reporting/logs_router.py writes logs/ relative to the workdir, but /app
-    # is root-owned and the image runs as vigil(1000). Since #376 that router
-    # catches OSError and degrades to console, so a wrong owner here costs the
-    # frontend log file rather than the process. A named volume mounts root-owned;
-    # tmpfs can be given the right owner, and scratch is the correct shape here
-    # since real logs go to stdout. Keep uid/gid in step with Dockerfile.backend.
+    # logs/ is workdir-relative and /app is root-owned, so tmpfs is the only
+    # mount that can carry the right owner. Keep uid/gid in step with
+    # Dockerfile.backend.
     tmpfs:
       - /app/logs:uid=1000,gid=1000
     depends_on:

--- a/clients/desktop/standalone/docker-compose.yml
+++ b/clients/desktop/standalone/docker-compose.yml
@@ -88,16 +88,20 @@ services:
     ports:
       - "127.0.0.1:6987:6987"
     volumes:
-      # HOME is /app in the image, so the encrypted secret store resolves to
-      # /app/.vigil. Without this volume every UI-configured key dies on restart.
-      - vigil_home:/app/.vigil
-    # core/reporting/logs_router.py writes logs/ relative to the workdir, but /app is
-    # root-owned and the image runs as vigil(999), so startup dies on
-    # PermissionError. A named volume mounts root-owned and fails the same way;
+      # HOME is /home/vigil in the image (set beside the uid-1000 user in
+      # Dockerfile.backend, #701), so the encrypted secret store resolves to
+      # /home/vigil/.vigil. Without this volume every UI-configured key dies on
+      # restart. The image pre-creates the dir owned by 1000:1000, so the named
+      # volume inherits that ownership on first mount.
+      - vigil_home:/home/vigil/.vigil
+    # core/reporting/logs_router.py writes logs/ relative to the workdir, but /app
+    # is root-owned and the image runs as vigil(1000). Since #376 that router
+    # catches OSError and degrades to console, so a wrong owner here costs the
+    # frontend log file rather than the process. A named volume mounts root-owned;
     # tmpfs can be given the right owner, and scratch is the correct shape here
-    # since real logs go to stdout.
+    # since real logs go to stdout. Keep uid/gid in step with Dockerfile.backend.
     tmpfs:
-      - /app/logs:uid=999,gid=999
+      - /app/logs:uid=1000,gid=1000
     depends_on:
       postgres:
         condition: service_healthy

--- a/core/config.py
+++ b/core/config.py
@@ -21,22 +21,15 @@ DEFAULT_REDIS_URL = "redis://localhost:6379/0"
 DEFAULT_SANDBOX_FILE_TYPES = "exe,dll,doc,docx,xls,xlsx,pdf,js,vbs,ps1,bat,msi"
 
 
-# The State Directory: one per-install directory holding what the metadata DB
-# does not — credentials, MCP enable flags, detection sources, exports.
+# The State Directory: the one per-install directory holding what the metadata
+# DB does not. VIGIL_DIR if exported, else ~/.vigil — nothing else. A write that
+# cannot happen raises; callers that want to degrade catch it themselves.
 #
-# Exactly two things decide where it is: VIGIL_DIR if exported, else ~/.vigil.
-# #701 briefly added VIGIL_HOME, a HOME=/ container remap, and a silent /tmp
-# fallback on mkdir failure; all three are gone. The /tmp fallback in particular
-# only applied to writes, so a file saved under it was never read back — the
-# save appeared to work and the value vanished. A write that cannot happen now
-# raises, and each caller keeps the policy it already had: telemetry and request
-# logging catch and degrade, the secrets store lets it propagate.
-#
-# Reads still fall back to the legacy ~/.deeptempo copy from before the rename;
-# writes always target the State Directory, so data drifts over on the next save.
+# Reads fall back to the legacy ~/.deeptempo copy from before the rename; writes
+# always target the State Directory, so data drifts over on the next save.
 def vigil_path(*parts: str, write: bool = False) -> Path:
-    # os.environ, not Settings: this resolves at import time, before Settings is
-    # safe to build, so VIGIL_DIR must be exported rather than set in .env.
+    # os.environ, not Settings: resolves before Settings is safe to build, so
+    # VIGIL_DIR must be exported rather than set in .env.
     override = os.environ.get("VIGIL_DIR")  # noqa: ENV001 - pre-Settings bootstrap
     if override:
         target = legacy = Path(override)
@@ -48,10 +41,10 @@ def vigil_path(*parts: str, write: bool = False) -> Path:
     if write:
         (target.parent if parts else target).mkdir(parents=True, exist_ok=True)
         return target
-    # Only ever a per-file read shim. Asked for the directory itself, always
-    # answer with the State Directory — otherwise a caller that stores files
-    # under it (the secrets backend) adopts the legacy copy as its write target.
-    if parts and target != legacy and not target.exists() and legacy.exists():
+    # Only ever a per-file shim. Asked for the directory itself it must answer
+    # with the State Directory, or the secrets backend adopts the legacy copy as
+    # its write target.
+    if parts and not target.exists() and legacy.exists():
         return legacy
     return target
 
@@ -59,19 +52,29 @@ def vigil_path(*parts: str, write: bool = False) -> Path:
 def state_dir_status() -> dict:
     """Where the State Directory resolved to, and whether it can be written.
 
-    Surfaced on /api/health so a misconfigured volume is visible before someone
-    loses a credential to it. #695 was diagnosable only from a traceback, and the
-    /tmp fallback that replaced it was not diagnosable at all.
+    Read-only: never creates the directory, so a health probe cannot be the
+    thing that brings the credential store into existence. A directory that does
+    not exist yet is probed at its nearest existing ancestor, which answers the
+    question that matters — whether the first save will land.
     """
     path = vigil_path()
+    status: dict = {"path": str(path), "exists": path.is_dir()}
+    target = path
+    while not target.is_dir() and target != target.parent:
+        target = target.parent
+    # Unique per process: a shared name races with concurrent health probes,
+    # where one caller's unlink makes the other's look unwritable.
+    probe = target / f".vigil-write-probe.{os.getpid()}"
     try:
-        path.mkdir(parents=True, exist_ok=True)
-        probe = path / ".write-probe"
         probe.touch()
-        probe.unlink()
-        return {"path": str(path), "writable": True}
+        return {**status, "writable": True}
     except OSError as exc:
-        return {"path": str(path), "writable": False, "error": str(exc)}
+        return {**status, "writable": False, "error": str(exc)}
+    finally:
+        try:
+            probe.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/core/config.py
+++ b/core/config.py
@@ -21,44 +21,57 @@ DEFAULT_REDIS_URL = "redis://localhost:6379/0"
 DEFAULT_SANDBOX_FILE_TYPES = "exe,dll,doc,docx,xls,xlsx,pdf,js,vbs,ps1,bat,msi"
 
 
-# Reads prefer ~/.vigil and fall back to the legacy ~/.deeptempo copy; writes
-# always target ~/.vigil, so data drifts over on the next save.
+# The State Directory: one per-install directory holding what the metadata DB
+# does not — credentials, MCP enable flags, detection sources, exports.
+#
+# Exactly two things decide where it is: VIGIL_DIR if exported, else ~/.vigil.
+# #701 briefly added VIGIL_HOME, a HOME=/ container remap, and a silent /tmp
+# fallback on mkdir failure; all three are gone. The /tmp fallback in particular
+# only applied to writes, so a file saved under it was never read back — the
+# save appeared to work and the value vanished. A write that cannot happen now
+# raises, and each caller keeps the policy it already had: telemetry and request
+# logging catch and degrade, the secrets store lets it propagate.
+#
+# Reads still fall back to the legacy ~/.deeptempo copy from before the rename;
+# writes always target the State Directory, so data drifts over on the next save.
 def vigil_path(*parts: str, write: bool = False) -> Path:
-    if "VIGIL_DIR" in os.environ:  # noqa: ENV001
-        target = Path(os.environ["VIGIL_DIR"])  # noqa: ENV001
-        legacy = target
-    elif "VIGIL_HOME" in os.environ:  # noqa: ENV001
-        target = Path(os.environ["VIGIL_HOME"]) / _VIGIL_DIRNAME  # noqa: ENV001
-        legacy = Path(os.environ["VIGIL_HOME"]) / _LEGACY_DIRNAME  # noqa: ENV001
+    # os.environ, not Settings: this resolves at import time, before Settings is
+    # safe to build, so VIGIL_DIR must be exported rather than set in .env.
+    override = os.environ.get("VIGIL_DIR")  # noqa: ENV001 - pre-Settings bootstrap
+    if override:
+        target = legacy = Path(override)
     else:
         home = Path.home()  # per call, so tests can patch home
-        if home == Path("/"):
-            app_dir = Path("/app")
-            if app_dir.is_dir() and os.access(app_dir, os.W_OK):
-                home = app_dir
-            elif os.access("/tmp", os.W_OK):
-                home = Path("/tmp")
-        target = home / _VIGIL_DIRNAME
-        legacy = home / _LEGACY_DIRNAME
+        target, legacy = home / _VIGIL_DIRNAME, home / _LEGACY_DIRNAME
     if parts:
         target, legacy = target.joinpath(*parts), legacy.joinpath(*parts)
     if write:
-        try:
-            (target.parent if parts else target).mkdir(parents=True, exist_ok=True)
-        except OSError as e:
-            logger.warning("Could not create directory for %s: %s; falling back to /tmp", target, e)
-            try:
-                tmp_target = Path("/tmp") / _VIGIL_DIRNAME
-                if parts:
-                    tmp_target = tmp_target.joinpath(*parts)
-                (tmp_target.parent if parts else tmp_target).mkdir(parents=True, exist_ok=True)
-                return tmp_target
-            except OSError:
-                pass
+        (target.parent if parts else target).mkdir(parents=True, exist_ok=True)
         return target
-    if not target.exists() and legacy.exists():
+    # Only ever a per-file read shim. Asked for the directory itself, always
+    # answer with the State Directory — otherwise a caller that stores files
+    # under it (the secrets backend) adopts the legacy copy as its write target.
+    if parts and target != legacy and not target.exists() and legacy.exists():
         return legacy
     return target
+
+
+def state_dir_status() -> dict:
+    """Where the State Directory resolved to, and whether it can be written.
+
+    Surfaced on /api/health so a misconfigured volume is visible before someone
+    loses a credential to it. #695 was diagnosable only from a traceback, and the
+    /tmp fallback that replaced it was not diagnosable at all.
+    """
+    path = vigil_path()
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        probe = path / ".write-probe"
+        probe.touch()
+        probe.unlink()
+        return {"path": str(path), "writable": True}
+    except OSError as exc:
+        return {"path": str(path), "writable": False, "error": str(exc)}
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -85,8 +98,6 @@ class Settings(BaseSettings):
     max_upload_size_mb: int = 500
     vigil_context_path: str = ""
     vigil_frontend_url: str = ""
-    vigil_dir: Optional[str] = None
-    vigil_home: Optional[str] = None
     mempalace_palace_path: Optional[str] = None
     # Call sites disagree on the default (shared_intel off, orchestrator on), so
     # this stays tri-state and each site supplies its own fallback.

--- a/core/detections/detection_rules_service.py
+++ b/core/detections/detection_rules_service.py
@@ -72,12 +72,14 @@ FORMAT_ENV_VARS = {
 }
 
 
+_CONFIG_FILENAME = "detection_sources.json"
+
+
 class DetectionRulesService:
     """Service for managing detection rule sources."""
 
     def __init__(self):
-        self.config_path = vigil_path("detection_sources.json")
-        self.write_path = vigil_path("detection_sources.json", write=True)
+        self.config_path = vigil_path(_CONFIG_FILENAME)
         self.base_dir = Path.home() / "security-detections"
         self.sources: List[Dict[str, Any]] = []
         self._load_config()
@@ -133,8 +135,10 @@ class DetectionRulesService:
         self._save_config()
 
     def _save_config(self):
+        # Resolved here, not in __init__: write=True creates the directory, and
+        # this service is constructed on the API startup path (#695).
         try:
-            with open(self.write_path, "w") as f:
+            with open(vigil_path(_CONFIG_FILENAME, write=True), "w") as f:
                 json.dump({"sources": self.sources, "version": 1}, f, indent=2)
         except Exception as e:
             logger.error(f"Error saving detection sources config: {e}")

--- a/core/integrations/mcp/service.py
+++ b/core/integrations/mcp/service.py
@@ -90,6 +90,10 @@ class MCPServer:
         try:
             # Prepare environment
             env = os.environ.copy()  # noqa: ENV001 - MCP child process env
+            # Children resolve ${VIGIL_DIR} from mcp-config.json, and an unset
+            # var substitutes to "" — which would root their paths at "/". Pin
+            # the parent's resolved State Directory so they cannot differ.
+            env.setdefault("VIGIL_DIR", str(vigil_path()))
             # httpx ignores REQUESTS_CA_BUNDLE, so inheriting it is not enough.
             env.update(ca_bundle_env())
             env.update(self.env)
@@ -213,8 +217,10 @@ class MCPServer:
 class MCPService:
     """Service for managing MCP servers."""
     
-    # Path to persist enabled/disabled state for each MCP server
-    _STATE_FILE = vigil_path("mcp_server_enabled.json")
+    # Resolved per call, never at class-definition time: an import-time write is
+    # what crashed the daemon in #695, and an import-time read would pin the load
+    # path while _save_enabled_state resolves the write path fresh.
+    _STATE_FILENAME = "mcp_server_enabled.json"
     
     def __init__(
         self,
@@ -256,8 +262,9 @@ class MCPService:
     def _load_enabled_state(self) -> Dict[str, bool]:
         """Load the enabled/disabled state from disk. Returns empty dict if no file."""
         try:
-            if self._STATE_FILE.exists():
-                with open(self._STATE_FILE, "r") as f:
+            state_file = vigil_path(self._STATE_FILENAME)
+            if state_file.exists():
+                with open(state_file, "r") as f:
                     data = json.load(f)
                 return data.get("enabled", {})
         except Exception as e:
@@ -267,7 +274,7 @@ class MCPService:
     def _save_enabled_state(self) -> None:
         """Persist the enabled/disabled state to disk."""
         try:
-            write_path = vigil_path("mcp_server_enabled.json", write=True)
+            write_path = vigil_path(self._STATE_FILENAME, write=True)
             with open(write_path, "w") as f:
                 json.dump({"enabled": self._enabled_servers}, f, indent=2)
         except Exception as e:
@@ -415,6 +422,7 @@ class MCPService:
                     # detection scans the raw config above, not this spawn env,
                     # so dormancy behavior is unchanged.
                     env = os.environ.copy()  # noqa: ENV001 - MCP child env
+                    env.setdefault("VIGIL_DIR", str(vigil_path()))
                     # httpx ignores REQUESTS_CA_BUNDLE, so inheriting it is
                     # not enough.
                     env.update(ca_bundle_env())

--- a/core/integrations/mcp/service.py
+++ b/core/integrations/mcp/service.py
@@ -6,7 +6,7 @@ import logging
 import json
 import re
 from pathlib import Path
-from typing import Optional, Dict, List
+from typing import Mapping, Optional, Dict, List
 from datetime import datetime
 import os
 
@@ -26,7 +26,7 @@ _ENV_PLACEHOLDER_RE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)\}")
 
 # Placeholders that are path sentinels, not credentials — never treat as
 # required env vars.
-_PLACEHOLDER_BLACKLIST = {"workspaceFolder", "HOME", "PYTHONPATH"}
+_PLACEHOLDER_BLACKLIST = {"workspaceFolder", "HOME", "PYTHONPATH", "VIGIL_DIR"}
 
 
 def extract_required_env_vars(raw_env: Dict[str, str], raw_args: List[str]) -> List[str]:
@@ -90,10 +90,6 @@ class MCPServer:
         try:
             # Prepare environment
             env = os.environ.copy()  # noqa: ENV001 - MCP child process env
-            # Children resolve ${VIGIL_DIR} from mcp-config.json, and an unset
-            # var substitutes to "" — which would root their paths at "/". Pin
-            # the parent's resolved State Directory so they cannot differ.
-            env.setdefault("VIGIL_DIR", str(vigil_path()))
             # httpx ignores REQUESTS_CA_BUNDLE, so inheriting it is not enough.
             env.update(ca_bundle_env())
             env.update(self.env)
@@ -217,9 +213,9 @@ class MCPServer:
 class MCPService:
     """Service for managing MCP servers."""
     
-    # Resolved per call, never at class-definition time: an import-time write is
-    # what crashed the daemon in #695, and an import-time read would pin the load
-    # path while _save_enabled_state resolves the write path fresh.
+    # A filename, not a path: resolving at class-definition time is what crashed
+    # the daemon in #695, and would pin the read path while the write path
+    # resolves fresh.
     _STATE_FILENAME = "mcp_server_enabled.json"
     
     def __init__(
@@ -307,31 +303,30 @@ class MCPService:
         """Return a dict of server_name -> enabled for every known server."""
         return {name: self.is_server_enabled(name) for name in self.servers}
     
-    def _substitute_env_vars(self, value: str) -> str:
-        """
-        Substitute environment variables in a string.
-        Supports ${VAR_NAME} and ${VAR_NAME:-default} formats.
+    def _substitute_env_vars(
+        self, value: str, env: Optional[Dict[str, str]] = None
+    ) -> str:
+        """Expand ``${VAR}`` and ``${VAR:-default}`` in a config string.
 
-        Args:
-            value: String that may contain environment variable references
-
-        Returns:
-            String with environment variables substituted
+        Resolves against ``env`` — the environment the child is actually spawned
+        with — so anything the spawn site pinned there is seen rather than
+        collapsed to an empty string.
         """
         import re
 
+        source: Mapping[str, str] = os.environ if env is None else env  # noqa: ENV001
         pattern = r'\$\{([^}:]+)(?::-((?:\$\{[^}]+\}|[^{}])*))?\}'
 
         def replace_var(match):
             var_name = match.group(1)
             default = match.group(2)
-            env_val = os.environ.get(var_name)  # noqa: ENV001 - operator export wins
+            env_val = source.get(var_name)  # operator export wins
             if env_val is None:
                 env_val = get_secret(var_name)  # UI-set credential, no restart needed
             if env_val is not None:
                 return env_val
             if default is not None:
-                return self._substitute_env_vars(default)
+                return self._substitute_env_vars(default, env)
             return ''
 
         prev = None
@@ -422,13 +417,15 @@ class MCPService:
                     # detection scans the raw config above, not this spawn env,
                     # so dormancy behavior is unchanged.
                     env = os.environ.copy()  # noqa: ENV001 - MCP child env
+                    # mcp-config.json refers to ${VIGIL_DIR}; an unset var would
+                    # substitute to "" and root child paths at "/".
                     env.setdefault("VIGIL_DIR", str(vigil_path()))
                     # httpx ignores REQUESTS_CA_BUNDLE, so inheriting it is
                     # not enough.
                     env.update(ca_bundle_env())
                     env.update(
                         {
-                            k: self._substitute_env_vars(v)
+                            k: self._substitute_env_vars(v, env)
                             for k, v in raw_env_strs.items()
                         }
                     )
@@ -436,7 +433,7 @@ class MCPService:
 
                     # Get args and perform environment variable substitution
                     raw_args = list(server_config.get("args") or [])
-                    args = [self._substitute_env_vars(arg) for arg in raw_args]
+                    args = [self._substitute_env_vars(arg, env) for arg in raw_args]
 
                     # Capture declared credential placeholders *before*
                     # substitution collapses missing vars to empty strings

--- a/core/secrets_manager.py
+++ b/core/secrets_manager.py
@@ -318,7 +318,6 @@ class EncryptedFileBackend(SecretsBackend):
     are never written to ``.env`` and are not exposed to other processes.
     """
 
-    DEFAULT_DIR = Path.home() / ".vigil"
     SECRETS_FILENAME = "secrets.enc"
     MASTER_KEY_FILENAME = "master.key"
 

--- a/env.example
+++ b/env.example
@@ -267,11 +267,11 @@ VIGIL_CORS_ORIGINS=""
 # "/vigil". Empty serves at the root.
 # VIGIL_CONTEXT_PATH=""
 
-# Explicit directory where Vigil stores runtime state/config (defaults to ~/.vigil).
+# The State Directory: where Vigil keeps credentials, MCP enable flags, detection
+# sources and exports (defaults to ~/.vigil). This is the ONLY override.
+# Resolved before Settings loads, so it must be exported — `export VIGIL_DIR=...`,
+# or a compose/Helm env entry. Setting it in this file has no effect.
 # VIGIL_DIR=""
-
-# Parent home directory containing .vigil (defaults to user home / $HOME).
-# VIGIL_HOME=""
 
 # Ceiling on uploaded evidence/ingest files, in megabytes.
 # MAX_UPLOAD_SIZE_MB=500

--- a/infra/helm/vigil/templates/_env.tpl
+++ b/infra/helm/vigil/templates/_env.tpl
@@ -25,6 +25,16 @@ chart-templated).
     name: {{ include "vigil.secret.fullname" . }}
 {{- end -}}
 
+{{/*
+State Directory. VIGIL_DIR is deliberately NOT in vigil.env: it must only be set
+where the volume is actually mounted, or a workload advertises a path it cannot
+write. Include all three together, or none.
+*/}}
+{{- define "vigil.stateEnv" -}}
+- name: VIGIL_DIR
+  value: {{ .Values.stateDirectory.mountPath | quote }}
+{{- end -}}
+
 {{- define "vigil.stateVolumeMount" -}}
 - name: vigil-state
   mountPath: {{ .Values.stateDirectory.mountPath }}
@@ -36,8 +46,6 @@ chart-templated).
 {{- end -}}
 
 {{- define "vigil.env" -}}
-- name: VIGIL_DIR
-  value: {{ .Values.stateDirectory.mountPath | quote }}
 - name: POSTGRES_HOST
   value: {{ include "vigil.postgres.host" . | quote }}
 - name: POSTGRES_PORT

--- a/infra/helm/vigil/templates/_env.tpl
+++ b/infra/helm/vigil/templates/_env.tpl
@@ -25,9 +25,19 @@ chart-templated).
     name: {{ include "vigil.secret.fullname" . }}
 {{- end -}}
 
+{{- define "vigil.stateVolumeMount" -}}
+- name: vigil-state
+  mountPath: {{ .Values.stateDirectory.mountPath }}
+{{- end -}}
+
+{{- define "vigil.stateVolume" -}}
+- name: vigil-state
+  {{- toYaml .Values.stateDirectory.volume | nindent 2 }}
+{{- end -}}
+
 {{- define "vigil.env" -}}
-- name: HOME
-  value: "/tmp"
+- name: VIGIL_DIR
+  value: {{ .Values.stateDirectory.mountPath | quote }}
 - name: POSTGRES_HOST
   value: {{ include "vigil.postgres.host" . | quote }}
 - name: POSTGRES_PORT

--- a/infra/helm/vigil/templates/backend-deployment.yaml
+++ b/infra/helm/vigil/templates/backend-deployment.yaml
@@ -88,6 +88,10 @@ spec:
             {{- toYaml .Values.backend.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            {{- include "vigil.stateVolumeMount" . | nindent 12 }}
+      volumes:
+        {{- include "vigil.stateVolume" . | nindent 8 }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/infra/helm/vigil/templates/backend-deployment.yaml
+++ b/infra/helm/vigil/templates/backend-deployment.yaml
@@ -47,6 +47,7 @@ spec:
                   name: {{ include "vigil.postgres.passwordSecret" . }}
                   key: {{ include "vigil.postgres.passwordSecretKey" . }}
             {{- include "vigil.env" . | nindent 12 }}
+            {{- include "vigil.stateEnv" . | nindent 12 }}
             {{- range $k, $v := .Values.backend.env }}
             - name: {{ $k }}
               value: {{ $v | quote }}

--- a/infra/helm/vigil/templates/daemon-statefulset.yaml
+++ b/infra/helm/vigil/templates/daemon-statefulset.yaml
@@ -65,6 +65,7 @@ spec:
                   name: {{ include "vigil.postgres.passwordSecret" . }}
                   key: {{ include "vigil.postgres.passwordSecretKey" . }}
             {{- include "vigil.env" . | nindent 12 }}
+            {{- include "vigil.stateEnv" . | nindent 12 }}
             {{- with .Values.daemon.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/infra/helm/vigil/templates/daemon-statefulset.yaml
+++ b/infra/helm/vigil/templates/daemon-statefulset.yaml
@@ -102,11 +102,14 @@ spec:
             {{- toYaml .Values.daemon.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-          {{- if .Values.daemon.persistence.enabled }}
           volumeMounts:
+            {{- include "vigil.stateVolumeMount" . | nindent 12 }}
+            {{- if .Values.daemon.persistence.enabled }}
             - name: investigations
               mountPath: {{ .Values.daemon.persistence.mountPath }}
-          {{- end }}
+            {{- end }}
+      volumes:
+        {{- include "vigil.stateVolume" . | nindent 8 }}
       {{- with .Values.daemon.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/infra/helm/vigil/templates/llm-worker-deployment.yaml
+++ b/infra/helm/vigil/templates/llm-worker-deployment.yaml
@@ -52,6 +52,10 @@ spec:
             {{- toYaml .Values.llmWorker.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            {{- include "vigil.stateVolumeMount" . | nindent 12 }}
+      volumes:
+        {{- include "vigil.stateVolume" . | nindent 8 }}
       {{- with .Values.llmWorker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/infra/helm/vigil/templates/llm-worker-deployment.yaml
+++ b/infra/helm/vigil/templates/llm-worker-deployment.yaml
@@ -45,6 +45,7 @@ spec:
                   name: {{ include "vigil.postgres.passwordSecret" . }}
                   key: {{ include "vigil.postgres.passwordSecretKey" . }}
             {{- include "vigil.env" . | nindent 12 }}
+            {{- include "vigil.stateEnv" . | nindent 12 }}
             {{- with .Values.llmWorker.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -448,15 +448,15 @@ serviceAccount:
 # State Directory
 # -----------------------------------------------------------------------------
 # Where Vigil keeps what the database does not: the secrets store, MCP enable
-# flags, detection sources. Exported as VIGIL_DIR to every workload.
+# flags, detection sources. Exported as VIGIL_DIR to the backend, daemon and
+# llm-worker.
 #
-# The default is an emptyDir, which is per-pod and cleared on restart. That is
-# deliberate: a ReadWriteOnce disk cannot be shared by backend.replicaCount > 1,
-# and ReadWriteMany storage is not available on every cluster, so neither can be
-# the default. For a Helm install, supply credentials through
-# `secrets.existingSecret` or ExternalSecrets rather than the Settings UI.
+# The emptyDir default is per-pod and cleared on restart, deliberately: a
+# ReadWriteOnce disk cannot be shared by backend.replicaCount > 1, and
+# ReadWriteMany is not available on every cluster. So supply credentials through
+# `secrets.existingSecret` or ExternalSecrets, not the Settings UI.
 #
-# To make it durable on a cluster with ReadWriteMany storage:
+# For durability on a cluster with ReadWriteMany storage:
 #   stateDirectory.volume:
 #     persistentVolumeClaim:
 #       claimName: vigil-state

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -445,6 +445,27 @@ serviceAccount:
   automountServiceAccountToken: false
 
 # -----------------------------------------------------------------------------
+# State Directory
+# -----------------------------------------------------------------------------
+# Where Vigil keeps what the database does not: the secrets store, MCP enable
+# flags, detection sources. Exported as VIGIL_DIR to every workload.
+#
+# The default is an emptyDir, which is per-pod and cleared on restart. That is
+# deliberate: a ReadWriteOnce disk cannot be shared by backend.replicaCount > 1,
+# and ReadWriteMany storage is not available on every cluster, so neither can be
+# the default. For a Helm install, supply credentials through
+# `secrets.existingSecret` or ExternalSecrets rather than the Settings UI.
+#
+# To make it durable on a cluster with ReadWriteMany storage:
+#   stateDirectory.volume:
+#     persistentVolumeClaim:
+#       claimName: vigil-state
+stateDirectory:
+  mountPath: /var/lib/vigil
+  volume:
+    emptyDir: {}
+
+# -----------------------------------------------------------------------------
 # Pod security
 # -----------------------------------------------------------------------------
 podSecurityContext:

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -21,7 +21,7 @@
       "command": "python3",
       "args": ["-m", "mempalace.mcp_server"],
       "env": {
-        "MEMPALACE_PALACE_PATH": "${MEMPALACE_PALACE_PATH:-${HOME}/.vigil/mempalace/palace}"
+        "MEMPALACE_PALACE_PATH": "${MEMPALACE_PALACE_PATH:-${VIGIL_DIR}/mempalace/palace}"
       }
     },
 

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -658,7 +658,7 @@ async def health_check():
     """Health check endpoint with storage backend info."""
     try:
         from core.storage.database_data_service import DatabaseDataService
-        from core.config import is_demo_mode
+        from core.config import is_demo_mode, state_dir_status
 
         service = DatabaseDataService()
         backend_info = service.get_backend_info()
@@ -667,6 +667,9 @@ async def health_check():
             "status": "healthy",
             "version": __version__,
             "demo_mode": is_demo_mode(),
+            # Where Vigil is actually putting credentials, and whether it can.
+            # A wrong mount is otherwise invisible until someone loses a key.
+            "state_directory": state_dir_status(),
             "storage": {
                 "backend": backend_info["backend"],
                 "database_available": backend_info.get("database_available", False),

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -662,14 +662,18 @@ async def health_check():
 
         service = DatabaseDataService()
         backend_info = service.get_backend_info()
+        state_dir = state_dir_status()
 
         return {
             "status": "healthy",
             "version": __version__,
             "demo_mode": is_demo_mode(),
-            # Where Vigil is actually putting credentials, and whether it can.
-            # A wrong mount is otherwise invisible until someone loses a key.
-            "state_directory": state_dir_status(),
+            # Booleans only — this route is public, and the resolved path names
+            # where credentials live. Full status: GET /api/config/state-directory.
+            "state_directory": {
+                "exists": state_dir["exists"],
+                "writable": state_dir["writable"],
+            },
             "storage": {
                 "backend": backend_info["backend"],
                 "database_available": backend_info.get("database_available", False),

--- a/services/api/routers/config.py
+++ b/services/api/routers/config.py
@@ -19,7 +19,7 @@ from core.secrets import get_secret, set_secret
 from core.storage.config_service import get_config_service
 from core.llm.defaults import DEFAULT_MODEL
 from core.integrations.integration_secrets import redact_secrets, secret_fields_for, split_secrets
-from core.config import get_settings, vigil_path
+from core.config import get_settings, state_dir_status, vigil_path
 
 router = APIRouter()
 
@@ -29,6 +29,19 @@ ROUTER_META = RouterMeta(
     auth=Auth.REQUIRED,
 )
 logger = logging.getLogger(__name__)
+
+
+def _mirror_to_file(filename: str, config_data: Dict[str, Any]) -> None:
+    """Copy config the database already owns, for backward compatibility.
+
+    Best-effort: the database write has committed, so an unwritable State
+    Directory must not fail a request that succeeded.
+    """
+    try:
+        with open(vigil_path(filename, write=True), "w") as f:
+            json.dump(config_data, f, indent=2)
+    except OSError as e:
+        logger.warning(f"Could not mirror {filename} to the State Directory: {e}")
 
 
 class ClaudeConfig(BaseModel):
@@ -392,10 +405,7 @@ async def set_s3_config(config: S3Config):
                 status_code=500, detail="Failed to save S3 config to database"
             )
 
-        # Also save to file for backward compatibility
-        config_file = vigil_path("s3_config.json", write=True)
-        with open(config_file, "w") as f:
-            json.dump(config_data, f, indent=2)
+        _mirror_to_file("s3_config.json", config_data)
 
         # Only overwrite credentials if new values were provided
         if config.access_key_id:
@@ -689,10 +699,7 @@ async def set_theme_config(config: ThemeConfig):
                 status_code=500, detail="Failed to save theme to database"
             )
 
-        # Also save to file for backward compatibility
-        config_file = vigil_path("theme_config.json", write=True)
-        with open(config_file, "w") as f:
-            json.dump(config_data, f, indent=2)
+        _mirror_to_file("theme_config.json", config_data)
 
         return {"success": True, "message": "Theme saved"}
     except HTTPException:
@@ -826,14 +833,13 @@ async def set_integrations_config(
             if not success:
                 logger.error(f"Failed to save integration '{integration_id}'")
 
-        # Also save to file for backward compatibility — sanitized only.
-        config_file = vigil_path("integrations_config.json", write=True)
-        config_data = {
-            "enabled_integrations": config.enabled_integrations,
-            "integrations": sanitized_integrations,
-        }
-        with open(config_file, "w") as f:
-            json.dump(config_data, f, indent=2)
+        _mirror_to_file(
+            "integrations_config.json",
+            {
+                "enabled_integrations": config.enabled_integrations,
+                "integrations": sanitized_integrations,
+            },
+        )
 
         # Derive <ID>_MCP_URL env vars (e.g. LOGLM_MCP_URL) from any
         # connectorUrl just saved, so static mcp-config.json remote-MCP
@@ -847,6 +853,16 @@ async def set_integrations_config(
     except Exception as e:
         logger.error(f"Error setting integrations config: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/state-directory")
+async def get_state_directory():
+    """Resolved State Directory path and writability.
+
+    Authenticated: /api/health carries only the booleans, since it is public and
+    this names where credentials live.
+    """
+    return {"success": True, "state_directory": state_dir_status()}
 
 
 @router.get("/integrations/status")
@@ -1011,10 +1027,7 @@ async def set_general_config(config: GeneralConfig):
                 status_code=500, detail="Failed to save configuration to database"
             )
 
-        # Also save to file for backward compatibility (during transition)
-        config_file = vigil_path("general_config.json", write=True)
-        with open(config_file, "w") as f:
-            json.dump(config_data, f, indent=2)
+        _mirror_to_file("general_config.json", config_data)
 
         # Update the global secrets manager if keyring setting changed
         try:

--- a/tests/unit/_ratchets/test_settings_env_example.py
+++ b/tests/unit/_ratchets/test_settings_env_example.py
@@ -105,6 +105,10 @@ NOT_SETTINGS = {
     # Bootstrap for the secrets manager itself, which cannot depend on Settings.
     "ENABLE_KEYRING",
     "SECRETS_BACKEND",
+    # Locates the State Directory. vigil_path() resolves it at import time, before
+    # Settings can be built, so it is read from the environment and must be
+    # exported rather than set in .env.
+    "VIGIL_DIR",
     # Provider selection still handled by the DB provider registry.
     "DEFAULT_LLM_PROVIDER",
     "OPENAI_BASE_URL",

--- a/tests/unit/platform/test_vigil_path.py
+++ b/tests/unit/platform/test_vigil_path.py
@@ -1,8 +1,14 @@
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
+# chmod cannot deny root, so the unwritable cases prove nothing there.
+needs_unprivileged = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0, reason="requires a non-root user"
+)
 
 from core.config import state_dir_status, vigil_path
 
@@ -63,8 +69,7 @@ def test_vigil_dir_overrides_home(tmp_path, monkeypatch):
 
 @pytest.mark.unit
 def test_vigil_dir_has_no_legacy_fallback(home, tmp_path, monkeypatch):
-    # An explicit override means exactly that dir. Reaching back to ~/.deeptempo
-    # from under a VIGIL_DIR the operator chose would be a surprise.
+    # An explicit override means exactly that directory.
     (home / ".deeptempo").mkdir()
     (home / ".deeptempo" / "a.json").write_text("{}")
     custom = tmp_path / "state"
@@ -73,10 +78,10 @@ def test_vigil_dir_has_no_legacy_fallback(home, tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
+@needs_unprivileged
 def test_write_failure_raises_rather_than_relocating(home):
-    # #701 caught OSError and silently wrote to /tmp instead. Reads never
-    # followed, so the save looked fine and the value was gone. Callers that
-    # want to degrade (telemetry, request logging) catch this themselves.
+    # A silent /tmp relocation applied to writes only, so the save looked fine
+    # and the value was gone. Callers that want to degrade catch this themselves.
     home.chmod(0o500)
     try:
         with pytest.raises(OSError):
@@ -88,10 +93,13 @@ def test_write_failure_raises_rather_than_relocating(home):
 @pytest.mark.unit
 def test_state_dir_status_reports_path_and_writability(home):
     status = state_dir_status()
-    assert status == {"path": str(home / ".vigil"), "writable": True}
+    assert status == {"path": str(home / ".vigil"), "exists": False, "writable": True}
+    (home / ".vigil").mkdir()
+    assert state_dir_status()["exists"] is True
 
 
 @pytest.mark.unit
+@needs_unprivileged
 def test_state_dir_status_reports_unwritable_without_raising(home):
     home.chmod(0o500)
     try:
@@ -104,15 +112,15 @@ def test_state_dir_status_reports_unwritable_without_raising(home):
 
 @pytest.mark.unit
 def test_bare_directory_never_resolves_to_legacy(home):
-    # Regression: the secrets backend asks for the directory itself. If that
-    # answered ~/.deeptempo, every credential written after would land there.
+    # The secrets backend asks for the directory itself; answering ~/.deeptempo
+    # would send every credential written after it there.
     (home / ".deeptempo").mkdir()
     assert vigil_path() == home / ".vigil"
 
 
 @pytest.mark.unit
 def test_bare_directory_is_not_created_on_read(home):
-    # Constructed unconditionally at startup, so it must not touch the disk.
     assert not (home / ".vigil").exists()
     vigil_path()
+    state_dir_status()
     assert not (home / ".vigil").exists()

--- a/tests/unit/platform/test_vigil_path.py
+++ b/tests/unit/platform/test_vigil_path.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from core.config import vigil_path
+from core.config import state_dir_status, vigil_path
 
 
 @pytest.fixture
@@ -53,38 +53,66 @@ def test_write_with_no_parts_creates_the_directory_itself(home):
 
 
 @pytest.mark.unit
-def test_vigil_dir_env_var_override(tmp_path, monkeypatch):
-    custom_dir = tmp_path / "custom_vigil_state"
-    monkeypatch.setenv("VIGIL_DIR", str(custom_dir))
-    assert vigil_path("test.json") == custom_dir / "test.json"
-    target = vigil_path("test.json", write=True)
-    assert target == custom_dir / "test.json"
-    assert custom_dir.is_dir()
+def test_vigil_dir_overrides_home(tmp_path, monkeypatch):
+    custom = tmp_path / "state"
+    monkeypatch.setenv("VIGIL_DIR", str(custom))
+    assert vigil_path("a.json") == custom / "a.json"
+    assert vigil_path("a.json", write=True) == custom / "a.json"
+    assert custom.is_dir()
 
 
 @pytest.mark.unit
-def test_vigil_home_env_var_override(tmp_path, monkeypatch):
-    custom_home = tmp_path / "custom_user_home"
-    monkeypatch.setenv("VIGIL_HOME", str(custom_home))
-    assert vigil_path("test.json") == custom_home / ".vigil" / "test.json"
-    target = vigil_path("test.json", write=True)
-    assert target == custom_home / ".vigil" / "test.json"
-    assert (custom_home / ".vigil").is_dir()
+def test_vigil_dir_has_no_legacy_fallback(home, tmp_path, monkeypatch):
+    # An explicit override means exactly that dir. Reaching back to ~/.deeptempo
+    # from under a VIGIL_DIR the operator chose would be a surprise.
+    (home / ".deeptempo").mkdir()
+    (home / ".deeptempo" / "a.json").write_text("{}")
+    custom = tmp_path / "state"
+    monkeypatch.setenv("VIGIL_DIR", str(custom))
+    assert vigil_path("a.json") == custom / "a.json"
 
 
 @pytest.mark.unit
-def test_root_home_fallback_to_app_or_tmp(tmp_path, monkeypatch):
-    # When running in a container where HOME=/ or unset, Path.home() is Path("/")
-    with patch.object(Path, "home", return_value=Path("/")):
-        # If /tmp is accessible and /app is not a writable dir
-        target = vigil_path("test.json")
-        assert target != Path("/.vigil/test.json")
-        assert target.name == "test.json"
-        assert target.parent.name == ".vigil"
+def test_write_failure_raises_rather_than_relocating(home):
+    # #701 caught OSError and silently wrote to /tmp instead. Reads never
+    # followed, so the save looked fine and the value was gone. Callers that
+    # want to degrade (telemetry, request logging) catch this themselves.
+    home.chmod(0o500)
+    try:
+        with pytest.raises(OSError):
+            vigil_path("a.json", write=True)
+    finally:
+        home.chmod(0o700)
 
 
 @pytest.mark.unit
-def test_write_oserror_logs_warning_without_raising():
-    with patch.object(Path, "mkdir", side_effect=OSError("Permission denied")):
-        target = vigil_path("test.json", write=True)
-        assert target.name == "test.json"
+def test_state_dir_status_reports_path_and_writability(home):
+    status = state_dir_status()
+    assert status == {"path": str(home / ".vigil"), "writable": True}
+
+
+@pytest.mark.unit
+def test_state_dir_status_reports_unwritable_without_raising(home):
+    home.chmod(0o500)
+    try:
+        status = state_dir_status()
+        assert status["writable"] is False
+        assert status["path"] == str(home / ".vigil")
+    finally:
+        home.chmod(0o700)
+
+
+@pytest.mark.unit
+def test_bare_directory_never_resolves_to_legacy(home):
+    # Regression: the secrets backend asks for the directory itself. If that
+    # answered ~/.deeptempo, every credential written after would land there.
+    (home / ".deeptempo").mkdir()
+    assert vigil_path() == home / ".vigil"
+
+
+@pytest.mark.unit
+def test_bare_directory_is_not_created_on_read(home):
+    # Constructed unconditionally at startup, so it must not touch the disk.
+    assert not (home / ".vigil").exists()
+    vigil_path()
+    assert not (home / ".vigil").exists()


### PR DESCRIPTION
Follow-up to #701, which fixed the #695 crash but left the surrounding hardening in a state that broke three deployment paths. Closes the gap; does not revert the fix.

## What #701 left behind

#701 deferred the import-time `mkdir` that crashed the daemon — that part was right and stays. Alongside it, it added four more ways to decide where Vigil's per-install state lives, on top of the existing `HOME`-derived default:

| Mechanism | Result |
|---|---|
| `VIGIL_HOME` | redundant with `VIGIL_DIR` — `VIGIL_HOME=/x` is exactly `VIGIL_DIR=/x/.vigil` |
| `HOME=/` → `/app` → `/tmp` remap | implicit, container-only |
| `mkdir` fails → `/tmp` | silent relocation of the credential store |
| `HOME=/tmp` in the chart | cancels the `/home/vigil` the same PR added to the Dockerfile |

The `/tmp` fallback is the one that cost something. It lives only in the `write` branch, so reads never followed it:

```
save an API key  → lands in /tmp/.vigil/
read it back     → looks in ~/.vigil/ → nothing
```

The UI reports success and the value is gone immediately — not on restart. One `logger.warning` is the only trace.

## What this changes

**Two mechanisms, not five.** `VIGIL_DIR` if exported, else `~/.vigil`. `VIGIL_HOME`, the container remap, the `/tmp` fallback, and the two dead `Settings` fields are gone.

**Failures are loud and locatable.** A write that cannot happen raises, and each caller keeps the policy it already had: `core/telemetry.py` and `MCPService._save_enabled_state` catch and degrade, `DetectionRulesService._save_config` logs, the secrets store lets it propagate. `#701` had overridden all of them at once.

**`/api/health` reports whether the State Directory is writable**, so a wrong mount is visible before it costs a credential rather than only from a traceback. The public route carries the two booleans only — the resolved path names where credentials live, so that plus the failure text sit behind auth on `GET /api/config/state-directory`. The probe never creates the directory: a health check should not be what brings the credential store into existence, so a directory that does not exist yet is probed at its nearest existing ancestor, which answers the question that actually matters. The probe filename is per-process, since a shared one races — one concurrent caller's `unlink` makes the other report the directory unwritable, and liveness plus readiness plus the UI poll means concurrency is the normal case, not an edge.

**The legacy fallback is scoped to files.** `~/.deeptempo` is a per-file read shim from before the rename. Asked for the bare directory it answered with the legacy copy, which `EncryptedFileBackend` then adopted as its **write** destination — inverting the documented "writes always target `~/.vigil`" contract. Two regression tests cover this.

**Write paths resolve where the write happens.** `MCPService._STATE_FILE` was still evaluated at class-definition time — the read half of exactly what #695 hit on the write side. It also meant the read path was pinned at import while `_save_enabled_state` resolved the write path fresh, so under the `/tmp` fallback the two silently disagreed. `DetectionRulesService.__init__` had the same shape and worse placement: `write=True` in a constructor created the State Directory as a side effect of building the service, and it is built unguarded on the API startup path, so an unwritable directory took the whole backend down. Both now resolve at their save sites.

**Config the database owns is mirrored best-effort.** `theme_config.json`, `s3_config.json`, `integrations_config.json` and `general_config.json` are written for backward compatibility *after* the authoritative database write has committed. Letting those raise failed requests that had already succeeded — the UI reporting "could not save" for a setting that saved fine — and in the integrations case skipped the `<ID>_MCP_URL` derivation that follows. They log and continue. `general_config.json` under `set_demo_mode` still raises: no database row backs it, so the file is the only store.

## Deployment paths repointed

These were broken by #701's uid/`HOME` change and are the user-visible part:

- **Desktop** — the persistent volume was still mounted at `/app/.vigil` while the image moved to `/home/vigil`, so every UI-configured key died on restart. That file's own comment predicted this failure verbatim. The image pre-creates `/home/vigil/.vigil` owned by `1000:1000`, so a fresh named volume inherits it — but a `vigil_home` volume created before #701 does not, and now that the `/tmp` fallback is gone that fails loudly instead of silently. **Existing desktop installs should recreate the volume.** The logs `tmpfs` owner follows the uid from 999 to 1000; that one degrades rather than crashes, because `core/reporting/logs_router.py` has caught `OSError` since #376 — the comment claiming it kills startup was stale and is corrected.
- **Helm** — `HOME=/tmp` replaced with an explicit `VIGIL_DIR` on a mounted volume across backend, daemon and llm-worker. `VIGIL_DIR` lives in its own `vigil.stateEnv` helper rather than the shared `vigil.env`, so it is only ever set where the volume is actually mounted: `agent-serve` and `agent-worker` include `vigil.env` and would otherwise advertise a path with nothing behind it.
- **`env.example`** — `VIGIL_DIR` is resolved before `Settings` loads, so setting it in `.env` does nothing. Now says so, and moves to `NOT_SETTINGS` alongside the other pre-`Settings` bootstrap keys.
- **`mcp-config.json`** — was hardcoding `${HOME}/.vigil/mempalace/palace`, which could diverge from wherever the app resolved. Now `${VIGIL_DIR}`, which takes two supporting changes to actually work: `_substitute_env_vars` resolves against the environment the child is spawned with rather than the parent's `os.environ`, so the value the spawn site pins is visible to substitution instead of collapsing to `""` and rooting child paths at `/`; and `VIGIL_DIR` joins `HOME` in the placeholder blacklist, since `extract_required_env_vars` would otherwise read a path sentinel as a missing credential and mark mempalace dormant whenever the variable is not exported.

## Known gap, shipped deliberately

The chart's state volume defaults to `emptyDir`. A `ReadWriteOnce` disk cannot back `backend.replicaCount: 2`, and `ReadWriteMany` storage is not available on every cluster, so neither can be the default. Helm installs should supply credentials through `secrets.existingSecret` or ExternalSecrets rather than the Settings UI — the values block documents this and how to point it at RWX storage.

That leaves `mcp_server_enabled.json` and `detection_sources.json` non-durable under Helm. No worse than today, but now a known gap rather than an accident. The real fix is moving both into `system_config`, where the rest of the UI-editable config already lives and where the two are stragglers rather than a design — tracked as follow-up.

The eager `~/.deeptempo` migration that would let the legacy fallback be deleted outright is also follow-up; call-time path resolution was its prerequisite and is done here.

## Verification

- 1590 unit tests pass (`pytest tests/unit/ -m "not external_service"`)
- `tests/security/test_route_auth_coverage.py` passes with the new authenticated route
- `lint-imports` — 3/3 contracts kept
- `helm lint` clean; `helm template` renders default and dev values with `HOME` absent, and `VIGIL_DIR` present on exactly the three workloads that mount the volume
- `flake8` clean at 88 chars; `mcp-config.json` and the desktop compose file both parse

`black`/`isort` wanted to reformat ~270 unrelated lines in `core/integrations/mcp/service.py` and `services/api/main.py` — files CI never enforces, since its style steps are `continue-on-error` at 120 chars. Left alone to keep the diff reviewable.

Refs #695, #701
