### PR TITLE
fix(llm): push custom OpenAI-compatible base_url to Bifrost

### DIFF
--- a/core/llm/bifrost/admin.py
+++ b/core/llm/bifrost/admin.py
@@ -68,9 +68,25 @@ def _bifrost_base_url() -> str:
 _UNMANAGED_PROVIDER_TYPES = frozenset({"ollama", "vertex"})
 
 # Public OpenAI cloud — Bifrost already points there. Custom OpenAI-compatible
-# hosts (OpenRouter, LiteLLM, vLLM, ...) are the ones we must push.
+# hosts (OpenRouter, LiteLLM, vLLM, ...) are the ones we must push. Derived
+# from the SSRF allow-list so this file never names the stock host (one-egress
+# ratchet); ``.openai.com`` keeps Azure-style hosts from matching.
 _STOCK_OPENAI_HOSTS = frozenset(
-    host for host in DEFAULT_ALLOWED_PROVIDER_HOSTS if "openai" in host
+    host for host in DEFAULT_ALLOWED_PROVIDER_HOSTS if host.endswith(".openai.com")
+)
+
+# Fields Bifrost accepts on PUT /api/providers/{name}. Everything else on the
+# GET document is read-back (name, status, config_hash, keys, ...).
+_PROVIDER_WRITE_FIELDS = frozenset(
+    {
+        "network_config",
+        "concurrency_and_buffer_size",
+        "proxy_config",
+        "send_back_raw_request",
+        "send_back_raw_response",
+        "store_raw_request_response",
+        "custom_provider_config",
+    }
 )
 
 # Read-only/derived fields Bifrost returns but rejects or ignores on write.
@@ -413,7 +429,9 @@ def sync_provider_base_url(provider_type: str, base_url: Optional[str]) -> bool:
     stored URL is host-side and would resolve to the Bifrost container itself.
 
     GET/PUT ``/api/providers/{name}`` (the provider document, not ``/keys``).
-    Other ``network_config`` fields are preserved; ``keys`` are never sent.
+    Other ``network_config`` fields are preserved; only writable provider
+    fields are sent, never ``keys``. Reverting to empty/stock clears a
+    previously pushed custom host so inference does not keep using it.
 
     Returns True on success or when there is nothing to write. Failures are
     logged and return False so the catalog sync still proceeds.
@@ -421,23 +439,30 @@ def sync_provider_base_url(provider_type: str, base_url: Optional[str]) -> bool:
     if not provider_type or provider_type != "openai":
         return True
     target = _custom_openai_base_url(base_url)
-    if target is None:
-        return True
 
     with httpx.Client() as client:
         doc = _get_provider_document(provider_type, client)
         if doc is None:
-            return False
-        doc.pop("keys", None)
+            # Stock/empty has nothing to write; a custom host cannot land if
+            # the provider document is missing.
+            return target is None
         network = dict(doc.get("network_config") or {})
         current = (network.get("base_url") or "").rstrip("/")
-        if current == target:
+        if target is None:
+            # Leave Bifrost's default host. If we previously pushed a custom
+            # URL, drop it so inference does not keep hitting the old gateway.
+            if not current or _custom_openai_base_url(current) is None:
+                return True
+            network.pop("base_url", None)
+        elif current == target:
             return True
-        network["base_url"] = target
-        doc["network_config"] = network
+        else:
+            network["base_url"] = target
+        body = {k: v for k, v in doc.items() if k in _PROVIDER_WRITE_FIELDS}
+        body["network_config"] = network
         url = _provider_url(provider_type)
         try:
