### PR TITLE
fix: stop documenting DATABASE_URL as Python's DB source of truth

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -106,8 +106,9 @@ class Settings(BaseSettings):
     # this stays tri-state and each site supplies its own fallback.
     mempalace_daemon_enabled: Optional[bool] = None
 
-    # Database
-    database_url: Optional[str] = None
+    # Database. DATABASE_URL is not a field: Settings.extra is ignore so the
+    # agent and scripts/migrate_schema.py can keep it in the environment.
+    # Python sessions go through DatabaseConfig (encrypted DSN / POSTGRES_*).
     postgresql_connection_string: Optional[str] = None
     postgres_host: str = "localhost"
     postgres_port: int = 5432

--- a/core/storage/connection.py
+++ b/core/storage/connection.py
@@ -221,10 +221,9 @@ class DatabaseConfig:
     def __init__(self, *, connection_string: Optional[str] = None):
         """Initialize from the encrypted-store DSN, else POSTGRES_*.
 
-        DATABASE_URL is not consulted. The TypeScript agent and
-        ``scripts/migrate_schema.py`` read it; ranking an env DSN here would
-        let the MCP default in ``services/api/main.py`` pin an operator's
-        target to localhost. See ``_load_connection_string_secret``.
+        DATABASE_URL is not consulted — that is the TypeScript agent's
+        knob, and ``scripts/migrate_schema.py``. Inserting it as a third
+        source would break the ranking this class is built on.
         """
         dsn = (
             connection_string

--- a/core/storage/connection.py
+++ b/core/storage/connection.py
@@ -219,7 +219,13 @@ def _load_connection_string_secret() -> Optional[str]:
 
 class DatabaseConfig:
     def __init__(self, *, connection_string: Optional[str] = None):
-        """Initialize from the connection-string secret, else the environment."""
+        """Initialize from the encrypted-store DSN, else POSTGRES_*.
+
+        DATABASE_URL is not consulted. The TypeScript agent and
+        ``scripts/migrate_schema.py`` read it; ranking an env DSN here would
+        let the MCP default in ``services/api/main.py`` pin an operator's
+        target to localhost. See ``_load_connection_string_secret``.
+        """
         dsn = (
             connection_string
             if connection_string is not None

--- a/env.example
+++ b/env.example
@@ -73,11 +73,17 @@ DEV_MODE=true
 # -----------------------------------------------------------------------------
 # Database
 # -----------------------------------------------------------------------------
+# Two layers, two knobs. Python (core/storage/connection.py) reads the encrypted
+# POSTGRESQL_CONNECTION_STRING, then falls back to POSTGRES_*. It never reads
+# DATABASE_URL — ranking an env DSN would let the MCP default in
+# services/api/main.py pin an operator's target to localhost.
+#
+# The TypeScript agent (services/agent/core/db.ts) and scripts/migrate_schema.py
+# read DATABASE_URL. Keep it here so local/CI agent processes have a DSN.
 DATABASE_URL="postgresql://deeptempo:deeptempo_secure_password_change_me@localhost:5432/deeptempo_soc"
 POSTGRES_PASSWORD="deeptempo_secure_password_change_me"
 
-# DATABASE_URL is the single source of truth. The POSTGRES_* parts below are
-# only consulted when it is unset or unparseable.
+# Python connection target when the encrypted DSN is unset or unparseable.
 # POSTGRES_HOST="localhost"
 # POSTGRES_PORT=5432
 # POSTGRES_DB="deeptempo_soc"

--- a/env.example
+++ b/env.example
@@ -75,8 +75,7 @@ DEV_MODE=true
 # -----------------------------------------------------------------------------
 # Two layers, two knobs. Python (core/storage/connection.py) reads the encrypted
 # POSTGRESQL_CONNECTION_STRING, then falls back to POSTGRES_*. It never reads
-# DATABASE_URL — ranking an env DSN would let the MCP default in
-# services/api/main.py pin an operator's target to localhost.
+# DATABASE_URL.
 #
 # The TypeScript agent (services/agent/core/db.ts) and scripts/migrate_schema.py
 # read DATABASE_URL. Keep it here so local/CI agent processes have a DSN.

--- a/infra/helm/vigil/templates/_helpers.tpl
+++ b/infra/helm/vigil/templates/_helpers.tpl
@@ -285,15 +285,6 @@ needs to pick that up.
 {{- end -}}
 
 {{/*
-DATABASE_URL — assembled from postgres host/port/db/user plus password secret.
-Templates should pull this via env valueFrom; only dbInit needs the plaintext
-password, which it pulls from the secret directly.
-*/}}
-{{- define "vigil.databaseUrlNoPassword" -}}
-{{- printf "postgresql://%s@%s:%s/%s" (include "vigil.postgres.username" .) (include "vigil.postgres.host" .) (include "vigil.postgres.port" . | toString) (include "vigil.postgres.database" .) -}}
-{{- end -}}
-
-{{/*
 REDIS_URL resolution. Same three modes as Postgres.
 
 Bitnami redis defaults to password auth on — we pull the password from the

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -280,7 +280,8 @@ postgresql:
     # Either set .existingSecret + .existingSecretKey OR provide password via secrets.postgresPassword.
     existingSecret: ""
     existingSecretKey: POSTGRES_PASSWORD
-    # If true, append ?sslmode=require to the DATABASE_URL.
+    # Unused: Helm injects discrete POSTGRES_* vars, not a DSN. Require SSL with
+    # POSTGRES_SSL_MODE=require via extraConfig / extraEnv.
     sslRequired: false
 
   # Bitnami postgresql subchart (issue #114). When enabled, the MVP in-chart
@@ -522,7 +523,8 @@ secrets:
   # Required (at least one of these must be set for the backend to do useful work).
   anthropicApiKey: ""
 
-  # DB. Used by dbInit and DATABASE_URL assembly.
+  # DB password. Materialized as POSTGRES_PASSWORD; db-init and app pods
+  # consume the discrete POSTGRES_* parts, not an assembled DSN.
   postgresPassword: "change-me-before-production"
 
   # Required when DEV_MODE=false (see env.example). Generate with:

--- a/scripts/compute_tuning_recommendations.py
+++ b/scripts/compute_tuning_recommendations.py
@@ -16,10 +16,13 @@ Operators run this periodically — say, monthly — and apply the
 recommendations through Settings → AI Config → AI Operations (PR-F) or
 by editing ``core/agents/builtins.py`` for per-agent thinking budgets.
 
+Connects through ``get_session()`` (encrypted DSN / POSTGRES_*), the same
+path the backend and daemon use. ``DATABASE_URL`` is not consulted.
+
 Usage::
 
-    DATABASE_URL=postgresql://... python scripts/compute_tuning_recommendations.py
-    DATABASE_URL=...  python scripts/compute_tuning_recommendations.py --days 30
+    python scripts/compute_tuning_recommendations.py
+    python scripts/compute_tuning_recommendations.py --days 30
 
 Exit code 0 always — this is informational, never a gate.
 """
@@ -227,7 +230,8 @@ def main() -> int:
     except Exception as exc:  # noqa: BLE001
         print(f"[ERROR] Unable to read LLMInteractionLog: {exc}", file=sys.stderr)
         print(
-            "  Check DATABASE_URL. This script is read-only — it needs the",
+            "  Check POSTGRES_* / the encrypted POSTGRESQL_CONNECTION_STRING.",
+            "  This script is read-only — it uses get_session() and needs the",
             "  same DB the backend + daemon write interaction logs to.",
             sep="\n",
             file=sys.stderr,

--- a/services/daemon/config.py
+++ b/services/daemon/config.py
@@ -134,9 +134,6 @@ class DaemonConfig:
     llm_queue: LLMQueueConfig = field(default_factory=LLMQueueConfig)
     kafka: KafkaConfig = field(default_factory=KafkaConfig)
 
-    # Database
-    database_url: Optional[str] = None
-
     # Logging
     log_level: str = "INFO"
     log_format: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -146,7 +143,6 @@ class DaemonConfig:
         config = cls()
         settings = get_settings()
 
-        config.database_url = settings.database_url
         config.log_level = settings.daemon_log_level
 
         config.polling.splunk_interval = settings.daemon_splunk_poll_interval

--- a/tests/unit/_ratchets/test_database_url_split.py
+++ b/tests/unit/_ratchets/test_database_url_split.py
@@ -1,0 +1,50 @@
+"""DATABASE_URL is the agent's knob, not Python's (#752).
+
+env.example used to call it the single source of truth. Settings bound it,
+DaemonConfig copied it, and nothing in core/ or services/ read the copy.
+A field that is only assigned is how the trap stayed invisible. These
+assertions fail if that wiring comes back, or if Helm/docs claim a DSN
+the chart does not assemble.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from core.config import Settings
+from services.daemon.config import DaemonConfig
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ENV_EXAMPLE = REPO_ROOT / "env.example"
+HELM_HELPERS = REPO_ROOT / "infra" / "helm" / "vigil" / "templates" / "_helpers.tpl"
+HELM_VALUES = REPO_ROOT / "infra" / "helm" / "vigil" / "values.yaml"
+
+pytestmark = pytest.mark.unit
+
+
+def test_settings_does_not_bind_database_url(monkeypatch):
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql://other:pw@agent-only.example/agent_db"
+    )
+    assert "database_url" not in Settings.model_fields
+    assert "database_url" not in Settings().model_dump()
+
+
+def test_daemon_config_does_not_copy_database_url():
+    assert "database_url" not in DaemonConfig.__dataclass_fields__
+
+
+def test_env_example_states_the_split_instead_of_a_single_source():
+    text = ENV_EXAMPLE.read_text()
+    assert "DATABASE_URL is the single source of truth" not in text
+    assert "DATABASE_URL=" in text
+    assert "services/agent/core/db.ts" in text
+    assert "migrate_schema.py" in text
+
+
+def test_helm_does_not_assemble_database_url():
+    helpers = HELM_HELPERS.read_text()
+    values = HELM_VALUES.read_text()
+    assert "databaseUrlNoPassword" not in helpers
+    assert "append ?sslmode=require to the DATABASE_URL" not in values
+    assert "DATABASE_URL assembly" not in values

--- a/tests/unit/_ratchets/test_settings_env_example.py
+++ b/tests/unit/_ratchets/test_settings_env_example.py
@@ -93,6 +93,9 @@ NOT_SETTINGS = {
     # Read by the TypeScript agent processes themselves, not by Settings.
     "AGENT_HEALTH_PORT",
     "AGENT_HTTP_PORT",
+    # Agent (services/agent/core/db.ts) and scripts/migrate_schema.py.
+    # Python DatabaseConfig reads the encrypted DSN / POSTGRES_* instead (#752).
+    "DATABASE_URL",
     # The agent worker's Redis parts. Python has no equivalent -- it reads
     # REDIS_URL, which is a Setting.
     "REDIS_HOST",

--- a/tests/unit/detections/test_tuning_recommendations.py
+++ b/tests/unit/detections/test_tuning_recommendations.py
@@ -167,3 +167,12 @@ class TestDaemonThinkingBudget:
     def test_no_daemon_rows(self, rec):
         rows = [_row(agent_id="investigator", thinking_content="x" * 40000)]
         assert rec.recommend_daemon_thinking_budget(rows) == {"samples": 0}
+
+
+def test_script_does_not_tell_operators_to_set_database_url():
+    """Usage used to export DATABASE_URL. The script connects through
+    get_session(), which ignores that variable (#752)."""
+    text = SCRIPT.read_text()
+    assert "DATABASE_URL=" not in text
+    assert "Check DATABASE_URL" not in text
+    assert "get_session()" in text

--- a/tests/unit/storage/test_dsn_parsing.py
+++ b/tests/unit/storage/test_dsn_parsing.py
@@ -136,3 +136,18 @@ def test_env_connection_string_does_not_outrank_postgres_vars(monkeypatch):
     assert cfg.source == "env"
     assert cfg.host == "db.prod.internal"
     assert cfg.database == "prod_db"
+
+
+def test_database_url_does_not_select_the_python_target(monkeypatch):
+    """DATABASE_URL is the agent's knob. DatabaseConfig must not grow a third
+    source ranked between the encrypted DSN and POSTGRES_* (#752)."""
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql://other:pw@agent-only.example:5432/agent_db",
+    )
+    monkeypatch.setenv("POSTGRES_HOST", "db.prod.internal")
+    monkeypatch.setenv("POSTGRES_DB", "prod_db")
+    cfg = DatabaseConfig()
+    assert cfg.source == "env"
+    assert cfg.host == "db.prod.internal"
+    assert cfg.database == "prod_db"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Python never read `DATABASE_URL`. `DatabaseConfig` still ranks the encrypted `POSTGRESQL_CONNECTION_STRING`, then `POSTGRES_*`. The Settings/DaemonConfig fields that bound the env var were assigned and never consulted, which made `env.example`'s "single source of truth" comment look wired up.

This deletes those dead fields (`Settings.extra` stays `ignore`, so the agent and `scripts/migrate_schema.py` can keep the variable), documents the split, and drops leftover Helm claims that the chart assembles a DSN.

Closes #752

## What changed
- Removed `Settings.database_url` and `DaemonConfig.database_url`
- Left `DatabaseConfig` ranking unchanged (encrypted DSN, else `POSTGRES_*`)
- Rewrote the `env.example` comment above `DATABASE_URL`; the variable stays for the TypeScript agent and `migrate_schema.py`
- Deleted unused `vigil.databaseUrlNoPassword`; corrected `sslRequired` / `postgresPassword` comments that claimed DSN assembly
- Pointed `scripts/compute_tuning_recommendations.py` at `get_session()` / `POSTGRES_*` instead of `DATABASE_URL`

Left for other issues: `nightly.yml` (#753). Helm and compose still inject `POSTGRES_*` only.

## Validation
- 45 targeted unit tests passed (`test_database_url_split`, `test_settings_env_example`, `test_dsn_parsing`, `test_tuning_recommendations`)
- `black --check`, `isort --check-only`, and `flake8` clean on the changed `core/` and `services/` files
- New ratchets fail if `database_url` is rebound on Settings/DaemonConfig, if `env.example` calls `DATABASE_URL` the source of truth, or if Helm reassembles a DSN

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d62ad07d-c25b-4bbd-bd63-b738095603e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d62ad07d-c25b-4bbd-bd63-b738095603e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

