### PR TITLE
fix(cases): append notes as JSONB list entries

### DIFF
--- a/core/ingestion/ingestion_service.py
+++ b/core/ingestion/ingestion_service.py
@@ -354,6 +354,16 @@ class IngestionService:
             self.stats["cases_errors"] += 1
             return False
 
+        notes = case_data.get("notes", [])
+        if isinstance(notes, str):
+            notes = [
+                {
+                    "timestamp": utcnow().isoformat() + "Z",
+                    "content": notes,
+                }
+            ]
+            case_data = {**case_data, "notes": notes}
+
         try:
             if self.use_database and self.db_service:
                 # Check if case already exists
@@ -362,15 +372,6 @@ class IngestionService:
                     logger.debug(f"Case {case_id} already exists, skipping")
                     self.stats["cases_skipped"] += 1
                     return True
-
-                notes = case_data.get("notes", [])
-                if isinstance(notes, str):
-                    notes = [
-                        {
-                            "timestamp": utcnow().isoformat() + "Z",
-                            "content": notes,
-                        }
-                    ]
 
                 # Create case in database
                 case = self.db_service.create_case(

--- a/core/ingestion/ingestion_service.py
+++ b/core/ingestion/ingestion_service.py
@@ -363,6 +363,15 @@ class IngestionService:
                     self.stats["cases_skipped"] += 1
                     return True
 
+                notes = case_data.get("notes", [])
+                if isinstance(notes, str):
+                    notes = [
+                        {
+                            "timestamp": utcnow().isoformat() + "Z",
+                            "content": notes,
+                        }
+                    ]
+
                 # Create case in database
                 case = self.db_service.create_case(
                     case_id=case_id,
@@ -373,7 +382,7 @@ class IngestionService:
                     priority=case_data.get("priority", "medium"),
                     assignee=case_data.get("assignee"),
                     tags=case_data.get("tags", []),
-                    notes=case_data.get("notes", []),
+                    notes=notes,
                     timeline=case_data.get("timeline", []),
                     activities=case_data.get("activities", []),
                     resolution_steps=case_data.get("resolution_steps", []),

--- a/core/integrations/splunk/enrichment.py
+++ b/core/integrations/splunk/enrichment.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List
 from core.integrations.splunk.client import SplunkService
 from core.llm.harness.claude import ClaudeService
 from core.storage.database_data_service import DatabaseDataService
+from core.time import utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -455,8 +456,14 @@ Focus on:
 ---
 """
 
-        # Add enrichment note to case
-        self.data_service.update_case(case_id, notes=notes_entry)
+        notes = case.get("notes") or []
+        notes.append(
+            {
+                "timestamp": utcnow().isoformat() + "Z",
+                "content": notes_entry,
+            }
+        )
+        self.data_service.update_case(case_id, notes=notes)
 
         logger.info(f"Enrichment completed for case {case_id}")
 

--- a/services/api/routers/cases.py
+++ b/services/api/routers/cases.py
@@ -271,7 +271,17 @@ async def update_case(case_id: str, case_data: CaseUpdate):
     if case_data.priority is not None:
         updates["priority"] = case_data.priority
     if case_data.notes is not None:
-        updates["notes"] = case_data.notes
+        case = data_service.get_case(case_id)
+        if not case:
+            raise HTTPException(status_code=404, detail="Case not found")
+        notes = case.get("notes") or []
+        notes.append(
+            {
+                "timestamp": utcnow().isoformat() + "Z",
+                "content": case_data.notes,
+            }
+        )
+        updates["notes"] = notes
 
     success = data_service.update_case(case_id, **updates)
 

--- a/tests/unit/cases/test_case_notes_append.py
+++ b/tests/unit/cases/test_case_notes_append.py
@@ -1,0 +1,102 @@
+"""PATCH /api/cases/{id} must append a notes entry, not assign a string.
+
+``Case.notes`` is a ``JSONBList`` (#709). Writing a plain str raises
+``ValueError`` inside ``update_case``, which the endpoint used to surface
+as 404 and drop the rest of the payload. The router now does the same
+read-modify-write as ``add_case_activity``: load, append
+``{timestamp, content}``, write the full list.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+pytestmark = pytest.mark.unit
+
+
+def _patch_data_service(monkeypatch, *, case, update=None):
+    from services.api.routers import cases
+
+    captured = {}
+
+    def _update(case_id, **updates):
+        if isinstance(updates.get("notes"), str):
+            raise ValueError(
+                "Attribute 'notes' does not accept objects of type <class 'str'>"
+            )
+        captured["case_id"] = case_id
+        captured["updates"] = updates
+        return True if update is None else update(case_id, **updates)
+
+    monkeypatch.setattr(cases.data_service, "get_case", lambda case_id: case)
+    monkeypatch.setattr(cases.data_service, "update_case", _update)
+    return cases, captured
+
+
+@pytest.mark.asyncio
+async def test_patch_appends_a_note_entry(monkeypatch):
+    from services.api.routers.cases import CaseUpdate
+
+    existing = {
+        "case_id": "c1",
+        "notes": [{"timestamp": "2026-01-01T00:00:00Z", "content": "prior"}],
+    }
+    cases, captured = _patch_data_service(monkeypatch, case=existing)
+
+    result = await cases.update_case("c1", CaseUpdate(notes="analyst comment"))
+
+    assert result == {"success": True}
+    notes = captured["updates"]["notes"]
+    assert notes[0]["content"] == "prior"
+    assert notes[1]["content"] == "analyst comment"
+    assert notes[1]["timestamp"].endswith("Z")
+    assert set(notes[1]) == {"timestamp", "content"}
+
+
+@pytest.mark.asyncio
+async def test_patch_notes_starts_a_list_when_case_has_none(monkeypatch):
+    from services.api.routers.cases import CaseUpdate
+
+    cases, captured = _patch_data_service(
+        monkeypatch, case={"case_id": "c1", "notes": None}
+    )
+
+    await cases.update_case("c1", CaseUpdate(notes="first"))
+
+    notes = captured["updates"]["notes"]
+    assert len(notes) == 1
+    assert notes[0]["content"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_patch_keeps_other_fields_when_appending_notes(monkeypatch):
+    from services.api.routers.cases import CaseUpdate
+
+    cases, captured = _patch_data_service(
+        monkeypatch, case={"case_id": "c1", "notes": []}
+    )
+
+    await cases.update_case("c1", CaseUpdate(title="retitled", notes="wrapped"))
+
+    updates = captured["updates"]
+    assert updates["title"] == "retitled"
+    assert isinstance(updates["notes"], list)
+    assert updates["notes"][0]["content"] == "wrapped"
+
+
+@pytest.mark.asyncio
+async def test_patch_notes_404_when_case_missing(monkeypatch):
+    from services.api.routers import cases
+    from services.api.routers.cases import CaseUpdate
+
+    monkeypatch.setattr(cases.data_service, "get_case", lambda case_id: None)
+    monkeypatch.setattr(cases.data_service, "update_case", MagicMock())
+
+    with pytest.raises(HTTPException) as exc:
+        await cases.update_case("missing", CaseUpdate(notes="nope"))
+
+    assert exc.value.status_code == 404
+    cases.data_service.update_case.assert_not_called()

--- a/tests/unit/ingestion/test_ingest_case_notes.py
+++ b/tests/unit/ingestion/test_ingest_case_notes.py
@@ -1,0 +1,52 @@
+"""ingest_case wraps a string ``notes`` into a one-element list of entries."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.ingestion.ingestion_service import IngestionService
+
+pytestmark = pytest.mark.unit
+
+
+def _service():
+    svc = IngestionService.__new__(IngestionService)
+    svc.use_database = True
+    svc.db_service = MagicMock()
+    svc.db_service.get_case.return_value = None
+    svc.db_service.create_case.return_value = object()
+    svc.stats = {
+        "findings_total": 0,
+        "findings_imported": 0,
+        "findings_skipped": 0,
+        "findings_errors": 0,
+        "cases_total": 0,
+        "cases_imported": 0,
+        "cases_skipped": 0,
+        "cases_errors": 0,
+    }
+    svc._identity_warned = set()
+    return svc
+
+
+def test_ingest_case_wraps_string_notes_into_an_entry():
+    svc = _service()
+
+    assert svc.ingest_case({"case_id": "c1", "notes": "imported as text"}) is True
+
+    notes = svc.db_service.create_case.call_args.kwargs["notes"]
+    assert isinstance(notes, list)
+    assert notes[0]["content"] == "imported as text"
+    assert notes[0]["timestamp"].endswith("Z")
+    assert set(notes[0]) == {"timestamp", "content"}
+
+
+def test_ingest_case_passes_list_notes_through():
+    svc = _service()
+    original = [{"timestamp": "2026-01-01T00:00:00Z", "content": "already a list"}]
+
+    assert svc.ingest_case({"case_id": "c1", "notes": original}) is True
+
+    assert svc.db_service.create_case.call_args.kwargs["notes"] is original

--- a/tests/unit/ingestion/test_ingest_case_notes.py
+++ b/tests/unit/ingestion/test_ingest_case_notes.py
@@ -50,3 +50,41 @@ def test_ingest_case_passes_list_notes_through():
     assert svc.ingest_case({"case_id": "c1", "notes": original}) is True
 
     assert svc.db_service.create_case.call_args.kwargs["notes"] is original
+
+
+def test_ingest_case_wraps_string_notes_on_json_fallback(monkeypatch):
+    svc = IngestionService.__new__(IngestionService)
+    svc.use_database = False
+    svc.db_service = None
+    svc.stats = {
+        "findings_total": 0,
+        "findings_imported": 0,
+        "findings_skipped": 0,
+        "findings_errors": 0,
+        "cases_total": 0,
+        "cases_imported": 0,
+        "cases_skipped": 0,
+        "cases_errors": 0,
+    }
+    svc._identity_warned = set()
+
+    stored = []
+
+    class _FakeDataService:
+        def get_cases(self):
+            return stored
+
+        def save_cases(self, cases):
+            stored[:] = list(cases)
+            return True
+
+    monkeypatch.setattr(
+        "core.storage.database_data_service.DatabaseDataService",
+        _FakeDataService,
+    )
+
+    incoming = {"case_id": "c1", "notes": "imported as text"}
+    assert svc.ingest_case(incoming) is True
+    assert incoming["notes"] == "imported as text"
+    assert stored[0]["notes"][0]["content"] == "imported as text"
+    assert set(stored[0]["notes"][0]) == {"timestamp", "content"}

--- a/tests/unit/integrations/test_splunk_enrichment.py
+++ b/tests/unit/integrations/test_splunk_enrichment.py
@@ -1,0 +1,79 @@
+"""Splunk enrich_case must append a notes entry, not assign a markdown string."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.integrations.splunk.enrichment import SplunkEnrichmentService
+
+pytestmark = pytest.mark.unit
+
+
+def _service():
+    svc = SplunkEnrichmentService.__new__(SplunkEnrichmentService)
+    svc.splunk_service = MagicMock()
+    svc.claude_service = MagicMock()
+    svc.data_service = MagicMock()
+    svc.extract_indicators = MagicMock(
+        return_value={
+            "ips": [],
+            "domains": [],
+            "hashes": [],
+            "usernames": [],
+            "hostnames": [],
+        }
+    )
+    svc.query_splunk_for_indicators = MagicMock(
+        return_value={"summary": {"total_events": 4}}
+    )
+    svc.analyze_with_claude = MagicMock(return_value="ai analysis")
+    return svc
+
+
+def test_enrich_case_appends_note_and_keeps_existing():
+    svc = _service()
+    prior = {"timestamp": "2026-01-01T00:00:00Z", "content": "analyst note"}
+    svc.data_service.get_case.return_value = {
+        "case_id": "c1",
+        "finding_ids": [],
+        "notes": [prior],
+    }
+
+    result = svc.enrich_case("c1")
+
+    assert result["success"] is True
+    svc.data_service.update_case.assert_called_once()
+    notes = svc.data_service.update_case.call_args.kwargs["notes"]
+    assert notes[0] == prior
+    assert "Splunk Enrichment" in notes[1]["content"]
+    assert "ai analysis" in notes[1]["content"]
+    assert notes[1]["timestamp"].endswith("Z")
+    assert set(notes[1]) == {"timestamp", "content"}
+
+
+def test_enrich_case_does_not_pass_a_string_as_notes():
+    """The pre-#718 writer assigned the markdown blob; MutableList refuses that."""
+    svc = _service()
+    svc.data_service.get_case.return_value = {
+        "case_id": "c1",
+        "finding_ids": [],
+        "notes": [],
+    }
+
+    def _reject_string(case_id, **updates):
+        if isinstance(updates.get("notes"), str):
+            raise ValueError(
+                "Attribute 'notes' does not accept objects of type <class 'str'>"
+            )
+        return True
+
+    svc.data_service.update_case.side_effect = _reject_string
+
+    result = svc.enrich_case("c1")
+
+    assert result["success"] is True
+    notes = svc.data_service.update_case.call_args.kwargs["notes"]
+    assert isinstance(notes, list)
+    assert len(notes) == 1

--- a/tests/unit/storage/test_jsonb_list_assignment.py
+++ b/tests/unit/storage/test_jsonb_list_assignment.py
@@ -1,0 +1,57 @@
+"""Assignment shape for every column wrapped in ``JSONBList``.
+
+#709 wrapped ``Case.notes`` (and the other JSONB arrays) in
+``MutableList.as_mutable(JSONB)`` so in-place appends persist. That wrap
+rejects a plain ``str`` with ``ValueError`` rather than coercing it —
+which is the contract the writers in #718 have to meet. These tests pin
+the assignment path #709 shipped without: a list is accepted on every
+wrapped column, and a string on ``Case.notes`` is refused.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import inspect as sa_inspect
+
+import core.storage.models as models
+from core.storage.models import JSONBList
+from tests.unit.storage.orm_sample_instances import iter_serializable_models
+
+pytestmark = pytest.mark.unit
+
+
+def _jsonb_list_columns():
+    """Every mapped column that uses the ``JSONBList`` type object."""
+    found = []
+    for name, model in iter_serializable_models():
+        for column in sa_inspect(model).mapper.columns:
+            if column.type is JSONBList:
+                found.append((name, model, column.key))
+    return found
+
+
+def test_jsonb_list_discovery_includes_case_notes():
+    """The walk must actually see the wrap; an empty list would hide a revert."""
+    names = {(name, key) for name, _model, key in _jsonb_list_columns()}
+    assert ("Case", "notes") in names
+    assert ("Case", "timeline") in names
+    assert ("Case", "activities") in names
+    assert ("Case", "resolution_steps") in names
+    assert ("CaseEvidence", "chain_of_custody") in names
+
+
+@pytest.mark.parametrize(
+    "model_name,key",
+    [(name, key) for name, _model, key in _jsonb_list_columns()] or [("Case", "notes")],
+)
+def test_jsonb_list_column_accepts_a_list(model_name, key):
+    model = getattr(models, model_name)
+    instance = model()
+    setattr(instance, key, [{"ok": True}])
+    assert list(getattr(instance, key)) == [{"ok": True}]
+
+
+def test_assigning_a_string_to_case_notes_raises():
+    case = models.Case()
+    with pytest.raises(ValueError, match="does not accept objects of type"):
+        case.notes = "some note text"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`Case.notes` is a `MutableList` after #709. Assigning a plain `str` raises `ValueError`, which `update_case` swallowed into a 404 (and dropped the rest of the PATCH payload) and which Splunk enrichment logged while still returning success.

This keeps the wrap and fixes the three string writers so they pass a list of `{timestamp, content}` dicts — the shape timeline already reads.

## Writers

- **`PATCH /api/cases/{id}`** — `CaseUpdate.notes` stays `Optional[str]`. When set, the handler loads the case, appends one entry, and writes the full list (same read-modify-write as `add_case_activity`). Other fields in the same request still go through.
- **Splunk `enrich_case`** — appends the markdown block onto existing notes instead of assigning the string (or replacing with a one-element list).
- **`ingest_case`** — a `str` becomes a one-element list; an existing list is passed through. The wrap sits above the database/JSON branch so both paths store the list, without mutating the caller's dict.

`DatabaseService.update_case` / `DatabaseDataService.update_case` stay generic setattr. `JSONBList` itself is unchanged. The 404-on-`False` mapping is left for #719.

## Tests

- Assigning a list to every `JSONBList` column succeeds; assigning a `str` to `Case.notes` raises `ValueError`.
- PATCH appends an entry (and keeps sibling fields) rather than 404ing on a string.
- Splunk enrichment appends onto existing notes instead of dropping them.
- `ingest_case` wraps a string on both the DB and JSON-fallback paths.

Closes #718

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77ee5d33-aaf4-4d37-955b-2d117603d727?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77ee5d33-aaf4-4d37-955b-2d117603d727&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

