### PR TITLE
fix #769 ensure full db schema and reference data seeding on compose

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -49,9 +49,9 @@ services:
       - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      # Path is relative to this compose file (infra/docker/), so ../ points
-      # at infra/, where the schema SQL now lives (infra/database/init/).
-      - ../database/init:/docker-entrypoint-initdb.d
+      # SQL files at /db-init (not in initdb.d directly — see 00_apply.sh).
+      - ../database/init:/db-init:ro
+      - ./initdb/00_apply.sh:/docker-entrypoint-initdb.d/00_apply.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U deeptempo -d deeptempo_soc"]
       interval: 10s
@@ -118,6 +118,37 @@ services:
       bifrost:
         condition: service_healthy
     restart: unless-stopped
+    networks:
+      - deeptempo-network
+
+  # Second pass: replay init SQL after the backend's create_all has built
+  # ORM-managed tables. Mirrors clients/desktop/standalone/docker-compose.yml
+  # db-seed. /api/health answers while create_all may still be running, so
+  # the sentinel is an ORM-only table (sla_policies), not the health endpoint.
+  db-seed:
+    image: pgvector/pgvector:pg16
+    container_name: deeptempo-db-seed
+    depends_on:
+      backend:
+        condition: service_healthy
+    environment:
+      PGHOST: postgres
+      PGUSER: deeptempo
+      PGDATABASE: deeptempo_soc
+      PGPASSWORD: ${POSTGRES_PASSWORD:-deeptempo_secure_password_change_me}
+    volumes:
+      - ../database/init:/db-init:ro
+      - ./initdb/00_apply.sh:/apply.sh:ro
+    entrypoint:
+      - /bin/sh
+      - -c
+      - >
+        for i in $$(seq 1 60); do
+          [ "$$(psql -tAc "SELECT to_regclass('public.sla_policies') IS NOT NULL")" = t ] && break;
+          sleep 1;
+        done;
+        exec sh /apply.sh
+    restart: "no"
     networks:
       - deeptempo-network
 

--- a/infra/docker/initdb/00_apply.sh
+++ b/infra/docker/initdb/00_apply.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Apply every schema/seed file, tolerating failures.
+#
+# Postgres' own initdb.d runner uses ON_ERROR_STOP=1, so the first failure
+# aborts the whole init and leaves a half-built schema — silently, because the
+# container then restarts onto the already-initialized data dir and reports
+# healthy. Some files here legitimately fail depending on when they run: the
+# data-only ones target tables the backend's create_all builds at startup. The
+# Helm db-init Job tolerates failures for the same reason.
+#
+# Runs twice, from two contexts, which is why it is one script:
+#   initdb   — creates extensions and the auth tables (with their DEFAULT
+#              clauses, which create_all does not emit) and seeds the admin.
+#   db-seed  — after create_all, picks up the data whose tables only exist by
+#              then. Every file is idempotent, so the second pass is a no-op
+#              where the first already succeeded.
+# Connection comes from libpq env: initdb has POSTGRES_* and a local socket,
+# db-seed passes PGHOST/PGUSER/PGDATABASE/PGPASSWORD.
+: "${PGUSER:=${POSTGRES_USER}}"
+: "${PGDATABASE:=${POSTGRES_DB}}"
+export PGUSER PGDATABASE
+
+for f in /db-init/*.sql; do
+    echo "applying $(basename "$f")"
+    psql -v ON_ERROR_STOP=0 -q -f "$f" || true
+done
+echo "apply complete"


### PR DESCRIPTION
- Add infra/docker/initdb/00_apply.sh to execute all SQL files in /db-init with ON_ERROR_STOP=0 during postgres initdb and db-seed passes.
- Update postgres service volume mounts in infra/docker/docker-compose.yml to mount SQL files to /db-init:ro and 00_apply.sh into initdb.d.
- Add db-seed service to infra/docker/docker-compose.yml that waits for the sla_policies sentinel table after backend create_all and replays all SQL files to seed roles, case templates, and non-ORM tables.
fixes #769 