### PR TITLE
chore(env): Docker daemon for Cloud Agent verification

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,61 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# git, curl, and sudo are required on a custom Cloud Agent image (checkout
+# and passwordless docker start). python3 is the repo's test runtime; this
+# Dockerfile replaces Cursor's default image rather than layering on it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        openssh-server \
+        python3 \
+        python3-pip \
+        python3-venv \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+########################################################
+# DOCKER INSTALLATION
+# https://cursor.com/docs/cloud-agent/setup
+########################################################
+
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    chmod a+r /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y \
+    docker-ce=5:28.5.2-1~ubuntu.24.04~noble \
+    docker-ce-cli=5:28.5.2-1~ubuntu.24.04~noble \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y fuse-overlayfs && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/docker && \
+    printf '%s\n' '{' \
+    '  "storage-driver": "fuse-overlayfs"' \
+    '}' > /etc/docker/daemon.json
+RUN apt-get update && apt-get install -y iptables && rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+########################################################
+# CONFIG UBUNTU USER
+########################################################
+
+RUN echo 'PasswordAuthentication no\nChallengeResponseAuthentication no\nUsePAM no' > /etc/ssh/sshd_config.d/disable_password_auth.conf
+
+RUN id -u ubuntu &>/dev/null || useradd -m -s /bin/bash ubuntu
+RUN groupadd -f docker && usermod -aG docker ubuntu
+RUN usermod -aG sudo ubuntu
+RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
+RUN echo "ubuntu:ubuntu" | chpasswd
+
+USER ubuntu

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "name": "Vigil",
+  "user": "ubuntu",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "start": "sudo service docker start"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Factory implementers could not run the checks they named, because the Cloud Agent machine has no Docker:

- #782 (`nightly.yml` service containers): *“Could not execute the nightly job here: it is `schedule` / `workflow_dispatch` only, and this environment has no Docker.”*
- #783 (live Bifrost `network_config.base_url`): *“Not verified against a running Bifrost image in this environment (no gateway).”*

#765 had no environment gap (unit tests ran).

Docker would not have triggered GitHub’s scheduled nightly — `actionlint` remains the right check for the workflow YAML itself. It *does* let an agent start the same images that job uses (`pgvector/pgvector:pg16`, `redis:7-alpine`) and `maximhq/bifrost`, which is the part the machine actually lacked.

## What

Repo-managed Cloud Agent environment, following [Cursor’s Docker-in-agent Dockerfile](https://cursor.com/docs/cloud-agent/setup):

- `.cursor/Dockerfile` — Ubuntu 24.04, Docker CE 28.5.2, `fuse-overlayfs`, `iptables-legacy`, `ubuntu` in the `docker` group. `git`/`curl`/`sudo`/`python3` are here only because a custom image replaces the default toolchain rather than adding to it.
- `.cursor/environment.json` — build that image, `start`: `sudo service docker start`.

The daemon only. No compose stack, no always-on postgres/redis/bifrost — agents can `docker compose` / `docker run` what a given task needs.

`.gitignore` still ignores `.cursor/`; these two files are force-added so they are the committed environment source.

## Out of scope

- Credentials (LLM keys, GitHub workflow dispatch). Those are not environment packages.
- Changing `.gitignore` or application code.

## Validation

| Check | Result |
| --- | --- |
| Draft build [bld-20260901-9bb19029-7079-402c-8120-6416b6d185a2](https://cursor.com/dashboard/cloud-agents/builds/bld-20260901-9bb19029-7079-402c-8120-6416b6d185a2) | SUCCEEDED |
| Fresh agent on that build | `ubuntu` in `docker` group; Docker 28.5.2; Python 3.12.3; daemon already up |
| `docker info` storage driver | `fuse-overlayfs` |
| `docker run --rm hello-world` | succeeded (pulled and ran) |

This draft was built from the PR branch, so it can be tested but not promoted. After merge, a main-branch environment build is what new agents will boot from.

Environment: [121d9222-a0f1-11f1-b532-320a589b8025](https://cursor.com/dashboard/cloud-agents/environments/e/121d9222-a0f1-11f1-b532-320a589b8025)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a8d9de6-1207-42ed-a905-4e83d4d8801f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a8d9de6-1207-42ed-a905-4e83d4d8801f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

