### PR TITLE
fix(storage): correct investigations.trigger_ids to List[str]

### DIFF
--- a/core/storage/models.py
+++ b/core/storage/models.py
@@ -1514,7 +1514,16 @@ class Investigation(Base):
     workflow_id: Mapped[str] = mapped_column(String(50), nullable=False)
 
     trigger_type: Mapped[str] = mapped_column(String(30), nullable=False)
-    trigger_ids: Mapped[List[dict]] = mapped_column(JSONB, nullable=False, default=list)
+    # Finding ids, not objects (#554). Both writers build a list of
+    # ``findings.finding_id`` strings -- services/daemon/orchestrator.py:407
+    # (``[f.get("finding_id") for f in findings ...]``) and :942
+    # (``finding_ids[:10]``) -- and every reader treats the elements as those
+    # strings: services/api/routers/orchestrator.py:484 tests them for set
+    # membership against ``Finding.finding_id``, and orchestrator.py:1098 writes
+    # ``trigger_ids[0]`` straight into ``AIDecisionLog.finding_id``, a
+    # String(50) FK. The old ``List[dict]`` annotation matched no writer or
+    # reader. Storage stays JSONB; promoting the column is deferred to #468.
+    trigger_ids: Mapped[List[str]] = mapped_column(JSONB, nullable=False, default=list)
 
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="queued")
 


### PR DESCRIPTION
Closes #554.

The issue asked for an answer, not a migration. Here it is, with the annotation corrected.

## Verdict: `List[str]` of `findings.finding_id`, and it belongs with the **child-table** promotions, not the scalar-array ones

## Every writer, from constructing code

There are only two, and both build a list of finding-id strings:

| site | what it constructs |
|---|---|
| `services/daemon/orchestrator.py:407` | `[f.get("finding_id") for f in findings if f.get("finding_id")]` |
| `services/daemon/orchestrator.py:942` | `finding_ids[:10]`, from `case_data["finding_ids"]` |

That second one is a pass-through, so I followed it: `finding_ids` is `List[str]` or `Sequence[str]` everywhere it carries a type — `core/storage/case_repository.py:38` and `:50`, `core/cases/case_workflow_service.py:145`, `core/cases/case_templates_router.py:54`.

Investigation rows are constructed in exactly one place, `services/daemon/orchestrator.py:1303`, so those two writers are the complete set.

## The reader that settles it

`services/api/routers/orchestrator.py:484` collects the elements into a set and tests `Finding.finding_id` for membership — that only ever matches if the elements are those strings.

But the decisive one is `services/daemon/orchestrator.py:1098`:

```python
finding_id = trigger_ids[0] if isinstance(trigger_ids, list) else None
```

which is then assigned to `AIDecisionLog.finding_id` — `String(50)`, a foreign key to `findings.finding_id` with `ON DELETE CASCADE` (`core/storage/models.py:313`). A `dict` element there would be a type error against a foreign key. `List[dict]` was never true.

**Element type: `str`, bounded by `findings.finding_id`'s `String(50)`.**

## Real rows: none exist, in any environment

The acceptance criteria asked for a sample and which environment it came from. The honest answer is that there is nothing to sample — `investigations` is empty in all three environments reachable from here:

| environment | rows |
|---|---|
| live `dt-vigil` demo database (GKE, chart 0.5.0) | 0 |
| `pg_dump` of that same database taken pre-upgrade at 0.4.0 | 0 |
| local `docker-compose` Postgres | 0 |

The DDL in that dump does confirm the storage type independently: `trigger_ids jsonb NOT NULL`, matching the model. So the verdict rests on the code, which is unanimous, rather than on data — and that limitation is worth stating plainly rather than implying the shape was confirmed empirically.

## Why child-table rather than `ARRAY(TEXT)`

The elements aren't opaque scalars — they're foreign keys, and one of them is *already used as* a foreign key value. Two consequences:

1. **Integrity.** Nothing today stops `trigger_ids` referencing a deleted finding. When that happens, `trigger_ids[0]` flows into `AIDecisionLog.finding_id` and the insert hits an FK violation at a point far from the cause. A join table with its own FK and `ON DELETE CASCADE` keeps the list consistent by construction; both `ARRAY(TEXT)` and JSONB leave dangling ids possible.
2. **The read pattern wants a join.** `routers/orchestrator.py:482-486` loads *every* Investigation row and flattens all `trigger_ids` into a Python set to answer "which findings are already under investigation". That is a full table scan in application code. A join table turns it into an indexed query; `ARRAY(TEXT)` with a GIN index would at least make it `SELECT DISTINCT unnest(...)`.

Cardinality is small — one writer caps at 10 — so this is a correctness argument, not a performance one.

`ARRAY(TEXT)` is the reasonable middle if a join table is judged too heavy. Keeping JSONB is defensible only as a holding position, which is what this PR does: **storage is unchanged here**, per the issue's "no migration in this issue".

## Three things found along the way that the issue didn't anticipate

**1. `docs/JSONB_AUDIT.md` does not exist.** The issue cites it for "rationale and full classification", but #546, which would have added it, was **closed without merging** on 2026-08-13 with no closing comment. The content is still recoverable — the branch `docs/468-jsonb-column-audit` survives on the `craig-dt` fork, and its version of the doc contains the very `trigger_ids` row that motivated this issue. Worth either relanding it or removing the reference, since #468 is still open and points at a document nobody can read.

**2. `investigations` is an ORM-only table.** There is no `CREATE TABLE investigations` in any `.sql` file in the repo — the table comes from SQLAlchemy `create_all`. The issue's migration-mechanism section assumes delivery via a numbered file in `database/init/`, which doesn't apply to this table as written. That is exactly the drift #562 describes, and it means any future promotion of this column needs a different mechanism than the issue anticipates.

**3. `InvestigationSchema.trigger_ids` is still `Optional[Any]`** (`core/storage/schemas/workflow.py:156`). Tightening it to `Optional[List[str]]` is the natural follow-up, but I left it out deliberately: `ORMSchema.dump` goes through `model_validate`, so narrowing the type converts "unexpected data reads through" into "unexpected data raises a `ValidationError` in an API response". That is a runtime behaviour change and doesn't belong in an investigation PR.

## Path drift

The issue's line references predate `refactor/reorg-481`. Current locations: `database/models.py:2000` → `core/storage/models.py:1517`; `daemon/orchestrator.py:950` → `services/daemon/orchestrator.py:942`; `daemon/orchestrator.py:1167` → `services/daemon/orchestrator.py:1308`.

## Testing

No test accompanies this. A `Mapped[...]` annotation on a JSONB column has no runtime behaviour to assert — SQLAlchemy doesn't enforce it and the stored type is unchanged. The gate is `mypy services/ core/ --ignore-missing-imports`, which CI already runs; its output is byte-identical before and after this change.

`tests/unit/storage` passes (167). `flake8` reports the same 5 findings on `core/storage/models.py` before and after, all pre-existing and none on the changed lines; `black` would reformat the file both before and after, at hunks nowhere near this change, so I left it alone.

Pre-existing on this base, unrelated: `tests/unit/daemon/test_orchestrator_{heartbeat,runs}.py` and `tests/unit/api/test_service_dependency_overrides.py` fail to collect with `No module named 'bullmq'`.