-            r = client.put(url, json=doc, timeout=_DEFAULT_TIMEOUT)
+            r = client.put(url, json=body, timeout=_DEFAULT_TIMEOUT)
             if r.status_code >= 400:
                 logger.warning(
                     "Bifrost: PUT %s returned %s: %s",
@@ -449,7 +474,7 @@ def sync_provider_base_url(provider_type: str, base_url: Optional[str]) -> bool:
             logger.info(
                 "Bifrost: set network_config.base_url for provider %s to %s",
                 provider_type,
-                target,
+                target or "default",
             )
             return True
         except Exception as e:

--- a/core/llm/bifrost/admin.py
+++ b/core/llm/bifrost/admin.py
@@ -12,7 +12,7 @@ manager under ``llm_provider_<id>_api_key``. Pushing via the API keeps a
 single source of truth in the secrets manager, and is why the seeded
 ``config.json`` key is an empty placeholder rather than a real credential.
 
-Three properties of that API shape the code below, all learned the hard way:
+Four properties of that API shape the code below, all learned the hard way:
 
 * **Keys are a subresource.** They live at ``/api/providers/{name}/keys``,
   *not* on the ``/api/providers/{name}`` document — which returns no ``keys``
@@ -22,6 +22,12 @@ Three properties of that API shape the code below, all learned the hard way:
   are always re-read from the secrets store, never round-tripped.
 * **A key must carry a non-empty value.** There is no models-only update, and
   clearing a credential means deleting the key rather than blanking it.
+* **Custom OpenAI-compatible ``base_url`` lives on the provider document.**
+  Vigil stores the SDK form (often with a trailing ``/v1``). Bifrost stores
+  the API root under ``network_config.base_url`` and appends the versioned
+  path itself, so only that suffix is trimmed. This PUT must not send
+  ``keys``. Anthropic ignores the field; Ollama's stored URL is host-side
+  and would mean the Bifrost container itself.
 """
 
 from __future__ import annotations
@@ -29,10 +35,12 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 import httpx
 
 from core.config import get_settings
+from core.platform.url_safety import DEFAULT_ALLOWED_PROVIDER_HOSTS
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +67,12 @@ def _bifrost_base_url() -> str:
 # allow-list refusing every model. The seeded wildcard in the Bifrost config is it.
 _UNMANAGED_PROVIDER_TYPES = frozenset({"ollama", "vertex"})
 
+# Public OpenAI cloud — Bifrost already points there. Custom OpenAI-compatible
+# hosts (OpenRouter, LiteLLM, vLLM, ...) are the ones we must push.
+_STOCK_OPENAI_HOSTS = frozenset(
+    host for host in DEFAULT_ALLOWED_PROVIDER_HOSTS if "openai" in host
+)
+
 # Read-only/derived fields Bifrost returns but rejects or ignores on write.
 # ``value`` is dropped separately — see the module docstring on masking.
 _KEY_READBACK_ONLY = frozenset({"id", "config_hash", "status", "description"})
@@ -74,6 +88,10 @@ _KEY_STATUS_OK = frozenset({"success", "unknown"})
 def _keys_url(provider_name: str, key_id: Optional[str] = None) -> str:
     base = f"{_bifrost_base_url()}/api/providers/{provider_name}/keys"
     return f"{base}/{key_id}" if key_id else base
+
+
+def _provider_url(provider_name: str) -> str:
+    return f"{_bifrost_base_url()}/api/providers/{provider_name}"
 
 
 def _get_provider_keys(
@@ -348,6 +366,97 @@ def sync_provider_models(
         return ok
 
 
+def _normalize_openai_compat_base_url(base_url: str) -> str:
+    """Strip a trailing ``/v1``; Bifrost appends the versioned path itself.
+
+    Any other path prefix (``/api``, ``/openai``, a tenant slug) is kept.
+    """
+    url = base_url.strip().rstrip("/")
+    if url.lower().endswith("/v1"):
+        url = url[:-3].rstrip("/")
+    return url
+
+
+def _custom_openai_base_url(base_url: Optional[str]) -> Optional[str]:
+    """Normalized Bifrost form, or None when the stock host should stay."""
+    if not base_url or not str(base_url).strip():
+        return None
+    target = _normalize_openai_compat_base_url(str(base_url))
+    if not target:
+        return None
+    host = (urlparse(target).hostname or "").lower()
+    if host in _STOCK_OPENAI_HOSTS:
+        return None
+    return target
+
+
+def _get_provider_document(name: str, client: httpx.Client) -> Optional[Dict[str, Any]]:
+    """Return ``name``'s provider document, or None if it is absent."""
+    try:
+        r = client.get(_provider_url(name), timeout=_DEFAULT_TIMEOUT)
+        if r.status_code == 404:
+            logger.debug("Bifrost: provider %s not configured", name)
+            return None
+        r.raise_for_status()
+        doc = r.json()
+        return doc if isinstance(doc, dict) else None
+    except Exception as e:
+        logger.warning("Bifrost: could not fetch provider %s: %s", name, e)
+        return None
+
+
+def sync_provider_base_url(provider_type: str, base_url: Optional[str]) -> bool:
+    """Write a custom OpenAI-compatible ``base_url`` to Bifrost.
+
+    Only ``openai`` rows with a non-stock host are pushed. Anthropic ignores
+    ``network_config.base_url`` (see ``core.llm.providers.clients``); Ollama's
+    stored URL is host-side and would resolve to the Bifrost container itself.
+
+    GET/PUT ``/api/providers/{name}`` (the provider document, not ``/keys``).
+    Other ``network_config`` fields are preserved; ``keys`` are never sent.
+
+    Returns True on success or when there is nothing to write. Failures are
+    logged and return False so the catalog sync still proceeds.
+    """
+    if not provider_type or provider_type != "openai":
+        return True
+    target = _custom_openai_base_url(base_url)
+    if target is None:
+        return True
+
+    with httpx.Client() as client:
+        doc = _get_provider_document(provider_type, client)
+        if doc is None:
+            return False
+        doc.pop("keys", None)
+        network = dict(doc.get("network_config") or {})
+        current = (network.get("base_url") or "").rstrip("/")
+        if current == target:
+            return True
+        network["base_url"] = target
+        doc["network_config"] = network
+        url = _provider_url(provider_type)
+        try:
+            r = client.put(url, json=doc, timeout=_DEFAULT_TIMEOUT)
+            if r.status_code >= 400:
+                logger.warning(
+                    "Bifrost: PUT %s returned %s: %s",
+                    url,
+                    r.status_code,
+                    r.text[:200],
+                )
+                return False
+            logger.info(
+                "Bifrost: set network_config.base_url for provider %s to %s",
+                provider_type,
+                target,
+            )
+            return True
+        except Exception as e:
+            logger.warning("Bifrost: PUT %s failed: %s", url, e)
+            return False
+
+
 async def sync_all_provider_models() -> Dict[str, Any]:
     """Canonical refresh for every active LLM provider.
 
@@ -362,12 +471,14 @@ async def sync_all_provider_models() -> Dict[str, Any]:
     3. Populates ``_MODEL_LIST_CACHE[provider_id]`` in
        ``core.llm.providers.registry`` so the UI dropdown reads the same
        list the sync just computed.
-    4. Unions per-provider-type across rows and PUTs that to Bifrost's
+    4. For OpenAI-compatible rows, writes ``network_config.base_url`` so
+       the gateway uses the custom host rather than the stock OpenAI cloud.
+    5. Unions per-provider-type across rows and PUTs that to Bifrost's
        allow-list via the admin API, so LLM traffic routes for every
        model the dropdown shows.
 
-    Because all three surfaces (dropdown cache, live-meta cache, Bifrost
-    allow-list) are written in the same pass, they cannot drift.
+    Because all four surfaces (dropdown cache, live-meta cache, Bifrost
+    host, Bifrost allow-list) are written in the same pass, they cannot drift.
 
     Concurrent calls are coalesced — if a sync is already running (e.g.
     the scheduled refresher kicked off at the same time as a dropdown
@@ -375,8 +486,9 @@ async def sync_all_provider_models() -> Dict[str, Any]:
     issuing a duplicate round of upstream fetches.
 
     Best-effort — never raises. Returns a dict with per-provider-type
-    Bifrost sync flags under ``bifrost`` and the computed per-row model
-    lists under ``models_by_provider`` for observability.
+    Bifrost sync flags under ``bifrost``, custom-host flags under
+    ``bifrost_base_url``, and the computed per-row model lists under
+    ``models_by_provider`` for observability.
     """
     global _sync_in_flight
     if _sync_in_flight is not None and not _sync_in_flight.done():
@@ -441,6 +553,7 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
             )
 
     bifrost_results: Dict[str, bool] = {}
