### PR TITLE
fix(web): UserMenu no longer white-screens when full_name is null

### DIFF
--- a/clients/web/src/shell/UserMenu.test.tsx
+++ b/clients/web/src/shell/UserMenu.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import UserMenu from './UserMenu'
+
+const auth = vi.hoisted(() => ({
+  user: {
+    username: 'dev-user',
+    full_name: 'Test User' as string | null,
+    email: 'dev@localhost',
+    role_id: 'role-admin',
+    mfa_enabled: false,
+  },
+  logout: vi.fn(),
+}))
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => auth,
+}))
+
+function renderMenu() {
+  return render(
+    <MemoryRouter>
+      <UserMenu />
+    </MemoryRouter>,
+  )
+}
+
+describe('UserMenu', () => {
+  it('renders initials and labels from full_name', () => {
+    auth.user.full_name = 'Test User'
+    renderMenu()
+    expect(screen.getByText('TU')).toBeInTheDocument()
+    expect(screen.getAllByText('Test User').length).toBeGreaterThan(0)
+  })
+
+  it('falls back to username when full_name is null', async () => {
+    auth.user.full_name = null
+    renderMenu()
+    expect(screen.getByRole('button', { name: 'Account menu' })).toBeInTheDocument()
+    expect(screen.getByText('D')).toBeInTheDocument()
+    expect(screen.getAllByText('dev-user').length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Account menu' }))
+    const menu = await screen.findByRole('menu', { name: 'Account' })
+    expect(menu).toHaveTextContent('dev-user')
+  })
+})

--- a/clients/web/src/shell/UserMenu.test.tsx
+++ b/clients/web/src/shell/UserMenu.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import UserMenu from './UserMenu'
@@ -6,7 +6,7 @@ import UserMenu from './UserMenu'
 const auth = vi.hoisted(() => ({
   user: {
     username: 'dev-user',
-    full_name: 'Test User' as string | null,
+    full_name: 'Test User' as string | null | undefined,
     email: 'dev@localhost',
     role_id: 'role-admin',
     mfa_enabled: false,
@@ -27,22 +27,29 @@ function renderMenu() {
 }
 
 describe('UserMenu', () => {
-  it('renders initials and labels from full_name', () => {
+  beforeEach(() => {
+    auth.user.username = 'dev-user'
     auth.user.full_name = 'Test User'
+  })
+
+  it('renders initials and labels from full_name', () => {
     renderMenu()
     expect(screen.getByText('TU')).toBeInTheDocument()
     expect(screen.getAllByText('Test User').length).toBeGreaterThan(0)
   })
 
-  it('falls back to username when full_name is null', async () => {
-    auth.user.full_name = null
-    renderMenu()
-    expect(screen.getByRole('button', { name: 'Account menu' })).toBeInTheDocument()
-    expect(screen.getByText('D')).toBeInTheDocument()
-    expect(screen.getAllByText('dev-user').length).toBeGreaterThan(0)
+  it.each([null, undefined, '', '   '])(
+    'falls back to username when full_name is %j',
+    async (full_name) => {
+      auth.user.full_name = full_name
+      renderMenu()
+      expect(screen.getByRole('button', { name: 'Account menu' })).toBeInTheDocument()
+      expect(screen.getByText('D')).toBeInTheDocument()
+      expect(screen.getAllByText('dev-user').length).toBeGreaterThan(0)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Account menu' }))
-    const menu = await screen.findByRole('menu', { name: 'Account' })
-    expect(menu).toHaveTextContent('dev-user')
-  })
+      fireEvent.click(screen.getByRole('button', { name: 'Account menu' }))
+      const menu = await screen.findByRole('menu', { name: 'Account' })
+      expect(menu).toHaveTextContent('dev-user')
+    },
+  )
 })

--- a/clients/web/src/shell/UserMenu.tsx
+++ b/clients/web/src/shell/UserMenu.tsx
@@ -47,8 +47,11 @@ export default function UserMenu() {
 
   if (!user) return null
 
-  const initials = user.full_name
-    .split(' ')
+  // full_name is null on the in-memory DEV_MODE user (and any account without one)
+  const displayName = user.full_name?.trim() || user.username
+  const initials = displayName
+    .split(/\s+/)
+    .filter(Boolean)
     .map((n) => n[0])
     .join('')
     .toUpperCase()
@@ -72,7 +75,7 @@ export default function UserMenu() {
         style={{ position: 'fixed', left: pos.left, bottom: pos.bottom, zIndex: 80 }}
       >
         <div className="user-pop-head">
-          <div className="user-pop-name">{user.full_name}</div>
+          <div className="user-pop-name">{displayName}</div>
           <div className="user-pop-email">{user.email}</div>
           <div className="user-pop-role">Role: {role}</div>
         </div>
@@ -100,8 +103,8 @@ export default function UserMenu() {
         aria-label="Account menu"
       >
         <span className="avatar">{initials}</span>
-        <span className="nav-label">{user.full_name}</span>
-        <span className="tip">{user.full_name}</span>
+        <span className="nav-label">{displayName}</span>
+        <span className="tip">{displayName}</span>
       </button>
       {menu && (root ? createPortal(menu, root) : menu)}
     </div>

--- a/clients/web/src/shell/UserMenu.tsx
+++ b/clients/web/src/shell/UserMenu.tsx
@@ -47,8 +47,8 @@ export default function UserMenu() {
 
   if (!user) return null
 
-  // full_name is null on the in-memory DEV_MODE user (and any account without one)
-  const displayName = user.full_name?.trim() || user.username
+  // /auth/me can send null/omitted full_name even though the TS type is string
+  const displayName = user.full_name?.trim() || user.username || ''
   const initials = displayName
     .split(/\s+/)
     .filter(Boolean)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #768

`UserMenu` computed avatar initials with `user.full_name.split(' ')` after only guarding `user`. `full_name` is null at runtime (`UserSchema.dump` and the in-memory `_get_dev_user` User), so React threw during render and unmounted the whole console.

## Change

- Fall back to `username` for initials, the nav label, tooltip, and popover name
- Trim whitespace so a blank `full_name` uses the same fallback
- Guard the same crash if `username` is also missing (empty initials, no throw)

No schema change, no chrome ErrorBoundary, and the mock/dev user is left alone — those were explicitly out of scope.

## Validation

- `UserMenu` tests: named user still shows initials; `null` / `undefined` / `''` / `'   '` fall back to `username` without throwing, including the open menu
- `npm run test:run` — 83 passed
- `npx tsc --noEmit` — clean
- `npm run lint` — no new issues (existing warnings only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-172ba7ec-9115-4f01-be01-15014b16b312?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-172ba7ec-9115-4f01-be01-15014b16b312&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

