### PR TITLE
feat(mcp): connect enabled servers concurrently at API boot

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -203,6 +203,54 @@ def _mcp_auto_connect_enabled() -> bool:
     return eager_connect_enabled()
 
 
+async def _connect_enabled_mcp_servers(mcp_client) -> int:
+    """Connect enabled MCP servers concurrently. Returns how many succeeded."""
+    import asyncio
+
+    mcp_service = mcp_client.mcp_service
+    servers = mcp_service.list_servers()
+
+    async def _connect_one(server_name: str) -> bool:
+        try:
+            success = await mcp_client.connect_to_server(server_name, persistent=True)
+            if success:
+                logger.info(f"✓ Persistent connection established: {server_name}")
+                return True
+            missing = mcp_client.get_missing_credentials(server_name)
+            if missing:
+                logger.info(
+                    "MCP server %s dormant — awaiting env vars: %s",
+                    server_name,
+                    ", ".join(missing),
+                )
+            else:
+                logger.warning(f"Failed to connect to MCP server: {server_name}")
+            return False
+        except Exception as e:
+            logger.error(f"Error connecting to {server_name}: {e}")
+            return False
+
+    to_connect = []
+    for server_name in servers:
+        # A disabled server is intentionally off, not a failure — don't
+        # dial it or log it as one (the old code tried every server and
+        # reported each disabled one as "Failed to connect", which read
+        # as dozens of errors on a normal boot).
+        if not mcp_service.is_server_enabled(server_name):
+            logger.debug("MCP server %s disabled, skipping", server_name)
+            continue
+        to_connect.append(server_name)
+
+    if not to_connect:
+        return 0
+
+    results = await asyncio.gather(
+        *(_connect_one(name) for name in to_connect),
+        return_exceptions=True,
+    )
+    return sum(1 for r in results if r is True)
+
+
 async def _connect_external_services(mcp_client, registry):
     """Connect external startup integrations (skipped under TESTING)."""
     import asyncio
@@ -270,38 +318,7 @@ async def _connect_external_services(mcp_client, registry):
             mcp_service = mcp_client.mcp_service
             servers = mcp_service.list_servers()
 
-            connected_count = 0
-            for server_name in servers:
-                # A disabled server is intentionally off, not a failure — don't
-                # dial it or log it as one (the old code tried every server and
-                # reported each disabled one as "Failed to connect", which read
-                # as dozens of errors on a normal boot).
-                if not mcp_service.is_server_enabled(server_name):
-                    logger.debug("MCP server %s disabled, skipping", server_name)
-                    continue
-                try:
-                    success = await mcp_client.connect_to_server(
-                        server_name, persistent=True
-                    )
-                    if success:
-                        connected_count += 1
-                        logger.info(
-                            f"✓ Persistent connection established: {server_name}"
-                        )
-                    else:
-                        missing = mcp_client.get_missing_credentials(server_name)
-                        if missing:
-                            logger.info(
-                                "MCP server %s dormant — awaiting env vars: %s",
-                                server_name,
-                                ", ".join(missing),
-                            )
-                        else:
-                            logger.warning(
-                                f"Failed to connect to MCP server: {server_name}"
-                            )
-                except Exception as e:
-                    logger.error(f"Error connecting to {server_name}: {e}")
+            connected_count = await _connect_enabled_mcp_servers(mcp_client)
 
             logger.info(
                 f"MCP initialization complete: {connected_count}/{len(servers)} persistent connections"

--- a/tests/unit/api/test_local_startup.py
+++ b/tests/unit/api/test_local_startup.py
@@ -62,7 +62,14 @@ async def test_enabled_mcp_servers_connect_concurrently():
 
 @pytest.mark.asyncio
 async def test_one_mcp_connect_failure_does_not_block_the_rest():
+    attempted = []
+    gate = asyncio.Event()
+
     async def connect(server_name, persistent=True):
+        attempted.append(server_name)
+        if len(attempted) >= 3:
+            gate.set()
+        await gate.wait()
         if server_name == "bad":
             raise RuntimeError("spawn failed")
         return True
@@ -73,8 +80,9 @@ async def test_one_mcp_connect_failure_does_not_block_the_rest():
         connect,
     )
 
