### PR TITLE
fix(desktop): stage the bifrost config from infra/

### DIFF
--- a/clients/desktop/scripts/prepare-standalone.js
+++ b/clients/desktop/scripts/prepare-standalone.js
@@ -10,6 +10,7 @@ const path = require("path");
 
 const version = require("../package.json").version;
 const image = `ghcr.io/vigil-soc/vigil-backend:${version}`;
+const repoRoot = path.join(__dirname, "..", "..", "..");
 const outDir = path.join(__dirname, "..", "standalone");
 const dbInit = path.join(outDir, "db-init");
 
@@ -54,7 +55,7 @@ fs.writeFileSync(
 );
 
 fs.copyFileSync(
-  path.join(__dirname, "..", "..", "..", "docker", "bifrost", "config.json"),
+  path.join(repoRoot, "infra", "docker", "bifrost", "config.json"),
   path.join(outDir, "bifrost-config.json"),
 );
 


### PR DESCRIPTION
`npm run dist` in `clients/desktop` cannot build a DMG on `main`. It runs `node scripts/prepare-standalone.js` before electron-builder, and that script resolved the Bifrost gateway config at the pre-reorg `<repo>/docker/bifrost/config.json`. The infra reorg moved the file to `infra/docker/bifrost/config.json`, so `fs.copyFileSync` threw ENOENT and the build stopped before electron-builder was ever invoked.

The fix adds the missing `infra` segment. Rather than growing a sixth `".."` inline — which pushed the line to 86 characters in a file where every other line is ≤80 — the repo root becomes a named const alongside the existing `outDir`/`dbInit` ones.

```diff
+const repoRoot = path.join(__dirname, "..", "..", "..");
 const outDir = path.join(__dirname, "..", "standalone");
...
 fs.copyFileSync(
-  path.join(__dirname, "..", "..", "..", "docker", "bifrost", "config.json"),
+  path.join(repoRoot, "infra", "docker", "bifrost", "config.json"),
   path.join(outDir, "bifrost-config.json"),
 );
```

## Sweep for other pre-reorg paths

I grepped all of `clients/desktop` for root-relative `docker/`, `helm/`, and `database/` references. Nothing else is stale:

| Location | Status |
|---|---|
| `scripts/bundle-image.sh:18` | Already correct — `-f infra/docker/Dockerfile.backend` |
| `standalone/docker-compose.yml` | Comments only, and they already read `infra/docker/docker-compose.yml` |
| `src/main.ts` | All `docker` hits are the **binary** name (`whichBin("docker")`, `spawn("docker", …)`), not paths |

The other repo-relative paths in `src/main.ts` (`scripts/`, `venv/bin/python`, `clients/web/build/index.html`, `logs/`) and the `findRepoRoot` markers (`VERSION`, `scripts/app_up.sh`) all still resolve after the reorg.

## Verification

Ran the full script with Docker up, so the `docker create` / `docker cp` / `docker rm` path is exercised for real and not just the one changed line:

```
  • standalone: 15 schema files from ghcr.io/vigil-soc/vigil-backend:0.3.0
```

That line prints *after* the `copyFileSync`, so reaching it is itself proof the copy no longer throws. On disk:

- `standalone/bifrost-config.json` — 1483 bytes, `diff -q` against `infra/docker/bifrost/config.json` reports identical
- `standalone/db-init/` — the 15 `.sql` files from the pinned image plus the generated `99_drop_seed_admin.sql`

Both outputs are already covered by `clients/desktop/.gitignore` (lines 12–13), so the run leaves nothing untracked behind.

Not verified: electron-builder itself past this point, and code signing. This only establishes that the pre-electron-builder staging step completes.
