### PR TITLE
fix(daemon): keep synchronous DB calls off the event loop

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -196,6 +196,10 @@ class Settings(BaseSettings):
     daemon_auto_triage: bool = True
     daemon_auto_enrich: bool = True
     daemon_batch_size: int = 10
+    # Processor worker coroutines, and the cap on concurrent enrichment LLM
+    # calls — processor.py uses this value for both. Was hard-coded at 5 with
+    # no way to raise it, which put a ceiling on daemon throughput.
+    daemon_max_concurrent_tasks: int = 5
     daemon_enrich_max_inflight: int = 50
     daemon_enrich_backfill: bool = True
     daemon_enrich_backfill_interval: int = 300

--- a/env.example
+++ b/env.example
@@ -536,6 +536,8 @@ DAEMON_AUTO_TRIAGE="true"
 DAEMON_AUTO_ENRICH="true"
 # Findings to process per batch
 DAEMON_BATCH_SIZE="10"
+# Processor worker coroutines, and the cap on concurrent enrichment LLM calls
+DAEMON_MAX_CONCURRENT_TASKS="5"
 # Max pending background enrich tasks (backpressure: workers block when reached)
 DAEMON_ENRICH_MAX_INFLIGHT="50"
 # Backfill sweep: re-triage findings stored but never enriched (ai_enrichment NULL)

--- a/services/daemon/config.py
+++ b/services/daemon/config.py
@@ -150,6 +150,7 @@ class DaemonConfig:
         config.processing.auto_triage_enabled = settings.daemon_auto_triage
         config.processing.auto_enrich_enabled = settings.daemon_auto_enrich
         config.processing.batch_size = settings.daemon_batch_size
+        config.processing.max_concurrent_tasks = settings.daemon_max_concurrent_tasks
         config.processing.enrich_max_inflight = settings.daemon_enrich_max_inflight
         config.processing.enrich_backfill_enabled = settings.daemon_enrich_backfill
         config.processing.enrich_backfill_interval = settings.daemon_enrich_backfill_interval

--- a/services/daemon/orchestrator.py
+++ b/services/daemon/orchestrator.py
@@ -888,25 +888,32 @@ class Orchestrator:
             from core.storage.connection import get_db_manager
             from core.storage.models import Investigation as InvModel
 
