### PR TITLE
Migrate in-repo MCP servers to the mcp 2.x API and unpin

### DIFF
--- a/core/integrations/alienvault_otx/tool.py
+++ b/core/integrations/alienvault_otx/tool.py
@@ -149,9 +149,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/alienvault_otx/tool.py
+++ b/core/integrations/alienvault_otx/tool.py
@@ -22,7 +22,6 @@ from core.integrations._base.config import resolve
 from core.integrations.alienvault_otx.descriptor import ALIENVAULT_OTX
 
 logger = logging.getLogger(__name__)
-server = Server("alienvault-otx")
 
 
 def result(data):
@@ -33,7 +32,6 @@ def get_config():
     return resolve(ALIENVAULT_OTX)
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -66,7 +64,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     config = get_config()
     api_key = config.get("api_key")
@@ -145,6 +142,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
         )
     except Exception as e:
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "alienvault-otx",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/anyrun/tool.py
+++ b/core/integrations/anyrun/tool.py
@@ -22,14 +22,12 @@ from core.integrations._base.config import resolve
 from core.integrations.anyrun.descriptor import ANYRUN
 
 logger = logging.getLogger(__name__)
-server = Server("anyrun")
 
 
 def result(data):
     return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -53,7 +51,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     config = resolve(ANYRUN)
     api_key = config.get("api_key")
@@ -99,6 +96,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
         return result({"error": f"Unknown tool: {name}"})
     except Exception as e:
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "anyrun",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/anyrun/tool.py
+++ b/core/integrations/anyrun/tool.py
@@ -103,9 +103,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/azure_ad/tool.py
+++ b/core/integrations/azure_ad/tool.py
@@ -161,9 +161,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/azure_ad/tool.py
+++ b/core/integrations/azure_ad/tool.py
@@ -22,7 +22,6 @@ from core.integrations._base.config import resolve
 from core.integrations.azure_ad.descriptor import AZURE_AD
 
 logger = logging.getLogger(__name__)
-server = Server("azure-ad")
 
 
 def result(data):
@@ -53,7 +52,6 @@ def get_token():
         return None
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -92,7 +90,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     token = get_token()
     if not token:
@@ -157,6 +154,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
         return result({"error": f"Unknown tool: {name}"})
     except Exception as e:
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "azure-ad",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/cape_sandbox/tool.py
+++ b/core/integrations/cape_sandbox/tool.py
@@ -35,8 +35,6 @@ from core.integrations._base.config import resolve
 from core.integrations.cape_sandbox.descriptor import CAPE_SANDBOX
 
 logger = logging.getLogger(__name__)
-server = Server("cape-sandbox")
-
 
 DEFAULT_TIMEOUT = 30
 REPORT_TIMEOUT = 60
@@ -108,7 +106,6 @@ def _extract_iocs(report: Dict[str, Any]) -> Dict[str, List[str]]:
     return {k: sorted(v) for k, v in iocs.items()}
 
 
-@server.list_tools()
 async def handle_list_tools() -> List[types.Tool]:
     return [
         types.Tool(
@@ -220,7 +217,6 @@ async def handle_list_tools() -> List[types.Tool]:
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: Optional[dict]):
     cfg = _load_config()
     base = cfg["url"]
@@ -394,6 +390,23 @@ async def handle_call_tool(name: str, arguments: Optional[dict]):
     except Exception as e:
         logger.exception("CAPE tool call failed")
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "cape-sandbox",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main() -> None:

--- a/core/integrations/cape_sandbox/tool.py
+++ b/core/integrations/cape_sandbox/tool.py
@@ -397,9 +397,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/carbon_black/tool.py
+++ b/core/integrations/carbon_black/tool.py
@@ -148,9 +148,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/carbon_black/tool.py
+++ b/core/integrations/carbon_black/tool.py
@@ -22,14 +22,12 @@ from core.integrations._base.config import missing, resolve
 from core.integrations.carbon_black.descriptor import CARBON_BLACK
 
 logger = logging.getLogger(__name__)
-server = Server("carbon-black")
 
 
 def result(data):
     return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -68,7 +66,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     config = resolve(CARBON_BLACK)
     url = config.get("url")
@@ -144,6 +141,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
         return result({"error": f"Unknown tool: {name}"})
     except Exception as e:
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "carbon-black",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/cloudflare/tool.py
+++ b/core/integrations/cloudflare/tool.py
@@ -32,8 +32,6 @@ from core.integrations._base.config import resolve
 from core.integrations.cloudflare.descriptor import CLOUDFLARE
 
 logger = logging.getLogger(__name__)
-server = Server("cloudflare")
-
 CF_API_BASE = "https://api.cloudflare.com/client/v4"
 DEFAULT_TIMEOUT = 30
 
@@ -58,7 +56,6 @@ def _headers(api_token: str) -> Dict[str, str]:
     }
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -161,7 +158,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     cfg = _config()
     if cfg is None:
