### PR TITLE
fix(tests): make the DSN credential tests hermetic

### DIFF
--- a/tests/unit/storage/test_database_connection_url.py
+++ b/tests/unit/storage/test_database_connection_url.py
@@ -26,6 +26,19 @@ def special_char_config(monkeypatch):
     monkeypatch.setenv("POSTGRES_PORT", "5432")
     monkeypatch.setenv("POSTGRES_DB", "deeptempo_soc")
     monkeypatch.setenv("POSTGRES_SSL_MODE", "prefer")
+    # `DatabaseConfig` reads the password through `get_secret`, whose lookup
+    # order is encrypted store -> environment -> dotenv. Setting the env var is
+    # therefore not enough: on any machine with a real POSTGRES_PASSWORD in
+    # ~/.vigil/secrets.enc the store wins, and these assertions end up
+    # comparing against the developer's own credential rather than the
+    # special-character fixture. Patching the accessor is what makes the
+    # fixture actually control what the config sees.
+    monkeypatch.setattr(
+        "core.storage.connection.get_secret",
+        lambda key, default=None: (
+            SPECIAL_PASSWORD if key == "POSTGRES_PASSWORD" else default
+        ),
+    )
     return DatabaseConfig()
 
 


### PR DESCRIPTION
Four tests in `tests/unit/storage/test_database_connection_url.py` fail on a clean checkout of `main` on any machine that has a real `POSTGRES_PASSWORD` in `~/.vigil/secrets.enc`:

```
FAILED tests/unit/storage/test_database_connection_url.py::test_special_chars_round_trip[False]
FAILED tests/unit/storage/test_database_connection_url.py::test_special_chars_round_trip[True]
FAILED tests/unit/storage/test_database_connection_url.py::test_password_is_percent_encoded_in_dsn
FAILED tests/unit/storage/test_database_connection_url.py::test_host_override_round_trips_credentials
```

## Why

The fixture sets the password with `monkeypatch.setenv("POSTGRES_PASSWORD", ...)`, but `DatabaseConfig` reads it through `get_secret` (`core/storage/connection.py`), and that lookup order is **encrypted store → environment → dotenv**. The store wins, so the assertions compare the parsed DSN against the developer own credential rather than the special-character fixture.

Whether the suite passes therefore depends on what happens to be on the machine running it — it passes only where the secret store is empty, which is why CI does not catch it.

## The fix

Patch the accessor so the fixture actually controls what the config sees. Thirteen lines, test-only.

The encoding logic under test is untouched, so the issue #306 regression coverage still does its job — and it now does it **the same way on every machine**, rather than only on one with an empty secret store.

## Notes

- **No production behaviour changes.** Reading a credential from the encrypted store ahead of the environment is deliberate and documented; this does not alter it.
- `get_secret` is stubbed only for `POSTGRES_PASSWORD`; every other key falls through to the default.
- `flake8` clean. `black` is not run on the file: it is not currently black-clean on `main` (a blank line near the imports), and reformatting it would bury a 13-line change.