### PR TITLE
fix/543-JSONB-array-to-list

### DIFF
--- a/core/storage/models.py
+++ b/core/storage/models.py
@@ -24,12 +24,15 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableList
 from pgvector.sqlalchemy import Vector
 import uuid
 
 # Fixed width for the findings vector column; sources of other dimensions
 # (LogLM 512) are zero-padded/truncated to this before storage.
 EMBEDDING_DIM = 768
+
+JSONBList = MutableList.as_mutable(JSONB)
 
 
 class Base(DeclarativeBase):
@@ -167,22 +170,24 @@ class Case(Base):
     assignee: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
 
     # Tags (array of strings)
-    tags: Mapped[List[str]] = mapped_column(ARRAY(String), nullable=True, default=[])
+    tags: Mapped[List[str]] = mapped_column(ARRAY(String), nullable=True, default=list)
 
     # Notes (JSONB array)
-    notes: Mapped[List[dict]] = mapped_column(JSONB, nullable=True, default=[])
+    notes: Mapped[List[dict]] = mapped_column(JSONBList, nullable=True, default=list)
 
     # Timeline events (JSONB array)
-    timeline: Mapped[List[dict]] = mapped_column(JSONB, nullable=False, default=[])
+    timeline: Mapped[List[dict]] = mapped_column(
+        JSONBList, nullable=False, default=list
+    )
 
     # Activities (JSONB array)
     activities: Mapped[Optional[List[dict]]] = mapped_column(
-        JSONB, nullable=True, default=[]
+        JSONBList, nullable=True, default=list
     )
 
     # Resolution steps (JSONB array)
     resolution_steps: Mapped[Optional[List[dict]]] = mapped_column(
-        JSONB, nullable=True, default=[]
+        JSONBList, nullable=True, default=list
     )
 
     # MITRE ATT&CK techniques
@@ -857,7 +862,7 @@ class CaseEvidence(Base):
 
     # Chain of custody (JSONB array of custody entries)
     chain_of_custody: Mapped[List[dict]] = mapped_column(
-        JSONB, nullable=False, default=[]
+        JSONBList, nullable=False, default=list
     )
 
     # Analysis results
@@ -1054,7 +1059,7 @@ class CaseTemplate(Base):
 
     # Task templates (JSONB array)
     task_templates: Mapped[List[dict]] = mapped_column(
-        JSONB, nullable=False, default=[]
+        JSONB, nullable=False, default=list
     )
 
     # Playbook steps (JSONB array)
@@ -1509,7 +1514,7 @@ class Investigation(Base):
     workflow_id: Mapped[str] = mapped_column(String(50), nullable=False)
 
     trigger_type: Mapped[str] = mapped_column(String(30), nullable=False)
-    trigger_ids: Mapped[List[dict]] = mapped_column(JSONB, nullable=False, default=[])
+    trigger_ids: Mapped[List[dict]] = mapped_column(JSONB, nullable=False, default=list)
 
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="queued")
 


### PR DESCRIPTION
Fixes #543. @nestor-deeptempo 

## Problem

`case.timeline.append(...)` mutates a `JSONB` column in place. No JSONB column was wrapped in `MutableList`/`MutableDict` and `flag_modified` appears nowhere in the tree, so SQLAlchemy never marks the attribute dirty, emits no `UPDATE`, and the event is silently dropped on commit. The commit succeeds and nothing errors.

Today that loses the escalation entry written by `escalate_case()` (`core/cases/case_workflow_service.py:294`) — the case row *is* dirty there via `case.assignee = escalated_to`, but the emitted `UPDATE` simply omits `timeline`.

Note: of the three append sites the issue lists, only escalation still exists — `grep` for `.timeline.append` returns exactly one hit, and the file has moved to `core/cases/`. The auto-assignment and playbook-step sites appear to have been refactored away since the issue was written. This ORM-layer fix covers them if they return.

## Fix

- Wrap the JSONB arrays that are appended to in place in `MutableList` (via a `JSONBList` alias), so in-place mutation is tracked: `cases.notes`, `cases.timeline`, `cases.activities`, `cases.resolution_steps`, `case_evidence.chain_of_custody`. This is preferred over per-call-site `flag_modified` because the next `.append()` anyone writes is then correct by default.
- Replace the shared-list `default=[]` constant with the `default=list` factory on the affected columns (also `cases.tags`, `case_templates.task_templates`, `investigations.trigger_ids`).

ORM-layer only: no schema change, so no migration and no init-SQL/Helm work. `MutableList` is a `list` subclass, so the emitted `timeline`/`activities` payloads are unchanged.

## Verification

The acceptance-criteria scenario was run directly against this pattern — append via the ORM, commit, re-read in a **new session**:

- with `MutableList.as_mutable(...)`: `[{'event': 'escalated'}]`
- without it (current `main`): `[]`

So the fix is confirmed and the pre-fix failure is confirmed. No test file is included in this PR; say the word and I'll add the new-session persistence test plus an `escalate_case()` regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)