### PR TITLE
test: isolate import-time Settings from a developer root .env

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -80,11 +80,20 @@ def state_dir_status() -> dict:
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _settings_env_file() -> Optional[Path]:
+    # Tests set this before collection so import-time get_settings() captures
+    # do not read a developer's root .env. os.environ, not Settings: resolved
+    # while Settings is being defined, like VIGIL_DIR.
+    if os.environ.get("VIGIL_DISABLE_DOTENV"):  # noqa: ENV001 - pre-Settings bootstrap
+        return None
+    return REPO_ROOT / ".env"
+
+
 class Settings(BaseSettings):
     # Anchored to the repo so the same .env loads regardless of working directory.
     # Real env vars still win, keeping container and Helm injection authoritative.
     model_config = SettingsConfigDict(
-        env_file=REPO_ROOT / ".env",
+        env_file=_settings_env_file(),
         env_file_encoding="utf-8",
         extra="ignore",
         case_sensitive=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 # DEV_MODE=true before any test module imports: API tests import routers at module
 # load, and auth_service raises at import time without DEV_MODE or JWT_SECRET_KEY.
+# VIGIL_DISABLE_DOTENV likewise: import-time get_settings() captures run during
+# collection, before the autouse fixture can neutralize env_file.
 
 import os
 
 os.environ.setdefault("DEV_MODE", "true")
+os.environ["VIGIL_DISABLE_DOTENV"] = "1"
 
 import pytest  # noqa: E402
 

--- a/tests/unit/platform/test_settings_dotenv.py
+++ b/tests/unit/platform/test_settings_dotenv.py
@@ -1,0 +1,80 @@
+"""Import-time Settings must not read a developer's root .env (#577)."""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from core.config import REPO_ROOT, _settings_env_file
+
+
+def _run_isolated(script: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("VIGIL_DISABLE_DOTENV", None)
+    env["PYTHONPATH"] = (
+        f"{REPO_ROOT}{os.pathsep}{env['PYTHONPATH']}"
+        if env.get("PYTHONPATH")
+        else str(REPO_ROOT)
+    )
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+
+@pytest.mark.unit
+def test_settings_env_file_skips_dotenv_when_disabled(monkeypatch):
+    monkeypatch.setenv("VIGIL_DISABLE_DOTENV", "1")
+    assert _settings_env_file() is None
+
+
+@pytest.mark.unit
+def test_settings_env_file_loads_repo_root_dotenv_by_default(monkeypatch):
+    monkeypatch.delenv("VIGIL_DISABLE_DOTENV", raising=False)
+    assert _settings_env_file() == REPO_ROOT / ".env"
+
+
+@pytest.mark.unit
+def test_conftest_disables_dotenv_before_settings_import():
+    """pytest loads tests/conftest.py before collecting modules that capture
+    get_settings() at import time. The autouse fixture is too late; this
+    subprocess imports conftest the same way collection does, without running
+    fixtures, and checks Settings was defined with env_file already off.
+    """
+    script = textwrap.dedent(
+        """\
+        import tests.conftest  # noqa: F401
+        from core.config import Settings
+
+        env_file = Settings.model_config.get("env_file")
+        assert env_file is None, f"env_file still {env_file!r}"
+        print("ok")
+        """
+    )
+    result = _run_isolated(script)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+@pytest.mark.unit
+def test_settings_loads_repo_dotenv_when_marker_absent():
+    """Production import must still point at the root .env (#520)."""
+    script = textwrap.dedent(
+        """\
+        from core.config import REPO_ROOT, Settings
+
+        env_file = Settings.model_config.get("env_file")
+        assert env_file == REPO_ROOT / ".env", f"env_file is {env_file!r}"
+        print("ok")
+        """
+    )
+    result = _run_isolated(script)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"

--- a/tests/unit/platform/test_settings_dotenv.py
+++ b/tests/unit/platform/test_settings_dotenv.py
@@ -48,16 +48,14 @@ def test_conftest_disables_dotenv_before_settings_import():
     subprocess imports conftest the same way collection does, without running
     fixtures, and checks Settings was defined with env_file already off.
     """
-    script = textwrap.dedent(
-        """\
+    script = textwrap.dedent("""\
         import tests.conftest  # noqa: F401
         from core.config import Settings
 
         env_file = Settings.model_config.get("env_file")
         assert env_file is None, f"env_file still {env_file!r}"
         print("ok")
-        """
-    )
+        """)
     result = _run_isolated(script)
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "ok"
@@ -66,15 +64,13 @@ def test_conftest_disables_dotenv_before_settings_import():
 @pytest.mark.unit
 def test_settings_loads_repo_dotenv_when_marker_absent():
     """Production import must still point at the root .env (#520)."""
-    script = textwrap.dedent(
-        """\
+    script = textwrap.dedent("""\
         from core.config import REPO_ROOT, Settings
 
         env_file = Settings.model_config.get("env_file")
         assert env_file == REPO_ROOT / ".env", f"env_file is {env_file!r}"
         print("ok")
-        """
-    )
+        """)
     result = _run_isolated(script)
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "ok"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #577

The autouse fixture in `tests/conftest.py` set `Settings.model_config["env_file"] = None` per test, which is after collection. Fourteen module-level `get_settings()` captures evaluate while `env_file` is still the repo-root `.env`, so a developer’s local file could shift values the suite asserts on (green in CI, red locally).

## Change

- Set `VIGIL_DISABLE_DOTENV=1` at conftest **module scope**, before any test module is imported.
- `core/config.py` treats that marker as a pre-Settings bootstrap read (same shape as `VIGIL_DIR`: `noqa: ENV001`, not a Settings field, not in `env.example` / `NOT_SETTINGS`). When it is set, `env_file` is `None`.
- Leave the capture sites as import-time constants and do not import `core.config` from conftest at module scope or in `pytest_configure`.
- The existing autouse cache/`env_file` fixture stays for runtime `get_settings()` reads.

## Tests

- Helper unit tests for the marker on/off.
- Subprocess that imports `tests.conftest` then `Settings` (collection without fixtures) and asserts `env_file is None` — fails if either side of the wiring is missing.
- Subprocess without the marker asserts production still points at `REPO_ROOT / ".env"`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f85008d-ad0c-49e5-9b5a-80fab3a82cbc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f85008d-ad0c-49e5-9b5a-80fab3a82cbc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

