### PR TITLE
fix(response): make should_auto_approve's threshold parameter effective

### DIFF
--- a/core/response/approval_service.py
+++ b/core/response/approval_service.py
@@ -116,6 +116,14 @@ def _row_to_pending(row: ApprovalActionRow) -> PendingAction:
 class ApprovalService:
     """Service for managing approval workflow for autonomous actions."""
 
+    #: How far below the auto-approval threshold an action still runs, flagged
+    #: for review. One constant so the threshold, the flag band and
+    #: :meth:`get_action_decision` cannot drift apart.
+    FLAG_MARGIN = 0.05
+
+    #: Below this, an action is watched rather than proposed at all.
+    MONITOR_ONLY_BELOW = 0.70
+
     def __init__(self, data_dir: Optional[Path] = None, dry_run: bool = False):
         """
         Initialize approval service.
@@ -181,32 +189,60 @@ class ApprovalService:
         """Get the current force manual approval setting."""
         return self.force_manual_approval
 
+    def _auto_approve_floor(self, threshold: float) -> float:
+        """The lowest confidence that may run unattended.
+
+        One flag band below ``threshold``, but never below
+        :attr:`MONITOR_ONLY_BELOW`: an action too weak to be worth proposing
+        is not one to carry out on its own, and a threshold configured low
+        enough to cross that line would otherwise have
+        :meth:`get_action_decision` returning ``monitor_only`` for something
+        :meth:`should_auto_approve` had already cleared.
+        """
+        return max(threshold - self.FLAG_MARGIN, self.MONITOR_ONLY_BELOW)
+
     def should_auto_approve(
         self,
         action: Dict,
         threshold: float = 0.90,
         force_manual: bool = False,
     ) -> bool:
-        """Decide if an action should auto-approve based on confidence."""
+        """Decide if an action should auto-approve based on confidence.
+
+        Auto-approval starts one flag band below ``threshold``: an action in
+        ``[threshold - FLAG_MARGIN, threshold)`` still runs, and
+        :meth:`needs_flag` marks it for review afterwards.
+
+        The band is derived from ``threshold`` rather than hard-coded, which
+        is what makes the parameter mean anything. It used to fall back to a
+        literal ``0.85`` after the threshold check, so every value above 0.85
+        was ignored -- passing ``threshold=0.99`` still auto-approved an
+        action at 0.86. For a knob whose only purpose is to make the service
+        more conservative, that is the dangerous direction to fail in.
+        """
         if force_manual or self.get_force_manual_approval():
             return False
         confidence = action.get("confidence", 0.0)
-        if confidence >= threshold:
-            return True
-        if confidence >= 0.85:
-            return True
-        return False
+        return confidence >= self._auto_approve_floor(threshold)
 
-    def needs_flag(self, confidence: float) -> bool:
-        """Check if an action needs a flag (confidence 0.85-0.89)."""
-        return 0.85 <= confidence < 0.90
+    def needs_flag(self, confidence: float, threshold: float = 0.90) -> bool:
+        """Whether an auto-approved action should be flagged for review.
+
+        The band just below ``threshold``: approved on confidence alone, but
+        close enough to the line to be worth a second look.
+        """
+        return self._auto_approve_floor(threshold) <= confidence < threshold
 
     def get_action_decision(self, action: Dict, threshold: float = 0.90) -> str:
-        """Get the decision for an action based on confidence."""
+        """Get the decision for an action based on confidence.
+
+        The auto-approval line is the same one :meth:`should_auto_approve`
+        uses, so the two cannot disagree about an action.
+        """
         confidence = action.get("confidence", 0.0)
-        if confidence < 0.70:
+        if confidence < self.MONITOR_ONLY_BELOW:
             return "monitor_only"
-        elif confidence < 0.85:
+        elif confidence < self._auto_approve_floor(threshold):
             return "manual_approval"
         else:
             return "auto_approve"

--- a/tests/unit/response/test_auto_approve_threshold.py
+++ b/tests/unit/response/test_auto_approve_threshold.py
@@ -1,0 +1,145 @@
+"""The ``threshold`` on ``should_auto_approve`` has to mean something.
+
+It used to fall back to a literal ``0.85`` after checking the threshold, so
+any value above 0.85 was ignored: ``threshold=0.99`` still auto-approved an
+action at 0.86. For a parameter whose only purpose is to make the service more
+conservative, being inert is the dangerous direction -- an operator raising it
+got no error, no warning, and no change in behaviour.
+
+The 0.85 itself was not the defect. It is the bottom of a flag band that
+``needs_flag`` and ``get_action_decision`` also draw at 0.85, and actions in
+that band are meant to run and be reviewed afterwards. The fix derives the
+band from ``threshold`` instead of repeating the literal, so the three agree
+by construction and the default behaviour is unchanged.
+"""
+
+import pytest
+
+from core.response.approval_service import ApprovalService
+
+MARGIN = ApprovalService.FLAG_MARGIN
+
+
+@pytest.fixture
+def service(monkeypatch):
+    svc = ApprovalService.__new__(ApprovalService)
+    svc.force_manual_approval = False
+    return svc
+
+
+def action(confidence):
+    return {"type": "block_ip", "confidence": confidence}
+
+
+class TestTheThresholdIsHonoured:
+    def test_raising_it_withholds_approval(self):
+        # The regression. 0.86 cleared the old hard-coded 0.85 whatever the
+        # caller asked for.
+        svc = ApprovalService.__new__(ApprovalService)
+        svc.force_manual_approval = False
+        assert svc.should_auto_approve(action(0.86), threshold=0.99) is False
+
+    def test_lowering_it_grants_approval(self, service):
+        assert service.should_auto_approve(action(0.76), threshold=0.80) is True
+        assert service.should_auto_approve(action(0.74), threshold=0.80) is False
+
+    def test_the_flag_band_moves_with_it(self, service):
+        assert service.should_auto_approve(action(0.94), threshold=0.99) is True
+        assert service.should_auto_approve(action(0.93), threshold=0.99) is False
+
+    @pytest.mark.parametrize("threshold", [0.80, 0.90, 0.99])
+    def test_the_band_is_always_one_margin_wide(self, service, threshold):
+        floor = threshold - MARGIN
+        assert service.should_auto_approve(action(floor), threshold=threshold) is True
+        assert (
+            service.should_auto_approve(action(floor - 0.01), threshold=threshold)
+            is False
+        )
+
+    def test_the_monitor_line_is_a_floor_the_threshold_cannot_cross(self, service):
+        """An action too weak to be worth proposing is not one to carry out
+        unattended. Without the clamp, a low threshold would have
+        get_action_decision returning monitor_only for something
+        should_auto_approve had already cleared."""
+        low = ApprovalService.MONITOR_ONLY_BELOW - 0.05
+        assert service.should_auto_approve(action(low), threshold=low) is False
+        assert (
+            service.should_auto_approve(
+                action(ApprovalService.MONITOR_ONLY_BELOW), threshold=low
+            )
+            is True
+        )
+
+
+class TestTheDefaultsAreUnchanged:
+    """The shipped behaviour is documented by the existing suite; this pins
+    that the change is inert at the default threshold."""
+
+    @pytest.mark.parametrize(
+        "confidence,expected",
+        [
+            (0.95, True),
+            (0.90, True),
+            (0.87, True),
+            (0.85, True),
+            (0.84, False),
+            (0.75, False),
+            (0.55, False),
+        ],
+    )
+    def test_auto_approval(self, service, confidence, expected):
+        assert service.should_auto_approve(action(confidence)) is expected
+
+    @pytest.mark.parametrize(
+        "confidence,expected",
+        [(0.90, False), (0.89, True), (0.85, True), (0.84, False)],
+    )
+    def test_the_flag_band(self, service, confidence, expected):
+        assert service.needs_flag(confidence) is expected
+
+    @pytest.mark.parametrize(
+        "confidence,expected",
+        [
+            (0.95, "auto_approve"),
+            (0.85, "auto_approve"),
+            (0.84, "manual_approval"),
+            (0.70, "manual_approval"),
+            (0.69, "monitor_only"),
+        ],
+    )
+    def test_the_decision(self, service, confidence, expected):
+        assert service.get_action_decision(action(confidence)) == expected
+
+
+class TestTheThreeAgree:
+    """One constant, so a caller cannot be told two different things about the
+    same action."""
+
+    @pytest.mark.parametrize("threshold", [0.60, 0.90, 0.99])
+    @pytest.mark.parametrize("confidence", [0.55, 0.72, 0.86, 0.94, 0.99])
+    def test_auto_approval_and_the_decision_never_disagree(
+        self, service, threshold, confidence
+    ):
+        approves = service.should_auto_approve(action(confidence), threshold=threshold)
+        decision = service.get_action_decision(action(confidence), threshold=threshold)
+        if decision == "auto_approve":
+            assert approves is True
+        else:
+            assert approves is False
+
+    def test_a_flagged_action_is_one_that_was_approved(self, service):
+        for confidence in (0.85, 0.87, 0.89):
+            assert service.needs_flag(confidence) is True
+            assert service.should_auto_approve(action(confidence)) is True
+
+
+class TestForceManualStillWins:
+    def test_the_argument(self, service):
+        assert (
+            service.should_auto_approve(action(0.99), threshold=0.50, force_manual=True)
+            is False
+        )
+
+    def test_the_service_setting(self, service):
+        service.force_manual_approval = True
+        assert service.should_auto_approve(action(0.99), threshold=0.50) is False


### PR DESCRIPTION
`ApprovalService.should_auto_approve` checks `confidence >= threshold` and then falls through to `confidence >= 0.85`, so the second check answers for every threshold above 0.85:

```python
service.should_auto_approve({"confidence": 0.86}, threshold=0.99)  # True
```

An operator raising the bar to be more conservative gets no error, no warning and no change in behaviour. For a knob whose only purpose is to make the service stricter, that is the dangerous direction to fail in.

## The 0.85 is not the bug

It is the bottom of a flag band that `needs_flag` and `get_action_decision` also draw at 0.85 — actions there are meant to run and be reviewed afterwards, and `test_auto_approve_with_flag` documents exactly that. So this derives the band from `threshold` instead of repeating the literal in three places:

- `FLAG_MARGIN` (0.05) and `MONITOR_ONLY_BELOW` (0.70) name the two lines.
- `_auto_approve_floor()` returns `threshold - FLAG_MARGIN`, clamped so it never drops below the monitor line. Without the clamp a low threshold makes `get_action_decision` return `monitor_only` for an action `should_auto_approve` has already cleared.
- `needs_flag` takes the same `threshold`, defaulted, so existing callers are unaffected.

## Compatibility

**Behaviour at the default threshold is unchanged.** The existing `TestConfidenceThresholds` cases pass unmodified:

| confidence | before | after |
|---|---|---|
| 0.95 | approve | approve |
| 0.87 | approve (flagged) | approve (flagged) |
| 0.85 | approve | approve |
| 0.84 | manual | manual |

`should_auto_approve`, `needs_flag` and `get_action_decision` have no callers outside tests today, so nothing downstream changes shape.

## Tests

`tests/unit/response/test_auto_approve_threshold.py` covers the moved band, the clamp, and a matrix asserting the three methods cannot disagree about the same action — that matrix is what caught the clamp being necessary.