+    base_url_results: Dict[str, bool] = {}
     per_row_models: Dict[str, List[str]] = {}
 
     for provider_type, provider_rows in rows_by_type.items():
@@ -513,6 +626,14 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
                 type_seen.add(mid)
                 type_union.append(mid)
 
+        # Host before allow-list: namespaced models are meaningless if the
+        # gateway still talks to the stock OpenAI cloud. One document per
+        # type; the default row already sits first, matching the key we push.
+        if provider_type == "openai":
+            base_url_results[provider_type] = sync_provider_base_url(
+                provider_type, provider_rows[0].get("base_url")
+            )
+
         if not type_union:
             # Preserve bootstrap: don't overwrite Bifrost's allow-list
             # with an empty list if every row failed and there are no
@@ -534,6 +655,7 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
 
     return {
         "bifrost": bifrost_results,
+        "bifrost_base_url": base_url_results,
         "models_by_provider": per_row_models,
     }
 

--- a/tests/unit/llm/test_bifrost_admin.py
+++ b/tests/unit/llm/test_bifrost_admin.py
@@ -768,7 +768,8 @@ def test_sync_provider_base_url_skips_empty_and_stock_openai():
             bifrost_admin.sync_provider_base_url("openai", "https://api.openai.com/v1")
             is True
         )
