### PR TITLE
chore(deps): drop unused claude-agent-sdk

### DIFF
--- a/core/integrations/integration_compatibility_service.py
+++ b/core/integrations/integration_compatibility_service.py
@@ -150,14 +150,6 @@ class IntegrationCompatibilityService:
                 "display_name": "PostgreSQL",
                 "category": "Data Storage",
             },
-            # Core
-            "claude-agent-sdk": {
-                "package": "claude-agent-sdk",
-                "min_version": "0.1.0",
-                "display_name": "Claude Agent SDK",
-                "category": "Core",
-                "python_min_version": "3.10",
-            },
         }
 
     def check_package_installed(self, package_name: str) -> Tuple[bool, Optional[str]]:

--- a/core/integrations/mcp/registry.py
+++ b/core/integrations/mcp/registry.py
@@ -95,29 +95,6 @@ class MCPRegistry:
         """Get all tool names (server-prefixed) from active servers."""
         return [t["name"] for t in self.get_all_tools()]
 
-    def get_agent_sdk_configs(self) -> List[Dict]:
-        """
-        Get MCP server configurations formatted for Agent SDK's
-        ClaudeAgentOptions.mcp_servers parameter.
-
-        Returns:
-            List of MCP server config dicts with name, command, args, env.
-        """
-        configs = []
-        for name in self.get_active_servers():
-            server_info = self._servers.get(name, {})
-            config = server_info.get("config", {})
-            if config.get("command"):
-                configs.append(
-                    {
-                        "name": name,
-                        "command": config["command"],
-                        "args": config.get("args", []),
-                        "env": config.get("env", {}),
-                    }
-                )
-        return configs
-
     def get_summary(self) -> Dict[str, Any]:
         """Get a summary of the registry state."""
         return {

--- a/core/llm/harness/claude.py
+++ b/core/llm/harness/claude.py
@@ -1,4 +1,4 @@
-"""Claude API service for Anthropic integration with Agent SDK support."""
+"""Claude API service for Anthropic integration."""
 
 import json
 import logging
@@ -81,7 +81,7 @@ from core.integrations.mcp.registry import MCPRegistry  # noqa: E402
 
 
 class ClaudeService:
-    """Service for interacting with Claude API with Agent SDK support."""
+    """Service for interacting with Claude API."""
 
     SERVICE_NAME = "deeptempo-ai-soc"
     API_KEY_NAME = "claude_api_key"
@@ -960,5 +960,3 @@ Provide only the JSON, no additional text."""
         except Exception as e:
             logger.error(f"Error generating event analysis: {e}")
             raise
-
-    # Agent SDK Methods

--- a/requirements.lock
+++ b/requirements.lock
@@ -25,7 +25,6 @@ antlr4-python3-runtime==4.13.2
 anyio==4.14.2
     # via
     #   anthropic
-    #   claude-agent-sdk
     #   httpx
     #   httpx2
     #   mcp
@@ -76,8 +75,6 @@ charset-normalizer==3.5.1
     #   requests
 chromadb==1.5.9
     # via mempalace
-claude-agent-sdk==0.2.144
-    # via -r requirements.txt
 click==8.4.2
     # via
     #   arq
@@ -194,7 +191,6 @@ jmespath==1.1.0
 jsonschema==4.26.0
     # via
     #   chromadb
-    #   claude-agent-sdk
     #   mcp
 jsonschema-specifications==2025.9.1
     # via jsonschema
@@ -205,9 +201,7 @@ limits==5.8.0
 markdown-it-py==4.2.0
     # via rich
 mcp==1.29.1
-    # via
-    #   -r requirements.txt
-    #   claude-agent-sdk
+    # via -r requirements.txt
 mdurl==0.1.2
     # via markdown-it-py
 mmh3==5.2.1
@@ -473,7 +467,6 @@ slowapi==0.1.10
 sniffio==1.3.1
     # via
     #   anthropic
-    #   claude-agent-sdk
     #   openai
 socksio==1.0.0
     # via -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,21 +7,16 @@
 
 
 # Vigil SOC - Requirements
-# Python 3.10+ required (claude-agent-sdk requires >=3.10)
 
 # Core
 numpy>=1.26.0
 pyarrow>=15.0.0
 ijson>=3.2.0
 anthropic>=0.45.0
-claude-agent-sdk>=0.1.0
-# The MCP SDK arrives transitively via claude-agent-sdk; pinned for the same
-# reason as httpx below, and urgently: every core/integrations/*/tool.py
-# registers its handlers with @server.list_tools()/@server.call_tool(), which
-# mcp 2.0.0 replaced with add_request_handler()/MCPServer. Until those 21
-# servers are migrated, 2.x breaks them at import. claude-agent-sdk capped
-# mcp at <2.0.0 through 0.2.139 and relaxed to <3.0.0 in 0.2.140, so this was
-# only ever held back by someone else's ceiling.
+# Direct pin: every core/integrations/*/tool.py registers handlers with
+# @server.list_tools()/@server.call_tool(), which mcp 2.0.0 replaced with
+# add_request_handler()/MCPServer. Until those 21 servers are migrated,
+# 2.x breaks them at import.
 mcp>=1.23.0,<2.0.0
 openai>=1.40.0
 # HTTP client for every integration client and MCP tool server. Arrives

--- a/tests/unit/_ratchets/test_no_claude_agent_sdk.py
+++ b/tests/unit/_ratchets/test_no_claude_agent_sdk.py
@@ -1,0 +1,103 @@
+"""claude-agent-sdk is gone. Dependabot must not propose bumps against it.
+
+#471 dropped the SDK and ran agents on the neutral loop; #638 landed the loop.
+The PyPI pin, the compatibility-UI row, and ``MCPRegistry.get_agent_sdk_configs``
+were leftover. #691 is the current Dependabot bump of a package nothing imports.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from core.integrations.integration_compatibility_service import (
+    IntegrationCompatibilityService,
+)
+from core.integrations.mcp.registry import MCPRegistry
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACKAGES = ("core", "services", "tools", "scripts")
+_REQUIREMENT_NAME = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
+# PEP 503: claude_agent_sdk and Claude.Agent.SDK are the same package.
+_NORMALIZE = re.compile(r"[-_.]+")
+
+pytestmark = pytest.mark.unit
+
+
+def _canonical(name: str) -> str:
+    return _NORMALIZE.sub("-", name).lower()
+
+
+def _requirement_names(path: Path) -> set[str]:
+    names: set[str] = set()
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        match = _REQUIREMENT_NAME.match(line)
+        if match:
+            names.add(_canonical(match.group(1)))
+    return names
+
+
+def _python_files():
+    for package in PACKAGES:
+        root = REPO_ROOT / package
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            yield path.relative_to(REPO_ROOT)
+
+
+def _imports_claude_agent_sdk(rel_path: Path) -> list[int]:
+    source = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(rel_path))
+    lines: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(
+                alias.name.split(".")[0] == "claude_agent_sdk" for alias in node.names
+            ):
+                lines.append(node.lineno)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module.split(".")[0] == "claude_agent_sdk":
+                lines.append(node.lineno)
+    return lines
+
+
+def test_requirements_do_not_declare_claude_agent_sdk():
+    declared = _requirement_names(REPO_ROOT / "requirements.txt")
+    locked = _requirement_names(REPO_ROOT / "requirements.lock")
+    assert "claude-agent-sdk" not in declared
+    assert "claude-agent-sdk" not in locked
+
+
+def test_nothing_imports_claude_agent_sdk():
+    hits = [
+        f"{rel}:{lineno}"
+        for rel in _python_files()
+        for lineno in _imports_claude_agent_sdk(rel)
+    ]
+    assert not hits, "claude_agent_sdk import survived the drop:\n" + "\n".join(hits)
+
+
+def test_compatibility_service_does_not_list_claude_agent_sdk():
+    integrations = IntegrationCompatibilityService().integrations
+    assert "claude-agent-sdk" not in integrations
+    packages = {info.get("package") for info in integrations.values()}
+    assert "claude-agent-sdk" not in packages
+
+
+def test_mcp_registry_has_no_agent_sdk_config_shaper():
+    assert not hasattr(MCPRegistry, "get_agent_sdk_configs")
+
+
+def test_claude_harness_does_not_claim_agent_sdk_support():
+    source = (REPO_ROOT / "core" / "llm" / "harness" / "claude.py").read_text()
+    assert "Agent SDK" not in source


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#471 dropped the Claude Agent SDK and #638 landed the neutral loop, but the PyPI pin and supporting leftovers stayed. Dependabot keeps proposing bumps against a package nothing imports (#691).

