### PR TITLE
feat(memory): pin the recall event payload and tool signature (#729)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -133,11 +133,43 @@ several — Splunk has both an official server and the self-hosted one Vigil shi
 `mcp-config.json` key.
 _Avoid_: integration id, tool name
 
+**Declared Gap**:
+A question an investigation never gathered evidence for, carrying why nothing was
+gathered. Not a **Verdict** with an empty outcome: it has no activity window,
+because there was no activity to bound. Gaps are the common case rather than the
+exception, and what ranks an entity up is accumulation of them across
+investigations, never being one.
+_Avoid_: visibility gap (that is a tool that could not answer), unknown, null result
+
 **Episodic Memory** (`memory`):
 What earlier investigations saw and concluded, derived from a **Ledger** after a
 run reaches its terminal so a later run stops re-deriving a settled answer.
 Reorders the frontier and never decides (ADR 0015).
 _Avoid_: MemPalace (the component this replaces), cache, RAG
+
+**Recall**:
+One read of **Episodic Memory** on exact entity keys. A run performs one at start
+and renders it into the frozen prefix; a worker performs one mid-run through the
+`recall_entity` tool, which lands in the prompt tail and leaves the prefix
+undisturbed. Recall never contributes to corroboration — it reorders what to look
+at and settles nothing (ADR 0015).
+_Avoid_: search, retrieval, lookup (unqualified), context
+
+**Recall Event**:
+The **Ledger** record of one run-start **Recall**: the keys queried, the rows
+returned with their provenance, what was dropped and why, and the selection
+parameters in force. It carries rows and not an order — the order they were
+presented in is a fold, so ranking may change without invalidating a historical
+Ledger. The parameters are copied in rather than referenced, because a **RunSpec**
+records the arch by name and not by version.
+_Avoid_: recall log (that is the audit table, which is Python's), snapshot
+
+**Sighting**:
+What one investigation observed about one entity from one source. One row per
+entity, investigation and source, so growth tracks hunts and not telemetry
+volume. The weaker and truer claim a **Verdict** does not make: *seen during a run
+that concluded X*, rather than a subject of that conclusion.
+_Avoid_: finding, evidence, observation, hit
 
 **Source Tier**:
 What a source *is*: `telemetry` observed our own estate, `feed` asserts about the
@@ -145,6 +177,13 @@ world, `not_evidence` is neither. Distinct from **Trust**, which is who
 concluded — `analyst` or `agent`. Both sit on a **Verdict**'s sources, and one
 does not imply the other: a feed can be cited by an analyst.
 _Avoid_: connector trust, confidence, severity
+
+**Stance**:
+How one source bore on a **Verdict**: `supports`, `weakens` or `neither`. Replaces
+a flat corroborated list, which cannot express direction — a source that weakened
+a hypothesis and a source that never bore on it are not the same row.
+_Avoid_: corroboration (that is the effect of several sources agreeing, not one
+source's direction), confidence, polarity, sentiment
 
 **Trust**:
 Who concluded — `analyst` when a person closed it, `agent` when the daemon did.
@@ -276,6 +315,13 @@ _Avoid_: page, tab, view
   was corroborated
 - **Trust** is unrelated to **Connector Trust**, which is about admitting a
   third-party origin rather than weighing a conclusion
+- A **Recall** returns **Sightings**, **Verdicts** and **Declared Gaps** in one
+  shape, carried two ways: journaled verbatim as the **Recall Event** at run
+  start, and returned as the single row of a `recall_entity` tool result mid-run.
+  One shape and not two — a parallel payload is a second contract, and the second
+  one drifts. Declared in `core/memory/recall_contract.py` and
+  `services/agent/contracts/memory.ts`, with a ratchet that fails when they
+  disagree
 - **Ingestion** produces **Findings** and depends on **Storage** (never the reverse)
 - **Federation** drives **Ingestion** (an adapter wraps an ingestion service);
   Ingestion never depends on Federation

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -264,6 +264,14 @@ run-scoped concept, distinct from **Source Evidence**, which attaches to a
 Finding.
 _Avoid_: finding, result, observation
 
+**Visibility Gap**:
+Something a run could not see because a tool timed out or was unavailable —
+recorded so an absence of evidence is not read as evidence of absence. A refusal
+or a bad argument is a defect and must never be recorded as one
+(`services/agent/contracts/tool.ts`). Distinct from a **Declared Gap**, which is
+a question nobody gathered evidence for rather than a lookup that failed.
+_Avoid_: declared gap, error, failure, unknown
+
 **Digest**:
 The bounded view of a Projection presented to the lead for a single decision:
 recent Evidence, entities seen, open questions. Its sampling is seeded from the

--- a/core/memory/recall_contract.py
+++ b/core/memory/recall_contract.py
@@ -1,0 +1,345 @@
+"""The recall contract (#729), Python's half.
+
+The two contracts between this side and the harness, pinned before either side
+builds against them: what a read of episodic memory returns, and the signature
+of the tool that performs one. A mismatch fails as "no history" — the same
+shape as every other silent failure in this area — so it is agreed before code
+exists rather than discovered after.
+
+The TypeScript half is ``services/agent/contracts/memory.ts``.
+``tests/unit/_ratchets/test_recall_contract_agrees.py`` fails when the two
+drift, which is what makes this an agreement rather than two documents.
+
+There is one shape, carried two ways. The run-start read journals it verbatim
+as the recall event payload; a mid-run :data:`RECALL_TOOL` call carries the same
+mapping as the single row of a ``ToolResult``. Not two shapes that agree — a
+parallel payload is a second contract, and the second one drifts.
+
+Nothing calls this yet. ``distil`` (#731) writes the rows, #732 lands the tool,
+and the harness lands the event. Arriving first is the point: three slices join
+to one declaration instead of three guesses.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping, Tuple
+
+RECALL_TOOL = "recall_entity"
+
+# What the arch asks for, not what this deployment calls it: a ToolSpec binds the
+# capability to the tool id via `provides`. A capability nothing provides is
+# dropped rather than fatal, so a role may ask for recall where there is no
+# memory yet.
+RECALL_CAPABILITY = "entity_recall"
+
+# Which caller gets which tool, empties included: a role granted nothing is a
+# decision, and reads as an oversight when it is left out.
+#
+# Keyed by the role names `services/agent/arch/threathunt.yaml` actually declares,
+# not by a class called "worker" that appears in no file. The arch nests the three
+# under `roles.workers`, and a grant is written on each.
+#
+# Workers get exact lookups. The lead does not — it never queries, it reads a
+# digest — and narrative search, the lead's alone, ships no tool here. The critic
+# already holds nothing.
+#
+# The run-start read appears nowhere below: it is not a tool call, so it needs no
+# grant. Which is also why only it needs an event kind of its own, while a
+# mid-run call is journaled as an ordinary dispatch.
+RECALL_GRANTS: Mapping[str, Tuple[str, ...]] = {
+    "lead": (),
+    "critic": (),
+    "threat_hunter": (RECALL_CAPABILITY,),
+    "network_analyst": (RECALL_CAPABILITY,),
+    "threat_intel": (RECALL_CAPABILITY,),
+}
+
+# The arguments the tool accepts. `entity_keys` is the contract; a singular
+# `entity_key` is wrapped, because a model given a list parameter will sometimes
+# send one string.
+#
+# The handler takes an args mapping and not these as keyword parameters:
+# `tools_router._bounded` injects `limit` into every backend call from the
+# harness's bounds, and a handler with an explicit signature would answer
+# `invalid_args` to every recall. That bound is also not honoured — the caps
+# here are memory's own and are reported back in `ranking`, and letting a
+# per-tool row ceiling replace them would make what a run remembered depend on
+# a number set for a different reason.
+RECALL_ARGS: Tuple[str, ...] = (
+    "entity_keys",
+    "entity_key",
+    "as_of",
+    "caller_kind",
+    "caller_id",
+)
+
+# The types, because a name agreed without one is half a signature. `timestamptz`
+# rather than a date: an as-of read that loses the time of day answers a different
+# question on the day an investigation concluded.
+RECALL_ARG_TYPES: Mapping[str, str] = {
+    "entity_keys": "array of `type:value` strings, min 1",
+    "entity_key": "string, wrapped into entity_keys",
+    "as_of": "timestamptz, default now",
+    "caller_kind": "string, default `unknown`",
+    "caller_id": "string, default `unknown`",
+}
+
+RECALL_REQUIRED_ARGS: Tuple[str, ...] = ("entity_keys",)
+
+# The keys of the returned mapping. One mapping and not a list, so
+# `tools_router._rows` does not slice the inner lists into rows of their own and
+# lose which list each came from.
+RECALL_RESULT_KEYS: Tuple[str, ...] = (
+    "keys",
+    "as_of",
+    "sightings",
+    "verdicts",
+    "gaps",
+    "dropped",
+    "ranking",
+)
+
+# Provenance sits on every row rather than on the envelope: one read returns rows
+# from many investigations, and which one concluded a thing is the whole reason a
+# later run trusts it.
+#
+# `concluded_at` is when the investigation concluded, not when the row was
+# written. The Distil polls, so an investigation that ended Monday can be written
+# Wednesday carrying Monday's date — inside the freshness predicate, absent from
+# the read that ran on Tuesday. Which is why recall journals its rows.
+_PROVENANCE: Tuple[str, ...] = (
+    "investigation_kind",
+    "investigation_id",
+    "concluded_at",
+)
+
+# One row per entity, investigation and source, so growth tracks hunts rather
+# than telemetry volume. Never one row per evidence record.
+SIGHTING_FIELDS: Tuple[str, ...] = _PROVENANCE + (
+    "entity_key",
+    "source_system",
+    "hit_count",
+    # Aggregated over the evidence in the group. An entity every record naming it
+    # could have been named by an adversary cannot clear a branch on its own.
+    "attacker_influenceable",
+    "window",
+)
+
+VERDICT_FIELDS: Tuple[str, ...] = _PROVENANCE + (
+    # Stable, because the prose gets re-worded and a key that moves when someone
+    # edits a sentence is not a key.
+    "hypothesis_id",
+    "statement",
+    "outcome",
+    # The one field here that reaches no ranking function: model text that sounds
+    # confident must not be able to move a priority (ADR 0015). Carried for a
+    # human reading the run back.
+    "rationale",
+    # The entities the hypothesis named, typically one to three — not the 38 to
+    # 76 its evidence touched, which stay reachable through Sightings as the
+    # weaker and truer claim (ADR 0016).
+    "subject_entities",
+    # True when every source was something an adversary could have authored. Not
+    # per-source: what a branch-clearing rule asks is whether anything
+    # independent was seen at all.
+    "attacker_influenceable_only",
+    "trust",
+    "window",
+    "window_source",
+    "sources",
+)
+
+# Replaces a flat corroborated list, which cannot express direction: a source
+# that weakened a hypothesis and a source that never bore on it are not the same
+# row. `source_system` is memory's own column and not a foreign key into either
+# producer — a hunt-derived Verdict fills it from the Ledger, a Case-derived one
+# from the `data_source` of its Findings — which is why the tier map is keyed
+# twice.
+# `source_tier` carries #728's vocabulary and is not restated here. A
+# `not_evidence` value on one of these rows is a defect rather than a weak row —
+# citing a rule catalogue as corroboration is a run treating a lookup as an
+# observation — and it is representable so that it is visible.
+VERDICT_SOURCE_FIELDS: Tuple[str, ...] = ("source_system", "stance", "source_tier")
+
+# No activity window, which is the reason a Gap is not a Verdict with an empty
+# outcome.
+GAP_FIELDS: Tuple[str, ...] = _PROVENANCE + (
+    "hypothesis_id",
+    "statement",
+    "disposition",
+    "reason",
+    "subject_entities",
+)
+
+# Both ends inclusive, ISO-8601 with an offset. Separate from a conclusion date
+# because a sweep that concluded today about last March is not newly relevant.
+WINDOW_FIELDS: Tuple[str, ...] = ("first_seen", "last_seen")
+
+# Why rows are missing, per kind, because the two reasons mean different things
+# to the caller: `per_key_cap` means one entity had more history than its share,
+# `overall_cap` means the read was broad. A total is the sum and is not restated.
+DROPPED_KINDS: Tuple[str, ...] = ("sightings", "verdicts", "gaps")
+DROPPED_REASONS: Tuple[str, ...] = ("per_key_cap", "overall_cap")
+
+# Who concluded, as distinct from what the source is. Two axes, because telemetry
+# observes and a feed asserts but neither concludes, so an ordered list of the
+# four could never place two of them on a Verdict at all.
+TRUST_LEVELS: Tuple[str, ...] = ("analyst", "agent")
+
+STANCES: Tuple[str, ...] = ("supports", "weakens", "neither")
+
+# Keyed by kind and id, never by `run_id`: a run-keyed schema cannot represent
+# the Case-authored Verdicts the writer split requires. `analyst` is declared and
+# written by nothing yet — chat never writes memory, and an analyst thinking
+# aloud is not a Verdict.
+#
+# Wider than `source_tier.InvestigationKind`, deliberately. That enum selects a
+# source vocabulary, and an `analyst` investigation names no sources of its own.
+INVESTIGATION_KINDS: Tuple[str, ...] = ("hunt", "case", "analyst")
+
+# `proven` and `disproven` come straight through; `inconclusive` covers a
+# hypothesis that gathered evidence and did not settle; `handed_off` is terminal
+# for the hunt and not an ending of the claim, so it ranks up like a Gap while
+# still carrying evidence, a window and sources; `false_positive` arrives only
+# from a Case closure.
+VERDICT_OUTCOMES: Tuple[str, ...] = (
+    "proven",
+    "disproven",
+    "inconclusive",
+    "handed_off",
+    "false_positive",
+)
+
+# Whether the window was seen or claimed. A retrospective sweep over old archives
+# asserts its window, and ranking discounts the weaker one, so it has to be able
+# to tell them apart.
+WINDOW_SOURCES: Tuple[str, ...] = ("observed", "asserted")
+
+# Why nothing was gathered. A closed set, so the reasons a question went
+# unanswered stay apart instead of collapsing into one.
+#
+# Each value traces to a line of the spec, because a disposition invented here is
+# one #731 would write against and nothing would review:
+#   deprioritised       — the status map's `parked` arm ("parked | Gap,
+#                          deprioritised")
+#   no_evidence_gathered — the `inconclusive` and `active` arms, both of which
+#                          write "Verdict if evidence was gathered, else Declared
+#                          Gap". Also where a `data_starved` run's open questions
+#                          land, since such a run "writes normally"
+#   budget_exhausted    — "work abandoned for budget is not abandoned forever",
+#                          and the `budget_terminated` run terminal
+#
+# Deliberately not `never_dispatched`: a hypothesis that reached `inconclusive`
+# with nothing gathered *was* dispatched, and a value naming the dispatch would
+# have made those two indistinguishable. Deliberately not a `no_data_source`
+# value either — a tool that could not answer is a **Visibility Gap**, which
+# CONTEXT.md keeps distinct from a **Declared Gap** on purpose.
+GAP_DISPOSITIONS: Tuple[str, ...] = (
+    "deprioritised",
+    "no_evidence_gathered",
+    "budget_exhausted",
+)
+
+# How a queried key is matched against a stored one. Pinned rather than described,
+# because the two sides normalise in different languages: the rule lives in
+# `services/agent/workflows/hunt/entities.ts` (`defang`, then case-fold) and Python
+# has to reproduce it exactly or an exact join quietly misses.
+#
+# The exception is the part that breaks silently. An ARN's resource part and an
+# AWS key id are case-significant, so folding them makes two different principals
+# one key — and the join still returns rows, just the wrong ones.
+KEY_CASE_SENSITIVE_TYPES: Tuple[str, ...] = ("arn", "aws_key")
+
+# The total order the caps are applied under. A LIMIT over a partial order lets
+# Postgres return a different set on identical data, which makes what a run
+# remembered nondeterministic and surfaces as a replay diff rather than an error.
+# Ties break on the primary key.
+RECALL_ORDER = "concluded_at DESC, id ASC"
+
+# Applied as a LATERAL and before the overall cap. A plain trailing LIMIT lets
+# one entity present in every hunt — a resolver, a proxy — consume the whole
+# budget, which makes memory less useful the more it holds.
+RECALL_PER_KEY_CAP = 20
+RECALL_OVERALL_CAP = 100
+
+# Copied into the result rather than referenced, because a RunSpec records the
+# arch by name and not by version: a replay resolving these afresh would select
+# under today's values against rows chosen under the old ones.
+#
+# Selection only. The order the rows were *presented* in is a fold and is
+# deliberately absent — the harness's ranking curve may change without
+# invalidating a historical Ledger, which is only true while the event carries
+# rows and not an order.
+RANKING_KEYS: Tuple[str, ...] = ("order", "per_key_cap", "overall_cap")
+
+
+def recall_ranking() -> Dict[str, object]:
+    """The selection parameters in force, for the result and the read log."""
+    return {
+        "order": RECALL_ORDER,
+        "per_key_cap": RECALL_PER_KEY_CAP,
+        "overall_cap": RECALL_OVERALL_CAP,
+    }
+
+
+def empty_dropped() -> Dict[str, Dict[str, int]]:
+    """Nothing dropped: zeros rather than an absent key.
+
+    No field in a recall result is nullable and no list is optional. An empty
+    list means known-to-be-none, and there is no unknown state to represent --
+    which is why an entity with no history is zeros and empty lists, never an
+    error.
+    """
+    return {kind: {reason: 0 for reason in DROPPED_REASONS} for kind in DROPPED_KINDS}
+
+
+# Two points this contract does not settle, recorded here rather than in a thread
+# because a contract's unresolved edges are part of it.
+#
+# `dropped` diverges from #732's grooming note, which reads `dropped {sightings,
+# verdicts, gaps}` and would have an implementer write three integers. #729 asks
+# for "the dropped count and why", and one integer cannot carry the why, so the
+# leaf is a mapping of the two cap reasons. :func:`empty_dropped` exists so #732
+# builds the shape rather than inferring it from the groom. A total is the sum.
+#
+# Per-entity counts of open questions are what the spec's ranking-inputs section
+# owes the harness, and they are the one item that section names which no field
+# here carries. They are *nearly* derivable — open questions are Gaps plus
+# `handed_off` Verdicts, grouped by `subject_entities` — but the per-key cap
+# truncates precisely the entities the count exists to surface, and `dropped` is
+# aggregated across the read rather than per key, so a caller cannot tell 20 from
+# 60. Resolving it means either a count taken before the caps or per-key drop
+# attribution, and both add a key #732's groom does not have. Flagged rather than
+# chosen: the ranking is the harness's, so which of the two it wants is theirs to
+# say.
+
+
+# Every read of memory, whoever asked. The harness's Ledger event exists for
+# replay and has to live in the Ledger; this log exists for audit, and it is the
+# only thing that makes "we can see what it knew" true for a caller that has no
+# Ledger. It holds reads rather than facts, so it is the one part of the tier
+# that needs a retention policy.
+# Column names, not paraphrases: #732 owns the DDL and this is what it creates.
+# `row_counts` rather than `returned` because the log holds how many came back per
+# kind and not the rows themselves — it is an audit trail, and copying the rows
+# into it would make it a second store of facts with its own retention.
+READ_LOG_FIELDS: Tuple[str, ...] = (
+    "id",
+    "ts",
+    "caller_kind",
+    "caller_id",
+    "keys",
+    "as_of",
+    "row_counts",
+    "dropped",
+    "ranking",
+)
+
+# Stated here because "it needs one" is not a policy. The read log is the one part
+# of the tier that has retention at all: it holds lookups, and the facts they
+# looked up are kept forever.
+READ_LOG_RETENTION_DAYS = 90
+
+# An unattributed read is still worth logging, so the caller fields default
+# rather than being required.
+UNKNOWN_CALLER = "unknown"

--- a/core/memory/recall_contract.py
+++ b/core/memory/recall_contract.py
@@ -1,51 +1,109 @@
 """The recall contract (#729), Python's half.
 
-The two contracts between this side and the harness, pinned before either side
-builds against them: what a read of episodic memory returns, and the signature
-of the tool that performs one. A mismatch fails as "no history" — the same
-shape as every other silent failure in this area — so it is agreed before code
-exists rather than discovered after.
+What a read of episodic memory returns, and the signature of the tool that
+performs one. There is one shape, carried two ways: the run-start read journals
+it verbatim as the recall event payload, and a mid-run :data:`RECALL_TOOL` call
+carries the same mapping as the single row of a ``ToolResult``. A parallel
+payload would be a second contract, and the second one drifts.
 
-The TypeScript half is ``services/agent/contracts/memory.ts``.
-``tests/unit/_ratchets/test_recall_contract_agrees.py`` fails when the two
-drift, which is what makes this an agreement rather than two documents.
-
-There is one shape, carried two ways. The run-start read journals it verbatim
-as the recall event payload; a mid-run :data:`RECALL_TOOL` call carries the same
-mapping as the single row of a ``ToolResult``. Not two shapes that agree — a
-parallel payload is a second contract, and the second one drifts.
-
-Nothing calls this yet. ``distil`` (#731) writes the rows, #732 lands the tool,
-and the harness lands the event. Arriving first is the point: three slices join
-to one declaration instead of three guesses.
+A mismatch between the halves fails as "no history", which is indistinguishable
+from an entity nobody has looked at. The TypeScript half is
+``services/agent/contracts/memory.ts`` and
+``tests/unit/_ratchets/test_recall_contract_agrees.py`` fails when they
+disagree — nothing calls either half yet, so a static check is the only one
+available.
 """
 
 from __future__ import annotations
 
-from typing import Dict, Mapping, Tuple
+from enum import Enum
+from typing import Any, Dict, Mapping, Tuple
+
+
+class Trust(str, Enum):
+    """Who concluded, as opposed to what the source is (**Source Tier**)."""
+
+    ANALYST = "analyst"
+    AGENT = "agent"
+
+
+class Stance(str, Enum):
+    """How one source bore on a **Verdict**.
+
+    Three-valued because a flat corroborated list cannot express direction: a
+    source that weakened a hypothesis and one that never bore on it are not the
+    same row.
+    """
+
+    SUPPORTS = "supports"
+    WEAKENS = "weakens"
+    NEITHER = "neither"
+
+
+class InvestigationKind(str, Enum):
+    """Keyed by kind and id, never ``run_id``.
+
+    A run-keyed schema cannot represent the Case-authored Verdicts the writer
+    split requires. Wider than ``source_tier.InvestigationKind``, which selects
+    a source vocabulary — an ``analyst`` investigation names no sources, and
+    nothing writes one yet.
+    """
+
+    HUNT = "hunt"
+    CASE = "case"
+    ANALYST = "analyst"
+
+
+class VerdictOutcome(str, Enum):
+    """``handed_off`` is terminal for the hunt and not an ending of the claim, so
+    it ranks up like a Gap while still carrying evidence, a window and sources.
+    ``false_positive`` arrives only from a Case closure.
+    """
+
+    PROVEN = "proven"
+    DISPROVEN = "disproven"
+    INCONCLUSIVE = "inconclusive"
+    HANDED_OFF = "handed_off"
+    FALSE_POSITIVE = "false_positive"
+
+
+class WindowSource(str, Enum):
+    """A retrospective sweep over old archives asserts its window rather than
+    observing it, and ranking discounts the weaker one.
+    """
+
+    OBSERVED = "observed"
+    ASSERTED = "asserted"
+
+
+class GapDisposition(str, Enum):
+    """Why nothing was gathered.
+
+    Each value traces to a line of the spec, because a disposition invented here
+    is one #731 writes against and nothing reviews. ``DEPRIORITISED`` is the
+    status map's ``parked`` arm; ``NO_EVIDENCE_GATHERED`` is its ``inconclusive``
+    and ``active`` arms, and where a ``data_starved`` run's open questions land;
+    ``BUDGET_EXHAUSTED`` is work abandoned for budget.
+
+    Not ``never_dispatched``: a hypothesis that reached ``inconclusive`` with
+    nothing gathered *was* dispatched. Not ``no_data_source`` either — a tool
+    that could not answer is a **Visibility Gap**, which CONTEXT.md keeps
+    distinct from a **Declared Gap**.
+    """
+
+    DEPRIORITISED = "deprioritised"
+    NO_EVIDENCE_GATHERED = "no_evidence_gathered"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+
 
 RECALL_TOOL = "recall_entity"
 
-# What the arch asks for, not what this deployment calls it: a ToolSpec binds the
-# capability to the tool id via `provides`. A capability nothing provides is
-# dropped rather than fatal, so a role may ask for recall where there is no
-# memory yet.
+# What the arch asks for; a ToolSpec binds it to the tool id via `provides`.
 RECALL_CAPABILITY = "entity_recall"
 
-# Which caller gets which tool, empties included: a role granted nothing is a
-# decision, and reads as an oversight when it is left out.
-#
-# Keyed by the role names `services/agent/arch/threathunt.yaml` actually declares,
-# not by a class called "worker" that appears in no file. The arch nests the three
-# under `roles.workers`, and a grant is written on each.
-#
-# Workers get exact lookups. The lead does not — it never queries, it reads a
-# digest — and narrative search, the lead's alone, ships no tool here. The critic
-# already holds nothing.
-#
-# The run-start read appears nowhere below: it is not a tool call, so it needs no
-# grant. Which is also why only it needs an event kind of its own, while a
-# mid-run call is journaled as an ordinary dispatch.
+# Keyed by the role names threathunt.yaml declares, not by a class called
+# "worker" that appears in no file. Empties are decisions: the lead never
+# queries, and narrative search — the lead's alone — ships no tool here.
 RECALL_GRANTS: Mapping[str, Tuple[str, ...]] = {
     "lead": (),
     "critic": (),
@@ -54,41 +112,48 @@ RECALL_GRANTS: Mapping[str, Tuple[str, ...]] = {
     "threat_intel": (RECALL_CAPABILITY,),
 }
 
-# The arguments the tool accepts. `entity_keys` is the contract; a singular
-# `entity_key` is wrapped, because a model given a list parameter will sometimes
-# send one string.
+# The shape `core/llm/tool_schemas.py` already uses, so #732 registers this
+# rather than transcribing it.
 #
-# The handler takes an args mapping and not these as keyword parameters:
-# `tools_router._bounded` injects `limit` into every backend call from the
-# harness's bounds, and a handler with an explicit signature would answer
-# `invalid_args` to every recall. That bound is also not honoured — the caps
-# here are memory's own and are reported back in `ranking`, and letting a
-# per-tool row ceiling replace them would make what a run remembered depend on
-# a number set for a different reason.
-RECALL_ARGS: Tuple[str, ...] = (
-    "entity_keys",
-    "entity_key",
-    "as_of",
-    "caller_kind",
-    "caller_id",
-)
-
-# The types, because a name agreed without one is half a signature. `timestamptz`
-# rather than a date: an as-of read that loses the time of day answers a different
-# question on the day an investigation concluded.
-RECALL_ARG_TYPES: Mapping[str, str] = {
-    "entity_keys": "array of `type:value` strings, min 1",
-    "entity_key": "string, wrapped into entity_keys",
-    "as_of": "timestamptz, default now",
-    "caller_kind": "string, default `unknown`",
-    "caller_id": "string, default `unknown`",
+# `required` is empty on purpose. Neither key argument can be required, because
+# the singular exists for the caller that sends one string *instead of* the
+# list; requiring the list makes that call invalid. The invariant is
+# RECALL_KEY_ARGS, checked at the call rather than by the schema.
+RECALL_PARAMETERS: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "entity_keys": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Entity Keys as `type:value`, at least one",
+        },
+        "entity_key": {
+            "type": "string",
+            "description": "One Entity Key, wrapped into entity_keys",
+        },
+        "as_of": {
+            "type": "string",
+            "description": "Freshness filter, ISO-8601 with an offset; defaults to now",
+        },
+        "caller_kind": {"type": "string", "default": "unknown"},
+        "caller_id": {"type": "string", "default": "unknown"},
+    },
+    "required": [],
 }
 
-RECALL_REQUIRED_ARGS: Tuple[str, ...] = ("entity_keys",)
+# At least one, never both required. A call naming neither is invalid_args.
+RECALL_KEY_ARGS: Tuple[str, ...] = ("entity_keys", "entity_key")
 
-# The keys of the returned mapping. One mapping and not a list, so
-# `tools_router._rows` does not slice the inner lists into rows of their own and
-# lose which list each came from.
+RECALL_ARGS: Tuple[str, ...] = tuple(RECALL_PARAMETERS["properties"])
+
+# The handler takes an args mapping, not these as keyword parameters:
+# `tools_router._bounded` injects `limit` into every backend call, and an
+# explicit signature would answer invalid_args to every recall. That bound is
+# not honoured either — the caps below are memory's own.
+RECALL_IGNORED_ARGS: Tuple[str, ...] = ("limit",)
+
+# One mapping, not a list, so `tools_router._rows` does not slice the inner
+# lists into rows of their own and lose which list each came from.
 RECALL_RESULT_KEYS: Tuple[str, ...] = (
     "keys",
     "as_of",
@@ -99,49 +164,38 @@ RECALL_RESULT_KEYS: Tuple[str, ...] = (
     "ranking",
 )
 
-# Provenance sits on every row rather than on the envelope: one read returns rows
-# from many investigations, and which one concluded a thing is the whole reason a
-# later run trusts it.
-#
-# `concluded_at` is when the investigation concluded, not when the row was
-# written. The Distil polls, so an investigation that ended Monday can be written
-# Wednesday carrying Monday's date — inside the freshness predicate, absent from
-# the read that ran on Tuesday. Which is why recall journals its rows.
+# On every row, not the envelope: one read returns rows from many
+# investigations. `concluded_at` is when the investigation concluded, not when
+# the row was written — the Distil polls, so an investigation that ended Monday
+# can be written Wednesday carrying Monday's date, inside the freshness
+# predicate and absent from the read that ran on Tuesday.
 _PROVENANCE: Tuple[str, ...] = (
     "investigation_kind",
     "investigation_id",
     "concluded_at",
 )
 
-# One row per entity, investigation and source, so growth tracks hunts rather
-# than telemetry volume. Never one row per evidence record.
+# One row per entity, investigation and source, so growth tracks hunts and not
+# telemetry volume.
 SIGHTING_FIELDS: Tuple[str, ...] = _PROVENANCE + (
     "entity_key",
     "source_system",
     "hit_count",
-    # Aggregated over the evidence in the group. An entity every record naming it
-    # could have been named by an adversary cannot clear a branch on its own.
     "attacker_influenceable",
     "window",
 )
 
 VERDICT_FIELDS: Tuple[str, ...] = _PROVENANCE + (
-    # Stable, because the prose gets re-worded and a key that moves when someone
-    # edits a sentence is not a key.
+    # Stable, because the prose gets re-worded.
     "hypothesis_id",
     "statement",
     "outcome",
-    # The one field here that reaches no ranking function: model text that sounds
-    # confident must not be able to move a priority (ADR 0015). Carried for a
-    # human reading the run back.
+    # Reaches no ranking function: confident-sounding model text must not move a
+    # priority (ADR 0015). Carried for a human reading the run back.
     "rationale",
     # The entities the hypothesis named, typically one to three — not the 38 to
-    # 76 its evidence touched, which stay reachable through Sightings as the
-    # weaker and truer claim (ADR 0016).
+    # 76 its evidence touched, which stay reachable through Sightings (ADR 0016).
     "subject_entities",
-    # True when every source was something an adversary could have authored. Not
-    # per-source: what a branch-clearing rule asks is whether anything
-    # independent was seen at all.
     "attacker_influenceable_only",
     "trust",
     "window",
@@ -149,20 +203,13 @@ VERDICT_FIELDS: Tuple[str, ...] = _PROVENANCE + (
     "sources",
 )
 
-# Replaces a flat corroborated list, which cannot express direction: a source
-# that weakened a hypothesis and a source that never bore on it are not the same
-# row. `source_system` is memory's own column and not a foreign key into either
-# producer — a hunt-derived Verdict fills it from the Ledger, a Case-derived one
-# from the `data_source` of its Findings — which is why the tier map is keyed
-# twice.
-# `source_tier` carries #728's vocabulary and is not restated here. A
-# `not_evidence` value on one of these rows is a defect rather than a weak row —
-# citing a rule catalogue as corroboration is a run treating a lookup as an
-# observation — and it is representable so that it is visible.
+# `source_tier` carries #728's vocabulary and is not restated. `not_evidence`
+# here is a defect rather than a weak row — citing a rule catalogue as
+# corroboration is a run treating a lookup as an observation — and is
+# representable so that it is visible.
 VERDICT_SOURCE_FIELDS: Tuple[str, ...] = ("source_system", "stance", "source_tier")
 
-# No activity window, which is the reason a Gap is not a Verdict with an empty
-# outcome.
+# No window, which is why a Gap is not a Verdict with an empty outcome.
 GAP_FIELDS: Tuple[str, ...] = _PROVENANCE + (
     "hypothesis_id",
     "statement",
@@ -171,106 +218,40 @@ GAP_FIELDS: Tuple[str, ...] = _PROVENANCE + (
     "subject_entities",
 )
 
-# Both ends inclusive, ISO-8601 with an offset. Separate from a conclusion date
-# because a sweep that concluded today about last March is not newly relevant.
 WINDOW_FIELDS: Tuple[str, ...] = ("first_seen", "last_seen")
 
-# Why rows are missing, per kind, because the two reasons mean different things
-# to the caller: `per_key_cap` means one entity had more history than its share,
-# `overall_cap` means the read was broad. A total is the sum and is not restated.
+# Per kind, and per reason: the two reasons mean different things to a caller.
+# A total is the sum and is not restated.
 DROPPED_KINDS: Tuple[str, ...] = ("sightings", "verdicts", "gaps")
 DROPPED_REASONS: Tuple[str, ...] = ("per_key_cap", "overall_cap")
 
-# Who concluded, as distinct from what the source is. Two axes, because telemetry
-# observes and a feed asserts but neither concludes, so an ordered list of the
-# four could never place two of them on a Verdict at all.
-TRUST_LEVELS: Tuple[str, ...] = ("analyst", "agent")
-
-STANCES: Tuple[str, ...] = ("supports", "weakens", "neither")
-
-# Keyed by kind and id, never by `run_id`: a run-keyed schema cannot represent
-# the Case-authored Verdicts the writer split requires. `analyst` is declared and
-# written by nothing yet — chat never writes memory, and an analyst thinking
-# aloud is not a Verdict.
-#
-# Wider than `source_tier.InvestigationKind`, deliberately. That enum selects a
-# source vocabulary, and an `analyst` investigation names no sources of its own.
-INVESTIGATION_KINDS: Tuple[str, ...] = ("hunt", "case", "analyst")
-
-# `proven` and `disproven` come straight through; `inconclusive` covers a
-# hypothesis that gathered evidence and did not settle; `handed_off` is terminal
-# for the hunt and not an ending of the claim, so it ranks up like a Gap while
-# still carrying evidence, a window and sources; `false_positive` arrives only
-# from a Case closure.
-VERDICT_OUTCOMES: Tuple[str, ...] = (
-    "proven",
-    "disproven",
-    "inconclusive",
-    "handed_off",
-    "false_positive",
-)
-
-# Whether the window was seen or claimed. A retrospective sweep over old archives
-# asserts its window, and ranking discounts the weaker one, so it has to be able
-# to tell them apart.
-WINDOW_SOURCES: Tuple[str, ...] = ("observed", "asserted")
-
-# Why nothing was gathered. A closed set, so the reasons a question went
-# unanswered stay apart instead of collapsing into one.
-#
-# Each value traces to a line of the spec, because a disposition invented here is
-# one #731 would write against and nothing would review:
-#   deprioritised       — the status map's `parked` arm ("parked | Gap,
-#                          deprioritised")
-#   no_evidence_gathered — the `inconclusive` and `active` arms, both of which
-#                          write "Verdict if evidence was gathered, else Declared
-#                          Gap". Also where a `data_starved` run's open questions
-#                          land, since such a run "writes normally"
-#   budget_exhausted    — "work abandoned for budget is not abandoned forever",
-#                          and the `budget_terminated` run terminal
-#
-# Deliberately not `never_dispatched`: a hypothesis that reached `inconclusive`
-# with nothing gathered *was* dispatched, and a value naming the dispatch would
-# have made those two indistinguishable. Deliberately not a `no_data_source`
-# value either — a tool that could not answer is a **Visibility Gap**, which
-# CONTEXT.md keeps distinct from a **Declared Gap** on purpose.
-GAP_DISPOSITIONS: Tuple[str, ...] = (
-    "deprioritised",
-    "no_evidence_gathered",
-    "budget_exhausted",
-)
-
-# How a queried key is matched against a stored one. Pinned rather than described,
-# because the two sides normalise in different languages: the rule lives in
-# `services/agent/workflows/hunt/entities.ts` (`defang`, then case-fold) and Python
-# has to reproduce it exactly or an exact join quietly misses.
-#
-# The exception is the part that breaks silently. An ARN's resource part and an
-# AWS key id are case-significant, so folding them makes two different principals
-# one key — and the join still returns rows, just the wrong ones.
+# How a queried key is matched against a stored one. The rule is `defang` then
+# case-fold, in `services/agent/workflows/hunt/entities.ts`; Python reproduces
+# it. The exception is the half that breaks silently: an ARN's resource part and
+# an AWS key id are case-significant, so folding them makes two principals one
+# key and the join still returns rows, just the wrong ones.
 KEY_CASE_SENSITIVE_TYPES: Tuple[str, ...] = ("arn", "aws_key")
 
-# The total order the caps are applied under. A LIMIT over a partial order lets
-# Postgres return a different set on identical data, which makes what a run
-# remembered nondeterministic and surfaces as a replay diff rather than an error.
-# Ties break on the primary key.
+# A LIMIT over a partial order lets Postgres return a different set on identical
+# data, so ties break on the primary key.
 RECALL_ORDER = "concluded_at DESC, id ASC"
 
-# Applied as a LATERAL and before the overall cap. A plain trailing LIMIT lets
-# one entity present in every hunt — a resolver, a proxy — consume the whole
-# budget, which makes memory less useful the more it holds.
+# Rows per kind, per key — 20 sightings and 20 verdicts and 20 gaps for one key,
+# not 20 between them. Applied as a LATERAL and before the overall cap, which
+# one entity present in every hunt would otherwise consume by itself.
 RECALL_PER_KEY_CAP = 20
+
+# Rows across all kinds and keys, applied after the per-key cap.
 RECALL_OVERALL_CAP = 100
 
 # Copied into the result rather than referenced, because a RunSpec records the
-# arch by name and not by version: a replay resolving these afresh would select
-# under today's values against rows chosen under the old ones.
-#
-# Selection only. The order the rows were *presented* in is a fold and is
-# deliberately absent — the harness's ranking curve may change without
-# invalidating a historical Ledger, which is only true while the event carries
-# rows and not an order.
+# arch by name and not by version. Selection only: the order the rows were
+# *presented* in is a fold, so the harness's ranking may change without
+# invalidating a historical Ledger. Named `ranking` because #729 and #732 both
+# call it that.
 RANKING_KEYS: Tuple[str, ...] = ("order", "per_key_cap", "overall_cap")
+
+UNKNOWN_CALLER = "unknown"
 
 
 def recall_ranking() -> Dict[str, object]:
@@ -285,61 +266,7 @@ def recall_ranking() -> Dict[str, object]:
 def empty_dropped() -> Dict[str, Dict[str, int]]:
     """Nothing dropped: zeros rather than an absent key.
 
-    No field in a recall result is nullable and no list is optional. An empty
-    list means known-to-be-none, and there is no unknown state to represent --
-    which is why an entity with no history is zeros and empty lists, never an
-    error.
+    No field in a recall result is nullable and no list is optional, so an
+    entity with no history is zeros and empty lists rather than an error.
     """
     return {kind: {reason: 0 for reason in DROPPED_REASONS} for kind in DROPPED_KINDS}
-
-
-# Two points this contract does not settle, recorded here rather than in a thread
-# because a contract's unresolved edges are part of it.
-#
-# `dropped` diverges from #732's grooming note, which reads `dropped {sightings,
-# verdicts, gaps}` and would have an implementer write three integers. #729 asks
-# for "the dropped count and why", and one integer cannot carry the why, so the
-# leaf is a mapping of the two cap reasons. :func:`empty_dropped` exists so #732
-# builds the shape rather than inferring it from the groom. A total is the sum.
-#
-# Per-entity counts of open questions are what the spec's ranking-inputs section
-# owes the harness, and they are the one item that section names which no field
-# here carries. They are *nearly* derivable — open questions are Gaps plus
-# `handed_off` Verdicts, grouped by `subject_entities` — but the per-key cap
-# truncates precisely the entities the count exists to surface, and `dropped` is
-# aggregated across the read rather than per key, so a caller cannot tell 20 from
-# 60. Resolving it means either a count taken before the caps or per-key drop
-# attribution, and both add a key #732's groom does not have. Flagged rather than
-# chosen: the ranking is the harness's, so which of the two it wants is theirs to
-# say.
-
-
-# Every read of memory, whoever asked. The harness's Ledger event exists for
-# replay and has to live in the Ledger; this log exists for audit, and it is the
-# only thing that makes "we can see what it knew" true for a caller that has no
-# Ledger. It holds reads rather than facts, so it is the one part of the tier
-# that needs a retention policy.
-# Column names, not paraphrases: #732 owns the DDL and this is what it creates.
-# `row_counts` rather than `returned` because the log holds how many came back per
-# kind and not the rows themselves — it is an audit trail, and copying the rows
-# into it would make it a second store of facts with its own retention.
-READ_LOG_FIELDS: Tuple[str, ...] = (
-    "id",
-    "ts",
-    "caller_kind",
-    "caller_id",
-    "keys",
-    "as_of",
-    "row_counts",
-    "dropped",
-    "ranking",
-)
-
-# Stated here because "it needs one" is not a policy. The read log is the one part
-# of the tier that has retention at all: it holds lookups, and the facts they
-# looked up are kept forever.
-READ_LOG_RETENTION_DAYS = 90
-
-# An unattributed read is still worth logging, so the caller fields default
-# rather than being required.
-UNKNOWN_CALLER = "unknown"

--- a/services/agent/contracts/memory.ts
+++ b/services/agent/contracts/memory.ts
@@ -1,49 +1,28 @@
-// The recall contract (#729): the one shape Python returns and TypeScript
-// journals, agreed before either side built against it. A mismatch here fails as
-// "no history", which is the same shape as every other silent failure in this
-// area, so it is pinned before code exists rather than after.
+// The recall contract (#729): what a read of episodic memory returns, and the
+// signature of the tool that performs one.
 //
-// There is one shape, carried two ways. The run-start read journals it verbatim
-// as the recall event payload; a mid-run tool call carries the same object as the
-// single row of a ToolResult. Not two types that happen to agree -- a parallel
-// payload would be a second contract, and the second one is the one that drifts.
+// One shape, carried two ways. The run-start read journals it verbatim as the
+// recall event payload; a mid-run recall_entity call carries the same object as
+// the single row of a ToolResult. A parallel payload would be a second contract,
+// and the second one drifts.
 //
-// The Python half is core/memory/recall_contract.py, and
-// tests/unit/_ratchets/test_recall_contract_agrees.py fails when the two drift.
-// That ratchet is what makes this an agreement rather than two documents.
-//
-// Nothing imports this yet. #732 lands the tool, #731 the rows it reads, and the
-// harness's recall call lands the event. The point of arriving first is that
-// three slices join to one declaration instead of three guesses.
+// A mismatch between the halves fails as "no history", indistinguishable from an
+// entity nobody has looked at. The Python half is core/memory/recall_contract.py
+// and tests/unit/_ratchets/test_recall_contract_agrees.py fails when they
+// disagree. Nothing imports either half yet -- #731 writes the rows, #732 lands
+// the tool, the harness lands the event -- which is why a static check is the
+// only one available.
 
 import type { ToolResult } from "./tool.js";
 
 export const RECALL_TOOL = "recall_entity";
 
-// What the arch asks for, not what this deployment calls it (core/spec.ts,
-// RoleSpec.needs). A capability nothing provides is dropped rather than fatal, so
-// a role may ask for recall in a deployment that has no memory yet.
+// What the arch asks for; a ToolSpec binds it to the tool id via `provides`.
 export const RECALL_CAPABILITY = "entity_recall";
 
-// Which caller gets which tool, empties included: a role granted nothing is a
-// decision here and reads as an oversight when it is left out.
-//
-// Keyed by the role names arch/threathunt.yaml actually declares, not by a class
-// called "worker" that appears in no file. The arch nests the three under
-// roles.workers, and a grant is written on each.
-//
-// Workers get exact lookups. The lead does not -- it never queries, it reads a
-// digest -- and narrative search, the lead's alone, is a later change that ships
-// no tool here. The critic already holds nothing.
-//
-// The run-start read appears in no row: it is not a tool call, so it needs no
-// grant. Which is also why only it needs an event kind, while a mid-run call is
-// journaled as an ordinary dispatch.
-//
-// One tool, not three. `prior_investigations` and `attribution` are deferrable:
-// attribution is a Verdict with an actor in it, and an as-of parameter belongs on
-// every read rather than being a tool of its own. Each extra tool costs prompt
-// surface, a grant per role, and a choice the model can get wrong.
+// Keyed by the role names threathunt.yaml declares, not by a class called
+// "worker" that appears in no file. Empties are decisions: the lead never
+// queries, and narrative search -- the lead's alone -- ships no tool here.
 export const RECALL_GRANTS = {
   lead: [],
   critic: [],
@@ -52,107 +31,97 @@ export const RECALL_GRANTS = {
   threat_intel: [RECALL_CAPABILITY],
 } as const;
 
-// Who concluded, as distinct from what the source is. Two axes, because telemetry
-// observes and a feed asserts but neither concludes -- so an ordered list of the
-// four could never place two of them on a Verdict at all.
+// Who concluded, as opposed to what the source is.
 export const TRUST_LEVELS = ["analyst", "agent"] as const;
 export type Trust = (typeof TRUST_LEVELS)[number];
 
-// What a source *is*. `not_evidence` on a Verdict is a defect rather than a weak
-// row: citing a rule catalogue as corroboration is a run treating a lookup as an
-// observation. It is representable so that it is visible.
+// #728 owns this vocabulary; it is followed here, not restated.
 export const SOURCE_TIERS = ["telemetry", "feed", "not_evidence"] as const;
 export type SourceTier = (typeof SOURCE_TIERS)[number];
 
-// Three-valued, replacing a flat corroborated list, which cannot express
-// direction: a source that weakened a hypothesis and a source that never bore on
-// it are not the same row.
+// Three-valued, because a flat corroborated list cannot express direction.
 export const STANCES = ["supports", "weakens", "neither"] as const;
 export type Stance = (typeof STANCES)[number];
 
-// Keyed by kind and id, never by run_id: a run-keyed schema cannot represent the
-// Case-authored Verdicts the writer split requires. `analyst` is declared here and
-// written by nothing yet -- chat never writes memory, and an analyst thinking
-// aloud is not a Verdict.
+// Keyed by kind and id, never run_id: a run-keyed schema cannot represent the
+// Case-authored Verdicts the writer split requires. Nothing writes `analyst` yet.
 export const INVESTIGATION_KINDS = ["hunt", "case", "analyst"] as const;
 export type InvestigationKind = (typeof INVESTIGATION_KINDS)[number];
 
-// proven and disproven come straight through; inconclusive covers a hypothesis
-// that gathered evidence and did not settle; handed_off is terminal for the hunt
-// and not an ending of the claim, so it ranks up like a Gap while still carrying
-// evidence, a window and sources; false_positive arrives only from a Case closure.
+// handed_off is terminal for the hunt and not an ending of the claim, so it ranks
+// up like a Gap while still carrying evidence, a window and sources.
+// false_positive arrives only from a Case closure.
 export const VERDICT_OUTCOMES = ["proven", "disproven", "inconclusive", "handed_off", "false_positive"] as const;
 export type VerdictOutcome = (typeof VERDICT_OUTCOMES)[number];
 
-// Whether the window was seen or claimed. A retrospective sweep over old archives
-// asserts its window; ranking discounts the weaker one, so it has to be able to
-// tell them apart.
+// A retrospective sweep over old archives asserts its window rather than
+// observing it, and ranking discounts the weaker one.
 export const WINDOW_SOURCES = ["observed", "asserted"] as const;
 export type WindowSource = (typeof WINDOW_SOURCES)[number];
 
-// ISO-8601 with an offset, both ends inclusive. Separate from a conclusion date
-// because a sweep that concluded today about last March is not newly relevant.
+// Each value traces to a line of the spec, because a disposition invented here is
+// one #731 writes against and nothing reviews. Not `never_dispatched`: a
+// hypothesis that reached inconclusive with nothing gathered *was* dispatched.
+// Not `no_data_source` either -- a tool that could not answer is a Visibility
+// Gap, which CONTEXT.md keeps distinct from a Declared Gap.
+export const GAP_DISPOSITIONS = ["deprioritised", "no_evidence_gathered", "budget_exhausted"] as const;
+export type GapDisposition = (typeof GAP_DISPOSITIONS)[number];
+
+// The rule is `defang` then case-fold, in workflows/hunt/entities.ts. The
+// exception is the half that breaks silently: an ARN's resource part and an AWS
+// key id are case-significant, so folding them makes two principals one key and
+// the join still returns rows, just the wrong ones.
+export const KEY_CASE_SENSITIVE_TYPES = ["arn", "aws_key"] as const;
+
+// Both ends inclusive. Separate from a conclusion date, because a sweep that
+// concluded today about last March is not newly relevant.
 export interface ActivityWindow {
   readonly first_seen: string;
   readonly last_seen: string;
 }
 
-// Where a row came from, on every row rather than on the envelope: one read
-// returns rows from many investigations, and which one concluded a thing is the
-// whole reason a later run trusts it.
+// On every row, not the envelope: one read returns rows from many
+// investigations. concluded_at is when the investigation concluded, not when the
+// row was written -- the Distil polls, so an investigation that ended Monday can
+// be written Wednesday carrying Monday's date, inside the freshness predicate and
+// absent from the read that ran on Tuesday.
 export interface RecalledProvenance {
   readonly investigation_kind: InvestigationKind;
   readonly investigation_id: string;
-  // When the investigation concluded, not when the row was written. The Distil
-  // polls, so an investigation that ended Monday can be written Wednesday
-  // carrying Monday's date -- inside the freshness predicate, absent from the
-  // read that ran on Tuesday. Which is why recall journals its rows.
   readonly concluded_at: string;
 }
 
-// What an investigation observed, one row per entity, investigation and source, so
-// growth tracks hunts rather than telemetry volume. Never one row per evidence
-// record.
+// One row per entity, investigation and source, so growth tracks hunts and not
+// telemetry volume.
 export interface RecalledSighting extends RecalledProvenance {
   readonly entity_key: string;
   readonly source_system: string;
   readonly hit_count: number;
-  // Aggregated over the evidence in the group. An entity every record naming it
-  // could have been named by an adversary cannot clear a branch on its own.
   readonly attacker_influenceable: boolean;
   readonly window: ActivityWindow;
 }
 
-// One row per source on a Verdict. source_system is memory's own column and not a
-// foreign key into either producer: a hunt-derived Verdict fills it from the
-// Ledger's source_system, a Case-derived one from the data_source of its Findings.
-// Two vocabularies land in one column, which is why the tier map is keyed twice.
+// source_system is memory's own column, not a foreign key into either producer: a
+// hunt-derived Verdict fills it from the Ledger, a Case-derived one from the
+// data_source of its Findings. A not_evidence tier here is a defect rather than a
+// weak row, and is representable so that it is visible.
 export interface RecalledVerdictSource {
   readonly source_system: string;
   readonly stance: Stance;
-  // Stamped at write time, never joined at read time, so an integration removed
-  // or recategorised later cannot change how a past Verdict was corroborated.
   readonly source_tier: SourceTier;
 }
 
-// What one investigation concluded about one hypothesis.
 export interface RecalledVerdict extends RecalledProvenance {
-  // Stable, because the prose gets re-worded and a key that moves when someone
-  // edits a sentence is not a key.
+  // Stable, because the prose gets re-worded.
   readonly hypothesis_id: string;
   readonly statement: string;
   readonly outcome: VerdictOutcome;
-  // Prose, and the one field here that reaches no ranking function: model text
-  // that sounds confident must not be able to move a priority (ADR 0015). It is
-  // carried for a human reading the run back.
+  // Reaches no ranking function: confident-sounding model text must not move a
+  // priority (ADR 0015). Carried for a human reading the run back.
   readonly rationale: string;
   // The entities the hypothesis named, typically one to three -- not the 38 to 76
-  // its evidence touched, which are mostly shared infrastructure and remain
-  // reachable through Sightings as the weaker and truer claim (ADR 0016).
+  // its evidence touched, which stay reachable through Sightings (ADR 0016).
   readonly subject_entities: readonly string[];
-  // True when every source on the verdict was something an adversary could have
-  // authored. Not per-source: the question a branch-clearing rule asks is whether
-  // anything independent was seen at all.
   readonly attacker_influenceable_only: boolean;
   readonly trust: Trust;
   readonly window: ActivityWindow;
@@ -160,42 +129,7 @@ export interface RecalledVerdict extends RecalledProvenance {
   readonly sources: readonly RecalledVerdictSource[];
 }
 
-// Why nothing was gathered. A closed set, so the reasons a question went
-// unanswered stay apart instead of collapsing into one.
-//
-// Each value traces to a line of the spec, because a disposition invented here is
-// one #731 would write against and nothing would review. `deprioritised` is the
-// status map's `parked` arm; `no_evidence_gathered` is the `inconclusive` and
-// `active` arms, both of which write a Verdict if evidence was gathered and a Gap
-// otherwise, and is also where a `data_starved` run's open questions land, since
-// such a run writes normally; `budget_exhausted` is work abandoned for budget and
-// the `budget_terminated` run terminal.
-//
-// Deliberately not `never_dispatched`: a hypothesis that reached `inconclusive`
-// with nothing gathered *was* dispatched, and a value naming the dispatch would
-// have made those two indistinguishable. Deliberately not a `no_data_source`
-// value either -- a tool that could not answer is a Visibility Gap, which
-// CONTEXT.md keeps distinct from a Declared Gap on purpose.
-export const GAP_DISPOSITIONS = ["deprioritised", "no_evidence_gathered", "budget_exhausted"] as const;
-export type GapDisposition = (typeof GAP_DISPOSITIONS)[number];
-
-// How a queried key is matched against a stored one. Pinned rather than
-// described, because the two sides normalise in different languages: the rule is
-// `defang` then case-fold in workflows/hunt/entities.ts, and Python has to
-// reproduce it exactly or an exact join quietly misses.
-//
-// The exception is the part that breaks silently. An ARN's resource part and an
-// AWS key id are case-significant, so folding them makes two different principals
-// one key -- and the join still returns rows, just the wrong ones.
-export const KEY_CASE_SENSITIVE_TYPES = ["arn", "aws_key"] as const;
-
-// A question an investigation never gathered evidence for. Carries no activity
-// window, which is the reason it is not a Verdict with an empty outcome.
-//
-// Gaps are the common case, not the exception: the committed fixtures leave 14 of
-// 18 hypotheses open at terminal. What ranks an entity up is accumulation across
-// investigations -- six open questions over four runs is a host nobody has
-// finished looking at; one is an ordinary run ending.
+// No window, which is why a Gap is not a Verdict with an empty outcome.
 export interface RecalledGap extends RecalledProvenance {
   readonly hypothesis_id: string;
   readonly statement: string;
@@ -204,9 +138,9 @@ export interface RecalledGap extends RecalledProvenance {
   readonly subject_entities: readonly string[];
 }
 
-// Why rows are missing, per kind, because the two reasons mean different things to
-// a caller. per_key_cap means one entity had more history than its share; overall
-// means the read was broad. A total is the sum and is not restated.
+// Per reason, because the two mean different things to a caller: per_key_cap
+// means one entity had more history than its share, overall means the read was
+// broad. A total is the sum and is not restated.
 export interface DroppedRows {
   readonly per_key_cap: number;
   readonly overall_cap: number;
@@ -219,35 +153,19 @@ export interface RecallDropped {
 }
 
 // The parameters that chose this set, copied in rather than referenced: a RunSpec
-// records the arch by name and not by version, so a replay resolving them afresh
-// would select under today's values against rows chosen under the old ones.
-//
-// Selection only. The order the rows were *presented* in is a fold and is
-// deliberately absent -- the harness's ranking curve may change without
-// invalidating a historical Ledger, which is only true while the event carries
-// rows and not an order.
+// records the arch by name and not by version. Selection only -- the order the
+// rows were *presented* in is a fold, so ranking may change without invalidating
+// a historical Ledger.
 export interface RecallRanking {
-  // The total order the caps were applied under, as SQL. A LIMIT over a partial
-  // order lets Postgres return a different set on identical data, which surfaces
-  // as a replay diff rather than an error, so ties break on the primary key.
   readonly order: string;
-  // Applied as a LATERAL and before the overall cap. A plain trailing LIMIT lets
-  // one entity present in every hunt -- a resolver, a proxy -- consume the whole
-  // budget, which makes memory less useful the more it holds.
+  // Rows per kind, per key. Applied as a LATERAL and before the overall cap.
   readonly per_key_cap: number;
+  // Rows across all kinds and keys.
   readonly overall_cap: number;
 }
 
-// One read of episodic memory. Journaled verbatim as the recall event payload at
-// run start, and carried as ToolResult.rows[0] when a worker calls the tool
-// mid-run.
-//
-// No field is optional and no list is nullable: an empty list means
-// known-to-be-none, and there is no unknown state to represent. An entity with no
-// history is empty lists and zeros, never an error.
-// Named as a value and not only as a type, so recallOf can check for them and the
-// ratchet can compare them against Python's. A type alone is invisible at runtime,
-// which is where the drift arrives.
+// Named as a value too, so recallOf can check for them at runtime, which is where
+// the drift arrives.
 export const RECALL_RESULT_KEYS = [
   "keys",
   "as_of",
@@ -258,13 +176,14 @@ export const RECALL_RESULT_KEYS = [
   "ranking",
 ] as const;
 
+// No field is optional and no list nullable: an empty list means
+// known-to-be-none, so an entity with no history is empty lists and zeros rather
+// than an error.
 export interface RecallResult {
-  // Normalised, so a key differing only by case or defanging is the same key. The
-  // keys as queried, not as asked for: only Python writes an Entity Key, and the
-  // TypeScript extractor's output travels as candidate data.
+  // Normalised, and as queried rather than as asked for: only Python writes an
+  // Entity Key, so the extractor's output travels as candidate data.
   readonly keys: readonly string[];
-  // The freshness filter that ran (`concluded_at <= as_of`). A filter, and not a
-  // substitute for journaling the rows -- see RecalledProvenance.concluded_at.
+  // The freshness filter that ran, and not a substitute for journaling the rows.
   readonly as_of: string;
   readonly sightings: readonly RecalledSighting[];
   readonly verdicts: readonly RecalledVerdict[];
@@ -273,64 +192,46 @@ export interface RecallResult {
   readonly ranking: RecallRanking;
 }
 
-// The event payload is the result. Named separately because the two carriers are
-// read by different code and an alias says they cannot diverge, where a copied
-// interface would only say they happen not to have yet.
+// The event payload is the result. An alias, because a copied interface would say
+// only that the two happen not to have diverged yet.
 export type RecallPayload = RecallResult;
 
-// What the tool accepts. entity_keys is the contract; a singular entity_key is
-// wrapped, because a model given a list parameter will sometimes send one string.
-//
-// `limit` is not in the signature and is not honoured: tools_router injects it
-// into every backend call from the harness's bounds, so the handler has to take
-// an args mapping and ignore it. The caps here are memory's own and are reported
-// in `ranking`; a bound that silently replaced them would make what a run
-// remembered depend on a per-tool row ceiling.
+// Both key arguments are optional and at least one is required. The singular
+// exists for the caller that sends one string *instead of* the list, so requiring
+// the list would make that call invalid; the schema cannot express "one of", so
+// the invariant is data and is checked at the call.
+export const RECALL_KEY_ARGS = ["entity_keys", "entity_key"] as const;
+
 export interface RecallArgs {
-  readonly entity_keys: readonly string[];
+  readonly entity_keys?: readonly string[];
   readonly entity_key?: string;
-  // Defaults to now. Every read takes one, rather than an as-of read being a tool
-  // of its own.
+  // Every read takes one, rather than an as-of read being a tool of its own.
   readonly as_of?: string;
-  // For the read log, which exists for audit and is the only thing that makes "we
-  // can see what it knew" true for a caller with no Ledger. Default `unknown`
-  // rather than required: an unattributed read is still worth logging.
+  // For the read log, which is #732's. Defaulted rather than required: an
+  // unattributed read is still worth logging.
   readonly caller_kind?: string;
   readonly caller_id?: string;
 }
 
-// Two points this contract does not settle, recorded here rather than in a thread
-// because a contract's unresolved edges are part of it.
+// Two points this contract does not settle.
 //
-// `dropped` diverges from #732's grooming note, which reads `dropped {sightings,
-// verdicts, gaps}` and would have an implementer write three integers. #729 asks
-// for "the dropped count and why", and one integer cannot carry the why, so the
-// leaf is a mapping of the two cap reasons.
+// `dropped` diverges from #732's grooming note, which reads three integers where
+// #729 asks for the count *and why*.
 //
-// Per-entity counts of open questions are what the spec's ranking-inputs section
-// owes this side, and they are the one item that section names which no field here
-// carries. They are *nearly* derivable -- open questions are Gaps plus
-// `handed_off` Verdicts, grouped by subject_entities -- but the per-key cap
-// truncates precisely the entities the count exists to surface, and `dropped` is
-// aggregated across the read rather than per key, so a caller cannot tell 20 from
-// 60. Resolving it means either a count taken before the caps or per-key drop
-// attribution. Flagged rather than chosen: the ranking is the harness's, so which
-// of the two it wants is the harness's to say.
+// Per-entity counts of open questions are the one ranking input the spec names
+// that no field here carries. Nearly derivable -- Gaps plus handed_off Verdicts,
+// grouped by subject_entities -- except the per-key cap truncates precisely the
+// entities the count exists to surface, and dropped is aggregated across the read
+// rather than per key. Both fixes add a key; the ranking is the harness's, so the
+// choice is the harness's.
 
-// The mid-run carrier, narrowed. One row holding the whole mapping, so
-// tools_router does not slice the inner lists into rows of their own and lose
-// which list each came from.
-//
-// It validates rather than casting, because the failure this contract exists to
-// prevent is a shape mismatch that reads as "no history". A cast would let a
-// drifted payload through as a RecallResult with undefined fields, which renders
-// as an entity nobody has looked at -- true of every entity, so nothing looks
-// wrong. Returning null makes the drift a case the caller has to answer for.
+// One row holding the whole mapping. It validates rather than casting, because a
+// cast would let a drifted payload through as a RecallResult of undefined fields,
+// which renders as an entity nobody has looked at -- true of every entity, so
+// nothing looks wrong.
 export const recallOf = (result: ToolResult): RecallResult | null => {
   if (!result.ok || result.rowCount !== 1 || result.rows.length !== 1) return null;
   const row = result.rows[0];
   if (typeof row !== "object" || row === null) return null;
-  // rowCount is the adapter's word for how many rows there are; the keys are the
-  // only evidence of what they hold.
   return RECALL_RESULT_KEYS.every((key) => key in row) ? (row as RecallResult) : null;
 };

--- a/services/agent/contracts/memory.ts
+++ b/services/agent/contracts/memory.ts
@@ -1,0 +1,336 @@
+// The recall contract (#729): the one shape Python returns and TypeScript
+// journals, agreed before either side built against it. A mismatch here fails as
+// "no history", which is the same shape as every other silent failure in this
+// area, so it is pinned before code exists rather than after.
+//
+// There is one shape, carried two ways. The run-start read journals it verbatim
+// as the recall event payload; a mid-run tool call carries the same object as the
+// single row of a ToolResult. Not two types that happen to agree -- a parallel
+// payload would be a second contract, and the second one is the one that drifts.
+//
+// The Python half is core/memory/recall_contract.py, and
+// tests/unit/_ratchets/test_recall_contract_agrees.py fails when the two drift.
+// That ratchet is what makes this an agreement rather than two documents.
+//
+// Nothing imports this yet. #732 lands the tool, #731 the rows it reads, and the
+// harness's recall call lands the event. The point of arriving first is that
+// three slices join to one declaration instead of three guesses.
+
+import type { ToolResult } from "./tool.js";
+
+export const RECALL_TOOL = "recall_entity";
+
+// What the arch asks for, not what this deployment calls it (core/spec.ts,
+// RoleSpec.needs). A capability nothing provides is dropped rather than fatal, so
+// a role may ask for recall in a deployment that has no memory yet.
+export const RECALL_CAPABILITY = "entity_recall";
+
+// Which caller gets which tool, empties included: a role granted nothing is a
+// decision here and reads as an oversight when it is left out.
+//
+// Keyed by the role names arch/threathunt.yaml actually declares, not by a class
+// called "worker" that appears in no file. The arch nests the three under
+// roles.workers, and a grant is written on each.
+//
+// Workers get exact lookups. The lead does not -- it never queries, it reads a
+// digest -- and narrative search, the lead's alone, is a later change that ships
+// no tool here. The critic already holds nothing.
+//
+// The run-start read appears in no row: it is not a tool call, so it needs no
+// grant. Which is also why only it needs an event kind, while a mid-run call is
+// journaled as an ordinary dispatch.
+//
+// One tool, not three. `prior_investigations` and `attribution` are deferrable:
+// attribution is a Verdict with an actor in it, and an as-of parameter belongs on
+// every read rather than being a tool of its own. Each extra tool costs prompt
+// surface, a grant per role, and a choice the model can get wrong.
+export const RECALL_GRANTS = {
+  lead: [],
+  critic: [],
+  threat_hunter: [RECALL_CAPABILITY],
+  network_analyst: [RECALL_CAPABILITY],
+  threat_intel: [RECALL_CAPABILITY],
+} as const;
+
+// Who concluded, as distinct from what the source is. Two axes, because telemetry
+// observes and a feed asserts but neither concludes -- so an ordered list of the
+// four could never place two of them on a Verdict at all.
+export const TRUST_LEVELS = ["analyst", "agent"] as const;
+export type Trust = (typeof TRUST_LEVELS)[number];
+
+// What a source *is*. `not_evidence` on a Verdict is a defect rather than a weak
+// row: citing a rule catalogue as corroboration is a run treating a lookup as an
+// observation. It is representable so that it is visible.
+export const SOURCE_TIERS = ["telemetry", "feed", "not_evidence"] as const;
+export type SourceTier = (typeof SOURCE_TIERS)[number];
+
+// Three-valued, replacing a flat corroborated list, which cannot express
+// direction: a source that weakened a hypothesis and a source that never bore on
+// it are not the same row.
+export const STANCES = ["supports", "weakens", "neither"] as const;
+export type Stance = (typeof STANCES)[number];
+
+// Keyed by kind and id, never by run_id: a run-keyed schema cannot represent the
+// Case-authored Verdicts the writer split requires. `analyst` is declared here and
+// written by nothing yet -- chat never writes memory, and an analyst thinking
+// aloud is not a Verdict.
+export const INVESTIGATION_KINDS = ["hunt", "case", "analyst"] as const;
+export type InvestigationKind = (typeof INVESTIGATION_KINDS)[number];
+
+// proven and disproven come straight through; inconclusive covers a hypothesis
+// that gathered evidence and did not settle; handed_off is terminal for the hunt
+// and not an ending of the claim, so it ranks up like a Gap while still carrying
+// evidence, a window and sources; false_positive arrives only from a Case closure.
+export const VERDICT_OUTCOMES = ["proven", "disproven", "inconclusive", "handed_off", "false_positive"] as const;
+export type VerdictOutcome = (typeof VERDICT_OUTCOMES)[number];
+
+// Whether the window was seen or claimed. A retrospective sweep over old archives
+// asserts its window; ranking discounts the weaker one, so it has to be able to
+// tell them apart.
+export const WINDOW_SOURCES = ["observed", "asserted"] as const;
+export type WindowSource = (typeof WINDOW_SOURCES)[number];
+
+// ISO-8601 with an offset, both ends inclusive. Separate from a conclusion date
+// because a sweep that concluded today about last March is not newly relevant.
+export interface ActivityWindow {
+  readonly first_seen: string;
+  readonly last_seen: string;
+}
+
+// Where a row came from, on every row rather than on the envelope: one read
+// returns rows from many investigations, and which one concluded a thing is the
+// whole reason a later run trusts it.
+export interface RecalledProvenance {
+  readonly investigation_kind: InvestigationKind;
+  readonly investigation_id: string;
+  // When the investigation concluded, not when the row was written. The Distil
+  // polls, so an investigation that ended Monday can be written Wednesday
+  // carrying Monday's date -- inside the freshness predicate, absent from the
+  // read that ran on Tuesday. Which is why recall journals its rows.
+  readonly concluded_at: string;
+}
+
+// What an investigation observed, one row per entity, investigation and source, so
+// growth tracks hunts rather than telemetry volume. Never one row per evidence
+// record.
+export interface RecalledSighting extends RecalledProvenance {
+  readonly entity_key: string;
+  readonly source_system: string;
+  readonly hit_count: number;
+  // Aggregated over the evidence in the group. An entity every record naming it
+  // could have been named by an adversary cannot clear a branch on its own.
+  readonly attacker_influenceable: boolean;
+  readonly window: ActivityWindow;
+}
+
+// One row per source on a Verdict. source_system is memory's own column and not a
+// foreign key into either producer: a hunt-derived Verdict fills it from the
+// Ledger's source_system, a Case-derived one from the data_source of its Findings.
+// Two vocabularies land in one column, which is why the tier map is keyed twice.
+export interface RecalledVerdictSource {
+  readonly source_system: string;
+  readonly stance: Stance;
+  // Stamped at write time, never joined at read time, so an integration removed
+  // or recategorised later cannot change how a past Verdict was corroborated.
+  readonly source_tier: SourceTier;
+}
+
+// What one investigation concluded about one hypothesis.
+export interface RecalledVerdict extends RecalledProvenance {
+  // Stable, because the prose gets re-worded and a key that moves when someone
+  // edits a sentence is not a key.
+  readonly hypothesis_id: string;
+  readonly statement: string;
+  readonly outcome: VerdictOutcome;
+  // Prose, and the one field here that reaches no ranking function: model text
+  // that sounds confident must not be able to move a priority (ADR 0015). It is
+  // carried for a human reading the run back.
+  readonly rationale: string;
+  // The entities the hypothesis named, typically one to three -- not the 38 to 76
+  // its evidence touched, which are mostly shared infrastructure and remain
+  // reachable through Sightings as the weaker and truer claim (ADR 0016).
+  readonly subject_entities: readonly string[];
+  // True when every source on the verdict was something an adversary could have
+  // authored. Not per-source: the question a branch-clearing rule asks is whether
+  // anything independent was seen at all.
+  readonly attacker_influenceable_only: boolean;
+  readonly trust: Trust;
+  readonly window: ActivityWindow;
+  readonly window_source: WindowSource;
+  readonly sources: readonly RecalledVerdictSource[];
+}
+
+// Why nothing was gathered. A closed set, so the reasons a question went
+// unanswered stay apart instead of collapsing into one.
+//
+// Each value traces to a line of the spec, because a disposition invented here is
+// one #731 would write against and nothing would review. `deprioritised` is the
+// status map's `parked` arm; `no_evidence_gathered` is the `inconclusive` and
+// `active` arms, both of which write a Verdict if evidence was gathered and a Gap
+// otherwise, and is also where a `data_starved` run's open questions land, since
+// such a run writes normally; `budget_exhausted` is work abandoned for budget and
+// the `budget_terminated` run terminal.
+//
+// Deliberately not `never_dispatched`: a hypothesis that reached `inconclusive`
+// with nothing gathered *was* dispatched, and a value naming the dispatch would
+// have made those two indistinguishable. Deliberately not a `no_data_source`
+// value either -- a tool that could not answer is a Visibility Gap, which
+// CONTEXT.md keeps distinct from a Declared Gap on purpose.
+export const GAP_DISPOSITIONS = ["deprioritised", "no_evidence_gathered", "budget_exhausted"] as const;
+export type GapDisposition = (typeof GAP_DISPOSITIONS)[number];
+
+// How a queried key is matched against a stored one. Pinned rather than
+// described, because the two sides normalise in different languages: the rule is
+// `defang` then case-fold in workflows/hunt/entities.ts, and Python has to
+// reproduce it exactly or an exact join quietly misses.
+//
+// The exception is the part that breaks silently. An ARN's resource part and an
+// AWS key id are case-significant, so folding them makes two different principals
+// one key -- and the join still returns rows, just the wrong ones.
+export const KEY_CASE_SENSITIVE_TYPES = ["arn", "aws_key"] as const;
+
+// A question an investigation never gathered evidence for. Carries no activity
+// window, which is the reason it is not a Verdict with an empty outcome.
+//
+// Gaps are the common case, not the exception: the committed fixtures leave 14 of
+// 18 hypotheses open at terminal. What ranks an entity up is accumulation across
+// investigations -- six open questions over four runs is a host nobody has
+// finished looking at; one is an ordinary run ending.
+export interface RecalledGap extends RecalledProvenance {
+  readonly hypothesis_id: string;
+  readonly statement: string;
+  readonly disposition: GapDisposition;
+  readonly reason: string;
+  readonly subject_entities: readonly string[];
+}
+
+// Why rows are missing, per kind, because the two reasons mean different things to
+// a caller. per_key_cap means one entity had more history than its share; overall
+// means the read was broad. A total is the sum and is not restated.
+export interface DroppedRows {
+  readonly per_key_cap: number;
+  readonly overall_cap: number;
+}
+
+export interface RecallDropped {
+  readonly sightings: DroppedRows;
+  readonly verdicts: DroppedRows;
+  readonly gaps: DroppedRows;
+}
+
+// The parameters that chose this set, copied in rather than referenced: a RunSpec
+// records the arch by name and not by version, so a replay resolving them afresh
+// would select under today's values against rows chosen under the old ones.
+//
+// Selection only. The order the rows were *presented* in is a fold and is
+// deliberately absent -- the harness's ranking curve may change without
+// invalidating a historical Ledger, which is only true while the event carries
+// rows and not an order.
+export interface RecallRanking {
+  // The total order the caps were applied under, as SQL. A LIMIT over a partial
+  // order lets Postgres return a different set on identical data, which surfaces
+  // as a replay diff rather than an error, so ties break on the primary key.
+  readonly order: string;
+  // Applied as a LATERAL and before the overall cap. A plain trailing LIMIT lets
+  // one entity present in every hunt -- a resolver, a proxy -- consume the whole
+  // budget, which makes memory less useful the more it holds.
+  readonly per_key_cap: number;
+  readonly overall_cap: number;
+}
+
+// One read of episodic memory. Journaled verbatim as the recall event payload at
+// run start, and carried as ToolResult.rows[0] when a worker calls the tool
+// mid-run.
+//
+// No field is optional and no list is nullable: an empty list means
+// known-to-be-none, and there is no unknown state to represent. An entity with no
+// history is empty lists and zeros, never an error.
+// Named as a value and not only as a type, so recallOf can check for them and the
+// ratchet can compare them against Python's. A type alone is invisible at runtime,
+// which is where the drift arrives.
+export const RECALL_RESULT_KEYS = [
+  "keys",
+  "as_of",
+  "sightings",
+  "verdicts",
+  "gaps",
+  "dropped",
+  "ranking",
+] as const;
+
+export interface RecallResult {
+  // Normalised, so a key differing only by case or defanging is the same key. The
+  // keys as queried, not as asked for: only Python writes an Entity Key, and the
+  // TypeScript extractor's output travels as candidate data.
+  readonly keys: readonly string[];
+  // The freshness filter that ran (`concluded_at <= as_of`). A filter, and not a
+  // substitute for journaling the rows -- see RecalledProvenance.concluded_at.
+  readonly as_of: string;
+  readonly sightings: readonly RecalledSighting[];
+  readonly verdicts: readonly RecalledVerdict[];
+  readonly gaps: readonly RecalledGap[];
+  readonly dropped: RecallDropped;
+  readonly ranking: RecallRanking;
+}
+
+// The event payload is the result. Named separately because the two carriers are
+// read by different code and an alias says they cannot diverge, where a copied
+// interface would only say they happen not to have yet.
+export type RecallPayload = RecallResult;
+
+// What the tool accepts. entity_keys is the contract; a singular entity_key is
+// wrapped, because a model given a list parameter will sometimes send one string.
+//
+// `limit` is not in the signature and is not honoured: tools_router injects it
+// into every backend call from the harness's bounds, so the handler has to take
+// an args mapping and ignore it. The caps here are memory's own and are reported
+// in `ranking`; a bound that silently replaced them would make what a run
+// remembered depend on a per-tool row ceiling.
+export interface RecallArgs {
+  readonly entity_keys: readonly string[];
+  readonly entity_key?: string;
+  // Defaults to now. Every read takes one, rather than an as-of read being a tool
+  // of its own.
+  readonly as_of?: string;
+  // For the read log, which exists for audit and is the only thing that makes "we
+  // can see what it knew" true for a caller with no Ledger. Default `unknown`
+  // rather than required: an unattributed read is still worth logging.
+  readonly caller_kind?: string;
+  readonly caller_id?: string;
+}
+
+// Two points this contract does not settle, recorded here rather than in a thread
+// because a contract's unresolved edges are part of it.
+//
+// `dropped` diverges from #732's grooming note, which reads `dropped {sightings,
+// verdicts, gaps}` and would have an implementer write three integers. #729 asks
+// for "the dropped count and why", and one integer cannot carry the why, so the
+// leaf is a mapping of the two cap reasons.
+//
+// Per-entity counts of open questions are what the spec's ranking-inputs section
+// owes this side, and they are the one item that section names which no field here
+// carries. They are *nearly* derivable -- open questions are Gaps plus
+// `handed_off` Verdicts, grouped by subject_entities -- but the per-key cap
+// truncates precisely the entities the count exists to surface, and `dropped` is
+// aggregated across the read rather than per key, so a caller cannot tell 20 from
+// 60. Resolving it means either a count taken before the caps or per-key drop
+// attribution. Flagged rather than chosen: the ranking is the harness's, so which
+// of the two it wants is the harness's to say.
+
+// The mid-run carrier, narrowed. One row holding the whole mapping, so
+// tools_router does not slice the inner lists into rows of their own and lose
+// which list each came from.
+//
+// It validates rather than casting, because the failure this contract exists to
+// prevent is a shape mismatch that reads as "no history". A cast would let a
+// drifted payload through as a RecallResult with undefined fields, which renders
+// as an entity nobody has looked at -- true of every entity, so nothing looks
+// wrong. Returning null makes the drift a case the caller has to answer for.
+export const recallOf = (result: ToolResult): RecallResult | null => {
+  if (!result.ok || result.rowCount !== 1 || result.rows.length !== 1) return null;
+  const row = result.rows[0];
+  if (typeof row !== "object" || row === null) return null;
+  // rowCount is the adapter's word for how many rows there are; the keys are the
+  // only evidence of what they hold.
+  return RECALL_RESULT_KEYS.every((key) => key in row) ? (row as RecallResult) : null;
+};

--- a/tests/unit/_ratchets/test_recall_contract_agrees.py
+++ b/tests/unit/_ratchets/test_recall_contract_agrees.py
@@ -1,0 +1,230 @@
+"""The recall contract is declared twice and must say the same thing.
+
+#729 pins two contracts between the Python domain and the harness: what a read
+of episodic memory returns, and the signature of the tool that performs one. A
+mismatch fails as "no history" — indistinguishable from an entity nobody has
+looked at, which is the same shape as every other silent failure in this area.
+
+There is no runtime seam to catch it either. Nothing calls either half yet: the
+rows are #731, the tool is #732, the event is the harness's. By the time a call
+exists, three slices will have been written against one of the two
+declarations. So the agreement is enforced here, statically, in the window where
+both halves are still only text.
+
+Field *order* is not checked. It is a struct on one side and a tuple on the
+other, and neither reads by position.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from core.memory import recall_contract as py
+from core.memory.source_tier import SourceTier
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+AGENT = REPO_ROOT / "services" / "agent"
+TYPESCRIPT = AGENT / "contracts" / "memory.ts"
+ARCH = AGENT / "arch" / "threathunt.yaml"
+ENTITIES = AGENT / "workflows" / "hunt" / "entities.ts"
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def ts() -> str:
+    return TYPESCRIPT.read_text()
+
+
+# A `const X = [...] as const` union. The declared string literals, in order.
+def ts_union(body: str, name: str) -> tuple[str, ...]:
+    match = re.search(rf"{name}\s*=\s*\[([^\]]*)\]\s*as const", body)
+    assert match, f"{name} not found in {TYPESCRIPT}"
+    return tuple(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+# The `readonly` property names of one interface, including those it extends.
+def ts_fields(body: str, name: str) -> frozenset[str]:
+    match = re.search(
+        rf"interface {name}(?: extends ([A-Za-z]+))?\s*\{{(.*?)^\}}", body, re.S | re.M
+    )
+    assert match, f"interface {name} not found in {TYPESCRIPT}"
+    inherited = ts_fields(body, match.group(1)) if match.group(1) else frozenset()
+    return inherited | frozenset(
+        re.findall(r"^\s*readonly (\w+)\??:", match.group(2), re.M)
+    )
+
+
+def ts_const(body: str, name: str) -> str:
+    match = re.search(rf"{name}\s*=\s*\"([^\"]*)\"\s*;", body)
+    assert match, f"const {name} not found in {TYPESCRIPT}"
+    return match.group(1)
+
+
+def entries(body: str) -> list[str]:
+    return [entry.strip() for entry in body.split(",") if entry.strip()]
+
+
+# Vocabularies whose values reach the wire in both directions. A value present on
+# one side only is a row one side can write and the other cannot read.
+CLOSED_SETS = (
+    "TRUST_LEVELS",
+    "STANCES",
+    "INVESTIGATION_KINDS",
+    "VERDICT_OUTCOMES",
+    "WINDOW_SOURCES",
+    "GAP_DISPOSITIONS",
+    "KEY_CASE_SENSITIVE_TYPES",
+    "RECALL_RESULT_KEYS",
+)
+
+# Declared in TypeScript but owned elsewhere, so there is no Python twin in this
+# module to compare against. Each needs a test of its own below, and the coverage
+# test at the bottom refuses a name added here without one.
+OWNED_ELSEWHERE = {
+    "SOURCE_TIERS": "core.memory.source_tier.SourceTier (#728)",
+}
+
+# Python holds field names because it builds the mappings; TypeScript holds
+# interfaces because it reads them out of a journaled event.
+ROW_SHAPES = {
+    "SIGHTING_FIELDS": "RecalledSighting",
+    "VERDICT_FIELDS": "RecalledVerdict",
+    "VERDICT_SOURCE_FIELDS": "RecalledVerdictSource",
+    "GAP_FIELDS": "RecalledGap",
+    "WINDOW_FIELDS": "ActivityWindow",
+    "RECALL_RESULT_KEYS": "RecallResult",
+    "RECALL_ARGS": "RecallArgs",
+    "DROPPED_KINDS": "RecallDropped",
+    "DROPPED_REASONS": "DroppedRows",
+    "RANKING_KEYS": "RecallRanking",
+}
+
+
+@pytest.mark.parametrize("name", CLOSED_SETS)
+def test_the_closed_sets_hold_the_same_values(ts: str, name: str):
+    assert ts_union(ts, name) == getattr(py, name), (
+        f"{name} differs between core/memory/recall_contract.py and "
+        f"{TYPESCRIPT.name}. A value one side accepts and the other refuses is a "
+        "row that reads as absent rather than as an error."
+    )
+
+
+def test_source_tier_is_not_restated_but_deferred_to(ts: str):
+    # #728 owns this vocabulary. The contract restating it would give the tier map
+    # and the wire two places to disagree about what a tier is.
+    assert ts_union(ts, "SOURCE_TIERS") == tuple(tier.value for tier in SourceTier), (
+        "SOURCE_TIERS in the contract has drifted from core/memory/source_tier.py. "
+        "The tier map is the owner; the contract follows it."
+    )
+
+
+@pytest.mark.parametrize("fields,interface", ROW_SHAPES.items())
+def test_every_row_shape_agrees(ts: str, fields: str, interface: str):
+    assert ts_fields(ts, interface) == frozenset(getattr(py, fields)), (
+        f"{fields} and interface {interface} name different fields. Whichever "
+        "side is missing one reads it as absent, and an absent field in a Verdict "
+        "is a conclusion nobody can see."
+    )
+
+
+def test_the_required_argument_is_the_only_one_not_optional(ts: str):
+    # Optional on one side and required on the other is a call that succeeds in
+    # testing and answers invalid_args in production.
+    body = re.search(r"interface RecallArgs\s*\{(.*?)^\}", ts, re.S | re.M)
+    assert body, f"interface RecallArgs not found in {TYPESCRIPT}"
+    required = frozenset(re.findall(r"^\s*readonly (\w+):", body.group(1), re.M))
+    assert required == frozenset(py.RECALL_REQUIRED_ARGS), (
+        "the tool's required arguments differ. An argument required on one side "
+        "only is a call one side will refuse and the other will happily make."
+    )
+
+
+def test_every_argument_has_a_declared_type():
+    # A name agreed without a type is half a signature, and the half that is left
+    # is the half nobody disagrees about.
+    assert frozenset(py.RECALL_ARG_TYPES) == frozenset(py.RECALL_ARGS), (
+        "RECALL_ARG_TYPES and RECALL_ARGS name different arguments; every "
+        "argument the tool accepts needs its type stated."
+    )
+
+
+# The two names a grant is written against. A capability spelled differently on
+# the two sides binds to nothing, and `providersOf` in core/spec.ts drops what
+# nothing provides rather than failing — so the role silently loses the tool.
+#
+# The caps are not checked, because TypeScript does not declare them. Python owns
+# them and copies them into every result; a second declaration to hold them would
+# be the reference the contract exists to avoid.
+def test_the_tool_and_capability_names_agree(ts: str):
+    assert ts_const(ts, "RECALL_TOOL") == py.RECALL_TOOL
+    assert ts_const(ts, "RECALL_CAPABILITY") == py.RECALL_CAPABILITY
+
+
+def test_the_role_grants_agree(ts: str):
+    match = re.search(r"RECALL_GRANTS = \{(.*?)\} as const", ts, re.S)
+    assert match, f"RECALL_GRANTS not found in {TYPESCRIPT}"
+    # The capability arrives as the RECALL_CAPABILITY identifier rather than a
+    # literal, which is the point of it being a constant.
+    names = {"RECALL_CAPABILITY": ts_const(ts, "RECALL_CAPABILITY")}
+    granted = {
+        role: tuple(
+            names.get(entry, entry.strip('"')) for entry in entries(capabilities)
+        )
+        for role, capabilities in re.findall(r"(\w+):\s*\[([^\]]*)\]", match.group(1))
+    }
+    assert granted == dict(py.RECALL_GRANTS), (
+        "the role grants differ. A role granted on one side only either calls a "
+        "tool it was never meant to hold, or silently holds none."
+    )
+
+
+def test_every_granted_role_is_a_role_the_arch_declares():
+    # A grant on a role that does not exist is not a grant. `providersOf` binds by
+    # role name, so a misspelling is a capability nothing asks for — dropped
+    # silently, because a deployment missing a tool is a supported state.
+    arch = ARCH.read_text()
+    declared = frozenset(re.findall(r"^ {2,4}(\w+):$", arch, re.M))
+    missing = frozenset(py.RECALL_GRANTS) - declared
+    assert not missing, (
+        "RECALL_GRANTS names roles that services/agent/arch/threathunt.yaml does "
+        "not declare:\n  " + "\n  ".join(sorted(missing))
+    )
+
+
+def test_key_normalisation_defers_to_the_extractor():
+    # The rule lives in the extractor and Python has to reproduce it. Folding an
+    # ARN or an AWS key id makes two different principals one key, and the join
+    # still returns rows — just the wrong ones.
+    match = re.search(r"CASE_SENSITIVE = new Set\(\[([^\]]*)\]\)", ENTITIES.read_text())
+    assert match, f"CASE_SENSITIVE not found in {ENTITIES}"
+    assert (
+        tuple(re.findall(r'"([^"]+)"', match.group(1))) == py.KEY_CASE_SENSITIVE_TYPES
+    ), (
+        "KEY_CASE_SENSITIVE_TYPES has drifted from `CASE_SENSITIVE` in "
+        f"{ENTITIES.relative_to(REPO_ROOT)}. The extractor owns the rule."
+    )
+
+
+def test_every_declared_vocabulary_is_ratcheted(ts: str):
+    # The one way this ratchet can fail to fail: a closed set or interface added
+    # to both halves and forgotten here passes by never being compared. The
+    # sibling test_run_kinds_agree.py keeps its exclusion list honest the same way.
+    unions = frozenset(re.findall(r"export const (\w+) = \[[^\]]*\] as const", ts))
+    unratcheted = unions - frozenset(CLOSED_SETS) - frozenset(OWNED_ELSEWHERE)
+    assert not unratcheted, (
+        "these closed sets are declared in the contract and compared by nothing. "
+        "Add each to CLOSED_SETS, or to OWNED_ELSEWHERE with the owner and a test "
+        "of its own:\n  " + "\n  ".join(sorted(unratcheted))
+    )
+
+    interfaces = frozenset(re.findall(r"export interface (\w+)", ts))
+    # Provenance is compared through the rows that extend it, not on its own.
+    unshaped = interfaces - frozenset(ROW_SHAPES.values()) - {"RecalledProvenance"}
+    assert not unshaped, (
+        "these row shapes are declared in the contract and compared by nothing. "
+        "Add each to ROW_SHAPES:\n  " + "\n  ".join(sorted(unshaped))
+    )

--- a/tests/unit/_ratchets/test_recall_contract_agrees.py
+++ b/tests/unit/_ratchets/test_recall_contract_agrees.py
@@ -1,18 +1,13 @@
 """The recall contract is declared twice and must say the same thing.
 
-#729 pins two contracts between the Python domain and the harness: what a read
-of episodic memory returns, and the signature of the tool that performs one. A
-mismatch fails as "no history" — indistinguishable from an entity nobody has
-looked at, which is the same shape as every other silent failure in this area.
+A mismatch fails as "no history" — indistinguishable from an entity nobody has
+looked at. Nothing calls either half yet (rows are #731, the tool #732, the
+event the harness's), so by the time a call exists three slices will have been
+written against one of the two declarations. The agreement is enforced here,
+statically, while both halves are still only text.
 
-There is no runtime seam to catch it either. Nothing calls either half yet: the
-rows are #731, the tool is #732, the event is the harness's. By the time a call
-exists, three slices will have been written against one of the two
-declarations. So the agreement is enforced here, statically, in the window where
-both halves are still only text.
-
-Field *order* is not checked. It is a struct on one side and a tuple on the
-other, and neither reads by position.
+Field order is not checked: it is a struct on one side and a tuple on the other,
+and neither reads by position.
 """
 
 from __future__ import annotations
@@ -23,6 +18,7 @@ from pathlib import Path
 import pytest
 
 from core.memory import recall_contract as py
+from core.memory.source_tier import InvestigationKind as SourceNamingKind
 from core.memory.source_tier import SourceTier
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -39,14 +35,13 @@ def ts() -> str:
     return TYPESCRIPT.read_text()
 
 
-# A `const X = [...] as const` union. The declared string literals, in order.
 def ts_union(body: str, name: str) -> tuple[str, ...]:
     match = re.search(rf"{name}\s*=\s*\[([^\]]*)\]\s*as const", body)
     assert match, f"{name} not found in {TYPESCRIPT}"
     return tuple(re.findall(r'"([^"]+)"', match.group(1)))
 
 
-# The `readonly` property names of one interface, including those it extends.
+# Property names of one interface, including those it extends.
 def ts_fields(body: str, name: str) -> frozenset[str]:
     match = re.search(
         rf"interface {name}(?: extends ([A-Za-z]+))?\s*\{{(.*?)^\}}", body, re.S | re.M
@@ -59,37 +54,32 @@ def ts_fields(body: str, name: str) -> frozenset[str]:
 
 
 def ts_const(body: str, name: str) -> str:
-    match = re.search(rf"{name}\s*=\s*\"([^\"]*)\"\s*;", body)
+    match = re.search(rf'{name}\s*=\s*"([^"]*)"\s*;', body)
     assert match, f"const {name} not found in {TYPESCRIPT}"
     return match.group(1)
 
 
-def entries(body: str) -> list[str]:
-    return [entry.strip() for entry in body.split(",") if entry.strip()]
+def values(vocabulary) -> tuple[str, ...]:
+    return tuple(member.value for member in vocabulary)
 
 
-# Vocabularies whose values reach the wire in both directions. A value present on
-# one side only is a row one side can write and the other cannot read.
-CLOSED_SETS = (
-    "TRUST_LEVELS",
-    "STANCES",
-    "INVESTIGATION_KINDS",
-    "VERDICT_OUTCOMES",
-    "WINDOW_SOURCES",
-    "GAP_DISPOSITIONS",
-    "KEY_CASE_SENSITIVE_TYPES",
-    "RECALL_RESULT_KEYS",
-)
-
-# Declared in TypeScript but owned elsewhere, so there is no Python twin in this
-# module to compare against. Each needs a test of its own below, and the coverage
-# test at the bottom refuses a name added here without one.
-OWNED_ELSEWHERE = {
-    "SOURCE_TIERS": "core.memory.source_tier.SourceTier (#728)",
+# TypeScript declares a vocabulary as an `as const` array; Python declares one as
+# an Enum where callers hold a value, and as a tuple where it is only a wire key.
+ENUMS = {
+    "TRUST_LEVELS": py.Trust,
+    "STANCES": py.Stance,
+    "INVESTIGATION_KINDS": py.InvestigationKind,
+    "VERDICT_OUTCOMES": py.VerdictOutcome,
+    "WINDOW_SOURCES": py.WindowSource,
+    "GAP_DISPOSITIONS": py.GapDisposition,
 }
 
-# Python holds field names because it builds the mappings; TypeScript holds
-# interfaces because it reads them out of a journaled event.
+TUPLES = ("KEY_CASE_SENSITIVE_TYPES", "RECALL_RESULT_KEYS", "RECALL_KEY_ARGS")
+
+# Declared in TypeScript but owned by another module, so each needs an owner test
+# below rather than a twin here.
+OWNED_ELSEWHERE = {"SOURCE_TIERS": "core.memory.source_tier.SourceTier (#728)"}
+
 ROW_SHAPES = {
     "SIGHTING_FIELDS": "RecalledSighting",
     "VERDICT_FIELDS": "RecalledVerdict",
@@ -103,63 +93,75 @@ ROW_SHAPES = {
     "RANKING_KEYS": "RecallRanking",
 }
 
-
-@pytest.mark.parametrize("name", CLOSED_SETS)
-def test_the_closed_sets_hold_the_same_values(ts: str, name: str):
-    assert ts_union(ts, name) == getattr(py, name), (
-        f"{name} differs between core/memory/recall_contract.py and "
-        f"{TYPESCRIPT.name}. A value one side accepts and the other refuses is a "
-        "row that reads as absent rather than as an error."
-    )
+DRIFT = (
+    "A value one side accepts and the other refuses is a row that reads as "
+    "absent rather than as an error."
+)
 
 
-def test_source_tier_is_not_restated_but_deferred_to(ts: str):
-    # #728 owns this vocabulary. The contract restating it would give the tier map
-    # and the wire two places to disagree about what a tier is.
-    assert ts_union(ts, "SOURCE_TIERS") == tuple(tier.value for tier in SourceTier), (
-        "SOURCE_TIERS in the contract has drifted from core/memory/source_tier.py. "
-        "The tier map is the owner; the contract follows it."
+@pytest.mark.parametrize("name,vocabulary", ENUMS.items())
+def test_the_enum_vocabularies_hold_the_same_values(ts: str, name: str, vocabulary):
+    assert ts_union(ts, name) == values(vocabulary), f"{name} differs. {DRIFT}"
+
+
+@pytest.mark.parametrize("name", TUPLES)
+def test_the_wire_key_vocabularies_hold_the_same_values(ts: str, name: str):
+    assert ts_union(ts, name) == getattr(py, name), f"{name} differs. {DRIFT}"
+
+
+def test_source_tier_is_followed_not_restated(ts: str):
+    assert ts_union(ts, "SOURCE_TIERS") == values(
+        SourceTier
+    ), "SOURCE_TIERS has drifted from core/memory/source_tier.py, which owns it."
+
+
+def test_investigation_kinds_extend_the_source_naming_ones():
+    # source_tier's enum selects a source vocabulary and covers only the kinds
+    # that name sources. Ours is the domain vocabulary and must contain it, or
+    # the tier map cannot grade a row this contract can carry.
+    extra = set(values(py.InvestigationKind)) - set(values(SourceNamingKind))
+    assert extra == {"analyst"}, (
+        "InvestigationKind must extend core/memory/source_tier.py's by exactly "
+        f"`analyst`, the kind that names no sources; it adds {sorted(extra)}."
     )
 
 
 @pytest.mark.parametrize("fields,interface", ROW_SHAPES.items())
 def test_every_row_shape_agrees(ts: str, fields: str, interface: str):
     assert ts_fields(ts, interface) == frozenset(getattr(py, fields)), (
-        f"{fields} and interface {interface} name different fields. Whichever "
-        "side is missing one reads it as absent, and an absent field in a Verdict "
-        "is a conclusion nobody can see."
+        f"{fields} and interface {interface} name different fields. An absent "
+        "field in a Verdict is a conclusion nobody can see."
     )
 
 
-def test_the_required_argument_is_the_only_one_not_optional(ts: str):
-    # Optional on one side and required on the other is a call that succeeds in
-    # testing and answers invalid_args in production.
+def test_no_argument_is_required_and_the_key_invariant_stands(ts: str):
+    # Requiring `entity_keys` would make the singular unusable, which is the one
+    # call it exists for. "At least one key argument" is data, not a type.
     body = re.search(r"interface RecallArgs\s*\{(.*?)^\}", ts, re.S | re.M)
     assert body, f"interface RecallArgs not found in {TYPESCRIPT}"
     required = frozenset(re.findall(r"^\s*readonly (\w+):", body.group(1), re.M))
-    assert required == frozenset(py.RECALL_REQUIRED_ARGS), (
-        "the tool's required arguments differ. An argument required on one side "
-        "only is a call one side will refuse and the other will happily make."
+    assert not required, (
+        "these RecallArgs are required, which makes the singular entity_key "
+        "unusable:\n  " + "\n  ".join(sorted(required))
     )
+    assert py.RECALL_KEY_ARGS, "RECALL_KEY_ARGS must name the keys a call needs"
+    assert frozenset(py.RECALL_KEY_ARGS) <= frozenset(
+        py.RECALL_ARGS
+    ), "RECALL_KEY_ARGS names arguments the tool does not accept"
 
 
-def test_every_argument_has_a_declared_type():
-    # A name agreed without a type is half a signature, and the half that is left
-    # is the half nobody disagrees about.
-    assert frozenset(py.RECALL_ARG_TYPES) == frozenset(py.RECALL_ARGS), (
-        "RECALL_ARG_TYPES and RECALL_ARGS name different arguments; every "
-        "argument the tool accepts needs its type stated."
-    )
+def test_every_argument_is_declared_in_the_registrable_schema():
+    # RECALL_ARGS derives from the schema, so this catches a name added to one of
+    # the wire halves and not the other via the row-shape test above.
+    assert py.RECALL_ARGS == tuple(py.RECALL_PARAMETERS["properties"])
+    assert (
+        py.RECALL_PARAMETERS["required"] == []
+    ), "the schema must require nothing; the key invariant is RECALL_KEY_ARGS"
 
 
-# The two names a grant is written against. A capability spelled differently on
-# the two sides binds to nothing, and `providersOf` in core/spec.ts drops what
-# nothing provides rather than failing — so the role silently loses the tool.
-#
-# The caps are not checked, because TypeScript does not declare them. Python owns
-# them and copies them into every result; a second declaration to hold them would
-# be the reference the contract exists to avoid.
 def test_the_tool_and_capability_names_agree(ts: str):
+    # A capability spelled differently binds to nothing, and `providersOf` drops
+    # what nothing provides rather than failing, so the role silently loses it.
     assert ts_const(ts, "RECALL_TOOL") == py.RECALL_TOOL
     assert ts_const(ts, "RECALL_CAPABILITY") == py.RECALL_CAPABILITY
 
@@ -167,12 +169,13 @@ def test_the_tool_and_capability_names_agree(ts: str):
 def test_the_role_grants_agree(ts: str):
     match = re.search(r"RECALL_GRANTS = \{(.*?)\} as const", ts, re.S)
     assert match, f"RECALL_GRANTS not found in {TYPESCRIPT}"
-    # The capability arrives as the RECALL_CAPABILITY identifier rather than a
-    # literal, which is the point of it being a constant.
+    # The capability arrives as an identifier, which is the point of the constant.
     names = {"RECALL_CAPABILITY": ts_const(ts, "RECALL_CAPABILITY")}
     granted = {
         role: tuple(
-            names.get(entry, entry.strip('"')) for entry in entries(capabilities)
+            names.get(entry.strip(), entry.strip().strip('"'))
+            for entry in capabilities.split(",")
+            if entry.strip()
         )
         for role, capabilities in re.findall(r"(\w+):\s*\[([^\]]*)\]", match.group(1))
     }
@@ -183,48 +186,43 @@ def test_the_role_grants_agree(ts: str):
 
 
 def test_every_granted_role_is_a_role_the_arch_declares():
-    # A grant on a role that does not exist is not a grant. `providersOf` binds by
-    # role name, so a misspelling is a capability nothing asks for — dropped
-    # silently, because a deployment missing a tool is a supported state.
-    arch = ARCH.read_text()
-    declared = frozenset(re.findall(r"^ {2,4}(\w+):$", arch, re.M))
+    declared = frozenset(re.findall(r"^ {2,4}(\w+):$", ARCH.read_text(), re.M))
     missing = frozenset(py.RECALL_GRANTS) - declared
     assert not missing, (
-        "RECALL_GRANTS names roles that services/agent/arch/threathunt.yaml does "
-        "not declare:\n  " + "\n  ".join(sorted(missing))
+        "RECALL_GRANTS names roles threathunt.yaml does not declare, and a grant "
+        "on a role that does not exist is dropped silently:\n  "
+        + "\n  ".join(sorted(missing))
     )
 
 
 def test_key_normalisation_defers_to_the_extractor():
-    # The rule lives in the extractor and Python has to reproduce it. Folding an
-    # ARN or an AWS key id makes two different principals one key, and the join
-    # still returns rows — just the wrong ones.
     match = re.search(r"CASE_SENSITIVE = new Set\(\[([^\]]*)\]\)", ENTITIES.read_text())
     assert match, f"CASE_SENSITIVE not found in {ENTITIES}"
-    assert (
-        tuple(re.findall(r'"([^"]+)"', match.group(1))) == py.KEY_CASE_SENSITIVE_TYPES
-    ), (
-        "KEY_CASE_SENSITIVE_TYPES has drifted from `CASE_SENSITIVE` in "
-        f"{ENTITIES.relative_to(REPO_ROOT)}. The extractor owns the rule."
+    declared = tuple(re.findall(r'"([^"]+)"', match.group(1)))
+    assert declared == py.KEY_CASE_SENSITIVE_TYPES, (
+        "KEY_CASE_SENSITIVE_TYPES has drifted from CASE_SENSITIVE in "
+        f"{ENTITIES.relative_to(REPO_ROOT)}, which owns the rule. Folding an ARN "
+        "returns rows, just the wrong ones."
     )
 
 
 def test_every_declared_vocabulary_is_ratcheted(ts: str):
-    # The one way this ratchet can fail to fail: a closed set or interface added
-    # to both halves and forgotten here passes by never being compared. The
-    # sibling test_run_kinds_agree.py keeps its exclusion list honest the same way.
+    # The one way this ratchet could stop being able to fail: something added to
+    # both halves and compared by neither.
     unions = frozenset(re.findall(r"export const (\w+) = \[[^\]]*\] as const", ts))
-    unratcheted = unions - frozenset(CLOSED_SETS) - frozenset(OWNED_ELSEWHERE)
+    unratcheted = (
+        unions - frozenset(ENUMS) - frozenset(TUPLES) - frozenset(OWNED_ELSEWHERE)
+    )
     assert not unratcheted, (
-        "these closed sets are declared in the contract and compared by nothing. "
-        "Add each to CLOSED_SETS, or to OWNED_ELSEWHERE with the owner and a test "
-        "of its own:\n  " + "\n  ".join(sorted(unratcheted))
+        "these vocabularies are declared and compared by nothing. Add each to "
+        "ENUMS or TUPLES, or to OWNED_ELSEWHERE with an owner test:\n  "
+        + "\n  ".join(sorted(unratcheted))
     )
 
     interfaces = frozenset(re.findall(r"export interface (\w+)", ts))
-    # Provenance is compared through the rows that extend it, not on its own.
+    # Provenance is compared through the rows that extend it.
     unshaped = interfaces - frozenset(ROW_SHAPES.values()) - {"RecalledProvenance"}
     assert not unshaped, (
-        "these row shapes are declared in the contract and compared by nothing. "
-        "Add each to ROW_SHAPES:\n  " + "\n  ".join(sorted(unshaped))
+        "these row shapes are declared and compared by nothing. Add each to "
+        "ROW_SHAPES:\n  " + "\n  ".join(sorted(unshaped))
     )


### PR DESCRIPTION
Closes #729. Parent epic #727. Base is `episodic-memory`, not `main`.

## What this is

The two contracts between this side and the harness, written down before either side builds against them: what a read of episodic memory returns, and the signature of the tool that performs one. A mismatch here fails as "no history" — the same shape as every other silent failure in this area — which is why it is worth pinning before code exists rather than after.

Nothing imports it yet, by design. #731 writes the rows, #732 lands the tool, and the harness lands the event. The point of arriving first is that three slices join to one declaration instead of three guesses.

| File | |
|---|---|
| `services/agent/contracts/memory.ts` | the harness half |
| `core/memory/recall_contract.py` | the Python half |
| `tests/unit/_ratchets/test_recall_contract_agrees.py` | 28 tests that fail when the halves drift |
| `CONTEXT.md` | **Recall**, **Recall Event**, **Sighting**, **Declared Gap**, **Stance**, **Visibility Gap**, plus one relationship |

## One shape, carried two ways

The run-start read journals it verbatim as the recall event payload; a mid-run `recall_entity` call carries the same mapping as the single row of a `ToolResult`. Not two types that happen to agree — the return shape already exists as `ToolResult`, and a parallel payload is a second contract, which is always the one that drifts.

`recall` is deliberately **not** registered as an event kind, in either `RUN_EVENT_KINDS` or `HuntKinds`. Registering it forces a fold arm in `services/agent/workflows/hunt/ledger.ts`, and #737 requires that arm to carry the rows into the projection so a replay reads what the run was given rather than re-querying. A no-op `case "recall": break;` now would bake in exactly the bug that gate exists to catch.

The event carries rows and not an order. The order they were presented in is a fold, so ranking may change without invalidating a historical Ledger. What is copied in is the *selection* — the total order and the two caps that chose the set — because a RunSpec records the arch by name and not by version.

Arguments are a registrable `input_schema` in the shape `core/llm/tool_schemas.py` already uses, so #732 registers `RECALL_PARAMETERS` rather than transcribing it. Closed sets are Enums matching `core/memory/source_tier.py`, so #731 writes `Stance.SUPPORTS` rather than a bare string.

Grants are stated as data and not wired. `providersOf` in `services/agent/core/spec.ts` drops a capability nothing provides, so `needs: [entity_recall]` would not fail today, but the tool is #732 and a grant is worth landing alongside the thing it grants.

## The ratchet is the point

AC 4 asks that both sides have read and agreed. Two documents cannot hold each other to that; a cross-language test that fails on drift can. It compares the closed sets, every row shape, the argument list, the role grants against the roles `arch/threathunt.yaml` actually declares, and the key-normalisation exception against `workflows/hunt/entities.ts`, which owns it. It also refuses a vocabulary added to both halves and compared by neither — the one way it could quietly stop being able to fail.

Mutation-tested rather than trusted green. Nine injected drifts each failed the right test, including `entity_keys` made required again, a schema that requires anything, a fourth investigation kind, a renamed enum value, a role the arch does not declare, a dropped `arn`/`aws_key` exception, and a new closed set or interface nothing compares.

## Fixed after review

Three defects in the first commit, corrected in `7df6adc2`:

**`entity_keys` was required while `entity_key` was optional** — which made the one call the singular exists for, a model sending one string instead of the list, invalid under the contract. The ratchet then locked the contradiction in. Neither key argument is required now, and "at least one" is data (`RECALL_KEY_ARGS`) rather than a type: a JSON Schema cannot express one-of, and a TypeScript union is invisible to the half that has to honour it.

**The caps were bare scalars.** The groom reads "20 rows per kind per key" and `dropped` is per-kind, so per-kind against across-kinds was exactly the silent mismatch this slice exists to prevent — in the slice itself. Both units are now stated.

**`INVESTIGATION_KINDS` restated a vocabulary `source_tier.py` owns**, with the superset left in a comment while `SOURCE_TIERS` got a proper owner test. Now enforced: ours must extend the source-naming enum by exactly `analyst`, the kind that names no sources.

Also dropped the read-log surface (`READ_LOG_FIELDS`, retention). Its DDL is #732's and is named in that issue's groom; a second declaration here was the same mistake as a parallel payload, by this contract's own argument. And `CONTEXT.md` gains **Visibility Gap**, which `contracts/tool.ts` has cited as a defined term for some time and which nothing defined — two new files leaned on the same distinction.

Comments are cut to what the code does not say. The two halves carried near-verbatim rationale, and since the ratchet compares values and not prose, the second copy was the one that would drift.

## Two edges this does not settle

**`dropped` diverges from #732's grooming note**, which reads `dropped {sightings, verdicts, gaps}` — three integers. #729 asks for the dropped count *and why*, and one integer cannot carry the why, so the leaf is a mapping of the two cap reasons. `empty_dropped()` exists so #732 builds the shape rather than inferring it from the groom. **#732's brief needs amending before someone implements the three integers.**

**Per-entity counts of open questions are the one ranking input the spec names that no field here carries.** Nearly derivable — Gaps plus `handed_off` Verdicts, grouped by `subject_entities` — except the per-key cap truncates precisely the entities the count exists to surface, and `dropped` is aggregated across the read rather than per key, so a caller cannot tell 20 from 60. Resolving it means either a count taken before the caps or per-key drop attribution, and both add a key the groom does not have. The ranking is the harness's, so which one it wants is theirs to say.

## Verification

`tsc --noEmit` clean. TS unit suite 630/630. Python unit suite 1657 passed, with the same 6 pre-existing `tests/unit/response/test_approval_workflow.py` failures present on the base commit. flake8 7.3.0, black 26.5.1 and isort 8.0.1 clean across `core/` and `services/`. `lint-imports` 3 kept, 0 broken.

The 37 `services/agent/tests/integration/*` failures in my local run are Postgres and Redis being down on this machine, not this change.

## One thing this PR cannot do

AC 4 is "Both sides have read and agreed it." Nothing in a diff satisfies that — it needs the harness side to actually read this. The ratchet enforces self-consistency between two files written on one side; it makes the agreement enforceable, not made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
