### PR TITLE
fix(compose): re-apply init SQL after create_all on docker compose up

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -70,10 +70,10 @@ services:
   # Second pass over the same files, once the backend's create_all has built the
   # tables the data-only scripts need. On the default `up` (no profile): a seed
   # profile would never run — this compose file has no wrapper that `compose
-  # run`s it. A healthy backend only means /api/health answers and create_all
-  # may still be running, so wait for a table only it creates — its DDL is one
-  # transaction, so that sentinel implies the rest. Re-runs on every `up` so a
-  # volume that aborted at 05 still gets the rest of the files.
+  # run`s it. /api/health always returns 200, so wait for a table only create_all
+  # creates — its DDL is one transaction, so that sentinel implies the rest.
+  # Re-runs on every `up` so a volume that aborted at 05 still gets the rest of
+  # the files.
   db-seed:
     image: postgres:16-alpine
     container_name: deeptempo-db-seed
@@ -93,14 +93,18 @@ services:
           [ "$$(psql -tAc "SELECT to_regclass('public.sla_policies') IS NOT NULL")" = t ] && break;
           sleep 1;
         done;
+        if [ "$$(psql -tAc "SELECT to_regclass('public.sla_policies') IS NOT NULL")" != t ]; then
+          echo "sla_policies still missing after wait; applying anyway" >&2;
+        fi;
         exec sh /apply.sh
     depends_on:
       postgres:
         condition: service_healthy
-      # service_started, not service_healthy: /api/health answers "healthy"
-      # even when create_all is still running (or failed). The wait loop above
-      # is the real gate. Started implies postgres/redis/bifrost are already up,
-      # which a postgres-only depends_on would not.
+      # service_started, not service_healthy: /api/health always returns 200
+      # "healthy" (including on error), so compose treating the backend as
+      # ready is not a schema signal. The wait loop above is the real gate.
+      # Started implies postgres/redis/bifrost are already up, which a
+      # postgres-only depends_on would not.
       backend:
         condition: service_started
     restart: "no"

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -51,13 +51,59 @@ services:
       - postgres_data:/var/lib/postgresql/data
       # Path is relative to this compose file (infra/docker/), so ../ points
       # at infra/, where the schema SQL now lives (infra/database/init/).
-      - ../database/init:/docker-entrypoint-initdb.d
+      # Must run here, not just in db-seed: the extensions have to exist before
+      # the backend's create_all (its indexes use pg_trgm's gin_trgm_ops), and
+      # the auth tables have to be created by this SQL — with the DEFAULT
+      # clauses create_all does not emit. 00_apply.sh explains why it isn't
+      # plain *.sql (Postgres initdb uses ON_ERROR_STOP=1 and would abort at 05).
+      - ./initdb:/docker-entrypoint-initdb.d:ro
+      - ../database/init:/db-init:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U deeptempo -d deeptempo_soc"]
       interval: 10s
       timeout: 5s
       retries: 5
     restart: unless-stopped
+    networks:
+      - deeptempo-network
+
+  # Second pass over the same files, once the backend's create_all has built the
+  # tables the data-only scripts need. On the default `up` (no profile): a seed
+  # profile would never run — this compose file has no wrapper that `compose
+  # run`s it. A healthy backend only means /api/health answers and create_all
+  # may still be running, so wait for a table only it creates — its DDL is one
+  # transaction, so that sentinel implies the rest. Re-runs on every `up` so a
+  # volume that aborted at 05 still gets the rest of the files.
+  db-seed:
+    image: postgres:16-alpine
+    container_name: deeptempo-db-seed
+    environment:
+      PGHOST: postgres
+      PGUSER: deeptempo
+      PGDATABASE: deeptempo_soc
+      PGPASSWORD: ${POSTGRES_PASSWORD:-deeptempo_secure_password_change_me}
+    volumes:
+      - ../database/init:/db-init:ro
+      - ./initdb/00_apply.sh:/apply.sh:ro
+    entrypoint:
+      - /bin/sh
+      - -c
+      - >
+        for i in $$(seq 1 60); do
+          [ "$$(psql -tAc "SELECT to_regclass('public.sla_policies') IS NOT NULL")" = t ] && break;
+          sleep 1;
+        done;
+        exec sh /apply.sh
+    depends_on:
+      postgres:
+        condition: service_healthy
+      # service_started, not service_healthy: /api/health answers "healthy"
+      # even when create_all is still running (or failed). The wait loop above
+      # is the real gate. Started implies postgres/redis/bifrost are already up,
+      # which a postgres-only depends_on would not.
+      backend:
+        condition: service_started
+    restart: "no"
     networks:
       - deeptempo-network
 

