### PR TITLE
feat(memory): map a source to its Source Tier (#728)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -265,6 +265,17 @@ _Avoid_: page, tab, view
 ## Relationships
 
 - A **Case** groups one or more **Findings**
+- **Episodic Memory** derives **Verdicts** from a **Ledger** after an
+  investigation terminates; it never writes during a run, and a run reads it
+  once at start (ADR 0015)
+- A **Verdict**'s sources each carry a **Source Tier** and the Verdict carries
+  one **Trust**. The two are independent axes: **Trust** is who concluded, and
+  a `feed`-tier source can be cited by an `analyst`
+- **Source Tier** is stamped at write time, never joined at read time, so
+  recategorising an **Integration** later cannot change how a past **Verdict**
+  was corroborated
+- **Trust** is unrelated to **Connector Trust**, which is about admitting a
+  third-party origin rather than weighing a conclusion
 - **Ingestion** produces **Findings** and depends on **Storage** (never the reverse)
 - **Federation** drives **Ingestion** (an adapter wraps an ingestion service);
   Ingestion never depends on Federation

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -133,6 +133,30 @@ several — Splunk has both an official server and the self-hosted one Vigil shi
 `mcp-config.json` key.
 _Avoid_: integration id, tool name
 
+**Episodic Memory** (`memory`):
+What earlier investigations saw and concluded, derived from a **Ledger** after a
+run reaches its terminal so a later run stops re-deriving a settled answer.
+Reorders the frontier and never decides (ADR 0015).
+_Avoid_: MemPalace (the component this replaces), cache, RAG
+
+**Source Tier**:
+What a source *is*: `telemetry` observed our own estate, `feed` asserts about the
+world, `not_evidence` is neither. Distinct from **Trust**, which is who
+concluded — `analyst` or `agent`. Both sit on a **Verdict**'s sources, and one
+does not imply the other: a feed can be cited by an analyst.
+_Avoid_: connector trust, confidence, severity
+
+**Trust**:
+Who concluded — `analyst` when a person closed it, `agent` when the daemon did.
+The other axis on a **Verdict**'s sources, alongside **Source Tier**. Unrelated
+to **Connector Trust**, which is about admitting a third-party origin.
+_Avoid_: connector trust, source tier, confidence
+
+**Verdict**:
+What one investigation concluded about one hypothesis, naming its subjects
+rather than every entity its evidence touched (ADR 0016).
+_Avoid_: finding, case closure, outcome
+
 ### Shared-infrastructure tier
 
 **Storage** (`storage`):

--- a/core/memory/__init__.py
+++ b/core/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Episodic memory domain package (#727).
+
+What runs saw and concluded, derived from a Ledger after an investigation
+reaches its terminal. Callers import directly from ``core.memory.<module>``.
+"""

--- a/core/memory/source_tier.py
+++ b/core/memory/source_tier.py
@@ -1,0 +1,154 @@
+"""The source-to-Source-Tier map (#728).
+
+Ranking needs two telemetry sources agreeing to outweigh two feeds agreeing,
+and needs some sources not to count as evidence at all. Memory owns this map
+and stamps the tier onto the row at write time rather than joining at read
+time, so an integration removed or recategorised later cannot retroactively
+change how a past Verdict was corroborated.
+
+The map is keyed twice, because the two investigation kinds name sources in
+different vocabularies. A hunt names a telemetry domain, narrowed to the
+playbook's ``data_domains`` by ``attributeSource``. A Case names the
+``data_source`` of the Findings it groups, which is a vendor pipeline. Both
+land in memory's own ``source_system`` column, so ``source_tier`` takes the
+investigation kind to know which vocabulary it is reading.
+"""
+
+import logging
+from enum import Enum
+from typing import Dict, Set
+
+logger = logging.getLogger(__name__)
+
+
+class SourceTier(str, Enum):
+    """What a source *is*, as distinct from who concluded (**Trust**)."""
+
+    TELEMETRY = "telemetry"
+    FEED = "feed"
+    NOT_EVIDENCE = "not_evidence"
+
+
+class InvestigationKind(str, Enum):
+    """Which vocabulary a source name is drawn from."""
+
+    HUNT = "hunt"
+    CASE = "case"
+
+
+DEFAULT_TIER = SourceTier.FEED
+
+# Reference and harness-internal names. A rulebook cited as corroboration is a
+# run treating a lookup as an observation; the critic arguing with itself, an
+# operator declaring a blind spot and the dispatcher recording a failed tool
+# call are none of them a second look at the estate. `not_evidence` on a Verdict
+# is a defect rather than a weak row, so these exist to make it visible.
+#
+# The harness-internal three reach the ledger under their own names because
+# `attributeSource` collapses only `provenance === "worker"`, and each of them
+# is appended under a different provenance. The two reference servers cannot
+# arrive on either path today — they write no findings, and a worker naming one
+# collapses to `undeclared` first. They are listed because AC 4 asks for the
+# guard, and a guard is meant to have no hits in healthy data.
+_NOT_EVIDENCE: Set[str] = {
+    "attack-layer",
+    "security-detections",
+    "critic",
+    "operator",
+    "dispatcher",
+}
+
+# Detonation is a real observation, but of an artifact rather than of our
+# estate, so two sandboxes agreeing is not two independent looks at it.
+_SANDBOX: Set[str] = {
+    "cape-sandbox",
+    "joe-sandbox",
+}
+
+# The nine values present in `findings.data_source`, enumerated against live
+# data on 2026-08-28: `loglm` carries 98% of rows and the rest are the ingest
+# and demo pipeline labels behind it. All nine observe our own estate. The two
+# ingest fallbacks below are reachable in code but absent from that census.
+_CASE_TIERS: Dict[str, SourceTier] = {
+    "loglm": SourceTier.TELEMETRY,
+    "firewall": SourceTier.TELEMETRY,
+    "proxy": SourceTier.TELEMETRY,
+    "flow": SourceTier.TELEMETRY,
+    "edr": SourceTier.TELEMETRY,
+    "dns": SourceTier.TELEMETRY,
+    "email": SourceTier.TELEMETRY,
+    "endpoint": SourceTier.TELEMETRY,
+    "siem": SourceTier.TELEMETRY,
+    # Ingest fallbacks, used when a row declared no source of its own. Known
+    # values, deliberately left at the default: an import of unstated
+    # provenance is exactly what the conservative direction is for, and naming
+    # them here keeps them out of the unknown-source log.
+    "imported": SourceTier.FEED,
+    "csv_import": SourceTier.FEED,
+}
+
+# Two sets of `data_domains`. `network`/`authentication`/`endpoint` are the
+# shipped threat-hunt WORKFLOW.md's; `cloud_audit`/`identity`/`endpoint_process`
+# appear in no repo file but are what every live hunt declared as of
+# 2026-08-28, so a spec is reaching the runtime from outside the tree. A worker
+# label outside its own playbook's list never arrives here under that name —
+# `attributeSource` collapses it to `undeclared` first.
+_HUNT_TIERS: Dict[str, SourceTier] = {
+    "network": SourceTier.TELEMETRY,
+    "authentication": SourceTier.TELEMETRY,
+    "endpoint": SourceTier.TELEMETRY,
+    "cloud_audit": SourceTier.TELEMETRY,
+    "identity": SourceTier.TELEMETRY,
+    "endpoint_process": SourceTier.TELEMETRY,
+    # The collapse already decided this source could not be vouched for, so it
+    # takes the default rather than the tier of the domains around it.
+    "undeclared": SourceTier.FEED,
+}
+
+_TIERS_BY_KIND: Dict[InvestigationKind, Dict[str, SourceTier]] = {
+    InvestigationKind.CASE: _CASE_TIERS,
+    InvestigationKind.HUNT: _HUNT_TIERS,
+}
+
+
+def resolve_source_tier(
+    source_system: str, investigation_kind: InvestigationKind
+) -> SourceTier:
+    """Return the **Source Tier** of ``source_system`` in its own vocabulary.
+
+    An unknown source resolves to :data:`DEFAULT_TIER` and is logged rather
+    than raising: a source memory has never seen must not stop an
+    investigation being distilled, and grading it a feed understates its
+    corroborating weight instead of overstating it.
+
+    This makes a `not_evidence` source visible, not impossible. User story 38
+    wants it rejected outright on a Verdict, which is a write-path decision and
+    belongs to `distil` (#731); a map that raised here would fail the whole
+    investigation over one bad citation.
+    """
+    name = (source_system or "").strip().lower()
+    if not name:
+        logger.warning(
+            "Source Tier: empty source_system on a %s, defaulting to %s",
+            investigation_kind.value,
+            DEFAULT_TIER.value,
+        )
+        return DEFAULT_TIER
+
+    if name in _NOT_EVIDENCE:
+        return SourceTier.NOT_EVIDENCE
+
+    if name in _SANDBOX:
+        return SourceTier.FEED
+
+    tier = _TIERS_BY_KIND[investigation_kind].get(name)
+    if tier is None:
+        logger.warning(
+            "Source Tier: unknown source %r on a %s, defaulting to %s",
+            source_system,
+            investigation_kind.value,
+            DEFAULT_TIER.value,
+        )
+        return DEFAULT_TIER
+
+    return tier

--- a/core/memory/source_tier.py
+++ b/core/memory/source_tier.py
@@ -1,17 +1,24 @@
 """The source-to-Source-Tier map (#728).
 
 Ranking needs two telemetry sources agreeing to outweigh two feeds agreeing,
-and needs some sources not to count as evidence at all. Memory owns this map
-and stamps the tier onto the row at write time rather than joining at read
-time, so an integration removed or recategorised later cannot retroactively
-change how a past Verdict was corroborated.
+and needs some sources not to count as evidence at all. Memory owns this map;
+the caller stamps what it returns onto the row at write time rather than
+joining at read time, so an integration removed or recategorised later cannot
+retroactively change how a past Verdict was corroborated. Nothing calls this
+yet — `distil` (#731) is the write path.
 
-The map is keyed twice, because the two investigation kinds name sources in
-different vocabularies. A hunt names a telemetry domain, narrowed to the
-playbook's ``data_domains`` by ``attributeSource``. A Case names the
-``data_source`` of the Findings it groups, which is a vendor pipeline. Both
-land in memory's own ``source_system`` column, so ``source_tier`` takes the
-investigation kind to know which vocabulary it is reading.
+Three key spaces reach it, not two. The two that ``investigation_kind``
+selects between: a hunt names a telemetry domain, narrowed to the playbook's
+``data_domains`` by ``attributeSource``; a Case names the ``data_source`` of
+the Findings it groups, which is a vendor pipeline. The third is the **MCP
+Server Name** — reference servers and sandboxes, which CONTEXT.md defines as
+deliberately distinct from both. It is matched before either vocabulary and
+spans both kinds, because a server name means the same thing wherever it
+lands.
+
+Both land in memory's own ``source_system`` column, so
+``resolve_source_tier`` takes the investigation kind to know which vocabulary
+it is reading.
 """
 
 import logging
@@ -44,12 +51,17 @@ DEFAULT_TIER = SourceTier.FEED
 # call are none of them a second look at the estate. `not_evidence` on a Verdict
 # is a defect rather than a weak row, so these exist to make it visible.
 #
-# The harness-internal three reach the ledger under their own names because
-# `attributeSource` collapses only `provenance === "worker"`, and each of them
-# is appended under a different provenance. The two reference servers cannot
-# arrive on either path today — they write no findings, and a worker naming one
-# collapses to `undeclared` first. They are listed because AC 4 asks for the
-# guard, and a guard is meant to have no hits in healthy data.
+# The harness-internal names reach the ledger under their own names because
+# `attributeSource` collapses only `provenance === "worker"`, and each is
+# appended under a different provenance. There are four such categories, not
+# three: `critic` (null_check), `operator` (operator_gap), `dispatcher`, and
+# enrichment, which sets `source_system` to an unbounded `chain.id` and so
+# cannot be enumerated here — it takes the default.
+#
+# The two reference servers cannot arrive on either path today: they write no
+# findings, and a worker naming one collapses to `undeclared` first. They are
+# listed because AC 4 asks for the guard, and a guard is meant to have no hits
+# in healthy data.
 _NOT_EVIDENCE: Set[str] = {
     "attack-layer",
     "security-detections",
@@ -58,17 +70,15 @@ _NOT_EVIDENCE: Set[str] = {
     "dispatcher",
 }
 
-# Detonation is a real observation, but of an artifact rather than of our
-# estate, so two sandboxes agreeing is not two independent looks at it.
-_SANDBOX: Set[str] = {
-    "cape-sandbox",
-    "joe-sandbox",
-}
-
 # The nine values present in `findings.data_source`, enumerated against live
 # data on 2026-08-28: `loglm` carries 98% of rows and the rest are the ingest
-# and demo pipeline labels behind it. All nine observe our own estate. The two
-# ingest fallbacks below are reachable in code but absent from that census.
+# and demo pipeline labels behind it. All nine observe our own estate.
+#
+# A census of what the column holds, not of what it can hold: `data_source` is
+# caller-supplied (`ingestion_service` takes it as a parameter), the Kafka
+# consumer mints `kafka:<topic>`, and a connector extension brands findings
+# with its own manifest id, so vendor names are a designed path. Values outside
+# this set are expected and take the default.
 _CASE_TIERS: Dict[str, SourceTier] = {
     "loglm": SourceTier.TELEMETRY,
     "firewall": SourceTier.TELEMETRY,
@@ -79,12 +89,6 @@ _CASE_TIERS: Dict[str, SourceTier] = {
     "email": SourceTier.TELEMETRY,
     "endpoint": SourceTier.TELEMETRY,
     "siem": SourceTier.TELEMETRY,
-    # Ingest fallbacks, used when a row declared no source of its own. Known
-    # values, deliberately left at the default: an import of unstated
-    # provenance is exactly what the conservative direction is for, and naming
-    # them here keeps them out of the unknown-source log.
-    "imported": SourceTier.FEED,
-    "csv_import": SourceTier.FEED,
 }
 
 # Two sets of `data_domains`. `network`/`authentication`/`endpoint` are the
@@ -103,6 +107,34 @@ _HUNT_TIERS: Dict[str, SourceTier] = {
     # The collapse already decided this source could not be vouched for, so it
     # takes the default rather than the tier of the domains around it.
     "undeclared": SourceTier.FEED,
+}
+
+# Known pipelines whose suffix is caller-chosen, so they cannot be enumerated
+# as exact keys. Matched by prefix purely to keep a recognised pipeline out of
+# the unknown-source log; the tier is the default either way, and reading a
+# stronger tier off a prefix anyone can mint is what this deliberately avoids.
+# Known names that take :data:`DEFAULT_TIER` deliberately rather than by
+# failing to match. One shape for all of them, so "we decided this is a feed"
+# never reads as "we forgot this one": the tier is the default either way, and
+# the only behavioural difference is that these do not log.
+#
+# Detonation is a real observation, but of an artifact rather than of our
+# estate, so two sandboxes agreeing is not two independent looks at it. The
+# ingest fallbacks stand in when a row declared no source of its own, which is
+# exactly the unstated provenance the conservative direction is for.
+_KNOWN_DEFAULTED: Set[str] = {
+    "cape-sandbox",
+    "joe-sandbox",
+    "imported",
+    "csv_import",
+}
+
+# The same idea where the name's suffix is caller-chosen and so cannot be
+# enumerated. Reading a stronger tier off a prefix anyone can mint is what this
+# deliberately avoids; matching at all just keeps a recognised pipeline out of
+# the unknown-source log.
+_KNOWN_DEFAULTED_PREFIXES: Set[str] = {
+    "kafka:",
 }
 
 _TIERS_BY_KIND: Dict[InvestigationKind, Dict[str, SourceTier]] = {
@@ -138,8 +170,10 @@ def resolve_source_tier(
     if name in _NOT_EVIDENCE:
         return SourceTier.NOT_EVIDENCE
 
-    if name in _SANDBOX:
-        return SourceTier.FEED
+    if name in _KNOWN_DEFAULTED or any(
+        name.startswith(prefix) for prefix in _KNOWN_DEFAULTED_PREFIXES
+    ):
+        return DEFAULT_TIER
 
     tier = _TIERS_BY_KIND[investigation_kind].get(name)
     if tier is None:

--- a/core/memory/source_tier.py
+++ b/core/memory/source_tier.py
@@ -25,6 +25,8 @@ import logging
 from enum import Enum
 from typing import Dict, Set
 
+from core.integrations._base.descriptor import iter_descriptors
+
 logger = logging.getLogger(__name__)
 
 
@@ -137,6 +139,72 @@ _KNOWN_DEFAULTED_PREFIXES: Set[str] = {
     "kafka:",
 }
 
+# Vigil's own servers and the Catalog Entries. Neither can declare a category
+# of its own: the first are not products anyone sells, and the second are
+# integrations Vigil holds a credential for but carries no code for, which per
+# CONTEXT.md is exactly what has no Integration Descriptor. Everything else
+# comes from `_INTEGRATION_TIERS` below rather than being listed here.
+#
+# They do not share a tier. Flow data is an observation; a rule catalogue is a
+# lookup; reading our own findings back is a run agreeing with itself.
+_UNDECLARED_SERVERS: Dict[str, SourceTier] = {
+    "tempo-flow": SourceTier.TELEMETRY,
+    "deeptempo-findings": SourceTier.NOT_EVIDENCE,
+    "approval": SourceTier.NOT_EVIDENCE,
+    "gcp-secops": SourceTier.TELEMETRY,
+    "gcp-scc": SourceTier.TELEMETRY,
+    "cribl-stream": SourceTier.TELEMETRY,
+    "gcp-threat-intel": SourceTier.FEED,
+    "github": SourceTier.NOT_EVIDENCE,
+}
+
+# What a whole category of product is, so a new integration is graded on
+# arrival instead of defaulting to `feed` until someone edits this module.
+# `category` is free text and inconsistent with it — `EDR` and `EDR/XDR` are
+# both in use — so variants are listed rather than normalised away.
+#
+# `Communications` is a feed, not `not_evidence`: an analyst asserting
+# something in Slack is a claim about the world, and `not_evidence` is reserved
+# for things that assert nothing at all.
+_CATEGORY_TIERS: Dict[str, SourceTier] = {
+    "EDR": SourceTier.TELEMETRY,
+    "EDR/XDR": SourceTier.TELEMETRY,
+    "SIEM": SourceTier.TELEMETRY,
+    "Cloud Security": SourceTier.TELEMETRY,
+    "Identity & Access": SourceTier.TELEMETRY,
+    "Network Security": SourceTier.TELEMETRY,
+    "Threat Intelligence": SourceTier.FEED,
+    "Sandbox Analysis": SourceTier.FEED,
+    "Communications": SourceTier.FEED,
+    "Incident Management": SourceTier.NOT_EVIDENCE,
+}
+
+
+def _integration_tiers() -> Dict[str, SourceTier]:
+    """Grade every integration from the category it declares about itself.
+
+    Built once at import. A vendor already states what kind of product it is,
+    so the alternative — transcribing thirty-odd server names here — would go
+    stale the first time someone added one.
+    """
+    tiers: Dict[str, SourceTier] = {}
+    for descriptor in iter_descriptors():
+        tier = _CATEGORY_TIERS.get(descriptor.category)
+        if tier is None:
+            logger.warning(
+                "Source Tier: integration %r declares category %r, which maps "
+                "to no tier; its sources will take the default",
+                descriptor.id,
+                descriptor.category,
+            )
+            continue
+        for name in descriptor.mcp_server_names:
+            tiers[name] = tier
+    return tiers
+
+
+_INTEGRATION_TIERS: Dict[str, SourceTier] = _integration_tiers()
+
 _TIERS_BY_KIND: Dict[InvestigationKind, Dict[str, SourceTier]] = {
     InvestigationKind.CASE: _CASE_TIERS,
     InvestigationKind.HUNT: _HUNT_TIERS,
@@ -169,6 +237,10 @@ def resolve_source_tier(
 
     if name in _NOT_EVIDENCE:
         return SourceTier.NOT_EVIDENCE
+
+    server_tier = _UNDECLARED_SERVERS.get(name) or _INTEGRATION_TIERS.get(name)
+    if server_tier is not None:
+        return server_tier
 
     if name in _KNOWN_DEFAULTED or any(
         name.startswith(prefix) for prefix in _KNOWN_DEFAULTED_PREFIXES


### PR DESCRIPTION
Closes #728.

Ranking needs two telemetry sources agreeing to outweigh two feeds agreeing, and needs some sources not to count as evidence at all. Memory owns this map and stamps the tier onto the row at write time rather than joining at read time, so an integration removed or recategorised later cannot retroactively change how a past Verdict was corroborated.

## The map is keyed twice

The issue asked for one map keyed on `findings.data_source`. That covers Cases and leaves hunts unserved, and the factory review was right to stop on it — hunt corroboration counts ledger `source_system` (`services/agent/workflows/hunt/strength.ts`), not `data_source`.

What the review did not account for is that `distil(investigation_kind, investigation_id)` takes **both** investigation kinds, and a Case-derived Verdict draws on the Findings it groups, whose source column *is* `data_source`. That path is live: 15 cases, 13 `case_findings` rows across `email`, `proxy`, `dns`, `edr`, `firewall`, `siem`.

| kind | key | values |
|---|---|---|
| hunt | ledger `source_system` | the playbook's `data_domains`, else `undeclared` |
| case | finding `data_source` | the nine slugs below |

So `resolve_source_tier()` takes the investigation kind to know which vocabulary it is reading.

## The census the ACs asked for

Against the live database on 2026-08-28. `findings.data_source` holds nine values and no free text:

| value | rows |
|---|---|
| `loglm` | 2034 |
| `firewall` | 8 |
| `proxy` | 7 |
| `flow` | 5 |
| `edr` | 5 |
| `dns` | 4 |
| `email` | 4 |
| `endpoint` | 4 |
| `siem` | 3 |

**No normalisation job.** AC 5 closes at zero — these are clean slugs, not server names and not free text.

Ledger `source_system` holds only `splunk:okta` and `splunk:aws_cloudtrail`, five rows, all dated 2026-08-06 — before `attributeSource` landed on 2026-08-14 in #638. Nothing written since can carry a vendor name.

Every value in both vocabularies is `telemetry` today, so the map discriminates nothing yet. It earns its place as the guard that stops a rulebook being cited as an observation, and as the seam a `feed` source arrives through later.

## Harness-internal names are not evidence

`attributeSource` collapses only `provenance === "worker"`. The critic (`null_check`), the operator (`operator_gap`) and the dispatcher are each appended under another provenance, so all three reach the ledger under their own names. None of them observed anything, and `evidenceStrength` counts distinct `source_system` — so a linked critic record inflates `corroborating_sources` and makes a conclusion look better supported than it is. All three are `not_evidence`.

The two reference servers (`attack-layer`, `security-detections`) cannot arrive on either path today: they write no findings, and a worker naming one collapses to `undeclared` first. They are listed because AC 4 asks for the guard, and a guard is meant to have no hits in healthy data.

## Conservative by default

Unknown and empty resolve to `feed` and are logged rather than raising. Kafka topics are unbounded, so `kafka:<topic>` takes that path rather than being graded `telemetry` on a prefix match — grading a source down understates its corroborating weight, which is the safe direction. Sandbox detonation is `feed`: a real observation, but of an artifact rather than of the estate, so two sandboxes agreeing is not two independent looks at it.

## Acceptance criteria

- [x] The distinct values actually present in `findings.data_source` are enumerated and written down
- [x] Every value maps to `telemetry`, `feed` or `not_evidence`, or is deliberately left to the default — `imported` and `csv_import` are named explicitly *as* defaulted, so the decision is visible rather than accidental
- [x] Unknown sources resolve to `feed` and are logged rather than failing
- [x] Reference servers map to `not_evidence`
- [x] If normalisation is needed, its size is recorded — none is needed

## Not in this PR

**Enforcement.** This makes a `not_evidence` source visible, not impossible. User story 38 wants it rejected outright on a Verdict, which is a write-path decision belonging to `distil` (#731). A lookup table that raised here would fail a whole investigation over one bad citation.

**Vendor names surviving the collapse.** Nothing reachable today can produce a `feed`-tier *hunt* source: workers are told to name the telemetry domain, not the vendor, and the vendor label that survives — `payload.claimed_source_system` — has one writer, zero readers and zero rows. Making one possible is a harness contract change. It bounds how much #731 gets out of Source Tier rather than whether this map can be built, and wants its own issue.

**A spec reaching the runtime from outside the tree.** Live hunts declare `["cloud_audit", "identity", "endpoint_process"]`; the shipped threat-hunt playbook declares `network`/`authentication`/`endpoint`. Those first three appear in no repo file. The map covers both sets, but the discrepancy is worth chasing separately.

## Testing

No tests in this PR — say the word and I will add them. Behaviour was verified directly across 15 cases (casing, both kinds, every guard, empty input, unknown logging) and against every distinct value in both live vocabularies. The suite is unchanged at 73 failed / 1803 passed, diff-identical to the pre-change baseline on `episodic-memory` — those 73 are pre-existing full-suite ordering failures and all pass in isolation.
