### PR TITLE
fix(llm): honor Ollama thinking preference

### DIFF
--- a/core/llm/router/router.py
+++ b/core/llm/router/router.py
@@ -264,6 +264,7 @@ class LLMRouter:
                 max_tokens=max_tokens,
                 temperature=temperature,
                 tools=tools,
+                enable_thinking=enable_thinking,
                 extra_headers=extra_headers_or_none,
             )
         )
@@ -280,6 +281,7 @@ class LLMRouter:
         max_tokens: int,
         temperature: Optional[float],
         tools: Optional[List[Dict[str, Any]]],
+        enable_thinking: bool = False,
         extra_headers: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         from openai import AsyncOpenAI  # lazy — avoids hard dep for tests
@@ -303,6 +305,13 @@ class LLMRouter:
             "messages": oai_messages,
             "max_tokens": max_tokens,
         }
+        # Ollama's OpenAI-compatible API uses ``reasoning_effort`` rather
+        # than its native ``think`` field. When the option is omitted,
+        # reasoning-capable local models may enable it implicitly and consume
+        # the response budget before producing user-visible content. Preserve
+        # the caller's explicit thinking choice across the Bifrost boundary.
+        if provider.provider_type == "ollama":
+            kwargs["reasoning_effort"] = "medium" if enable_thinking else "none"
         if temperature is not None:
             kwargs["temperature"] = temperature
         if tools:
@@ -361,6 +370,7 @@ class LLMRouter:
         tools: Optional[List[Dict[str, Any]]] = None,
         interaction_id: Optional[str] = None,
         include_usage: bool = False,
+        enable_thinking: bool = False,
     ):
         """Yield raw OpenAI stream chunks (tool-call deltas, finish_reason,
         usage) for non-Anthropic Bifrost providers."""
@@ -384,6 +394,8 @@ class LLMRouter:
             "max_tokens": max_tokens,
             "stream": True,
         }
+        if provider.provider_type == "ollama":
+            kwargs["reasoning_effort"] = "medium" if enable_thinking else "none"
         if include_usage:
             kwargs["stream_options"] = {"include_usage": True}
         if temperature is not None:
@@ -422,6 +434,7 @@ class LLMRouter:
         temperature: Optional[float] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
         interaction_id: Optional[str] = None,
+        enable_thinking: bool = False,
     ):
         """Yield OpenAI-format text chunks for non-Anthropic Bifrost providers."""
         async for chunk in self.stream_openai_raw(
@@ -433,6 +446,7 @@ class LLMRouter:
             temperature=temperature,
             tools=tools,
             interaction_id=interaction_id,
+            enable_thinking=enable_thinking,
         ):
             if not chunk.choices:
                 continue

--- a/tests/unit/llm/test_llm_router.py
+++ b/tests/unit/llm/test_llm_router.py
@@ -95,6 +95,7 @@ async def test_dispatch_bifrost_for_ollama():
     assert kwargs["model"] == "ollama/llama3.1:8b"
     assert kwargs["messages"][0] == {"role": "system", "content": "be terse"}
     assert kwargs["messages"][1] == {"role": "user", "content": "hi"}
+    assert kwargs["reasoning_effort"] == "none"
 
     assert out["path"] == "bifrost"
     assert out["provider"] == "ollama"
@@ -103,6 +104,31 @@ async def test_dispatch_bifrost_for_ollama():
     assert out["output_tokens"] == 7
     # The OpenAI-format dispatcher must close its client (no httpx pool leak).
     mock_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_bifrost_maps_enabled_ollama_thinking_to_reasoning_effort():
+    router = LLMRouter(bifrost_url="http://test-bifrost:8080")
+    fake_resp = SimpleNamespace(
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content="done", tool_calls=None))
+        ],
+        model="ollama/llama3.1:8b",
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=fake_resp)
+
+    with patch("openai.AsyncOpenAI", return_value=mock_client):
+        await router.dispatch(
+            provider=_ollama_spec(),
+            messages=[{"role": "user", "content": "think"}],
+            enable_thinking=True,
+        )
+
+    kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert kwargs["reasoning_effort"] == "medium"
 
 
 @pytest.mark.asyncio
@@ -240,6 +266,8 @@ async def test_dispatch_bifrost_openai_no_cache_details_safe():
             provider=_openai_spec(),
             messages=[{"role": "user", "content": "hi"}],
         )
+    kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert "reasoning_effort" not in kwargs
     assert out["cache_read_tokens"] == 0
     assert out["cache_creation_tokens"] == 0
 
@@ -631,6 +659,7 @@ async def test_dispatch_openai_stream_yields_text_and_skips_empty():
     assert oai_ctor.call_args.kwargs["base_url"] == "http://test-bifrost:8080/v1"
     kwargs = mock_client.chat.completions.create.call_args.kwargs
     assert kwargs["stream"] is True
+    assert kwargs["reasoning_effort"] == "none"
     # model is provider-prefixed so Bifrost routes to the right backend
     assert kwargs["model"] == "ollama/llama3.1:8b"
     assert kwargs["messages"][0] == {"role": "system", "content": "be terse"}
@@ -652,12 +681,14 @@ async def test_stream_openai_raw_include_usage_sets_stream_options():
                 provider=_ollama_spec(),
                 messages=[{"role": "user", "content": "hi"}],
                 include_usage=True,
+                enable_thinking=True,
             )
         ]
 
     kwargs = mock_client.chat.completions.create.call_args.kwargs
     assert kwargs["stream"] is True
     assert kwargs["stream_options"] == {"include_usage": True}
+    assert kwargs["reasoning_effort"] == "medium"
     mock_client.close.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary

- carry the existing `enable_thinking` choice through non-streaming Bifrost requests
- map Ollama thinking to `reasoning_effort`: `none` when disabled and `medium` when enabled
- apply the same behavior to streaming requests
- leave non-Ollama providers unchanged

## Why

Reasoning-capable Ollama models may enable thinking implicitly when the OpenAI-compatible request omits a reasoning setting. That can consume the response budget before producing user-visible content. This preserves the caller's explicit choice at the provider boundary.

## Validation

- all 20 LLM router unit tests passed
- targeted Ruff and diff checks passed
- tests cover enabled, disabled, streaming, and non-Ollama behavior

The touched router file has pre-existing formatting debt unchanged by this PR. No provider credentials, customer settings, or deployment-specific configuration are included.
