### PR TITLE
Stop leaking raw exception text on leftover 5xx handlers

### DIFF
--- a/core/integrations/cloudflare/cloudflare_webhooks_router.py
+++ b/core/integrations/cloudflare/cloudflare_webhooks_router.py
@@ -139,14 +139,7 @@ def _ingest(payload: Dict[str, Any]) -> Dict[str, Any]:
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Unable to transform Cloudy event payload",
         )
-    try:
-        ok = service.ingestion_service.ingest_finding(finding)
-    except Exception as exc:
-        logger.exception("Cloudy event ingestion failed")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ingestion error: {exc}",
-        )
+    ok = service.ingestion_service.ingest_finding(finding)
     if not ok:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/core/integrations/darktrace/darktrace_webhook_router.py
+++ b/core/integrations/darktrace/darktrace_webhook_router.py
@@ -166,14 +166,7 @@ def _ingest(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Unable to transform Darktrace {alert_type} payload",
         )
-    try:
-        ok = service.ingestion_service.ingest_finding(finding)
-    except Exception as e:
-        logger.exception("Darktrace %s ingestion failed", alert_type)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ingestion error: {e}",
-        )
+    ok = service.ingestion_service.ingest_finding(finding)
     if not ok:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/services/api/routers/findings.py
+++ b/services/api/routers/findings.py
@@ -389,11 +389,6 @@ async def get_or_generate_enrichment(
         raise HTTPException(status_code=503, detail=NO_PROVIDER_DETAIL)
     except ProviderUnavailable as e:
         raise HTTPException(status_code=503, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error generating enrichment for {finding_id}: {e}")
-        raise HTTPException(
-            status_code=500, detail=f"Failed to generate enrichment: {str(e)}"
-        )
 
     return {"finding_id": finding_id, "cached": False, "enrichment": enrichment}
 

--- a/services/api/routers/local_services.py
+++ b/services/api/routers/local_services.py
@@ -176,9 +176,7 @@ def write_autostart(
         raise HTTPException(status_code=400, detail=str(e))
     except OSError:
         logger.exception("Could not persist autostart list")
-        raise HTTPException(
-            status_code=500, detail="Could not persist autostart list"
-        )
+        raise HTTPException(status_code=500, detail="Could not persist autostart list")
 
 
 # --- Generic routes ---

--- a/services/api/routers/local_services.py
+++ b/services/api/routers/local_services.py
@@ -174,9 +174,10 @@ def write_autostart(
         return {"services": set_autostart_services(body.services)}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    except OSError as e:
+    except OSError:
+        logger.exception("Could not persist autostart list")
         raise HTTPException(
-            status_code=500, detail=f"Could not persist autostart list: {e}"
+            status_code=500, detail="Could not persist autostart list"
         )
 
 

--- a/services/api/routers/mcp.py
+++ b/services/api/routers/mcp.py
@@ -352,23 +352,17 @@ async def reload_servers(
     """
     require_integrations_admin(current_user)
     logger.info("User %s requested MCP server reload", current_user.user_id)
-    try:
-        svc = _service()
-        # Reinitialise servers dict in place so the MCPClient's reference
-        # to this same instance keeps seeing the new catalog.
-        svc.servers.clear()
-        svc._initialize_servers()
+    svc = _service()
+    # Reinitialise servers dict in place so the MCPClient's reference
+    # to this same instance keeps seeing the new catalog.
+    svc.servers.clear()
+    svc._initialize_servers()
 
-        new_servers = list(svc.servers.keys())
+    new_servers = list(svc.servers.keys())
 
-        return {
-            "success": True,
-            "message": "MCP servers reloaded successfully",
-            "total_servers": len(new_servers),
-            "servers": new_servers,
-        }
-
-    except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Failed to reload MCP servers: {str(e)}"
-        )
+    return {
+        "success": True,
+        "message": "MCP servers reloaded successfully",
+        "total_servers": len(new_servers),
+        "servers": new_servers,
+    }

--- a/tests/unit/findings/test_findings_enrich_endpoint.py
+++ b/tests/unit/findings/test_findings_enrich_endpoint.py
@@ -26,9 +26,9 @@ import pytest
 REPO = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(REPO))
 
-from fastapi import HTTPException  # noqa: E402
+from fastapi import FastAPI, HTTPException  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
-from services.api.routers import findings as findings_api  # noqa: E402
 from core.findings.enrichment import (  # noqa: E402
     EmptyProviderResponse,
     FindingNotFound,
@@ -36,6 +36,8 @@ from core.findings.enrichment import (  # noqa: E402
     ProviderUnavailable,
 )
 from core.findings.enrichment import service as enrichment_service  # noqa: E402
+from services.api.errors import register_exception_handlers  # noqa: E402
+from services.api.routers import findings as findings_api  # noqa: E402
 
 pytestmark = pytest.mark.unit
 
@@ -232,6 +234,23 @@ async def test_unexpected_failure_propagates(stub_data_service, monkeypatch):
 
     with pytest.raises(RuntimeError, match="gateway exploded"):
         await findings_api.get_or_generate_enrichment(FINDING_ID, False)
+
+
+def test_unexpected_failure_does_not_leak_to_the_client(stub_data_service, monkeypatch):
+    _stub_enrich(monkeypatch, raises=RuntimeError("gateway exploded"))
+
+    app = FastAPI()
+    register_exception_handlers(app)
+    app.add_api_route(
+        "/enrich/{finding_id}",
+        findings_api.get_or_generate_enrichment,
+        methods=["POST"],
+    )
+    response = TestClient(app).post(f"/enrich/{FINDING_ID}")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Internal server error"
+    assert "gateway exploded" not in response.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/findings/test_findings_enrich_endpoint.py
+++ b/tests/unit/findings/test_findings_enrich_endpoint.py
@@ -8,7 +8,8 @@ tests pin both, so the extraction is provably behaviour-preserving:
 * cached hit short-circuits (and ``force_regenerate`` bypasses it)
 * ``NoProviderConfigured`` → 503 carrying the structured ``NO_PROVIDER_DETAIL``
   payload the chat drawer matches on — *not* a bare string
-* ``ProviderUnavailable`` → 503, any other failure → 500
+* ``ProviderUnavailable`` → 503; other failures propagate so the global
+  handler can render 500 ``Internal server error`` without ``str(e)``
 * the success envelope is ``{finding_id, cached: False, enrichment}``
 
 They also cover ``_resolve_provider``'s error mapping, which is where the old
@@ -216,29 +217,21 @@ async def test_finding_not_found_from_the_module_is_404(stub_data_service, monke
     assert exc_info.value.status_code == 404
 
 
-async def test_empty_provider_response_is_500(stub_data_service, monkeypatch):
+async def test_empty_provider_response_propagates(stub_data_service, monkeypatch):
     _stub_enrich(
         monkeypatch,
         raises=EmptyProviderResponse("LLM provider returned an empty response"),
     )
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(EmptyProviderResponse):
         await findings_api.get_or_generate_enrichment(FINDING_ID, False)
 
-    assert exc_info.value.status_code == 500
-    assert exc_info.value.detail == (
-        "Failed to generate enrichment: LLM provider returned an empty response"
-    )
 
-
-async def test_unexpected_failure_is_500(stub_data_service, monkeypatch):
+async def test_unexpected_failure_propagates(stub_data_service, monkeypatch):
     _stub_enrich(monkeypatch, raises=RuntimeError("gateway exploded"))
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(RuntimeError, match="gateway exploded"):
         await findings_api.get_or_generate_enrichment(FINDING_ID, False)
-
-    assert exc_info.value.status_code == 500
-    assert exc_info.value.detail == "Failed to generate enrichment: gateway exploded"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #540

`HTTPException.detail` still interpolated `str(e)` on a handful of 5xx paths, so the `#655` sanitizer never ran. Clients could see gateway/S3/DB internals on those responses.

## What changed

- Drop wrap-only `except Exception` catch-alls on enrichment, MCP reload, and Darktrace/Cloudflare ingestion so unhandled failures hit the existing handler (`"Internal server error"` + trace id).
- Keep FindingNotFound / NoProviderConfigured / ProviderUnavailable mappings on enrichment.
- Autostart `OSError` stays (sibling `ValueError` 400), but the 500 detail is now a static string.
- Enrichment unit tests no longer assert the leaked text; unexpected failures are expected to propagate.

## Out of scope

No new sanitizer, no EnrichmentError→SOCError conversion, no repo-wide re-audit of 4xx or admin test-connection 502s.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2978b1e-323d-4de5-96c5-6b812fc9aec1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2978b1e-323d-4de5-96c5-6b812fc9aec1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

