### PR TITLE
feat(memory): distil a finished hunt into episodic rows (#731)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -35,6 +35,7 @@ forbidden_modules =
     core.ingestion
     core.integrations
     core.llm
+    core.memory
     core.reporting
     core.response
     core.skills

--- a/core/agents/projections.py
+++ b/core/agents/projections.py
@@ -35,22 +35,34 @@ def _headers() -> Dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-# None means "nothing to report yet" and is not an error: a run enqueued a moment
-# ago has no ledger, and a supervisor must read that as still starting.
-async def read_projection(run_id: str) -> Optional[Dict[str, Any]]:
+async def _read_fold(run_id: str, view: str) -> Optional[Dict[str, Any]]:
     import httpx
 
-    url = agent_route(f"/runs/{run_id}/projection")
+    url = agent_route(f"/runs/{run_id}/{view}")
     try:
         async with httpx.AsyncClient(timeout=READ_TIMEOUT_S) as client:
             response = await client.get(url, headers=_headers())
     except Exception as exc:  # noqa: BLE001 — unreachable is not terminal
-        logger.debug("could not read the projection for %s: %s", run_id, exc)
+        logger.debug("could not read the %s for %s: %s", view, run_id, exc)
         return None
 
     if response.status_code == 404:
         return None
     if response.status_code != 200:
-        logger.warning("projection for %s answered %s", run_id, response.status_code)
+        logger.warning("%s for %s answered %s", view, run_id, response.status_code)
         return None
     return response.json()
+
+
+# None means "nothing to report yet" and is not an error: a run enqueued a moment
+# ago has no ledger, and a supervisor must read that as still starting.
+async def read_projection(run_id: str) -> Optional[Dict[str, Any]]:
+    return await _read_fold(run_id, "projection")
+
+
+# What episodic memory reads once a run has ended, folded on the side that owns
+# the events; see services/agent/workflows/hunt/distil.ts for why it is not the
+# projection. None reads as "nothing to distil yet", never as "this run saw
+# nothing" — the difference matters, because the second would be a fact.
+async def read_distil(run_id: str) -> Optional[Dict[str, Any]]:
+    return await _read_fold(run_id, "distil")

--- a/core/memory/distil.py
+++ b/core/memory/distil.py
@@ -1,7 +1,7 @@
 """The Distil (#731): a finished hunt becomes Sightings, Verdicts and Gaps.
 
 Poll rather than push. Nothing tells this job that a run ended; it finds
-terminals with no marker itself, using the ledger's partial index. That buys
+terminals no marker covers itself, using the ledger's partial index. That buys
 three things a trigger does not: no change to the agent layer, a lost signal
 becomes a late write rather than a missing one, and backfill is the same code
 path exercised on every tick. Nothing is waiting on it either — memory is read
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
@@ -57,20 +59,29 @@ from core.storage.unit_of_work import unit_of_work
 
 logger = logging.getLogger(__name__)
 
-# Bumped when the mapping below changes what it writes. Re-deriving is
-# delete-then-insert, so a bump that now yields fewer rows leaves none behind.
-DISTIL_VERSION = 1
+# This side's version: bumped when the mapping below changes what it writes.
+# Re-deriving is delete-then-insert, so a bump that now yields fewer rows leaves
+# none behind. Stamped on the marker, and the poll re-offers everything stamped
+# with any other value.
+DISTIL_MAPPING_VERSION = 1
 
-# The payload schema this understands. A newer one is refused rather than
-# mis-mapped: a field that changed meaning is worse read optimistically than not
-# read at all, and the marker's absence brings the investigation back next tick.
-SUPPORTED_PAYLOAD_VERSION = 1
+# The other side's version: the wire schema of the payload this understands,
+# which `DISTIL_SCHEMA_VERSION` in services/agent/workflows/hunt/distil.ts
+# stamps. A newer one is refused rather than mis-mapped -- a field that changed
+# meaning is worse read optimistically than not read at all, and the marker's
+# absence brings the investigation back next tick.
+SUPPORTED_SCHEMA_VERSION = 1
 
 # Only hunts are distilled today. A Case closure writes its own Verdict from the
 # Case, not from a ledger, and no other run kind concludes anything.
 DISTILLED_RUN_KINDS: Tuple[str, ...] = ("hunt",)
 
 DEFAULT_BATCH = 25
+
+# One retry, and then it is reported. A write that fails twice is a store that is
+# down or a payload that is wrong, and neither gets better by being hammered
+# inside a poll tick that will come round again anyway.
+ATTEMPTS = 2
 
 # A crash is not an outcome. Nothing an aborted run believed at the moment it
 # died is a conclusion, so none of it becomes memory. Running out is different:
@@ -79,28 +90,59 @@ DEFAULT_BATCH = 25
 ABORTED = "aborted"
 BUDGET_TERMINATED = "budget_terminated"
 
-# Terminals whose ledger this job has not folded at this version. `<>` and not
-# `<` because running an older Distil deliberately is a re-derive too.
+# Terminals no marker at this version covers. The join is on the covered-runs
+# array and not on origin_run_id: one investigation can span more than one run,
+# and agent_events carries no investigation id for the poll to key on, so a
+# marker has to say which runs it accounts for. Matching the version in the join
+# rather than the filter is what makes a bump re-offer every covered run instead
+# of only the origin one.
 _CANDIDATES = text(
     """
     SELECT DISTINCT ON (e.run_id) e.run_id AS run_id, e.seq AS seq
     FROM agent_events e
-    LEFT JOIN episodic_distil_markers m ON m.origin_run_id = e.run_id
+    LEFT JOIN episodic_distil_markers m
+           ON m.origin_run_ids @> ARRAY[e.run_id]
+          AND m.distil_version = :version
     WHERE e.kind = 'terminal'
       AND e.run_kind = ANY(:kinds)
-      AND (m.investigation_id IS NULL OR m.distil_version <> :version OR m.origin_seq < e.seq)
+      AND (
+        m.investigation_id IS NULL
+        OR (m.origin_run_id = e.run_id AND m.origin_seq < e.seq)
+      )
     ORDER BY e.run_id, e.seq DESC
     LIMIT :limit
     """
 )
 
 
+@dataclass(frozen=True)
+class Terminal:
+    """One run's terminal event: what the poll finds and the writer works from."""
+
+    run_id: uuid.UUID
+    seq: int
+
+
+@dataclass(frozen=True)
+class Concluded:
+    """A payload the writer has accepted, with what every row built from it needs.
+
+    The investigation id and the conclusion time are read once, refused once if
+    they are absent, and then travel together because no row can be built
+    without all three.
+    """
+
+    payload: Mapping[str, Any]
+    investigation_id: str
+    concluded_at: datetime
+
+
 class DistilRefused(RuntimeError):
     """A payload this job will not map. Raised rather than written around."""
 
 
-def _ts(value: object) -> Optional[datetime]:
-    """Parse a harness timestamp, or None when it is absent or unreadable.
+def _utc(value: object) -> Optional[datetime]:
+    """The UTC instant a harness timestamp names, or None if it names none.
 
     The columns are ``timestamptz``, so a value that arrived without an offset
     is read as UTC rather than as the server's local time — the harness stamps
@@ -159,10 +201,14 @@ def _sources_of(conclusion: Mapping[str, Any], investigation_id: str) -> List[Di
 
     The tier is stamped here and never joined at read time: an integration
     removed or recategorised later must not retroactively change how a past
-    Verdict was corroborated. A ``not_evidence`` source is written and logged
-    rather than dropped — citing a rule catalogue as corroboration is a defect
-    worth being able to see, and a silent drop is a Verdict that looks thinner
-    than it is for no recorded reason.
+    Verdict was corroborated.
+
+    The harness's own records are already gone — the fold drops them before a
+    stance is taken, which is what makes ``not_evidence`` impossible on a Verdict
+    rather than merely visible on one. What survives to be graded here is a real
+    source the tier map regrades, and one that comes back ``not_evidence`` is
+    written and logged rather than dropped: a silent drop is a Verdict that looks
+    thinner than it is for no recorded reason.
     """
     rows: List[Dict[str, str]] = []
     seen = set()
@@ -194,15 +240,14 @@ def _sources_of(conclusion: Mapping[str, Any], investigation_id: str) -> List[Di
     return rows
 
 
-def _sighting_rows(
-    payload: Mapping[str, Any], investigation_id: str, concluded_at: datetime
-) -> List[Dict[str, Any]]:
+def _sighting_rows(concluded: Concluded) -> List[Dict[str, Any]]:
+    payload, investigation_id = concluded.payload, concluded.investigation_id
     rows: List[Dict[str, Any]] = []
     for sighting in payload.get("sightings") or []:
         entity = sighting.get("entity") or {}
         key = entity_key(str(entity.get("type", "")), str(entity.get("value", "")))
-        first = _ts(sighting.get("first_seen"))
-        last = _ts(sighting.get("last_seen"))
+        first = _utc(sighting.get("first_seen"))
+        last = _utc(sighting.get("last_seen"))
         hits = int(sighting.get("hit_count") or 0)
         # A row missing any of these cannot be joined, ordered or counted, and
         # writing a guessed one puts an entity in history it was never in.
@@ -222,16 +267,15 @@ def _sighting_rows(
                 # take the whole investigation down with it.
                 "first_seen": min(first, last),
                 "last_seen": max(first, last),
-                "concluded_at": concluded_at,
+                "concluded_at": concluded.concluded_at,
             }
         )
     return rows
 
 
-def _conclusion_rows(
-    payload: Mapping[str, Any], investigation_id: str, concluded_at: datetime
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+def _conclusion_rows(concluded: Concluded) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Split the hunt's conclusions into Verdict rows and Gap rows."""
+    payload, investigation_id = concluded.payload, concluded.investigation_id
     run_outcome = str(payload.get("outcome") or "")
     verdicts: List[Dict[str, Any]] = []
     gaps: List[Dict[str, Any]] = []
@@ -264,13 +308,13 @@ def _conclusion_rows(
                     "disposition": disposition.value,
                     "reason": rationale or _GAP_REASONS[disposition],
                     "subject_entities": subjects,
-                    "concluded_at": concluded_at,
+                    "concluded_at": concluded.concluded_at,
                 }
             )
             continue
 
-        first = _ts(conclusion.get("first_seen")) or concluded_at
-        last = _ts(conclusion.get("last_seen")) or concluded_at
+        first = _utc(conclusion.get("first_seen")) or concluded.concluded_at
+        last = _utc(conclusion.get("last_seen")) or concluded.concluded_at
         verdicts.append(
             {
                 "row": {
@@ -294,7 +338,7 @@ def _conclusion_rows(
                         if conclusion.get("window_observed")
                         else WindowSource.ASSERTED.value
                     ),
-                    "concluded_at": concluded_at,
+                    "concluded_at": concluded.concluded_at,
                 },
                 "sources": _sources_of(conclusion, investigation_id),
             }
@@ -319,50 +363,79 @@ def _clear(session: Session, kind: InvestigationKind, investigation_id: str) -> 
         )
 
 
-def write_distil(session: Session, run_id: str, seq: int, payload: Mapping[str, Any]) -> Dict[str, int]:
+def _accept(terminal: Terminal, payload: Mapping[str, Any]) -> Concluded:
+    """The payload, or a refusal saying which field it could not be read on."""
+    version = payload.get("distil_schema_version")
+    # An absent version is refused rather than read as 0: a payload that does not
+    # say what it is could be any shape, and mapping it optimistically writes
+    # rows nobody can trust more quietly than writing none.
+    if not isinstance(version, int) or version > SUPPORTED_SCHEMA_VERSION:
+        raise DistilRefused(
+            f"{terminal.run_id} answered distil schema {version!r}; "
+            f"this Distil understands {SUPPORTED_SCHEMA_VERSION}"
+        )
+
+    investigation_id = str(payload.get("investigation_id", "")).strip()
+    if not investigation_id:
+        raise DistilRefused(
+            f"{terminal.run_id} answered a distil payload with no investigation id"
+        )
+
+    concluded_at = _utc(payload.get("concluded_at"))
+    if concluded_at is None:
+        raise DistilRefused(f"{terminal.run_id} has not concluded, so there is nothing to distil")
+
+    return Concluded(payload, investigation_id, concluded_at)
+
+
+def _superseded_by(marker: Optional[EpisodicDistilMarker], concluded: Concluded, terminal: Terminal) -> bool:
+    """Whether this investigation already holds rows from a later terminal.
+
+    One investigation can reach a terminal in more than one run, and the poll
+    offers each run separately because it has nothing but run ids to go on. Two
+    runs both re-deriving the same investigation would leave whichever ran last
+    on the record, and they would take turns forever. The later terminal wins,
+    and the earlier one is recorded as covered without touching the rows.
+    """
+    return (
+        marker is not None
+        and marker.distil_version == DISTIL_MAPPING_VERSION
+        and marker.origin_run_id != terminal.run_id
+        and marker.concluded_at >= concluded.concluded_at
+    )
+
+
+def write_distil(session: Session, terminal: Terminal, payload: Mapping[str, Any]) -> Dict[str, int]:
     """Map one payload to rows and write them, marker included.
 
     Everything here is one transaction the caller owns. A failure raises with
     nothing written and no marker, so the investigation comes back next tick
     rather than being recorded as done.
     """
-    version = payload.get("distil_schema_version")
-    # An absent version is refused rather than read as 0: a payload that does not
-    # say what it is could be any shape, and mapping it optimistically writes
-    # rows nobody can trust more quietly than writing none.
-    if not isinstance(version, int) or version > SUPPORTED_PAYLOAD_VERSION:
-        raise DistilRefused(
-            f"{run_id} answered distil schema {version!r}; "
-            f"this Distil understands {SUPPORTED_PAYLOAD_VERSION}"
-        )
+    concluded = _accept(terminal, payload)
+    kind = InvestigationKind.HUNT
 
-    investigation_id = str(payload.get("investigation_id", "")).strip()
-    if not investigation_id:
-        raise DistilRefused(f"{run_id} answered a distil payload with no investigation id")
+    marker = session.get(EpisodicDistilMarker, (kind.value, concluded.investigation_id))
+    # origin_run_id included, so the covered set is what the poll needs on its own.
+    covered = sorted({*(marker.origin_run_ids if marker is not None else []), terminal.run_id})
 
-    concluded_at = _ts(payload.get("concluded_at"))
-    if concluded_at is None:
-        raise DistilRefused(f"{run_id} has not concluded, so there is nothing to distil")
+    if _superseded_by(marker, concluded, terminal):
+        marker.origin_run_ids = covered  # type: ignore[union-attr]
+        return {"sightings": 0, "verdicts": 0, "gaps": 0, "derived": 0}
 
-    outcome = str(payload.get("outcome") or "")
-
-    # Before the outcome is read, because a re-derive replaces this
-    # investigation's rows as a set and an abort is a re-derive that yields none.
-    # An outcome is never downgraded once on the record and `aborted` outranks
-    # every other, so a hunt that concluded and was later aborted is an
-    # investigation whose conclusions are withdrawn — the clear is what withdraws
-    # them, and skipping it would leave the old rows reading as current.
-    _clear(session, InvestigationKind.HUNT, investigation_id)
-
-    # A crash is not an outcome, so an aborted run contributes no memory. It
-    # still takes a marker: the marker records that the investigation was
-    # processed, not that it was remembered, and without one this run comes back
-    # on every tick forever.
-    if outcome == ABORTED:
+    # A crash is not an outcome, so an aborted run contributes no memory — and
+    # withdraws none either. What an earlier terminal of this investigation
+    # concluded was concluded; a later run dying does not unsay it, so the clear
+    # belongs to the re-derive and not to the abort. The abort still takes a
+    # marker: a marker records that the investigation was processed, not that it
+    # was remembered, and without one this run comes back on every tick forever.
+    if str(payload.get("outcome") or "") == ABORTED:
         counts = {"sightings": 0, "verdicts": 0, "gaps": 0}
     else:
-        sightings = _sighting_rows(payload, investigation_id, concluded_at)
-        verdicts, gaps = _conclusion_rows(payload, investigation_id, concluded_at)
+        _clear(session, kind, concluded.investigation_id)
+
+        sightings = _sighting_rows(concluded)
+        verdicts, gaps = _conclusion_rows(concluded)
 
         session.bulk_insert_mappings(EpisodicSighting, sightings)
         session.bulk_insert_mappings(EpisodicGap, gaps)
@@ -378,91 +451,135 @@ def write_distil(session: Session, run_id: str, seq: int, payload: Mapping[str, 
 
         counts = {"sightings": len(sightings), "verdicts": len(verdicts), "gaps": len(gaps)}
 
-    marker = {
-        "investigation_kind": InvestigationKind.HUNT.value,
-        "investigation_id": investigation_id,
-        "origin_run_id": run_id,
-        "origin_seq": seq,
-        "distil_version": DISTIL_VERSION,
+    row = {
+        "investigation_kind": kind.value,
+        "investigation_id": concluded.investigation_id,
+        "origin_run_id": terminal.run_id,
+        "origin_seq": terminal.seq,
+        "origin_run_ids": covered,
+        "distil_version": DISTIL_MAPPING_VERSION,
         "sightings_written": counts["sightings"],
         "verdicts_written": counts["verdicts"],
         "gaps_written": counts["gaps"],
-        "concluded_at": concluded_at,
+        "concluded_at": concluded.concluded_at,
     }
     # The one upsert here, and the only row it is right for: a marker is one row
     # keyed by the investigation, so there is no set of stale rows to leave behind.
     # Counts are set from what was just written, never incremented.
     session.execute(
         insert(EpisodicDistilMarker)
-        .values(**marker)
+        .values(**row)
         .on_conflict_do_update(
             index_elements=["investigation_kind", "investigation_id"],
-            set_={key: marker[key] for key in marker if key not in ("investigation_kind", "investigation_id")}
+            set_={key: row[key] for key in row if key not in ("investigation_kind", "investigation_id")}
             | {"distilled_at": text("now()")},
         )
     )
-    return counts
+    return counts | {"derived": 1}
 
 
-def pending(session: Session, limit: int = DEFAULT_BATCH) -> List[Tuple[str, int]]:
-    """Terminals with no marker at this version, newest terminal per run."""
+def pending(session: Session, limit: int = DEFAULT_BATCH) -> List[Terminal]:
+    """Terminals no marker at this version covers, newest terminal per run."""
     rows = session.execute(
         _CANDIDATES,
-        {"kinds": list(DISTILLED_RUN_KINDS), "version": DISTIL_VERSION, "limit": limit},
+        {"kinds": list(DISTILLED_RUN_KINDS), "version": DISTIL_MAPPING_VERSION, "limit": limit},
     ).all()
-    return [(str(row.run_id), int(row.seq)) for row in rows]
+    return [Terminal(uuid.UUID(str(row.run_id)), int(row.seq)) for row in rows]
 
 
 async def distil_once(limit: int = DEFAULT_BATCH) -> Dict[str, int]:
     """One pass: find terminals, read each fold, write each investigation.
 
     One transaction per investigation, so a payload this job refuses costs that
-    investigation and not the batch. A refusal writes no marker, which is what
-    brings it back once the reason is fixed.
+    investigation and not the batch. Nothing here is swallowed: a refusal, an
+    unreadable fold and a failed write are each counted and each logged at a
+    level that says which, because a Distil that goes quiet leaves a store that
+    reads as healthy and a memory that reads as empty — and empty is also what an
+    entity nobody has looked at reads as. None of the three writes a marker,
+    which is what brings the investigation back once the reason is fixed.
     """
     candidates = await asyncio.to_thread(_pending_in_own_session, limit)
-    written = {"investigations": 0, "sightings": 0, "verdicts": 0, "gaps": 0, "refused": 0}
+    written = {
+        "investigations": 0,
+        "sightings": 0,
+        "verdicts": 0,
+        "gaps": 0,
+        "refused": 0,
+        "unreadable": 0,
+        "failed": 0,
+    }
 
-    for run_id, seq in candidates:
-        payload = await read_distil(run_id)
+    for terminal in candidates:
+        payload = await read_distil(str(terminal.run_id))
         if payload is None:
-            # Not an error and not a skip-forever: the agent layer may simply be
-            # unreachable, and this run is a candidate again next tick.
-            logger.debug("Distil: %s had no readable fold", run_id)
-            continue
-        try:
-            counts = await asyncio.to_thread(_write_in_own_session, run_id, seq, payload)
-        except DistilRefused as exc:
-            logger.warning("Distil refused %s: %s", run_id, exc)
-            written["refused"] += 1
-            continue
-        except Exception:
-            # Raised, not swallowed: a write path that swallows is what makes a
-            # dead store read as healthy to every surface that reads it.
-            logger.exception("Distil failed on %s, leaving neither rows nor marker", run_id)
-            written["refused"] += 1
+            # Not terminal and not a skip-forever: the agent layer may simply be
+            # unreachable, and this run is a candidate again next tick. Said out
+            # loud all the same, because an agent layer that is never reachable
+            # is a memory that silently never fills.
+            logger.warning("Distil: %s had no readable fold", terminal.run_id)
+            written["unreadable"] += 1
             continue
 
-        written["investigations"] += 1
-        for kind in ("sightings", "verdicts", "gaps"):
-            written[kind] += counts[kind]
+        counts = await _write_with_retry(terminal, payload, written)
+        if counts is None:
+            continue
+
+        written["investigations"] += counts["derived"]
+        for name in ("sightings", "verdicts", "gaps"):
+            written[name] += counts[name]
 
     return written
 
 
-def _pending_in_own_session(limit: int) -> List[Tuple[str, int]]:
+async def _write_with_retry(
+    terminal: Terminal, payload: Mapping[str, Any], written: Dict[str, int]
+) -> Optional[Dict[str, int]]:
+    """One investigation's write, retried once. None when it did not land.
+
+    A refusal is not retried: the payload will not become mappable by being read
+    again, and the fix is on the other side of the contract.
+    """
+    for attempt in range(1, ATTEMPTS + 1):
+        try:
+            return await asyncio.to_thread(_write_in_own_session, terminal, payload)
+        except DistilRefused as exc:
+            logger.warning("Distil refused %s: %s", terminal.run_id, exc)
+            written["refused"] += 1
+            return None
+        except Exception:
+            if attempt < ATTEMPTS:
+                logger.warning(
+                    "Distil failed on %s, attempt %s of %s; retrying",
+                    terminal.run_id,
+                    attempt,
+                    ATTEMPTS,
+                )
+                continue
+            logger.error(
+                "Distil failed on %s after %s attempts, leaving neither rows nor marker",
+                terminal.run_id,
+                ATTEMPTS,
+                exc_info=True,
+            )
+            written["failed"] += 1
+            return None
+    return None
+
+
+def _pending_in_own_session(limit: int) -> List[Terminal]:
     with unit_of_work() as session:
         return pending(session, limit)
 
 
-def _write_in_own_session(run_id: str, seq: int, payload: Mapping[str, Any]) -> Dict[str, int]:
+def _write_in_own_session(terminal: Terminal, payload: Mapping[str, Any]) -> Dict[str, int]:
     with unit_of_work() as session:
-        return write_distil(session, run_id, seq, payload)
+        return write_distil(session, terminal, payload)
 
 
 __all__: Sequence[str] = (
-    "DISTIL_VERSION",
+    "DISTIL_MAPPING_VERSION",
     "DistilRefused",
+    "Terminal",
     "distil_once",
     "pending",
     "write_distil",

--- a/core/memory/distil.py
+++ b/core/memory/distil.py
@@ -1,0 +1,469 @@
+"""The Distil (#731): a finished hunt becomes Sightings, Verdicts and Gaps.
+
+Poll rather than push. Nothing tells this job that a run ended; it finds
+terminals with no marker itself, using the ledger's partial index. That buys
+three things a trigger does not: no change to the agent layer, a lost signal
+becomes a late write rather than a missing one, and backfill is the same code
+path exercised on every tick. Nothing is waiting on it either — memory is read
+at the *start* of the next run, so a write that lands an hour later is a write
+that lands in time. Memory that waits to be told stops being written the moment
+the teller is down.
+
+It maps the harness's already-typed conclusions and never re-derives them. The
+fold is TypeScript and a second implementation here would drift while only one
+is gated, so a field this job needs and cannot find is a contract change to ask
+for. What it reads is ``GET /runs/<id>/distil``.
+
+Idempotency is delete-then-insert, scoped to the investigation, in one
+transaction. Not ``ON CONFLICT DO UPDATE``: upserting fixes rows that still
+exist and does nothing about rows that should not, so bumping the version on
+logic that now yields six Sightings where it yielded eight would leave two stale
+rows indistinguishable from real ones. The marker goes in the same transaction —
+split them and a crash between either double-writes the investigation or marks
+it done when it is not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from sqlalchemy import delete, text
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from core.agents.projections import read_distil
+from core.memory.entity_keys import entity_key, entity_keys
+from core.memory.recall_contract import (
+    GapDisposition,
+    InvestigationKind,
+    Stance,
+    Trust,
+    VerdictOutcome,
+    WindowSource,
+)
+from core.memory.source_tier import InvestigationKind as TierKind
+from core.memory.source_tier import SourceTier, resolve_source_tier
+from core.storage.models import (
+    EpisodicDistilMarker,
+    EpisodicGap,
+    EpisodicSighting,
+    EpisodicVerdict,
+    EpisodicVerdictSource,
+)
+from core.storage.unit_of_work import unit_of_work
+
+logger = logging.getLogger(__name__)
+
+# Bumped when the mapping below changes what it writes. Re-deriving is
+# delete-then-insert, so a bump that now yields fewer rows leaves none behind.
+DISTIL_VERSION = 1
+
+# The payload schema this understands. A newer one is refused rather than
+# mis-mapped: a field that changed meaning is worse read optimistically than not
+# read at all, and the marker's absence brings the investigation back next tick.
+SUPPORTED_PAYLOAD_VERSION = 1
+
+# Only hunts are distilled today. A Case closure writes its own Verdict from the
+# Case, not from a ledger, and no other run kind concludes anything.
+DISTILLED_RUN_KINDS: Tuple[str, ...] = ("hunt",)
+
+DEFAULT_BATCH = 25
+
+# A crash is not an outcome. Nothing an aborted run believed at the moment it
+# died is a conclusion, so none of it becomes memory. Running out is different:
+# a hunt that spent its budget or found no data still concluded what it
+# concluded, and those write normally.
+ABORTED = "aborted"
+BUDGET_TERMINATED = "budget_terminated"
+
+# Terminals whose ledger this job has not folded at this version. `<>` and not
+# `<` because running an older Distil deliberately is a re-derive too.
+_CANDIDATES = text(
+    """
+    SELECT DISTINCT ON (e.run_id) e.run_id AS run_id, e.seq AS seq
+    FROM agent_events e
+    LEFT JOIN episodic_distil_markers m ON m.origin_run_id = e.run_id
+    WHERE e.kind = 'terminal'
+      AND e.run_kind = ANY(:kinds)
+      AND (m.investigation_id IS NULL OR m.distil_version <> :version OR m.origin_seq < e.seq)
+    ORDER BY e.run_id, e.seq DESC
+    LIMIT :limit
+    """
+)
+
+
+class DistilRefused(RuntimeError):
+    """A payload this job will not map. Raised rather than written around."""
+
+
+def _ts(value: object) -> Optional[datetime]:
+    """Parse a harness timestamp, or None when it is absent or unreadable.
+
+    The columns are ``timestamptz``, so a value that arrived without an offset
+    is read as UTC rather than as the server's local time — the harness stamps
+    in UTC and a naive value here would silently shift by the deployment's zone.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _gap_disposition(status: str, run_outcome: str) -> GapDisposition:
+    """Why nothing was gathered for this question.
+
+    ``parked`` is the hunt saying it chose not to pursue this one. Everything
+    else is the hunt not getting to it, which is budget when the run ran out of
+    budget and plain absence otherwise.
+    """
+    if status == "parked":
+        return GapDisposition.DEPRIORITISED
+    if run_outcome == BUDGET_TERMINATED:
+        return GapDisposition.BUDGET_EXHAUSTED
+    return GapDisposition.NO_EVIDENCE_GATHERED
+
+
+# Why a Gap exists, when the harness gave no reason of its own. Stated rather
+# than left empty: an empty reason reads as a missing field, and these are the
+# three known absences.
+_GAP_REASONS: Mapping[GapDisposition, str] = {
+    GapDisposition.DEPRIORITISED: "parked at the hunt's terminal and never resumed",
+    GapDisposition.BUDGET_EXHAUSTED: "the hunt ran out of budget before gathering evidence for it",
+    GapDisposition.NO_EVIDENCE_GATHERED: "the hunt ended with no evidence gathered for it",
+}
+
+
+def _outcome_of(status: str) -> Optional[VerdictOutcome]:
+    """The Verdict a Hypothesis status becomes, or None when it becomes a Gap.
+
+    ``active`` and ``inconclusive`` are the same case: a claim still standing at
+    a terminal did not conclude, and whether that is a Verdict or a Gap is
+    decided by whether anything was gathered, not by which of the two it is.
+    ``false_positive`` is unreachable here — it arrives only from a Case closure.
+    """
+    if status in ("proven", "disproven", "handed_off"):
+        return VerdictOutcome(status)
+    if status in ("inconclusive", "active"):
+        return VerdictOutcome.INCONCLUSIVE
+    return None
+
+
+def _sources_of(conclusion: Mapping[str, Any], investigation_id: str) -> List[Dict[str, str]]:
+    """Per-source Stance and stamped Source Tier.
+
+    The tier is stamped here and never joined at read time: an integration
+    removed or recategorised later must not retroactively change how a past
+    Verdict was corroborated. A ``not_evidence`` source is written and logged
+    rather than dropped — citing a rule catalogue as corroboration is a defect
+    worth being able to see, and a silent drop is a Verdict that looks thinner
+    than it is for no recorded reason.
+    """
+    rows: List[Dict[str, str]] = []
+    seen = set()
+    for source in conclusion.get("sources") or []:
+        system = str(source.get("source_system", "")).strip()
+        try:
+            stance = Stance(str(source.get("stance", "")).strip())
+        except ValueError:
+            logger.warning(
+                "Distil: %s cites %r with a stance this contract has no value for",
+                investigation_id,
+                system,
+            )
+            continue
+        if not system or system in seen:
+            continue
+        seen.add(system)
+        tier = resolve_source_tier(system, TierKind.HUNT)
+        if tier is SourceTier.NOT_EVIDENCE:
+            logger.warning(
+                "Distil: %s cites %r on hypothesis %s, which is not evidence",
+                investigation_id,
+                system,
+                conclusion.get("hypothesis_id"),
+            )
+        rows.append(
+            {"source_system": system, "stance": stance.value, "source_tier": tier.value}
+        )
+    return rows
+
+
+def _sighting_rows(
+    payload: Mapping[str, Any], investigation_id: str, concluded_at: datetime
+) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for sighting in payload.get("sightings") or []:
+        entity = sighting.get("entity") or {}
+        key = entity_key(str(entity.get("type", "")), str(entity.get("value", "")))
+        first = _ts(sighting.get("first_seen"))
+        last = _ts(sighting.get("last_seen"))
+        hits = int(sighting.get("hit_count") or 0)
+        # A row missing any of these cannot be joined, ordered or counted, and
+        # writing a guessed one puts an entity in history it was never in.
+        if not key or first is None or last is None or hits <= 0:
+            logger.warning("Distil: %s dropped an unusable sighting %r", investigation_id, sighting)
+            continue
+        rows.append(
+            {
+                "entity_key": key,
+                "investigation_kind": InvestigationKind.HUNT.value,
+                "investigation_id": investigation_id,
+                "source_system": str(sighting.get("source_system", "")),
+                "hit_count": hits,
+                "attacker_influenceable": bool(sighting.get("attacker_influenceable")),
+                # Both ends inclusive, and ordered: a harness that stamped them
+                # out of order would otherwise fail the window constraint and
+                # take the whole investigation down with it.
+                "first_seen": min(first, last),
+                "last_seen": max(first, last),
+                "concluded_at": concluded_at,
+            }
+        )
+    return rows
+
+
+def _conclusion_rows(
+    payload: Mapping[str, Any], investigation_id: str, concluded_at: datetime
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Split the hunt's conclusions into Verdict rows and Gap rows."""
+    run_outcome = str(payload.get("outcome") or "")
+    verdicts: List[Dict[str, Any]] = []
+    gaps: List[Dict[str, Any]] = []
+
+    for conclusion in payload.get("conclusions") or []:
+        hypothesis_id = str(conclusion.get("hypothesis_id", "")).strip()
+        if not hypothesis_id:
+            logger.warning("Distil: %s has a conclusion with no hypothesis id", investigation_id)
+            continue
+
+        status = str(conclusion.get("status", ""))
+        subjects = entity_keys(conclusion.get("subject_entities"))
+        statement = str(conclusion.get("statement", ""))
+        rationale = str(conclusion.get("rationale", ""))
+        outcome = _outcome_of(status)
+        gathered = int(conclusion.get("evidence_count") or 0) > 0
+
+        # A claim that concluded nothing and gathered nothing is a question the
+        # hunt never answered, not a conclusion with an empty outcome. handed_off
+        # is never one: it carries evidence, a window and sources, so neither
+        # "never looked" nor "failed to conclude" is true of it.
+        if outcome is None or (outcome is VerdictOutcome.INCONCLUSIVE and not gathered):
+            disposition = _gap_disposition(status, run_outcome)
+            gaps.append(
+                {
+                    "investigation_kind": InvestigationKind.HUNT.value,
+                    "investigation_id": investigation_id,
+                    "hypothesis_id": hypothesis_id,
+                    "statement": statement,
+                    "disposition": disposition.value,
+                    "reason": rationale or _GAP_REASONS[disposition],
+                    "subject_entities": subjects,
+                    "concluded_at": concluded_at,
+                }
+            )
+            continue
+
+        first = _ts(conclusion.get("first_seen")) or concluded_at
+        last = _ts(conclusion.get("last_seen")) or concluded_at
+        verdicts.append(
+            {
+                "row": {
+                    "investigation_kind": InvestigationKind.HUNT.value,
+                    "investigation_id": investigation_id,
+                    "hypothesis_id": hypothesis_id,
+                    "statement": statement,
+                    "outcome": outcome.value,
+                    "rationale": rationale,
+                    "subject_entities": subjects,
+                    "attacker_influenceable_only": bool(
+                        conclusion.get("attacker_influenceable_only")
+                    ),
+                    # A hunt is agent-concluded. `analyst` arrives only when a
+                    # person closed the Case that authored the Verdict.
+                    "trust": Trust.AGENT.value,
+                    "first_seen": min(first, last),
+                    "last_seen": max(first, last),
+                    "window_source": (
+                        WindowSource.OBSERVED.value
+                        if conclusion.get("window_observed")
+                        else WindowSource.ASSERTED.value
+                    ),
+                    "concluded_at": concluded_at,
+                },
+                "sources": _sources_of(conclusion, investigation_id),
+            }
+        )
+
+    return verdicts, gaps
+
+
+def _clear(session: Session, kind: InvestigationKind, investigation_id: str) -> None:
+    """Everything this investigation wrote, scoped to it and to nothing else.
+
+    Verdict sources go with their Verdicts through the foreign key, which is why
+    they are not deleted here: deleting them separately would leave a window in
+    which a Verdict has none.
+    """
+    for model in (EpisodicSighting, EpisodicVerdict, EpisodicGap):
+        session.execute(
+            delete(model).where(
+                model.investigation_kind == kind.value,
+                model.investigation_id == investigation_id,
+            )
+        )
+
+
+def write_distil(session: Session, run_id: str, seq: int, payload: Mapping[str, Any]) -> Dict[str, int]:
+    """Map one payload to rows and write them, marker included.
+
+    Everything here is one transaction the caller owns. A failure raises with
+    nothing written and no marker, so the investigation comes back next tick
+    rather than being recorded as done.
+    """
+    version = payload.get("distil_schema_version")
+    # An absent version is refused rather than read as 0: a payload that does not
+    # say what it is could be any shape, and mapping it optimistically writes
+    # rows nobody can trust more quietly than writing none.
+    if not isinstance(version, int) or version > SUPPORTED_PAYLOAD_VERSION:
+        raise DistilRefused(
+            f"{run_id} answered distil schema {version!r}; "
+            f"this Distil understands {SUPPORTED_PAYLOAD_VERSION}"
+        )
+
+    investigation_id = str(payload.get("investigation_id", "")).strip()
+    if not investigation_id:
+        raise DistilRefused(f"{run_id} answered a distil payload with no investigation id")
+
+    concluded_at = _ts(payload.get("concluded_at"))
+    if concluded_at is None:
+        raise DistilRefused(f"{run_id} has not concluded, so there is nothing to distil")
+
+    outcome = str(payload.get("outcome") or "")
+
+    # Before the outcome is read, because a re-derive replaces this
+    # investigation's rows as a set and an abort is a re-derive that yields none.
+    # An outcome is never downgraded once on the record and `aborted` outranks
+    # every other, so a hunt that concluded and was later aborted is an
+    # investigation whose conclusions are withdrawn — the clear is what withdraws
+    # them, and skipping it would leave the old rows reading as current.
+    _clear(session, InvestigationKind.HUNT, investigation_id)
+
+    # A crash is not an outcome, so an aborted run contributes no memory. It
+    # still takes a marker: the marker records that the investigation was
+    # processed, not that it was remembered, and without one this run comes back
+    # on every tick forever.
+    if outcome == ABORTED:
+        counts = {"sightings": 0, "verdicts": 0, "gaps": 0}
+    else:
+        sightings = _sighting_rows(payload, investigation_id, concluded_at)
+        verdicts, gaps = _conclusion_rows(payload, investigation_id, concluded_at)
+
+        session.bulk_insert_mappings(EpisodicSighting, sightings)
+        session.bulk_insert_mappings(EpisodicGap, gaps)
+        for verdict in verdicts:
+            row = EpisodicVerdict(**verdict["row"])
+            session.add(row)
+            # Flushed for the id its sources reference. One statement per Verdict
+            # rather than one for the batch, because a source row cannot name a
+            # Verdict that has no id yet.
+            session.flush()
+            for source in verdict["sources"]:
+                session.add(EpisodicVerdictSource(verdict_id=row.id, **source))
+
+        counts = {"sightings": len(sightings), "verdicts": len(verdicts), "gaps": len(gaps)}
+
+    marker = {
+        "investigation_kind": InvestigationKind.HUNT.value,
+        "investigation_id": investigation_id,
+        "origin_run_id": run_id,
+        "origin_seq": seq,
+        "distil_version": DISTIL_VERSION,
+        "sightings_written": counts["sightings"],
+        "verdicts_written": counts["verdicts"],
+        "gaps_written": counts["gaps"],
+        "concluded_at": concluded_at,
+    }
+    # The one upsert here, and the only row it is right for: a marker is one row
+    # keyed by the investigation, so there is no set of stale rows to leave behind.
+    # Counts are set from what was just written, never incremented.
+    session.execute(
+        insert(EpisodicDistilMarker)
+        .values(**marker)
+        .on_conflict_do_update(
+            index_elements=["investigation_kind", "investigation_id"],
+            set_={key: marker[key] for key in marker if key not in ("investigation_kind", "investigation_id")}
+            | {"distilled_at": text("now()")},
+        )
+    )
+    return counts
+
+
+def pending(session: Session, limit: int = DEFAULT_BATCH) -> List[Tuple[str, int]]:
+    """Terminals with no marker at this version, newest terminal per run."""
+    rows = session.execute(
+        _CANDIDATES,
+        {"kinds": list(DISTILLED_RUN_KINDS), "version": DISTIL_VERSION, "limit": limit},
+    ).all()
+    return [(str(row.run_id), int(row.seq)) for row in rows]
+
+
+async def distil_once(limit: int = DEFAULT_BATCH) -> Dict[str, int]:
+    """One pass: find terminals, read each fold, write each investigation.
+
+    One transaction per investigation, so a payload this job refuses costs that
+    investigation and not the batch. A refusal writes no marker, which is what
+    brings it back once the reason is fixed.
+    """
+    candidates = await asyncio.to_thread(_pending_in_own_session, limit)
+    written = {"investigations": 0, "sightings": 0, "verdicts": 0, "gaps": 0, "refused": 0}
+
+    for run_id, seq in candidates:
+        payload = await read_distil(run_id)
+        if payload is None:
+            # Not an error and not a skip-forever: the agent layer may simply be
+            # unreachable, and this run is a candidate again next tick.
+            logger.debug("Distil: %s had no readable fold", run_id)
+            continue
+        try:
+            counts = await asyncio.to_thread(_write_in_own_session, run_id, seq, payload)
+        except DistilRefused as exc:
+            logger.warning("Distil refused %s: %s", run_id, exc)
+            written["refused"] += 1
+            continue
+        except Exception:
+            # Raised, not swallowed: a write path that swallows is what makes a
+            # dead store read as healthy to every surface that reads it.
+            logger.exception("Distil failed on %s, leaving neither rows nor marker", run_id)
+            written["refused"] += 1
+            continue
+
+        written["investigations"] += 1
+        for kind in ("sightings", "verdicts", "gaps"):
+            written[kind] += counts[kind]
+
+    return written
+
+
+def _pending_in_own_session(limit: int) -> List[Tuple[str, int]]:
+    with unit_of_work() as session:
+        return pending(session, limit)
+
+
+def _write_in_own_session(run_id: str, seq: int, payload: Mapping[str, Any]) -> Dict[str, int]:
+    with unit_of_work() as session:
+        return write_distil(session, run_id, seq, payload)
+
+
+__all__: Sequence[str] = (
+    "DISTIL_VERSION",
+    "DistilRefused",
+    "distil_once",
+    "pending",
+    "write_distil",
+)

--- a/core/memory/entity_keys.py
+++ b/core/memory/entity_keys.py
@@ -1,0 +1,68 @@
+"""Entity Keys, and the one rule for making one.
+
+Only Python writes an Entity Key. The harness extracts candidates and hands over
+a type and a value; the key they join on is minted here, so a stored key and a
+queried key cannot be normalised by two rules that drift.
+
+The rule is ``defang`` then case-fold, mirroring
+``services/agent/workflows/hunt/entities.ts``. The exception is the half that
+breaks silently: an ARN's resource part and an AWS key id are case-significant,
+so folding them makes two principals one key — and the join still returns rows,
+just the wrong ones.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+from core.memory.recall_contract import KEY_CASE_SENSITIVE_TYPES
+
+# Threat intel writes addresses defanged, and threat_intel is a worker whose
+# output feeds this, so normalising first is cheaper than carrying defanged
+# variants of every key.
+_DEFANG: Tuple[Tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\[\.\]|\(\.\)|\{\.\}"), "."),
+    (re.compile(r"\bh(?:xx)p", re.IGNORECASE), "http"),
+    (re.compile(r"\[:\]"), ":"),
+    (re.compile(r"\[at\]", re.IGNORECASE), "@"),
+)
+
+
+def defang(text: str) -> str:
+    for pattern, replacement in _DEFANG:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def entity_key(entity_type: str, value: str) -> str:
+    """Return ``type:value``, or ``""`` when either half is absent.
+
+    An empty key is dropped by the caller rather than raising: one unusable
+    candidate in a payload must not fail the investigation it arrived in.
+    """
+    kind = (entity_type or "").strip().lower()
+    text = defang((value or "").strip())
+    if not kind or not text:
+        return ""
+    if kind not in KEY_CASE_SENSITIVE_TYPES:
+        text = text.lower()
+    return f"{kind}:{text}"
+
+
+def entity_keys(entities: object) -> List[str]:
+    """Keys for a list of ``{"type", "value"}`` candidates, deduped in order.
+
+    Order is kept because a Verdict's subjects read back to a human, and an
+    unusable candidate is skipped rather than stored as a partial key.
+    """
+    keys: List[str] = []
+    seen = set()
+    for entity in entities if isinstance(entities, list) else []:
+        if not isinstance(entity, dict):
+            continue
+        key = entity_key(str(entity.get("type", "")), str(entity.get("value", "")))
+        if key and key not in seen:
+            seen.add(key)
+            keys.append(key)
+    return keys

--- a/core/storage/models.py
+++ b/core/storage/models.py
@@ -6,12 +6,14 @@ Defines the database schema for cases, findings, and related entities.
 
 import uuid
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, Iterable, List, Optional
 
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     ARRAY,
+    BigInteger,
     Boolean,
+    CheckConstraint,
     Column,
     DateTime,
     Float,
@@ -25,7 +27,7 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -2294,4 +2296,254 @@ class ChatMessage(Base):
     __table_args__ = (
         UniqueConstraint("conversation_id", "seq", name="uq_chat_messages_conv_seq"),
         Index("idx_chat_messages_conversation", "conversation_id"),
+    )
+
+
+# --- Episodic memory (#731) ------------------------------------------------
+#
+# The vocabularies below are imported, not restated: `core/memory/recall_contract.py`
+# declares them and `services/agent/contracts/memory.ts` mirrors it under a ratchet,
+# so a value added there reaches these constraints without a second edit.
+from core.memory.recall_contract import (  # noqa: E402
+    GapDisposition,
+    InvestigationKind,
+    Stance,
+    Trust,
+    VerdictOutcome,
+    WindowSource,
+)
+from core.memory.source_tier import SourceTier  # noqa: E402
+
+#
+# What investigations saw and what they concluded, joined on entity keys.
+# Everything is keyed by investigation_kind + investigation_id and never by
+# run_id: a run-keyed schema cannot represent the Case-authored Verdicts that
+# follow, which have a Case behind them and no run at all.
+#
+# No column is nullable. An empty list means known-to-be-none, and there is no
+# unknown state to represent. The DDL these mirror is
+# infra/database/init/22_episodic_memory.sql.
+
+def _one_of(column: str, values: Iterable[str], name: str) -> CheckConstraint:
+    """A CHECK spelling out a vocabulary the contract already declares.
+
+    Built from the enum rather than restated, so a value added to the contract
+    cannot be enforced here in an older spelling.
+    """
+    allowed = ", ".join(f"'{value}'" for value in values)
+    return CheckConstraint(f"{column} IN ({allowed})", name=name)
+
+
+def _kind_check(name: str) -> CheckConstraint:
+    return _one_of("investigation_kind", _values(InvestigationKind), name)
+
+
+def _values(enum: type) -> List[str]:
+    return [member.value for member in enum]
+
+
+class EpisodicSighting(Base):
+    """What an investigation observed: one row per entity, investigation and source.
+
+    Never one row per evidence record — growth tracks investigations, not
+    telemetry volume, so a hunt that saw one address ten thousand times in one
+    system writes one row carrying a hit count.
+    """
+
+    __tablename__ = "episodic_sightings"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    # ``type:value``, normalised by Python. Only Python writes an Entity Key;
+    # the harness's extractor output arrives as a candidate type and value.
+    entity_key: Mapped[str] = mapped_column(Text, nullable=False)
+    investigation_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    investigation_id: Mapped[str] = mapped_column(Text, nullable=False)
+    # Memory's own column, not a foreign key into either producer: a hunt fills
+    # it from the Ledger's source_system, a Case from its Findings' data_source.
+    source_system: Mapped[str] = mapped_column(Text, nullable=False)
+    hit_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    attacker_influenceable: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    first_seen: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_seen: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # When the investigation concluded, not when the row was written: the Distil
+    # polls, so one that ended Monday can be written Wednesday carrying Monday.
+    concluded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "entity_key",
+            "investigation_kind",
+            "investigation_id",
+            "source_system",
+            name="episodic_sightings_unique",
+        ),
+        _kind_check("episodic_sightings_kind"),
+        CheckConstraint("hit_count > 0", name="episodic_sightings_hits"),
+        CheckConstraint("first_seen <= last_seen", name="episodic_sightings_window"),
+        # The recall join and the order it reads in. Ties break on the primary
+        # key: a LIMIT over a partial order lets Postgres return a different set
+        # on identical data, which surfaces as a replay diff rather than an error.
+        Index("idx_episodic_sightings_recall", "entity_key", text("concluded_at DESC"), "id"),
+        Index("idx_episodic_sightings_investigation", "investigation_kind", "investigation_id"),
+    )
+
+
+class EpisodicVerdict(Base):
+    """What an investigation concluded, one row per Hypothesis."""
+
+    __tablename__ = "episodic_verdicts"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    investigation_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    investigation_id: Mapped[str] = mapped_column(Text, nullable=False)
+    # Stable, because the prose gets re-worded. A Case's is its case id.
+    hypothesis_id: Mapped[str] = mapped_column(Text, nullable=False)
+    statement: Mapped[str] = mapped_column(Text, nullable=False)
+    outcome: Mapped[str] = mapped_column(String(16), nullable=False)
+    # Reaches no ranking function: confident-sounding model text must not move a
+    # priority (ADR 0015). Carried for a human reading the run back.
+    rationale: Mapped[str] = mapped_column(Text, nullable=False)
+    # The entities the Hypothesis named, typically one to three — not the 38 to
+    # 76 its evidence touched, which stay reachable through Sightings (ADR 0016).
+    # Empty is legitimate: "is there any lateral movement at all" names none.
+    subject_entities: Mapped[List[str]] = mapped_column(
+        ARRAY(Text), nullable=False, server_default=text("ARRAY[]::text[]")
+    )
+    attacker_influenceable_only: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    # Who concluded, as distinct from what the source is.
+    trust: Mapped[str] = mapped_column(String(16), nullable=False)
+    first_seen: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_seen: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # A retrospective sweep over old archives asserts its window rather than
+    # observing it, and ranking discounts the weaker one.
+    window_source: Mapped[str] = mapped_column(String(16), nullable=False)
+    concluded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "investigation_kind",
+            "investigation_id",
+            "hypothesis_id",
+            name="episodic_verdicts_unique",
+        ),
+        _kind_check("episodic_verdicts_kind"),
+        _one_of("outcome", _values(VerdictOutcome), "episodic_verdicts_outcome"),
+        _one_of("trust", _values(Trust), "episodic_verdicts_trust"),
+        _one_of("window_source", _values(WindowSource), "episodic_verdicts_window_source"),
+        CheckConstraint("first_seen <= last_seen", name="episodic_verdicts_window"),
+        # Recall joins Verdicts on the subject array rather than a key column.
+        Index(
+            "idx_episodic_verdicts_subjects",
+            "subject_entities",
+            postgresql_using="gin",
+        ),
+        Index("idx_episodic_verdicts_recall", text("concluded_at DESC"), "id"),
+        Index("idx_episodic_verdicts_investigation", "investigation_kind", "investigation_id"),
+    )
+
+
+class EpisodicVerdictSource(Base):
+    """One row per Verdict and source, carrying direction.
+
+    Replaces a flat corroborated list, which cannot say that a source argued
+    against the claim.
+    """
+
+    __tablename__ = "episodic_verdict_sources"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    verdict_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("episodic_verdicts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    source_system: Mapped[str] = mapped_column(Text, nullable=False)
+    stance: Mapped[str] = mapped_column(String(16), nullable=False)
+    # Stamped at write time and never joined at read time: an integration removed
+    # or recategorised later must not retroactively change how a past Verdict was
+    # corroborated. ``not_evidence`` here is a defect rather than a weak row, and
+    # is representable so that it is visible.
+    source_tier: Mapped[str] = mapped_column(String(16), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("verdict_id", "source_system", name="episodic_verdict_sources_unique"),
+        _one_of("stance", _values(Stance), "episodic_verdict_sources_stance"),
+        _one_of("source_tier", _values(SourceTier), "episodic_verdict_sources_tier"),
+    )
+
+
+class EpisodicGap(Base):
+    """A question an investigation never gathered evidence for.
+
+    No activity window, which is the reason these are not Verdict rows carrying
+    an empty outcome.
+    """
+
+    __tablename__ = "episodic_gaps"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    investigation_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    investigation_id: Mapped[str] = mapped_column(Text, nullable=False)
+    hypothesis_id: Mapped[str] = mapped_column(Text, nullable=False)
+    statement: Mapped[str] = mapped_column(Text, nullable=False)
+    disposition: Mapped[str] = mapped_column(String(32), nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    subject_entities: Mapped[List[str]] = mapped_column(
+        ARRAY(Text), nullable=False, server_default=text("ARRAY[]::text[]")
+    )
+    concluded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "investigation_kind",
+            "investigation_id",
+            "hypothesis_id",
+            name="episodic_gaps_unique",
+        ),
+        _kind_check("episodic_gaps_kind"),
+        _one_of("disposition", _values(GapDisposition), "episodic_gaps_disposition"),
+        Index("idx_episodic_gaps_subjects", "subject_entities", postgresql_using="gin"),
+        Index("idx_episodic_gaps_recall", text("concluded_at DESC"), "id"),
+        Index("idx_episodic_gaps_investigation", "investigation_kind", "investigation_id"),
+    )
+
+
+class EpisodicDistilMarker(Base):
+    """The only record that an investigation was processed.
+
+    Deliberately not derived from the presence of rows: an investigation that
+    concluded nothing writes no Sightings, no Verdicts and no Gaps, and is still
+    done. Written in the same transaction as the rows.
+    """
+
+    __tablename__ = "episodic_distil_markers"
+
+    investigation_kind: Mapped[str] = mapped_column(String(16), primary_key=True)
+    investigation_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    # Where it came from, so a marker can be traced back to a ledger.
+    origin_run_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    # The seq of the terminal this was derived from. A hunt that resumed past its
+    # own terminal appends a second one to the same run, and comparing seq is what
+    # makes the later conclusions re-derive instead of being skipped as a run
+    # already seen.
+    origin_seq: Mapped[int] = mapped_column(Integer, nullable=False)
+    # Bumped when the mapping changes. Re-deriving is delete-then-insert, so a
+    # bump that now yields fewer rows leaves none of the old ones behind.
+    distil_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    # Set, never incremented: a count that drifts from its rows is worse than no
+    # count, because it reads as authoritative.
+    sightings_written: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    verdicts_written: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    gaps_written: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    concluded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    distilled_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    __table_args__ = (
+        _kind_check("episodic_distil_markers_kind"),
+        CheckConstraint("sightings_written >= 0", name="episodic_markers_sightings"),
+        CheckConstraint("verdicts_written >= 0", name="episodic_markers_verdicts"),
+        CheckConstraint("gaps_written >= 0", name="episodic_markers_gaps"),
+        Index("idx_episodic_markers_origin", "origin_run_id"),
     )

--- a/core/storage/models.py
+++ b/core/storage/models.py
@@ -6,14 +6,13 @@ Defines the database schema for cases, findings, and related entities.
 
 import uuid
 from datetime import datetime
-from typing import Any, Iterable, List, Optional
+from typing import Any, List, Optional
 
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     ARRAY,
     BigInteger,
     Boolean,
-    CheckConstraint,
     Column,
     DateTime,
     Float,
@@ -2301,45 +2300,21 @@ class ChatMessage(Base):
 
 # --- Episodic memory (#731) ------------------------------------------------
 #
-# The vocabularies below are imported, not restated: `core/memory/recall_contract.py`
-# declares them and `services/agent/contracts/memory.ts` mirrors it under a ratchet,
-# so a value added there reaches these constraints without a second edit.
-from core.memory.recall_contract import (  # noqa: E402
-    GapDisposition,
-    InvestigationKind,
-    Stance,
-    Trust,
-    VerdictOutcome,
-    WindowSource,
-)
-from core.memory.source_tier import SourceTier  # noqa: E402
-
-#
 # What investigations saw and what they concluded, joined on entity keys.
 # Everything is keyed by investigation_kind + investigation_id and never by
 # run_id: a run-keyed schema cannot represent the Case-authored Verdicts that
 # follow, which have a Case behind them and no run at all.
 #
 # No column is nullable. An empty list means known-to-be-none, and there is no
-# unknown state to represent. The DDL these mirror is
-# infra/database/init/22_episodic_memory.sql.
-
-def _one_of(column: str, values: Iterable[str], name: str) -> CheckConstraint:
-    """A CHECK spelling out a vocabulary the contract already declares.
-
-    Built from the enum rather than restated, so a value added to the contract
-    cannot be enforced here in an older spelling.
-    """
-    allowed = ", ".join(f"'{value}'" for value in values)
-    return CheckConstraint(f"{column} IN ({allowed})", name=name)
-
-
-def _kind_check(name: str) -> CheckConstraint:
-    return _one_of("investigation_kind", _values(InvestigationKind), name)
-
-
-def _values(enum: type) -> List[str]:
-    return [member.value for member in enum]
+# unknown state to represent.
+#
+# The domains these columns range over are stated once, in
+# infra/database/init/22_episodic_memory.sql, as every other table in that
+# directory states them. They are not restated here: `core/memory` owns the
+# vocabularies and `core/storage` is the tier underneath it, so mirroring them
+# would mean the shared-infrastructure tier importing a capability domain
+# (CONTEXT.md, and the `tiers` contract in .importlinter). These models carry
+# the uniqueness and the indexes, which is what the rest of this file carries.
 
 
 class EpisodicSighting(Base):
@@ -2377,9 +2352,6 @@ class EpisodicSighting(Base):
             "source_system",
             name="episodic_sightings_unique",
         ),
-        _kind_check("episodic_sightings_kind"),
-        CheckConstraint("hit_count > 0", name="episodic_sightings_hits"),
-        CheckConstraint("first_seen <= last_seen", name="episodic_sightings_window"),
         # The recall join and the order it reads in. Ties break on the primary
         # key: a LIMIT over a partial order lets Postgres return a different set
         # on identical data, which surfaces as a replay diff rather than an error.
@@ -2426,11 +2398,6 @@ class EpisodicVerdict(Base):
             "hypothesis_id",
             name="episodic_verdicts_unique",
         ),
-        _kind_check("episodic_verdicts_kind"),
-        _one_of("outcome", _values(VerdictOutcome), "episodic_verdicts_outcome"),
-        _one_of("trust", _values(Trust), "episodic_verdicts_trust"),
-        _one_of("window_source", _values(WindowSource), "episodic_verdicts_window_source"),
-        CheckConstraint("first_seen <= last_seen", name="episodic_verdicts_window"),
         # Recall joins Verdicts on the subject array rather than a key column.
         Index(
             "idx_episodic_verdicts_subjects",
@@ -2467,8 +2434,6 @@ class EpisodicVerdictSource(Base):
 
     __table_args__ = (
         UniqueConstraint("verdict_id", "source_system", name="episodic_verdict_sources_unique"),
-        _one_of("stance", _values(Stance), "episodic_verdict_sources_stance"),
-        _one_of("source_tier", _values(SourceTier), "episodic_verdict_sources_tier"),
     )
 
 
@@ -2500,8 +2465,6 @@ class EpisodicGap(Base):
             "hypothesis_id",
             name="episodic_gaps_unique",
         ),
-        _kind_check("episodic_gaps_kind"),
-        _one_of("disposition", _values(GapDisposition), "episodic_gaps_disposition"),
         Index("idx_episodic_gaps_subjects", "subject_entities", postgresql_using="gin"),
         Index("idx_episodic_gaps_recall", text("concluded_at DESC"), "id"),
         Index("idx_episodic_gaps_investigation", "investigation_kind", "investigation_id"),
@@ -2520,13 +2483,21 @@ class EpisodicDistilMarker(Base):
 
     investigation_kind: Mapped[str] = mapped_column(String(16), primary_key=True)
     investigation_id: Mapped[str] = mapped_column(Text, primary_key=True)
-    # Where it came from, so a marker can be traced back to a ledger.
+    # The terminal these rows were derived from, so a marker can be traced back
+    # to a ledger.
     origin_run_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
-    # The seq of the terminal this was derived from. A hunt that resumed past its
-    # own terminal appends a second one to the same run, and comparing seq is what
-    # makes the later conclusions re-derive instead of being skipped as a run
-    # already seen.
+    # The seq of that terminal. A hunt that resumed past its own terminal appends
+    # a second one to the same run, and comparing seq is what makes the later
+    # conclusions re-derive instead of being skipped as a run already seen.
     origin_seq: Mapped[int] = mapped_column(Integer, nullable=False)
+    # Every run this investigation has been distilled from, origin_run_id
+    # included. One investigation can span more than one run, and the poll has
+    # only run ids to work with because agent_events carries no investigation id;
+    # without this, each run of one investigation misses the other's marker and
+    # both re-distil on every tick forever.
+    origin_run_ids: Mapped[List[uuid.UUID]] = mapped_column(
+        ARRAY(UUID(as_uuid=True)), nullable=False, server_default=text("ARRAY[]::uuid[]")
+    )
     # Bumped when the mapping changes. Re-deriving is delete-then-insert, so a
     # bump that now yields fewer rows leaves none of the old ones behind.
     distil_version: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -2541,9 +2512,5 @@ class EpisodicDistilMarker(Base):
     )
 
     __table_args__ = (
-        _kind_check("episodic_distil_markers_kind"),
-        CheckConstraint("sightings_written >= 0", name="episodic_markers_sightings"),
-        CheckConstraint("verdicts_written >= 0", name="episodic_markers_verdicts"),
-        CheckConstraint("gaps_written >= 0", name="episodic_markers_gaps"),
-        Index("idx_episodic_markers_origin", "origin_run_id"),
+        Index("idx_episodic_markers_origin", "origin_run_ids", postgresql_using="gin"),
     )

--- a/infra/database/init/22_episodic_memory.sql
+++ b/infra/database/init/22_episodic_memory.sql
@@ -11,9 +11,9 @@
 
 -- The vocabularies are spelled as CHECK constraints rather than as enum types:
 -- altering an enum takes a lock this schema does not need, and every other table
--- in this directory states its domains the same way. They are declared in
--- core/memory/recall_contract.py, which the models build these same constraints
--- from -- a value added there must be added here too.
+-- in this directory states its domains the same way. This file is where they are
+-- enforced; core/memory/recall_contract.py is where they are declared for the
+-- code that writes them, and a value added there must be added here too.
 
 -- What an investigation observed. One row per entity, investigation and source,
 -- so growth tracks investigations and not telemetry volume: a hunt that saw one
@@ -115,8 +115,10 @@ CREATE TABLE IF NOT EXISTS episodic_verdict_sources (
     stance        text      NOT NULL CHECK (stance IN ('supports', 'weakens', 'neither')),
     -- Stamped at write time and never joined at read time: an integration
     -- removed or recategorised later must not retroactively change how a past
-    -- Verdict was corroborated. `not_evidence` here is a defect rather than a
-    -- weak row, and is representable so that it is visible.
+    -- Verdict was corroborated. The harness's own records never reach here --
+    -- the fold drops them before a stance is taken -- so `not_evidence` is a
+    -- fail-closed guard against a source the tier map regrades later, and is
+    -- representable so that such a row is visible rather than silently absent.
     source_tier   text      NOT NULL CHECK (source_tier IN ('telemetry', 'feed', 'not_evidence')),
 
     CONSTRAINT episodic_verdict_sources_unique UNIQUE (verdict_id, source_system)
@@ -162,13 +164,20 @@ COMMENT ON TABLE episodic_gaps IS
 CREATE TABLE IF NOT EXISTS episodic_distil_markers (
     investigation_kind text        NOT NULL CHECK (investigation_kind IN ('hunt', 'case', 'analyst')),
     investigation_id   text        NOT NULL,
-    -- Where it came from, so a marker can be traced back to a ledger.
+    -- The terminal these rows were derived from, so a marker can be traced back
+    -- to a ledger.
     origin_run_id      uuid        NOT NULL,
-    -- The seq of the terminal this was derived from. A hunt that resumed past
-    -- its own terminal appends a second one to the same run, and comparing seq
-    -- is what makes the later conclusions re-derive instead of being skipped as
-    -- a run already seen.
+    -- The seq of that terminal. A hunt that resumed past its own terminal
+    -- appends a second one to the same run, and comparing seq is what makes the
+    -- later conclusions re-derive instead of being skipped as a run already seen.
     origin_seq         integer     NOT NULL,
+    -- Every run this investigation has been distilled from, origin_run_id
+    -- included. One investigation can span more than one run -- a resumed hunt
+    -- is the case the rest of this schema is keyed for -- and the poll has only
+    -- run ids to work with, because agent_events carries no investigation id.
+    -- Without this, each run of one investigation misses the other's marker and
+    -- both re-distil on every tick forever.
+    origin_run_ids     uuid[]      NOT NULL DEFAULT ARRAY[]::uuid[],
     -- Bumped when the mapping changes. Re-deriving is delete-then-insert, so a
     -- bump that now yields fewer rows leaves none of the old ones behind.
     distil_version     integer     NOT NULL,
@@ -183,9 +192,9 @@ CREATE TABLE IF NOT EXISTS episodic_distil_markers (
     PRIMARY KEY (investigation_kind, investigation_id)
 );
 
--- The Distil's poll: which terminals have no marker at the current version.
+-- The Distil's poll: which terminals no marker at the current version covers.
 CREATE INDEX IF NOT EXISTS idx_episodic_markers_origin
-    ON episodic_distil_markers (origin_run_id);
+    ON episodic_distil_markers USING GIN (origin_run_ids);
 
 COMMENT ON TABLE episodic_distil_markers IS
     'One row per distilled investigation, written in the same transaction as its rows.';

--- a/infra/database/init/22_episodic_memory.sql
+++ b/infra/database/init/22_episodic_memory.sql
@@ -1,0 +1,191 @@
+-- Episodic memory: what investigations saw and what they concluded, joined on
+-- entity keys. Written by the Distil (core/memory/distil.py), read by recall.
+--
+-- Everything is keyed by investigation_kind + investigation_id and never by
+-- run_id: a run-keyed schema cannot represent the Case-authored Verdicts that
+-- follow, which have a Case behind them and no run at all.
+--
+-- No column is nullable. An empty list means known-to-be-none, and there is no
+-- unknown state to represent -- a row nobody can read as "we did not record
+-- this" is a row nobody has to guess about.
+
+-- The vocabularies are spelled as CHECK constraints rather than as enum types:
+-- altering an enum takes a lock this schema does not need, and every other table
+-- in this directory states its domains the same way. They are declared in
+-- core/memory/recall_contract.py, which the models build these same constraints
+-- from -- a value added there must be added here too.
+
+-- What an investigation observed. One row per entity, investigation and source,
+-- so growth tracks investigations and not telemetry volume: a hunt that saw one
+-- address ten thousand times in one system writes one row with a hit count.
+CREATE TABLE IF NOT EXISTS episodic_sightings (
+    id                     bigserial   PRIMARY KEY,
+    -- `type:value`, normalised by Python. Only Python writes an Entity Key; the
+    -- harness's extractor output arrives as candidate type and value.
+    entity_key             text        NOT NULL,
+    investigation_kind     text        NOT NULL CHECK (investigation_kind IN ('hunt', 'case', 'analyst')),
+    investigation_id       text        NOT NULL,
+    -- Memory's own column, not a foreign key into either producer: a hunt fills
+    -- it from the Ledger's source_system, a Case from its Findings' data_source.
+    source_system          text        NOT NULL,
+    hit_count              integer     NOT NULL CHECK (hit_count > 0),
+    -- Aggregated over the group: one record an adversary could have authored is
+    -- enough to say so of the group.
+    attacker_influenceable boolean     NOT NULL,
+    -- Both ends inclusive, and observed rather than asserted -- a Sighting that
+    -- did not observe its window is not a Sighting.
+    first_seen             timestamptz NOT NULL,
+    last_seen              timestamptz NOT NULL,
+    -- When the investigation concluded, not when the row was written. The Distil
+    -- polls, so an investigation that ended Monday can be written Wednesday
+    -- carrying Monday's date.
+    concluded_at           timestamptz NOT NULL,
+
+    CONSTRAINT episodic_sightings_unique
+        UNIQUE (entity_key, investigation_kind, investigation_id, source_system),
+    CONSTRAINT episodic_sightings_window CHECK (first_seen <= last_seen)
+);
+
+-- The recall join, and the order it reads in. Ties break on the primary key
+-- because a LIMIT over a partial order lets Postgres return a different set on
+-- identical data, which surfaces as a replay diff rather than as an error.
+CREATE INDEX IF NOT EXISTS idx_episodic_sightings_recall
+    ON episodic_sightings (entity_key, concluded_at DESC, id ASC);
+
+-- The Distil's own delete, which is scoped to one investigation.
+CREATE INDEX IF NOT EXISTS idx_episodic_sightings_investigation
+    ON episodic_sightings (investigation_kind, investigation_id);
+
+COMMENT ON TABLE episodic_sightings IS
+    'What an investigation observed: one row per entity, investigation and source, never per evidence record.';
+
+-- What an investigation concluded, one row per Hypothesis.
+CREATE TABLE IF NOT EXISTS episodic_verdicts (
+    id                          bigserial   PRIMARY KEY,
+    investigation_kind          text        NOT NULL CHECK (investigation_kind IN ('hunt', 'case', 'analyst')),
+    investigation_id            text        NOT NULL,
+    -- Stable, because the prose gets re-worded. A Case's is its case id.
+    hypothesis_id               text        NOT NULL,
+    statement                   text        NOT NULL,
+    outcome                     text        NOT NULL CHECK (
+        outcome IN ('proven', 'disproven', 'inconclusive', 'handed_off', 'false_positive')
+    ),
+    -- Reaches no ranking function: confident-sounding model text must not move a
+    -- priority (ADR 0015). Carried for a human reading the run back.
+    rationale                   text        NOT NULL,
+    -- The entities the Hypothesis named, typically one to three -- not the 38 to
+    -- 76 its evidence touched, which stay reachable through Sightings (ADR 0016).
+    -- Empty is legitimate: "is there any lateral movement at all" names none, and
+    -- such a Verdict is written and reachable only by narrative recall.
+    subject_entities            text[]      NOT NULL DEFAULT ARRAY[]::text[],
+    attacker_influenceable_only boolean     NOT NULL,
+    -- Who concluded, as distinct from what the source is.
+    trust                       text        NOT NULL CHECK (trust IN ('analyst', 'agent')),
+    first_seen                  timestamptz NOT NULL,
+    last_seen                   timestamptz NOT NULL,
+    -- A retrospective sweep over old archives asserts its window rather than
+    -- observing it, and ranking discounts the weaker one.
+    window_source               text        NOT NULL CHECK (window_source IN ('observed', 'asserted')),
+    concluded_at                timestamptz NOT NULL,
+
+    CONSTRAINT episodic_verdicts_unique
+        UNIQUE (investigation_kind, investigation_id, hypothesis_id),
+    CONSTRAINT episodic_verdicts_window CHECK (first_seen <= last_seen)
+);
+
+-- Recall joins Verdicts on the subject array rather than on a key column.
+CREATE INDEX IF NOT EXISTS idx_episodic_verdicts_subjects
+    ON episodic_verdicts USING GIN (subject_entities);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_verdicts_recall
+    ON episodic_verdicts (concluded_at DESC, id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_verdicts_investigation
+    ON episodic_verdicts (investigation_kind, investigation_id);
+
+COMMENT ON TABLE episodic_verdicts IS
+    'One conclusion per Hypothesis, naming its subject entities and not its evidence''s.';
+
+-- One row per Verdict and source, carrying direction. Replaces a flat
+-- corroborated list, which cannot say that a source argued against the claim.
+CREATE TABLE IF NOT EXISTS episodic_verdict_sources (
+    id            bigserial PRIMARY KEY,
+    verdict_id    bigint    NOT NULL REFERENCES episodic_verdicts (id) ON DELETE CASCADE,
+    source_system text      NOT NULL,
+    stance        text      NOT NULL CHECK (stance IN ('supports', 'weakens', 'neither')),
+    -- Stamped at write time and never joined at read time: an integration
+    -- removed or recategorised later must not retroactively change how a past
+    -- Verdict was corroborated. `not_evidence` here is a defect rather than a
+    -- weak row, and is representable so that it is visible.
+    source_tier   text      NOT NULL CHECK (source_tier IN ('telemetry', 'feed', 'not_evidence')),
+
+    CONSTRAINT episodic_verdict_sources_unique UNIQUE (verdict_id, source_system)
+);
+
+COMMENT ON TABLE episodic_verdict_sources IS
+    'Per-source Stance and stamped Source Tier for one Verdict; the tier is a fact of write time.';
+
+-- Questions an investigation never gathered evidence for. No activity window,
+-- which is the reason these are not Verdict rows with an empty outcome.
+CREATE TABLE IF NOT EXISTS episodic_gaps (
+    id                 bigserial   PRIMARY KEY,
+    investigation_kind text        NOT NULL CHECK (investigation_kind IN ('hunt', 'case', 'analyst')),
+    investigation_id   text        NOT NULL,
+    hypothesis_id      text        NOT NULL,
+    statement          text        NOT NULL,
+    disposition        text        NOT NULL CHECK (
+        disposition IN ('deprioritised', 'no_evidence_gathered', 'budget_exhausted')
+    ),
+    reason             text        NOT NULL,
+    subject_entities   text[]      NOT NULL DEFAULT ARRAY[]::text[],
+    concluded_at       timestamptz NOT NULL,
+
+    CONSTRAINT episodic_gaps_unique
+        UNIQUE (investigation_kind, investigation_id, hypothesis_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_gaps_subjects
+    ON episodic_gaps USING GIN (subject_entities);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_gaps_recall
+    ON episodic_gaps (concluded_at DESC, id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_gaps_investigation
+    ON episodic_gaps (investigation_kind, investigation_id);
+
+COMMENT ON TABLE episodic_gaps IS
+    'A question an investigation left unanswered, with why nothing was gathered for it.';
+
+-- The only record that an investigation was processed. Deliberately not derived
+-- from the presence of rows: an investigation that concluded nothing writes no
+-- Sightings, no Verdicts and no Gaps, and is still done.
+CREATE TABLE IF NOT EXISTS episodic_distil_markers (
+    investigation_kind text        NOT NULL CHECK (investigation_kind IN ('hunt', 'case', 'analyst')),
+    investigation_id   text        NOT NULL,
+    -- Where it came from, so a marker can be traced back to a ledger.
+    origin_run_id      uuid        NOT NULL,
+    -- The seq of the terminal this was derived from. A hunt that resumed past
+    -- its own terminal appends a second one to the same run, and comparing seq
+    -- is what makes the later conclusions re-derive instead of being skipped as
+    -- a run already seen.
+    origin_seq         integer     NOT NULL,
+    -- Bumped when the mapping changes. Re-deriving is delete-then-insert, so a
+    -- bump that now yields fewer rows leaves none of the old ones behind.
+    distil_version     integer     NOT NULL,
+    -- Set, never incremented: a count that drifts from its rows is worse than no
+    -- count, because it reads as authoritative.
+    sightings_written  integer     NOT NULL CHECK (sightings_written >= 0),
+    verdicts_written   integer     NOT NULL CHECK (verdicts_written >= 0),
+    gaps_written       integer     NOT NULL CHECK (gaps_written >= 0),
+    concluded_at       timestamptz NOT NULL,
+    distilled_at       timestamptz NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (investigation_kind, investigation_id)
+);
+
+-- The Distil's poll: which terminals have no marker at the current version.
+CREATE INDEX IF NOT EXISTS idx_episodic_markers_origin
+    ON episodic_distil_markers (origin_run_id);
+
+COMMENT ON TABLE episodic_distil_markers IS
+    'One row per distilled investigation, written in the same transaction as its rows.';

--- a/infra/helm/vigil/files/database-init/22_episodic_memory.sql
+++ b/infra/helm/vigil/files/database-init/22_episodic_memory.sql
@@ -1,0 +1,200 @@
+-- Episodic memory: what investigations saw and what they concluded, joined on
+-- entity keys. Written by the Distil (core/memory/distil.py), read by recall.
+--
+-- Everything is keyed by investigation_kind + investigation_id and never by
+-- run_id: a run-keyed schema cannot represent the Case-authored Verdicts that
+-- follow, which have a Case behind them and no run at all.
+--
+-- No column is nullable. An empty list means known-to-be-none, and there is no
+-- unknown state to represent -- a row nobody can read as "we did not record
+-- this" is a row nobody has to guess about.
+
+-- The vocabularies are spelled as CHECK constraints rather than as enum types:
+-- altering an enum takes a lock this schema does not need, and every other table
+-- in this directory states its domains the same way. This file is where they are
+-- enforced; core/memory/recall_contract.py is where they are declared for the
+-- code that writes them, and a value added there must be added here too.
+
+-- What an investigation observed. One row per entity, investigation and source,
+-- so growth tracks investigations and not telemetry volume: a hunt that saw one
+-- address ten thousand times in one system writes one row with a hit count.
+CREATE TABLE IF NOT EXISTS episodic_sightings (
+    id                     bigserial   PRIMARY KEY,
+    -- `type:value`, normalised by Python. Only Python writes an Entity Key; the
+    -- harness's extractor output arrives as candidate type and value.
+    entity_key             text        NOT NULL,
+    investigation_kind     text        NOT NULL CHECK (investigation_kind IN ('hunt', 'case', 'analyst')),
+    investigation_id       text        NOT NULL,
+    -- Memory's own column, not a foreign key into either producer: a hunt fills
+    -- it from the Ledger's source_system, a Case from its Findings' data_source.
+    source_system          text        NOT NULL,
+    hit_count              integer     NOT NULL CHECK (hit_count > 0),
+    -- Aggregated over the group: one record an adversary could have authored is
+    -- enough to say so of the group.
+    attacker_influenceable boolean     NOT NULL,
+    -- Both ends inclusive, and observed rather than asserted -- a Sighting that
+    -- did not observe its window is not a Sighting.
+    first_seen             timestamptz NOT NULL,
+    last_seen              timestamptz NOT NULL,
+    -- When the investigation concluded, not when the row was written. The Distil
+    -- polls, so an investigation that ended Monday can be written Wednesday
+    -- carrying Monday's date.
+    concluded_at           timestamptz NOT NULL,
+
+    CONSTRAINT episodic_sightings_unique
+        UNIQUE (entity_key, investigation_kind, investigation_id, source_system),
+    CONSTRAINT episodic_sightings_window CHECK (first_seen <= last_seen)
+);
+
+-- The recall join, and the order it reads in. Ties break on the primary key
+-- because a LIMIT over a partial order lets Postgres return a different set on
+-- identical data, which surfaces as a replay diff rather than as an error.
+CREATE INDEX IF NOT EXISTS idx_episodic_sightings_recall
+    ON episodic_sightings (entity_key, concluded_at DESC, id ASC);
+
+-- The Distil's own delete, which is scoped to one investigation.
+CREATE INDEX IF NOT EXISTS idx_episodic_sightings_investigation
+    ON episodic_sightings (investigation_kind, investigation_id);
+
+COMMENT ON TABLE episodic_sightings IS
+    'What an investigation observed: one row per entity, investigation and source, never per evidence record.';
+
+-- What an investigation concluded, one row per Hypothesis.
+CREATE TABLE IF NOT EXISTS episodic_verdicts (
+    id                          bigserial   PRIMARY KEY,
+    investigation_kind          text        NOT NULL CHECK (investigation_kind IN ('hunt', 'case', 'analyst')),
+    investigation_id            text        NOT NULL,
+    -- Stable, because the prose gets re-worded. A Case's is its case id.
+    hypothesis_id               text        NOT NULL,
+    statement                   text        NOT NULL,
+    outcome                     text        NOT NULL CHECK (
+        outcome IN ('proven', 'disproven', 'inconclusive', 'handed_off', 'false_positive')
+    ),
+    -- Reaches no ranking function: confident-sounding model text must not move a
+    -- priority (ADR 0015). Carried for a human reading the run back.
+    rationale                   text        NOT NULL,
+    -- The entities the Hypothesis named, typically one to three -- not the 38 to
+    -- 76 its evidence touched, which stay reachable through Sightings (ADR 0016).
+    -- Empty is legitimate: "is there any lateral movement at all" names none, and
+    -- such a Verdict is written and reachable only by narrative recall.
+    subject_entities            text[]      NOT NULL DEFAULT ARRAY[]::text[],
+    attacker_influenceable_only boolean     NOT NULL,
+    -- Who concluded, as distinct from what the source is.
+    trust                       text        NOT NULL CHECK (trust IN ('analyst', 'agent')),
+    first_seen                  timestamptz NOT NULL,
+    last_seen                   timestamptz NOT NULL,
+    -- A retrospective sweep over old archives asserts its window rather than
+    -- observing it, and ranking discounts the weaker one.
+    window_source               text        NOT NULL CHECK (window_source IN ('observed', 'asserted')),
+    concluded_at                timestamptz NOT NULL,
+
+    CONSTRAINT episodic_verdicts_unique
+        UNIQUE (investigation_kind, investigation_id, hypothesis_id),
+    CONSTRAINT episodic_verdicts_window CHECK (first_seen <= last_seen)
+);
+
+-- Recall joins Verdicts on the subject array rather than on a key column.
+CREATE INDEX IF NOT EXISTS idx_episodic_verdicts_subjects
+    ON episodic_verdicts USING GIN (subject_entities);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_verdicts_recall
+    ON episodic_verdicts (concluded_at DESC, id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_verdicts_investigation
+    ON episodic_verdicts (investigation_kind, investigation_id);
+
+COMMENT ON TABLE episodic_verdicts IS
+    'One conclusion per Hypothesis, naming its subject entities and not its evidence''s.';
+
+-- One row per Verdict and source, carrying direction. Replaces a flat
+-- corroborated list, which cannot say that a source argued against the claim.
+CREATE TABLE IF NOT EXISTS episodic_verdict_sources (
+    id            bigserial PRIMARY KEY,
+    verdict_id    bigint    NOT NULL REFERENCES episodic_verdicts (id) ON DELETE CASCADE,
+    source_system text      NOT NULL,
+    stance        text      NOT NULL CHECK (stance IN ('supports', 'weakens', 'neither')),
+    -- Stamped at write time and never joined at read time: an integration
+    -- removed or recategorised later must not retroactively change how a past
+    -- Verdict was corroborated. The harness's own records never reach here --
+    -- the fold drops them before a stance is taken -- so `not_evidence` is a
+    -- fail-closed guard against a source the tier map regrades later, and is
+    -- representable so that such a row is visible rather than silently absent.
+    source_tier   text      NOT NULL CHECK (source_tier IN ('telemetry', 'feed', 'not_evidence')),
+
+    CONSTRAINT episodic_verdict_sources_unique UNIQUE (verdict_id, source_system)
+);
+
+COMMENT ON TABLE episodic_verdict_sources IS
+    'Per-source Stance and stamped Source Tier for one Verdict; the tier is a fact of write time.';
+
+-- Questions an investigation never gathered evidence for. No activity window,
+-- which is the reason these are not Verdict rows with an empty outcome.
+CREATE TABLE IF NOT EXISTS episodic_gaps (
+    id                 bigserial   PRIMARY KEY,
+    investigation_kind text        NOT NULL CHECK (investigation_kind IN ('hunt', 'case', 'analyst')),
+    investigation_id   text        NOT NULL,
+    hypothesis_id      text        NOT NULL,
+    statement          text        NOT NULL,
+    disposition        text        NOT NULL CHECK (
+        disposition IN ('deprioritised', 'no_evidence_gathered', 'budget_exhausted')
+    ),
+    reason             text        NOT NULL,
+    subject_entities   text[]      NOT NULL DEFAULT ARRAY[]::text[],
+    concluded_at       timestamptz NOT NULL,
+
+    CONSTRAINT episodic_gaps_unique
+        UNIQUE (investigation_kind, investigation_id, hypothesis_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_gaps_subjects
+    ON episodic_gaps USING GIN (subject_entities);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_gaps_recall
+    ON episodic_gaps (concluded_at DESC, id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_gaps_investigation
+    ON episodic_gaps (investigation_kind, investigation_id);
+
+COMMENT ON TABLE episodic_gaps IS
+    'A question an investigation left unanswered, with why nothing was gathered for it.';
+
+-- The only record that an investigation was processed. Deliberately not derived
+-- from the presence of rows: an investigation that concluded nothing writes no
+-- Sightings, no Verdicts and no Gaps, and is still done.
+CREATE TABLE IF NOT EXISTS episodic_distil_markers (
+    investigation_kind text        NOT NULL CHECK (investigation_kind IN ('hunt', 'case', 'analyst')),
+    investigation_id   text        NOT NULL,
+    -- The terminal these rows were derived from, so a marker can be traced back
+    -- to a ledger.
+    origin_run_id      uuid        NOT NULL,
+    -- The seq of that terminal. A hunt that resumed past its own terminal
+    -- appends a second one to the same run, and comparing seq is what makes the
+    -- later conclusions re-derive instead of being skipped as a run already seen.
+    origin_seq         integer     NOT NULL,
+    -- Every run this investigation has been distilled from, origin_run_id
+    -- included. One investigation can span more than one run -- a resumed hunt
+    -- is the case the rest of this schema is keyed for -- and the poll has only
+    -- run ids to work with, because agent_events carries no investigation id.
+    -- Without this, each run of one investigation misses the other's marker and
+    -- both re-distil on every tick forever.
+    origin_run_ids     uuid[]      NOT NULL DEFAULT ARRAY[]::uuid[],
+    -- Bumped when the mapping changes. Re-deriving is delete-then-insert, so a
+    -- bump that now yields fewer rows leaves none of the old ones behind.
+    distil_version     integer     NOT NULL,
+    -- Set, never incremented: a count that drifts from its rows is worse than no
+    -- count, because it reads as authoritative.
+    sightings_written  integer     NOT NULL CHECK (sightings_written >= 0),
+    verdicts_written   integer     NOT NULL CHECK (verdicts_written >= 0),
+    gaps_written       integer     NOT NULL CHECK (gaps_written >= 0),
+    concluded_at       timestamptz NOT NULL,
+    distilled_at       timestamptz NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (investigation_kind, investigation_id)
+);
+
+-- The Distil's poll: which terminals no marker at the current version covers.
+CREATE INDEX IF NOT EXISTS idx_episodic_markers_origin
+    ON episodic_distil_markers USING GIN (origin_run_ids);
+
+COMMENT ON TABLE episodic_distil_markers IS
+    'One row per distilled investigation, written in the same transaction as its rows.';

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -408,6 +408,7 @@ dbInit:
     - 19_agent_ledger.sql
     - 20_agent_directives.sql
     - 21_agent_run_leases.sql
+    - 22_episodic_memory.sql
   resources:
     requests:
       cpu: 50m

--- a/services/agent/arch/registry.ts
+++ b/services/agent/arch/registry.ts
@@ -3,6 +3,7 @@ import type { AgentEvent, RunKind } from "../contracts/events.js";
 import type { Notes } from "../core/memory.js";
 import type { State } from "../core/seams.js";
 import { SpecError, type Owned } from "../core/spec.js";
+import { huntDistil } from "../workflows/hunt/distil.js";
 import type { HuntKinds } from "../workflows/hunt/ledger.js";
 import { huntProjection } from "../workflows/hunt/projection.js";
 import { huntNotes } from "../workflows/hunt/recall.js";
@@ -27,6 +28,10 @@ export interface ArchEntry {
   // What a reader outside this process is told about a run of this kind. Absent
   // means there is nothing to report but the terminal the ledger already carries.
   projection?: (runId: string, events: readonly AgentEvent<Record<never, never>>[]) => unknown;
+  // What episodic memory is told about a finished run of this kind; the fold
+  // itself says why it is not the projection. Absent means a run of this kind is
+  // not distilled, which is the honest default rather than empty rows.
+  distil?: (runId: string, events: readonly AgentEvent<Record<never, never>>[]) => unknown;
 }
 
 const REGISTERED: Partial<Record<RunKind, ArchEntry>> = {
@@ -40,6 +45,7 @@ const REGISTERED: Partial<Record<RunKind, ArchEntry>> = {
     // kind, the same trade the worker makes when it hands a ledger to a workflow.
     notes: (state, runId) => huntNotes(state as unknown as State<HuntKinds>, runId),
     projection: (runId, events) => huntProjection(runId, events as readonly AgentEvent<HuntKinds>[]),
+    distil: (runId, events) => huntDistil(runId, events as readonly AgentEvent<HuntKinds>[]),
   },
   investigate: {
     arch: packaged("investigate.yaml"),

--- a/services/agent/serve.ts
+++ b/services/agent/serve.ts
@@ -16,6 +16,8 @@ import { harnessFor, type HarnessFactory } from "./harness.js";
 const CHAT = "/chat/stream";
 // GET /runs/<id>/projection -- what a supervisor outside this process reads.
 const PROJECTION = /^\/runs\/([0-9a-fA-F-]{36})\/projection$/;
+// GET /runs/<id>/distil -- what episodic memory reads once the run has ended.
+const DISTIL = /^\/runs\/([0-9a-fA-F-]{36})\/distil$/;
 // A conversation is prose and a config, not an upload. Anything larger is a
 // mistake or an attack, and either way it is refused before it is parsed.
 const MAX_BODY = 1_000_000;
@@ -118,22 +120,26 @@ function refuse(res: ServerResponse, status: number, detail: string): void {
   res.end(JSON.stringify({ detail }));
 }
 
-// A run folded by the workflow that owns it. The events stay ours: a supervisor
-// reads what the run decided, never how it was written down.
-export async function projectionOf(state: State, runId: string): Promise<unknown | null> {
+// A run folded by the workflow that owns it. The events stay ours: a reader gets
+// what the run decided or what it saw, never how either was written down.
+async function foldedBy(state: State, runId: string, view: "projection" | "distil"): Promise<unknown | null> {
   const events = await state.read(runId);
   const opened = events[0];
   if (opened === undefined || !registeredKinds().includes(opened.run_kind)) return null;
 
-  const project = archFor(opened.run_kind).projection;
+  const project = archFor(opened.run_kind)[view];
   return project === undefined ? null : project(runId, events);
 }
 
-async function readProjection(state: State, runId: string, res: ServerResponse): Promise<void> {
-  const projection = await projectionOf(state, runId);
-  if (projection === null) return refuse(res, 404, `no readable run: ${runId}`);
+export async function projectionOf(state: State, runId: string): Promise<unknown | null> {
+  return foldedBy(state, runId, "projection");
+}
+
+async function readFold(state: State, runId: string, view: "projection" | "distil", res: ServerResponse): Promise<void> {
+  const folded = await foldedBy(state, runId, view);
+  if (folded === null) return refuse(res, 404, `no readable run: ${runId}`);
   res.writeHead(200, { "content-type": "application/json" });
-  res.end(JSON.stringify(projection));
+  res.end(JSON.stringify(folded));
 }
 
 async function openChat(state: State, req: IncomingMessage, res: ServerResponse, build: HarnessFactory): Promise<void> {
@@ -165,7 +171,10 @@ export function chatServer(state: State, ready: Ready, build: HarnessFactory = h
       if (req.method === "POST" && url === CHAT) return openChat(state, req, res, build);
 
       const run = req.method === "GET" ? PROJECTION.exec(url) : null;
-      if (run !== null) return readProjection(state, run[1] as string, res);
+      if (run !== null) return readFold(state, run[1] as string, "projection", res);
+
+      const distilled = req.method === "GET" ? DISTIL.exec(url) : null;
+      if (distilled !== null) return readFold(state, distilled[1] as string, "distil", res);
 
       return refuse(res, 404, `no such route: ${req.method} ${url}`);
     })();

--- a/services/agent/serve.ts
+++ b/services/agent/serve.ts
@@ -131,10 +131,6 @@ async function foldedBy(state: State, runId: string, view: "projection" | "disti
   return project === undefined ? null : project(runId, events);
 }
 
-export async function projectionOf(state: State, runId: string): Promise<unknown | null> {
-  return foldedBy(state, runId, "projection");
-}
-
 async function readFold(state: State, runId: string, view: "projection" | "distil", res: ServerResponse): Promise<void> {
   const folded = await foldedBy(state, runId, view);
   if (folded === null) return refuse(res, 404, `no readable run: ${runId}`);

--- a/services/agent/workflows/hunt/distil.ts
+++ b/services/agent/workflows/hunt/distil.ts
@@ -1,7 +1,7 @@
 import { fromText } from "./entities.js";
 import { fold, type HuntEvent, type Projection } from "./ledger.js";
 import { evidenceStrength, isGap, NULL_CHECK_PROVENANCE } from "./strength.js";
-import type { Entity, EvidenceRecord, HuntOutcome, HuntStatus, HypothesisStatus, LinkRelation } from "./types.js";
+import type { Entity, EvidenceRecord, HuntOutcome, HypothesisStatus, LinkRelation } from "./types.js";
 
 // What the Distil (#731) is told about a finished hunt, folded here because the
 // fold is this side's. The projection cannot serve it: a supervisor is told how
@@ -73,8 +73,6 @@ export interface DistilConclusion {
   // False when the window fell back to the hunt's own dates because nothing was
   // linked. Ranking discounts an asserted window against an observed one.
   window_observed: boolean;
-  // Empty rather than null: a hypothesis nobody escalated is known-to-be-none.
-  handed_off_case_id: string;
 }
 
 export interface DistilPayload {
@@ -82,8 +80,6 @@ export interface DistilPayload {
   // The hunt, not the run. A run-keyed schema cannot represent the Case-authored
   // Verdicts that follow, and a resumed hunt is one investigation across two runs.
   investigation_id: string;
-  run_id: string;
-  status: HuntStatus;
   // The hunt's own outcome, which the terminal event does not carry: `outcomeOf`
   // narrows it to the domain-free RunOutcome set on the way out, so `aborted`,
   // `budget_terminated` and `data_starved` are distinguishable only here.
@@ -149,24 +145,25 @@ function conclusionsIn(projection: Projection): DistilConclusion[] {
         return record === undefined ? [] : [{ relation: link.relation, record }];
       });
 
+    // Over what was gathered, and nothing else. A dispatcher's failed query, an
+    // operator's declared blind spot and the critic's benign case are the harness
+    // talking, and citing one as corroboration is the rulebook-as-observation
+    // defect the Source Tier map exists to catch. Filtered here rather than
+    // graded `not_evidence` downstream, so it cannot reach a Verdict at all.
+    const gathered = linked.filter(({ record }) => observed(record));
+
     const stances = new Map<string, LinkRelation>();
-    for (const { relation, record } of linked) {
+    for (const { relation, record } of gathered) {
       const held = stances.get(record.source_system);
       if (held === undefined || PRECEDENCE[relation] > PRECEDENCE[held]) {
         stances.set(record.source_system, relation);
       }
     }
 
-    // Over what was gathered, so a gap record's capture time never stands in for
-    // having seen something.
-    const times = linked
-      .filter(({ record }) => observed(record))
-      .map(({ record }) => record.captured_at)
-      .sort();
+    // A gap record's capture time never stands in for having seen something.
+    const times = gathered.map(({ record }) => record.captured_at).sort();
     const first = times[0];
     const last = times[times.length - 1];
-    const handoff = projection.handoffs.find((each) => each.hypothesis_id === hypothesis.hypothesis_id);
-
     return {
       hypothesis_id: hypothesis.hypothesis_id,
       statement: hypothesis.statement,
@@ -181,19 +178,16 @@ function conclusionsIn(projection: Projection): DistilConclusion[] {
       first_seen: first ?? hunt.created_at,
       last_seen: last ?? hunt.terminated_at ?? hunt.created_at,
       window_observed: first !== undefined,
-      handed_off_case_id: handoff?.case_id ?? "",
     };
   });
 }
 
-export function huntDistil(runId: string, events: readonly HuntEvent[]): DistilPayload {
+export function huntDistil(_runId: string, events: readonly HuntEvent[]): DistilPayload {
   const projection = fold(events);
 
   return {
     investigation_kind: "hunt",
     investigation_id: projection.hunt.hunt_id,
-    run_id: runId,
-    status: projection.hunt.status,
     outcome: projection.hunt.outcome,
     concluded_at: projection.hunt.terminated_at ?? "",
     distil_schema_version: DISTIL_SCHEMA_VERSION,

--- a/services/agent/workflows/hunt/distil.ts
+++ b/services/agent/workflows/hunt/distil.ts
@@ -1,0 +1,203 @@
+import { fromText } from "./entities.js";
+import { fold, type HuntEvent, type Projection } from "./ledger.js";
+import { evidenceStrength, isGap, NULL_CHECK_PROVENANCE } from "./strength.js";
+import type { Entity, EvidenceRecord, HuntOutcome, HuntStatus, HypothesisStatus, LinkRelation } from "./types.js";
+
+// What the Distil (#731) is told about a finished hunt, folded here because the
+// fold is this side's. The projection cannot serve it: a supervisor is told how
+// each belief stands and how many records were gathered, never which entities
+// they touched or which system produced them, and Sightings are exactly those.
+// Re-folding the ledger in Python would be the second implementation that drifts
+// while only one is gated, so the fields are asked for here instead.
+//
+// Facts, not rows. The status-to-row mapping, the Entity Keys and the Source
+// Tiers are the Python domain's; this bumps when what this side *can* say changes.
+export const DISTIL_SCHEMA_VERSION = 1;
+
+// A record the hunt gathered, as opposed to one it wrote to itself. The three
+// excluded provenances are the harness talking: `dispatcher` when a query could
+// not run, `operator` when a human declared a blind spot, `critic` when it argued
+// the benign case. Python's tier map independently grades all three
+// `not_evidence`, so a record that slips this filter is visible rather than
+// silently counted as an observation.
+function observed(record: EvidenceRecord): boolean {
+  return !isGap(record) && record.provenance !== NULL_CHECK_PROVENANCE;
+}
+
+function dedupe(entities: readonly Entity[]): Entity[] {
+  const seen = new Map<string, Entity>();
+  for (const entity of entities) seen.set(`${entity.type}:${entity.value}`, entity);
+  return [...seen.values()];
+}
+
+// Candidate data, deliberately. Only Python writes an Entity Key, so the type and
+// the value travel separately and this extractor's output is never a stored key.
+export interface DistilSighting {
+  entity: Entity;
+  source_system: string;
+  hit_count: number;
+  // Aggregated over the group: one record an adversary could have authored is
+  // enough to say so of the group, which is the fail-closed direction.
+  attacker_influenceable: boolean;
+  first_seen: string;
+  last_seen: string;
+}
+
+export interface DistilSource {
+  source_system: string;
+  // `weakens` beats `supports` beats `neither` where one system did both. A
+  // source that ever argued against the claim is not a clean corroborator, and
+  // collapsing the other way would let a corroboration count include it.
+  stance: LinkRelation;
+}
+
+// One per Hypothesis, before the status map decides whether it becomes a Verdict
+// or a Declared Gap. That decision needs the schema and belongs beside it.
+export interface DistilConclusion {
+  hypothesis_id: string;
+  statement: string;
+  status: HypothesisStatus;
+  // The harness's own words for why it landed here. Reaches no ranking function
+  // (ADR 0015); carried for a human reading the run back.
+  rationale: string;
+  // Drawn from the statement, not from the evidence: a hypothesis touches forty
+  // to seventy entities and is about one to three of them (ADR 0016).
+  subject_entities: Entity[];
+  // Linked observations. The status map reads it as "was evidence gathered",
+  // which separates an inconclusive that looked from one that never did.
+  evidence_count: number;
+  attacker_influenceable_only: boolean;
+  sources: DistilSource[];
+  first_seen: string;
+  last_seen: string;
+  // False when the window fell back to the hunt's own dates because nothing was
+  // linked. Ranking discounts an asserted window against an observed one.
+  window_observed: boolean;
+  // Empty rather than null: a hypothesis nobody escalated is known-to-be-none.
+  handed_off_case_id: string;
+}
+
+export interface DistilPayload {
+  investigation_kind: "hunt";
+  // The hunt, not the run. A run-keyed schema cannot represent the Case-authored
+  // Verdicts that follow, and a resumed hunt is one investigation across two runs.
+  investigation_id: string;
+  run_id: string;
+  status: HuntStatus;
+  // The hunt's own outcome, which the terminal event does not carry: `outcomeOf`
+  // narrows it to the domain-free RunOutcome set on the way out, so `aborted`,
+  // `budget_terminated` and `data_starved` are distinguishable only here.
+  outcome: HuntOutcome | null;
+  // When the hunt ended. Empty while it has not, which the Distil refuses.
+  concluded_at: string;
+  distil_schema_version: number;
+  sightings: DistilSighting[];
+  conclusions: DistilConclusion[];
+}
+
+interface Group {
+  entity: Entity;
+  source_system: string;
+  hit_count: number;
+  attacker_influenceable: boolean;
+  first_seen: string;
+  last_seen: string;
+}
+
+// One row per entity, investigation and source, so growth tracks hunts and not
+// telemetry volume. A record naming the same entity twice counts once: the hit
+// count means records, and the extractor already deduped within one of them.
+function sightingsIn(projection: Projection): DistilSighting[] {
+  const groups = new Map<string, Group>();
+
+  for (const record of projection.evidence.values()) {
+    if (!observed(record)) continue;
+    for (const entity of dedupe(record.entities)) {
+      const id = `${entity.type}:${entity.value} ${record.source_system}`;
+      const group = groups.get(id);
+      if (group === undefined) {
+        groups.set(id, {
+          entity,
+          source_system: record.source_system,
+          hit_count: 1,
+          attacker_influenceable: record.attacker_influenceable,
+          first_seen: record.captured_at,
+          last_seen: record.captured_at,
+        });
+        continue;
+      }
+      group.hit_count += 1;
+      group.attacker_influenceable ||= record.attacker_influenceable;
+      if (record.captured_at < group.first_seen) group.first_seen = record.captured_at;
+      if (record.captured_at > group.last_seen) group.last_seen = record.captured_at;
+    }
+  }
+
+  return [...groups.values()];
+}
+
+const PRECEDENCE: Record<LinkRelation, number> = { neither: 0, supports: 1, weakens: 2 };
+
+function conclusionsIn(projection: Projection): DistilConclusion[] {
+  const hunt = projection.hunt;
+
+  return [...projection.hypotheses.values()].map((hypothesis) => {
+    const linked = projection.links
+      .filter((link) => link.hypothesis_id === hypothesis.hypothesis_id)
+      .flatMap((link) => {
+        const record = projection.evidence.get(link.evidence_id);
+        return record === undefined ? [] : [{ relation: link.relation, record }];
+      });
+
+    const stances = new Map<string, LinkRelation>();
+    for (const { relation, record } of linked) {
+      const held = stances.get(record.source_system);
+      if (held === undefined || PRECEDENCE[relation] > PRECEDENCE[held]) {
+        stances.set(record.source_system, relation);
+      }
+    }
+
+    // Over what was gathered, so a gap record's capture time never stands in for
+    // having seen something.
+    const times = linked
+      .filter(({ record }) => observed(record))
+      .map(({ record }) => record.captured_at)
+      .sort();
+    const first = times[0];
+    const last = times[times.length - 1];
+    const handoff = projection.handoffs.find((each) => each.hypothesis_id === hypothesis.hypothesis_id);
+
+    return {
+      hypothesis_id: hypothesis.hypothesis_id,
+      statement: hypothesis.statement,
+      status: hypothesis.status,
+      rationale: hypothesis.resolution_reason ?? "",
+      subject_entities: dedupe(fromText(hypothesis.statement)),
+      evidence_count: times.length,
+      attacker_influenceable_only: evidenceStrength(projection, hypothesis.hypothesis_id).attacker_influenceable_only,
+      sources: [...stances].map(([source_system, stance]) => ({ source_system, stance })),
+      // A hypothesis that concluded on nothing gathered still has a window, and
+      // saying which dates those are is the honest version of leaving it null.
+      first_seen: first ?? hunt.created_at,
+      last_seen: last ?? hunt.terminated_at ?? hunt.created_at,
+      window_observed: first !== undefined,
+      handed_off_case_id: handoff?.case_id ?? "",
+    };
+  });
+}
+
+export function huntDistil(runId: string, events: readonly HuntEvent[]): DistilPayload {
+  const projection = fold(events);
+
+  return {
+    investigation_kind: "hunt",
+    investigation_id: projection.hunt.hunt_id,
+    run_id: runId,
+    status: projection.hunt.status,
+    outcome: projection.hunt.outcome,
+    concluded_at: projection.hunt.terminated_at ?? "",
+    distil_schema_version: DISTIL_SCHEMA_VERSION,
+    sightings: sightingsIn(projection),
+    conclusions: conclusionsIn(projection),
+  };
+}

--- a/services/daemon/orchestrator.py
+++ b/services/daemon/orchestrator.py
@@ -784,6 +784,19 @@ class Orchestrator:
                         written["verdicts"],
                         written["gaps"],
                     )
+                # Surfaced here and not only where they happened: one refusal in
+                # a log is a line nobody reads, and a tick that wrote nothing
+                # because everything failed must not look like a tick with
+                # nothing to do.
+                if written["refused"] or written["unreadable"] or written["failed"]:
+                    logger.warning(
+                        "Distil left %s investigation(s) undistilled: "
+                        "%s refused, %s unreadable, %s failed",
+                        written["refused"] + written["unreadable"] + written["failed"],
+                        written["refused"],
+                        written["unreadable"],
+                        written["failed"],
+                    )
 
             except asyncio.CancelledError:
                 break

--- a/services/daemon/orchestrator.py
+++ b/services/daemon/orchestrator.py
@@ -187,6 +187,7 @@ class Orchestrator:
                 asyncio.create_task(self._intake_loop(shutdown_event)),
                 asyncio.create_task(self._supervision_loop(shutdown_event)),
                 asyncio.create_task(self._review_loop(shutdown_event)),
+                asyncio.create_task(self._distil_loop(shutdown_event)),
             ]
 
             while not shutdown_event.is_set() and self._enabled:
@@ -756,6 +757,42 @@ class Orchestrator:
                 break
             except Exception as e:
                 logger.error(f"Review loop error: {e}", exc_info=True)
+
+            await self._sleep(shutdown_event, self.config.loop_interval)
+
+    # Its own loop rather than a step of the supervision one: the Distil is not
+    # supervising anything, it reads terminals the supervisor has already left
+    # behind. Slower than the others because nothing waits on it — memory is read
+    # at the start of the next run, so a write that lands minutes later is a
+    # write that lands in time.
+    async def _distil_loop(self, shutdown_event: asyncio.Event):
+        """Turn finished hunts into episodic memory (#731)."""
+        from core.memory.distil import distil_once
+
+        while not shutdown_event.is_set():
+            try:
+                if not self._enabled:
+                    await self._sleep(shutdown_event, 10)
+                    continue
+
+                written = await distil_once()
+                if written["investigations"]:
+                    logger.info(
+                        "Distilled %s investigation(s): %s sightings, %s verdicts, %s gaps",
+                        written["investigations"],
+                        written["sightings"],
+                        written["verdicts"],
+                        written["gaps"],
+                    )
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                # Logged and retried rather than swallowed into a quiet stop: a
+                # Distil that dies silently is a memory that reads as empty
+                # rather than as broken, and empty is what an entity nobody has
+                # looked at also reads as.
+                logger.error(f"Distil loop error: {e}", exc_info=True)
 
             await self._sleep(shutdown_event, self.config.loop_interval)
 


### PR DESCRIPTION
The episodic tables, and a finished hunt turning into rows in them.

A Python job polls the ledger for terminals with no distil marker, reads what the run saw and concluded, and writes Sightings, Verdicts, verdict sources and Declared Gaps. Poll over push: no change the agent layer has to make, a lost signal becomes a late write rather than a missing one, and backfill is the same code path exercised on every tick. Nothing waits on it, because memory is read at the *start* of the next run.

## The one deviation from the issue, and why

The issue says the Distil must not change the agent layer. It cannot be met that way. `GET /runs/<id>/projection` is the only Python-reachable read, and `HuntProjection` carries hypothesis standing, `evidence_count` and a `HuntReport` — never which entities the evidence touched, which system produced it, or when it was captured. Sightings and verdict sources are exactly those fields.

The issue's own rule settles it: *"A field the Distil needs and cannot find is a contract change to request, not something to reconstruct here."* So this adds a fold-owned distil payload beside the projection, served at `GET /runs/<id>/distil` and registered per run kind like the projection is. Re-folding `agent_events` in Python was the alternative, and it is the second implementation that drifts while only one is gated.

The split stays clean: the fold is TypeScript's, and the status mapping, the Entity Keys and the Source Tiers are Python's.

## What landed

| Piece | Where |
|---|---|
| Fold-owned distil payload | `services/agent/workflows/hunt/distil.ts` |
| Route + arch registration | `services/agent/serve.ts`, `services/agent/arch/registry.ts` |
| Five tables | `infra/database/init/22_episodic_memory.sql` + models |
| The job | `core/memory/distil.py` |
| Entity Key minting | `core/memory/entity_keys.py` |
| Poll wiring | `_distil_loop` in `services/daemon/orchestrator.py` |

Five tables, no nullable columns — an empty list means known-to-be-none. Everything is keyed by `investigation_kind` + `investigation_id`, never `run_id`.

The read log named in the epic is deliberately **not** here. It belongs with the reader that writes it (#732); shipping it now would be a table with no writer, which is the `shared_iocs` hole #730 exists to close.

Idempotency is delete-then-insert scoped to the investigation, in one transaction with the marker. The one upsert is the marker itself — a single row keyed by the investigation, so there is no set of stale rows to leave behind.

An aborted run writes no memory but does take a marker: a marker records that an investigation was *processed*, not that it was remembered, and without one the run is a candidate again on every tick forever.

## Acceptance criteria

Exercised against a scratch Postgres with the real DDL and the real functions.

| Criterion | |
|---|---|
| Terminal produces Sightings, Verdicts, sources and Gaps | ✅ |
| Sightings one row per entity, investigation and source, with count and window | ✅ |
| All six hypothesis statuses map, `handed_off` included | ✅ |
| A Verdict names only entities drawn from its Hypothesis statement | ✅ see below |
| Each source carries a Stance and a stamped Source Tier | ✅ |
| An aborted run writes nothing | ✅ no rows; marker only |
| A run that concluded nothing still writes a marker | ✅ |
| Running twice leaves the rows unchanged | ✅ |
| Re-deriving fewer rows leaves nothing stale | ✅ |
| A crash mid-write leaves neither rows nor marker | ✅ |

Also covered: a payload from a newer (or absent) schema version is refused rather than mapped optimistically; `budget_terminated` relabels an ungathered Gap; a second terminal on a resumed run re-derives via `origin_seq`.

## Known limitation, worth a decision before this is built on

ADR 0016 draws a Verdict's subjects from its Hypothesis statement, "typically one to three". Run over all ten committed hunt ledgers, that extraction yields **zero entities for all eighteen hypotheses**.

The statements are playbook templates written before the hunt looks — *"An internal host is beaconing to external infrastructure on a regular interval"*, *"A acme AWS identity is making API calls from infrastructure it has not used before"*. They name entity classes, never values.

So every Verdict is written with `subject_entities = []` and is unreachable through the exact-join tier, which is what ADR 0016 anticipates as the odd case but is here the only case. Sightings join normally, so nothing is lost from entity history — but "what did past runs conclude about this host" returns nothing until either the ADR or the statements change.

This implements the ADR as written rather than inventing a rule. `hunt.scope.entities` and `OpenQuestion.entity_key` both carry real values if subjects should draw on them instead; it is a one-line change in `conclusionsIn()`.

Secondary: the fixture ledgers' source systems (`net_flow`, `http`, `dns`, `win_events`, and worker role names like `threat_hunter`) are mostly absent from #728's hunt tier map, so they resolve to `feed` with a warning. #728's census was of live hunts; the committed fixtures disagree with it.

## Notes

No tests in this PR, per the usual preference here. The one gap worth knowing about: nothing currently ratchets the new distil payload the way `test_recall_contract_agrees.py` ratchets the recall contract, so `DISTIL_SCHEMA_VERSION` (TS) and `SUPPORTED_PAYLOAD_VERSION` (Python) can drift silently.

`#731` is currently closed as `not planned` and will need reopening.

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)
