### PR TITLE
feat(web): filter timeline by date range

### DIFF
--- a/clients/web/src/screens/dashboard/DashboardScreen.tsx
+++ b/clients/web/src/screens/dashboard/DashboardScreen.tsx
@@ -386,6 +386,12 @@ function EntityStub() {
 
 const DAY = 86400000
 
+function calendarDayIso(value: string, endOfDay = false): string | undefined {
+  if (!value) return undefined
+  const date = new Date(`${value}T${endOfDay ? '23:59:59.999' : '00:00:00'}`)
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
+}
+
 interface TLBar {
   e: TimelineEvent
   left: number
@@ -466,6 +472,8 @@ function computeLayout(events: TimelineEvent[], zoom: number, containerW: number
 
 function TimelineTab() {
   const [filter, setFilter] = useState<'all' | 'finding'>('all')
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
   const [speed, setSpeed] = useState(1)
   const [zoom, setZoom] = useState(1)
   const [playing, setPlaying] = useState(false)
@@ -483,8 +491,13 @@ function TimelineTab() {
   const speedRef = useRef(1)
   const downRef = useRef(false)
 
-  const { events: tlEvents, phase: tlPhase } = useTimeline()
+  const dateStart = calendarDayIso(dateFrom)
+  const dateEnd = calendarDayIso(dateTo, true)
+  const validDateRange = !dateFrom || !dateTo || dateFrom <= dateTo
+  const hasDateFilter = Boolean(dateFrom || dateTo)
+  const { events: tlEvents, phase: tlPhase } = useTimeline(dateStart, dateEnd, validDateRange)
   const events = useMemo(() => tlEvents.filter((e) => filter === 'all' || e.kind === 'finding'), [tlEvents, filter])
+  const eventCountLabel = `${events.length} event${events.length === 1 ? '' : 's'}`
   const layout = useMemo(() => computeLayout(events, zoom, containerW), [events, zoom, containerW])
   const layoutRef = useRef(layout)
   layoutRef.current = layout
@@ -588,6 +601,23 @@ function TimelineTab() {
     engagedRef.current = false
     setFilter(f)
   }
+  const resetTimelineState = () => {
+    pause()
+    engagedRef.current = false
+  }
+  const changeDateFrom = (value: string) => {
+    resetTimelineState()
+    setDateFrom(value)
+  }
+  const changeDateTo = (value: string) => {
+    resetTimelineState()
+    setDateTo(value)
+  }
+  const clearDateRange = () => {
+    resetTimelineState()
+    setDateFrom('')
+    setDateTo('')
+  }
   const setZoomF = (f: number) => setZoom((z) => Math.max(1, Math.min(12, z * f)))
   const fit = () => {
     pause()
@@ -617,7 +647,38 @@ function TimelineTab() {
           <button className={filter === 'all' ? 'active' : ''} onClick={() => changeFilter('all')}>All</button>
           <button className={filter === 'finding' ? 'active' : ''} onClick={() => changeFilter('finding')}>finding</button>
         </div>
-        <span className="tl-count">{tlPhase === 'loading' ? 'Loading…' : `${events.length} events`}</span>
+        <span className="tl-count">{tlPhase === 'loading' ? 'Loading…' : eventCountLabel}</span>
+        <div className="tl-date-filter" role="group" aria-label="Timeline date range">
+          <span className="tl-date-filter-title">Date range</span>
+          <label className="tl-date-field">
+            <span>From</span>
+            <input
+              type="date"
+              aria-label="Timeline start date"
+              aria-invalid={!validDateRange}
+              max={dateTo || undefined}
+              value={dateFrom}
+              onChange={(e) => changeDateFrom(e.target.value)}
+            />
+          </label>
+          <label className="tl-date-field">
+            <span>To</span>
+            <input
+              type="date"
+              aria-label="Timeline end date"
+              aria-invalid={!validDateRange}
+              min={dateFrom || undefined}
+              value={dateTo}
+              onChange={(e) => changeDateTo(e.target.value)}
+            />
+          </label>
+          {hasDateFilter && (
+            <button type="button" className="tl-date-clear" onClick={clearDateRange}>Clear</button>
+          )}
+          {!validDateRange && (
+            <span className="tl-date-error" role="alert">Start date must be on or before end date.</span>
+          )}
+        </div>
         <div className="grow" />
         <button className="tl-iconbtn" title="Zoom in" onClick={() => setZoomF(1.5)}><Icon name="zoomIn" /></button>
         <button className="tl-iconbtn" title="Zoom out" onClick={() => setZoomF(1 / 1.5)}><Icon name="zoomOut" /></button>
@@ -636,9 +697,9 @@ function TimelineTab() {
       {tlPhase === 'ready' && events.length === 0 && (
         <EmptyState
           icon="clock"
-          title={filter === 'finding' ? 'No finding events in this window' : 'No timeline events yet'}
-          body={filter === 'finding' ? 'Switch to All events or load findings with timestamps.' : 'Create cases or ingest findings to build an investigation timeline.'}
-          primary={filter === 'finding' ? { label: 'Show all events', onClick: () => changeFilter('all'), icon: 'filter' } : undefined}
+          title={!validDateRange ? 'Invalid date range' : hasDateFilter ? 'No events match this date range' : filter === 'finding' ? 'No finding events in this window' : 'No timeline events yet'}
+          body={!validDateRange ? 'Choose a start date on or before the end date.' : hasDateFilter ? 'Try a wider date range or clear the filter.' : filter === 'finding' ? 'Switch to All events or load findings with timestamps.' : 'Create cases or ingest findings to build an investigation timeline.'}
+          primary={!validDateRange || hasDateFilter ? { label: 'Clear date range', onClick: clearDateRange, icon: 'filter' } : filter === 'finding' ? { label: 'Show all events', onClick: () => changeFilter('all'), icon: 'filter' } : undefined}
         />
       )}
       <div className="tl-scroll" ref={scrollRef}>

--- a/clients/web/src/screens/dashboard/useTimeline.ts
+++ b/clients/web/src/screens/dashboard/useTimeline.ts
@@ -18,17 +18,28 @@ const sevOf = (s?: string): TimelineEvent['sev'] => {
 }
 const kindOf = (t?: string): TimelineKind => (t === 'case' ? 'case' : t === 'alert' ? 'alert' : 'finding')
 
-export function useTimeline() {
+export function useTimeline(start?: string, end?: string, enabled = true) {
   const [events, setEvents] = useState<TimelineEvent[]>([])
   const [phase, setPhase] = useState<Phase>('loading')
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
+
+    if (!enabled) {
+      setEvents([])
+      setPhase('ready')
+      setError(null)
+      return () => {
+        cancelled = true
+      }
+    }
+
     setPhase('loading')
     setError(null)
+    setEvents([])
     timelineApi
-      .getTimelineRange({ limit: 200 })
+      .getTimelineRange({ limit: 200, start, end })
       .then((res) => {
         if (cancelled) return
         const list = (res.data?.events || []) as RangeEvent[]
@@ -53,7 +64,7 @@ export function useTimeline() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [start, end, enabled])
 
   return { events, phase, error }
 }

--- a/clients/web/src/shell/SocConsole.test.tsx
+++ b/clients/web/src/shell/SocConsole.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { ColorSchemeProvider } from '../contexts/ColorSchemeContext'
 import SocConsole from './SocConsole'
 // these resolve to the mocked implementations (vi.mock below is hoisted)
-import { streamFetch, aiDecisionsApi, approvalsApi } from '../services/api'
+import { streamFetch, aiDecisionsApi, approvalsApi, timelineApi } from '../services/api'
 
 vi.mock('../contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -99,10 +99,17 @@ vi.mock('../services/api', () => ({
     getFindingsByTechnique: () => Promise.resolve({ data: { findings: [] } }),
   },
   timelineApi: {
-    getTimelineRange: () =>
-      Promise.resolve({
-        data: { events: [{ id: 'finding-f-1', start: '2026-06-12T11:36:33Z', type: 'finding', severity: 'medium', metadata: { finding_id: 'f-1' } }] },
-      }),
+    getTimelineRange: vi.fn((params: { start?: string; end?: string } = {}) => {
+      const events = [
+        { id: 'finding-f-1', start: '2026-06-12T11:36:33Z', type: 'finding', severity: 'medium', metadata: { finding_id: 'f-1' } },
+        { id: 'finding-f-2', start: '2026-06-13T11:36:33Z', type: 'finding', severity: 'high', metadata: { finding_id: 'f-2' } },
+      ]
+      const start = params.start ? Date.parse(params.start) : Number.NEGATIVE_INFINITY
+      const end = params.end ? Date.parse(params.end) : Number.POSITIVE_INFINITY
+      return Promise.resolve({
+        data: { events: events.filter((event) => Date.parse(event.start) >= start && Date.parse(event.start) <= end) },
+      })
+    }),
   },
   aiDecisionsApi: {
     getPendingFeedback: () =>
@@ -233,6 +240,46 @@ describe('SocConsole', () => {
     expect(await screen.findByText(/events$/)).toBeInTheDocument()
     fireEvent.click(screen.getByRole('tab', { name: 'Entity Graph' }))
     expect(screen.getByText('No entity graph yet')).toBeInTheDocument()
+  })
+
+  it('filters Timeline events by an inclusive date range and clears it', async () => {
+    renderConsole()
+    fireEvent.click(screen.getByRole('tab', { name: 'Timeline' }))
+    expect(await screen.findByText('2 events')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Timeline start date'), { target: { value: '2026-06-12' } })
+    fireEvent.change(screen.getByLabelText('Timeline end date'), { target: { value: '2026-06-12' } })
+
+    await waitFor(() => expect(screen.getByText('1 event')).toBeInTheDocument())
+    const timelineCalls = vi.mocked(timelineApi.getTimelineRange).mock.calls
+    const lastTimelineQuery = timelineCalls[timelineCalls.length - 1]?.[0]
+    expect(lastTimelineQuery).toMatchObject({ limit: 200 })
+    expect(lastTimelineQuery?.start).toBe(new Date('2026-06-12T00:00:00').toISOString())
+    expect(lastTimelineQuery?.end).toBe(new Date('2026-06-12T23:59:59.999').toISOString())
+
+    fireEvent.click(screen.getByRole('button', { name: /^Clear$/ }))
+    await waitFor(() => expect(screen.getByText('2 events')).toBeInTheDocument())
+  })
+
+  it('rejects an inverted Timeline date range without sending it to the API', async () => {
+    renderConsole()
+    fireEvent.click(screen.getByRole('tab', { name: 'Timeline' }))
+    expect(await screen.findByText('2 events')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Timeline start date'), { target: { value: '2026-06-13' } })
+    await waitFor(() => {
+      const calls = vi.mocked(timelineApi.getTimelineRange).mock.calls
+      expect(calls[calls.length - 1]?.[0]?.start).toBe(new Date('2026-06-13T00:00:00').toISOString())
+    })
+    const callsBeforeInvalidEnd = vi.mocked(timelineApi.getTimelineRange).mock.calls.length
+
+    fireEvent.change(screen.getByLabelText('Timeline end date'), { target: { value: '2026-06-12' } })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Start date must be on or before end date.')
+    expect(screen.getByLabelText('Timeline start date')).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByLabelText('Timeline end date')).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByText('0 events')).toBeInTheDocument()
+    await waitFor(() => expect(vi.mocked(timelineApi.getTimelineRange)).toHaveBeenCalledTimes(callsBeforeInvalidEnd))
   })
 
   it('opens the Cases master-detail and returns to the table', async () => {

--- a/clients/web/src/styles.css
+++ b/clients/web/src/styles.css
@@ -4601,6 +4601,67 @@
       padding: 5px 11px;
    }
 
+   .tl-date-filter {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+   }
+
+   .tl-date-filter-title {
+      color: var(--tx-3);
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+   }
+
+   .tl-date-field {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      color: var(--tx-3);
+      font-size: 11px;
+   }
+
+   .tl-date-field input {
+      height: 34px;
+      min-width: 132px;
+      padding: 0 8px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--bg-2);
+      color: var(--tx);
+      font: 12px var(--mono);
+      outline: none;
+   }
+
+   .tl-date-field input:focus {
+      border-color: var(--accent-line);
+   }
+
+   .tl-date-field input[aria-invalid='true'] {
+      border-color: var(--crit);
+   }
+
+   .tl-date-clear {
+      padding: 5px 8px;
+      border: none;
+      background: none;
+      color: var(--accent-2);
+      font-size: 12px;
+   }
+
+   .tl-date-clear:hover {
+      text-decoration: underline;
+   }
+
+   .tl-date-error {
+      flex-basis: 100%;
+      color: var(--crit);
+      font-size: 11px;
+   }
+
    .tl-iconbtn {
       width: 34px;
       height: 34px;


### PR DESCRIPTION
## Summary

- add accessible start-date and end-date controls to the Timeline view
- convert local calendar selections to inclusive start-of-day and end-of-day ISO parameters
- reject inverted ranges with accessible feedback and suppress invalid API requests
- clear stale timeline data when the query changes and provide a one-click range reset
- correct singular event-count grammar

## Why

Analysts need to constrain the Timeline without relying on deployment-specific presets or manually editing request parameters. Calendar-day semantics should also include the entire selected end date rather than stopping at midnight.

## Validation

- 18 focused SocConsole integration tests passed
- targeted ESLint passed
- TypeScript compilation and the Vite production build passed
- rendered browser QA verified the responsive controls with live events and zero console errors

Tests cover inclusive API parameters, range clearing, invalid-state accessibility, inverted-range request suppression, and singular grammar. The diff contains no customer data, deployment configuration, secrets, or generated artifacts.

## Dependency and merge order

This branch and #757 both touch `DashboardScreen.tsx` and `SocConsole.test.tsx`. Merge #757 first, then rebase this branch onto the updated `main`, resolve the narrow overlap, and refresh its verification before merging this PR.