-    count = await _connect_enabled_mcp_servers(client)
+    count = await asyncio.wait_for(_connect_enabled_mcp_servers(client), timeout=1.0)
 
+    assert set(attempted) == {"good", "bad", "also-good"}
     assert count == 2
 
 

--- a/tests/unit/api/test_local_startup.py
+++ b/tests/unit/api/test_local_startup.py
@@ -1,4 +1,12 @@
-from services.api.main import _mcp_auto_connect_enabled
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.api.main import (
+    _connect_enabled_mcp_servers,
+    _mcp_auto_connect_enabled,
+)
 
 
 def test_mcp_auto_connect_is_off_by_default_in_dev(monkeypatch):
@@ -13,3 +21,71 @@ def test_mcp_auto_connect_can_be_explicitly_enabled(monkeypatch):
     monkeypatch.setenv("MCP_AUTO_CONNECT_ON_STARTUP", "true")
 
     assert _mcp_auto_connect_enabled() is True
+
+
+def _client(servers, enabled, connect):
+    client = MagicMock()
+    client.mcp_service.list_servers.return_value = list(servers)
+    client.mcp_service.is_server_enabled.side_effect = lambda name: enabled[name]
+    client.connect_to_server = connect
+    client.get_missing_credentials.return_value = None
+    return client
+
+
+@pytest.mark.asyncio
+async def test_enabled_mcp_servers_connect_concurrently():
+    started = []
+    gate = asyncio.Event()
+
+    persistents = []
+
+    async def connect(server_name, persistent=True):
+        started.append(server_name)
+        persistents.append(persistent)
+        if len(started) >= 2:
+            gate.set()
+        await gate.wait()
+        return True
+
+    client = _client(
+        ["alpha", "beta", "disabled"],
+        {"alpha": True, "beta": True, "disabled": False},
+        connect,
+    )
+
+    count = await asyncio.wait_for(_connect_enabled_mcp_servers(client), timeout=1.0)
+
+    assert count == 2
+    assert set(started) == {"alpha", "beta"}
+    assert persistents == [True, True]
+
+
+@pytest.mark.asyncio
+async def test_one_mcp_connect_failure_does_not_block_the_rest():
+    async def connect(server_name, persistent=True):
+        if server_name == "bad":
+            raise RuntimeError("spawn failed")
+        return True
+
+    client = _client(
+        ["good", "bad", "also-good"],
+        {"good": True, "bad": True, "also-good": True},
+        connect,
+    )
+
+    count = await _connect_enabled_mcp_servers(client)
+
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_dormant_mcp_server_is_not_counted_as_connected():
+    async def connect(server_name, persistent=True):
+        return False
+
+    client = _client(["dormant"], {"dormant": True}, connect)
+    client.get_missing_credentials.return_value = ["API_KEY"]
+
+    count = await _connect_enabled_mcp_servers(client)
+
+    assert count == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #702

## Why

Production API boot still dialed enabled MCP servers one at a time. Those stdio children do not share a process, so overlapping the awaits is the actual startup cost. Settings/UX “deep integration” work is out of this PR.

## What

- `_connect_external_services` now connects enabled servers concurrently via `asyncio.gather(..., return_exceptions=True)`.
- Per-server failure isolation is unchanged: a failed or raising connect is logged and the rest continue.
- Disabled servers are still skipped before dial; credential-dormant servers still return without spawning.
- After the connect wave, `MCPClient.list_tools` still reads `tools_cache` for servers that connected. No second parallel connect path, no connect deadline, no `.mcp-capability-cache.json`, no worker-pool type, and `_connection_locks` is left unused. `close_all` stays sequential. Existing `data/mcp_tools_cache.json` / `tools_cache` is reused.

## Test plan

- [x] `pytest tests/unit/api/test_local_startup.py` — concurrent overlap, failure isolation (failing server is dialed alongside successes), dormant not counted as connected
- [x] Related MCP unit tests (`test_mcp_required_env.py`, `test_mcp_registry_population.py`)
- [x] `black` / `flake8` on the changed files

This is not a user-visible UI change; no browser walkthrough.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5594a86-cd9e-4e9e-bb2e-38caa9f33dbc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5594a86-cd9e-4e9e-bb2e-38caa9f33dbc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