-    assert rec.calls == []
+    assert _provider_puts(rec) == []
+    assert all(c["method"] == "GET" and "/keys" not in c["url"] for c in rec.calls)
 
 
 def test_sync_provider_base_url_returns_false_when_provider_missing():
@@ -781,16 +782,44 @@ def test_sync_provider_base_url_returns_false_when_provider_missing():
     assert _provider_puts(rec) == []
 
 
-def test_base_url_put_drops_legacy_embedded_keys():
+def test_sync_provider_base_url_returns_false_on_put_error():
+    rec = _RecordingClient(provider_payload=_provider_doc(), put_status=500)
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        ok = bifrost_admin.sync_provider_base_url(
+            "openai", "https://openrouter.ai/api/v1"
+        )
+    assert ok is False
+
+
+def test_sync_provider_base_url_clears_stale_custom_host_when_reverting_to_stock():
+    rec = _RecordingClient(
+        provider_payload=_provider_doc(base_url="https://openrouter.ai/api")
+    )
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        ok = bifrost_admin.sync_provider_base_url("openai", "https://api.openai.com/v1")
+    assert ok is True
+    network = _provider_puts(rec)[0]["kwargs"]["json"]["network_config"]
+    assert "base_url" not in network
+    assert network["default_request_timeout_in_seconds"] == 30
+
+
+def test_base_url_put_omits_readback_only_fields():
     rec = _RecordingClient(
         provider_payload=_provider_doc(
-            keys=[{"id": "should-not-be-echoed", "models": ["gpt-4o"]}]
+            status="active",
+            config_hash="abc",
+            keys=[{"id": "should-not-be-echoed", "models": ["gpt-4o"]}],
         )
     )
     with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
         bifrost_admin.sync_provider_base_url("openai", "https://openrouter.ai/api/v1")
     body = _provider_puts(rec)[0]["kwargs"]["json"]
     assert "keys" not in body
+    assert "status" not in body
+    assert "config_hash" not in body
+    assert "name" not in body
+    assert "network_config" in body
+    assert "concurrency_and_buffer_size" in body
 
 
 def test_base_url_refresh_keeps_namespaced_model_on_key_allow_list():

