### PR TITLE
chore(env): add Helm so cloud agents can template the chart

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -44,6 +44,24 @@ RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
     update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
 ########################################################
+# HELM
+########################################################
+
+# Pin matches .github/workflows/helm-chart.yml so `helm template` matches CI.
+RUN ARCH="$(dpkg --print-architecture)" \
+    && HELM_VERSION=v3.15.2 \
+    && cd /tmp \
+    && curl --retry 3 --retry-delay 5 -fsSL -O "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" \
+    && curl --retry 3 --retry-delay 5 -fsSL -O "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz.sha256sum" \
+    && sha256sum -c "helm-${HELM_VERSION}-linux-${ARCH}.tar.gz.sha256sum" \
+    && tar -xzf "helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" \
+    && mv "linux-${ARCH}/helm" /usr/local/bin/helm \
+    && rm -rf "/tmp/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" \
+              "/tmp/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz.sha256sum" \
+              "/tmp/linux-${ARCH}" \
+    && helm version --short
+
+########################################################
 # CONFIG UBUNTU USER
 ########################################################
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#789 could not run `helm template | grep apply` because Helm was not on the machine. This puts the same Helm **v3.15.2** pin CI uses (`azure/setup-helm` in `.github/workflows/helm-chart.yml`) into `.cursor/Dockerfile`. `.cursor/environment.json` is unchanged.

## Why

The db-init Job templates `apply "<file>"` from `dbInit.sqlFiles`. Confirming a new SQL file actually lands in that Job needs `helm template`, not just a values.yaml grep.

## What agents can run after this merges

```bash
helm repo add bitnami https://charts.bitnami.com/bitnami
helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
helm dependency update infra/helm/vigil
# .helmignore lists *.tgz, so extract subcharts the same way CI does
for tgz in infra/helm/vigil/charts/*.tgz; do tar -xzf "$tgz" -C infra/helm/vigil/charts/; done
helm template release-check infra/helm/vigil \
  --set secrets.anthropicApiKey=test-key \
  --set secrets.postgresPassword=test-password \
  | grep 'apply "'
```

## Verification

- Local `docker build` of `.cursor/Dockerfile`: Helm checksum OK, `ubuntu` has `/usr/local/bin/helm` **v3.15.2**.
- Same `helm template | grep 'apply "'` pipeline emits `apply "24_finding_mitre_predictions.sql"`.
- Draft environment build [bld-20260902-a3e4fb16-5978-4f09-be64-9f1cbdc9e409](https://cursor.com/dashboard/cloud-agents/builds/bld-20260902-a3e4fb16-5978-4f09-be64-9f1cbdc9e409) from this branch succeeded (Dockerfile layer: `helm-v3.15.2-linux-amd64.tar.gz: OK` / `v3.15.2+g1a500d5`).
- Fresh Cloud Agent booted from that build: `ubuntu`, Helm v3.15.2, and the apply line above were present.

No application code changes. This draft build is not the default for new agents until the PR is merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33117d13-abeb-4420-af01-1125c11d5078?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33117d13-abeb-4420-af01-1125c11d5078&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

