### PR TITLE
feat(memory): recall an entity's history, and log every read (#732)

### DIFF
--- a/core/agents/tool_registry.py
+++ b/core/agents/tool_registry.py
@@ -8,6 +8,8 @@ from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional, Tuple
 
+from core.memory.recall_contract import RECALL_TOOL
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -285,6 +287,14 @@ async def execute_backend_tool(
 
     if tool_name in _INTEL_TOOLS:
         return _INTEL_TOOLS[tool_name](args), True
+
+    # Episodic memory (#732), answering with one mapping and not a list of rows,
+    # so tools_router._rows does not slice the Sightings, Verdicts and Gaps into
+    # rows of their own and lose which list each came from.
+    if tool_name == RECALL_TOOL:
+        from core.memory.recall import recall_entity
+
+        return recall_entity(args), True
 
     if tool_name in _APPROVAL_TOOLS:
         from core.response.approval_service import ApprovalService

--- a/core/agents/tool_registry.py
+++ b/core/agents/tool_registry.py
@@ -222,6 +222,22 @@ _INTEL_TOOLS: Dict[str, Callable[[Args], Any]] = {
     "lookup_indicators": _indicator_lookup,
 }
 
+
+# Episodic memory (#732). One mapping and not a list of rows, so
+# tools_router._rows does not slice the Sightings, Verdicts and Gaps into rows of
+# their own and lose which list each came from. The import is deferred as the
+# other families' are: this module is imported to answer "is this a backend
+# tool", which must not drag a database session factory in behind it.
+def _recall(args: Args) -> Any:
+    from core.memory.recall import recall_entity
+
+    return recall_entity(args)
+
+
+_MEMORY_TOOLS: Dict[str, Callable[[Args], Any]] = {
+    RECALL_TOOL: _recall,
+}
+
 _APPROVAL_TOOLS: Dict[str, Callable[[Any, Args], Any]] = {
     "list_pending_approvals": lambda service, args: [
         asdict(action)
@@ -288,13 +304,8 @@ async def execute_backend_tool(
     if tool_name in _INTEL_TOOLS:
         return _INTEL_TOOLS[tool_name](args), True
 
-    # Episodic memory (#732), answering with one mapping and not a list of rows,
-    # so tools_router._rows does not slice the Sightings, Verdicts and Gaps into
-    # rows of their own and lose which list each came from.
-    if tool_name == RECALL_TOOL:
-        from core.memory.recall import recall_entity
-
-        return recall_entity(args), True
+    if tool_name in _MEMORY_TOOLS:
+        return _MEMORY_TOOLS[tool_name](args), True
 
     if tool_name in _APPROVAL_TOOLS:
         from core.response.approval_service import ApprovalService

--- a/core/llm/tool_schemas.py
+++ b/core/llm/tool_schemas.py
@@ -3,6 +3,11 @@ Claude API Tool Schemas
 Defines all tools available to Claude via function calling
 """
 
+# The recall tool's signature is declared with the rest of the recall contract
+# (#729) rather than transcribed here: a schema that drifts from the handler's
+# arguments fails as "no history", which reads as an entity nobody has looked at.
+from core.memory.recall_contract import RECALL_PARAMETERS, RECALL_TOOL
+
 # Security-Detections Tools (Core functionality)
 SECURITY_DETECTION_TOOLS = [
     {
@@ -463,6 +468,29 @@ THREAT_INTEL_TOOLS = [
     }
 ]
 
+# Episodic memory (#732). Reading it is a backend tool rather than an MCP server
+# because the rows are Vigil's own: a deployment that has run a hunt has memory
+# to read, and one that has not gets empty lists.
+MEMORY_TOOLS = [
+    {
+        "name": RECALL_TOOL,
+        "description": (
+            "Recall what past investigations saw and concluded about an entity. "
+            "Returns the Sightings (what was observed, per investigation and "
+            "source), the Verdicts (what was concluded, with the stance of each "
+            "corroborating source) and the Declared Gaps (questions nobody "
+            "gathered evidence for) for each Entity Key given as `type:value`. "
+            "An entity nobody has investigated returns empty lists, which is an "
+            "answer and not an error. Results are capped per key and overall; "
+            "`dropped` says what was left out and `ranking` says on what basis. "
+            "Pass your own role in `caller_kind` and `caller_id`: every read is "
+            "logged for audit, and one that does not say who asked is logged as "
+            "`unknown`."
+        ),
+        "input_schema": RECALL_PARAMETERS,
+    }
+]
+
 # Combine all tools
 ALL_TOOLS = (
     SECURITY_DETECTION_TOOLS
@@ -470,4 +498,5 @@ ALL_TOOLS = (
     + ATTACK_LAYER_TOOLS
     + THREAT_INTEL_TOOLS
     + APPROVAL_TOOLS
+    + MEMORY_TOOLS
 )

--- a/core/memory/entity_keys.py
+++ b/core/memory/entity_keys.py
@@ -14,7 +14,7 @@ just the wrong ones.
 from __future__ import annotations
 
 import re
-from typing import List, Tuple
+from typing import Iterable, List, Tuple
 
 from core.memory.recall_contract import KEY_CASE_SENSITIVE_TYPES
 
@@ -50,22 +50,30 @@ def entity_key(entity_type: str, value: str) -> str:
     return f"{kind}:{text}"
 
 
-def entity_keys(entities: object) -> List[str]:
-    """Keys for a list of ``{"type", "value"}`` candidates, deduped in order.
+def _deduped(minted: Iterable[str]) -> List[str]:
+    """Keys in the order they were minted, without repeats or empties.
 
-    Order is kept because a Verdict's subjects read back to a human, and an
-    unusable candidate is skipped rather than stored as a partial key.
+    Order is kept because a Verdict's subjects read back to a human. An unusable
+    candidate is dropped rather than raising: one bad key among ten is a read of
+    nine, and one unusable candidate in a payload must not fail the investigation
+    it arrived in.
     """
     keys: List[str] = []
     seen = set()
-    for entity in entities if isinstance(entities, list) else []:
-        if not isinstance(entity, dict):
-            continue
-        key = entity_key(str(entity.get("type", "")), str(entity.get("value", "")))
+    for key in minted:
         if key and key not in seen:
             seen.add(key)
             keys.append(key)
     return keys
+
+
+def entity_keys(entities: object) -> List[str]:
+    """Keys for a list of ``{"type", "value"}`` candidates, deduped in order."""
+    return _deduped(
+        entity_key(str(entity.get("type", "")), str(entity.get("value", "")))
+        for entity in (entities if isinstance(entities, list) else [])
+        if isinstance(entity, dict)
+    )
 
 
 def normalise_key(key: str) -> str:
@@ -80,16 +88,8 @@ def normalise_key(key: str) -> str:
 
 
 def normalise_keys(keys: object) -> List[str]:
-    """Keys for a list of ``type:value`` strings, deduped in order.
-
-    An unusable key is dropped rather than raising: a read naming one bad key
-    among ten is a read of nine, not a failed call.
-    """
-    normalised: List[str] = []
-    seen = set()
-    for key in keys if isinstance(keys, (list, tuple)) else []:
-        normal = normalise_key(str(key))
-        if normal and normal not in seen:
-            seen.add(normal)
-            normalised.append(normal)
-    return normalised
+    """Keys for a list of ``type:value`` strings, deduped in order."""
+    return _deduped(
+        normalise_key(str(key))
+        for key in (keys if isinstance(keys, (list, tuple)) else [])
+    )

--- a/core/memory/entity_keys.py
+++ b/core/memory/entity_keys.py
@@ -66,3 +66,30 @@ def entity_keys(entities: object) -> List[str]:
             seen.add(key)
             keys.append(key)
     return keys
+
+
+def normalise_key(key: str) -> str:
+    """Normalise a stored-form ``type:value`` key the way the writer minted it.
+
+    The reader is handed keys as one string, where the writer was handed a type
+    and a value. Splitting on the *first* colon is what keeps a URL or an IPv6
+    address whole: everything after the type belongs to the value.
+    """
+    kind, _, value = (key or "").strip().partition(":")
+    return entity_key(kind, value)
+
+
+def normalise_keys(keys: object) -> List[str]:
+    """Keys for a list of ``type:value`` strings, deduped in order.
+
+    An unusable key is dropped rather than raising: a read naming one bad key
+    among ten is a read of nine, not a failed call.
+    """
+    normalised: List[str] = []
+    seen = set()
+    for key in keys if isinstance(keys, (list, tuple)) else []:
+        normal = normalise_key(str(key))
+        if normal and normal not in seen:
+            seen.add(normal)
+            normalised.append(normal)
+    return normalised

--- a/core/memory/recall.py
+++ b/core/memory/recall.py
@@ -1,0 +1,476 @@
+"""Reading episodic memory (#732): an entity's history, and the log of the read.
+
+One query serves both callers. A hunt worker calls ``recall_entity`` mid-run and
+gets the mapping as the single row of a ToolResult; the run-start read hands the
+same function the keys its harness extracted and journals the same mapping as the
+recall event. A second query for the second caller would be a second contract,
+and the second one drifts.
+
+Three things the query has to get right, and each of them fails quietly rather
+than loudly if it does not.
+
+**A total order.** ``LIMIT`` over a partial order lets Postgres return a
+different set on identical data. Nothing errors; the run simply remembers
+something else, and it surfaces a release later as a replay diff. Ties break on
+the primary key, which is what :data:`RECALL_ORDER` says and what the recall
+indexes are built for.
+
+**A per-key cap before the overall budget, as a LATERAL.** A trailing ``LIMIT``
+lets one entity present in every hunt -- a resolver, a domain controller -- spend
+the whole budget on itself, which makes memory *less* useful the more of it there
+is. The cap is applied per key and per kind, inside a lateral, before the overall
+cap sees a row.
+
+**The dropped count is reported.** A caller shown a partial view has no way to
+tell it apart from an entity with a short history unless it is told.
+
+``concluded_at <= as_of`` is a freshness filter and nothing more, never a
+substitute for logging the rows. ``23_episodic_read_log.sql`` says why on the
+column that carries it.
+
+The log is written here, inside the query, rather than at either call site, so a
+read through ``/internal/tools/invoke`` and a direct ``execute_backend_tool``
+leave the same record. It holds reads and not facts, which is why it is the one
+part of the tier with a retention policy: the daemon's cleanup sweep deletes rows
+older than ``scheduler.cleanup_retention_days``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from sqlalchemy import Text as SAText
+from sqlalchemy import bindparam, text
+from sqlalchemy.dialects.postgresql import ARRAY as PGArray
+from sqlalchemy.orm import Session
+
+from core.memory.entity_keys import normalise_keys
+from core.memory.recall_contract import (
+    DROPPED_KINDS,
+    RECALL_IGNORED_ARGS,
+    RECALL_KEY_ARGS,
+    RECALL_ORDER,
+    RECALL_OVERALL_CAP,
+    RECALL_PER_KEY_CAP,
+    RECALL_TOOL,
+    UNKNOWN_CALLER,
+    empty_dropped,
+    recall_ranking,
+)
+from core.storage.unit_of_work import unit_of_work
+
+Args = Dict[str, Any]
+Row = Dict[str, Any]
+
+# The kinds, in the order a result presents them, and the keys of `dropped` and
+# `row_counts` too -- the contract's tuple rather than a second copy of it, so a
+# kind added there cannot be one this module quietly stops returning.
+KINDS: Tuple[str, ...] = DROPPED_KINDS
+
+
+# One statement per kind, and two laterals in it: how many distinct rows matched
+# at all, and the per-key capped page of them. Two statements would read two
+# snapshots under READ COMMITTED, and the dropped count would then describe a set
+# nobody was shown.
+#
+# The total counts distinct rows over *all* the keys, not per key. A Verdict
+# naming two of the queried keys matches twice and is returned once, so a per-key
+# sum would report ten rows withheld where five distinct conclusions were.
+#
+# The outer ORDER BY is not decoration. Without it the join order is Postgres's
+# to choose, and the dedup below -- that same Verdict, arriving twice -- would
+# keep whichever copy came first.
+def _order_by(alias: str) -> str:
+    """RECALL_ORDER as a clause on one alias.
+
+    Derived rather than transcribed: the result and the read log report
+    RECALL_ORDER as the basis the rows were chosen on, and a hardcoded ORDER BY
+    would let that claim go on being true after the query stopped honouring it.
+    """
+    return ", ".join(f"{alias}.{term.strip()}" for term in RECALL_ORDER.split(","))
+
+
+def _statement(table: str, predicate: str, matches_any: str, columns: str) -> Any:
+    return text(
+        f"""
+        SELECT m.total AS matched_total, {columns}
+        FROM unnest(CAST(:keys AS text[])) AS k(key)
+        CROSS JOIN LATERAL (
+            SELECT count(*) AS total
+            FROM {table} AS c
+            WHERE {matches_any.format(alias="c")} AND c.concluded_at <= :as_of
+        ) AS m
+        CROSS JOIN LATERAL (
+            SELECT *
+            FROM {table} AS p
+            WHERE {predicate.format(alias="p")} AND p.concluded_at <= :as_of
+            ORDER BY {_order_by("p")}
+            LIMIT :per_key_cap
+        ) AS r
+        ORDER BY {_order_by("r")}, k.key ASC
+        """
+    ).bindparams(bindparam("keys", type_=PGArray(SAText)))
+
+
+# Sightings carry the key on a column. Verdicts and Gaps name their subjects in
+# an array -- typically one to three entities, not the 38 to 76 their evidence
+# touched (ADR 0016) -- and the containment operator is what the GIN indexes on
+# subject_entities answer.
+_BY_KEY = "{alias}.entity_key = k.key"
+_BY_SUBJECT = "{alias}.subject_entities @> ARRAY[k.key]"
+
+# The same joins against the whole key list at once, for the distinct total the
+# per-key cap is measured against. Both are the indexed forms: `= ANY` uses the
+# recall index and the overlap operator uses the GIN one.
+_ANY_KEY = "{alias}.entity_key = ANY(CAST(:keys AS text[]))"
+_ANY_SUBJECT = "{alias}.subject_entities && CAST(:keys AS text[])"
+
+_SIGHTING_COLUMNS = (
+    "r.id, r.entity_key, r.investigation_kind, r.investigation_id, "
+    "r.source_system, r.hit_count, r.attacker_influenceable, "
+    "r.first_seen, r.last_seen, r.concluded_at"
+)
+_VERDICT_COLUMNS = (
+    "r.id, r.investigation_kind, r.investigation_id, r.hypothesis_id, "
+    "r.statement, r.outcome, r.rationale, r.subject_entities, "
+    "r.attacker_influenceable_only, r.trust, r.first_seen, r.last_seen, "
+    "r.window_source, r.concluded_at"
+)
+_GAP_COLUMNS = (
+    "r.id, r.investigation_kind, r.investigation_id, r.hypothesis_id, "
+    "r.statement, r.disposition, r.reason, r.subject_entities, r.concluded_at"
+)
+
+_QUERIES = {
+    "sightings": _statement(
+        "episodic_sightings", _BY_KEY, _ANY_KEY, _SIGHTING_COLUMNS
+    ),
+    "verdicts": _statement(
+        "episodic_verdicts", _BY_SUBJECT, _ANY_SUBJECT, _VERDICT_COLUMNS
+    ),
+    "gaps": _statement("episodic_gaps", _BY_SUBJECT, _ANY_SUBJECT, _GAP_COLUMNS),
+}
+
+# Fetched for the Verdicts that survived both caps rather than joined into the
+# page above, which would multiply a Verdict by its sources and spend the per-key
+# cap on copies of one conclusion.
+_VERDICT_SOURCES = text(
+    """
+    SELECT verdict_id, source_system, stance, source_tier
+    FROM episodic_verdict_sources
+    WHERE verdict_id = ANY(CAST(:verdict_ids AS bigint[]))
+    ORDER BY verdict_id ASC, source_system ASC
+    """
+)
+
+_LOG_READ = text(
+    """
+    INSERT INTO episodic_read_log
+        (caller_kind, caller_id, keys, as_of, row_counts, dropped, ranking)
+    VALUES
+        (:caller_kind, :caller_id, CAST(:keys AS text[]), :as_of,
+         CAST(:row_counts AS jsonb), CAST(:dropped AS jsonb), CAST(:ranking AS jsonb))
+    """
+).bindparams(bindparam("keys", type_=PGArray(SAText)))
+
+
+_EXPIRE_READ_LOG = text("DELETE FROM episodic_read_log WHERE ts < :cutoff")
+
+
+def _iso(value: Any) -> Any:
+    """Timestamps travel as ISO-8601 with an offset, matching the contract."""
+    if isinstance(value, datetime):
+        return value.isoformat().replace("+00:00", "Z")
+    return value
+
+
+def _as_of(raw: Any) -> datetime:
+    """The freshness filter, defaulting to now.
+
+    A naive value is read as UTC rather than refused: every timestamp this tier
+    stores is offset-aware, so a caller that dropped the offset meant UTC, and
+    failing the read would tell it nothing it could act on.
+    """
+    if isinstance(raw, datetime):
+        moment = raw
+    elif raw is None or (isinstance(raw, str) and not raw.strip()):
+        return datetime.now(timezone.utc)
+    else:
+        stamp = str(raw).strip()
+        try:
+            moment = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValueError(
+                f"{RECALL_TOOL} could not read as_of {stamp!r}; "
+                "it takes ISO-8601 with an offset"
+            ) from None
+    return moment if moment.tzinfo else moment.replace(tzinfo=timezone.utc)
+
+
+def _window(row: Mapping[str, Any]) -> Dict[str, Any]:
+    return {"first_seen": _iso(row["first_seen"]), "last_seen": _iso(row["last_seen"])}
+
+
+def _provenance(row: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "investigation_kind": row["investigation_kind"],
+        "investigation_id": row["investigation_id"],
+        "concluded_at": _iso(row["concluded_at"]),
+    }
+
+
+def _sighting(row: Mapping[str, Any]) -> Row:
+    return {
+        **_provenance(row),
+        "entity_key": row["entity_key"],
+        "source_system": row["source_system"],
+        "hit_count": int(row["hit_count"]),
+        "attacker_influenceable": bool(row["attacker_influenceable"]),
+        "window": _window(row),
+    }
+
+
+def _verdict(row: Mapping[str, Any]) -> Row:
+    return {
+        **_provenance(row),
+        "hypothesis_id": row["hypothesis_id"],
+        "statement": row["statement"],
+        "outcome": row["outcome"],
+        "rationale": row["rationale"],
+        "subject_entities": list(row["subject_entities"] or []),
+        "attacker_influenceable_only": bool(row["attacker_influenceable_only"]),
+        "trust": row["trust"],
+        "window": _window(row),
+        "window_source": row["window_source"],
+        # Filled once the overall cap has said which Verdicts survive.
+        "sources": [],
+    }
+
+
+def _gap(row: Mapping[str, Any]) -> Row:
+    return {
+        **_provenance(row),
+        "hypothesis_id": row["hypothesis_id"],
+        "statement": row["statement"],
+        "disposition": row["disposition"],
+        "reason": row["reason"],
+        "subject_entities": list(row["subject_entities"] or []),
+    }
+
+
+_SHAPES = {"sightings": _sighting, "verdicts": _verdict, "gaps": _gap}
+
+
+# A row and the two numbers the caps are decided on, kept beside it rather than
+# inside it: `id` is per-table and would collide across kinds in the result, and
+# `concluded_at` is already there as a string.
+_Selected = Tuple[datetime, int, Row]
+
+
+def _page(
+    session: Session, kind: str, params: Mapping[str, Any]
+) -> Tuple[List[_Selected], int]:
+    """One kind's rows, per-key capped, deduped, and what the cap withheld.
+
+    A Verdict or Gap naming two of the queried keys matches twice and is returned
+    once; the first copy wins, which the statement's ORDER BY makes a decision
+    rather than an accident.
+
+    The drop count is distinct rows matched minus distinct rows returned, and not
+    a per-key sum of overshoot -- that same shared Verdict would otherwise be
+    counted as withheld from each key it names, reporting ten rows lost where
+    five conclusions were. Zero rows matched means the total was never observed,
+    which is the same thing as nothing having been withheld.
+    """
+    shape = _SHAPES[kind]
+    selected: List[_Selected] = []
+    seen: set = set()
+    matched = 0
+
+    for row in session.execute(_QUERIES[kind], dict(params)).mappings():
+        matched = int(row["matched_total"])
+        if row["id"] in seen:
+            continue
+        seen.add(row["id"])
+        selected.append((row["concluded_at"], int(row["id"]), shape(row)))
+
+    return selected, max(0, matched - len(selected))
+
+
+def _apply_overall_cap(
+    pages: Mapping[str, List[_Selected]]
+) -> Tuple[Dict[str, List[_Selected]], Dict[str, int]]:
+    """Spend the overall cap across all kinds and keys, newest first.
+
+    One budget rather than one per kind, which is what the contract's
+    ``overall_cap`` says. Ordering across kinds needs one term more than
+    :data:`RECALL_ORDER` has: ids are per-table, so a Sighting and a Gap sharing a
+    ``concluded_at`` and an ``id`` are a tie it cannot break, and an unbroken tie
+    is exactly the nondeterminism the total order exists to prevent. The kind
+    breaks it.
+
+    That extra term decides *which* rows the budget keeps and never the order
+    they are presented in: each returned list is one kind, and within a kind the
+    order is RECALL_ORDER exactly as the result and the log report it.
+
+    Sorted in two passes rather than on a negated key: ``concluded_at`` carries
+    microseconds and a float epoch does not, so negating it to reverse one field
+    of a tuple would make two rows a millionth of a second apart into a tie.
+    """
+    ordered = sorted(
+        ((kind, selected) for kind in KINDS for selected in pages[kind]),
+        key=lambda entry: (entry[0], entry[1][1]),
+    )
+    ordered.sort(key=lambda entry: entry[1][0], reverse=True)
+
+    kept: Dict[str, List[_Selected]] = {kind: [] for kind in KINDS}
+    for kind, selected in ordered[:RECALL_OVERALL_CAP]:
+        kept[kind].append(selected)
+
+    dropped = {kind: len(pages[kind]) - len(kept[kind]) for kind in KINDS}
+    return kept, dropped
+
+
+def _attach_sources(session: Session, verdicts: Sequence[_Selected]) -> None:
+    """Give each surviving Verdict its per-source Stance and stamped Source Tier."""
+    by_id = {verdict_id: row for _, verdict_id, row in verdicts}
+    if not by_id:
+        return
+    for row in session.execute(
+        _VERDICT_SOURCES, {"verdict_ids": sorted(by_id)}
+    ).mappings():
+        by_id[row["verdict_id"]]["sources"].append(
+            {
+                "source_system": row["source_system"],
+                "stance": row["stance"],
+                "source_tier": row["source_tier"],
+            }
+        )
+
+
+def _log(
+    session: Session,
+    result: Mapping[str, Any],
+    as_of: datetime,
+    caller_kind: str,
+    caller_id: str,
+) -> None:
+    """Record that the read happened, whoever asked.
+
+    In the same transaction as the read and not best-effort. "Every read is
+    logged" is the whole claim this table exists to make, and a read that
+    answered without leaving a record is indistinguishable afterwards from a read
+    nobody made. A failure here means the table is gone or the database is down,
+    in which case the query above would not have answered either.
+    """
+    session.execute(
+        _LOG_READ,
+        {
+            "caller_kind": caller_kind,
+            "caller_id": caller_id,
+            "keys": list(result["keys"]),
+            "as_of": as_of,
+            "row_counts": json.dumps({kind: len(result[kind]) for kind in KINDS}),
+            "dropped": json.dumps(result["dropped"]),
+            "ranking": json.dumps(result["ranking"]),
+        },
+    )
+
+
+def recall(
+    keys: Iterable[str],
+    *,
+    as_of: Any = None,
+    caller_kind: str = UNKNOWN_CALLER,
+    caller_id: str = UNKNOWN_CALLER,
+    session: Optional[Session] = None,
+) -> Dict[str, Any]:
+    """What is remembered about these entities, and a log row saying it was asked.
+
+    Unknown keys are empty lists and zeros rather than an error: an entity nobody
+    has investigated and an entity that does not exist are the same answer, and
+    there is nothing a caller could do differently about either.
+    """
+    normalised = normalise_keys(list(keys))
+    moment = _as_of(as_of)
+    result: Dict[str, Any] = {
+        "keys": normalised,
+        "as_of": _iso(moment),
+        "sightings": [],
+        "verdicts": [],
+        "gaps": [],
+        "dropped": empty_dropped(),
+        "ranking": recall_ranking(),
+    }
+
+    with unit_of_work(session) as db:
+        if normalised:
+            params = {
+                "keys": normalised,
+                "as_of": moment,
+                "per_key_cap": RECALL_PER_KEY_CAP,
+            }
+            pages: Dict[str, List[_Selected]] = {}
+            for kind in KINDS:
+                pages[kind], over = _page(db, kind, params)
+                result["dropped"][kind]["per_key_cap"] = over
+
+            kept, spent = _apply_overall_cap(pages)
+            for kind in KINDS:
+                result[kind] = [row for _, _, row in kept[kind]]
+                result["dropped"][kind]["overall_cap"] = spent[kind]
+
+            _attach_sources(db, kept["verdicts"])
+
+        _log(db, result, moment, caller_kind, caller_id)
+
+    return result
+
+
+def recall_entity(args: Args) -> Dict[str, Any]:
+    """The backend tool, taking an args mapping rather than keyword parameters.
+
+    ``tools_router._bounded`` injects ``limit`` into every backend call, so an
+    explicit signature would answer ``invalid_args`` to every recall. That bound
+    is ignored here on purpose -- the caps are memory's own, and a row budget
+    meant for a page of findings is not one for an entity's history.
+    """
+    supplied = dict(args or {})
+    for ignored in RECALL_IGNORED_ARGS:
+        supplied.pop(ignored, None)
+
+    keys = supplied.get("entity_keys")
+    if isinstance(keys, str):
+        keys = [keys]
+    if not keys:
+        single = supplied.get("entity_key")
+        keys = [single] if single else []
+    if not keys:
+        # Worded so tools_router reads it as invalid_args rather than a backend
+        # failure: the model can fix this by calling again, and the contract
+        # keeps "the call was wrong" apart from "the tool could not answer".
+        raise TypeError(
+            f"{RECALL_TOOL} is missing a required keyword-only argument: "
+            + " or ".join(RECALL_KEY_ARGS)
+        )
+
+    return recall(
+        keys,
+        as_of=supplied.get("as_of"),
+        caller_kind=str(supplied.get("caller_kind") or UNKNOWN_CALLER),
+        caller_id=str(supplied.get("caller_id") or UNKNOWN_CALLER),
+    )
+
+
+def expire_read_log(cutoff: datetime, *, session: Optional[Session] = None) -> int:
+    """Delete read log rows older than ``cutoff``, returning how many went.
+
+    Called by the daemon's cleanup sweep with ``scheduler.cleanup_retention_days``
+    rather than a setting of its own: this log ages out on the same schedule as
+    the rest of the daemon's bulk data, and a second knob would be a second thing
+    to get wrong.
+    """
+    with unit_of_work(session) as db:
+        return int(db.execute(_EXPIRE_READ_LOG, {"cutoff": cutoff}).rowcount or 0)

--- a/core/memory/recall.py
+++ b/core/memory/recall.py
@@ -30,16 +30,25 @@ column that carries it.
 
 The log is written here, inside the query, rather than at either call site, so a
 read through ``/internal/tools/invoke`` and a direct ``execute_backend_tool``
-leave the same record. It holds reads and not facts, which is why it is the one
-part of the tier with a retention policy: the daemon's cleanup sweep deletes rows
-older than ``scheduler.cleanup_retention_days``.
+leave the same record. What it is for, and why it alone is retained, is stated on
+the table in ``infra/database/init/23_episodic_read_log.sql``.
 """
 
 from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 from sqlalchemy import Text as SAText
 from sqlalchemy import bindparam, text
@@ -70,6 +79,25 @@ Row = Dict[str, Any]
 KINDS: Tuple[str, ...] = DROPPED_KINDS
 
 
+# RECALL_ORDER as (field, descending) pairs. Both the SQL below and the overall
+# cap in Python sort on these, because the result and the read log report
+# RECALL_ORDER as the basis the rows were chosen on -- and a step that restated
+# the order instead of deriving it would go on keeping the old rows while the
+# result reported the new constant, which is the drift this exists to prevent.
+_ORDER_TERMS: Tuple[Tuple[str, bool], ...] = tuple(
+    (term.split()[0], term.split()[-1].upper() == "DESC")
+    for term in RECALL_ORDER.split(",")
+)
+
+# The term the kind has to outrank; see _apply_overall_cap.
+_PRIMARY_KEY = "id"
+
+
+def _order_by(alias: str) -> str:
+    """RECALL_ORDER as a clause on one alias."""
+    return ", ".join(f"{alias}.{term.strip()}" for term in RECALL_ORDER.split(","))
+
+
 # One statement per kind, and two laterals in it: how many distinct rows matched
 # at all, and the per-key capped page of them. Two statements would read two
 # snapshots under READ COMMITTED, and the dropped count would then describe a set
@@ -80,18 +108,8 @@ KINDS: Tuple[str, ...] = DROPPED_KINDS
 # sum would report ten rows withheld where five distinct conclusions were.
 #
 # The outer ORDER BY is not decoration. Without it the join order is Postgres's
-# to choose, and the dedup below -- that same Verdict, arriving twice -- would
+# to choose, and the dedup in _page -- that same Verdict, arriving twice -- would
 # keep whichever copy came first.
-def _order_by(alias: str) -> str:
-    """RECALL_ORDER as a clause on one alias.
-
-    Derived rather than transcribed: the result and the read log report
-    RECALL_ORDER as the basis the rows were chosen on, and a hardcoded ORDER BY
-    would let that claim go on being true after the query stopped honouring it.
-    """
-    return ", ".join(f"{alias}.{term.strip()}" for term in RECALL_ORDER.split(","))
-
-
 def _statement(table: str, predicate: str, matches_any: str, columns: str) -> Any:
     return text(
         f"""
@@ -186,12 +204,23 @@ def _iso(value: Any) -> Any:
     return value
 
 
+# What tools_router._is_bad_arguments matches on, so a mistake the caller can fix
+# comes back as invalid_args and not backend_error -- the contract keeps "the call
+# was wrong" apart from "the tool could not answer", and only the first tells the
+# model to try again. Coupling to the router's wording is fragile in both
+# directions; it is the router's contract, and stating it once here is better than
+# two error classes for two spellings of the same caller mistake.
+def _refuse(detail: str) -> TypeError:
+    return TypeError(f"{RECALL_TOOL}: {detail} (required keyword-only argument)")
+
+
 def _as_of(raw: Any) -> datetime:
     """The freshness filter, defaulting to now.
 
     A naive value is read as UTC rather than refused: every timestamp this tier
     stores is offset-aware, so a caller that dropped the offset meant UTC, and
-    failing the read would tell it nothing it could act on.
+    failing the read would tell it nothing it could act on. An unreadable one is
+    the caller's mistake and is refused as such, the same as a call naming no key.
     """
     if isinstance(raw, datetime):
         moment = raw
@@ -202,9 +231,8 @@ def _as_of(raw: Any) -> datetime:
         try:
             moment = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
         except ValueError:
-            raise ValueError(
-                f"{RECALL_TOOL} could not read as_of {stamp!r}; "
-                "it takes ISO-8601 with an offset"
+            raise _refuse(
+                f"as_of {stamp!r} is not ISO-8601 with an offset"
             ) from None
     return moment if moment.tzinfo else moment.replace(tzinfo=timezone.utc)
 
@@ -263,10 +291,19 @@ def _gap(row: Mapping[str, Any]) -> Row:
 _SHAPES = {"sightings": _sighting, "verdicts": _verdict, "gaps": _gap}
 
 
-# A row and the two numbers the caps are decided on, kept beside it rather than
-# inside it: `id` is per-table and would collide across kinds in the result, and
-# `concluded_at` is already there as a string.
-_Selected = Tuple[datetime, int, Row]
+class _Selected(NamedTuple):
+    """A chosen row, beside the two values the total order sorts it on.
+
+    They sit alongside the row rather than in it because neither belongs in the
+    result: ``id`` is per-table and would collide across kinds, and
+    ``concluded_at`` is already on the row as a string. Named rather than a bare
+    tuple so :func:`_apply_overall_cap` can reach the field RECALL_ORDER
+    nominates by name instead of by position.
+    """
+
+    concluded_at: datetime
+    id: int
+    row: Row
 
 
 def _page(
@@ -290,11 +327,14 @@ def _page(
     matched = 0
 
     for row in session.execute(_QUERIES[kind], dict(params)).mappings():
+        # Constant across every row -- the lateral that computes it joins on the
+        # whole key list and is uncorrelated -- so this reads the same value each
+        # time rather than accumulating one.
         matched = int(row["matched_total"])
         if row["id"] in seen:
             continue
         seen.add(row["id"])
-        selected.append((row["concluded_at"], int(row["id"]), shape(row)))
+        selected.append(_Selected(row["concluded_at"], int(row["id"]), shape(row)))
 
     return selected, max(0, matched - len(selected))
 
@@ -305,25 +345,37 @@ def _apply_overall_cap(
     """Spend the overall cap across all kinds and keys, newest first.
 
     One budget rather than one per kind, which is what the contract's
-    ``overall_cap`` says. Ordering across kinds needs one term more than
-    :data:`RECALL_ORDER` has: ids are per-table, so a Sighting and a Gap sharing a
-    ``concluded_at`` and an ``id`` are a tie it cannot break, and an unbroken tie
-    is exactly the nondeterminism the total order exists to prevent. The kind
-    breaks it.
+    ``overall_cap`` says. This is the step that decides which rows a caller
+    actually sees, so it sorts on :data:`_ORDER_TERMS` -- RECALL_ORDER parsed --
+    and not on directions written out here. Restating them would leave the
+    laterals following the constant while the budget kept the opposite rows, and
+    the result would go on reporting the constant as the basis for a set chosen
+    some other way.
+
+    Ordering across kinds needs one term more than RECALL_ORDER has. Ids are
+    per-table, so a Sighting and a Gap sharing a ``concluded_at`` and an ``id``
+    are a tie it cannot break, and an unbroken tie is the nondeterminism the
+    total order exists to prevent. The kind breaks it, and it is applied directly
+    above the primary key -- the term it exists to make meaningful -- rather than
+    appended, which would leave it below the tie it is there to settle.
 
     That extra term decides *which* rows the budget keeps and never the order
     they are presented in: each returned list is one kind, and within a kind the
     order is RECALL_ORDER exactly as the result and the log report it.
 
-    Sorted in two passes rather than on a negated key: ``concluded_at`` carries
-    microseconds and a float epoch does not, so negating it to reverse one field
-    of a tuple would make two rows a millionth of a second apart into a tie.
+    One stable sort per term, applied least-significant first, rather than one
+    key over the whole tuple: the terms differ in direction, and reversing just
+    one of them by negating it would need a number -- which for ``concluded_at``
+    means a float epoch, turning two rows a microsecond apart into a tie.
     """
-    ordered = sorted(
-        ((kind, selected) for kind in KINDS for selected in pages[kind]),
-        key=lambda entry: (entry[0], entry[1][1]),
-    )
-    ordered.sort(key=lambda entry: entry[1][0], reverse=True)
+    ordered = [(kind, selected) for kind in KINDS for selected in pages[kind]]
+
+    for field, descending in reversed(_ORDER_TERMS):
+        ordered.sort(
+            key=lambda entry, f=field: getattr(entry[1], f), reverse=descending
+        )
+        if field == _PRIMARY_KEY:
+            ordered.sort(key=lambda entry: entry[0])
 
     kept: Dict[str, List[_Selected]] = {kind: [] for kind in KINDS}
     for kind, selected in ordered[:RECALL_OVERALL_CAP]:
@@ -335,7 +387,7 @@ def _apply_overall_cap(
 
 def _attach_sources(session: Session, verdicts: Sequence[_Selected]) -> None:
     """Give each surviving Verdict its per-source Stance and stamped Source Tier."""
-    by_id = {verdict_id: row for _, verdict_id, row in verdicts}
+    by_id = {selected.id: selected.row for selected in verdicts}
     if not by_id:
         return
     for row in session.execute(
@@ -392,6 +444,11 @@ def recall(
     Unknown keys are empty lists and zeros rather than an error: an entity nobody
     has investigated and an entity that does not exist are the same answer, and
     there is nothing a caller could do differently about either.
+
+    Passing ``session`` joins the caller's transaction, and ``unit_of_work`` then
+    neither commits nor closes it. The log row is written into that transaction,
+    so committing it becomes the caller's obligation -- a caller that rolls back
+    has un-logged the read it performed. Only the tests pass one today.
     """
     normalised = normalise_keys(list(keys))
     moment = _as_of(as_of)
@@ -419,7 +476,7 @@ def recall(
 
             kept, spent = _apply_overall_cap(pages)
             for kind in KINDS:
-                result[kind] = [row for _, _, row in kept[kind]]
+                result[kind] = [selected.row for selected in kept[kind]]
                 result["dropped"][kind]["overall_cap"] = spent[kind]
 
             _attach_sources(db, kept["verdicts"])
@@ -448,13 +505,7 @@ def recall_entity(args: Args) -> Dict[str, Any]:
         single = supplied.get("entity_key")
         keys = [single] if single else []
     if not keys:
-        # Worded so tools_router reads it as invalid_args rather than a backend
-        # failure: the model can fix this by calling again, and the contract
-        # keeps "the call was wrong" apart from "the tool could not answer".
-        raise TypeError(
-            f"{RECALL_TOOL} is missing a required keyword-only argument: "
-            + " or ".join(RECALL_KEY_ARGS)
-        )
+        raise _refuse("a call needs " + " or ".join(RECALL_KEY_ARGS))
 
     return recall(
         keys,

--- a/core/storage/models.py
+++ b/core/storage/models.py
@@ -2514,3 +2514,47 @@ class EpisodicDistilMarker(Base):
     __table_args__ = (
         Index("idx_episodic_markers_origin", "origin_run_ids", postgresql_using="gin"),
     )
+
+
+class EpisodicReadLog(Base):
+    """One row per read of episodic memory, for audit rather than replay.
+
+    The harness's Ledger recall event exists for replay and lives on the Ledger.
+    This is the only record a caller with no Ledger leaves behind, which is what
+    makes "we can see what it knew" true of an evaluation harness or a console
+    query. It holds reads and not facts, so it is the one part of the tier that
+    has a retention policy.
+    """
+
+    __tablename__ = "episodic_read_log"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    ts: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    # An unattributed read is still worth logging, so these default rather than
+    # bind: a log that refuses the reads it cannot attribute is a log of the
+    # well-behaved callers only.
+    caller_kind: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'unknown'")
+    )
+    caller_id: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'unknown'")
+    )
+    # As queried rather than as asked for: normalised, so a row here compares
+    # against a stored key without re-deriving it.
+    keys: Mapped[List[str]] = mapped_column(ARRAY(Text), nullable=False)
+    # The freshness filter that ran, which is not the time the read happened.
+    as_of: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # Counts and not rows: the rows are still in their own tables, and a copy
+    # would freeze what the Distil's delete-then-insert may since have replaced.
+    row_counts: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    dropped: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    ranking: Mapped[dict] = mapped_column(JSONB, nullable=False)
+
+    __table_args__ = (
+        # The cleanup sweep's only query, and the order an audit reads in.
+        Index("idx_episodic_read_log_ts", "ts"),
+        # "What has anyone asked about this entity", without a scan.
+        Index("idx_episodic_read_log_keys", "keys", postgresql_using="gin"),
+    )

--- a/core/storage/models.py
+++ b/core/storage/models.py
@@ -2519,11 +2519,8 @@ class EpisodicDistilMarker(Base):
 class EpisodicReadLog(Base):
     """One row per read of episodic memory, for audit rather than replay.
 
-    The harness's Ledger recall event exists for replay and lives on the Ledger.
-    This is the only record a caller with no Ledger leaves behind, which is what
-    makes "we can see what it knew" true of an evaluation harness or a console
-    query. It holds reads and not facts, so it is the one part of the tier that
-    has a retention policy.
+    Why it exists and why it alone is retained is stated once, in
+    ``infra/database/init/23_episodic_read_log.sql``.
     """
 
     __tablename__ = "episodic_read_log"
@@ -2532,29 +2529,19 @@ class EpisodicReadLog(Base):
     ts: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )
-    # An unattributed read is still worth logging, so these default rather than
-    # bind: a log that refuses the reads it cannot attribute is a log of the
-    # well-behaved callers only.
     caller_kind: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=text("'unknown'")
     )
     caller_id: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=text("'unknown'")
     )
-    # As queried rather than as asked for: normalised, so a row here compares
-    # against a stored key without re-deriving it.
     keys: Mapped[List[str]] = mapped_column(ARRAY(Text), nullable=False)
-    # The freshness filter that ran, which is not the time the read happened.
     as_of: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    # Counts and not rows: the rows are still in their own tables, and a copy
-    # would freeze what the Distil's delete-then-insert may since have replaced.
     row_counts: Mapped[dict] = mapped_column(JSONB, nullable=False)
     dropped: Mapped[dict] = mapped_column(JSONB, nullable=False)
     ranking: Mapped[dict] = mapped_column(JSONB, nullable=False)
 
     __table_args__ = (
-        # The cleanup sweep's only query, and the order an audit reads in.
         Index("idx_episodic_read_log_ts", "ts"),
-        # "What has anyone asked about this entity", without a scan.
         Index("idx_episodic_read_log_keys", "keys", postgresql_using="gin"),
     )

--- a/core/workflows/playbook_resolver.py
+++ b/core/workflows/playbook_resolver.py
@@ -72,6 +72,9 @@ CAPABILITIES: Dict[str, Tuple[str, ...]] = {
     ),
     "findings_search": ("search_findings",),
     "similar_findings": ("nearest_neighbors",),
+    # One candidate and no fallback: episodic memory is Vigil's own tier, so a
+    # deployment either carries it or has no history to offer.
+    "entity_recall": ("recall_entity",),
 }
 
 
@@ -255,6 +258,9 @@ HUNT_CAPABILITIES = (
     "similar_findings",
     "telemetry_search",
     "indicator_lookup",
+    # Bound on the run rather than granted to every role: `needs` in the arch is
+    # what decides who holds it, and the lead and critic are not granted it.
+    "entity_recall",
 )
 
 # A hunt is bounded by iterations rather than phases, and each one costs a lead

--- a/infra/database/init/23_episodic_read_log.sql
+++ b/infra/database/init/23_episodic_read_log.sql
@@ -1,0 +1,67 @@
+-- Every read of episodic memory, whoever asked. Written by core/memory/recall.py
+-- inside the query itself, so a read that reached the database is a read that was
+-- logged whether it arrived through /internal/tools/invoke or through a direct
+-- execute_backend_tool call.
+--
+-- Not the harness's Ledger recall event, and not a substitute for it. That event
+-- exists for replay and lives on the Ledger; this exists for audit, and it is the
+-- only thing that makes "we can see what it knew" true for a caller that has no
+-- Ledger at all -- an evaluation harness, a console query, a Case-side reader.
+--
+-- It holds reads rather than facts, which is why it is the one part of the tier
+-- with a retention policy: the Sightings and Verdicts a read returned are still
+-- in their own tables, so an expired log row loses the fact that someone asked
+-- and never the answer they were given. Retained for the daemon's
+-- scheduler.cleanup_retention_days, 90 days by default.
+
+CREATE TABLE IF NOT EXISTS episodic_read_log (
+    id          bigserial   PRIMARY KEY,
+    ts          timestamptz NOT NULL DEFAULT now(),
+    -- Deliberately open text and not a CHECK, unlike every domain in
+    -- 22_episodic_memory.sql: the callers are a hunt worker, an evaluation
+    -- harness, a Case-side reader and whatever asks next, and a closed list here
+    -- would turn a new kind of caller into a failed read rather than a logged
+    -- one. Defaulted at 'unknown' because an unattributed read is still worth
+    -- logging; a log that refuses what it cannot attribute is a log of the
+    -- well-behaved callers only.
+    caller_kind text        NOT NULL DEFAULT 'unknown',
+    caller_id   text        NOT NULL DEFAULT 'unknown',
+    -- As queried, not as asked for: normalised by core/memory/entity_keys.py, so
+    -- a row here can be compared against a stored key without re-deriving it.
+    keys        text[]      NOT NULL,
+    -- The freshness filter that ran. Distinct from ts, because the Distil polls:
+    -- an investigation that ended Monday can be written Wednesday carrying
+    -- Monday's date, inside this predicate and absent from a read that ran on
+    -- Tuesday. Recording as_of is what lets a later reader tell those apart.
+    as_of       timestamptz NOT NULL,
+    -- Counts and not the rows. Copying the rows would double the tier's storage
+    -- to say what the tier already says, and would freeze a copy that the
+    -- Distil's delete-then-insert may since have superseded.
+    row_counts  jsonb       NOT NULL,
+    -- What the caller was not shown, per kind and per reason. A caller given a
+    -- partial view needs to know it was partial, and this is the record that it
+    -- was told.
+    dropped     jsonb       NOT NULL,
+    -- The parameters that chose the set, copied in rather than referenced: the
+    -- caps are constants in the reader and a later release may change them, at
+    -- which point a row without them cannot be read back.
+    ranking     jsonb       NOT NULL
+);
+
+COMMENT ON TABLE episodic_read_log IS
+    'One row per read of episodic memory, for audit rather than replay. Retention is the daemon''s cleanup sweep, which deletes rows older than scheduler.cleanup_retention_days -- 90 days unless a deployment says otherwise.';
+
+COMMENT ON COLUMN episodic_read_log.keys IS
+    'The Entity Keys as queried -- normalised -- rather than as the caller spelled them.';
+
+COMMENT ON COLUMN episodic_read_log.as_of IS
+    'The freshness filter the read ran with, which is not the time the read happened.';
+
+-- The cleanup sweep's only query, and the ordering an audit reads in.
+CREATE INDEX IF NOT EXISTS idx_episodic_read_log_ts
+    ON episodic_read_log (ts);
+
+-- "What has anyone asked about this entity", which is the audit question that
+-- does not scan.
+CREATE INDEX IF NOT EXISTS idx_episodic_read_log_keys
+    ON episodic_read_log USING GIN (keys);

--- a/infra/helm/vigil/files/database-init/23_episodic_read_log.sql
+++ b/infra/helm/vigil/files/database-init/23_episodic_read_log.sql
@@ -1,0 +1,67 @@
+-- Every read of episodic memory, whoever asked. Written by core/memory/recall.py
+-- inside the query itself, so a read that reached the database is a read that was
+-- logged whether it arrived through /internal/tools/invoke or through a direct
+-- execute_backend_tool call.
+--
+-- Not the harness's Ledger recall event, and not a substitute for it. That event
+-- exists for replay and lives on the Ledger; this exists for audit, and it is the
+-- only thing that makes "we can see what it knew" true for a caller that has no
+-- Ledger at all -- an evaluation harness, a console query, a Case-side reader.
+--
+-- It holds reads rather than facts, which is why it is the one part of the tier
+-- with a retention policy: the Sightings and Verdicts a read returned are still
+-- in their own tables, so an expired log row loses the fact that someone asked
+-- and never the answer they were given. Retained for the daemon's
+-- scheduler.cleanup_retention_days, 90 days by default.
+
+CREATE TABLE IF NOT EXISTS episodic_read_log (
+    id          bigserial   PRIMARY KEY,
+    ts          timestamptz NOT NULL DEFAULT now(),
+    -- Deliberately open text and not a CHECK, unlike every domain in
+    -- 22_episodic_memory.sql: the callers are a hunt worker, an evaluation
+    -- harness, a Case-side reader and whatever asks next, and a closed list here
+    -- would turn a new kind of caller into a failed read rather than a logged
+    -- one. Defaulted at 'unknown' because an unattributed read is still worth
+    -- logging; a log that refuses what it cannot attribute is a log of the
+    -- well-behaved callers only.
+    caller_kind text        NOT NULL DEFAULT 'unknown',
+    caller_id   text        NOT NULL DEFAULT 'unknown',
+    -- As queried, not as asked for: normalised by core/memory/entity_keys.py, so
+    -- a row here can be compared against a stored key without re-deriving it.
+    keys        text[]      NOT NULL,
+    -- The freshness filter that ran. Distinct from ts, because the Distil polls:
+    -- an investigation that ended Monday can be written Wednesday carrying
+    -- Monday's date, inside this predicate and absent from a read that ran on
+    -- Tuesday. Recording as_of is what lets a later reader tell those apart.
+    as_of       timestamptz NOT NULL,
+    -- Counts and not the rows. Copying the rows would double the tier's storage
+    -- to say what the tier already says, and would freeze a copy that the
+    -- Distil's delete-then-insert may since have superseded.
+    row_counts  jsonb       NOT NULL,
+    -- What the caller was not shown, per kind and per reason. A caller given a
+    -- partial view needs to know it was partial, and this is the record that it
+    -- was told.
+    dropped     jsonb       NOT NULL,
+    -- The parameters that chose the set, copied in rather than referenced: the
+    -- caps are constants in the reader and a later release may change them, at
+    -- which point a row without them cannot be read back.
+    ranking     jsonb       NOT NULL
+);
+
+COMMENT ON TABLE episodic_read_log IS
+    'One row per read of episodic memory, for audit rather than replay. Retention is the daemon''s cleanup sweep, which deletes rows older than scheduler.cleanup_retention_days -- 90 days unless a deployment says otherwise.';
+
+COMMENT ON COLUMN episodic_read_log.keys IS
+    'The Entity Keys as queried -- normalised -- rather than as the caller spelled them.';
+
+COMMENT ON COLUMN episodic_read_log.as_of IS
+    'The freshness filter the read ran with, which is not the time the read happened.';
+
+-- The cleanup sweep's only query, and the ordering an audit reads in.
+CREATE INDEX IF NOT EXISTS idx_episodic_read_log_ts
+    ON episodic_read_log (ts);
+
+-- "What has anyone asked about this entity", which is the audit question that
+-- does not scan.
+CREATE INDEX IF NOT EXISTS idx_episodic_read_log_keys
+    ON episodic_read_log USING GIN (keys);

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -409,6 +409,7 @@ dbInit:
     - 20_agent_directives.sql
     - 21_agent_run_leases.sql
     - 22_episodic_memory.sql
+    - 23_episodic_read_log.sql
   resources:
     requests:
       cpu: 50m

--- a/services/agent/arch/threathunt.yaml
+++ b/services/agent/arch/threathunt.yaml
@@ -179,7 +179,7 @@ roles:
   workers:
     threat_hunter:
       description: broad behavioural hunting across the detected signal and the raw telemetry behind it
-      needs: [findings_search, similar_findings, telemetry_search]
+      needs: [findings_search, similar_findings, telemetry_search, entity_recall]
       prompt: |
         You have two surfaces and they answer different questions.
 
@@ -223,7 +223,7 @@ roles:
 
     network_analyst:
       description: traffic shape — beaconing intervals, jitter, volume asymmetry, DNS and HTTP
-      needs: [telemetry_search, findings_search]
+      needs: [telemetry_search, findings_search, entity_recall]
       prompt: |
         You query the network telemetry -- flows, HTTP and DNS -- in the query
         language of whichever system this deployment runs. Vigil's findings carry
@@ -244,7 +244,7 @@ roles:
 
     threat_intel:
       description: reputation and attribution for observables, against the indicator database and whatever intel integrations are connected
-      needs: [indicator_lookup]
+      needs: [indicator_lookup, entity_recall]
       prompt: |
         You look up observables — IPs, domains, URLs, file hashes — against
         Vigil's indicator database and whatever intelligence integrations this

--- a/services/daemon/scheduler.py
+++ b/services/daemon/scheduler.py
@@ -421,10 +421,8 @@ class TaskScheduler:
         if expired:
             logger.info("Cleanup expired %d unanswered approvals", expired)
 
-        # The episodic read log (#732), which holds reads rather than facts and
-        # is the one part of the memory tier with a retention policy. The rows a
-        # read returned live in their own tables, so an expired log row loses the
-        # fact that somebody asked and never the answer they were given.
+        # The episodic read log (#732), the one part of the memory tier with a
+        # retention policy. Off-thread for the same reason the sweep above is.
         from core.memory.recall import expire_read_log
 
         reads = await asyncio.to_thread(expire_read_log, cutoff)

--- a/services/daemon/scheduler.py
+++ b/services/daemon/scheduler.py
@@ -421,7 +421,21 @@ class TaskScheduler:
         if expired:
             logger.info("Cleanup expired %d unanswered approvals", expired)
 
-        return {"cutoff_date": cutoff.isoformat(), "approvals_expired": expired}
+        # The episodic read log (#732), which holds reads rather than facts and
+        # is the one part of the memory tier with a retention policy. The rows a
+        # read returned live in their own tables, so an expired log row loses the
+        # fact that somebody asked and never the answer they were given.
+        from core.memory.recall import expire_read_log
+
+        reads = await asyncio.to_thread(expire_read_log, cutoff)
+        if reads:
+            logger.info("Cleanup removed %d episodic read log rows", reads)
+
+        return {
+            "cutoff_date": cutoff.isoformat(),
+            "approvals_expired": expired,
+            "read_log_removed": reads,
+        }
 
     async def _run_sandbox_poll(self):
         """Advance pending sandbox submissions to completed reports."""

--- a/tests/unit/_ratchets/test_recall_contract_agrees.py
+++ b/tests/unit/_ratchets/test_recall_contract_agrees.py
@@ -195,6 +195,28 @@ def test_every_granted_role_is_a_role_the_arch_declares():
     )
 
 
