### PR TITLE
fix(ci): provision nightly full-test-suite like the PR integration job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,9 +18,14 @@ jobs:
     # Skipping (not failing) keeps forks quiet.
     if: github.repository == 'Vigil-SOC/vigil'
     runs-on: ubuntu-latest
+    # Same services, job env, extensions, init_database(), and agent-layer SQL
+    # as ci-cd.yml test-integration (and the DB pieces of test-unit-backend-db).
+    # DatabaseConfig does not read DATABASE_URL (#752); POSTGRES_* on the job
+    # is what Python actually uses. DATABASE_URL stays for the TypeScript
+    # walking-skeleton test, which shells out to npx tsx and reads it itself.
     services:
       postgres:
-        image: postgres:16-alpine
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_DB: deeptempo_test
           POSTGRES_USER: test
@@ -32,7 +37,29 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-    
+      # The walking-skeleton test enqueues onto BullMQ and spawns the TypeScript
+      # worker, so this job needs Redis and Node as well as Postgres.
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+    env:
+      TESTING: "true"
+      DEV_MODE: "true"
+      SECRET_KEY: "test-secret-key"
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: "5432"
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: deeptempo_test
+      DATABASE_URL: postgresql://test:test@localhost:5432/deeptempo_test
+      REDIS_URL: redis://localhost:6379/0
+
     steps:
       - uses: actions/checkout@v7
         with:
@@ -44,18 +71,51 @@ jobs:
         with:
           python-version-file: .python-version
           cache: 'pip'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/agent/package-lock.json
+
+      - name: Install agent-layer dependencies
+        working-directory: services/agent
+        run: npm ci
       
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.lock
+
+      - name: Enable Postgres extensions
+        run: |
+          PGPASSWORD=test psql -h localhost -p 5432 -U test -d deeptempo_test \
+            -c "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+
+      - name: Initialize schema
+        # Strict here, and only here: CI provisions from empty, so a schema that
+        # cannot serve the models at this point is a provisioning bug rather
+        # than a stale deployment (#562). Scoped to the step rather than the job
+        # so it does not change how every test in the job behaves.
+        env:
+          DB_STRICT_SCHEMA: "true"
+        run: |
+          python -c "from core.storage.connection import init_database; init_database()"
+
+      # The agent layer's tables are raw SQL with no ORM model, deliberately:
+      # Python makes two reads against the ledger and a model invites writes.
+      # init_database() builds from the models, so it creates none of them.
+      - name: Apply agent-layer schema
+        run: |
+          PGPASSWORD=test psql -h localhost -p 5432 -U test -d deeptempo_test \
+            -f infra/database/init/19_agent_ledger.sql \
+            -f infra/database/init/20_agent_directives.sql \
+            -f infra/database/init/21_agent_run_leases.sql
       
       - name: Run all tests
         run: |
           pytest tests/ -v --cov --cov-report=xml --cov-report=term
-        env:
-          TESTING: true
-          DATABASE_URL: postgresql://test:test@localhost:5432/deeptempo_test
       
       - name: Upload coverage
         uses: codecov/codecov-action@v7


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Nightly's Full Test Suite has failed every night for a week (`9 failed, 1982 passed, 90 skipped, 11 errors` on [33481020245](https://github.com/Vigil-SOC/vigil/actions/runs/33481020245)). Three provisioning gaps, none of which the green PR jobs in `ci-cd.yml` have:

1. The job set `DATABASE_URL` on the pytest step only. `DatabaseConfig` does not read it (#752), so Python fell through to the `deeptempo` defaults against a container whose only user is `test`. 58 tests then skipped on the connection error instead of failing.
2. No Redis service — the walking-skeleton test (and others) hit `ConnectionError` on 6379.
3. Image was `postgres:16-alpine`, so `vector` is not installable. No `CREATE EXTENSION`, no `init_database()`, no agent-layer SQL.

A permanently red nightly is not a gate.

## What

Copy the Full Test Suite job's provisioning from `ci-cd.yml` `test-integration` (and the DB pieces of `test-unit-backend-db`):

- `pgvector/pgvector:pg16` + `redis:7-alpine`
- Job `env:` with `POSTGRES_*`, `REDIS_URL`, `DATABASE_URL`, `DEV_MODE`, `SECRET_KEY`
- `CREATE EXTENSION vector/pg_trgm`, `init_database()`, then `19_agent_ledger.sql` / `20_agent_directives.sql` / `21_agent_run_leases.sql`
- Node 20 and `npm ci` in `services/agent` — `tests/integration/test_agent_run_walking_skeleton.py` shells out to `npx tsx` and reads `DATABASE_URL` itself

`DATABASE_URL` stays in the env for that TypeScript process. This PR does not teach `DatabaseConfig` to honour it.

Left out on purpose: no composite action, no skip-on-connection-error flips, no lifting `tests/unit/conftest.py`'s throwaway DB onto `tests/conftest.py`. Nightly still runs one `pytest tests/` invocation.

## Redis / API 500s

`test_status_reports_required_flag` and `tests/integration/test_mcp_enable_transactional.py` already pass in the green `test-integration` job on main. They were downstream of no DB / no Redis, not independent bugs. If they stay red after this job actually runs, that is a follow-up.

## Verification

- YAML parse of `nightly.yml`
- actionlint 1.7.12 (same pin as CI)
- Independent review of the full diff against `test-integration` / `test-unit-backend-db`

Could not execute the nightly job here: it is `schedule` / `workflow_dispatch` only, and this environment has no Docker. PR CI will still run actionlint over the workflow files.

Closes #753

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-066a87d3-2b21-4430-b23b-f973dbe0eb6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-066a87d3-2b21-4430-b23b-f973dbe0eb6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