@@ -434,6 +430,23 @@ def _lookup_domain_threat(
             "geolocation and threat intel tools for full domain context."
         ),
     }
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "cloudflare",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/cloudflare/tool.py
+++ b/core/integrations/cloudflare/tool.py
@@ -437,9 +437,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/custom_integration_service.py
+++ b/core/integrations/custom_integration_service.py
@@ -308,9 +308,6 @@ def get_config():
         logger.error(f"Error loading config: {{e}}")
         return {{}}
 
-server = Server("integration-id-server")
-
-@server.list_tools()
 async def handle_list_tools() -> list[types.Tool]:
     \"\"\"List available tools.\"\"\"
     return [
@@ -330,7 +327,6 @@ async def handle_list_tools() -> list[types.Tool]:
         )
     ]
 
-@server.call_tool()
 async def handle_call_tool(
     name: str, arguments: dict | None
 ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
@@ -367,6 +363,20 @@ async def handle_call_tool(
                 "tool": name
             }}, indent=2)
         )]
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+server = Server(
+    "integration-id-server",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 async def main():
     \"\"\"Run the MCP server.\"\"\"
@@ -620,8 +630,8 @@ Only generate the JSON response when you have enough information to create a com
 
             # Check for required components
             has_server_init = "Server(" in code
-            has_list_tools = "@server.list_tools()" in code
-            has_call_tool = "@server.call_tool()" in code
+            has_list_tools = "on_list_tools" in code
+            has_call_tool = "on_call_tool" in code
             has_main = "async def main():" in code
 
             validation_checks = {

--- a/core/integrations/custom_integration_service.py
+++ b/core/integrations/custom_integration_service.py
@@ -368,9 +368,14 @@ async def _on_list_tools(_ctx, _params):
     return types.ListToolsResult(tools=await handle_list_tools())
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 server = Server(
     "integration-id-server",

--- a/core/integrations/elastic/tool.py
+++ b/core/integrations/elastic/tool.py
@@ -32,8 +32,6 @@ except ImportError:
     pass
 
 logger = logging.getLogger(__name__)
-server = Server("elastic")
-
 _elastic_service = None
 
 
@@ -72,7 +70,6 @@ def get_elastic_service():
 # ------------------------------------------------------------------
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -147,7 +144,6 @@ async def handle_list_tools():
 # ------------------------------------------------------------------
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     svc = get_elastic_service()
     if svc is None:
@@ -275,6 +271,23 @@ async def _get_detection_alerts(svc, args: dict):
 # ------------------------------------------------------------------
 # Main
 # ------------------------------------------------------------------
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "elastic",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/elastic/tool.py
+++ b/core/integrations/elastic/tool.py
@@ -278,9 +278,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/hybrid_analysis/tool.py
+++ b/core/integrations/hybrid_analysis/tool.py
@@ -22,14 +22,12 @@ from core.integrations._base.config import resolve
 from core.integrations.hybrid_analysis.descriptor import HYBRID_ANALYSIS
 
 logger = logging.getLogger(__name__)
-server = Server("hybrid-analysis")
 
 
 def result(data):
     return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -53,7 +51,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     config = resolve(HYBRID_ANALYSIS)
     api_key = config.get("api_key")
@@ -93,6 +90,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
         return result({"error": f"Unknown tool: {name}"})
     except Exception as e:
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "hybrid-analysis",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/hybrid_analysis/tool.py
+++ b/core/integrations/hybrid_analysis/tool.py
@@ -97,9 +97,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/ip_geolocation/tool.py
+++ b/core/integrations/ip_geolocation/tool.py
@@ -82,9 +82,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/ip_geolocation/tool.py
+++ b/core/integrations/ip_geolocation/tool.py
@@ -9,14 +9,12 @@ from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
 logger = logging.getLogger(__name__)
-server = Server("ip-geolocation")
 
 
 def result(data):
     return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -40,7 +38,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     args = arguments or {}
 
@@ -78,6 +75,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
         return result({"count": len(results), "results": results})
 
     return result({"error": f"Unknown tool: {name}"})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "ip-geolocation",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/mcp/client.py
+++ b/core/integrations/mcp/client.py
@@ -139,7 +139,7 @@ class PersistentServerSession:
                         content_list.append({"type": "text", "text": str(content_item)})
 
                 return {
-                    "error": result.isError if hasattr(result, "isError") else False,
+                    "error": result.is_error,
                     "content": content_list,
                 }
 
@@ -303,7 +303,7 @@ class MCPClient:
             self.tools_cache[server_name] = []
             for tool in tools_result.tools:
                 # Get input schema - handle both dict and object formats
-                input_schema = tool.inputSchema
+                input_schema = tool.input_schema
                 if hasattr(input_schema, "model_dump"):
                     input_schema = input_schema.model_dump()
                 elif hasattr(input_schema, "dict"):

--- a/core/integrations/microsoft_defender/tool.py
+++ b/core/integrations/microsoft_defender/tool.py
@@ -148,9 +148,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/microsoft_defender/tool.py
+++ b/core/integrations/microsoft_defender/tool.py
@@ -22,7 +22,6 @@ from core.integrations._base.config import resolve
 from core.integrations.microsoft_defender.descriptor import MICROSOFT_DEFENDER
 
 logger = logging.getLogger(__name__)
-server = Server("microsoft-defender")
 
 
 def result(data):
@@ -53,7 +52,6 @@ def get_token():
         return None
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -89,7 +87,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     token = get_token()
     if not token:
@@ -144,6 +141,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
         return result({"error": f"Unknown tool: {name}"})
     except Exception as e:
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "microsoft-defender",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/microsoft_teams/tool.py
+++ b/core/integrations/microsoft_teams/tool.py
@@ -105,9 +105,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/microsoft_teams/tool.py
+++ b/core/integrations/microsoft_teams/tool.py
@@ -22,14 +22,12 @@ from core.integrations._base.config import resolve
 from core.integrations.microsoft_teams.descriptor import MICROSOFT_TEAMS
 
 logger = logging.getLogger(__name__)
-server = Server("microsoft-teams")
 
 
 def result(data):
     return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -51,7 +49,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     config = resolve(MICROSOFT_TEAMS)
     webhook = config.get("webhook_url")
@@ -101,6 +98,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
             return result({"error": str(e)})
 
     return result({"error": f"Unknown tool: {name}"})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "microsoft-teams",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/misp/tool.py
+++ b/core/integrations/misp/tool.py
@@ -22,7 +22,6 @@ from core.integrations._base.config import missing, resolve
 from core.integrations.misp.descriptor import MISP
 
 logger = logging.getLogger(__name__)
-server = Server("misp")
 
 
 def result(data):
@@ -33,7 +32,6 @@ def get_config():
     return resolve(MISP)
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -57,7 +55,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     config = get_config()
     api_key = config.get("api_key")
@@ -128,6 +125,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
         return result({"error": f"Unknown tool: {name}"})
     except Exception as e:
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "misp",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/misp/tool.py
+++ b/core/integrations/misp/tool.py
@@ -132,9 +132,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/palo_alto/tool.py
+++ b/core/integrations/palo_alto/tool.py
@@ -22,14 +22,12 @@ from core.integrations._base.config import missing, resolve
 from core.integrations.palo_alto.descriptor import PALO_ALTO
 
 logger = logging.getLogger(__name__)
-server = Server("palo-alto")
 
 
 def result(data):
     return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -53,7 +51,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     config = resolve(PALO_ALTO)
     api_key = config.get("api_key")
@@ -120,6 +117,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
         return result({"error": f"Unknown tool: {name}"})
     except Exception as e:
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "palo-alto",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/palo_alto/tool.py
+++ b/core/integrations/palo_alto/tool.py
@@ -124,9 +124,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/slack/tool.py
+++ b/core/integrations/slack/tool.py
@@ -111,9 +111,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/slack/tool.py
+++ b/core/integrations/slack/tool.py
@@ -22,7 +22,6 @@ from core.integrations._base.config import resolve
 from core.integrations.slack.descriptor import SLACK
 
 logger = logging.getLogger(__name__)
-server = Server("slack")
 
 
 def result(data):
@@ -33,7 +32,6 @@ def get_config():
     return resolve(SLACK)
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -55,7 +53,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     config = get_config()
     token = config.get("bot_token")
@@ -107,6 +104,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
             return result({"error": str(e)})
 
     return result({"error": f"Unknown tool: {name}"})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "slack",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/splunk/tool.py
+++ b/core/integrations/splunk/tool.py
@@ -47,8 +47,6 @@ def _read_credential(key: str, default: str | None = None) -> str | None:
 
 
 logger = logging.getLogger(__name__)
-server = Server("splunk")
-
 SPL_TEMPLATES = {
     "failed login": "index=* (failed OR failure) (login OR logon) | stats count by src_ip, user | sort -count",
     "powershell": "index=* sourcetype=WinEventLog:Security EventCode=4688 powershell.exe | table _time, Computer, User, CommandLine",
@@ -222,7 +220,6 @@ def _telemetry_summary() -> str:
     return _summary_cache
 
 
-@server.list_tools()
 async def handle_list_tools():
     telemetry = _telemetry_summary()
     return [
@@ -293,7 +290,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     args = arguments or {}
 
@@ -398,6 +394,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
             return result({"error": str(e), "spl": spl_result["spl_query"]})
 
     return result({"error": f"Unknown tool: {name}"})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "splunk",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/splunk/tool.py
+++ b/core/integrations/splunk/tool.py
@@ -401,9 +401,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/url_analysis/tool.py
+++ b/core/integrations/url_analysis/tool.py
@@ -96,9 +96,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/url_analysis/tool.py
+++ b/core/integrations/url_analysis/tool.py
@@ -9,14 +9,12 @@ from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
 logger = logging.getLogger(__name__)
-server = Server("url-analysis")
 
 
 def result(data):
     return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -40,7 +38,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     args = arguments or {}
 
@@ -92,6 +89,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
             return result({"error": str(e)})
 
     return result({"error": f"Unknown tool: {name}"})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "url-analysis",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/core/integrations/vstrike/tool.py
+++ b/core/integrations/vstrike/tool.py
@@ -406,9 +406,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/core/integrations/vstrike/tool.py
+++ b/core/integrations/vstrike/tool.py
@@ -46,7 +46,6 @@ except ImportError:
     pass
 
 logger = logging.getLogger(__name__)
-server = Server("vstrike")
 
 
 def _result(data) -> list[types.TextContent]:
@@ -65,7 +64,6 @@ def _get_service():
         return None
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -247,7 +245,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     args = arguments or {}
     service = _get_service()
@@ -402,6 +399,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
         return _result({"result": result})
 
     return _result({"error": f"Unknown tool: {name}"})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "vstrike",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/requirements.lock
+++ b/requirements.lock
@@ -148,13 +148,11 @@ httpx==0.28.1
     #   -r requirements.txt
     #   chromadb
     #   huggingface-hub
-    #   mcp
     #   respx
-httpx-sse==0.4.3
-    # via mcp
 httpx2==2.12.0
     # via
     #   anthropic
+    #   mcp
     #   openai
 httpx2-jsfetch==1.0 ; sys_platform == 'emscripten'
     # via httpx2
@@ -200,8 +198,10 @@ limits==5.8.0
     # via slowapi
 markdown-it-py==4.2.0
     # via rich
-mcp==1.29.1
+mcp==2.1.1
     # via -r requirements.txt
+mcp-types==2.1.1
+    # via mcp
 mdurl==0.1.2
     # via markdown-it-py
 mmh3==5.2.1
@@ -228,6 +228,7 @@ opentelemetry-api==1.44.0
     # via
     #   -r requirements.txt
     #   chromadb
+    #   mcp
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-exporter-prometheus
@@ -349,6 +350,7 @@ pydantic==2.13.4
     #   chromadb
     #   fastapi
     #   mcp
+    #   mcp-types
     #   openai
     #   pydantic-settings
 pydantic-core==2.46.4
@@ -357,7 +359,6 @@ pydantic-settings==2.15.0
     # via
     #   -r requirements.txt
     #   chromadb
-    #   mcp
 pygments==2.21.0
     # via
     #   pytest
@@ -517,6 +518,7 @@ typing-extensions==4.16.0
     #   huggingface-hub
     #   limits
     #   mcp
+    #   mcp-types
     #   openai
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,11 +13,9 @@ numpy>=1.26.0
 pyarrow>=15.0.0
 ijson>=3.5.1
 anthropic>=0.45.0
-# Direct pin: every core/integrations/*/tool.py registers handlers with
-# @server.list_tools()/@server.call_tool(), which mcp 2.0.0 replaced with
-# add_request_handler()/MCPServer. Until those 21 servers are migrated,
-# 2.x breaks them at import.
-mcp>=1.23.0,<2.0.0
+# In-repo servers use the 2.x lowlevel Server(on_list_tools=..., on_call_tool=...)
+# surface. Cap below 3 so a 3.x drop does not repeat the 1.x→2.x break.
+mcp>=2,<3
 openai>=1.40.0
 # HTTP client for every integration client and MCP tool server. Arrives
 # transitively via anthropic/openai; pinned so we don't rely on someone

--- a/tests/unit/integrations/test_vstrike_mcp_server.py
+++ b/tests/unit/integrations/test_vstrike_mcp_server.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from mcp.types import CallToolResult
 
 ROOT = Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
@@ -299,3 +300,31 @@ async def test_call_tool_ui_rightpanel_focus_forwards_extras(mock_service):
             "vstrike_ui_rightpanel_focus", {"future_field": "x"}
         )
     mock_service.ui_rightpanel_focus.assert_called_once_with(future_field="x")
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_turns_handler_exceptions_into_error_results(mock_service):
+    """v2 does not wrap exceptions; do it at on_call_tool or they become JSON-RPC."""
+    with patch.object(vstrike_module, "_get_service", return_value=mock_service):
+        result = await vstrike_module._on_call_tool(
+            None,
+            SimpleNamespace(
+                name="vstrike_get_segment_findings",
+                arguments={"segment": "dmz", "limit": "bad"},
+            ),
+        )
+    assert isinstance(result, CallToolResult)
+    assert result.is_error is True
+    assert "invalid literal" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_keeps_handler_content_as_success(mock_service):
+    with patch.object(vstrike_module, "_get_service", return_value=mock_service):
+        result = await vstrike_module._on_call_tool(
+            None,
+            SimpleNamespace(name="does_not_exist", arguments={}),
+        )
+    assert isinstance(result, CallToolResult)
+    assert result.is_error is False
+    assert "Unknown tool" in result.content[0].text

--- a/tools/mcp/approval.py
+++ b/tools/mcp/approval.py
@@ -250,9 +250,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/tools/mcp/approval.py
+++ b/tools/mcp/approval.py
@@ -8,7 +8,6 @@ from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
 logger = logging.getLogger(__name__)
-server = Server("approval")
 
 
 def result(data):
@@ -16,13 +15,15 @@ def result(data):
 
 
 def get_approval_svc():
-    from core.response.approval_service import (ActionStatus, ActionType,
-                                                get_approval_service)
+    from core.response.approval_service import (
+        ActionStatus,
+        ActionType,
+        get_approval_service,
+    )
 
     return get_approval_service(), ActionType, ActionStatus
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -119,7 +120,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     try:
         svc, ActionType, ActionStatus = get_approval_svc()
@@ -243,6 +243,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
 
     except Exception as e:
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "approval",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/tools/mcp/attack_layer.py
+++ b/tools/mcp/attack_layer.py
@@ -215,9 +215,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(

--- a/tools/mcp/attack_layer.py
+++ b/tools/mcp/attack_layer.py
@@ -8,7 +8,6 @@ from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
 logger = logging.getLogger(__name__)
-server = Server("attack-layer")
 
 
 def result(data):
@@ -21,7 +20,6 @@ def get_db():
     return DatabaseService()
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -64,7 +62,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     try:
         db = get_db()
@@ -211,6 +208,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
 
     except Exception as e:
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "attack-layer",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/tools/mcp/base.py
+++ b/tools/mcp/base.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import Any
 
 import numpy as np
-from mcp.server.fastmcp import FastMCP
 
 logger = logging.getLogger(__name__)
 
@@ -28,10 +27,6 @@ def json_response(data: Any, indent: int = 2) -> str:
 
 def error_response(message: str, **extra) -> str:
     return json_response({"error": message, **extra})
-
-
-def create_server(name: str) -> FastMCP:
-    return FastMCP(name)
 
 
 # There is deliberately no config/credential helper here. These servers talk to

--- a/tools/mcp/deeptempo_findings.py
+++ b/tools/mcp/deeptempo_findings.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from typing import Optional
 
 import numpy as np
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from core.time import utcnow
 
 logger = logging.getLogger(__name__)
-mcp = FastMCP("deeptempo-findings")
+mcp = MCPServer("deeptempo-findings")
 
 DATA_DIR = Path(
     os.environ.get("DEEPTEMPO_DATA_DIR", Path(__file__).parent.parent / "data")

--- a/tools/mcp/tempo_flow.py
+++ b/tools/mcp/tempo_flow.py
@@ -8,14 +8,12 @@ from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
 logger = logging.getLogger(__name__)
-server = Server("tempo-flow")
 
 
 def result(data):
     return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
 
 
-@server.list_tools()
 async def handle_list_tools():
     return [
         types.Tool(
@@ -38,7 +36,6 @@ async def handle_list_tools():
     ]
 
 
-@server.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None):
     args = arguments or {}
 
@@ -74,6 +71,23 @@ async def handle_call_tool(name: str, arguments: dict | None):
         return result({"error": f"Unknown tool: {name}"})
     except Exception as e:
         return result({"error": str(e)})
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    return types.CallToolResult(
+        content=await handle_call_tool(params.name, params.arguments)
+    )
+
+
+server = Server(
+    "tempo-flow",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def main():

--- a/tools/mcp/tempo_flow.py
+++ b/tools/mcp/tempo_flow.py
@@ -78,9 +78,14 @@ async def _on_list_tools(_ctx, _params):
 
 
 async def _on_call_tool(_ctx, params):
-    return types.CallToolResult(
-        content=await handle_call_tool(params.name, params.arguments)
-    )
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
 
 
 server = Server(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #698

The `mcp>=1.23.0,<2.0.0` pin was a holding action around a deleted 1.x API. This ports the in-repo servers to the official 2.x surface, then drops the cap.

## What changed

Lowlevel servers (`core/integrations/*/tool.py` and `tools/mcp/{approval,attack_layer,tempo_flow}.py`) now register with `Server(..., on_list_tools=..., on_call_tool=...)`. Hand-written `types.Tool(..., inputSchema={...})` lists and name-dispatch bodies are unchanged. Thin `_on_*` wrappers keep `handle_list_tools()` / `handle_call_tool(name, arguments)` callable as today, so existing tests do not need a `(ctx, params)` rewrite.

`_on_call_tool` catches handler exceptions and returns `CallToolResult(is_error=True)`. mcp 2.x no longer does that itself, and an uncaught raise would become a JSON-RPC error (a dropped session to our client). Handler-caught failures still return JSON in `TextContent` with `is_error=False`, as they did on 1.x.

Also ported:

- `tools/mcp/deeptempo_findings.py`: `FastMCP` → `MCPServer`. `mcp.run()` and `@mcp.tool()` stay.
- `tools/mcp/base.py`: unused `create_server()` deleted with the FastMCP import.
- `core/integrations/mcp/client.py`: `tool.input_schema` and `result.is_error` (the `hasattr(..., "isError")` fallback would silently report success on 2.x). Cache/registry dict keys remain `"inputSchema"`.
- Custom-integration generator template and `validate()` substring checks updated to the 2.x surface. No compatibility layer for already-generated `~/.vigil/custom_integrations/*_server.py`.

`core.integrations.mcp.service.MCPServer` (process record) is untouched. `_detect_server_type`'s `"fastmcp"` label stays. Tool servers stay on `httpx`; mcp 2.x's `httpx2` is internal.

## Out of scope

- FastMCP-style per-function rewrite of the 74 hand-written schemas
- A 1.x decorator shim
- External servers in `mcp-config.json` (#516)

## Verification

- black / isort / flake8 on `services/` and `core/`
- 560 unit tests in `tests/unit/integrations/`, `tests/unit/_ratchets/`, and related MCP tests
- Smoke-import of every migrated server under mcp 2.1.1
- Wrapper test: vstrike `int("bad")` still raises from `handle_call_tool`, and `_on_call_tool` turns it into `CallToolResult(is_error=True)`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fb0998b-0192-4973-b912-3a5223dcd352?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fb0998b-0192-4973-b912-3a5223dcd352&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