--- a/infra/docker/initdb/00_apply.sh
+++ b/infra/docker/initdb/00_apply.sh
@@ -11,8 +11,9 @@
 #   initdb   — creates extensions and the auth tables (with their DEFAULT
 #              clauses, which create_all does not emit) and seeds roles.
 #   db-seed  — after create_all, picks up the data whose tables only exist by
-#              then. Every file is idempotent, so the second pass is a no-op
-#              where the first already succeeded.
+#              then. Files use IF NOT EXISTS / ON CONFLICT, so a second pass is
+#              a no-op where the first already succeeded; other errors (e.g.
+#              trigger already exists) are tolerated.
 # Connection comes from libpq env: initdb has POSTGRES_* and a local socket,
 # db-seed passes PGHOST/PGUSER/PGDATABASE/PGPASSWORD.
 : "${PGUSER:=${POSTGRES_USER}}"

--- a/infra/docker/initdb/00_apply.sh
+++ b/infra/docker/initdb/00_apply.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Apply every schema/seed file, tolerating failures.
+#
+# Postgres' own initdb.d runner uses ON_ERROR_STOP=1, so the first failure
+# aborts the whole init and leaves a half-built schema — silently, because the
+# container then restarts onto the already-initialized data dir and reports
+# healthy. Some files here legitimately fail depending on when they run: the
+# data-only ones target tables the backend's create_all builds at startup.
+#
+# Runs twice, from two contexts, which is why it is one script:
+#   initdb   — creates extensions and the auth tables (with their DEFAULT
+#              clauses, which create_all does not emit) and seeds roles.
+#   db-seed  — after create_all, picks up the data whose tables only exist by
+#              then. Every file is idempotent, so the second pass is a no-op
+#              where the first already succeeded.
+# Connection comes from libpq env: initdb has POSTGRES_* and a local socket,
+# db-seed passes PGHOST/PGUSER/PGDATABASE/PGPASSWORD.
+: "${PGUSER:=${POSTGRES_USER}}"
+: "${PGDATABASE:=${POSTGRES_DB}}"
+export PGUSER PGDATABASE
+
+for f in /db-init/*.sql; do
+    echo "applying $(basename "$f")"
+    psql -v ON_ERROR_STOP=0 -q -f "$f" || true
+done
+echo "apply complete"

--- a/tests/unit/_ratchets/test_compose_db_seed.py
+++ b/tests/unit/_ratchets/test_compose_db_seed.py
@@ -1,0 +1,81 @@
+"""Compose must re-apply infra/database/init/*.sql after create_all on `up`.
+
+Issue #769: mounting the SQL at /docker-entrypoint-initdb.d lets Postgres run
+it with ON_ERROR_STOP=1 before the backend's create_all. 05 is data-only
+against ORM tables, so it aborts and 06–23 never run. Roles stay empty and
+agent_run_leases is never created. A seed profile is not a fix — this compose
+file has no wrapper that `compose run`s it. The desktop stack already does
+the right thing: 00_apply.sh (ON_ERROR_STOP=0) plus db-seed waiting on
+sla_policies, not /api/health.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[3]
+COMPOSE_PATH = REPO / "infra" / "docker" / "docker-compose.yml"
+APPLY_SH = REPO / "infra" / "docker" / "initdb" / "00_apply.sh"
+INIT_SQL = REPO / "infra" / "database" / "init"
+
+
+def _services() -> dict:
+    raw = yaml.safe_load(COMPOSE_PATH.read_text(encoding="utf-8"))
+    return (raw or {}).get("services") or {}
+
+
+def _volume_targets(spec: dict) -> dict[str, str]:
+    """Map container path -> host path for bind mounts."""
+    out: dict[str, str] = {}
+    for entry in spec.get("volumes") or []:
+        if not isinstance(entry, str) or ":" not in entry:
+            continue
+        host, container = entry.split(":", 1)
+        container = container.split(":")[0]
+        out[container] = host
+    return out
+
+
+def _entrypoint_text(spec: dict) -> str:
+    ep = spec.get("entrypoint") or []
+    if isinstance(ep, str):
+        return ep
+    return "\n".join(str(part) for part in ep)
+
+
+def test_postgres_does_not_feed_sql_to_initdb_entrypoint() -> None:
+    # The official image runs *.sql here with ON_ERROR_STOP=1. That was the bug.
+    mounts = _volume_targets(_services()["postgres"])
+    assert mounts.get("/docker-entrypoint-initdb.d") == "./initdb"
+    assert mounts.get("/db-init") == "../database/init"
+
+
+def test_apply_script_tolerates_errors_and_runs_every_file() -> None:
+    text = APPLY_SH.read_text(encoding="utf-8")
+    assert "ON_ERROR_STOP=0" in text
+    # Glob, not a hardcoded 06–21 range: 22 and 23 exist, and more will land.
+    assert "/db-init/*.sql" in text
+    assert list(INIT_SQL.glob("*.sql")), "no SQL files to apply"
+
+
+def test_db_seed_runs_on_default_up() -> None:
+    spec = _services()["db-seed"]
+    assert not spec.get("profiles"), (
+        "db-seed is behind a profile, so `docker compose up` will not run it"
+    )
+    text = _entrypoint_text(spec)
+    assert "to_regclass('public.sla_policies')" in text
+    assert "/api/health" not in text
+    mounts = _volume_targets(spec)
+    assert mounts.get("/db-init") == "../database/init"
+    assert mounts.get("/apply.sh") == "./initdb/00_apply.sh"
+    assert not spec.get("ports"), "db-seed is a one-shot client, not a published service"
+    depends = spec.get("depends_on") or {}
+    # A postgres-only depends_on starts db-seed before bifrost, so the 60s
+    # sla_policies wait can expire before create_all has even begun.
+    assert (depends.get("backend") or {}).get("condition") == "service_started"

--- a/tests/unit/_ratchets/test_compose_db_seed.py
+++ b/tests/unit/_ratchets/test_compose_db_seed.py
@@ -53,6 +53,9 @@ def test_postgres_does_not_feed_sql_to_initdb_entrypoint() -> None:
     mounts = _volume_targets(_services()["postgres"])
     assert mounts.get("/docker-entrypoint-initdb.d") == "./initdb"
     assert mounts.get("/db-init") == "../database/init"
+    assert not list((REPO / "infra" / "docker" / "initdb").glob("*.sql")), (
+        "SQL under initdb/ would be run by Postgres with ON_ERROR_STOP=1"
+    )
 
 
 def test_apply_script_tolerates_errors_and_runs_every_file() -> None:
@@ -68,9 +71,13 @@ def test_db_seed_runs_on_default_up() -> None:
     assert not spec.get("profiles"), (
         "db-seed is behind a profile, so `docker compose up` will not run it"
     )
+    assert spec.get("restart") == "no", (
+        "db-seed must be one-shot; unless-stopped would replay CREATE TRIGGER forever"
+    )
     text = _entrypoint_text(spec)
     assert "to_regclass('public.sla_policies')" in text
     assert "/api/health" not in text
+    assert "exec sh /apply.sh" in text
     mounts = _volume_targets(spec)
     assert mounts.get("/db-init") == "../database/init"
     assert mounts.get("/apply.sh") == "./initdb/00_apply.sh"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`docker compose up` mounted `infra/database/init/*.sql` at `/docker-entrypoint-initdb.d`. Postgres runs those files with `ON_ERROR_STOP=1` **before** the backend’s `create_all`. `05_case_management_extended.sql` inserts into ORM-only tables (`sla_policies`, `case_templates`), so it errors and every later file is skipped.

A fresh volume therefore never runs `06_auth_tables.sql` (empty `roles`, no `role-admin`) or `21_agent_run_leases.sql` (worker sweep fails forever). Host `./start.sh` recovers via `scripts/seed_reference_data.py`; that script is not in the backend image, and this compose file has no wrapper that `compose run`s a seed profile.

## What

Copy the desktop standalone pattern onto the default `up` path:

- `infra/docker/initdb/00_apply.sh` applies every `infra/database/init/*.sql` with `ON_ERROR_STOP=0` (initdb first pass, so 06 and 21 still run when 05 fails).
- `db-seed` (no profile) waits on `to_regclass('public.sla_policies')`, not `/api/health`, then reapplies the same files. Existing half-seeded volumes skip initdb; this second pass still runs on every `up`.

Out of scope: Helm, `_vigil_schema_versions`, copying `scripts/` into `Dockerfile.backend`, a roles/healthcheck gate, #768/#767/#567/#568.

## Test plan

- [x] `pytest tests/unit/_ratchets/test_compose_db_seed.py tests/security/test_compose_port_binding.py` — compose contract (no seed profile, glob `*.sql`, wait on `sla_policies`, `restart: no`)
- [ ] Full-stack `docker compose up` was not run here (no Docker daemon in this environment). On a fresh volume, `roles` should contain `role-admin` and `agent_run_leases` should exist; on a volume that previously aborted at 05, `up` should still seed those.

Closes #769

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abcdf0ab-9bc0-453a-83b4-d0149b8a56d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abcdf0ab-9bc0-453a-83b4-d0149b8a56d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