--- a/tests/unit/llm/test_bifrost_admin.py
+++ b/tests/unit/llm/test_bifrost_admin.py
@@ -1,11 +1,11 @@
 """Unit tests for core.llm.bifrost.admin sync helpers.
 
 Covers the key upsert path against Bifrost's ``/api/providers/{name}/keys``
-subresource: empty-list guard, dedup, create-vs-update, clearing, and error
-handling. Two of these are regression tests for traps in that API — keys are
-absent from the provider document, and secrets come back masked on read, so a
-naive read-modify-write stores the mask as the credential. httpx is
-monkeypatched via a fake client so tests don't depend on a running Bifrost.
+subresource and the OpenAI-compatible ``network_config.base_url`` push on
+the provider document. The recording client must distinguish those two
+GETs — a shared payload is what hid the keys-subresource contract change.
+httpx is monkeypatched via a fake client so tests don't depend on a
+running Bifrost.
 """
 
 from __future__ import annotations
@@ -50,6 +50,8 @@ class _RecordingClient:
         post_status=200,
         delete_status=200,
         write_payload=None,
+        provider_payload=None,
+        provider_status=200,
     ):
         self._get_payload = get_payload
         self._get_status = get_status
@@ -57,6 +59,12 @@ class _RecordingClient:
         self._post_status = post_status
         self._delete_status = delete_status
         self._write_payload = write_payload if write_payload is not None else {}
+        # Provider document is a different resource from /keys. Default to an
+        # empty doc (no keys) so a shared payload cannot hide that split.
+        self._provider_payload = (
+            provider_payload if provider_payload is not None else {}
+        )
+        self._provider_status = provider_status
         self.calls: List[Dict[str, Any]] = []
 
     def __enter__(self):
@@ -71,7 +79,9 @@ class _RecordingClient:
 
     def get(self, url, **kwargs):
         self.calls.append({"method": "GET", "url": url, "kwargs": kwargs})
-        return _FakeResp(self._get_status, self._get_payload)
+        if "/keys" in url:
+            return _FakeResp(self._get_status, self._get_payload)
+        return _FakeResp(self._provider_status, self._provider_payload)
 
     def put(self, url, **kwargs):
         return self._record("PUT", self._put_status, url, kwargs)
@@ -103,6 +113,22 @@ def _key_doc(models=None, value="sk-ant-****-masked", key_id="key-1"):
         ],
         "total": 1,
     }
+
+
+def _provider_doc(base_url=None, extra_network=None, **extra):
+    network = {"default_request_timeout_in_seconds": 30, "max_retries": 3}
+    if extra_network:
+        network.update(extra_network)
+    if base_url is not None:
+        network["base_url"] = base_url
+    doc = {
+        "name": "openai",
+        "network_config": network,
+        "concurrency_and_buffer_size": {"concurrency": 1000, "buffer_size": 5000},
+        "send_back_raw_request": False,
+    }
+    doc.update(extra)
+    return doc
 
 
 def test_sync_provider_models_skips_empty_list():
@@ -296,14 +322,14 @@ def test_push_provider_key_reports_false_on_write_error():
 
 
 class _FakeProviderRow:
-    def __init__(self, provider_id, provider_type):
+    def __init__(self, provider_id, provider_type, base_url=None, is_default=False):
         self.provider_id = provider_id
         self.provider_type = provider_type
-        self.base_url = None
+        self.base_url = base_url
         self.api_key_ref = None
         self.config = {}
         self.is_active = True
-        self.is_default = False
+        self.is_default = is_default
 
 
 class _FakeSessionScope:
@@ -627,3 +653,249 @@ def test_fetch_meta_for_row_ollama_bypasses_ssrf_ip_gate():
         "base_url": "http://10.64.201.1:11434",
         "allow_loopback": True,
     }
