### PR TITLE
fix(compose): stop shipping pgAdmin as an unauthenticated console

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -339,9 +339,18 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@deeptempo.ai}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-admin}
-      PGADMIN_CONFIG_SERVER_MODE: 'False'
+      # SERVER_MODE is deliberately left at pgAdmin's default (True). Setting it
+      # to 'False' selects desktop mode, which disables the login prompt
+      # entirely -- the container logs "Configuring authentication for DESKTOP
+      # mode" and GET / lands straight on /browser/ with no credential check.
+      # That made PGADMIN_DEFAULT_PASSWORD decorative rather than a gate (#707).
     ports:
-      - "5050:80"
+      # Loopback-only, for the same reason as postgres and redis above. This
+      # console reaches the database over deeptempo-network by service name, so
+      # it is inside the perimeter that the loopback binds establish -- an
+      # unauthenticated console published on 0.0.0.0 would route straight around
+      # them, using the default password committed above.
+      - "127.0.0.1:5050:80"
     volumes:
       - pgadmin_data:/var/lib/pgadmin
     depends_on:

--- a/tests/security/test_pgadmin_exposure.py
+++ b/tests/security/test_pgadmin_exposure.py
@@ -1,0 +1,101 @@
+"""pgAdmin must not ship as an unauthenticated database console.
+
+Issue #707. The `pgadmin` service in `infra/docker/docker-compose.yml` combined
+two settings that cancelled each other out: it published `5050` on every
+interface, and it set `PGADMIN_CONFIG_SERVER_MODE: 'False'`, which selects
+pgAdmin's desktop mode and disables the login prompt outright. The container
+logged `Configuring authentication for DESKTOP mode` and `GET /` landed
+straight on `/browser/` with no credential check, which made
+`PGADMIN_DEFAULT_PASSWORD` decorative rather than a gate.
+
+That mattered more than a stray published port usually would, because pgAdmin
+sits *inside* the boundary that #587 established. #587 bound Postgres to
+loopback on the host, but pgAdmin reaches the database over the
+`deeptempo-network` bridge by service name, so an unauthenticated console
+published on `0.0.0.0` routed straight around the fix, using a default password
+committed to this repo.
+
+Two separate properties are asserted, because either one alone is insufficient:
+a login prompt on an internet-facing port is still a credential-stuffing target,
+and a loopback bind with no login still trusts every local process and every
+other container. The port check duplicates a little of
+`test_compose_port_binding.py`, which deliberately scopes itself to services
+that start without a profile; pgAdmin is behind the opt-in `dev` profile and so
+falls outside it. Those two files are worth consolidating once both changes
+have landed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+# Resolved from this file rather than by importing application code, so an
+# unrelated dependency break cannot disarm the gate.
+REPO = Path(__file__).resolve().parents[2]
+COMPOSE_PATH = Path("infra/docker/docker-compose.yml")
+
+LOOPBACK = frozenset({"127.0.0.1", "::1", "localhost"})
+
+# Values pgAdmin reads as "desktop mode", i.e. no login prompt. It parses the
+# variable as a string, so quoting variants all have to be caught.
+DESKTOP_MODE_VALUES = frozenset({"false", "0", "no", "off"})
+
+
+def _pgadmin() -> dict:
+    raw = yaml.safe_load((REPO / COMPOSE_PATH).read_text(encoding="utf-8"))
+    services = (raw or {}).get("services") or {}
+    assert "pgadmin" in services, (
+        f"no pgadmin service in {COMPOSE_PATH}. If it was removed, delete this "
+        f"file; if it was renamed, update it -- do not let it pass vacuously."
+    )
+    return services["pgadmin"]
+
+
+def _environment() -> dict[str, str]:
+    """pgAdmin's env, normalised across compose's mapping and list forms."""
+    env = _pgadmin().get("environment") or {}
+    if isinstance(env, list):  # - KEY=value form
+        parsed = {}
+        for item in env:
+            key, _, value = str(item).partition("=")
+            parsed[key] = value
+        return parsed
+    return {str(k): str(v) for k, v in env.items()}  # KEY: value form
+
+
+def _host_interface(mapping) -> str:
+    if isinstance(mapping, dict):
+        return str(mapping.get("host_ip") or "0.0.0.0").strip("[]")
+    parts = str(mapping).split("/")[0].rsplit(":", 2)
+    return parts[0].strip("[]") if len(parts) == 3 else "0.0.0.0"
+
+
+def test_pgadmin_publishes_on_loopback_only() -> None:
+    wide = [
+        str(m)
+        for m in (_pgadmin().get("ports") or [])
+        if _host_interface(m) not in LOOPBACK
+    ]
+    assert not wide, (
+        f"pgadmin publishes {wide} on a non-loopback interface. It is a database "
+        f"console with a default password and it reaches Postgres over the "
+        f"compose bridge, so publishing it off-host bypasses the loopback binds "
+        f"on Postgres itself (#707)."
+    )
+
+
+def test_pgadmin_does_not_disable_its_login() -> None:
+    value = _environment().get("PGADMIN_CONFIG_SERVER_MODE")
+    assert (
+        value is None or value.strip().strip("'\"").lower() not in DESKTOP_MODE_VALUES
+    ), (
+        f"pgadmin sets PGADMIN_CONFIG_SERVER_MODE={value!r}, which selects "
+        f"desktop mode and disables the login prompt entirely, making "
+        f"PGADMIN_DEFAULT_PASSWORD decorative. Leave it unset so pgAdmin "
+        f"defaults to server mode (#707)."
+    )


### PR DESCRIPTION
Closes #707.

## What changed

`infra/docker/docker-compose.yml`, `pgadmin` service:

| | before | after |
| --- | --- | --- |
| published port | `"5050:80"` (all interfaces) | `"127.0.0.1:5050:80"` |
| `PGADMIN_CONFIG_SERVER_MODE` | `'False'` (desktop mode, no login) | removed — pgAdmin defaults to server mode |

Both halves are needed. A login prompt on an off-host port is still a credential-stuffing target, and a loopback bind with no login still trusts every local process and every sibling container.

## Verified against a running container, not just read off the YAML

**Before** — the console had no authentication at all:

```
docker logs: NOTE: Configuring authentication for DESKTOP mode.
GET /          -> 302 -> /browser/
GET /browser/  -> 200, full pgAdmin console
login form markers in response: 0
```

So `PGADMIN_DEFAULT_PASSWORD:-admin` was decorative — there was no prompt to type it into.

**After:**

```
docker logs: NOTE: Configuring authentication for SERVER mode.
GET /                          -> 302 -> /login?next=/
GET /browser/  (no session)    -> 302 -> /login?next=/browser/
GET /browser/  (with session)  -> 200
```

The existing default credentials sign in fine, so the developer experience is one login prompt, not a lockout.

**Upgrade path tested.** Anyone who has already run `--profile dev` has a `pgadmin_data` volume initialised in desktop mode. I seeded a volume in desktop mode, then started the fixed service against that same volume: it comes up cleanly in server mode and redirects to `/login`, with no migration error.

All test containers and volumes were torn down afterwards.

## Why this is more than one more stray port

pgAdmin sits **inside** the boundary #587 just established. #587 bound Postgres to loopback on the host — but pgAdmin doesn't use the host mapping. It reaches the database over `deeptempo-network` by service name:

```
$ docker exec deeptempo-pgadmin getent hosts postgres
172.18.0.3   postgres
```

So an unauthenticated console published on `0.0.0.0` routed straight around the #587 fix, and the second step is the default password committed a few lines above it in this same file. No server connection is pre-registered, which is the one mitigating factor — an attacker has to add one by hand.

`pgadmin` is behind the opt-in `dev` profile, which is why #587 scoped it out. That profile is also exactly what a developer runs.

## Test

Adds `tests/security/test_pgadmin_exposure.py` asserting both properties. Verified red-then-green against three separate regressions:

| mutation | result |
| --- | --- |
| restore `"5050:80"` | ✅ fails `test_pgadmin_publishes_on_loopback_only` |
| restore `SERVER_MODE: 'False'` | ✅ fails `test_pgadmin_does_not_disable_its_login` |
| quoted variant `SERVER_MODE: "No"` | ✅ also caught |

It handles both of compose's `environment:` forms (mapping and `- KEY=value` list), and fails loudly rather than vacuously if the service is renamed or removed.

**On the overlap with #708:** the port assertion duplicates a little of `tests/security/test_compose_port_binding.py`, which deliberately scopes itself to services that start *without* a profile and therefore never sees pgAdmin. I added a focused file rather than widening that one, because that file belongs to the currently-open #708 and editing it from two branches guarantees a conflict. The two are worth consolidating into one gate once both have landed — I'm happy to send that follow-up.

The compose hunks in #708 (lines ~40–70) and this PR (~339) are far apart and merge cleanly in either order.

## Also

`docker compose config` exits 0; `black` and `flake8` clean on the new file. Pre-existing failures on this base, unrelated to this change: `test_unauth_endpoints.py` collection error (`No module named 'bullmq'`) and two in `test_route_auth_coverage.py`.