- Remove `claude-agent-sdk>=0.1.0` from `requirements.txt` and regenerate `requirements.lock` via `./scripts/update_lock.sh`
- Keep `mcp>=1.23.0,<2.0.0` (the 21 `core/integrations/*/tool.py` servers still use the 1.x decorator API); rewrite the comment so it no longer claims mcp arrives via the SDK
- Delete the `"claude-agent-sdk"` Core row from `IntegrationCompatibilityService`
- Delete dead `MCPRegistry.get_agent_sdk_configs()`
- Drop leftover "Agent SDK support" wording and the trailing `# Agent SDK Methods` comment in `core/llm/harness/claude.py`

Python floor, `lib.sh`, and product docs that still say "Agent SDK" as a name for backend tools are unchanged.

#691 should be closed rather than merged.

Closes #694

## Tests

- New ratchet `tests/unit/_ratchets/test_no_claude_agent_sdk.py` fails on current `main` (pin still declared, compatibility row present, `get_agent_sdk_configs` still defined, harness still claims Agent SDK support)
- `pytest tests/unit/_ratchets/test_no_claude_agent_sdk.py tests/unit/integrations/test_mcp_registry_population.py` — 14 passed
- black / isort / flake8 on the touched `core/` files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cff666-5284-445a-adff-aaa20d65661a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cff666-5284-445a-adff-aaa20d65661a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