+
+
+# ---------------------------------------------------------------------------
+# sync_provider_base_url — OpenAI-compatible custom host (#586)
+# ---------------------------------------------------------------------------
+
+
+def _provider_puts(rec):
+    return [c for c in rec.calls if c["method"] == "PUT" and "/keys" not in c["url"]]
+
+
+def _key_writes(rec):
+    return [
+        c for c in rec.calls if c["method"] in ("PUT", "POST") and "/keys" in c["url"]
+    ]
+
+
+def test_recording_client_distinguishes_provider_document_from_keys():
+    """The test double must not share a payload across the two GETs.
+
+    A single payload made provider-document reads look like they had keys,
+    which is the contract the gateway dropped and the suite kept green.
+    """
+    rec = _RecordingClient(
+        get_payload=_key_doc(models=["anthropic/claude-sonnet-5"]),
+        provider_payload=_provider_doc(),
+    )
+    with rec as client:
+        prov = client.get("http://localhost:8080/api/providers/openai")
+        keys = client.get("http://localhost:8080/api/providers/openai/keys")
+    assert "keys" not in prov.json()
+    assert "network_config" in prov.json()
+    assert keys.json()["keys"][0]["models"] == ["anthropic/claude-sonnet-5"]
+
+
+def test_sync_provider_base_url_trims_trailing_v1():
+    rec = _RecordingClient(provider_payload=_provider_doc())
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        ok = bifrost_admin.sync_provider_base_url(
+            "openai", "https://openrouter.ai/api/v1"
+        )
+    assert ok is True
+    put = _provider_puts(rec)[0]
+    assert put["url"].endswith("/api/providers/openai")
+    assert "/keys" not in put["url"]
+    body = put["kwargs"]["json"]
+    assert body["network_config"]["base_url"] == "https://openrouter.ai/api"
+    assert "keys" not in body
+
+
+def test_sync_provider_base_url_keeps_path_prefix_without_v1_suffix():
+    rec = _RecordingClient(provider_payload=_provider_doc())
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        ok = bifrost_admin.sync_provider_base_url(
+            "openai", "https://litellm.example/openai"
+        )
+    assert ok is True
+    body = _provider_puts(rec)[0]["kwargs"]["json"]
+    assert body["network_config"]["base_url"] == "https://litellm.example/openai"
+
+
+def test_sync_provider_base_url_preserves_unrelated_network_config():
+    rec = _RecordingClient(
+        provider_payload=_provider_doc(
+            extra_network={"retry_backoff_initial": 500, "insecure_skip_verify": False}
+        )
+    )
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        bifrost_admin.sync_provider_base_url("openai", "https://together.xyz/v1")
+    network = _provider_puts(rec)[0]["kwargs"]["json"]["network_config"]
+    assert network["base_url"] == "https://together.xyz"
+    assert network["default_request_timeout_in_seconds"] == 30
+    assert network["max_retries"] == 3
+    assert network["retry_backoff_initial"] == 500
+    assert network["insecure_skip_verify"] is False
+
+
+def test_sync_provider_base_url_is_idempotent_for_v1_and_bare_forms():
+    for stored, existing in (
+        ("https://openrouter.ai/api/v1", "https://openrouter.ai/api"),
+        ("https://openrouter.ai/api", "https://openrouter.ai/api"),
+    ):
+        rec = _RecordingClient(provider_payload=_provider_doc(base_url=existing))
+        with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+            ok = bifrost_admin.sync_provider_base_url("openai", stored)
+        assert ok is True
+        assert _provider_puts(rec) == []
+        assert any(c["method"] == "GET" and "/keys" not in c["url"] for c in rec.calls)
+
+
+def test_sync_provider_base_url_skips_anthropic_and_ollama():
+    rec = _RecordingClient(provider_payload=_provider_doc())
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        assert (
+            bifrost_admin.sync_provider_base_url(
+                "anthropic", "https://proxy.example/anthropic/v1"
+            )
+            is True
+        )
+        assert (
+            bifrost_admin.sync_provider_base_url("ollama", "http://localhost:11434")
+            is True
+        )
+    assert rec.calls == []
+
+
+def test_sync_provider_base_url_skips_empty_and_stock_openai():
+    rec = _RecordingClient(provider_payload=_provider_doc())
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        assert bifrost_admin.sync_provider_base_url("openai", None) is True
+        assert bifrost_admin.sync_provider_base_url("openai", "") is True
+        assert (
+            bifrost_admin.sync_provider_base_url("openai", "https://api.openai.com/v1")
+            is True
+        )
+    assert rec.calls == []
+
+
+def test_sync_provider_base_url_returns_false_when_provider_missing():
+    rec = _RecordingClient(provider_status=404, provider_payload=None)
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        ok = bifrost_admin.sync_provider_base_url(
+            "openai", "https://openrouter.ai/api/v1"
+        )
+    assert ok is False
+    assert _provider_puts(rec) == []
+
+
+def test_base_url_put_drops_legacy_embedded_keys():
+    rec = _RecordingClient(
+        provider_payload=_provider_doc(
+            keys=[{"id": "should-not-be-echoed", "models": ["gpt-4o"]}]
+        )
+    )
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        bifrost_admin.sync_provider_base_url("openai", "https://openrouter.ai/api/v1")
+    body = _provider_puts(rec)[0]["kwargs"]["json"]
+    assert "keys" not in body
+
+
+def test_base_url_refresh_keeps_namespaced_model_on_key_allow_list():
+    rec = _RecordingClient(
+        get_payload=_key_doc(models=["anthropic/claude-sonnet-5", "gpt-4o"]),
+        provider_payload=_provider_doc(),
+    )
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        assert bifrost_admin.sync_provider_base_url(
+            "openai", "https://openrouter.ai/api/v1"
+        )
+        assert bifrost_admin.sync_provider_models(
+            "openai",
+            ["anthropic/claude-sonnet-5", "gpt-4o"],
+            key_value=_SECRET,
+        )
+    assert "keys" not in _provider_puts(rec)[0]["kwargs"]["json"]
+    key_put = _key_writes(rec)[0]
+    assert key_put["kwargs"]["json"]["models"] == [
+        "anthropic/claude-sonnet-5",
+        "gpt-4o",
+    ]
+    assert key_put["kwargs"]["json"]["value"] == _SECRET
+    assert not isinstance(key_put["kwargs"]["json"]["value"], dict)
+
+
+def test_connection_test_success_leaves_bifrost_on_stock_host():
+    """Regression: discovery (and the connection probe) dial the custom host
+    directly. A green test is therefore not proof the gateway will route
+    there — that was the #586 failure mode.
+    """
+    rec = _RecordingClient(provider_payload=_provider_doc())
+
+    class _FakeDiscovery:
+        @staticmethod
+        async def fetch_openai_models(*_a, **_kw):
+            return []
+
+    row = {
+        "provider_id": "openrouter",
+        "provider_type": "openai",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key_ref": None,
+        "config": {},
+    }
+
+    import asyncio
+
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        asyncio.run(
+            bifrost_admin._fetch_meta_for_row(row, _FakeDiscovery, key="sk-or-test")
+        )
+
+    # Direct discovery never writes the gateway document.
+    assert rec.calls == []
+    assert "base_url" not in rec._provider_payload["network_config"]
+
+    with patch.object(bifrost_admin.httpx, "Client", lambda: rec):
+        bifrost_admin.sync_provider_base_url("openai", row["base_url"])
+
+    assert (
+        _provider_puts(rec)[0]["kwargs"]["json"]["network_config"]["base_url"]
+        == "https://openrouter.ai/api"
+    )
+
+
+def test_sync_all_pushes_default_openai_row_base_url(monkeypatch):
+    from core.llm.bifrost import admin as ba
+
+    _reset_registry()
+
+    rows = [
+        _FakeProviderRow(
+            "stock", "openai", base_url="https://api.openai.com/v1", is_default=False
+        ),
+        _FakeProviderRow(
+            "openrouter",
+            "openai",
+            base_url="https://openrouter.ai/api/v1",
+            is_default=True,
+        ),
+    ]
+    _patch_db(monkeypatch, rows)
+
+    async def fake_fetch_row(row_dict, discovery, key=None):
+        return [_M("gpt-4o"), _M("anthropic/claude-sonnet-5")]
+
+    rec = _RecordingClient(
+        get_payload=_key_doc(models=["gpt-4o"]),
+        provider_payload=_provider_doc(),
+    )
+    monkeypatch.setattr(ba, "_fetch_meta_for_row", fake_fetch_row)
+    monkeypatch.setattr(ba, "_resolve_row_key", lambda row: _SECRET)
+    monkeypatch.setattr(ba.httpx, "Client", lambda: rec)
+    monkeypatch.setenv("ANTHROPIC_EXTRA_MODELS", "")
+
+    import asyncio
+
+    result = asyncio.run(ba.sync_all_provider_models())
+
+    assert result["bifrost_base_url"]["openai"] is True
+    assert (
+        _provider_puts(rec)[0]["kwargs"]["json"]["network_config"]["base_url"]
+        == "https://openrouter.ai/api"
+    )
+    key_put = _key_writes(rec)[0]
+    assert "anthropic/claude-sonnet-5" in key_put["kwargs"]["json"]["models"]
+    _reset_registry()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #586.