-            with get_db_manager().session_scope() as session:
-                existing = (
-                    session.query(InvModel)
-                    .filter(
-                        InvModel.workflow_id == "case-review",
-                        InvModel.case_id == case_id,
-                        InvModel.status.notin_(["failed"]),
+            def _existing_review_id() -> Optional[str]:
+                """Synchronous SQLAlchemy — the caller runs this in a worker
+                thread. The id is read inside the session scope so the caller
+                never touches a detached instance."""
+                with get_db_manager().session_scope() as session:
+                    row = (
+                        session.query(InvModel)
+                        .filter(
+                            InvModel.workflow_id == "case-review",
+                            InvModel.case_id == case_id,
+                            InvModel.status.notin_(["failed"]),
+                        )
+                        .first()
                     )
-                    .first()
-                )
-                if existing:
-                    logger.debug(
-                        f"Case-review already exists for {case_id}: {existing.investigation_id}"
-                    )
-                    return
+                    return row.investigation_id if row else None
+
+            existing_id = await asyncio.to_thread(_existing_review_id)
+            if existing_id:
+                logger.debug(f"Case-review already exists for {case_id}: {existing_id}")
+                return
 
             case_data = None
             if self._data_service:
-                case_data = self._data_service.get_case(case_id)
+                case_data = await asyncio.to_thread(
+                    self._data_service.get_case, case_id
+                )
             if not case_data:
                 logger.warning(f"Case {case_id} not found, skipping case review")
                 return

--- a/services/daemon/poller.py
+++ b/services/daemon/poller.py
@@ -595,7 +595,9 @@ class DataPoller:
 
         try:
             from core.ingestion.ingestion_service import IngestionService
-            IngestionService().ingest_finding(finding)
+            # Synchronous SQLAlchemy — off the event loop, otherwise this
+            # fallback blocks the polling loop for the whole write.
+            await asyncio.to_thread(IngestionService().ingest_finding, finding)
             return True
         except Exception:
             logger.exception(

--- a/services/daemon/processor.py
+++ b/services/daemon/processor.py
@@ -395,7 +395,9 @@ class FindingProcessor:
                 continue
 
             try:
-                batch = self._data_service.get_findings_missing_enrichment(
+                # Synchronous SQLAlchemy — off the event loop, see _store_finding.
+                batch = await asyncio.to_thread(
+                    self._data_service.get_findings_missing_enrichment,
                     limit=self.config.enrich_backfill_batch,
                     max_age_hours=self.config.enrich_backfill_max_age_hours,
                 )
@@ -422,7 +424,7 @@ class FindingProcessor:
             from core.ingestion.ingestion_service import IngestionService
 
             ingestion = IngestionService()
-            return bool(ingestion.ingest_finding(finding))
+            return bool(await asyncio.to_thread(ingestion.ingest_finding, finding))
         except Exception as e:
             logger.error(f"Failed to store finding: {e}")
             return False
@@ -449,7 +451,11 @@ class FindingProcessor:
         if not updates:
             return
         # update_finding reports failure by returning False rather than raising.
-        if not self._data_service.update_finding(finding_id, **updates):
+        # Synchronous SQLAlchemy — off the event loop, see _store_finding.
+        stored = await asyncio.to_thread(
+            self._data_service.update_finding, finding_id, **updates
+        )
+        if not stored:
             logger.error(
                 "Failed to persist triage result for %s; the enrichment backfill "
                 "will re-queue it", finding_id,

--- a/tests/unit/daemon/test_db_calls_off_event_loop.py
+++ b/tests/unit/daemon/test_db_calls_off_event_loop.py
@@ -1,0 +1,107 @@
+"""The daemon's synchronous DB calls must not run on the event loop.
+
+The DB layer is synchronous SQLAlchemy (``create_engine`` + ``sessionmaker``
+over psycopg2). Any call made from an ``async def`` therefore has to be pushed
+through ``asyncio.to_thread`` — awaiting one inline freezes the loop for the
+whole round-trip, and ``services/daemon/main.py`` runs eight subsystems on that
+single loop, so one blocking write stalls polling, Kafka ingest and the
+orchestrator alike.
+
+These tests assert the offload by thread identity rather than by timing, so
+they are deterministic: a call that reports the loop's own thread id never
+went through a worker thread.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from services.daemon.config import PollingConfig, ProcessingConfig
+from services.daemon.poller import DataPoller
+from services.daemon.processor import FindingProcessor
+
+
+class _ThreadRecorder:
+    """Stands in for a synchronous DB call and records where it ran."""
+
+    def __init__(self, return_value=True):
+        self.thread_id = None
+        self.calls = []
+        self._return_value = return_value
+
+    def __call__(self, *args, **kwargs):
+        self.thread_id = threading.get_ident()
+        self.calls.append((args, kwargs))
+        return self._return_value
+
+
+def _assert_offloaded(recorder: _ThreadRecorder, loop_thread: int, name: str):
+    assert recorder.thread_id is not None, f"{name} was never called"
+    assert recorder.thread_id != loop_thread, (
+        f"{name} ran on the event loop thread — it is synchronous SQLAlchemy "
+        "and must go through asyncio.to_thread"
+    )
+
+
+async def test_store_finding_offloads_ingest():
+    loop_thread = threading.get_ident()
+    processor = FindingProcessor(ProcessingConfig())
+    recorder = _ThreadRecorder(return_value=True)
+
+    with patch("core.ingestion.ingestion_service.IngestionService") as ingestion_cls:
+        ingestion_cls.return_value.ingest_finding = recorder
+        stored = await processor._store_finding({"finding_id": "f-1"})
+
+    assert stored is True
+    _assert_offloaded(recorder, loop_thread, "ingest_finding")
+
+
+async def test_update_finding_offloads_the_write():
+    loop_thread = threading.get_ident()
+    processor = FindingProcessor(ProcessingConfig())
+    recorder = _ThreadRecorder()
+    processor._data_service = MagicMock()
+    processor._data_service.update_finding = recorder
+
+    await processor._update_finding({"finding_id": "f-1", "severity": "high"})
+
+    _assert_offloaded(recorder, loop_thread, "update_finding")
+    assert recorder.calls[0][0] == ("f-1",)
+    assert recorder.calls[0][1] == {"severity": "high"}
+
+
+async def test_poller_direct_store_offloads_ingest():
+    """The no-queue fallback in _enqueue_finding writes straight to the DB."""
+    loop_thread = threading.get_ident()
+    poller = DataPoller(PollingConfig())
+    poller._output_queue = None  # force the direct-store branch
+    poller._data_service = MagicMock()
+    recorder = _ThreadRecorder()
+
+    with patch("core.ingestion.ingestion_service.IngestionService") as ingestion_cls:
+        ingestion_cls.return_value.ingest_finding = recorder
+        await poller._enqueue_finding({"finding_id": "f-1"}, "test-source")
+
+    _assert_offloaded(recorder, loop_thread, "ingest_finding")
+
+
+async def test_case_review_lookup_offloads_the_query():
+    """_maybe_trigger_case_review opens a session to look for an existing
+    review, then reads the case. Both are synchronous, and both ran on the
+    orchestrator's loop."""
+    from services.daemon.config import OrchestratorConfig
+    from services.daemon.orchestrator import Orchestrator
+
+    loop_thread = threading.get_ident()
+    orchestrator = Orchestrator(OrchestratorConfig())
+    recorder = _ThreadRecorder(return_value={"title": "t", "finding_ids": []})
+    orchestrator._data_service = MagicMock()
+    orchestrator._data_service.get_case = recorder
+
+    with patch("core.storage.connection.get_db_manager") as manager:
+        scope = manager.return_value.session_scope.return_value
+        scope.__enter__.return_value.query.return_value.filter.return_value.first.return_value = (
+            None
+        )
+        await orchestrator._maybe_trigger_case_review("case-1")
+
+    _assert_offloaded(recorder, loop_thread, "get_case")

--- a/tests/unit/daemon/test_db_calls_off_event_loop.py
+++ b/tests/unit/daemon/test_db_calls_off_event_loop.py
@@ -105,3 +105,15 @@ async def test_case_review_lookup_offloads_the_query():
         await orchestrator._maybe_trigger_case_review("case-1")
 
     _assert_offloaded(recorder, loop_thread, "get_case")
+
+
+async def test_max_concurrent_tasks_is_settings_driven():
+    """It gates both the worker-coroutine count and the enrichment LLM cap, so
+    it has to be reachable from configuration rather than hard-coded."""
+    from core.config import Settings
+
+    assert hasattr(Settings(), "daemon_max_concurrent_tasks")
+
+    config = ProcessingConfig(max_concurrent_tasks=17)
+    processor = FindingProcessor(config)
+    assert processor._semaphore._value == 17


### PR DESCRIPTION
The DB layer is synchronous SQLAlchemy, so a call made from an `async def` freezes the loop for the whole round-trip. `services/daemon/main.py` runs eight subsystems on that one loop, so a blocking write stalls polling, Kafka ingest and the orchestrator alike.

## What changed

Six call sites now go through `asyncio.to_thread`:

| file | call site |
|---|---|
| `processor.py` | `_store_finding`, `_update_finding`, the backfill sweeper batch query |
| `poller.py` | the direct-store fallback in `_enqueue_finding` |
| `orchestrator.py` | the existing-review lookup and the case read in `_maybe_trigger_case_review` |

The orchestrator lookup also moved into a helper so the id is read inside the session scope — returning the ORM instance would hand the caller a detached object.

A second commit makes `max_concurrent_tasks` configurable. It gates both the worker-coroutine count and the enrichment LLM semaphore in `processor.py`, and nothing set it from configuration, so 5 was a throughput ceiling that could only be raised by editing the source. The default is unchanged, so it is inert until somebody sets it.

## Tests

`tests/unit/daemon/test_db_calls_off_event_loop.py` asserts the offload by **thread identity rather than by timing**, so it is deterministic — a call reporting the loop own thread id never went through a worker thread.

Each test was checked against the unfixed code first and fails there with the assertion it is meant to fail with, e.g.:

```
AssertionError: get_case ran on the event loop thread — it is synchronous
SQLAlchemy and must go through asyncio.to_thread
```

## Notes

- No behaviour change beyond where the work runs.
- `flake8` reports no new findings on any touched file. `black` is not run on them: these files are not currently black-clean on `main`, and reformatting them would bury the change.
- Found while running the daemon under load in a downstream deployment.