### PR TITLE
feat(web): export and remember findings views

### DIFF
--- a/clients/web/src/screens/dashboard/DashboardScreen.tsx
+++ b/clients/web/src/screens/dashboard/DashboardScreen.tsx
@@ -12,6 +12,13 @@ import FindingPopup from './FindingPopup'
 import AttackTechniqueFindings from './AttackTechniqueFindings'
 import { SEV_COLOR, TL_MONTHS, type TimelineEvent } from './attackData'
 import type { ConsoleScreenProps } from '../../shared/types'
+import { useToast } from '../../shell/toast'
+import { downloadFindingsCsv } from './findingsExport'
+import {
+  isFindingsSeverityFilter,
+  loadFindingsViewPreferences,
+  saveFindingsViewPreferences,
+} from './findingsPreferences'
 
 type DashTab = 'findings' | 'attack' | 'timeline' | 'entity'
 
@@ -59,17 +66,21 @@ function findingPrompt(f: Finding): string {
 }
 
 function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openChat' | 'goSettings'>) {
+  const { notify } = useToast()
   const { rows, phase, error, reload } = useFindings()
   const { kpis, reload: reloadKpis } = useDashboardKpis()
+  const [initialPreferences] = useState(loadFindingsViewPreferences)
   const [query, setQuery] = useState('')
-  const [sev, setSev] = useState('any')
-  const [src, setSrc] = useState('any')
+  const [sev, setSev] = useState(initialPreferences.severity)
+  const [src, setSrc] = useState(initialPreferences.source)
   const [detailId, setDetailId] = useState<string | null>(null)
   const [pageSize, setPageSize] = useState(10)
   const [page, setPage] = useState(1)
   // null = untouched, so use each column's default visibility. An empty Set is
   // meaningfully different: the user unhid everything.
-  const [hiddenCols, setHiddenCols] = useState<Set<string> | null>(null)
+  const [hiddenCols, setHiddenCols] = useState<Set<string> | null>(
+    initialPreferences.hiddenColumns ? new Set(initialPreferences.hiddenColumns) : null,
+  )
 
   // derived from whatever entity keys the rows carry, so a new source needs no
   // code change here
@@ -99,6 +110,20 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
     return [{ value: 'any', label: 'Any' }, ...set.map((s) => ({ value: s, label: s }))]
   }, [rows])
 
