### PR TITLE
Move findings.mitre_predictions to a queryable child table

### DIFF
--- a/core/reporting/analytics_service.py
+++ b/core/reporting/analytics_service.py
@@ -525,7 +525,12 @@ async def get_attack_time_heatmap(
 async def get_mitre_technique_distribution(
     db: Session, start_time: datetime, end_time: datetime, limit: int = 10
 ) -> List[Dict[str, Any]]:
-    """Get distribution of MITRE ATT&CK techniques from findings."""
+    """Get distribution of MITRE ATT&CK techniques from findings.
+
+    Counts child-table rows only. Nested / list-shaped JSONB maps were never a
+    findings column contract; numeric ``{key: confidence}`` values are what
+    create/update persist and what the backfill copies.
+    """
 
     rows = (
         db.query(

--- a/core/reporting/analytics_service.py
+++ b/core/reporting/analytics_service.py
@@ -12,7 +12,13 @@ from sqlalchemy import and_, func
 from sqlalchemy.orm import Session
 
 from core.llm.providers.registry import get_registry, infer_provider_type
-from core.storage.models import Case, CaseClosureInfo, Finding, LLMInteractionLog
+from core.storage.models import (
+    Case,
+    CaseClosureInfo,
+    Finding,
+    FindingMitrePrediction,
+    LLMInteractionLog,
+)
 from core.threat_intel.mitre_lookup import get_time_range, resolve_technique
 
 logger = logging.getLogger(__name__)
@@ -521,63 +527,34 @@ async def get_mitre_technique_distribution(
 ) -> List[Dict[str, Any]]:
     """Get distribution of MITRE ATT&CK techniques from findings."""
 
-    findings = (
-        db.query(Finding).filter(Finding.created_at.between(start_time, end_time)).all()
+    rows = (
+        db.query(
+            FindingMitrePrediction.technique_id,
+            func.count(FindingMitrePrediction.finding_id),
+        )
+        .join(Finding, Finding.finding_id == FindingMitrePrediction.finding_id)
+        .filter(Finding.created_at.between(start_time, end_time))
+        .group_by(FindingMitrePrediction.technique_id)
+        .order_by(func.count(FindingMitrePrediction.finding_id).desc())
+        .limit(limit)
+        .all()
     )
 
-    technique_counts: dict[str, int] = {}
-    technique_meta: dict[str, tuple[str, str]] = {}
-
-    def _record(tech):
-        tid, name, tactic = resolve_technique(tech)
-        if not tid:
-            return
-        technique_counts[tid] = technique_counts.get(tid, 0) + 1
-        if tid not in technique_meta:
-            technique_meta[tid] = (name, tactic)
-
-    for finding in findings:
-        if not finding.mitre_predictions:
+    techniques_list = []
+    for tech_id, count in rows:
+        resolved_id, name, tactic = resolve_technique(tech_id)
+        if not resolved_id:
             continue
+        techniques_list.append(
+            {
+                "techniqueId": resolved_id,
+                "techniqueName": name,
+                "tactic": tactic,
+                "count": count,
+            }
+        )
 
-        predictions = finding.mitre_predictions
-
-        if isinstance(predictions, dict):
-            if predictions and all(
-                isinstance(v, (int, float)) for v in predictions.values()
-            ):
-                # Standard format: {tactic_or_technique_id: confidence}
-                for tech_id in predictions.keys():
-                    _record(tech_id)
-            else:
-                if "techniques" in predictions:
-                    nested = predictions["techniques"]
-                elif "predicted_techniques" in predictions:
-                    nested = predictions["predicted_techniques"]
-                else:
-                    nested = [predictions]
-
-                for tech in nested:
-                    if isinstance(tech, dict):
-                        _record(tech)
-        elif isinstance(predictions, list):
-            for tech in predictions:
-                if isinstance(tech, dict):
-                    _record(tech)
-
-    techniques_list = [
-        {
-            "techniqueId": tech_id,
-            "techniqueName": technique_meta[tech_id][0],
-            "tactic": technique_meta[tech_id][1],
-            "count": count,
-        }
-        for tech_id, count in technique_counts.items()
-    ]
-
-    techniques_list.sort(key=lambda x: x["count"], reverse=True)
-
-    return techniques_list[:limit]
+    return techniques_list
 
 
 def _cost_time_series_from_bifrost(start_time, end_time) -> Optional[Dict[str, Any]]:

--- a/core/storage/connection.py
+++ b/core/storage/connection.py
@@ -50,6 +50,7 @@ from core.storage.models import (  # noqa: F401
     CustomAgent,
     CustomWorkflow,
     Finding,
+    FindingMitrePrediction,
     IntegrationConfig,
     Investigation,
     InvestigationLog,

--- a/core/storage/database_data_service.py
+++ b/core/storage/database_data_service.py
@@ -306,6 +306,57 @@ class DatabaseDataService:
                     return f
         return None
 
+    def get_findings_by_technique(
+        self, technique_id: str, limit: Optional[int] = None
+    ) -> List[Dict]:
+        """Findings predicting ``technique_id`` from the child table. DB only."""
+        if not self._db_available or not self._db_service:
+            return []
+        try:
+            findings = self._db_service.get_findings_by_technique(
+                technique_id, limit=limit
+            )
+            return FindingSchema.dump_many(findings)
+        except Exception as e:
+            logger.error(f"Error getting findings by technique from DB: {e}")
+            return []
+
+    def get_technique_max_confidence(self) -> Dict[str, float]:
+        if not self._db_available or not self._db_service:
+            return {}
+        try:
+            return self._db_service.get_technique_max_confidence()
+        except Exception as e:
+            logger.error(f"Error getting technique max confidence from DB: {e}")
+            return {}
+
+    def get_technique_severity_counts(
+        self,
+        min_confidence: float = 0.0,
+        start_time=None,
+        end_time=None,
+    ) -> list:
+        if not self._db_available or not self._db_service:
+            return []
+        try:
+            return self._db_service.get_technique_severity_counts(
+                min_confidence=min_confidence,
+                start_time=start_time,
+                end_time=end_time,
+            )
+        except Exception as e:
+            logger.error(f"Error getting technique severity counts from DB: {e}")
+            return []
+
+    def get_technique_occurrence_counts(self) -> Dict[str, int]:
+        if not self._db_available or not self._db_service:
+            return {}
+        try:
+            return self._db_service.get_technique_occurrence_counts()
+        except Exception as e:
+            logger.error(f"Error getting technique occurrence counts from DB: {e}")
+            return {}
+
     def create_finding(self, finding_data: Dict) -> Optional[Dict]:
         if self._demo_mode and self._demo_service:
             return self._demo_service.create_finding(finding_data)

--- a/core/storage/models.py
+++ b/core/storage/models.py
@@ -90,7 +90,6 @@ class Finding(Base):
     # Primary key
     finding_id: Mapped[str] = mapped_column(String(50), primary_key=True)
 
-    mitre_predictions: Mapped[dict] = mapped_column(JSONB, nullable=False)
     anomaly_score: Mapped[float] = mapped_column(Float, nullable=False)
 
     # Human-readable description (populated from ingestion or synthesized from entity_context)
@@ -133,6 +132,12 @@ class Finding(Base):
     cases: Mapped[List["Case"]] = relationship(
         "Case", secondary=case_findings, back_populates="findings", lazy="selectin"
     )
+    mitre_prediction_rows: Mapped[List["FindingMitrePrediction"]] = relationship(
+        "FindingMitrePrediction",
+        back_populates="finding",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
 
     # Indexes
     __table_args__ = (
@@ -156,6 +161,35 @@ class Finding(Base):
             postgresql_where=text(
                 "data_source IS NOT NULL AND external_id IS NOT NULL"
             ),
+        ),
+    )
+
+
+class FindingMitrePrediction(Base):
+    """One predicted ATT&CK technique (or ingest key) for a finding.
+
+    Keys are stored as text: parquet/CSV ingest uses tactic names, not only T-IDs.
+    """
+
+    __tablename__ = "finding_mitre_predictions"
+
+    finding_id: Mapped[str] = mapped_column(
+        String(50),
+        ForeignKey("findings.finding_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    technique_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+
+    finding: Mapped["Finding"] = relationship(
+        "Finding", back_populates="mitre_prediction_rows"
+    )
+
+    __table_args__ = (
+        Index(
+            "idx_finding_mitre_predictions_technique_confidence",
+            "technique_id",
+            text("confidence DESC"),
         ),
     )
 

--- a/core/storage/schemas/finding.py
+++ b/core/storage/schemas/finding.py
@@ -2,7 +2,17 @@
 
 from typing import Any, Optional
 
+from pydantic import model_validator
+
 from core.storage.schemas.base import OptDateTime, ORMSchema
+
+
+def _predictions_map(obj: Any) -> dict:
+    """Rebuild `{technique_id: confidence}` from child rows."""
+    rows = getattr(obj, "mitre_prediction_rows", None)
+    if not rows:
+        return {}
+    return {row.technique_id: row.confidence for row in rows}
 
 
 class FindingSchema(ORMSchema):
@@ -23,3 +33,18 @@ class FindingSchema(ORMSchema):
     ai_enrichment: Optional[Any] = None
     created_at: OptDateTime = None
     updated_at: OptDateTime = None
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _hydrate_predictions(cls, data: Any, handler):
+        """Nested dumps (e.g. CaseWithFindings) never call ``dump``."""
+        validated = handler(data)
+        if getattr(data, "mitre_prediction_rows", None) is not None:
+            validated.mitre_predictions = _predictions_map(data)
+        return validated
+
+    @classmethod
+    def dump(cls, obj: Any, **kwargs: Any) -> dict:
+        data = super().dump(obj, **kwargs)
+        data["mitre_predictions"] = _predictions_map(obj)
+        return data

--- a/core/storage/service.py
+++ b/core/storage/service.py
@@ -276,7 +276,7 @@ class DatabaseService:
         self, limit: int = 100, max_age_hours: Optional[int] = None
     ) -> List[Dict[str, Any]]:
         """Findings stored but never enriched (ai_enrichment IS NULL), oldest first.
-        Returns dicts (to_dict inside the session) so callers get detached-safe data.
+        Returns dicts (FindingSchema.dump inside the session) so callers get detached-safe data.
         ``max_age_hours`` bounds the working set so ancient, un-enrichable findings
         aren't retried forever."""
         with self.db_manager.session_scope() as session:

--- a/core/storage/service.py
+++ b/core/storage/service.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import and_, func, or_, select
+from sqlalchemy.orm import selectinload
 
 from core.exceptions import default_on_error
 from core.storage.case_repository import CaseRepository
@@ -17,11 +18,54 @@ from core.storage.models import (
     AIDecisionLog,
     Case,
     Finding,
+    FindingMitrePrediction,
 )
 from core.storage.schemas import FindingSchema
 from core.time import utcnow
 
 logger = logging.getLogger(__name__)
+
+_UNSET = object()
+
+
+def _numeric_prediction_items(mitre_predictions: Any) -> List[tuple[str, float]]:
+    """Persist numeric map values only; keys stay text (tactic names included)."""
+    if not isinstance(mitre_predictions, dict):
+        return []
+    items: List[tuple[str, float]] = []
+    for key, value in mitre_predictions.items():
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            continue
+        items.append((str(key), float(value)))
+    return items
+
+
+def _set_mitre_prediction_rows(finding: Finding, mitre_predictions: Any) -> None:
+    finding.mitre_prediction_rows.clear()
+    for technique_id, confidence in _numeric_prediction_items(mitre_predictions):
+        finding.mitre_prediction_rows.append(
+            FindingMitrePrediction(
+                technique_id=technique_id,
+                confidence=confidence,
+            )
+        )
+
+
+def findings_by_technique_stmt(technique_id: str, limit: Optional[int] = None):
+    """Findings predicting ``technique_id``, highest confidence first."""
+    stmt = (
+        select(Finding)
+        .join(
+            FindingMitrePrediction,
+            FindingMitrePrediction.finding_id == Finding.finding_id,
+        )
+        .where(FindingMitrePrediction.technique_id == technique_id)
+        .order_by(FindingMitrePrediction.confidence.desc())
+        .options(selectinload(Finding.mitre_prediction_rows))
+    )
+    if limit is not None:
+        stmt = stmt.limit(limit)
+    return stmt
 
 
 class DatabaseService:
@@ -60,7 +104,6 @@ class DatabaseService:
         with self.db_manager.session_scope() as session:
             finding = Finding(
                 finding_id=finding_id,
-                mitre_predictions=mitre_predictions,
                 anomaly_score=anomaly_score,
                 timestamp=timestamp,
                 data_source=data_source,
@@ -72,9 +115,11 @@ class DatabaseService:
                 severity=kwargs.get("severity"),
                 status=kwargs.get("status", "new"),
             )
+            _set_mitre_prediction_rows(finding, mitre_predictions)
             session.add(finding)
             session.flush()
             session.refresh(finding)
+            _ = finding.mitre_prediction_rows
             logger.info(f"Created finding: {finding_id}")
             return finding
 
@@ -97,22 +142,23 @@ class DatabaseService:
                 new_ids = [i for i in ids if i not in existing]
                 for finding_id in new_ids:
                     r = by_id[finding_id]
-                    session.add(
-                        Finding(
-                            finding_id=finding_id,
-                            mitre_predictions=r.get("mitre_predictions") or {},
-                            anomaly_score=r.get("anomaly_score", 0.0),
-                            timestamp=r["timestamp"],
-                            data_source=r.get("data_source", "imported"),
-                            external_id=r.get("external_id"),
-                            description=r.get("description"),
-                            entity_context=r.get("entity_context"),
-                            evidence_links=r.get("evidence_links"),
-                            cluster_id=r.get("cluster_id"),
-                            severity=r.get("severity"),
-                            status=r.get("status", "new"),
-                        )
+                    finding = Finding(
+                        finding_id=finding_id,
+                        anomaly_score=r.get("anomaly_score", 0.0),
+                        timestamp=r["timestamp"],
+                        data_source=r.get("data_source", "imported"),
+                        external_id=r.get("external_id"),
+                        description=r.get("description"),
+                        entity_context=r.get("entity_context"),
+                        evidence_links=r.get("evidence_links"),
+                        cluster_id=r.get("cluster_id"),
+                        severity=r.get("severity"),
+                        status=r.get("status", "new"),
                     )
+                    _set_mitre_prediction_rows(
+                        finding, r.get("mitre_predictions") or {}
+                    )
+                    session.add(finding)
                 session.flush()
                 return {"imported": len(new_ids), "skipped": len(rows) - len(new_ids)}
         except Exception as e:
@@ -131,7 +177,11 @@ class DatabaseService:
             Finding object or None if not found
         """
         with self.db_manager.session_scope() as session:
-            finding = session.get(Finding, finding_id)
+            finding = session.get(
+                Finding,
+                finding_id,
+                options=(selectinload(Finding.mitre_prediction_rows),),
+            )
             if finding:
                 # Detach from session to avoid lazy loading issues
                 session.expunge(finding)
@@ -170,7 +220,7 @@ class DatabaseService:
             List of Finding objects
         """
         with self.db_manager.session_scope() as session:
-            query = select(Finding)
+            query = select(Finding).options(selectinload(Finding.mitre_prediction_rows))
 
             filters = []
             if severity:
@@ -230,7 +280,11 @@ class DatabaseService:
         ``max_age_hours`` bounds the working set so ancient, un-enrichable findings
         aren't retried forever."""
         with self.db_manager.session_scope() as session:
-            query = select(Finding).where(Finding.ai_enrichment.is_(None))
+            query = (
+                select(Finding)
+                .options(selectinload(Finding.mitre_prediction_rows))
+                .where(Finding.ai_enrichment.is_(None))
+            )
             if max_age_hours:
                 cutoff = utcnow() - timedelta(hours=max_age_hours)
                 query = query.where(Finding.timestamp >= cutoff)
@@ -297,10 +351,16 @@ class DatabaseService:
             True if successful, False otherwise
         """
         with self.db_manager.session_scope() as session:
-            finding = session.get(Finding, finding_id)
+            finding = session.get(
+                Finding,
+                finding_id,
+                options=(selectinload(Finding.mitre_prediction_rows),),
+            )
             if not finding:
                 logger.warning(f"Finding not found: {finding_id}")
                 return False
+
+            mitre_predictions = updates.pop("mitre_predictions", _UNSET)
 
             # Unknown keys are skipped rather than rejected: the S3 sync path
             # passes whole external finding dicts. Say which, or a typo'd column
@@ -315,6 +375,9 @@ class DatabaseService:
             for key, value in updates.items():
                 if hasattr(finding, key):
                     setattr(finding, key, value)
+
+            if mitre_predictions is not _UNSET:
+                _set_mitre_prediction_rows(finding, mitre_predictions)
 
             finding.updated_at = utcnow()
             session.flush()
@@ -341,6 +404,76 @@ class DatabaseService:
             session.delete(finding)
             logger.info(f"Deleted finding: {finding_id}")
             return True
+
+    @default_on_error(list)
+    def get_findings_by_technique(
+        self, technique_id: str, limit: Optional[int] = None
+    ) -> List[Finding]:
+        """Findings predicting ``technique_id``, ordered by confidence descending."""
+        with self.db_manager.session_scope() as session:
+            findings = (
+                session.execute(findings_by_technique_stmt(technique_id, limit=limit))
+                .scalars()
+                .all()
+            )
+            for finding in findings:
+                session.expunge(finding)
+            return findings
+
+    @default_on_error(dict)
+    def get_technique_max_confidence(self) -> Dict[str, float]:
+        """Max confidence per technique_id across all prediction rows."""
+        with self.db_manager.session_scope() as session:
+            rows = session.execute(
+                select(
+                    FindingMitrePrediction.technique_id,
+                    func.max(FindingMitrePrediction.confidence),
+                ).group_by(FindingMitrePrediction.technique_id)
+            ).all()
+            return {tid: float(conf) for tid, conf in rows}
+
+    @default_on_error(list)
+    def get_technique_severity_counts(
+        self,
+        min_confidence: float = 0.0,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+    ) -> List[tuple]:
+        """(technique_id, severity, count) from the child table."""
+        with self.db_manager.session_scope() as session:
+            stmt = (
+                select(
+                    FindingMitrePrediction.technique_id,
+                    Finding.severity,
+                    func.count(),
+                )
+                .join(
+                    Finding,
+                    Finding.finding_id == FindingMitrePrediction.finding_id,
+                )
+                .where(FindingMitrePrediction.confidence >= min_confidence)
+                .group_by(FindingMitrePrediction.technique_id, Finding.severity)
+            )
+            if start_time is not None:
+                stmt = stmt.where(Finding.timestamp >= start_time)
+            if end_time is not None:
+                stmt = stmt.where(Finding.timestamp <= end_time)
+            return [
+                (tid, severity, int(count))
+                for tid, severity, count in session.execute(stmt).all()
+            ]
+
+    @default_on_error(dict)
+    def get_technique_occurrence_counts(self) -> Dict[str, int]:
+        """Finding-row counts per technique_id."""
+        with self.db_manager.session_scope() as session:
+            rows = session.execute(
+                select(
+                    FindingMitrePrediction.technique_id,
+                    func.count(),
+                ).group_by(FindingMitrePrediction.technique_id)
+            ).all()
+            return {tid: int(count) for tid, count in rows}
 
     # ========== Case Operations ==========
 
@@ -416,7 +549,8 @@ class DatabaseService:
             if case:
                 # Force load findings if needed
                 if include_findings:
-                    _ = case.findings  # Trigger lazy load
+                    for linked in case.findings:
+                        _ = linked.mitre_prediction_rows
                 session.expunge(case)
             return case
 

--- a/core/threat_intel/attack_router.py
+++ b/core/threat_intel/attack_router.py
@@ -56,19 +56,19 @@ def get_attack_layer():
         ATT&CK layer JSON
     """
     try:
-        findings = data_service.get_findings()
-
-        # Build technique scores from findings
-        technique_scores = {}
-        for finding in findings:
-            for tech in iter_techniques(finding):
-                tid = tech.get("technique_id") or tech.get("id")
-                confidence = tech.get("confidence", 0) or 0
-                if tid:
-                    # Track max confidence per technique
-                    technique_scores[tid] = max(
-                        technique_scores.get(tid, 0), confidence
-                    )
+        if data_service.is_using_database():
+            technique_scores = data_service.get_technique_max_confidence()
+        else:
+            findings = data_service.get_findings()
+            technique_scores = {}
+            for finding in findings:
+                for tech in iter_techniques(finding):
+                    tid = tech.get("technique_id") or tech.get("id")
+                    confidence = tech.get("confidence", 0) or 0
+                    if tid:
+                        technique_scores[tid] = max(
+                            technique_scores.get(tid, 0), confidence
+                        )
 
         techniques = [
             {
@@ -117,49 +117,80 @@ def get_technique_rollup(
         Technique statistics sorted by occurrence count, including
         human-readable technique name and tactic per row.
     """
-    findings = data_service.get_findings()
-
-    if time_range != "all":
-        start_time, end_time = get_time_range(time_range)
-        scoped: list[dict] = []
-        for finding in findings:
-            ts = _parse_finding_timestamp(finding)
-            if ts is None or start_time <= ts <= end_time:
-                scoped.append(finding)
-        findings = scoped
-
-    technique_counts: dict[str, int] = {}
-    technique_severities: dict[str, dict[str, int]] = {}
-    technique_meta: dict[str, tuple[str, str]] = {}
-
-    for finding in findings:
-        severity = finding.get("severity", "unknown")
-
-        for tech in iter_techniques(finding):
-            confidence = tech.get("confidence", 0) or 0
-
-            if confidence < min_confidence:
+    if data_service.is_using_database():
+        start_time = end_time = None
+        if time_range != "all":
+            start_time, end_time = get_time_range(time_range)
+        severity_rows = data_service.get_technique_severity_counts(
+            min_confidence=min_confidence,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        technique_counts: dict[str, int] = {}
+        technique_severities: dict[str, dict[str, int]] = {}
+        technique_meta: dict[str, tuple[str, str]] = {}
+        for tid, severity, count in severity_rows:
+            resolved_id, name, tactic = resolve_technique(tid)
+            if not resolved_id:
                 continue
-
-            tid, name, tactic = resolve_technique(tech)
-            if not tid:
-                continue
-
-            technique_counts[tid] = technique_counts.get(tid, 0) + 1
-            if tid not in technique_meta:
-                technique_meta[tid] = (name, tactic)
-
-            if tid not in technique_severities:
-                technique_severities[tid] = {
+            technique_counts[resolved_id] = technique_counts.get(resolved_id, 0) + count
+            if resolved_id not in technique_meta:
+                technique_meta[resolved_id] = (name, tactic)
+            if resolved_id not in technique_severities:
+                technique_severities[resolved_id] = {
                     "critical": 0,
                     "high": 0,
                     "medium": 0,
                     "low": 0,
                 }
-
-            technique_severities[tid][severity] = (
-                technique_severities[tid].get(severity, 0) + 1
+            sev_key = severity or "unknown"
+            technique_severities[resolved_id][sev_key] = (
+                technique_severities[resolved_id].get(sev_key, 0) + count
             )
+    else:
+        findings = data_service.get_findings()
+
+        if time_range != "all":
+            start_time, end_time = get_time_range(time_range)
+            scoped: list[dict] = []
+            for finding in findings:
+                ts = _parse_finding_timestamp(finding)
+                if ts is None or start_time <= ts <= end_time:
+                    scoped.append(finding)
+            findings = scoped
+
+        technique_counts = {}
+        technique_severities = {}
+        technique_meta = {}
+
+        for finding in findings:
+            severity = finding.get("severity", "unknown")
+
+            for tech in iter_techniques(finding):
+                confidence = tech.get("confidence", 0) or 0
+
+                if confidence < min_confidence:
+                    continue
+
+                tid, name, tactic = resolve_technique(tech)
+                if not tid:
+                    continue
+
+                technique_counts[tid] = technique_counts.get(tid, 0) + 1
+                if tid not in technique_meta:
+                    technique_meta[tid] = (name, tactic)
+
+                if tid not in technique_severities:
+                    technique_severities[tid] = {
+                        "critical": 0,
+                        "high": 0,
+                        "medium": 0,
+                        "low": 0,
+                    }
+
+                technique_severities[tid][severity] = (
+                    technique_severities[tid].get(severity, 0) + 1
+                )
 
     techniques = []
     for tid, count in technique_counts.items():
@@ -193,15 +224,15 @@ def get_findings_by_technique(technique_id: str):
     Returns:
         List of findings
     """
-    findings = data_service.get_findings()
-
-    matching_findings = []
-
-    for finding in findings:
-        for tech in iter_techniques(finding):
-            if (tech.get("technique_id") or tech.get("id")) == technique_id:
-                matching_findings.append(finding)
-                break
+    if data_service.is_using_database():
+        matching_findings = data_service.get_findings_by_technique(technique_id)
+    else:
+        matching_findings = []
+        for finding in data_service.get_findings():
+            for tech in iter_techniques(finding):
+                if (tech.get("technique_id") or tech.get("id")) == technique_id:
+                    matching_findings.append(finding)
+                    break
 
     return {
         "technique_id": technique_id,
@@ -218,14 +249,19 @@ def get_tactics_summary():
     Returns:
         Tactics summary
     """
-    findings = data_service.get_findings()
-
-    tactic_counts: dict[str, int] = {}
-
-    for finding in findings:
-        for tech in iter_techniques(finding):
-            _tid, _name, tactic = resolve_technique(tech)
-            tactic_counts[tactic] = tactic_counts.get(tactic, 0) + 1
+    if data_service.is_using_database():
+        technique_counts = data_service.get_technique_occurrence_counts()
+        tactic_counts: dict[str, int] = {}
+        for tid, count in technique_counts.items():
+            _tid, _name, tactic = resolve_technique(tid)
+            tactic_counts[tactic] = tactic_counts.get(tactic, 0) + count
+    else:
+        findings = data_service.get_findings()
+        tactic_counts = {}
+        for finding in findings:
+            for tech in iter_techniques(finding):
+                _tid, _name, tactic = resolve_technique(tech)
+                tactic_counts[tactic] = tactic_counts.get(tactic, 0) + 1
 
     return {
         "tactics": [

--- a/infra/database/init/24_finding_mitre_predictions.sql
+++ b/infra/database/init/24_finding_mitre_predictions.sql
@@ -1,0 +1,50 @@
+-- Promote findings.mitre_predictions JSONB to finding_mitre_predictions.
+--
+-- The map is one-to-many; ATT&CK readers need to filter / order / group by
+-- technique_id without loading every finding. create_all builds the child
+-- table on a fresh database; this file is what reaches existing deployments
+-- (backfill + DROP COLUMN). Idempotent and self-guarding: safe to re-run,
+-- safe when the findings table is absent (fresh install).
+--
+-- docker-compose mounts database/init/ at /docker-entrypoint-initdb.d, which
+-- Postgres runs only when initialising an empty data directory. An existing
+-- local volume will not pick this file up — recreate the volume or apply the
+-- SQL by hand.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables WHERE table_name = 'findings'
+    ) THEN
+        RAISE NOTICE '24_finding_mitre_predictions: findings table absent (fresh DB), nothing to migrate';
+        RETURN;
+    END IF;
+
+    CREATE TABLE IF NOT EXISTS finding_mitre_predictions (
+        finding_id VARCHAR(50) NOT NULL REFERENCES findings(finding_id) ON DELETE CASCADE,
+        technique_id TEXT NOT NULL,
+        confidence DOUBLE PRECISION NOT NULL,
+        PRIMARY KEY (finding_id, technique_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_finding_mitre_predictions_technique_confidence
+        ON finding_mitre_predictions (technique_id, confidence DESC);
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'findings' AND column_name = 'mitre_predictions'
+    ) THEN
+        INSERT INTO finding_mitre_predictions (finding_id, technique_id, confidence)
+        SELECT f.finding_id, kv.key, (kv.value)::text::double precision
+        FROM findings f
+        CROSS JOIN LATERAL jsonb_each(f.mitre_predictions) AS kv
+        WHERE jsonb_typeof(f.mitre_predictions) = 'object'
+          AND jsonb_typeof(kv.value) = 'number'
+        ON CONFLICT DO NOTHING;
+
+        ALTER TABLE findings DROP COLUMN IF EXISTS mitre_predictions;
+        RAISE NOTICE '24_finding_mitre_predictions: backfilled and dropped findings.mitre_predictions';
+    ELSE
+        RAISE NOTICE '24_finding_mitre_predictions: mitre_predictions column already absent';
+    END IF;
+END $$;

--- a/infra/helm/vigil/files/database-init/24_finding_mitre_predictions.sql
+++ b/infra/helm/vigil/files/database-init/24_finding_mitre_predictions.sql
@@ -1,0 +1,50 @@
+-- Promote findings.mitre_predictions JSONB to finding_mitre_predictions.
+--
+-- The map is one-to-many; ATT&CK readers need to filter / order / group by
+-- technique_id without loading every finding. create_all builds the child
+-- table on a fresh database; this file is what reaches existing deployments
+-- (backfill + DROP COLUMN). Idempotent and self-guarding: safe to re-run,
+-- safe when the findings table is absent (fresh install).
+--
+-- docker-compose mounts database/init/ at /docker-entrypoint-initdb.d, which
+-- Postgres runs only when initialising an empty data directory. An existing
+-- local volume will not pick this file up — recreate the volume or apply the
+-- SQL by hand.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables WHERE table_name = 'findings'
+    ) THEN
+        RAISE NOTICE '24_finding_mitre_predictions: findings table absent (fresh DB), nothing to migrate';
+        RETURN;
+    END IF;
+
+    CREATE TABLE IF NOT EXISTS finding_mitre_predictions (
+        finding_id VARCHAR(50) NOT NULL REFERENCES findings(finding_id) ON DELETE CASCADE,
+        technique_id TEXT NOT NULL,
+        confidence DOUBLE PRECISION NOT NULL,
+        PRIMARY KEY (finding_id, technique_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_finding_mitre_predictions_technique_confidence
+        ON finding_mitre_predictions (technique_id, confidence DESC);
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'findings' AND column_name = 'mitre_predictions'
+    ) THEN
+        INSERT INTO finding_mitre_predictions (finding_id, technique_id, confidence)
+        SELECT f.finding_id, kv.key, (kv.value)::text::double precision
+        FROM findings f
+        CROSS JOIN LATERAL jsonb_each(f.mitre_predictions) AS kv
+        WHERE jsonb_typeof(f.mitre_predictions) = 'object'
+          AND jsonb_typeof(kv.value) = 'number'
+        ON CONFLICT DO NOTHING;
+
+        ALTER TABLE findings DROP COLUMN IF EXISTS mitre_predictions;
+        RAISE NOTICE '24_finding_mitre_predictions: backfilled and dropped findings.mitre_predictions';
+    ELSE
+        RAISE NOTICE '24_finding_mitre_predictions: mitre_predictions column already absent';
+    END IF;
+END $$;

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -411,6 +411,7 @@ dbInit:
     - 21_agent_run_leases.sql
     - 22_workflow_run_deleted.sql
     - 23_drop_finding_embedding.sql
+    - 24_finding_mitre_predictions.sql
   resources:
     requests:
       cpu: 50m

--- a/scripts/export_postgres_to_splunk.py
+++ b/scripts/export_postgres_to_splunk.py
@@ -20,6 +20,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from core.storage.connection import get_db_manager
 from core.storage.models import Finding, Case
+from core.storage.schemas import FindingSchema
 from core.time import utcnow
 from sqlalchemy import func
 
@@ -144,7 +145,9 @@ class PostgresToSplunkExporter:
             "anomaly_score": finding.anomaly_score,
             
             # MITRE ATT&CK
-            "mitre_predictions": finding.mitre_predictions,
+            "mitre_predictions": FindingSchema.dump(finding).get(
+                "mitre_predictions", {}
+            ),
             
             # Entity context (if available)
             "entity_context": finding.entity_context,

--- a/services/api/routers/graph.py
+++ b/services/api/routers/graph.py
@@ -196,16 +196,17 @@ async def get_technique_graph(
     """
     data_service = DatabaseDataService()
 
-    # Get findings with this technique
-    all_findings = data_service.get_findings(limit=limit * 2)
-    findings = []
-
-    for finding in all_findings:
-        mitre_predictions = finding.get("mitre_predictions", {})
-        if technique_id in mitre_predictions:
-            findings.append(finding)
-            if len(findings) >= limit:
-                break
+    if data_service.is_using_database():
+        findings = data_service.get_findings_by_technique(technique_id, limit=limit)
+    else:
+        all_findings = data_service.get_findings(limit=limit * 2)
+        findings = []
+        for finding in all_findings:
+            mitre_predictions = finding.get("mitre_predictions", {})
+            if technique_id in mitre_predictions:
+                findings.append(finding)
+                if len(findings) >= limit:
+                    break
 
     if not findings:
         return GraphData(

--- a/tests/fixtures/orm_serialization_golden.json
+++ b/tests/fixtures/orm_serialization_golden.json
@@ -331,9 +331,7 @@
           ],
           "external_id": "external_id-value",
           "finding_id": "finding_id-value",
-          "mitre_predictions": {
-            "sample": "mitre_predictions-value"
-          },
+          "mitre_predictions": {},
           "severity": "severity-value",
           "status": "status-value",
           "timestamp": "2024-03-14T15:09:26.535000+00:00",
@@ -1170,9 +1168,7 @@
       ],
       "external_id": "external_id-value",
       "finding_id": "finding_id-value",
-      "mitre_predictions": {
-        "sample": "mitre_predictions-value"
-      },
+      "mitre_predictions": {},
       "severity": "severity-value",
       "status": "status-value",
       "timestamp": "2024-03-14T15:09:26.535000+00:00",
@@ -1189,7 +1185,7 @@
       "evidence_links": null,
       "external_id": null,
       "finding_id": null,
-      "mitre_predictions": null,
+      "mitre_predictions": {},
       "severity": null,
       "status": null,
       "timestamp": null,

--- a/tests/unit/api/test_technique_graph_lookup.py
+++ b/tests/unit/api/test_technique_graph_lookup.py
@@ -21,3 +21,18 @@ async def test_technique_graph_queries_child_table(monkeypatch):
     service.get_findings_by_technique.assert_called_once_with("T1071.001", limit=50)
     service.get_findings.assert_not_called()
     assert result.metadata["message"] == "No findings with technique T1071.001"
+
+
+@pytest.mark.asyncio
+async def test_technique_graph_falls_back_to_finding_maps_without_a_database(
+    monkeypatch,
+):
+    service = MagicMock()
+    service.is_using_database.return_value = False
+    service.get_findings.return_value = []
+    monkeypatch.setattr(graph_router, "DatabaseDataService", lambda: service)
+
+    await graph_router.get_technique_graph("T1071.001", limit=50)
+
+    service.get_findings.assert_called_once()
+    service.get_findings_by_technique.assert_not_called()

--- a/tests/unit/api/test_technique_graph_lookup.py
+++ b/tests/unit/api/test_technique_graph_lookup.py
@@ -1,0 +1,23 @@
+"""get_technique_graph must look up by child-table technique, not a findings page."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.api.routers import graph as graph_router
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_technique_graph_queries_child_table(monkeypatch):
+    service = MagicMock()
+    service.is_using_database.return_value = True
+    service.get_findings_by_technique.return_value = []
+    monkeypatch.setattr(graph_router, "DatabaseDataService", lambda: service)
+
+    result = await graph_router.get_technique_graph("T1071.001", limit=50)
+
+    service.get_findings_by_technique.assert_called_once_with("T1071.001", limit=50)
+    service.get_findings.assert_not_called()
+    assert result.metadata["message"] == "No findings with technique T1071.001"

--- a/tests/unit/storage/test_finding_mitre_predictions.py
+++ b/tests/unit/storage/test_finding_mitre_predictions.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from core.storage.models import Finding, FindingMitrePrediction
+from core.storage.models import Case, Finding, FindingMitrePrediction
+from core.storage.schemas.case import CaseWithFindingsSchema
 from core.storage.schemas.finding import FindingSchema
 from core.storage.service import _numeric_prediction_items
 from core.threat_intel import attack_router
@@ -35,6 +36,22 @@ def test_dump_empty_rows_emits_empty_map():
     assert FindingSchema.dump(finding)["mitre_predictions"] == {}
 
 
+def test_nested_case_dump_reconstructs_predictions_from_rows():
+    finding = Finding(
+        finding_id="f-1",
+        anomaly_score=0.1,
+        timestamp=datetime(2024, 1, 1),
+        data_source="test",
+    )
+    finding.mitre_prediction_rows = [
+        FindingMitrePrediction(technique_id="T1071.001", confidence=0.875),
+    ]
+    case = Case(case_id="c-1", title="nested dump")
+    case.findings = [finding]
+    dumped = CaseWithFindingsSchema.dump(case)
+    assert dumped["findings"][0]["mitre_predictions"] == {"T1071.001": 0.875}
+
+
 def test_numeric_items_keep_tactic_names_and_skip_non_numeric():
     items = dict(
         _numeric_prediction_items(
@@ -62,6 +79,37 @@ def test_get_findings_by_technique_queries_child_table(monkeypatch):
     service.get_findings.assert_not_called()
     assert result["total"] == 1
     assert result["findings"][0]["finding_id"] == "f-1"
+
+
+def test_attck_readers_fall_back_to_finding_maps_without_a_database(monkeypatch):
+    service = MagicMock()
+    service.is_using_database.return_value = False
+    service.get_findings.return_value = [
+        {
+            "finding_id": "f-1",
+            "severity": "high",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "mitre_predictions": {"T1071.001": 0.9},
+        },
+        {
+            "finding_id": "f-2",
+            "severity": "low",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "mitre_predictions": {"T1059.001": 0.1},
+        },
+    ]
+    monkeypatch.setattr(attack_router, "data_service", service)
+
+    by_tech = attack_router.get_findings_by_technique("T1071.001")
+    layer = attack_router.get_attack_layer()
+    rollup = attack_router.get_technique_rollup(time_range="all")
+    tactics = attack_router.get_tactics_summary()
+
+    service.get_findings_by_technique.assert_not_called()
+    assert by_tech["total"] == 1
+    assert layer["techniques"][0]["techniqueID"] == "T1071.001"
+    assert rollup["techniques"][0]["count"] == 1
+    assert tactics["tactics"][0]["count"] == 1
 
 
 def test_rollup_layer_and_tactics_query_child_table(monkeypatch):

--- a/tests/unit/storage/test_finding_mitre_predictions.py
+++ b/tests/unit/storage/test_finding_mitre_predictions.py
@@ -1,0 +1,85 @@
+"""Child-table MITRE predictions: dump reconstruction and ATT&CK readers."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.storage.models import Finding, FindingMitrePrediction
+from core.storage.schemas.finding import FindingSchema
+from core.storage.service import _numeric_prediction_items
+from core.threat_intel import attack_router
+
+pytestmark = pytest.mark.unit
+
+
+def test_dump_reconstructs_map_including_tactic_names():
+    finding = Finding(
+        finding_id="f-1",
+        anomaly_score=0.1,
+        timestamp=datetime(2024, 1, 1),
+        data_source="test",
+    )
+    finding.mitre_prediction_rows = [
+        FindingMitrePrediction(technique_id="T1071.001", confidence=0.875),
+        FindingMitrePrediction(technique_id="Initial Access", confidence=0.5),
+    ]
+    assert FindingSchema.dump(finding)["mitre_predictions"] == {
+        "T1071.001": 0.875,
+        "Initial Access": 0.5,
+    }
+
+
+def test_dump_empty_rows_emits_empty_map():
+    finding = Finding()
+    assert FindingSchema.dump(finding)["mitre_predictions"] == {}
+
+
+def test_numeric_items_keep_tactic_names_and_skip_non_numeric():
+    items = dict(
+        _numeric_prediction_items(
+            {
+                "T1071.001": 0.875,
+                "Initial Access": 1,
+                "nested": {"nope": 1},
+                "label": "ransomware",
+                "flag": True,
+            }
+        )
+    )
+    assert items == {"T1071.001": 0.875, "Initial Access": 1.0}
+
+
+def test_get_findings_by_technique_queries_child_table(monkeypatch):
+    service = MagicMock()
+    service.is_using_database.return_value = True
+    service.get_findings_by_technique.return_value = [{"finding_id": "f-1"}]
+    monkeypatch.setattr(attack_router, "data_service", service)
+
+    result = attack_router.get_findings_by_technique("T1071.001")
+
+    service.get_findings_by_technique.assert_called_once_with("T1071.001")
+    service.get_findings.assert_not_called()
+    assert result["total"] == 1
+    assert result["findings"][0]["finding_id"] == "f-1"
+
+
+def test_rollup_layer_and_tactics_query_child_table(monkeypatch):
+    service = MagicMock()
+    service.is_using_database.return_value = True
+    service.get_technique_max_confidence.return_value = {"T1071.001": 0.9}
+    service.get_technique_severity_counts.return_value = [
+        ("T1071.001", "high", 2),
+    ]
+    service.get_technique_occurrence_counts.return_value = {"T1071.001": 2}
+    monkeypatch.setattr(attack_router, "data_service", service)
+
+    layer = attack_router.get_attack_layer()
+    rollup = attack_router.get_technique_rollup()
+    tactics = attack_router.get_tactics_summary()
+
+    service.get_findings.assert_not_called()
+    assert layer["techniques"][0]["techniqueID"] == "T1071.001"
+    assert rollup["total_techniques"] == 1
+    assert rollup["techniques"][0]["count"] == 2
+    assert tactics["tactics"][0]["count"] == 2

--- a/tests/unit/storage/test_finding_mitre_predictions_db.py
+++ b/tests/unit/storage/test_finding_mitre_predictions_db.py
@@ -63,6 +63,17 @@ def test_create_update_and_bulk_persist_numeric_rows_only():
     replaced = FindingSchema.dump(service.get_finding("f-mitre-write-1"))
     assert replaced["mitre_predictions"] == {"T1048.003": 0.25}
 
+    assert service.update_finding(
+        "f-mitre-write-1",
+        mitre_predictions={"T1071.001": 0.25},
+        severity="low",
+        predicted_techniques=[{"technique_id": "T1071.001"}],
+        unknown_s3_field=True,
+    )
+    whole_dict = FindingSchema.dump(service.get_finding("f-mitre-write-1"))
+    assert whole_dict["mitre_predictions"] == {"T1071.001": 0.25}
+    assert whole_dict["severity"] == "low"
+
     bulk = service.bulk_create_findings(
         [
             {

--- a/tests/unit/storage/test_finding_mitre_predictions_db.py
+++ b/tests/unit/storage/test_finding_mitre_predictions_db.py
@@ -1,0 +1,204 @@
+"""Persistence, lookup, and migration for finding_mitre_predictions."""
+
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
+
+from core.reporting.analytics_service import get_mitre_technique_distribution
+from core.storage.models import FindingMitrePrediction
+from core.storage.schemas.finding import FindingSchema
+from core.storage.service import DatabaseService, findings_by_technique_stmt
+from core.time import utcnow
+
+pytestmark = [pytest.mark.unit, pytest.mark.external_service, pytest.mark.database]
+
+SQL_FILE = (
+    Path(__file__).resolve().parents[3]
+    / "infra"
+    / "database"
+    / "init"
+    / "24_finding_mitre_predictions.sql"
+)
+
+
+def _create(service: DatabaseService, finding_id: str, predictions: dict, **kwargs):
+    return service.create_finding(
+        finding_id=finding_id,
+        mitre_predictions=predictions,
+        anomaly_score=kwargs.get("anomaly_score", 0.4),
+        timestamp=kwargs.get("timestamp", utcnow()),
+        data_source=kwargs.get("data_source", "test"),
+        severity=kwargs.get("severity", "high"),
+        status=kwargs.get("status", "new"),
+    )
+
+
+def test_create_update_and_bulk_persist_numeric_rows_only():
+    service = DatabaseService()
+    created = _create(
+        service,
+        "f-mitre-write-1",
+        {
+            "T1071.001": 0.875,
+            "Initial Access": 0.5,
+            "nested": {"nope": 1},
+            "label": "ransomware",
+        },
+    )
+    dumped = FindingSchema.dump(created)
+    assert dumped["mitre_predictions"] == {
+        "T1071.001": 0.875,
+        "Initial Access": 0.5,
+    }
+
+    reread = FindingSchema.dump(service.get_finding("f-mitre-write-1"))
+    assert reread["mitre_predictions"] == dumped["mitre_predictions"]
+
+    assert service.update_finding(
+        "f-mitre-write-1", mitre_predictions={"T1048.003": 0.25}
+    )
+    replaced = FindingSchema.dump(service.get_finding("f-mitre-write-1"))
+    assert replaced["mitre_predictions"] == {"T1048.003": 0.25}
+
+    bulk = service.bulk_create_findings(
+        [
+            {
+                "finding_id": "f-mitre-bulk-1",
+                "mitre_predictions": {"T1059.001": 0.91},
+                "anomaly_score": 0.2,
+                "timestamp": utcnow(),
+                "data_source": "test",
+            }
+        ]
+    )
+    assert bulk["imported"] == 1
+    assert FindingSchema.dump(service.get_finding("f-mitre-bulk-1"))[
+        "mitre_predictions"
+    ] == {"T1059.001": 0.91}
+
+
+def test_get_findings_by_technique_orders_by_confidence_past_the_old_cap():
+    service = DatabaseService()
+    now = utcnow()
+    for i in range(12):
+        _create(
+            service,
+            f"f-mitre-cap-{i:03d}",
+            {"T1573.001": 0.1 + (i * 0.01)},
+            timestamp=now - timedelta(seconds=i),
+        )
+    _create(service, "f-mitre-cap-other", {"T1110": 0.99})
+
+    matches = service.get_findings_by_technique("T1573.001")
+    assert len(matches) == 12
+    confidences = [
+        FindingSchema.dump(f)["mitre_predictions"]["T1573.001"] for f in matches
+    ]
+    assert confidences == sorted(confidences, reverse=True)
+    assert "f-mitre-cap-other" not in {f.finding_id for f in matches}
+
+
+def test_query_plan_uses_technique_confidence_index():
+    service = DatabaseService()
+    now = utcnow()
+    for i in range(400):
+        _create(
+            service,
+            f"f-mitre-plan-{i:04d}",
+            {
+                "T1071.001": 0.2 if i % 10 else 0.9,
+                f"T1059.{i % 7:03d}": 0.3,
+            },
+            timestamp=now - timedelta(seconds=i),
+        )
+
+    manager = service.db_manager
+    with manager.session_scope() as session:
+        session.execute(text("ANALYZE finding_mitre_predictions"))
+        session.execute(text("SET LOCAL enable_seqscan = off"))
+        compiled = findings_by_technique_stmt("T1071.001").compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+        plan = "\n".join(
+            row[0] for row in session.execute(text(f"EXPLAIN {compiled}")).all()
+        )
+
+    assert "idx_finding_mitre_predictions_technique_confidence" in plan
+
+
+def test_migration_sql_backfills_numeric_values_only_and_drops_column():
+    service = DatabaseService()
+    _create(service, "f-mitre-migrate-1", {})
+
+    sql = SQL_FILE.read_text()
+    with service.db_manager.session_scope() as session:
+        session.execute(
+            text(
+                "ALTER TABLE findings ADD COLUMN IF NOT EXISTS mitre_predictions jsonb"
+            )
+        )
+        session.execute(
+            text("""
+                UPDATE findings
+                SET mitre_predictions = CAST(:payload AS jsonb)
+                WHERE finding_id = :fid
+                """),
+            {
+                "fid": "f-mitre-migrate-1",
+                "payload": (
+                    '{"T1071.001": 0.875, "Initial Access": 0.5,'
+                    ' "nested": {"x": 1}, "label": "ransomware"}'
+                ),
+            },
+        )
+        session.execute(
+            text("DELETE FROM finding_mitre_predictions WHERE finding_id = :fid"),
+            {"fid": "f-mitre-migrate-1"},
+        )
+        session.connection().exec_driver_sql(sql)
+
+        rows = (
+            session.query(FindingMitrePrediction)
+            .filter(FindingMitrePrediction.finding_id == "f-mitre-migrate-1")
+            .all()
+        )
+        by_id = {row.technique_id: row.confidence for row in rows}
+        assert by_id == {"T1071.001": 0.875, "Initial Access": 0.5}
+        columns = (
+            session.execute(
+                text(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = 'findings'"
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert "mitre_predictions" not in columns
+
+
+@pytest.mark.asyncio
+async def test_mitre_distribution_groups_child_table_rows():
+    service = DatabaseService()
+    now = utcnow()
+    _create(service, "f-mitre-dist-1", {"T9998.001": 0.8}, timestamp=now)
+    _create(
+        service,
+        "f-mitre-dist-2",
+        {"T9998.001": 0.7, "T9998.002": 0.6},
+        timestamp=now,
+    )
+    with service.db_manager.session_scope() as session:
+        result = await get_mitre_technique_distribution(
+            session,
+            now - timedelta(hours=1),
+            now + timedelta(hours=1),
+            limit=50,
+        )
+    by_id = {row["techniqueId"]: row["count"] for row in result}
+    assert by_id["T9998.001"] == 2
+    assert by_id["T9998.002"] == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #550

`findings.mitre_predictions` was a JSONB map on the hottest table, so “every finding predicting T1071.001, ordered by confidence” scanned a capped `get_findings()` page in Python. The map is now a child table those queries actually hit.

## What changed

- New `finding_mitre_predictions(finding_id, technique_id, confidence)` with composite PK and index on `(technique_id, confidence DESC)`.
- **Move, not copy:** backfill numeric JSONB values, then drop `findings.mitre_predictions`.
- `FindingSchema.dump` (and nested `CaseWithFindings` dumps) reconstruct `{technique_id: confidence}` so `graph_builder_service` and the SPA stay unchanged.
- `create_finding` / `update_finding` / `bulk_create_findings` still take `mitre_predictions=`; they persist rows internally. Replacing the map replaces the child rows. No new repository or write API.
- ATT&CK readers query the child table: `get_findings_by_technique`, rollup / layer / tactics, `get_technique_graph`, and `get_mitre_technique_distribution`.
- Keys stay **text** (parquet/CSV ingest stores tactic names, not only T-IDs). Non-numeric JSONB values are not backfilled or persisted.
- `predicted_techniques` is not a findings column and is not folded into this table.

## Migration

`infra/database/init/24_finding_mitre_predictions.sql` follows `23_drop_finding_embedding.sql`: no-op when `findings` is missing (fresh install; `create_all` builds the child table). Copied into `infra/helm/vigil/files/database-init/` and appended to `dbInit.sqlFiles`.

**Helm:** the db-init job records filenames in `_vigil_schema_versions` and applies new files on `helm upgrade`.

**docker-compose:** `/docker-entrypoint-initdb.d` still runs only on an empty data directory. Existing local volumes pick this file up on the next `docker compose up` via `db-seed`, which re-applies `infra/database/init/*.sql` after `create_all` (#778). A volume that is never `up`’d again would need the SQL applied by hand.

Verified locally: `diff -r infra/database/init infra/helm/vigil/files/database-init` is clean; `24_finding_mitre_predictions.sql` is listed in `dbInit.sqlFiles` (the Job templates `apply "<file>"` from that list). Helm was not installed in this environment, so `helm template | grep apply` was not run here.

## Tests

- Dump reconstruction including tactic-name keys; nested `CaseWithFindings` dump.
- Numeric-only create / replace / bulk; S3-style extra keys (`predicted_techniques`, unknown fields) still persist the map.
- `get_findings_by_technique` returns every match, ordered by confidence (not a `get_findings` page).
- EXPLAIN uses `idx_finding_mitre_predictions_technique_confidence`.
- Migration SQL backfills numeric values only (including tactic names) and drops the JSONB column.
- ATT&CK handlers call the child-table API when the DB is up, and still walk maps in demo/JSON mode.

`predicted_techniques` remains a demo/vstrike list shape that `iter_techniques` prefers when present. Converging that with the child table is a separate issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d3309ed-5d17-4ce4-81a9-bfa987bed50a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d3309ed-5d17-4ce4-81a9-bfa987bed50a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

