### PR TITLE
feat(watcher): Slice 1 — alert to hypothesis, spec, launch

### DIFF
--- a/docs/WATCHER_BUILD_PLAN.md
+++ b/docs/WATCHER_BUILD_PLAN.md
@@ -1,0 +1,221 @@
+# The Watcher — Build Plan (Slice 1: alert → evidence)
+
+> Companion to [WATCHER_SCOPING.md](WATCHER_SCOPING.md) (the *what* and *why*).
+> This is the *how*: an input→output build, one stage at a time, each with an
+> acceptance test and a running status log so it stays clear what was done and why.
+>
+> Branch: `feat/watcher-loop`.
+
+---
+
+## The framing decision that shapes everything
+
+The TS hunt engine (`services/agent/workflows/hunt/`) **already** does the hard part
+of Slice 1: it forms a board of hypotheses, fans out ≤4 read-only workers to gather
+evidence, runs a disconfirmation critic against a seeded null, and records every
+for/against ruling in a replayable ledger.
+
+But **the hunt Lead does not invent hypotheses** — it only *tests* ones it is handed.
+Hypotheses are seeded at start from the run spec (`controller.ts` `startHunt`,
+`provenance: "hunt_spec"`), and a hunt with nothing real to test is refused
+(`resolve_hunt` / `execute_workflow`). Today a **human** authors that hypothesis (plus
+scope and context) in the console; `resolve_hunt` reads it from workflow metadata.
+
+**So the Watcher's net-new job in Slice 1 is to be that human.** It turns an *alert*
+into the *hypothesis + context* a person types today, then rides the existing
+enqueue → worker → projection plumbing. That is one net-new reasoning step; the rest
+is wiring.
+
+```
+  alert (finding dict)
+        │
+        ▼
+  ┌─────────────────────────┐   A. Hypothesizer (NET-NEW)
+  │ "what attack could this │      the Watcher plays the human:
+  │  be?" → hypotheses      │      alert → hypotheses + scope + context
+  └─────────────────────────┘
+        │
+        ▼
+  ┌─────────────────────────┐   B. Spec builder (mechanical)
+  │ resolve_hunt-shaped      │     mirror the dict resolve_hunt emits
+  │ hunt request             │
+  └─────────────────────────┘
+        │
+        ▼
+  ┌─────────────────────────┐   C. Enqueue + reconcile (REUSE)
+  │ build_start_job(hunt)    │     BullMQ agent-runs → TS worker →
+  │  → runHunt → projection  │     read_projection
+  └─────────────────────────┘
+        │
+        ▼
+  hypotheses + evidence for/against   D. Surface (thin view over projection)
+```
+
+Slice 1 **stops here** — no decision, no response action, no cross-alert memory.
+Those are later slices (see Scoping §6).
+
+---
+
+## Where this cuts into the daemon
+
+The replacement seam is intake. Today:
+
+- Processor gate `_evaluate_for_response` (`services/daemon/processor.py:773`) decides a
+  finding is worth acting on and drops it on `orchestrator.investigation_queue`.
+- Intake loop `_create_investigation_for_finding` (`services/daemon/orchestrator.py:272`)
+  picks a **fixed playbook** via `select_workflow(finding)` (`plan_generator.py:69`) — a
+  dumb deterministic `if severity==... return "incident-response"` map — then materializes
+  an `investigate` run.
+
+Slice 1 adds a **parallel path** off that same queue: instead of `select_workflow` →
+`investigate`, the Watcher does Hypothesizer → hunt spec → `hunt` run. We do **not**
+rip out `select_workflow` yet; we add the Watcher path behind a flag so the existing
+daemon keeps working and we can A/B the two on the same alert.
+
+---
+
+## Reference: what stage B must produce
+
+`resolve_hunt` (`core/workflows/playbook_resolver.py:369`) reads these off workflow
+metadata today. Stage A must produce the *content*; stage B packs it into this shape:
+
+| Field | Source today (human) | Source in Watcher (stage A) |
+|---|---|---|
+| `hypotheses` | typed in console | synthesized from the finding — **required, ≥1** |
+| `attack_techniques` | workflow metadata | from `finding.mitre_predictions` keys |
+| `data_domains` | workflow metadata | inferred from `finding.data_source` / entity types |
+| `scope` | workflow metadata | from `finding.entity_context` (ips, hosts, users) |
+| `objectives`, `narrative`, `directives` | workflow body/metadata | short context derived from the finding |
+
+`config` (model, budgets, bound tools, thresholds, `hypothesis_loop`) is produced by
+`resolve_hunt` itself from capability binding — **we reuse it unchanged**.
+
+---
+
+## Stages
+
+Each stage is independently runnable and has an acceptance test. Don't start the next
+until the current one's test passes.
+
+### Stage A — Hypothesizer (net-new)
+
+- **Goal:** a finding dict → 1–N attacker-intent hypotheses + `attack_techniques`,
+  `data_domains`, `scope`, and a short context/narrative — the artifact a human
+  authors today.
+- **Input:** the normalized finding dict (`poller.py` shape: `entity_context`,
+  `mitre_predictions`, `severity`, `data_source`, `title`, `description`,
+  `anomaly_score`).
+- **Output:** a typed `WatcherHypothesisSet` (Pydantic) carrying the fields in the
+  table above.
+- **Files (planned):** `services/daemon/watcher/hypothesizer.py` (new),
+  schema alongside it. LLM call via `services/llm_router` / the sanctioned client
+  factory — never a raw `Anthropic()`.
+- **Acceptance test:** feed 3–5 real BOTSv3 alerts; each yields ≥1 concrete,
+  testable hypothesis (not "something suspicious happened") with technique IDs that
+  match the alert's `mitre_predictions`. Eyeball for intent quality. Unit test with a
+  fixed finding fixture asserts schema + ≥1 hypothesis.
+- **Design refinement (owner-steered):** the Hypothesizer reasons over an
+  *enriched* finding, not the raw alert — it gathers **reputation** (VT/Shodan/feed
+  off the finding) and builds **scope** from entities. Triage's
+  `category`/`recommended_action` are deliberately **not** fed in (premature guess).
+  **Asset context** (host role / user privilege) has no source and is an accepted
+  gap — the prompt tells the model it is blind there. **Cross-alert memory**
+  (prior-investigation history) is deferred — see the note below.
+- **Status:** ◑ built + unit-tested. `schemas.py` (contract) +
+  `hypothesizer.py` (context gather → prompt → parse → validate) +
+  `tests/unit/daemon/watcher/test_hypothesizer.py` (fake gateway, all green).
+  **Still pending:** the real-alert eyeball —
+  feed live BOTSv3 alerts through a running stack and judge seed quality (that
+  test decides whether the LLM seed earns its keep vs. a minimal deterministic
+  seed). Parked: renaming the `submit_triage` call for clarity.
+
+### Stage B — Spec builder (mechanical)
+
+- **Goal:** `WatcherHypothesisSet` → the exact `(playbook_yaml, config_yaml)` pair
+  `resolve_hunt` emits, so the TS worker can't tell a Watcher hunt from a console one.
+- **Files (planned):** `services/daemon/watcher/spec.py` (new). Reuse
+  `resolve_hunt`'s `config` half unchanged; only synthesize the `playbook` dict from
+  stage A's output.
+- **Acceptance test:** golden-diff — build a request from a fixture finding, diff the
+  YAML against a hand-authored console hunt for the same scenario; fields line up,
+  hypotheses present, `hypothesis_loop: true`.
+- **Contract finding (reshaped this stage):** the hunt has a per-run door for
+  **only `hypotheses`** (+ iterations/budgets). `attack_techniques`, `data_domains`,
+  and `scope` have **no per-run channel** — the agent contract sources them solely
+  from a stored hunt definition's front-matter (inline spec YAML is read as a *file
+  path*; job `overrides` reject everything but budgets/runtime; DB workflows drop
+  the fields and resolve as `compose`). **Owner decision:** don't fight it — fold
+  those three into the **target-context prompt** the hunt already reads (keeps the
+  information, loses only worker-schema enum-narrowing). So Stage B is a pure map
+  `WatcherHypothesisSet -> execute_workflow("threat-hunt", parameters)` — the exact
+  console call, machine-driven.
+- **Status:** ✅ built + unit-tested. `spec.py::build_hunt_parameters`
+  (`hypothesis` per-run; `finding_id`; `context` = narrative+techniques+domains+
+  scope) + `tests/unit/daemon/watcher/test_spec.py` (7 tests). Includes a guard
+  that emitted hypotheses survive `execute_workflow`'s `_not_a_claim` gate, so a
+  real hunt won't be refused.
+
+### Stage C — Enqueue + reconcile (reuse)
+
+- **Goal:** hand the request to the existing kickoff path and read the run back.
+- **Reuse as-is:** `build_start_job(run_id, "hunt", request)` (`core/agents/queue.py:50`)
+  → `enqueue_run` → BullMQ `agent-runs` → TS `runHunt` → `read_projection(run_id)`
+  (`core/agents/projections.py:40`). `run_id_for` keeps it deterministic.
+- **Files (planned):** the Watcher path in a new
+  `services/daemon/watcher/loop.py`, wired off `investigation_queue` behind a config
+  flag (`WATCHER_ENABLED`, default off).
+- **Acceptance test:** with live Splunk + BOTSv3 (see [BOTSV3_HUNT_SETUP.md](BOTSV3_HUNT_SETUP.md)),
+  a real alert enqueues a hunt that the agent layer picks up and drives to a terminal
+  outcome; `read_projection` returns a populated ledger (hypotheses, evidence,
+  dispatches). This is the first true end-to-end run.
+- **Status:** ◑ module built + unit-tested. `launch.py::launch_hunt`
+  (rides `WorkflowsService.execute_workflow("threat-hunt", params)` — the console's
+  own enqueue path) + `read_hunt` (wraps `read_projection`) +
+  `tests/unit/daemon/watcher/test_launch.py` (6 tests, fake WorkflowsService +
+  fake reader). The mock LogLM has a `--launch` flag that fires it end-to-end.
+  **Still pending:** an actual live run — needs DB+Redis (up), the agent layer
+  (`scripts/agent_up.sh`), and a *stable* Splunk with `telemetry_search` bound, or
+  the hunt is data-starved. Not yet wired as the daemon intake loop behind
+  `WATCHER_ENABLED` (that's the productionization step after the live run proves out).
+
+### Stage D — Surface output (thin view)
+
+- **Goal:** present Slice 1's output: each hypothesis with the evidence gathered
+  for and against it.
+- **Reuse:** the projection already carries `hypotheses`, `evidence`, `links`
+  (for/against rulings). `workflows_router.py:439` already attaches
+  `read_projection` to a row — mirror that read.
+- **Files (planned):** a small read in the Watcher loop that logs/persists the
+  for/against summary; console view is optional for Slice 1 (log-level acceptance is
+  fine).
+- **Acceptance test:** for a known BOTSv3 attack, the surfaced output shows the
+  hypothesis that matches the real attack accumulating supporting evidence and the
+  null (benign) explanation losing ground — i.e. the ledger's for/against is legible.
+- **Status:** ☐ not started
+
+---
+
+## Guardrails held for Slice 1
+
+- **No response actions.** The hunt's only terminal verb is `HANDOFF_IR`; we do not
+  wire `ActionType` / `approval_service` yet (that's a later slice + the net-new
+  consequence-tier map).
+- **No cross-alert memory.** Each alert → one independent hunt. Prior-investigation
+  history (`shared_intel.check_overlap`), standing hypotheses, entity-watch, decay,
+  and the attack-intent consolidation axis are all deferred (Scoping §6 Defer /
+  Build). The Hypothesizer no longer wires any memory source — reputation
+  enrichment (VT/Shodan, a per-alert fact) is not memory and stays.
+- **Existing daemon untouched.** Watcher path is additive behind `WATCHER_ENABLED`;
+  `select_workflow` → `investigate` still runs when the flag is off.
+- **Config via the sanctioned channels** (`core.config` / `core.secrets`), no
+  `os.getenv`; LLM via the client factory, not raw `Anthropic()`.
+
+---
+
+## Status log (what was done & why)
+
+- **2026-08-31** — Plan created. Mapped the three seams (daemon intake, TS hunt
+  engine, approval/consolidation) via read-only exploration; confirmed Slice 1 is
+  mostly wiring around one net-new reasoning step (the Hypothesizer). Branch
+  `feat/watcher-loop` cut from `feat/hunt-runnable-from-the-console` so the working
+  BOTSv3 hunt harness is available for Stage C/D validation.

--- a/docs/WATCHER_SCOPING.md
+++ b/docs/WATCHER_SCOPING.md
@@ -1,0 +1,173 @@
+# The Watcher — Role & Infrastructure Scoping
+
+> Status: **scoping only.** This defines what the Watcher *is*, the infra it
+> *needs*, what it *reuses*, and what is explicitly *out of scope*. It is not a
+> build plan. Decisions below were settled in a design-tree interview; open items
+> are called out in [Dependencies](#dependencies--open-items).
+
+---
+
+## 1. What the Watcher is
+
+The Watcher is the **autonomous decision core of the daemon** — it replaces the
+current `Orchestrator` intake logic. Where intake today picks a *fixed playbook*
+(`select_workflow(finding)`, no reasoning), the Watcher **forms a hypothesis about
+attacker intent, dispatches read-only delegates to confirm/disprove it, evaluates
+what comes back, and decides which response — if any — should proceed.** It is the
+software analogue of a SOC analyst reacting to an IOC: evaluate evidence, form a
+belief, direct investigation, act within a safe blast radius.
+
+It is a **stateful** loop: it carries open hypotheses and entities-under-watch
+*across* alerts, not just within a single run.
+
+---
+
+## 2. Settled decisions
+
+| # | Decision | Outcome |
+|---|----------|---------|
+| Autonomy | How much acts without a human? | **Autonomous within a blast radius.** Reversible/low-consequence actions auto-execute; high-consequence always escalates. Full no-human is a config toggle, not the default. |
+| Trigger | What wakes it? | **Both** — event-driven on inbound alerts *and* a periodic sweep for slow-burn patterns and cross-entity consolidation. |
+| Delegate | What is a delegate? | A **read-only, information-gathering sub-agent** the Watcher spawns to feed itself evidence. **≤ 4 delegates, depth 1.** Delegates gather; the Watcher acts. |
+| State | Stateless or stateful? | **Stateful.** Standing hypotheses + entity-watch set survive across triggers. |
+| Tier | Which process? | **Python daemon.** The reasoning/delegates are dispatched over the existing BullMQ `agent-runs` seam. |
+| vs Orchestrator | New / parallel / replace? | **Replaces** the orchestrator's intake decision *and* its review decision. Keeps supervision as guardrail infra (with caveats below). |
+| Consolidation | Reuse or build? | **Reuse** `shared_intel` entity/IOC indices; add a thin **attack-intent** axis (cluster by hypothesized MITRE technique / campaign) on top. |
+| Gate | How do actions gate? | **Consequence-gated, then confidence-gated.** Consequence sets the ceiling (high-consequence never auto-runs regardless of confidence); confidence gates the low-consequence actions so reversible actions don't fire on a weak hunch. |
+| Lifecycle | What closes a hypothesis? | **Resolution or decay.** Confirmed/disproven closes it; a TTL ages out untouched items so the stateful working set — and every sweep — stays bounded. |
+| Evidence injection | Live or at-tick? | **Live**, reusing the existing directive/inbox path (see §6). |
+| Review loop | Keep it? | **Dropped.** Its mechanical `completeness ≥ 0.8` check is not a real evaluation. Evaluating a delegate's return *is* a step in the Watcher's own decision cycle. |
+
+---
+
+## 3. Responsibilities
+
+- Form hypotheses about attacker intent from incoming alerts and standing state.
+- Prioritize and dispatch read-only delegates to confirm/disprove those hypotheses.
+- Evaluate response actions proposed by a completed run and weigh their
+  consequences before allowing them to proceed.
+- Consolidate alerts by entity (reuse) and by attack intent (new thin axis).
+- Introduce new evidence into active investigations as it arrives.
+- Keep delegates on-objective — detect and correct purpose drift.
+
+---
+
+## 4. Architecture — how it fits the daemon
+
+The daemon's `Orchestrator` runs three loops today: **intake**, **supervision**,
+**review**. The Watcher reshapes them:
+
+- **Intake → replaced.** `select_workflow(finding)` (pick a fixed playbook)
+  becomes: *form a hypothesis → dispatch delegates → decide.* The direct-playbook
+  path becomes one option the Watcher can choose, not the only behavior.
+- **Supervision → kept as guardrail infra, trimmed.** Approval-raising and
+  cross-correlation stay. **Stale-kill and cost-kill are redundant** for the
+  Watcher's own delegates: the **hunt controller already enforces per-delegate
+  iteration/cost budgets** internally. Daemon-level stale/cost supervision for
+  *other* (non-hunt) agents is **out of scope** for now.
+- **Review → dropped.** See the decision table. The Watcher's own evaluation
+  replaces the completeness checkbox. Only the useful side-effects of the old
+  review path survive (create approval action, persist to memory when that lands,
+  trigger cross-correlation) — now fired by the Watcher's judgment, not a %.
+
+The reasoning engine itself is **repurposed, not lifted wholesale**, from the TS
+hunt loop (`services/agent/workflows/hunt/`) — a mature Lead/Workers/Critic engine
+that already forms hypotheses, fans out to ≤ 4 depth-1 read-only workers, runs a
+**disconfirmation critic** and a seeded **null hypothesis**, and keeps a replayable
+evidence **ledger**. This is a new Watcher loop that reuses those components; it is
+a build to be done with the owner in the loop, not a rename of the hunt engine.
+
+---
+
+## 5. Delegation & safety model
+
+**Delegation.** ≤ 4 delegates, depth 1. Delegates are read-only info-gatherers
+dispatched over the BullMQ `agent-runs` seam the daemon already uses. Depth-1 means
+a delegate cannot itself spawn Watchers. Purpose-drift oversight reuses the hunt
+loop's coverage/critic pattern (every observation must be ruled for/against each
+active hypothesis, including the null).
+
+**Two-axis gate.** An action executes autonomously **only if** its *consequence
+tier* is low **and** confidence is high:
+
+| | Low consequence (reversible) | High consequence (isolate_host, disable_user, …) |
+|---|---|---|
+| **High confidence** | Auto-execute | **Escalate** |
+| **Low confidence** | **Escalate** | **Escalate** |
+
+Consequence is the ceiling; confidence gates the auto-execute corner. This needs
+one net-new deterministic piece: a static **`ActionType → consequence tier`** map
+layered onto the existing confidence gate in `approval_service`. Everything else on
+the safety path is reused.
+
+---
+
+## 6. Infrastructure — reuse / build / defer / out-of-scope
+
+### Reuse as-is
+- **Trigger + guardrail host:** the daemon's poll→triage→intake path, hourly/daily
+  cost caps, approval-raising, cross-correlation (`services/daemon/`).
+- **Reasoning components:** hunt Lead/Workers/Critic, evidence ledger,
+  null-hypothesis, disconfirmation critic, ≤4 fan-out (`services/agent/workflows/hunt/`).
+- **Response + gate:** `core/response/approval_service.py` (`ActionType`,
+  confidence gate, `force_manual_approval` kill-switch), autonomous response
+  execution.
+- **Consolidation substrate:** `shared_intel` entity/IOC indices, `check_overlap`,
+  `get_related_investigations`, case-linking.
+- **Live evidence injection:** the **directive/inbox** system —
+  `POST /agent-runs/{id}/directives` queues a `note` (free-text observation) or
+  `lead` (actionable lead); the running Lead drains it at the next iteration
+  boundary and folds it into its digest. The Watcher pushes new evidence this way.
+- **Kickoff/reconcile plumbing:** `build_start_job` / `enqueue_run` → BullMQ
+  `agent-runs` → TS worker → `read_projection` reconcile.
+
+### Build (net-new)
+- The **Watcher loop** in the daemon (replacing intake): hypothesis formation over
+  alerts/entities/cases, delegate prioritization, evaluate-and-decide cycle.
+- Lifting hunt-style hypothesis reasoning **up a tier** — over alerts/entities/cases
+  rather than intra-hunt telemetry only.
+- The **decision → response bridge**: today a hunt can only `HANDOFF_IR`; the
+  Watcher must drive `ActionType` responses through `approval_service`.
+- The static **`ActionType → consequence tier`** map (the one net-new safety piece).
+- The thin **attack-intent** consolidation axis on top of `shared_intel`.
+- **Hypothesis/entity decay** (TTL) over the standing state.
+
+### Defer (dependent on a broader decision)
+- **Watcher memory / standing state model.** The Watcher needs persistent state for
+  hypotheses that span alerts and outlive any single `Investigation` — nothing today
+  holds that. Its concrete shape is **deferred to the broader all-agent memory
+  conversation** rather than designed here.
+
+### Out of scope (now)
+- Reworking daemon-level stale/cost supervision for **non-hunt** agents.
+- Recursive delegation / depth > 1.
+- Full-autonomy-by-default (no-human) — remains a config toggle, off by default.
+
+---
+
+## 7. Trigger model
+
+- **Event:** the daemon's existing poller→processor feed *is* the event source; a
+  new finding that clears intake severity wakes the Watcher.
+- **Sweep:** a periodic tick re-weighs standing hypotheses, ages out decayed items,
+  runs entity/intent consolidation, and catches slow-burn patterns no single alert
+  trips.
+
+---
+
+## Dependencies & open items
+
+1. **All-agent memory model** — blocks the concrete Watcher standing-state design
+   (§6 Defer). The Watcher *needs* memory; its shape waits on that decision.
+2. Owner-in-the-loop build of the new Watcher loop (explicit ask — not a
+   delegate-and-forget task).
+
+---
+
+## Non-goals
+
+- Not a second brain running in parallel with the orchestrator — it **replaces**
+  the intake/review decision.
+- Not a re-home or rename of the TS hunt engine — a new loop that **reuses** its
+  components.
+- Not a full autonomous responder by default — high-consequence actions escalate.

--- a/services/daemon/watcher/__init__.py
+++ b/services/daemon/watcher/__init__.py
@@ -1,0 +1,5 @@
+"""The Watcher — the daemon's autonomous decision core.
+
+See docs/WATCHER_SCOPING.md (what it is) and docs/WATCHER_BUILD_PLAN.md (how it
+is built). Stage A is the Hypothesizer: an alert in, testable hypotheses out.
+"""

--- a/services/daemon/watcher/hypothesizer.py
+++ b/services/daemon/watcher/hypothesizer.py
@@ -1,0 +1,261 @@
+"""Stage A of the Watcher: turn one alert into testable hypotheses.
+
+The hunt engine tests hypotheses; it never invents them. Today a human authors
+the hypothesis + scope + context in the console. The Hypothesizer *is* that human
+for an incoming alert — it reads an (already enriched) finding and produces the
+``WatcherHypothesisSet`` a hunt needs to run.
+
+A human doesn't hypothesize from the raw alert alone — they first check what the
+entities *are*. So the Hypothesizer gathers context before it reasons:
+
+- **Reputation (facts):** VirusTotal / Shodan / local-feed hits already attached to
+  the finding by the daemon's enrichment step — "is this IOC known-bad".
+- **Asset context:** deliberately absent — no host-role / user-privilege source
+  exists yet (accepted gap). The prompt says so, so the model knows it is blind
+  there rather than guessing.
+
+What it does NOT feed the model: triage's ``category`` / ``recommended_action``.
+Those are a prior one-shot LLM guess made before any evidence; piping a guess into
+a guess just anchors this one. Only hard facts inform the hypothesis.
+
+Split of responsibility, on purpose:
+
+- **Deterministic (facts from the alert):** ``scope`` and any MITRE techniques the
+  finding already carries. The model does not get to invent or drop them.
+- **Model (judgement):** the hypotheses, a short narrative, inferred techniques
+  when the source gave none, and the data domains worth searching.
+
+The LLM call reuses the daemon's existing gateway (Bifrost-routed, cost-tracked) —
+the same path triage uses. No LLM client is constructed here.
+"""
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+from services.daemon.watcher.schemas import WatcherHypothesisSet
+
+logger = logging.getLogger(__name__)
+
+# How many entity buckets we recognize as scope, and the source keys (plural and
+# singular) each maps from. Findings arrive from many normalizers; be tolerant.
+_SCOPE_KEYS: Dict[str, tuple] = {
+    "src_ips": ("src_ips", "src_ip", "source_ip"),
+    "dest_ips": ("dest_ips", "dest_ip", "dst_ip", "destination_ip"),
+    "hostnames": ("hostnames", "hostname", "host"),
+    "usernames": ("usernames", "users", "username", "user"),
+}
+
+# Cap how much gathered context we pour into the prompt, so a noisy finding can't
+# blow up the request.
+_MAX_REPUTATION_LINES = 12
+
+
+class HypothesizerError(Exception):
+    """The Hypothesizer could not produce a valid hypothesis set for a finding."""
+
+
+def _scope_from_entities(
+    entity_context: Optional[Dict[str, Any]]
+) -> Dict[str, List[str]]:
+    """Collect the alert's real entities into the scope shape, tolerating the
+    plural/singular key variants different normalizers emit. Facts only."""
+    ctx = entity_context or {}
+    scope: Dict[str, List[str]] = {}
+    for bucket, source_keys in _SCOPE_KEYS.items():
+        values: List[str] = []
+        for key in source_keys:
+            raw = ctx.get(key)
+            if not raw:
+                continue
+            items = raw if isinstance(raw, list) else [raw]
+            values.extend(str(v).strip() for v in items if str(v).strip())
+        if values:
+            # De-dup, preserve first-seen order.
+            scope[bucket] = list(dict.fromkeys(values))
+    return scope
+
+
+def _reputation_lines(finding: Dict[str, Any]) -> List[str]:
+    """Pull known-bad signals the daemon's enrichment already attached to the
+    finding. Defensive: the enrichment shape drifts and two writers clobber the
+    same column (see QUESTIONABLE.md Q2), so read tolerantly and skip what we
+    don't recognize rather than trust a fixed schema."""
+    enrichment = finding.get("enrichment")
+    if not isinstance(enrichment, dict):
+        return []
+
+    lines: List[str] = []
+    for key, value in enrichment.items():
+        if not isinstance(value, dict):
+            continue
+        if key.startswith("ip_"):
+            ip = key[3:]
+            vt = value.get("virustotal") or {}
+            shodan = value.get("shodan") or {}
+            bits = []
+            if vt.get("malicious"):
+                mal, rep = vt.get("malicious"), vt.get("reputation")
+                bits.append(f"VT malicious={mal}, reputation={rep}")
+            if shodan.get("vulns"):
+                bits.append(f"Shodan vulns={list(shodan.get('vulns'))[:5]}")
+            if shodan.get("org"):
+                bits.append(f"org={shodan.get('org')}")
+            if bits:
+                lines.append(f"IP {ip}: " + "; ".join(bits))
+        elif key.startswith("hash_"):
+            malicious = value.get("malicious")
+            if malicious:
+                names = list(value.get("names") or [])[:3]
+                ftype = value.get("type")
+                lines.append(
+                    f"Hash {key[5:]}: VT malicious={malicious}, "
+                    f"type={ftype}, names={names}"
+                )
+        elif key == "threat_indicators":
+            for ind_key in list(value.keys())[:5]:
+                lines.append(f"Threat-feed hit: {ind_key}")
+        if len(lines) >= _MAX_REPUTATION_LINES:
+            break
+    return lines[:_MAX_REPUTATION_LINES]
+
+
+def _build_prompt(
+    finding: Dict[str, Any],
+    scope: Dict[str, List[str]],
+    reputation: List[str],
+) -> str:
+    """Ask the model for a JSON hypothesis set grounded in the alert + context."""
+    desc = (finding.get("description") or "N/A")[:800]
+    given_techniques = sorted((finding.get("mitre_predictions") or {}).keys())
+    reputation_block = "\n    ".join(reputation) if reputation else "none found"
+
+    return f"""You are a SOC analyst deciding what to investigate. Read the alert \
+and the context below and state what an attacker could be doing, as hypotheses a \
+hunt can test.
+
+ALERT
+  Finding ID: {finding.get('finding_id') or 'N/A'}
+  Source: {finding.get('data_source') or 'unknown'}
+  Severity (as the source reported it): {finding.get('severity') or 'unknown'}
+  Title: {finding.get('title') or 'N/A'}
+  Description: {desc}
+  Entities in scope: {json.dumps(scope) or '{}'}
+  MITRE signals from the source (may be tactics, not specific techniques): \
+{given_techniques or 'none'}
+
+CONTEXT (facts gathered on the entities — not guesses)
+  Reputation (known-bad signals):
+    {reputation_block}
+  Asset context (is this host critical? is this user privileged?): NOT AVAILABLE \
+— do not assume; if it would change your hypothesis, say so.
+
+Return ONLY a JSON object, no prose, with these keys:
+  "hypotheses": array of 1-4 strings. ATTACK hypotheses ONLY — each a concrete,
+      falsifiable claim about attacker intent that names the entity involved
+      (e.g. "the internal host 10.0.0.5 is conducting command-and-control with
+      external 203.0.113.9"), NOT a vague statement like "something suspicious
+      happened". Do NOT include the benign / "no attack" explanation — the hunt
+      seeds and argues that null itself, so a benign alternative here just
+      duplicates it. Claim only what the alert supports: if the protocol or
+      technique is not in the data, do not invent it — leave the hunt to discover
+      it. Ground them in the reputation/history facts above where relevant.
+  "narrative": one or two sentences of context — what the alert saw and why it is
+      worth a hunt.
+  "attack_techniques": array of MITRE technique IDs (e.g. "T1071.004") you can
+      justify from the alert. May be empty — do not guess a specific technique the
+      data doesn't support.
+  "data_domains": array naming where to look (e.g. "dns", "network", "endpoint",
+      "auth", "web", "cloud"). May be empty.
+
+If the alert is too thin to justify a specific hypothesis, still return your single
+best falsifiable ATTACK claim at the coarsest honest level (e.g. "10.0.0.5 is
+communicating with attacker-controlled 203.0.113.9") — never an empty array, and
+never the benign explanation."""
+
+
+def _extract_json(text: str) -> Dict[str, Any]:
+    """Pull the JSON object out of a model reply that may wrap it in prose or
+    ```json fences."""
+    stripped = text.strip()
+    fenced = re.search(r"```(?:json)?\s*(\{.*\})\s*```", stripped, re.DOTALL)
+    if fenced:
+        stripped = fenced.group(1)
+    else:
+        start = stripped.find("{")
+        end = stripped.rfind("}") + 1
+        if start != -1 and end > start:
+            stripped = stripped[start:end]
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        raise HypothesizerError(f"model reply was not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise HypothesizerError("model reply JSON was not an object")
+    return data
+
+
+async def form_hypotheses(
+    finding: Dict[str, Any],
+    *,
+    gateway: Any = None,
+) -> WatcherHypothesisSet:
+    """Form a testable hypothesis set from one enriched alert.
+
+    ``gateway`` (optional) is the LLM gateway, injectable for tests. In the daemon
+    it defaults to the shared one. Raises :class:`HypothesizerError` when no valid
+    set can be built.
+    """
+    finding_id = finding.get("finding_id")
+    if not finding_id:
+        raise HypothesizerError("finding has no finding_id")
+
+    scope = _scope_from_entities(finding.get("entity_context"))
+    reputation = _reputation_lines(finding)
+
+    if gateway is None:
+        from core.llm.gateway.gateway import get_llm_gateway
+
+        gateway = await get_llm_gateway()
+    if gateway is None:
+        raise HypothesizerError("LLM gateway unavailable")
+
+    prompt = _build_prompt(finding, scope, reputation)
+    reply = await gateway.submit_triage(prompt)
+    if not reply:
+        raise HypothesizerError("LLM gateway returned no reply")
+    if isinstance(reply, dict):
+        reply = reply.get("content", "")
+
+    data = _extract_json(reply)
+
+    # Merge the source's own techniques back in — an attested technique is a fact,
+    # not a suggestion. But the source's MITRE signal can be a *tactic* name
+    # (LogLM emits tactics, not technique IDs), and only T-code-shaped signals
+    # belong in attack_techniques. The raw signal still reaches the model via the
+    # prompt, so a tactic isn't lost — it just isn't mislabelled as a technique.
+    given = [
+        t
+        for t in (finding.get("mitre_predictions") or {})
+        if isinstance(t, str) and re.match(r"^T\d{4}", t)
+    ]
+    inferred = [t for t in (data.get("attack_techniques") or []) if isinstance(t, str)]
+    techniques = list(dict.fromkeys([*given, *inferred]))
+
+    try:
+        return WatcherHypothesisSet(
+            hypotheses=data.get("hypotheses") or [],
+            narrative=data.get("narrative") or "",
+            attack_techniques=techniques,
+            data_domains=[
+                d for d in (data.get("data_domains") or []) if isinstance(d, str)
+            ],
+            scope=scope,
+            source_finding_id=finding_id,
+        )
+    except ValueError as exc:
+        # Pydantic validation (e.g. empty hypotheses, blank narrative).
+        raise HypothesizerError(
+            f"model produced an invalid hypothesis set: {exc}"
+        ) from exc

--- a/services/daemon/watcher/launch.py
+++ b/services/daemon/watcher/launch.py
@@ -1,0 +1,60 @@
+"""Stage C of the Watcher: launch a hunt from a hypothesis set, and read it back.
+
+Launch rides the console's own path — ``WorkflowsService.execute_workflow`` — so a
+Watcher-launched hunt is indistinguishable from a human-launched one on the agent
+layer: it enqueues onto the BullMQ ``agent-runs`` queue, the TS worker resolves the
+``threat-hunt`` spec, merges in our hypotheses + context, and drives the hunt.
+
+Reconcile is ``read_projection``: the run's own ledger (hypotheses + evidence for
+and against each) read over HTTP from the agent layer. The daemon never writes
+beside that ledger — it only reads a projection of it.
+
+Both dependencies are injectable so this is testable without a live stack.
+"""
+
+from typing import Any, Dict, Optional
+
+from services.daemon.watcher.schemas import WatcherHypothesisSet
+from services.daemon.watcher.spec import HUNT_WORKFLOW_ID, build_hunt_parameters
+
+
+async def launch_hunt(
+    hypothesis_set: WatcherHypothesisSet,
+    *,
+    workflows: Any = None,
+    triggered_by: str = "watcher",
+    max_cost_usd: Optional[float] = None,
+    iterations: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Enqueue a threat hunt for one hypothesis set.
+
+    Returns ``execute_workflow``'s result dict: on success
+    ``{"success": True, "status": "queued", "run_id", "job_id", ...}``; on failure
+    ``{"success": False, "error", ...}``. ``workflows`` (a ``WorkflowsService``) is
+    injectable for tests; in the daemon it defaults to the real one.
+    """
+    if workflows is None:
+        from core.workflows.workflows_service import WorkflowsService
+
+        workflows = WorkflowsService()
+
+    params = build_hunt_parameters(
+        hypothesis_set, max_cost_usd=max_cost_usd, iterations=iterations
+    )
+    return await workflows.execute_workflow(
+        HUNT_WORKFLOW_ID, params, triggered_by=triggered_by
+    )
+
+
+async def read_hunt(run_id: str, *, reader: Any = None) -> Optional[Dict[str, Any]]:
+    """Read the hunt's projection (its ledger) for ``run_id``.
+
+    ``None`` means nothing to read yet (the run hasn't been picked up, or the agent
+    layer is unreachable) — not an error. ``reader`` is injectable for tests; in the
+    daemon it defaults to ``read_projection``.
+    """
+    if reader is None:
+        from core.agents.projections import read_projection
+
+        reader = read_projection
+    return await reader(run_id)

--- a/services/daemon/watcher/schemas.py
+++ b/services/daemon/watcher/schemas.py
@@ -1,0 +1,78 @@
+"""Typed output contract for the Watcher's Hypothesizer.
+
+The Hypothesizer reads an alert (a normalized finding dict) and produces the
+artifact a human authors in the console today: the hypotheses to test plus the
+scope and context a hunt needs to run. This module defines only the *shape* of
+that answer — the blanks the Hypothesizer must fill and the rules a valid answer
+obeys. No logic, no model call lives here.
+
+Only ``hypotheses`` (>=1) and ``narrative`` are required. Techniques and data
+domains are *inferred* by the Hypothesizer and may legitimately be empty — a
+source like Splunk arrives with ``mitre_predictions={}``, and an empty list just
+means the hunt does not narrow its worker search on that axis. Nothing here
+assumes the input finding is richly populated.
+"""
+
+from typing import Dict, List
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class WatcherHypothesisSet(BaseModel):
+    """What the Hypothesizer hands to the spec builder for one alert."""
+
+    hypotheses: List[str] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Concrete, testable attacker-intent claims derived from the alert. "
+            "At least one is required; a hunt with nothing real to test is refused."
+        ),
+    )
+    narrative: str = Field(
+        ...,
+        description=(
+            "One or two sentences of context: what the alert saw and why it is "
+            "worth a hunt. Not taken from the alert — written by the Hypothesizer."
+        ),
+    )
+    attack_techniques: List[str] = Field(
+        default_factory=list,
+        description=(
+            "MITRE technique IDs (e.g. 'T1071.004'). Taken from the finding's "
+            "mitre_predictions when present, otherwise inferred; empty is valid."
+        ),
+    )
+    data_domains: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Where to look: dns, network, endpoint, auth, etc. Inferred from the "
+            "finding's data_source and populated entity buckets; empty is valid."
+        ),
+    )
+    scope: Dict[str, List[str]] = Field(
+        default_factory=dict,
+        description=(
+            "Entities in play, mirroring the finding's entity_context "
+            "(src_ips, dest_ips, hostnames, usernames). May be partial."
+        ),
+    )
+    source_finding_id: str = Field(
+        ...,
+        description="The finding_id this hypothesis set was derived from.",
+    )
+
+    @field_validator("hypotheses")
+    @classmethod
+    def _no_blank_hypotheses(cls, value: List[str]) -> List[str]:
+        cleaned = [h.strip() for h in value if h and h.strip()]
+        if not cleaned:
+            raise ValueError("at least one non-empty hypothesis is required")
+        return cleaned
+
+    @field_validator("narrative")
+    @classmethod
+    def _narrative_not_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("narrative must not be empty")
+        return value.strip()

--- a/services/daemon/watcher/spec.py
+++ b/services/daemon/watcher/spec.py
@@ -1,0 +1,83 @@
+"""Stage B of the Watcher: turn a hypothesis set into hunt-launch parameters.
+
+The hunt engine only has a per-run door for ONE of the four things the
+Hypothesizer produces: ``hypotheses``. ``attack_techniques``, ``data_domains``,
+and ``scope`` have no per-run channel — the agent contract sources them only from
+a stored hunt definition's front-matter (see the resolution path in
+``services/agent/worker.ts`` / ``core/workflows/playbook_resolver.py``). Rather
+than fight that (a synthesized definition file or a contract change), we fold
+those three into the **target-context prompt** the hunt already receives. The
+hunt's Lead reads that context, so it still gets "focus on T1071.004, look in
+dns/network, these are the entities" — as natural language instead of as
+schema-narrowing fields. We lose only the worker-output-schema enum narrowing,
+never the information.
+
+So Stage B is a pure mapping ``WatcherHypothesisSet -> parameters`` for
+``WorkflowsService.execute_workflow(HUNT_WORKFLOW_ID, parameters)`` — the exact
+call the console makes, just driven by the machine. Enqueueing is Stage C.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from services.daemon.watcher.schemas import WatcherHypothesisSet
+
+# The shipped hunt definition the console references; resolves run_kind: hunt and
+# binds telemetry_search to whatever live MCP server the deployment carries.
+HUNT_WORKFLOW_ID = "threat-hunt"
+
+
+def _render_scope(scope: Dict[str, List[str]]) -> List[str]:
+    lines: List[str] = []
+    for bucket, values in scope.items():
+        if values:
+            lines.append(f"- {bucket}: {', '.join(values)}")
+    return lines
+
+
+def _render_context(hypothesis_set: WatcherHypothesisSet) -> str:
+    """The Hypothesizer's judgement, as context the hunt Lead reads. Carries the
+    three fields the per-run contract can't take (techniques, domains, scope)."""
+    techniques = ", ".join(hypothesis_set.attack_techniques) or "none inferred"
+    domains = ", ".join(hypothesis_set.data_domains) or "unspecified"
+    scope_lines = _render_scope(hypothesis_set.scope) or ["- (no entities extracted)"]
+
+    parts = [
+        "**Watcher hypothesis context** "
+        "(formed from the triggering alert, to be tested — not a conclusion)",
+        hypothesis_set.narrative,
+        f"Suspected MITRE techniques: {techniques}",
+        f"Data domains to search: {domains}",
+        "Entities in scope:",
+        *scope_lines,
+    ]
+    return "\n".join(parts)
+
+
+def build_hunt_parameters(
+    hypothesis_set: WatcherHypothesisSet,
+    *,
+    max_cost_usd: Optional[float] = None,
+    iterations: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Map a hypothesis set to the parameters for ``execute_workflow``.
+
+    - ``hypothesis``: the testable claims, one per line — the hunt seeds these as
+      operator hypotheses (peers of the definition's, if any).
+    - ``finding_id``: the source alert, so the target-context builder pulls the
+      canonical finding block from the store.
+    - ``context``: the Hypothesizer's narrative + techniques + domains + scope,
+      folded in because the per-run contract can't carry the last three.
+
+    ``max_cost_usd`` / ``iterations`` are optional per-run budget/depth knobs; when
+    unset the hunt keeps the definition's shipped policy.
+    """
+    params: Dict[str, Any] = {
+        "hypothesis": "\n".join(hypothesis_set.hypotheses),
+        "finding_id": hypothesis_set.source_finding_id,
+        "context": _render_context(hypothesis_set),
+    }
+    if max_cost_usd is not None:
+        params["max_cost_usd"] = max_cost_usd
+    if iterations is not None:
+        params["iterations"] = iterations
+    return params

--- a/tests/unit/daemon/watcher/test_hypothesizer.py
+++ b/tests/unit/daemon/watcher/test_hypothesizer.py
@@ -1,0 +1,184 @@
+"""Stage A acceptance: the Hypothesizer turns an enriched alert into a valid,
+testable hypothesis set — with no real LLM or network.
+
+The model is faked (a gateway that returns canned text), so these tests exercise
+the Hypothesizer's own logic: context gathering, prompt construction, reply
+parsing, technique merge, and validation.
+"""
+
+import json
+
+import pytest
+
+from services.daemon.watcher.hypothesizer import HypothesizerError, form_hypotheses
+from services.daemon.watcher.schemas import WatcherHypothesisSet
+
+pytestmark = pytest.mark.unit
+
+
+class FakeGateway:
+    """Records the prompt it was handed and returns a canned reply."""
+
+    def __init__(self, reply):
+        self.reply = reply
+        self.last_prompt = None
+
+    async def submit_triage(self, prompt):
+        self.last_prompt = prompt
+        return self.reply
+
+
+def _botsv3_finding():
+    """A BOTSv3-style enriched finding: entities + a source technique + the
+    reputation an enrichment pass would have attached."""
+    return {
+        "finding_id": "splunk-abc123",
+        "data_source": "splunk",
+        "severity": "high",
+        "title": "Suspicious DNS beaconing",
+        "description": "Host made periodic DNS lookups to a rare external domain.",
+        "entity_context": {
+            "src_ips": ["10.0.0.5"],
+            "dest_ips": ["115.238.245.8"],
+            "hostnames": ["WIN-ABC"],
+            "usernames": ["svc-backup"],
+        },
+        "mitre_predictions": {"T1071.004": 0.8},
+        "enrichment": {
+            "ip_115.238.245.8": {
+                "virustotal": {"malicious": 3, "reputation": -40},
+                "shodan": {"org": "EvilCorp", "vulns": ["CVE-2021-1234"]},
+            }
+        },
+    }
+
+
+def _valid_reply(**overrides):
+    payload = {
+        "hypotheses": [
+            "Host WIN-ABC is beaconing to external C2 at 115.238.245.8 over DNS",
+        ],
+        "narrative": "WIN-ABC made periodic DNS lookups to a VT-flagged IP.",
+        "attack_techniques": ["T1568.002"],
+        "data_domains": ["dns", "network"],
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+@pytest.mark.asyncio
+async def test_forms_a_valid_hypothesis_set():
+    gateway = FakeGateway(_valid_reply())
+    result = await form_hypotheses(_botsv3_finding(), gateway=gateway)
+
+    assert isinstance(result, WatcherHypothesisSet)
+    assert len(result.hypotheses) >= 1
+    assert result.narrative
+    assert result.source_finding_id == "splunk-abc123"
+
+
+@pytest.mark.asyncio
+async def test_scope_is_built_deterministically_from_entities():
+    gateway = FakeGateway(_valid_reply())
+    result = await form_hypotheses(_botsv3_finding(), gateway=gateway)
+
+    assert result.scope["src_ips"] == ["10.0.0.5"]
+    assert result.scope["dest_ips"] == ["115.238.245.8"]
+    assert result.scope["hostnames"] == ["WIN-ABC"]
+    assert result.scope["usernames"] == ["svc-backup"]
+
+
+@pytest.mark.asyncio
+async def test_scope_tolerates_singular_key_variants():
+    finding = _botsv3_finding()
+    finding["entity_context"] = {"src_ip": "10.0.0.9", "host": "DC-1", "user": "root"}
+    gateway = FakeGateway(_valid_reply())
+
+    result = await form_hypotheses(finding, gateway=gateway)
+
+    assert result.scope["src_ips"] == ["10.0.0.9"]
+    assert result.scope["hostnames"] == ["DC-1"]
+    assert result.scope["usernames"] == ["root"]
+
+
+@pytest.mark.asyncio
+async def test_source_techniques_are_merged_even_if_model_omits_them():
+    # Model returns only its inferred technique; the source's T1071.004 must survive.
+    gateway = FakeGateway(_valid_reply(attack_techniques=["T1568.002"]))
+    result = await form_hypotheses(_botsv3_finding(), gateway=gateway)
+
+    assert "T1071.004" in result.attack_techniques  # attested by the source
+    assert "T1568.002" in result.attack_techniques  # inferred by the model
+
+
+@pytest.mark.asyncio
+async def test_reputation_reaches_the_prompt():
+    gateway = FakeGateway(_valid_reply())
+
+    await form_hypotheses(_botsv3_finding(), gateway=gateway)
+
+    prompt = gateway.last_prompt
+    assert "VT malicious=3" in prompt  # reputation fact reached the model
+    assert "EvilCorp" in prompt
+
+
+@pytest.mark.asyncio
+async def test_prompt_declares_asset_context_unavailable():
+    gateway = FakeGateway(_valid_reply())
+    await form_hypotheses(_botsv3_finding(), gateway=gateway)
+
+    assert "NOT AVAILABLE" in gateway.last_prompt  # the accepted asset-context gap
+
+
+@pytest.mark.asyncio
+async def test_reply_wrapped_in_prose_and_fences_is_parsed():
+    fenced = "Here you go:\n```json\n" + _valid_reply() + "\n```\nHope this helps!"
+    gateway = FakeGateway(fenced)
+    result = await form_hypotheses(_botsv3_finding(), gateway=gateway)
+
+    assert len(result.hypotheses) >= 1
+
+
+@pytest.mark.asyncio
+async def test_dict_reply_content_is_parsed():
+    gateway = FakeGateway({"content": _valid_reply()})
+    result = await form_hypotheses(_botsv3_finding(), gateway=gateway)
+
+    assert len(result.hypotheses) >= 1
+
+
+@pytest.mark.asyncio
+async def test_malformed_reply_raises_cleanly():
+    gateway = FakeGateway("I could not analyze this alert, sorry.")
+    with pytest.raises(HypothesizerError):
+        await form_hypotheses(_botsv3_finding(), gateway=gateway)
+
+
+@pytest.mark.asyncio
+async def test_empty_hypotheses_is_rejected():
+    gateway = FakeGateway(_valid_reply(hypotheses=[]))
+    with pytest.raises(HypothesizerError):
+        await form_hypotheses(_botsv3_finding(), gateway=gateway)
+
+
+@pytest.mark.asyncio
+async def test_blank_narrative_is_rejected():
+    gateway = FakeGateway(_valid_reply(narrative="   "))
+    with pytest.raises(HypothesizerError):
+        await form_hypotheses(_botsv3_finding(), gateway=gateway)
+
+
+@pytest.mark.asyncio
+async def test_finding_without_id_raises():
+    finding = _botsv3_finding()
+    del finding["finding_id"]
+    gateway = FakeGateway(_valid_reply())
+    with pytest.raises(HypothesizerError):
+        await form_hypotheses(finding, gateway=gateway)
+
+
+@pytest.mark.asyncio
+async def test_empty_reply_raises():
+    gateway = FakeGateway("")
+    with pytest.raises(HypothesizerError):
+        await form_hypotheses(_botsv3_finding(), gateway=gateway)

--- a/tests/unit/daemon/watcher/test_launch.py
+++ b/tests/unit/daemon/watcher/test_launch.py
@@ -1,0 +1,104 @@
+"""Stage C: launch a hunt from a hypothesis set, read it back.
+
+Both dependencies are faked — a WorkflowsService that records the call and a
+projection reader — so the launch/reconcile wiring is exercised with no live
+agent layer, DB, or queue.
+"""
+
+import pytest
+
+from services.daemon.watcher.launch import launch_hunt, read_hunt
+from services.daemon.watcher.schemas import WatcherHypothesisSet
+
+pytestmark = pytest.mark.unit
+
+
+class FakeWorkflows:
+    """Records execute_workflow's arguments and returns a canned result."""
+
+    def __init__(self, result=None):
+        self.result = result or {
+            "success": True,
+            "status": "queued",
+            "run_id": "run-123",
+            "job_id": "job-123",
+        }
+        self.calls = []
+
+    async def execute_workflow(self, workflow_id, parameters, triggered_by=None):
+        self.calls.append((workflow_id, parameters, triggered_by))
+        return self.result
+
+
+def _hypothesis_set(**overrides):
+    data = {
+        "hypotheses": [
+            "The internal host 172.16.0.109 is conducting command-and-control "
+            "communication with attacker-controlled 45.77.53.176",
+        ],
+        "narrative": "LogLM flagged C2-tactic traffic to a VT-flagged host.",
+        "attack_techniques": [],
+        "data_domains": ["network"],
+        "scope": {"src_ips": ["172.16.0.109"], "dest_ips": ["45.77.53.176"]},
+        "source_finding_id": "f-20260831-abc",
+    }
+    data.update(overrides)
+    return WatcherHypothesisSet(**data)
+
+
+@pytest.mark.asyncio
+async def test_launches_threat_hunt_with_the_built_parameters():
+    wf = FakeWorkflows()
+    result = await launch_hunt(_hypothesis_set(), workflows=wf)
+
+    assert result["run_id"] == "run-123"
+    (workflow_id, params, triggered_by) = wf.calls[0]
+    assert workflow_id == "threat-hunt"
+    assert set(params) == {"hypothesis", "finding_id", "context"}
+    assert "45.77.53.176" in params["hypothesis"]
+    assert triggered_by == "watcher"
+
+
+@pytest.mark.asyncio
+async def test_budget_and_iteration_knobs_flow_into_parameters():
+    wf = FakeWorkflows()
+    await launch_hunt(_hypothesis_set(), workflows=wf, max_cost_usd=5.0, iterations=6)
+
+    (_, params, _) = wf.calls[0]
+    assert params["max_cost_usd"] == 5.0
+    assert params["iterations"] == 6
+
+
+@pytest.mark.asyncio
+async def test_triggered_by_is_passed_through():
+    wf = FakeWorkflows()
+    await launch_hunt(_hypothesis_set(), workflows=wf, triggered_by="daemon-sweep")
+    assert wf.calls[0][2] == "daemon-sweep"
+
+
+@pytest.mark.asyncio
+async def test_launch_surfaces_a_failed_enqueue():
+    wf = FakeWorkflows(result={"success": False, "error": "run queue unavailable"})
+    result = await launch_hunt(_hypothesis_set(), workflows=wf)
+    assert result["success"] is False
+    assert "queue" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_read_hunt_delegates_to_the_reader():
+    projection = {"hypotheses": {"h1": {"status": "active"}}, "evidence": {}}
+
+    async def fake_reader(run_id):
+        assert run_id == "run-123"
+        return projection
+
+    got = await read_hunt("run-123", reader=fake_reader)
+    assert got is projection
+
+
+@pytest.mark.asyncio
+async def test_read_hunt_returns_none_when_not_ready():
+    async def fake_reader(run_id):
+        return None
+
+    assert await read_hunt("run-123", reader=fake_reader) is None

--- a/tests/unit/daemon/watcher/test_spec.py
+++ b/tests/unit/daemon/watcher/test_spec.py
@@ -1,0 +1,88 @@
+"""Stage B: WatcherHypothesisSet -> execute_workflow parameters.
+
+The key contracts to hold:
+- hypotheses ride the per-run channel (newline-joined);
+- techniques / data_domains / scope / narrative are folded into `context`
+  (the per-run contract can't carry the first three as fields);
+- the finding id is passed so the console's target-context block resolves;
+- crucially, the hypotheses we emit must survive execute_workflow's own claim
+  gate (_not_a_claim), or a real hunt would be refused before it starts.
+"""
+
+import pytest
+
+from core.workflows.workflows_service import _asked_hypotheses, _not_a_claim
+from services.daemon.watcher.schemas import WatcherHypothesisSet
+from services.daemon.watcher.spec import (
+    HUNT_WORKFLOW_ID,
+    build_hunt_parameters,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _hypothesis_set(**overrides):
+    data = {
+        "hypotheses": [
+            "Host WIN-ABC is beaconing to external C2 at 115.238.245.8 over DNS",
+            "The svc-backup account is being used for lateral movement to DC-1",
+        ],
+        "narrative": "WIN-ABC made periodic DNS lookups to a VT-flagged IP.",
+        "attack_techniques": ["T1071.004", "T1021"],
+        "data_domains": ["dns", "network"],
+        "scope": {"hostnames": ["WIN-ABC", "DC-1"], "src_ips": ["10.0.0.5"]},
+        "source_finding_id": "splunk-abc123",
+    }
+    data.update(overrides)
+    return WatcherHypothesisSet(**data)
+
+
+def test_builds_the_expected_parameter_keys():
+    params = build_hunt_parameters(_hypothesis_set())
+    assert set(params) == {"hypothesis", "finding_id", "context"}
+    assert params["finding_id"] == "splunk-abc123"
+
+
+def test_hypotheses_are_newline_joined_one_per_line():
+    params = build_hunt_parameters(_hypothesis_set())
+    lines = params["hypothesis"].splitlines()
+    assert len(lines) == 2
+    assert lines[0].startswith("Host WIN-ABC is beaconing")
+
+
+def test_context_folds_in_techniques_domains_scope_and_narrative():
+    ctx = build_hunt_parameters(_hypothesis_set())["context"]
+    assert "T1071.004" in ctx and "T1021" in ctx  # techniques
+    assert "dns" in ctx and "network" in ctx  # data domains
+    assert "WIN-ABC" in ctx and "10.0.0.5" in ctx  # scope entities
+    assert "periodic DNS lookups" in ctx  # narrative
+
+
+def test_budget_and_iterations_are_optional():
+    bare = build_hunt_parameters(_hypothesis_set())
+    assert "max_cost_usd" not in bare and "iterations" not in bare
+
+    knobbed = build_hunt_parameters(_hypothesis_set(), max_cost_usd=5.0, iterations=6)
+    assert knobbed["max_cost_usd"] == 5.0
+    assert knobbed["iterations"] == 6
+
+
+def test_empty_techniques_and_domains_degrade_gracefully():
+    ctx = build_hunt_parameters(
+        _hypothesis_set(attack_techniques=[], data_domains=[])
+    )["context"]
+    assert "none inferred" in ctx
+    assert "unspecified" in ctx
+
+
+def test_emitted_hypotheses_survive_execute_workflow_claim_gate():
+    # If any hypothesis fails _not_a_claim, execute_workflow refuses the whole run.
+    params = build_hunt_parameters(_hypothesis_set())
+    parsed = _asked_hypotheses(params)
+    assert parsed, "hypotheses must survive parsing into claims"
+    for claim in parsed:
+        assert not _not_a_claim(claim), f"would be refused as a non-claim: {claim!r}"
+
+
+def test_hunt_workflow_id_is_the_shipped_threat_hunt():
+    assert HUNT_WORKFLOW_ID == "threat-hunt"


### PR DESCRIPTION
## What
Slice 1 of the Watcher (autonomous daemon decision core): turn one alert into the hypothesis + context a human types in the console today, then ride the existing hunt enqueue → worker → projection path. Net-new is one reasoning step; the rest is wiring.

- **`hypothesizer.py`** — enriched finding → `WatcherHypothesisSet` (hypotheses + narrative + techniques + data domains + scope). Gathers reputation (VT/Shodan off the finding) and builds scope from entities. **No cross-alert memory** — history recall is deliberately out of this slice.
- **`spec.py`** — maps the set to the exact `execute_workflow("threat-hunt", params)` call the console makes.
- **`launch.py`** — launches via `WorkflowsService.execute_workflow` and reads the run's projection back, so a Watcher hunt is indistinguishable from a console one on the agent layer.
- **`schemas.py`** — the `WatcherHypothesisSet` contract.

## Scope / guardrails
Stops at "alert → hypothesis + evidence gathered". No response actions, no cross-alert memory, existing daemon path untouched (this is additive). See `docs/WATCHER_BUILD_PLAN.md`.

## Tests
`tests/unit/daemon/watcher/` — 26 unit tests (fake gateway + fake workflows/reader), green on top of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)