+  useEffect(() => {
+    if (phase === 'ready' && src !== 'any' && !srcOptions.some((option) => option.value === src)) {
+      setSrc('any')
+    }
+  }, [phase, src, srcOptions])
+
+  useEffect(() => {
+    saveFindingsViewPreferences({
+      severity: sev,
+      source: src,
+      hiddenColumns: hiddenCols ? [...hiddenCols].sort() : null,
+    })
+  }, [sev, src, hiddenCols])
+
   const filtered = useMemo(() => {
     const byFacet = rows.filter((f) => {
       if (sev !== 'any' && f.sev.toLowerCase() !== sev) return false
@@ -112,6 +137,15 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
   }, [rows, query, sev, src, allColumns])
 
   const sorted = useMemo(() => sortRows(filtered, allColumns, sort), [filtered, allColumns, sort])
+
+  const exportFindings = () => {
+    try {
+      downloadFindingsCsv(sorted)
+      notify('ok', `Exported ${sorted.length} finding${sorted.length === 1 ? '' : 's'} as CSV.`)
+    } catch (error) {
+      notify('err', (error as { message?: string })?.message || 'Failed to export findings.')
+    }
+  }
 
   // re-sorting keeps the same rows, so it doesn't reset the page
   useEffect(() => { setPage(1) }, [query, sev, src, pageSize])
@@ -168,7 +202,9 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
           <FilterGroup
             label="Severity"
             value={sev}
-            onSelect={setSev}
+            onSelect={(value) => {
+              if (isFindingsSeverityFilter(value)) setSev(value)
+            }}
             options={[
               { value: 'any', label: 'Any' },
               { value: 'critical', label: 'Critical' },
@@ -191,7 +227,12 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
         </FilterButton>
         <div className="flex-1" />
         <button className="btn ghost icon" title="Refresh" onClick={refresh}><Icon name="refresh" /></button>
-        <button className="btn primary"><Icon name="download" /> Export</button>
+        <button
+          className="btn primary"
+          disabled={sorted.length === 0}
+          title="Export filtered findings as CSV"
+          onClick={exportFindings}
+        ><Icon name="download" /> Export</button>
       </div>
 
       <div className="table-wrap list-scroll list-scroll-kpi">

--- a/clients/web/src/screens/dashboard/findingsExport.test.ts
+++ b/clients/web/src/screens/dashboard/findingsExport.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import type { Finding } from '../../data/data'
+import { buildFindingsCsv } from './findingsExport'
+
+const finding: Finding = {
+  id: 'finding-1',
+  sev: 'High',
+  tech: 'T1059.001',
+  conf: 93,
+  tactic: 'Execution',
+  src: 'sensor,west',
+  host: 'host-1',
+  user: 'analyst "one"',
+  time: 'Jun 14, 17:30',
+  ts: Date.parse('2026-06-14T17:30:00Z'),
+  score: 0.91,
+  status: 'open',
+  extra: { device_id: 'device-7', analyst_note: '=WEBSERVICE("https://example.invalid")' },
+}
+
+describe('buildFindingsCsv', () => {
+  it('exports stable fields, source-specific fields, and escaped cells', () => {
+    const csv = buildFindingsCsv([finding])
+    expect(csv).toContain('finding_id,severity,mitre_technique')
+    expect(csv).toContain(',device_id\n')
+    expect(csv).toContain('"sensor,west"')
+    expect(csv).toContain('"analyst ""one"""')
+    expect(csv).toContain('2026-06-14T17:30:00.000Z')
+    expect(csv).toContain("'=WEBSERVICE")
+    expect(csv.endsWith('\n')).toBe(true)
+  })
+})

--- a/clients/web/src/screens/dashboard/findingsExport.ts
+++ b/clients/web/src/screens/dashboard/findingsExport.ts
@@ -1,0 +1,66 @@
+import type { Finding } from '../../data/data'
+
+const FIXED_HEADERS = [
+  'finding_id',
+  'severity',
+  'mitre_technique',
+  'confidence_percent',
+  'tactic',
+  'source',
+  'host',
+  'user',
+  'timestamp',
+  'anomaly_score',
+  'status',
+]
+
+function csvCell(value: string | number): string {
+  // CSV escaping does not stop spreadsheet formula execution. Finding fields
+  // can originate in attacker-controlled telemetry, so make formula-looking
+  // strings literal before they reach Excel or similar tools.
+  const text = typeof value === 'string' && /^\s*[=+\-@]/.test(value)
+    ? `'${value}`
+    : String(value)
+  return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text
+}
+
+function timestamp(finding: Finding): string {
+  if (typeof finding.ts === 'number' && Number.isFinite(finding.ts)) {
+    const date = new Date(finding.ts)
+    if (!Number.isNaN(date.getTime())) return date.toISOString()
+  }
+  return finding.time
+}
+
+export function buildFindingsCsv(findings: Finding[]): string {
+  const extraKeys = [...new Set(findings.flatMap((finding) => Object.keys(finding.extra ?? {})))].sort()
+  const rows: (string | number)[][] = [
+    [...FIXED_HEADERS, ...extraKeys],
+    ...findings.map((finding) => [
+      finding.id,
+      finding.sev,
+      finding.tech,
+      finding.conf,
+      finding.tactic,
+      finding.src,
+      finding.host,
+      finding.user,
+      timestamp(finding),
+      finding.score,
+      finding.status,
+      ...extraKeys.map((key) => finding.extra?.[key] ?? ''),
+    ]),
+  ]
+  return `${rows.map((row) => row.map(csvCell).join(',')).join('\n')}\n`
+}
+
+export function downloadFindingsCsv(findings: Finding[], now = new Date()): void {
+  const csv = buildFindingsCsv(findings)
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = `vigil-findings-${now.toISOString().slice(0, 10)}.csv`
+  anchor.click()
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}

--- a/clients/web/src/screens/dashboard/findingsPreferences.test.ts
+++ b/clients/web/src/screens/dashboard/findingsPreferences.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_FINDINGS_VIEW_PREFERENCES,
+  FINDINGS_VIEW_STORAGE_KEY,
+  loadFindingsViewPreferences,
+  saveFindingsViewPreferences,
+} from './findingsPreferences'
+
+function memoryStorage(initial?: string): Storage {
+  const values = new Map<string, string>()
+  if (initial !== undefined) values.set(FINDINGS_VIEW_STORAGE_KEY, initial)
+  return {
+    get length() { return values.size },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => { values.delete(key) },
+    setItem: (key, value) => { values.set(key, value) },
+  }
+}
+
+describe('findings view preferences', () => {
+  it('falls back safely for corrupt or invalid stored values', () => {
+    expect(loadFindingsViewPreferences(memoryStorage('{'))).toEqual(DEFAULT_FINDINGS_VIEW_PREFERENCES)
+    expect(loadFindingsViewPreferences(memoryStorage(JSON.stringify({
+      severity: 'urgent',
+      source: '',
+      hiddenColumns: ['host', 7, 'host', ''],
+    })))).toEqual({ severity: 'any', source: 'any', hiddenColumns: ['host'] })
+  })
+
+  it('round-trips a bounded versioned preference record', () => {
+    const storage = memoryStorage()
+    const preferences = { severity: 'high' as const, source: 'splunk', hiddenColumns: ['host', 'user'] }
+    expect(saveFindingsViewPreferences(preferences, storage)).toBe(true)
+    expect(loadFindingsViewPreferences(storage)).toEqual(preferences)
+  })
+})

--- a/clients/web/src/screens/dashboard/findingsPreferences.ts
+++ b/clients/web/src/screens/dashboard/findingsPreferences.ts
@@ -1,0 +1,79 @@
+export const FINDINGS_VIEW_STORAGE_KEY = 'soc.findings.filters.v1'
+
+export type FindingsSeverityFilter = 'any' | 'critical' | 'high' | 'medium' | 'low'
+
+export interface FindingsViewPreferences {
+  severity: FindingsSeverityFilter
+  source: string
+  hiddenColumns: string[] | null
+}
+
+export const DEFAULT_FINDINGS_VIEW_PREFERENCES: FindingsViewPreferences = {
+  severity: 'any',
+  source: 'any',
+  hiddenColumns: null,
+}
+
+const SEVERITIES = new Set<FindingsSeverityFilter>([
+  'any',
+  'critical',
+  'high',
+  'medium',
+  'low',
+])
+
+export function isFindingsSeverityFilter(value: unknown): value is FindingsSeverityFilter {
+  return typeof value === 'string' && SEVERITIES.has(value as FindingsSeverityFilter)
+}
+
+function safeStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function parsePreferences(raw: string | null): FindingsViewPreferences {
+  if (!raw) return DEFAULT_FINDINGS_VIEW_PREFERENCES
+  try {
+    const value = JSON.parse(raw) as Record<string, unknown>
+    const severity = isFindingsSeverityFilter(value.severity)
+      ? value.severity
+      : 'any'
+    const source = typeof value.source === 'string' && value.source.length > 0 && value.source.length <= 256
+      ? value.source
+      : 'any'
+    const hiddenColumns = value.hiddenColumns === null
+      ? null
+      : Array.isArray(value.hiddenColumns)
+        ? [...new Set(value.hiddenColumns.filter((key): key is string => typeof key === 'string' && key.length > 0 && key.length <= 256))].slice(0, 128)
+        : null
+    return { severity, source, hiddenColumns }
+  } catch {
+    return DEFAULT_FINDINGS_VIEW_PREFERENCES
+  }
+}
+
+export function loadFindingsViewPreferences(storage: Storage | null = safeStorage()): FindingsViewPreferences {
+  if (!storage) return DEFAULT_FINDINGS_VIEW_PREFERENCES
+  try {
+    return parsePreferences(storage.getItem(FINDINGS_VIEW_STORAGE_KEY))
+  } catch {
+    return DEFAULT_FINDINGS_VIEW_PREFERENCES
+  }
+}
+
+export function saveFindingsViewPreferences(
+  preferences: FindingsViewPreferences,
+  storage: Storage | null = safeStorage(),
+): boolean {
+  if (!storage) return false
+  try {
+    storage.setItem(FINDINGS_VIEW_STORAGE_KEY, JSON.stringify(preferences))
+    return true
+  } catch {
+    return false
+  }
+}

--- a/clients/web/src/shell/SocConsole.test.tsx
+++ b/clients/web/src/shell/SocConsole.test.tsx
@@ -235,6 +235,27 @@ describe('SocConsole', () => {
     expect(screen.getByText('No entity graph yet')).toBeInTheDocument()
   })
 
+  it('restores and clears versioned findings preferences', async () => {
+    localStorage.setItem('soc.findings.filters.v1', JSON.stringify({
+      severity: 'critical',
+      source: 'any',
+      hiddenColumns: null,
+    }))
+    renderConsole()
+    await screen.findByText('f-20260614-3b5c585e')
+
+    const filters = screen.getByRole('button', { name: /Filters/ })
+    expect(filters).toHaveClass('has-filters')
+    fireEvent.click(filters)
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all' }))
+
+    await waitFor(() => expect(JSON.parse(localStorage.getItem('soc.findings.filters.v1') || '{}')).toEqual({
+      severity: 'any',
+      source: 'any',
+      hiddenColumns: null,
+    }))
+  })
+
   it('opens the Cases master-detail and returns to the table', async () => {
     renderConsole()
     fireEvent.click(screen.getByRole('button', { name: 'Cases' }))
@@ -403,6 +424,25 @@ describe('SocConsole', () => {
 
     expect(createUrl).toHaveBeenCalledTimes(1)
     expect(captured?.type).toBe('text/csv')
+    clickSpy.mockRestore()
+  })
+
+  it('exports the filtered findings as a browser CSV download', async () => {
+    let captured: Blob | undefined
+    const createUrl = vi.fn((blob: Blob) => {
+      captured = blob
+      return 'blob:findings'
+    })
+    ;(URL as unknown as { createObjectURL: unknown }).createObjectURL = createUrl
+    ;(URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn()
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+    renderConsole()
+    await screen.findByText('f-20260614-3b5c585e')
+    fireEvent.click(screen.getByTitle('Export filtered findings as CSV'))
+
+    expect(createUrl).toHaveBeenCalledTimes(1)
+    expect(captured?.type).toBe('text/csv;charset=utf-8')
     clickSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary

- make the Findings export action download the currently loaded, filtered, and sorted view as CSV
- keep stable core columns while including a sorted union of source-specific fields
- escape CSV values and neutralize spreadsheet-formula prefixes
- persist severity, source, and hidden-column preferences in a versioned defensive local-storage record
- reset stale source preferences, disable empty exports, and report export success or failure

## Why

The existing export control was a no-op, and analysts had to rebuild their preferred Findings view after every reload. This makes the current view portable without introducing a backend or deployment-specific export contract.

## Validation

- 21 focused Vitest tests passed
- targeted ESLint passed
- TypeScript compilation and the Vite production build passed
- rendered browser QA verified filtering, reload persistence, export feedback, clearing, and zero console errors

The CSV tests cover stable and source-specific fields, escaping, download behavior, and formula-injection protection. The diff contains no customer data, deployment configuration, secrets, or generated artifacts.