+def test_the_arch_asks_for_what_the_grants_declare():
+    # Where the grant takes effect (#732). RECALL_GRANTS says which roles hold
+    # entity_recall; `needs` in threathunt.yaml is the only thing that makes it
+    # so, and bindCapabilities drops an unasked-for capability silently -- the
+    # role runs without the tool and nothing says why.
+    sections = re.split(r"^ {2,4}(\w+):$", ARCH.read_text(), flags=re.M)
+    asked = {}
+    for role, body in zip(sections[1::2], sections[2::2]):
+        needs = re.search(r"needs: \[([^\]]*)\]", body)
+        asked[role] = frozenset(re.findall(r"[\w-]+", needs.group(1))) if needs else frozenset()
+
+    holds = {
+        role: (py.RECALL_CAPABILITY,) if py.RECALL_CAPABILITY in asked.get(role, ()) else ()
+        for role in py.RECALL_GRANTS
+    }
+    assert holds == dict(py.RECALL_GRANTS), (
+        "threathunt.yaml's `needs` disagree with RECALL_GRANTS. A role granted "
+        "recall in the contract and not in the arch runs without the tool, and "
+        "the binding drops it silently rather than failing."
+    )
+
+
 def test_key_normalisation_defers_to_the_extractor():
     match = re.search(r"CASE_SENSITIVE = new Set\(\[([^\]]*)\]\)", ENTITIES.read_text())
     assert match, f"CASE_SENSITIVE not found in {ENTITIES}"

