### PR TITLE
chore(env): add Docker so cloud agents can run compose

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    nodejs \
+    npm \
+    python3 \
+    python3-pip \
+    python3-venv \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+########################################################
+# DOCKER INSTALLATION
+########################################################
+
+# Install Docker
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    chmod a+r /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y \
+    docker-ce=5:28.5.2-1~ubuntu.24.04~noble \
+    docker-ce-cli=5:28.5.2-1~ubuntu.24.04~noble \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y fuse-overlayfs && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/docker && \
+    printf '%s\n' '{' \
+    '  "storage-driver": "fuse-overlayfs"' \
+    '}' > /etc/docker/daemon.json
+RUN apt-get update && apt-get install -y iptables && rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+########################################################
+# CONFIG UBUNTU USER
+########################################################
+
+# ensure no password authentication
+RUN mkdir -p /etc/ssh/sshd_config.d && \
+    echo 'PasswordAuthentication no\nChallengeResponseAuthentication no\nUsePAM no' > /etc/ssh/sshd_config.d/disable_password_auth.conf
+
+# Create non-root user (only if it doesn't exist)
+RUN id -u ubuntu &>/dev/null || useradd -m -s /bin/bash ubuntu
+# Create docker group if it doesn't exist and add ubuntu user to it
+RUN groupadd -f docker && usermod -aG docker ubuntu
+RUN usermod -aG sudo ubuntu
+# Configure passwordless sudo for ubuntu user
+RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
+# Set a password for ubuntu user
+RUN echo "ubuntu:ubuntu" | chpasswd
+
+USER ubuntu

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "name": "Vigil",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "user": "ubuntu",
+  "start": "sudo service docker start"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -178,7 +178,9 @@ cython_debug/
 # IDEs
 .vscode/
 .idea/
-.cursor/
+.cursor/*
+!.cursor/environment.json
+!.cursor/Dockerfile
 .claude/
 *.swp
 *.swo


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Cloud agents on this repo had no Docker daemon. That blocked a check an implementer named and would have run.

### [#778](https://github.com/Vigil-SOC/vigil/pull/778) — environment gap (this PR)

The test plan on #778 is explicit: unit ratchets ran, but **full-stack `docker compose up` was not run here (no Docker daemon in this environment)**. The intended check is local: a fresh volume should have `role-admin` in `roles` and an `agent_run_leases` table; a volume that previously aborted at `05_*.sql` should still get those on `up`. Compose, the SQL, and the image Dockerfiles all live in the repo. No secret and no unpublished artifact is required for that seed assertion. The machine was missing Docker.

This PR installs Docker the way Cursor documents for Cloud Agents (`fuse-overlayfs`, `iptables-legacy`, `ubuntu` in the `docker` group) and starts the daemon on boot.

### [#777](https://github.com/Vigil-SOC/vigil/pull/777) — not an environment gap

The verification section says the job could not be run because **it pulls the just-built GHCR images**. Those images do not exist at review time. Putting Docker on the agent box does not produce `ghcr.io/vigil-soc/vigil-backend:<just-built-version>`. The local checks they did run (YAML parse, `bash -n`, actionlint) are the right ones. The smoke job is CI's job after GHCR push. If someone wants a pre-CI stand-in, build the Dockerfiles in-tree and run the same start/healthcheck scripts against those local tags — do not try to impersonate the release pull.

### [#770](https://github.com/Vigil-SOC/vigil/pull/770) — nothing blocked

`UserMenu` tests, `npm run test:run`, `tsc`, and lint all ran. No environment change.

## What

- `.cursor/Dockerfile` — Ubuntu 24.04 plus the documented docker-ce / fuse-overlayfs / iptables-legacy recipe. Host `python3` and `nodejs` stay so replacing the default image does not drop pytest/npm.
- `.cursor/environment.json` — build that Dockerfile, run as `ubuntu`, `sudo service docker start` on boot. No install script: compose builds its own images.
- `.gitignore` — keep ignoring `.cursor/*`, but allow those two files. The directory was ignored wholesale, which would have made this config uncommittable.

Nothing else in the app changes. Optional compose profiles (Splunk, Elastic, MISP, …) are still not in the image.

## Test plan

- [ ] After merge (or on an agent started from this branch), `docker info` works without sudo.
- [ ] `docker compose -f infra/docker/docker-compose.yml up` can be used to check `roles` / `agent_run_leases` as #778 described.
- [ ] Existing pytest / npm paths still have `python3` and `node` on PATH.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40947534-41fa-4c8b-834a-ad2d9c81fe70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40947534-41fa-4c8b-834a-ad2d9c81fe70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