## The remaining break

Defect B (keys moved to `/api/providers/{name}/keys`, so the whole sync was a no-op) already shipped in #640. Defect A did not: `LLMProviderConfig.base_url` is persisted, validated, and read into the catalog-sync row dict, but nothing writes Bifrost `network_config.base_url`.

Discovery and the connection test both dial the custom host directly, so OpenRouter / LiteLLM / vLLM / Together can look healthy in the UI while every completion still goes to the stock OpenAI host.

## What changed

`sync_provider_base_url` GET/PUTs `/api/providers/{name}` (the provider document, not `/keys`) from the existing `_do_sync_all_provider_models` pass, before the allow-list write:

- Scope is `openai` rows with a custom host. Anthropic is skipped (Bifrost ignores `network_config.base_url` for that provider). Ollama is skipped (the stored URL is host-side `localhost` and would mean the Bifrost container itself).
- Only a trailing `/v1` is trimmed; other path prefixes stay. Empty / stock OpenAI URLs leave Bifrost's default host, and a previously pushed custom host is cleared so revert/switch-default does not keep routing to the old gateway.
- Unrelated `network_config` fields are preserved. Only writable provider fields are sent; `keys` and read-back fields (`status`, `config_hash`, `name`) are never echoed.
- When several `openai` rows exist, the default row is used, matching the key already chosen for the allow-list.

SDK traffic still goes through `{bifrost_url}/v1`. This does not point the OpenAI client at the custom URL.

## Tests

`_RecordingClient` now distinguishes GET `/api/providers/{name}` from GET `.../keys` (one shared payload is what hid Defect B). Coverage includes `/v1` trim vs no-suffix, idempotent no-op, anthropic/ollama skipped, unrelated `network_config` kept, a namespaced model still on the key allow-list after a base_url refresh, clearing a stale custom host on revert to stock, omitting read-back fields on PUT, and the regression that discovery/connection-test success does not configure Bifrost's host.

The key `value` payload shape is unchanged (bare string).

## Verification

- `tests/unit/llm/test_bifrost_admin.py`: **34 passed** (plus 3 one-egress ratchet tests)
- `black --check`, `isort --check-only`, `flake8` clean on both files

Not verified against a running Bifrost image in this environment (no gateway). The original report's failure mode is covered by the recording-client suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d36bdc3d-3d67-44c8-895e-e867c4ed0952?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d36bdc3d-3d67-44c8-895e-e867c4ed0952&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

