### PR TITLE
fix(response): expire approvals nobody will ever answer

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -219,6 +219,10 @@ class Settings(BaseSettings):
     daemon_threat_hunt_enabled: bool = True
     daemon_threat_hunt_interval: int = 86400
     daemon_cleanup_retention_days: int = 90
+    # Separate from cleanup_retention_days on purpose: that governs bulk data
+    # retention and wants a long horizon, while an unanswered containment
+    # proposal goes stale in days (#675).
+    daemon_approval_expiry_days: int = 7
     daemon_metrics_enabled: bool = True
     daemon_health_host: str = "localhost"
     daemon_health_port: int = 9091

--- a/core/response/approval_service.py
+++ b/core/response/approval_service.py
@@ -351,6 +351,30 @@ class ApprovalService:
             logger.error("DB error listing actions: %s", e)
             return []
 
+    def list_stale_pending(self, cutoff: datetime) -> List[str]:
+        """Ids of pending actions created before ``cutoff``, oldest first.
+
+        Deliberately not expressed as ``list_actions(...)`` filtered in Python:
+        that orders newest-first and caps at 500, so once the queue is larger
+        than the cap it hides the oldest rows — the exact ones a sweep is for.
+        Ids rather than ``PendingAction`` because the caller only rejects them,
+        and because ``PendingAction.created_at`` is a serialized string, not a
+        datetime to compare against.
+        """
+        try:
+            db = get_db_manager()
+            with db.session_scope() as session:
+                stmt = (
+                    select(ApprovalActionRow.action_id)
+                    .where(ApprovalActionRow.status == ActionStatus.PENDING.value)
+                    .where(ApprovalActionRow.created_at < cutoff)
+                    .order_by(ApprovalActionRow.created_at.asc())
+                )
+                return list(session.execute(stmt).scalars().all())
+        except SQLAlchemyError as e:
+            logger.error("DB error listing stale pending actions: %s", e)
+            return []
+
     def approve_action(
         self,
         action_id: str,

--- a/core/response/checkpoints.py
+++ b/core/response/checkpoints.py
@@ -73,3 +73,39 @@ def withdraw_for_run(run_id: str, reason: str, approvals=None) -> int:
     if open_ones:
         logger.info("withdrew %d unanswered approvals for %s", len(open_ones), run_id)
     return len(open_ones)
+
+
+# The run-less siblings of withdraw_for_run. That function keys on
+# workflow_run_id, so approvals raised without a run behind them are unreachable
+# and nothing else ages them out: the queue only grows and the one question that
+# matters ends up buried (#675). It is also a safety line, not housekeeping —
+# these are containment proposals, and approving a weeks-old "isolate host" out
+# of a cluttered queue acts on a reason that stopped being true. Rejected rather
+# than deleted, and attributed to "system", so the record distinguishes the queue
+# ageing a question out from an analyst declining it.
+def expire_stale(older_than_days: int, approvals=None) -> int:
+    from datetime import timedelta
+
+    from core.response.approval_service import ApprovalService
+    from core.time import utcnow
+
+    if older_than_days < 1:
+        raise ValueError(
+            "older_than_days must be at least 1, got "
+            f"{older_than_days}: a zero or negative window expires approvals "
+            "raised seconds ago, including the one an operator is reading"
+        )
+
+    service = approvals or ApprovalService()
+    cutoff = utcnow() - timedelta(days=older_than_days)
+    reason = f"expired: unanswered for more than {older_than_days} days"
+    stale = service.list_stale_pending(cutoff)
+    for action_id in stale:
+        service.reject_action(action_id, reason, rejected_by="system")
+    if stale:
+        logger.info(
+            "expired %d approvals unanswered since before %s",
+            len(stale),
+            cutoff.isoformat(),
+        )
+    return len(stale)

--- a/env.example
+++ b/env.example
@@ -585,6 +585,9 @@ DAEMON_THREAT_HUNT_ENABLED="true"
 DAEMON_THREAT_HUNT_INTERVAL="86400"
 # Keep data for 90 days
 DAEMON_CLEANUP_RETENTION_DAYS="90"
+# Reject approvals nobody answered within this many days. Shorter than data
+# retention: a stale containment proposal is unsafe to approve, not just untidy.
+DAEMON_APPROVAL_EXPIRY_DAYS="7"
 
 # -----------------------------------------------------------------------------
 # Metrics / Monitoring

--- a/services/daemon/config.py
+++ b/services/daemon/config.py
@@ -67,6 +67,7 @@ class SchedulerConfig:
     cleanup_enabled: bool = True
     cleanup_interval: int = 86400  # Daily
     cleanup_retention_days: int = 90
+    approval_expiry_days: int = 7
 
 
 @dataclass
@@ -172,6 +173,7 @@ class DaemonConfig:
         config.scheduler.threat_hunt_enabled = settings.daemon_threat_hunt_enabled
         config.scheduler.threat_hunt_interval = settings.daemon_threat_hunt_interval
         config.scheduler.cleanup_retention_days = settings.daemon_cleanup_retention_days
+        config.scheduler.approval_expiry_days = settings.daemon_approval_expiry_days
 
         config.metrics.enabled = settings.daemon_metrics_enabled
         config.metrics.port = settings.daemon_health_port

--- a/services/daemon/scheduler.py
+++ b/services/daemon/scheduler.py
@@ -381,13 +381,23 @@ class TaskScheduler:
         # Calculate cutoff date
         cutoff = utcnow() - timedelta(days=self.config.cleanup_retention_days)
         
-        # For now, just log what would be cleaned
-        # In production, would delete old findings/processed events
+        # Findings/processed events are still only logged, not deleted.
         logger.info(f"Cleanup would remove data older than {cutoff.isoformat()}")
         
         # Dedup sets are pruned by RedisDedupSet itself (TTL + size cap)
 
-        return {"cutoff_date": cutoff.isoformat()}
+        # Approvals nobody will ever answer (#675). Off-thread because each
+        # expiry is its own write and the sweep is unbounded, while this runs on
+        # the daemon's event loop.
+        from core.response.checkpoints import expire_stale
+
+        expired = await asyncio.to_thread(
+            expire_stale, self.config.approval_expiry_days
+        )
+        if expired:
+            logger.info("Cleanup expired %d unanswered approvals", expired)
+
+        return {"cutoff_date": cutoff.isoformat(), "approvals_expired": expired}
     
     async def _run_sandbox_poll(self):
         """Advance pending sandbox submissions to completed reports."""

--- a/tests/unit/daemon/test_cleanup_expires_approvals.py
+++ b/tests/unit/daemon/test_cleanup_expires_approvals.py
@@ -1,0 +1,59 @@
+"""The scheduled cleanup actually expires stale approvals, at the configured window.
+
+The wiring is the risk here, not the sweep. `_run_cleanup` shipped as a stub that
+computed a cutoff and only logged it, so "cleanup runs" was true while nothing was
+cleaned. A sweep that is registered but never reached, or reached with the wrong
+window, fails exactly the same silent way (#675).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from services.daemon.config import SchedulerConfig
+from services.daemon.scheduler import TaskScheduler
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expires_approvals_using_the_configured_window():
+    config = SchedulerConfig()
+    config.approval_expiry_days = 3
+    scheduler = TaskScheduler(config)
+
+    with patch("core.response.checkpoints.expire_stale", return_value=2) as sweep:
+        result = await scheduler._run_cleanup()
+
+    sweep.assert_called_once_with(3)
+    assert result["approvals_expired"] == 2
+
+
+@pytest.mark.asyncio
+async def test_cleanup_reports_zero_when_nothing_is_stale():
+    scheduler = TaskScheduler(SchedulerConfig())
+
+    with patch("core.response.checkpoints.expire_stale", return_value=0):
+        result = await scheduler._run_cleanup()
+
+    assert result["approvals_expired"] == 0
+    # The data-retention half is still only logged; the cutoff it reports must
+    # not quietly disappear when the approval sweep is added alongside it.
+    assert "cutoff_date" in result
+
+
+def test_the_expiry_window_is_wired_from_settings(monkeypatch):
+    # A SchedulerConfig field nothing populates from Settings is a knob that
+    # silently does nothing — the failure mode this whole issue is about.
+    #
+    # Asserted against a NON-default value on purpose. Comparing the two
+    # defaults passes whether or not the wiring line exists, which is a
+    # vacuous test of exactly the thing being checked.
+    from core.config import get_settings
+    from services.daemon.config import DaemonConfig
+
+    monkeypatch.setenv("DAEMON_APPROVAL_EXPIRY_DAYS", "11")
+    get_settings.cache_clear()
+
+    config = DaemonConfig.from_env()
+    assert config.scheduler.approval_expiry_days == 11

--- a/tests/unit/response/test_expire_stale_approvals.py
+++ b/tests/unit/response/test_expire_stale_approvals.py
@@ -1,0 +1,85 @@
+"""An approval nobody will ever answer ages out instead of sitting pending.
+
+`withdraw_for_run` closes the questions an ended run left open, but it keys on
+`workflow_run_id`, so approvals raised without a run behind them are
+unreachable — nothing ages them out and the pending queue only grows (#675).
+A containment action proposed weeks ago is also not safe to approve out of a
+cluttered queue: the reason it was raised has stopped being true.
+"""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from core.response.checkpoints import expire_stale
+from core.time import utcnow
+
+
+class FakeApprovals:
+    def __init__(self, stale_ids):
+        self.stale_ids = list(stale_ids)
+        self.rejected = []
+        self.asked_cutoff = None
+
+    def list_stale_pending(self, cutoff):
+        self.asked_cutoff = cutoff
+        return list(self.stale_ids)
+
+    def reject_action(self, action_id, reason, rejected_by="analyst"):
+        self.rejected.append((action_id, reason, rejected_by))
+        return SimpleNamespace(action_id=action_id)
+
+
+@pytest.mark.unit
+def test_expires_every_approval_past_the_window():
+    approvals = FakeApprovals(["a", "b", "c"])
+
+    assert expire_stale(7, approvals) == 3
+    assert [one[0] for one in approvals.rejected] == ["a", "b", "c"]
+
+
+@pytest.mark.unit
+def test_attributes_the_expiry_to_the_sweep_not_to_a_human():
+    # The audit trail has to distinguish "the system aged this out" from "an
+    # analyst said no"; approved_by carries that, so it must not say "analyst".
+    approvals = FakeApprovals(["a"])
+
+    expire_stale(7, approvals)
+    action_id, reason, rejected_by = approvals.rejected[0]
+    assert rejected_by == "system"
+    assert "7" in reason and "expired" in reason.lower()
+
+
+@pytest.mark.unit
+def test_cutoff_is_the_window_before_now():
+    approvals = FakeApprovals([])
+    before = utcnow()
+
+    expire_stale(7, approvals)
+
+    after = utcnow()
+    # Bracketed rather than compared to a fixed instant, so the assertion does
+    # not depend on how long the call took.
+    assert before - timedelta(days=7) <= approvals.asked_cutoff
+    assert approvals.asked_cutoff <= after - timedelta(days=7)
+
+
+@pytest.mark.unit
+def test_rejects_nothing_when_the_queue_is_current():
+    approvals = FakeApprovals([])
+
+    assert expire_stale(7, approvals) == 0
+    assert approvals.rejected == []
+
+
+@pytest.mark.unit
+def test_a_zero_or_negative_window_is_refused():
+    # A window of 0 would expire approvals raised seconds ago, including the one
+    # an operator is looking at. Misconfiguration should not silently empty the
+    # queue.
+    approvals = FakeApprovals(["a"])
+
+    with pytest.raises(ValueError):
+        expire_stale(0, approvals)
+    assert approvals.rejected == []


### PR DESCRIPTION
Closes #675. @mattmorr1 @johnvanlowe — flagging you both, since this is milestoned v0.6.0 and the issue was blocked on decisions rather than work.

The issue left four questions open. Three of them turned out to have answers already sitting in the code; the fourth is a number, and it's the one thing here worth arguing about.

## The four decisions, as implemented

**Expired → `rejected`, not a new terminal status.** `withdraw_for_run` already set this precedent:

```python
service.reject_action(action.action_id, reason, rejected_by="agent")
```

`reject_action` persists `rejection_reason`, `approved_by` and `approved_at`, so `rejected_by="system"` plus an expiry reason is already fully distinguishable from an analyst declining. A new status would touch every consumer of `ActionStatus` for no information the existing columns don't carry.

**The sweep runs in the daemon scheduler's existing `cleanup` task**, which already had `cleanup_interval` and a retention setting.

Worth knowing what that task did before this PR:

```python
# For now, just log what would be cleaned
# In production, would delete old findings/processed events
logger.info(f"Cleanup would remove data older than {cutoff.isoformat()}")
```

Registered, scheduled, and deleting nothing. **This PR does not fix the data-retention half** — findings and processed events are still only logged. Only the approval sweep is real. The stub deserves its own issue; I didn't want to widen this one, but anything assuming "cleanup runs" today is wrong.

Not a lazy sweep at list time: that does writes on a read path, and doesn't run at all when nobody opens the page — which is precisely the situation the badge complaint describes.

**The pending list is not filtered instead.** That hides the badge symptom while leaving rows `pending` forever, puts the list and the database in disagreement, and drops the record that the action went unanswered. Any consumer querying by status still sees all of them.

**No `expires_at` column.** Expiry is `created_at + window`, so no migration — matching the issue's "not a migration" framing. A column only earns its place if per-action-type windows are wanted later (`isolate_host` ageing faster than something low-risk), which is worth deciding deliberately.

## The number is yours

`DAEMON_APPROVAL_EXPIRY_DAYS`, default **7**, deliberately separate from `cleanup_retention_days` (90) which governs bulk data retention and wants a far longer horizon.

I framed this as safety rather than tidiness: these are `isolate_host` and `block_ip` proposals, and approving a three-week-old "isolate host1" out of a cluttered queue acts on a reason that stopped being true. That argues short. But 7 is a judgement, not a finding — change it in review and I'll update the default and the `env.example` note.

## One trap worth calling out

`list_stale_pending` is a new query rather than `list_actions(...)` filtered in Python. `list_actions` is `ORDER BY created_at DESC LIMIT 500`, so once the pending queue exceeds the cap it hides the **oldest** rows — exactly the ones a sweep exists to find. A Python-side filter would have looked correct, passed tests against small fixtures, and silently done nothing on the queue that actually needed it. It also returns ids, because `PendingAction.created_at` is a serialized string rather than a datetime.

The sweep runs via `asyncio.to_thread`, matching how `poller.py`, `processor.py` and `orchestrator.py` handle blocking work, since each expiry is its own write and this sits on the daemon's event loop.

## Tests

Written test-first, stubbed to red on behaviour rather than on `ImportError`, then implemented. Two files: the sweep itself (5 cases, faked service) and the wiring (3 cases).

The wiring tests are the ones that matter, because a registered-but-unreached sweep fails exactly the way the old stub did. Verified by mutation:

| mutation | caught by |
|---|---|
| remove the sweep call from `_run_cleanup` | `test_cleanup_expires_approvals_using_the_configured_window` |
| hardcode the wrong window | same |
| delete the `Settings` → `SchedulerConfig` wiring line | `test_the_expiry_window_is_wired_from_settings` |

That last one initially **passed** against the mutation — both sides default to 7, so comparing the defaults proved nothing. It now asserts against a non-default value set through the environment. Flagging it because it was the same silent-no-op class the issue is about, reproduced in my own test.

Also covered: a window of `0` or less raises rather than emptying the queue, since misconfiguration shouldn't expire an approval an operator is currently reading.

## Checks

`mypy services/ core/` byte-identical before and after. `flake8` counts unchanged on every file touched (`services/daemon/scheduler.py` carries 69 pre-existing findings both before and after; I didn't run `black` over existing files). New test files are `black`-clean.

Pre-existing failure on this base, unrelated: `tests/unit/_ratchets/test_hunt_capabilities_agree.py::test_the_definition_rosters_the_workers_the_arch_carries`, confirmed by stashing.

I couldn't reproduce the 45 rows outside a dev database — `approval_actions` is empty in the deployed demo environment, so the code path is the argument here rather than live data.

**#472** is still open; if the `decide(action)` funnel lands, this is a small function to relocate onto it.
