### PR TITLE
fix(ci): start release images in smoke instead of importing packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,12 @@ jobs:
   # ---------------------------------------------------------------------------
   # Smoke-test: pull the images and verify they start
   # ---------------------------------------------------------------------------
+  # Backend and daemon run their default command and must answer the image
+  # HEALTHCHECK URL. An import of the package __init__ never loaded the
+  # entry point, which is why v0.5.0's smoke was green while the published
+  # images crash-looped. Agent has no HEALTHCHECK (the port depends on the
+  # command), so it still loads worker.js / serve.js via node --eval.
+  # ---------------------------------------------------------------------------
   smoke-test:
     name: Smoke test images
     if: github.repository == 'Vigil-SOC/vigil'
@@ -266,14 +272,45 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Backend — version check
+      # Default CMD: uvicorn services.api.main:app on 6987. Fail if the
+      # process exits or GET /api/health never answers — the same URL as
+      # Dockerfile.backend's HEALTHCHECK. HTTP 200 means the server accepted
+      # a connection, not that storage is up; DEV_MODE=true is enough.
+      - name: Backend — starts and answers /api/health
         run: |
-          docker run --rm \
+          set -eu
+          IMAGE=ghcr.io/vigil-soc/vigil-backend:${{ needs.version.outputs.version }}
+          cid=$(docker run -d \
             -e DEV_MODE=true \
             -e DATABASE_URL=postgresql://x:x@localhost/x \
             -e REDIS_URL=redis://localhost:6379 \
-            ghcr.io/vigil-soc/vigil-backend:${{ needs.version.outputs.version }} \
-            python -c "import core, services.api; print('backend ok')"
+            "$IMAGE")
+          ok=0
+          cleanup() {
+            if [ "$ok" != 1 ]; then
+              echo "::error::backend exited or did not answer GET /api/health on 6987"
+              docker logs "$cid" || true
+            fi
+            docker rm -f "$cid" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          i=0
+          while [ "$i" -lt 90 ]; do
+            i=$((i + 1))
+            if [ -z "$(docker ps -q --filter "id=$cid")" ]; then
+              exit 1
+            fi
+            if docker exec "$cid" curl -fsS --max-time 2 http://localhost:6987/api/health >/dev/null 2>&1; then
+              ok=1
+              echo "backend ok"
+              exit 0
+            fi
+            if [ $((i % 15)) -eq 0 ]; then
+              echo "waiting for GET /api/health (${i}s)"
+            fi
+            sleep 1
+          done
+          exit 1
 
       - name: Backend — SPA present
         run: |
@@ -282,12 +319,43 @@ jobs:
             test -f /app/clients/web/build/index.html \
             || { echo "::error::SPA missing from image — web client not copied to /app/clients/web/build"; exit 1; }
 
-      - name: Daemon — import check
+      # Default CMD: python services/daemon/main.py. MCP client construction
+      # happens in SOCDaemon._init_components() at runtime, so only a live
+      # process reaches the failure v0.5.0 hid. Probe GET /health on 9091 —
+      # the same URL as Dockerfile.daemon's HEALTHCHECK.
+      - name: Daemon — starts and answers /health
         run: |
-          docker run --rm \
+          set -eu
+          IMAGE=ghcr.io/vigil-soc/vigil-daemon:${{ needs.version.outputs.version }}
+          cid=$(docker run -d \
             -e DEV_MODE=true \
-            ghcr.io/vigil-soc/vigil-daemon:${{ needs.version.outputs.version }} \
-            python -c "import services.daemon; print('daemon ok')"
+            "$IMAGE")
+          ok=0
+          cleanup() {
+            if [ "$ok" != 1 ]; then
+              echo "::error::daemon exited or did not answer GET /health on 9091"
+              docker logs "$cid" || true
+            fi
+            docker rm -f "$cid" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          i=0
+          while [ "$i" -lt 90 ]; do
+            i=$((i + 1))
+            if [ -z "$(docker ps -q --filter "id=$cid")" ]; then
+              exit 1
+            fi
+            if docker exec "$cid" curl -fsS --max-time 2 http://localhost:9091/health >/dev/null 2>&1; then
+              ok=1
+              echo "daemon ok"
+              exit 0
+            fi
+            if [ $((i % 15)) -eq 0 ]; then
+              echo "waiting for GET /health (${i}s)"
+            fi
+            sleep 1
+          done
+          exit 1
 
       # Both commands the chart runs, loaded but not started: the main blocks
       # guard on process.argv[1], which --eval leaves undefined. Proves the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Release smoke imported `services.api` and `services.daemon`. Those `__init__.py` files do not load the modules the images actually run (`services.api.main` for uvicorn, `services/daemon/main.py` for the daemon). v0.5.0’s smoke job was green while the published images crash-looped.

Deepening the import to `.main` would still miss the daemon: MCP client construction happens in `SOCDaemon._init_components()` at runtime, so only a live process reaches it.

## What

`smoke-test` in `.github/workflows/release.yml` now runs each image’s default command and fails if the process exits or the Dockerfile HEALTHCHECK URL does not answer:

- backend: `GET /api/health` on 6987
- daemon: `GET /health` on 9091

The import steps are gone, not kept as a second layer. HTTP 200 means the server accepted a connection, not that storage is healthy — `/api/health` always returns 200. No Postgres, Redis, or compose: `DEV_MODE=true` is already how this job runs, and if a container cannot listen without a dep that is the failure.

Agent `node --eval` of `worker.js` / `serve.js` is unchanged. GHCR push and `latest` tagging are unchanged; this job still only gates `update-release`.

## Verification

- YAML parse of `release.yml`
- `bash -n` on the new `run:` scripts
- actionlint 1.7.12 (same pin as CI)
- Independent review of the full diff

Could not run the job itself here: it pulls the just-built GHCR images, and this environment has no Docker.

Closes #767

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6b8fb06-9a9c-4887-90da-bb77cba8e918?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6b8fb06-9a9c-4887-90da-bb77cba8e918&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