--- a/tests/unit/memory/test_recall_entity.py
+++ b/tests/unit/memory/test_recall_entity.py
@@ -284,6 +284,42 @@ def test_a_broad_read_stays_inside_the_overall_budget_and_names_what_it_dropped(
     assert result["dropped"]["sightings"]["per_key_cap"] == 0
 
 
+def test_the_overall_cap_sorts_on_the_order_it_reports_rather_than_a_copy(
+    session, monkeypatch
+):
+    """Flip RECALL_ORDER's direction and the budget must keep the other rows.
+
+    The laterals derive their ORDER BY from the constant, so a budget that
+    restated the directions would go on keeping the newest rows while the result
+    reported the constant as the basis for a set chosen some other way. That is
+    the one failure the derivation exists to prevent, and only reversing the
+    constant can show it is prevented.
+    """
+    from core.memory import recall as module
+
+    key = "ip:10.12.0.1"
+    for index in range(3):
+        sighting(
+            session,
+            key,
+            investigation=f"hunt-{index}",
+            concluded=EPOCH - timedelta(days=index),
+        )
+    session.commit()
+
+    newest_first = [row["investigation_id"] for row in recall([key])["sightings"]]
+    assert newest_first == ["hunt-0", "hunt-1", "hunt-2"]
+
+    # Only the budget's terms are flipped; the SQL keeps its own order, so what
+    # changes below can only be the step under test.
+    monkeypatch.setattr(module, "_ORDER_TERMS", (("concluded_at", False), ("id", True)))
+    monkeypatch.setattr(module, "RECALL_OVERALL_CAP", 1)
+
+    kept = recall([key])["sightings"]
+
+    assert [row["investigation_id"] for row in kept] == ["hunt-2"]
+
+
 def test_two_identical_reads_over_unchanged_data_return_the_same_rows_in_order(session):
     # Every row shares a concluded_at, so nothing but the primary-key tiebreak
     # decides the order or which rows the cap keeps.
@@ -435,20 +471,25 @@ def test_the_row_bound_the_router_injects_is_ignored(session):
     assert len(recall_entity({"entity_key": key, "limit": 1})["sightings"]) == 5
 
 
-def test_a_call_naming_no_key_is_invalid_arguments(session):
+@pytest.mark.parametrize(
+    "args",
+    [
+        {"caller_kind": "worker"},
+        {"entity_key": "ip:10.9.0.1", "as_of": "last tuesday"},
+    ],
+    ids=["no key named", "unreadable as_of"],
+)
+def test_a_caller_mistake_is_invalid_args_however_it_is_spelled(session, args):
+    # Both are the caller's to fix, so both must come back the same way. The
+    # router answers invalid_args only for Python's own wording for a call that
+    # did not fit its signature; anything else is a backend_error, which tells
+    # the model the tool broke rather than that it should call again.
     from core.agents.tools_router import _is_bad_arguments
 
     with pytest.raises(TypeError) as raised:
-        recall_entity({"caller_kind": "worker"})
+        recall_entity(args)
 
-    # The router reads Python's own wording for a call that did not fit its
-    # signature, and answers invalid_args so the model can call again.
     assert _is_bad_arguments(raised.value)
-
-
-def test_an_unreadable_as_of_is_refused_rather_than_silently_defaulted(session):
-    with pytest.raises(ValueError):
-        recall_entity({"entity_key": "ip:10.9.0.1", "as_of": "last tuesday"})
 
 
 def test_the_bridge_resolves_recall_entity_without_reaching_mcp(

--- a/tests/unit/memory/test_recall_entity.py
+++ b/tests/unit/memory/test_recall_entity.py
@@ -1,0 +1,493 @@
+"""Reading episodic memory (#732), against real rows and a real Postgres.
+
+The query is the thing under test and it is not portable: the per-key cap is a
+LATERAL, the Verdict join is array containment against a GIN index, and the total
+order exists because ``LIMIT`` over a partial one is nondeterministic. A fake
+would agree with whatever this module happened to do.
+
+Rows are seeded the way the Distil writes them rather than by running a hunt: a
+hunt exercises the fold, and what is being asserted here is the read.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from core.memory.recall import expire_read_log, recall, recall_entity
+from core.memory.recall_contract import (
+    RECALL_OVERALL_CAP,
+    RECALL_PER_KEY_CAP,
+    RECALL_RESULT_KEYS,
+    RECALL_TOOL,
+    recall_ranking,
+)
+from core.storage.connection import get_db_session
+from core.storage.models import (
+    EpisodicGap,
+    EpisodicReadLog,
+    EpisodicSighting,
+    EpisodicVerdict,
+    EpisodicVerdictSource,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.database, pytest.mark.external_service]
+
+EPOCH = datetime(2026, 8, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def session():
+    """A session on the throwaway database, emptied of episodic rows first.
+
+    Ordering between tests is arbitrary and every one of these reads the whole
+    table, so each starts from nothing rather than filtering its own rows out.
+    """
+    db = get_db_session()
+    try:
+        for model in (
+            EpisodicVerdictSource,
+            EpisodicVerdict,
+            EpisodicSighting,
+            EpisodicGap,
+            EpisodicReadLog,
+        ):
+            db.query(model).delete()
+        db.commit()
+        yield db
+    finally:
+        db.rollback()
+        db.close()
+
+
+def sighting(db, key: str, *, investigation: str, concluded: datetime, source="splunk"):
+    row = EpisodicSighting(
+        entity_key=key,
+        investigation_kind="hunt",
+        investigation_id=investigation,
+        source_system=source,
+        hit_count=3,
+        attacker_influenceable=True,
+        first_seen=concluded - timedelta(hours=1),
+        last_seen=concluded,
+        concluded_at=concluded,
+    )
+    db.add(row)
+    return row
+
+
+def verdict(db, keys, *, investigation: str, concluded: datetime, sources=()):
+    row = EpisodicVerdict(
+        investigation_kind="hunt",
+        investigation_id=investigation,
+        hypothesis_id=f"h-{investigation}",
+        statement="beaconing to a known-bad host",
+        outcome="proven",
+        rationale="regular interval, low jitter",
+        subject_entities=list(keys),
+        attacker_influenceable_only=False,
+        trust="agent",
+        first_seen=concluded - timedelta(hours=2),
+        last_seen=concluded,
+        window_source="observed",
+        concluded_at=concluded,
+    )
+    db.add(row)
+    db.flush()
+    for system, stance in sources:
+        db.add(
+            EpisodicVerdictSource(
+                verdict_id=row.id,
+                source_system=system,
+                stance=stance,
+                source_tier="telemetry",
+            )
+        )
+    return row
+
+
+def gap(db, keys, *, investigation: str, concluded: datetime):
+    row = EpisodicGap(
+        investigation_kind="hunt",
+        investigation_id=investigation,
+        hypothesis_id=f"g-{investigation}",
+        statement="did anything else talk to it",
+        disposition="budget_exhausted",
+        reason="the hunt ran out of turns",
+        subject_entities=list(keys),
+        concluded_at=concluded,
+    )
+    db.add(row)
+    return row
+
+
+@pytest.fixture
+def invoke(monkeypatch):
+    """The router's own endpoint, which is the seam an agent actually calls."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from core.agents import internal_auth, tools_router
+    from core.integrations.mcp.registry import MCPRegistry
+
+    monkeypatch.setattr(internal_auth, "get_secret", lambda name: "shhh")
+    app = FastAPI()
+    app.state.mcp_registry = MCPRegistry()
+    app.include_router(tools_router.router, prefix=tools_router.ROUTER_META.prefix)
+    client = TestClient(app)
+
+    def post(tool, args):
+        return client.post(
+            "/internal/tools/invoke",
+            json={
+                "tool": tool,
+                "args": args,
+                "bounds": {"max_rows": 5, "timeout_ms": 10_000},
+            },
+            headers={"Authorization": "Bearer shhh"},
+        )
+
+    return post
+
+
+def read_log(db):
+    from sqlalchemy import text
+
+    return list(
+        db.execute(
+            text(
+                "SELECT caller_kind, caller_id, keys, as_of, row_counts, dropped, "
+                "ranking, ts FROM episodic_read_log ORDER BY id ASC"
+            )
+        ).mappings()
+    )
+
+
+def test_an_entity_with_history_returns_its_sightings_verdicts_and_gaps(session):
+    key = "ip:10.0.0.7"
+    sighting(session, key, investigation="hunt-a", concluded=EPOCH)
+    verdict(
+        session,
+        [key],
+        investigation="hunt-a",
+        concluded=EPOCH,
+        sources=[("splunk", "supports"), ("crowdstrike", "weakens")],
+    )
+    gap(session, [key], investigation="hunt-a", concluded=EPOCH)
+    session.commit()
+
+    result = recall([key])
+
+    assert tuple(result) == RECALL_RESULT_KEYS
+    assert result["keys"] == [key]
+    assert len(result["sightings"]) == 1
+    assert len(result["verdicts"]) == 1
+    assert len(result["gaps"]) == 1
+    assert result["ranking"] == recall_ranking()
+
+    seen = result["sightings"][0]
+    assert seen["entity_key"] == key
+    assert seen["source_system"] == "splunk"
+    assert seen["hit_count"] == 3
+    assert seen["window"]["last_seen"].startswith("2026-08-01")
+
+    # A stance per source, and direction with it: a flat corroborated list could
+    # not say that CrowdStrike argued against the claim.
+    stances = {
+        s["source_system"]: s["stance"] for s in result["verdicts"][0]["sources"]
+    }
+    assert stances == {"splunk": "supports", "crowdstrike": "weakens"}
+    assert result["gaps"][0]["disposition"] == "budget_exhausted"
+
+
+def test_an_entity_with_no_history_is_an_empty_result_rather_than_an_error(session):
+    session.commit()
+
+    result = recall(["ip:203.0.113.9"])
+
+    assert result["keys"] == ["ip:203.0.113.9"]
+    assert result["sightings"] == result["verdicts"] == result["gaps"] == []
+    # Zeros rather than absent keys: an entity nobody has looked at and an entity
+    # whose history was truncated must not read the same.
+    assert all(
+        counts == {"per_key_cap": 0, "overall_cap": 0}
+        for counts in result["dropped"].values()
+    )
+
+
+def test_keys_differing_by_case_or_defanging_find_the_same_rows(session):
+    stored = "url:http://evil.com/a"
+    sighting(session, stored, investigation="hunt-a", concluded=EPOCH)
+    session.commit()
+
+    asked = recall(["URL:hxxp://Evil[.]com/A"])
+
+    assert asked["keys"] == [stored]
+    assert len(asked["sightings"]) == 1
+
+
+def test_a_case_significant_type_is_not_folded(session):
+    # Folding an ARN's resource part makes two principals one key, and the join
+    # still returns rows -- just the wrong ones.
+    stored = "arn:arn:aws:iam::1:role/Admin"
+    sighting(session, stored, investigation="hunt-a", concluded=EPOCH)
+    session.commit()
+
+    assert len(recall([stored])["sightings"]) == 1
+    assert recall(["arn:arn:aws:iam::1:role/admin"])["sightings"] == []
+
+
+def test_more_sightings_than_the_per_key_cap_returns_the_cap_and_says_what_went(
+    session,
+):
+    key = "ip:10.0.0.8"
+    over = 4
+    for index in range(RECALL_PER_KEY_CAP + over):
+        sighting(
+            session,
+            key,
+            investigation=f"hunt-{index:03d}",
+            concluded=EPOCH - timedelta(minutes=index),
+        )
+    session.commit()
+
+    result = recall([key])
+
+    assert len(result["sightings"]) == RECALL_PER_KEY_CAP
+    assert result["dropped"]["sightings"]["per_key_cap"] == over
+    # Newest first, which is what makes the cap a choice rather than a coin toss.
+    assert result["sightings"][0]["investigation_id"] == "hunt-000"
+
+
+def test_a_broad_read_stays_inside_the_overall_budget_and_names_what_it_dropped(
+    session,
+):
+    # One key under its own cap, many keys over the overall one: the two caps
+    # are different failures and the result has to tell them apart.
+    keys = [f"ip:10.1.0.{index}" for index in range(12)]
+    for key_index, key in enumerate(keys):
+        for row_index in range(10):
+            sighting(
+                session,
+                key,
+                investigation=f"hunt-{key_index:02d}-{row_index:02d}",
+                concluded=EPOCH - timedelta(minutes=key_index * 10 + row_index),
+            )
+    session.commit()
+
+    result = recall(keys)
+
+    total = sum(len(result[kind]) for kind in ("sightings", "verdicts", "gaps"))
+    assert total == RECALL_OVERALL_CAP
+    assert result["dropped"]["sightings"]["overall_cap"] == 120 - RECALL_OVERALL_CAP
+    assert result["dropped"]["sightings"]["per_key_cap"] == 0
+
+
+def test_two_identical_reads_over_unchanged_data_return_the_same_rows_in_order(session):
+    # Every row shares a concluded_at, so nothing but the primary-key tiebreak
+    # decides the order or which rows the cap keeps.
+    keys = [f"ip:10.2.0.{index}" for index in range(8)]
+    for key_index, key in enumerate(keys):
+        for row_index in range(20):
+            sighting(
+                session,
+                key,
+                investigation=f"hunt-{key_index:02d}-{row_index:02d}",
+                concluded=EPOCH,
+            )
+    session.commit()
+
+    # as_of is pinned because it defaults to now and would differ between the
+    # two calls; what is under test is the set and its order, not the clock.
+    first = recall(keys, as_of=EPOCH)
+    second = recall(keys, as_of=EPOCH)
+
+    assert first == second
+    assert len(first["sightings"]) == RECALL_OVERALL_CAP
+
+
+def test_a_shared_verdict_is_counted_once_when_the_cap_reports_what_it_withheld(
+    session,
+):
+    # Both keys name every Verdict, so each key's page is capped and the two
+    # pages hold the same rows. Counting the overshoot per key would report twice
+    # what was actually withheld -- the caller would be told 8 conclusions were
+    # held back when 4 were.
+    keys = ["ip:10.11.0.1", "host:dc01"]
+    over = 4
+    for index in range(RECALL_PER_KEY_CAP + over):
+        verdict(
+            session,
+            keys,
+            investigation=f"hunt-{index:03d}",
+            concluded=EPOCH - timedelta(minutes=index),
+        )
+    session.commit()
+
+    result = recall(keys)
+
+    assert len(result["verdicts"]) == RECALL_PER_KEY_CAP
+    assert result["dropped"]["verdicts"]["per_key_cap"] == over
+
+
+def test_a_verdict_naming_two_queried_keys_is_returned_once(session):
+    keys = ["ip:10.3.0.1", "host:web01"]
+    verdict(session, keys, investigation="hunt-a", concluded=EPOCH)
+    session.commit()
+
+    result = recall(keys)
+
+    assert len(result["verdicts"]) == 1
+
+
+def test_the_freshness_filter_excludes_what_concluded_after_as_of(session):
+    key = "ip:10.4.0.1"
+    sighting(session, key, investigation="hunt-old", concluded=EPOCH)
+    sighting(
+        session, key, investigation="hunt-new", concluded=EPOCH + timedelta(days=2)
+    )
+    session.commit()
+
+    result = recall([key], as_of=EPOCH + timedelta(days=1))
+
+    assert [row["investigation_id"] for row in result["sightings"]] == ["hunt-old"]
+    assert result["as_of"] == "2026-08-02T00:00:00Z"
+
+
+def test_every_read_writes_a_log_row_naming_the_caller_the_keys_and_the_answer(
+    session,
+):
+    key = "ip:10.5.0.1"
+    sighting(session, key, investigation="hunt-a", concluded=EPOCH)
+    session.commit()
+
+    recall([key], caller_kind="worker", caller_id="threat_hunter", as_of=EPOCH)
+
+    rows = read_log(session)
+    assert len(rows) == 1
+    logged = rows[0]
+    assert logged["caller_kind"] == "worker"
+    assert logged["caller_id"] == "threat_hunter"
+    assert list(logged["keys"]) == [key]
+    assert logged["as_of"] == EPOCH
+    assert logged["row_counts"] == {"sightings": 1, "verdicts": 0, "gaps": 0}
+    assert logged["ranking"] == recall_ranking()
+
+
+def test_a_read_that_found_nothing_is_logged_too(session):
+    session.commit()
+
+    recall(["ip:198.51.100.4"])
+
+    rows = read_log(session)
+    assert len(rows) == 1
+    # An unattributed read is still worth logging; refusing would make this a log
+    # of the well-behaved callers only.
+    assert rows[0]["caller_kind"] == "unknown"
+    assert rows[0]["row_counts"] == {"sightings": 0, "verdicts": 0, "gaps": 0}
+
+
+def test_the_read_log_is_swept_at_the_retention_boundary(session):
+    from sqlalchemy import text
+
+    session.execute(text("DELETE FROM episodic_read_log"))
+    session.commit()
+
+    recall(["ip:10.6.0.1"])
+    session.execute(
+        text("UPDATE episodic_read_log SET ts = now() - interval '91 days'")
+    )
+    session.commit()
+    recall(["ip:10.6.0.2"])
+
+    removed = expire_read_log(datetime.now(timezone.utc) - timedelta(days=90))
+
+    assert removed == 1
+    assert len(read_log(session)) == 1
+
+
+def test_the_singular_argument_is_wrapped(session):
+    key = "ip:10.7.0.1"
+    sighting(session, key, investigation="hunt-a", concluded=EPOCH)
+    session.commit()
+
+    result = recall_entity({"entity_key": key})
+
+    assert result["keys"] == [key]
+    assert len(result["sightings"]) == 1
+
+
+def test_the_row_bound_the_router_injects_is_ignored(session):
+    # tools_router._bounded puts `limit` on every backend call. The caps here are
+    # memory's own, and a budget meant for a page of findings is not one for an
+    # entity's history.
+    key = "ip:10.8.0.1"
+    for index in range(5):
+        sighting(
+            session,
+            key,
+            investigation=f"hunt-{index}",
+            concluded=EPOCH - timedelta(minutes=index),
+        )
+    session.commit()
+
+    assert len(recall_entity({"entity_key": key, "limit": 1})["sightings"]) == 5
+
+
+def test_a_call_naming_no_key_is_invalid_arguments(session):
+    from core.agents.tools_router import _is_bad_arguments
+
+    with pytest.raises(TypeError) as raised:
+        recall_entity({"caller_kind": "worker"})
+
+    # The router reads Python's own wording for a call that did not fit its
+    # signature, and answers invalid_args so the model can call again.
+    assert _is_bad_arguments(raised.value)
+
+
+def test_an_unreadable_as_of_is_refused_rather_than_silently_defaulted(session):
+    with pytest.raises(ValueError):
+        recall_entity({"entity_key": "ip:10.9.0.1", "as_of": "last tuesday"})
+
+
+def test_the_bridge_resolves_recall_entity_without_reaching_mcp(
+    invoke, monkeypatch, session
+):
+    """The read seam, end to end: an agent's call, answered by the backend.
+
+    Through the router's own endpoint rather than the registry alone, because
+    the fall-through to MCP is the router's: a name the registry declines is
+    exactly what reaches a server next. One call exercises the registry wiring,
+    the row bound the router injects, the envelope and the read log.
+    """
+    from core.agents import tools_router
+    from core.agents.tool_registry import MANIFEST
+
+    def refuse(name, args, timeout_s, registry):
+        raise AssertionError(f"{RECALL_TOOL} was routed to MCP")
+
+    monkeypatch.setattr(tools_router, "execute_mcp_tool", refuse)
+
+    key = "ip:10.10.0.1"
+    sighting(session, key, investigation="hunt-a", concluded=EPOCH)
+    session.commit()
+
+    assert RECALL_TOOL in MANIFEST, "the tool must be registered in ALL_TOOLS"
+    response = invoke(
+        RECALL_TOOL,
+        {"entity_keys": [key], "caller_kind": "worker", "caller_id": "threat_hunter"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    # One row holding the whole mapping, and not capped: _rows must not slice the
+    # Sightings, Verdicts and Gaps into rows of their own and lose which is which.
+    assert body["rowCount"] == 1
+    assert body["capped"] is False
+    assert tuple(body["rows"][0]) == RECALL_RESULT_KEYS
+    assert len(body["rows"][0]["sightings"]) == 1
+
+    # Attributed even though it arrived over HTTP, which is what the log is for.
+    assert read_log(session)[0]["caller_id"] == "threat_hunter"


### PR DESCRIPTION
## What this is

An agent asking about an entity gets what past investigations saw and concluded, and the read leaves a record.

`recall_entity` is a backend tool resolved by the existing tools bridge ahead of MCP — no subprocess, no `mcp-config.json` entry. It returns the **Sightings**, **Verdicts** and **Declared Gaps** for each Entity Key. Called mid-run it lands in the prompt tail, leaving the frozen prefix undisturbed, and is journaled as an ordinary tool call. The same function serves the run-start read, whose keys come from the run spec rather than from a worker — that caller is not wired here.

Base is `episodic-memory`, not `main`: this builds on #731's DDL, which only exists on that branch.

## Three things the query has to get right

Each of these fails quietly rather than loudly, which is why they are the design and not details.

**A total order.** `LIMIT` over a partial one lets Postgres return a different set on identical data. Nothing errors — the run simply remembers something else, and it surfaces a release later as a replay diff. Ties break on the primary key. Both the SQL `ORDER BY` and the overall cap's sort in Python are *derived* from the `RECALL_ORDER` the result reports, rather than transcribed beside it, so the reported basis cannot outlive the code honouring it. A test reverses those terms and fails if either step stops following them.

Ordering across kinds needs one term more than `RECALL_ORDER` has, since ids are per-table: the kind breaks that tie, applied directly above the primary key. It decides *which* rows the budget keeps and never the order they are presented in — each returned list is one kind, and within a kind the order is `RECALL_ORDER` exactly as reported.

**A per-key cap before the overall budget, as a `LATERAL`.** A trailing `LIMIT` lets one entity present in every hunt — a resolver, a domain controller — spend the whole budget on itself, which makes memory *less* useful the more of it there is. Twenty rows per kind per key, then a hundred across the read.

**The dropped count, per kind and per reason.** A caller shown a partial view cannot otherwise tell it apart from an entity with a short history. It counts distinct rows matched minus distinct rows returned, not per-key overshoot: a Verdict naming two of the queried keys matches twice and is returned once, so a per-key sum would report ten conclusions withheld where five were.

`concluded_at <= as_of` is a freshness filter and not a substitute for logging the rows. The Distil polls, so an investigation that ended Monday can be written Wednesday carrying Monday's date — inside the predicate of a read that ran on Tuesday, and absent from what that read returned.

## The read log

Every read is logged, whoever asked: caller, keys as queried, row counts, what was dropped, the ranking parameters and the `as_of` that ran.

The harness's Ledger recall event exists for replay and stays on the Ledger. This exists for audit, and it is the only thing that makes "we can see what it knew" true for a caller with no Ledger — an evaluation harness, a console query, a Case-side reader. It is written inside the query and in the same transaction, so the invariant holds for `/internal/tools/invoke` and a direct `execute_backend_tool` alike.

It holds reads rather than facts, which is why it is the one part of the tier with a retention policy: the daemon's existing cleanup sweep deletes rows past `scheduler.cleanup_retention_days` (90 days by default). No new setting.

## Who holds it

`threat_hunter`, `network_analyst` and `threat_intel` ask for `entity_recall`. The lead and the critic do not. A new ratchet fails when `threathunt.yaml`'s `needs` and `RECALL_GRANTS` disagree, because `bindCapabilities` drops an unasked-for capability silently — the role runs without the tool and nothing says why. Verified that the ratchet bites by breaking the arch and watching it fail.

## Acceptance criteria

- [x] `recall_entity` resolves through the existing backend tool bridge
- [x] An entity with history returns its Sightings, Verdicts and Gaps
- [x] An entity with no history returns an empty result rather than erroring
- [x] Keys differing only by case or defanging find the same rows
- [x] An entity with more Sightings than the per-key cap returns the cap and reports the rest as dropped
- [x] A read of many keys stays inside the token budget and names what it dropped
- [x] Two identical reads over unchanged data return the same rows in the same order
- [x] Every read writes a log row naming the caller, the keys and what came back
- [x] The read log has a stated retention policy

## Tests

18 tests in `tests/unit/memory/test_recall_entity.py`, against real rows and a real Postgres — the query is not portable, so a fake would only agree with whatever this module happened to do. Rows are seeded the way the Distil writes them rather than by running a hunt: a hunt exercises the fold, and what is asserted here is the read. The bridge test goes through the router's own endpoint, which is the seam an agent actually calls.

Full unit suite: **1706 passed, 37 skipped, 2 xfailed**. `helm template` applies the new SQL file, and the chart copy is byte-identical to `infra/database/init/`.

## One thing this does not close

Hunt-worker reads will log `caller_kind` / `caller_id` as `unknown` unless the model fills them in. The router passes tool args through verbatim and nothing injects attribution; changing `InvokeRequest` or `services/agent/core/remote.ts` is out of scope for this slice, so the tool description asking the caller to name itself is the only lever available here. Real attribution needs the harness to inject it, which belongs with the run-start read.

An unattributed read is still logged rather than refused, which is what `UNKNOWN_CALLER` is for. To be precise about the scope of that: every read that *reaches the database* writes a log row, in the same transaction. A call refused before it gets there — no key named, or an unreadable `as_of` — raises and records nothing, on the grounds that a refused call is not a read.

## Open question: what this table is called

`CONTEXT.md:165` says `_Avoid_: recall log (that is the audit table, which is Python's)`, so the domain map calls it the **recall log**. `docs/SPEC_EPISODIC_MEMORY.md` calls it the **read log** at lines 70, 92, 204 and 212. This follows the spec and ships `episodic_read_log`.

The two documents disagree, so this needs a decision rather than a rename: either rename the table to `recall_log`, or keep `read_log`, add a **Read Log** entry to `CONTEXT.md` and correct the Recall Event `_Avoid_` parenthetical. Cheap now, pre-merge and unreleased. Either way `CONTEXT.md` should gain an entry for the table, as the `22_` tables have.

## Out of scope, deliberately untouched

`Memory.recall`, `prefixOf` / `renderRecall`, `huntNotes`, `RUN_EVENT_KINDS`, `core/agents/builtins.py`, MemPalace, `mcp-config.json`, worker and lead prompts, and `InvokeRequest`. The run-start prefix and Ledger journaling are not this PR; MemPalace is #735.

Closes #732

