### PR TITLE
fix(config): validate Settings at llm-worker startup

### DIFF
--- a/services/daemon/llm_worker_manager.py
+++ b/services/daemon/llm_worker_manager.py
@@ -29,6 +29,8 @@ class LLMWorkerManager:
         while not shutdown_event.is_set():
             self._sync_enabled_from_db()
 
+            # EX_CONFIG (78) is treated like any other child death: restart
+            # on the next poll. Compose/Helm see 78 on the container.
             if self._enabled and not self._is_running():
                 self._start_worker()
             elif not self._enabled and self._is_running():

--- a/services/daemon/llm_worker_manager.py
+++ b/services/daemon/llm_worker_manager.py
@@ -29,8 +29,8 @@ class LLMWorkerManager:
         while not shutdown_event.is_set():
             self._sync_enabled_from_db()
 
-            # EX_CONFIG (78) is treated like any other child death: restart
-            # on the next poll. Compose/Helm see 78 on the container.
+            # Restart on any child death, including EX_CONFIG (78). This
+            # child inherited the daemon's already-validated env.
             if self._enabled and not self._is_running():
                 self._start_worker()
             elif not self._enabled and self._is_running():

--- a/services/worker/__main__.py
+++ b/services/worker/__main__.py
@@ -2,10 +2,14 @@ import asyncio
 
 from arq.worker import run_worker
 
-from services.worker.jobs import WorkerSettings
+from core.config import validate_settings_or_exit
 
 
 def main():
+    validate_settings_or_exit()
+    # jobs.py constructs Settings at import; must stay below the guard.
+    from services.worker.jobs import WorkerSettings
+
     # Python 3.12+ dropped implicit loop creation; ARQ's Worker needs one to exist.
     asyncio.set_event_loop(asyncio.new_event_loop())
     run_worker(WorkerSettings)

--- a/tests/unit/test_startup_config_validation.py
+++ b/tests/unit/test_startup_config_validation.py
@@ -16,7 +16,9 @@ class _EmptyValidationError:
         return []
 
 
-def _run_startup(command: str) -> subprocess.CompletedProcess[str]:
+def _run_startup(
+    command: str | None = None, *, module: str | None = None
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["DAEMON_HEALTH_PORT"] = "not-an-int"
     env["DEV_MODE"] = "true"
@@ -25,13 +27,19 @@ def _run_startup(command: str) -> subprocess.CompletedProcess[str]:
         if env.get("PYTHONPATH")
         else str(REPO_ROOT)
     )
+    if module is not None:
+        argv = [sys.executable, "-m", module]
+    else:
+        assert command is not None
+        argv = [sys.executable, "-c", command]
     return subprocess.run(
-        [sys.executable, "-c", command],
+        argv,
         cwd=REPO_ROOT,
         env=env,
         text=True,
         capture_output=True,
         check=False,
+        timeout=30,
     )
 
 
@@ -47,6 +55,16 @@ def test_api_startup_reports_labeled_configuration_error():
 
 def test_daemon_entrypoint_reports_labeled_configuration_error():
     result = _run_startup("from services.daemon.main import main; main()")
+
+    assert result.returncode == os.EX_CONFIG
+    assert result.stderr.count("configuration error:") == 1
+    assert "daemon_health_port" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert "ValidationError" not in result.stderr
+
+
+def test_worker_entrypoint_reports_labeled_configuration_error():
+    result = _run_startup(module="services.worker")
 
     assert result.returncode == os.EX_CONFIG
     assert result.stderr.count("configuration error:") == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- validate `Settings` at the llm-worker process boundary (`python -m services.worker`) and emit one `configuration error: …` line before `jobs.py` constructs settings
- exit invalid worker startup with `os.EX_CONFIG` (78), matching the API and daemon from #685
- defer `from services.worker.jobs import WorkerSettings` until after the guard so a module-level import cannot bypass it; `arq.worker.run_worker` stays at module scope
- add a load-bearing third case in `tests/unit/test_startup_config_validation.py` that runs `python -m services.worker`
- leave the daemon's `LLMWorkerManager` restart loop as-is: the supervised child inherits the daemon's already-validated env, so worker `EX_CONFIG` under that supervisor is degenerate. Compose/Helm deploy the worker as its own process and observe 78 there.

Closes #693.

cc @nestor-deeptempo

## Verification
- `python -m pytest tests/unit/test_startup_config_validation.py tests/unit/worker/test_worker_entrypoint.py -c tests/pytest.ini --no-cov` — 10 passed
- `DAEMON_HEALTH_PORT=not-an-int python -m services.worker` — one stderr line `configuration error: daemon_health_port: …`, exit 78, no traceback
- Moving `WorkerSettings` back to module-level import fails the new test (`assert 1 == 78`, `ValidationError` traceback)
- `black --check` / `isort --check-only` / `flake8` on the touched files — passed
- `lint-imports` — 3 contracts kept
- `git diff --check` — passed
- Independent review of the full diff: no blocking issues; supervisor comment tightened from that review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecfbab64-4db8-4b83-b6d6-c787ecae8c77?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecfbab64-4db8-4b83-b6d6-c787ecae8c77&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

