### PR TITLE
fix(splunk): search all indexes and map all-time earliest_time

### DIFF
--- a/core/integrations/splunk/client.py
+++ b/core/integrations/splunk/client.py
@@ -242,6 +242,19 @@ class SplunkService:
             logger.error(f"Error executing search: {e}")
             return None
 
+    @staticmethod
+    def _earliest_from_hours(hours: int) -> str:
+        """Turn a look-back window in hours into a valid Splunk earliest_time.
+
+        Callers pass a very large ``hours`` to mean "all time" (the tool's
+        all-time sentinel is 876000h). Splunk rejects such an offset as
+        ``Invalid earliest_time``, so map an absurd or non-positive window to
+        Splunk's all-time epoch ``"0"`` instead.
+        """
+        if not hours or hours <= 0 or hours >= 87600:  # ~10 years -> all time
+            return "0"
+        return f"-{hours}h"
+
     def search_by_ip(self, ip_address: str, hours: int = 24) -> Optional[List[Dict]]:
         """
         Search for events related to an IP address.
@@ -253,8 +266,8 @@ class SplunkService:
         Returns:
             List of events or None
         """
-        query = f'"{ip_address}" | head 1000'
-        return self.search(query, earliest_time=f"-{hours}h")
+        query = f'search index=* "{ip_address}" | head 1000'
+        return self.search(query, earliest_time=self._earliest_from_hours(hours))
 
     def search_by_hash(self, file_hash: str, hours: int = 24) -> Optional[List[Dict]]:
         """
@@ -267,8 +280,8 @@ class SplunkService:
         Returns:
             List of events or None
         """
-        query = f'"{file_hash}" | head 1000'
-        return self.search(query, earliest_time=f"-{hours}h")
+        query = f'search index=* "{file_hash}" | head 1000'
+        return self.search(query, earliest_time=self._earliest_from_hours(hours))
 
     def search_by_username(
         self, username: str, hours: int = 24
@@ -283,8 +296,11 @@ class SplunkService:
         Returns:
             List of events or None
         """
-        query = f'user="{username}" OR username="{username}" OR account="{username}" | head 1000'
-        return self.search(query, earliest_time=f"-{hours}h")
+        query = (
+            f'search index=* (user="{username}" OR username="{username}" '
+            f'OR account="{username}") | head 1000'
+        )
+        return self.search(query, earliest_time=self._earliest_from_hours(hours))
 
     def search_by_hostname(
         self, hostname: str, hours: int = 24
@@ -300,7 +316,7 @@ class SplunkService:
             List of events or None
         """
         query = (
-            f'host="{hostname}" OR hostname="{hostname}" OR dest="{hostname}" '
-            "| head 1000"
+            f'search index=* (host="{hostname}" OR hostname="{hostname}" '
+            f'OR dest="{hostname}") | head 1000'
         )
-        return self.search(query, earliest_time=f"-{hours}h")
+        return self.search(query, earliest_time=self._earliest_from_hours(hours))

--- a/core/integrations/splunk/tool.py
+++ b/core/integrations/splunk/tool.py
@@ -317,12 +317,14 @@ async def handle_call_tool(name: str, arguments: dict | None):
                 "now",
                 args.get("max_results", 100),
             )
+            if results is None:
+                return result({"error": "Splunk search failed or timed out", "query": spl})
             return result(
                 {
                     "success": True,
                     "query": spl,
-                    "count": len(results or []),
-                    "results": results or [],
+                    "count": len(results),
+                    "results": results,
                 }
             )
         except Exception as e:
@@ -337,13 +339,10 @@ async def handle_call_tool(name: str, arguments: dict | None):
             return result({"error": "Splunk not configured"})
         try:
             results = splunk.search_by_ip(ip, args.get("hours") or _ALL_TIME_HOURS)
+            if results is None:
+                return result({"error": "Splunk search failed or timed out", "ip": ip})
             return result(
-                {
-                    "success": True,
-                    "ip": ip,
-                    "count": len(results or []),
-                    "results": results or [],
-                }
+                {"success": True, "ip": ip, "count": len(results), "results": results}
             )
         except Exception as e:
             return result({"error": str(e)})
@@ -359,12 +358,16 @@ async def handle_call_tool(name: str, arguments: dict | None):
             results = splunk.search_by_hostname(
                 host, args.get("hours") or _ALL_TIME_HOURS
             )
+            if results is None:
+                return result(
+                    {"error": "Splunk search failed or timed out", "hostname": host}
+                )
             return result(
                 {
                     "success": True,
                     "hostname": host,
-                    "count": len(results or []),
-                    "results": results or [],
+                    "count": len(results),
+                    "results": results,
                 }
             )
         except Exception as e:
@@ -384,14 +387,21 @@ async def handle_call_tool(name: str, arguments: dict | None):
             results = splunk.search(
                 spl_result["spl_query"], _ALL_TIME, "now", args.get("max_results", 100)
             )
+            if results is None:
+                return result(
+                    {
+                        "error": "Splunk search failed or timed out",
+                        "spl": spl_result["spl_query"],
+                    }
+                )
             return result(
                 {
                     "success": True,
                     "query": query,
                     "spl": spl_result["spl_query"],
                     "pattern": spl_result["pattern"],
-                    "count": len(results or []),
-                    "results": results or [],
+                    "count": len(results),
+                    "results": results,
                 }
             )
         except Exception as e:

--- a/core/integrations/splunk/tool.py
+++ b/core/integrations/splunk/tool.py
@@ -318,7 +318,9 @@ async def handle_call_tool(name: str, arguments: dict | None):
                 args.get("max_results", 100),
             )
             if results is None:
-                return result({"error": "Splunk search failed or timed out", "query": spl})
+                return result(
+                    {"error": "Splunk search failed or timed out", "query": spl}
+                )
             return result(
                 {
                     "success": True,


### PR DESCRIPTION
## Problem
Two bugs in `SplunkService`'s entity-search helpers (`search_by_ip/hash/username/hostname`), both hit in normal use — the Splunk MCP tool (`core/integrations/splunk/tool.py`) calls these with the all-time sentinel by default.

1. **Invalid all-time window.** Callers pass a large `hours` to mean "all time" (`_ALL_TIME_HOURS` = 876000). The helpers built `earliest_time=-876000h`, which Splunk rejects as `Invalid earliest_time` → HTTP 400. So any all-time entity search failed.
2. **Default-index-only search.** Queries had no `index=` clause, so they searched only the user's default indexes and silently missed data in any custom index.

## Fix
- Add `_earliest_from_hours()` — maps an absurd/non-positive window (≥ ~10y) to Splunk's all-time epoch `"0"`.
- Prefix the four entity searches with `search index=*` so they reach all indexes.

Independent of the Watcher / botsv3 work — this is a standalone bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)