### PR TITLE
feat(memory): an eval reads a frozen copy of memory (#736)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -155,6 +155,18 @@ Case -- and both poll rather than being told, so a lost signal is a late write
 and not a missing one.
 _Avoid_: ETL, sync, ingest (those move data; this concludes about it)
 
+**Memory Snapshot** (`memory`):
+A frozen copy of **Episodic Memory**, held as a Postgres schema and named by
+date. An eval process reads one by putting it on its `search_path`, so the same
+hunts can be scored twice without the corpus moving underneath them -- the
+**Distil** polls, so live memory grows between two runs and the score moves with
+it. An empty one is the control the measurement rests on. Kept and never
+overwritten: an old one read by new code measures the code, a new one measures
+the system. Covers the exact-join tier only -- narrative search's corpus lives
+outside Postgres, so a snapshot freezes half of what a run can recall.
+_Avoid_: backup, restore, fixture, baseline, as-of (an as-of filter is what this
+replaces; the empty one is a **control**, and _baseline_ belongs to **Golden**)
+
 **Closure Category** (`cases`):
 What closing a **Case** determined: `resolved`, `false_positive`, `duplicate`,
 `unable_to_resolve`, or `unspecified` for a close that stated none. All but
@@ -178,6 +190,7 @@ presented in is a fold, so ranking may change without invalidating a historical
 Ledger. The parameters are copied in rather than referenced, because a **RunSpec**
 records the arch by name and not by version.
 _Avoid_: recall log (that is the audit table, which is Python's), snapshot
+(unqualified -- a **Memory Snapshot** is the frozen corpus, not this record)
 
 **Sighting**:
 What one investigation observed about one entity from one source. One row per

--- a/core/memory/snapshot.py
+++ b/core/memory/snapshot.py
@@ -1,0 +1,525 @@
+"""Freezing the episodic tier for an eval run (#736).
+
+An eval that reads live memory cannot tell you what it measured. The Distil
+polls, so a run that ended Monday can be written Wednesday carrying Monday's
+``concluded_at``: re-run the same hunts a week apart and the corpus underneath
+them has grown, which moves the score without anyone touching the code. That is
+also why this is a copy and not an as-of filter over the live tables -- rows
+carrying old dates keep arriving, so a filter that looks frozen is not.
+
+A snapshot is a Postgres schema holding a copy of the episodic tables. Nothing
+here is wired into recall: the eval process selects a snapshot by putting it on
+its ``search_path``, and every query in ``core/memory/recall.py`` then reads the
+copy unchanged.
+
+**How a process selects one.** Through ``PGOPTIONS`` in its environment, which
+libpq reads for any parameter the connection string does not set::
+
+    PGOPTIONS='-c search_path=episodic_snap_2026_09_01,public'
+
+Not through the DSN: ``core/storage/connection.py`` allows four connection
+parameters and ``options`` is not among them, so a snapshot named in the URL is
+refused before libpq sees it. Not through ``SET search_path`` on a borrowed
+connection either -- that leaks to whoever takes the connection next, including
+the Distil's writes. ``PGOPTIONS`` applies at connect time, so every connection
+in the pool comes up on the same schema and none of them can drift.
+
+**The variable belongs on whichever process runs the query, which is not
+always the eval.** It is read per connection, so a process holding it reads the
+snapshot for its lifetime and a process without it reads live, with no shared
+state between them and nothing to reset afterwards. For a Python caller of
+``recall_entity`` that process is the eval itself and the story ends there.
+
+For a hunt it does not. A worker reaches recall over ``/internal/tools/invoke``
+(``core/agents/tool_registry.py``), so the query runs in the long-lived backend
+and ``PGOPTIONS`` on the eval runner changes nothing. Setting it on that backend
+would work and is the wrong thing to do: the Distil writes through the same
+connections, so the backend would start distilling into the snapshot. What that
+case needs is a second backend that reads a snapshot and runs no Distil, which
+this does not build -- so a hunt-driven eval is not frozen by anything here yet.
+
+**There is no snapshot catalog.** ``pg_namespace`` already lists schemas and
+carries a comment per schema, so the creation stamp lives there and
+:func:`list_snapshots` reads it. A table recording which schemas exist would be a
+second answer to a question Postgres already answers, and the two would diverge.
+
+**Every episodic table is created, even the ones left empty.** ``search_path``
+falls through: a table absent from the snapshot resolves against ``public``
+instead, silently, and the eval reads -- or writes -- live rows believing they
+came from the copy. Discovering the tables by prefix rather than listing them
+means a table added to the tier later is created empty here rather than becoming
+a hole that points at production.
+
+**This freezes the exact-join tier and nothing else.** Narrative search's
+corpus lives outside Postgres, so a snapshot does not cover it: "we froze
+memory" is true of this half only, and an eval that leans on narrative recall is
+not frozen by anything here.
+
+**Each snapshot owns its sequences.** ``CREATE TABLE ... (LIKE ... INCLUDING
+ALL)`` copies a ``bigserial`` column's default as it stands, which still points
+at the original sequence -- so an eval writing its read journal into a snapshot
+would advance the live tier's counter. The defaults are repointed at sequences
+inside the schema, which is what makes a snapshot read-only with respect to
+live in fact and not just by intention.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from core.storage.unit_of_work import unit_of_work
+
+LIVE_SCHEMA = "public"
+SNAPSHOT_PREFIX = "episodic_snap_"
+
+
+def _like(prefix: str) -> str:
+    """A LIKE pattern matching everything under a prefix.
+
+    An unescaped underscore is a single-character wildcard, and both prefixes
+    here are full of them.
+    """
+    return prefix.replace("_", r"\_") + "%"
+
+
+# The tier's own prefix, which is how the tables are found.
+_TABLE_LIKE = _like("episodic_")
+
+# Whose rows are copied. The order is the insert order and it is load-bearing:
+# verdict_sources carries a foreign key into verdicts, so verdicts is written
+# first. Everything else the discovery finds -- the read log, the Distil's
+# markers and failures -- is created empty, because a journal of reads and a
+# record of what the Distil has processed are not things a hunt recalls.
+CORPUS_TABLES: Tuple[str, ...] = (
+    "episodic_sightings",
+    "episodic_verdicts",
+    "episodic_verdict_sources",
+    "episodic_gaps",
+)
+
+# No hyphens and no leading punctuation, so the schema name needs no quoting
+# anywhere -- including inside PGOPTIONS, where a quoted identifier would have
+# to survive a shell as well. A name may start with a digit because the prefix
+# does not: `episodic_snap_2026_09_01` is a bare identifier either way.
+_NAME = re.compile(r"^[a-z0-9][a-z0-9_]*$")
+
+# Postgres truncates an identifier at 63 bytes, which would silently collide two
+# snapshots whose names differ only past the limit.
+_MAX_NAME = 63 - len(SNAPSHOT_PREFIX)
+
+
+def _schema_for(name: str) -> str:
+    """The schema a snapshot name lives in. One definition, five callers."""
+    return SNAPSHOT_PREFIX + name
+
+
+class SnapshotError(RuntimeError):
+    """A snapshot could not be created, found or dropped."""
+
+
+class SnapshotExists(SnapshotError):
+    """The name is taken.
+
+    Snapshots are kept rather than overwritten: an old snapshot read by new code
+    measures the code, and a new snapshot read by new code measures the system.
+    Overwriting one silently retires the first of those.
+    """
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    """One frozen copy of the tier, and what it holds."""
+
+    name: str
+    created_at: Optional[datetime]
+    rows: Dict[str, int]
+
+    @property
+    def schema(self) -> str:
+        """Derived, not stored: _row_counts' reasoning applies to names too."""
+        return _schema_for(self.name)
+
+    @property
+    def is_empty(self) -> bool:
+        """The control: the same hunts against a copy that remembers nothing."""
+        return all(count == 0 for count in self.rows.values())
+
+    @property
+    def pgoptions(self) -> str:
+        """What an eval process exports to read this snapshot."""
+        return pgoptions_for(self.name)
+
+
+def pgoptions_for(name: str) -> str:
+    """The ``PGOPTIONS`` value that points a process at this snapshot.
+
+    ``public`` stays on the path behind it: pgvector's operators and every
+    non-episodic table the process touches live there, and only the episodic
+    tables are shadowed by the copy.
+    """
+    return f"-c search_path={_schema_for(_validated(name))},{LIVE_SCHEMA}"
+
+
+def create_snapshot(name: Optional[str] = None, *, empty: bool = False) -> Snapshot:
+    """Copy the live episodic tier into a schema of its own.
+
+    ``empty`` builds the same schema with the same tables and copies no rows.
+    That is the control the whole exercise rests on -- the same hunts against a
+    copy that remembers nothing, compared with a copy that does.
+
+    Takes no caller session, unlike the reads below. The copy is four statements
+    and its correctness is that they see one instant: under the default READ
+    COMMITTED each takes its own snapshot, and the Distil is a delete-then-
+    insert that polls, so a re-derive landing between the Verdicts copy and the
+    Verdict Sources copy yields Verdicts whose sources are missing -- a quiet
+    wrong answer, not a foreign key error. REPEATABLE READ is therefore part of
+    what this function is, and it can only be set on a transaction that has not
+    run a query yet, which is not something a caller's session can promise.
+    """
+    snapshot = _validated(name or _today())
+    schema = _schema_for(snapshot)
+
+    with unit_of_work(None) as db:
+        # First statement in the transaction, which is the only place Postgres
+        # accepts it.
+        db.execute(text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
+
+        if _schema_exists(db, schema):
+            raise SnapshotExists(f"snapshot {snapshot!r} already exists")
+
+        tables = _episodic_tables(db)
+        if not tables:
+            raise SnapshotError(
+                f"no episodic tables in {LIVE_SCHEMA}: nothing to snapshot"
+            )
+        missing = [table for table in CORPUS_TABLES if table not in tables]
+        if missing:
+            raise SnapshotError(
+                "corpus tables are missing from the live tier: "
+                + ", ".join(sorted(missing))
+            )
+
+        created = datetime.now(timezone.utc)
+        db.execute(text(f"CREATE SCHEMA {schema}"))
+        db.execute(
+            text(f"COMMENT ON SCHEMA {schema} IS :stamp"),
+            {"stamp": created.isoformat()},
+        )
+
+        for table in tables:
+            db.execute(
+                text(
+                    f"CREATE TABLE {schema}.{table} "
+                    f"(LIKE {LIVE_SCHEMA}.{table} INCLUDING ALL)"
+                )
+            )
+            _own_sequences(db, schema, table)
+
+        _copy_foreign_keys(db, schema)
+
+        if not empty:
+            for table in CORPUS_TABLES:
+                db.execute(
+                    text(
+                        f"INSERT INTO {schema}.{table} "
+                        f"SELECT * FROM {LIVE_SCHEMA}.{table}"
+                    )
+                )
+            for table in tables:
+                _advance_sequences(db, schema, table)
+
+        counts = _row_counts(db, schema)
+
+    return Snapshot(name=snapshot, created_at=created, rows=counts)
+
+
+def list_snapshots(*, session: Optional[Session] = None) -> List[Snapshot]:
+    """Every snapshot in the database, oldest name first."""
+    with unit_of_work(session) as db:
+        rows = (
+            db.execute(
+                text(
+                    "SELECT n.nspname AS schema, "
+                    "       obj_description(n.oid, 'pg_namespace') AS created_at "
+                    "FROM pg_namespace n "
+                    "WHERE n.nspname LIKE :prefix "
+                    "ORDER BY n.nspname"
+                ),
+                {"prefix": _like(SNAPSHOT_PREFIX)},
+            )
+            .mappings()
+            .all()
+        )
+
+        # A name this module would refuse to create is not a snapshot, whatever
+        # its schema is called, and listing it as one would hand back a Snapshot
+        # whose `pgoptions` cannot be built -- an accessor that raises on a row
+        # the listing itself chose to return. Tolerance below that line stands:
+        # a missing stamp and missing tables are states a real snapshot can be
+        # in, an unusable name is not.
+        named = [
+            row for row in rows if _NAME.match(row["schema"][len(SNAPSHOT_PREFIX) :])
+        ]
+        return [
+            Snapshot(
+                name=row["schema"][len(SNAPSHOT_PREFIX) :],
+                created_at=_stamp(row["created_at"]),
+                rows=_row_counts(db, row["schema"]),
+            )
+            for row in named
+        ]
+
+
+def get_snapshot(name: str, *, session: Optional[Session] = None) -> Snapshot:
+    """One snapshot by name, or :class:`SnapshotError` if there is no such thing."""
+    snapshot = _validated(name)
+    schema = _schema_for(snapshot)
+    with unit_of_work(session) as db:
+        if not _schema_exists(db, schema):
+            raise SnapshotError(f"no snapshot named {snapshot!r}")
+        created = db.execute(
+            text(
+                "SELECT obj_description(oid, 'pg_namespace') FROM pg_namespace "
+                "WHERE nspname = :schema"
+            ),
+            {"schema": schema},
+        ).scalar()
+        return Snapshot(
+            name=snapshot, created_at=_stamp(created), rows=_row_counts(db, schema)
+        )
+
+
+def drop_snapshot(
+    name: str,
+    *,
+    lock_timeout: Optional[str] = None,
+    session: Optional[Session] = None,
+) -> None:
+    """Delete a snapshot and everything in it.
+
+    ``lock_timeout`` bounds the wait for the schema's locks. Anything still
+    reading the snapshot holds them until its transaction ends, and
+    ``DROP ... CASCADE`` waits rather than failing -- which is a hang and not an
+    error, so a caller that cannot afford to wait forever says how long.
+    """
+    snapshot = _validated(name)
+    schema = _schema_for(snapshot)
+    with unit_of_work(session) as db:
+        if not _schema_exists(db, schema):
+            raise SnapshotError(f"no snapshot named {snapshot!r}")
+        if lock_timeout is not None:
+            db.execute(text("SET LOCAL lock_timeout = :wait"), {"wait": lock_timeout})
+        # Only ever a name that passed _validated and carries the prefix, which
+        # is what keeps this statement off `public`.
+        db.execute(text(f"DROP SCHEMA {schema} CASCADE"))
+
+
+def _validated(name: str) -> str:
+    if not isinstance(name, str) or not _NAME.match(name):
+        raise SnapshotError(
+            f"snapshot name {name!r} must be lowercase letters, digits and "
+            "underscores, starting with a letter or digit"
+        )
+    if len(name) > _MAX_NAME:
+        raise SnapshotError(
+            f"snapshot name {name!r} is longer than {_MAX_NAME} characters"
+        )
+    return name
+
+
+def _today() -> str:
+    """The default name. Dated, because what a snapshot is is a date."""
+    return datetime.now(timezone.utc).strftime("%Y_%m_%d")
+
+
+def _stamp(raw: Optional[str]) -> Optional[datetime]:
+    """The creation stamp off the schema comment.
+
+    Absent or unreadable is not an error: a schema someone created by hand is
+    still a snapshot, and refusing to list it would hide it.
+    """
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _schema_exists(db: Session, schema: str) -> bool:
+    return (
+        db.execute(
+            text("SELECT 1 FROM pg_namespace WHERE nspname = :schema"),
+            {"schema": schema},
+        ).scalar()
+        is not None
+    )
+
+
+def _episodic_tables(db: Session) -> Sequence[str]:
+    return (
+        db.execute(
+            text(
+                "SELECT tablename FROM pg_tables "
+                "WHERE schemaname = :live AND tablename LIKE :like "
+                "ORDER BY tablename"
+            ),
+            {"live": LIVE_SCHEMA, "like": _TABLE_LIKE},
+        )
+        .scalars()
+        .all()
+    )
+
+
+def _serial_columns(db: Session, schema: str, table: str) -> Sequence[str]:
+    return (
+        db.execute(
+            text(
+                "SELECT a.attname FROM pg_attribute a "
+                "WHERE a.attrelid = CAST(:relation AS regclass) "
+                "  AND a.attnum > 0 AND NOT a.attisdropped "
+                "  AND pg_get_serial_sequence(:relation, a.attname) IS NOT NULL "
+                "ORDER BY a.attnum"
+            ),
+            {"relation": f"{schema}.{table}"},
+        )
+        .scalars()
+        .all()
+    )
+
+
+def _sequence_name(schema: str, table: str, column: str) -> str:
+    """Named in one place because two callers have to agree.
+
+    _own_sequences creates it and _advance_sequences moves it past the copied
+    rows; a disagreement between them is a setval against a sequence nobody
+    reads, which fails as a duplicate key on the snapshot's first insert and
+    not before.
+    """
+    return f"{schema}.{table}_{column}_seq"
+
+
+def _own_sequences(db: Session, schema: str, table: str) -> None:
+    """Repoint the copy's serial defaults at sequences inside the schema."""
+    for column in _serial_columns(db, LIVE_SCHEMA, table):
+        sequence = _sequence_name(schema, table, column)
+        db.execute(text(f"CREATE SEQUENCE {sequence}"))
+        db.execute(
+            text(
+                f"ALTER TABLE {schema}.{table} ALTER COLUMN {column} "
+                f"SET DEFAULT nextval('{sequence}'::regclass)"
+            )
+        )
+        db.execute(
+            text(f"ALTER SEQUENCE {sequence} OWNED BY {schema}.{table}.{column}")
+        )
+
+
+def _advance_sequences(db: Session, schema: str, table: str) -> None:
+    """Move each sequence past the rows just copied, so a later insert is unique."""
+    for column in _serial_columns(db, schema, table):
+        db.execute(
+            text(
+                f"SELECT setval('{_sequence_name(schema, table, column)}', "
+                f"COALESCE((SELECT max({column}) FROM {schema}.{table}), 0) + 1, false)"
+            )
+        )
+
+
+def _copy_foreign_keys(db: Session, schema: str) -> None:
+    """Re-create the tier's foreign keys inside the copy.
+
+    ``LIKE ... INCLUDING ALL`` carries checks, indexes and defaults but not
+    foreign keys. They are read back as text and replayed with the snapshot on
+    the ``search_path``, so an unqualified ``REFERENCES episodic_verdicts``
+    binds to the copy.
+
+    Both halves are pinned rather than inherited, because
+    ``pg_get_constraintdef`` renders against whatever path it finds. Taking a
+    snapshot from a process that already has one selected -- which is exactly
+    what ``PGOPTIONS`` does, and the reason a backend running an eval would --
+    renders ``REFERENCES public.episodic_verdicts`` instead, and replaying that
+    gives the new snapshot a foreign key into the live tier. Silently: the
+    constraint is valid, it simply points at the wrong table.
+
+    The prior path is captured and put back, so this leaves the transaction as
+    it found it whatever the caller had selected.
+    """
+    prior = db.execute(text("SELECT current_setting('search_path', true)")).scalar()
+    _set_search_path(db, LIVE_SCHEMA)
+    constraints = (
+        db.execute(
+            text(
+                "SELECT t.relname AS table_name, c.conname AS name, "
+                "       pg_get_constraintdef(c.oid) AS definition "
+                "FROM pg_constraint c "
+                "JOIN pg_class t ON t.oid = c.conrelid "
+                "JOIN pg_namespace n ON n.oid = t.relnamespace "
+                "WHERE c.contype = 'f' AND n.nspname = :live AND t.relname LIKE :like "
+                "ORDER BY c.conname"
+            ),
+            {"live": LIVE_SCHEMA, "like": _TABLE_LIKE},
+        )
+        .mappings()
+        .all()
+    )
+
+    try:
+        if not constraints:
+            return
+        _set_search_path(db, schema)
+        for row in constraints:
+            db.execute(
+                text(
+                    f"ALTER TABLE {schema}.{row['table_name']} "
+                    f"ADD CONSTRAINT {row['name']} {row['definition']}"
+                )
+            )
+    finally:
+        _set_search_path(db, prior or LIVE_SCHEMA)
+
+
+def _set_search_path(db: Session, path: str) -> None:
+    """Transaction-local, and through set_config so the value can be bound.
+
+    ``SET LOCAL search_path = ...`` takes no parameter, so restoring a captured
+    path would mean interpolating it back; ``set_config`` takes it as a string.
+    """
+    db.execute(text("SELECT set_config('search_path', :path, true)"), {"path": path})
+
+
+def _row_counts(db: Session, schema: str) -> Dict[str, int]:
+    """What the snapshot holds, counted rather than recorded.
+
+    Counting on read keeps the answer true. A stored count is a second copy of
+    the same fact, and it is wrong the moment anyone touches the schema.
+    """
+    counts: Dict[str, int] = {}
+    for table in CORPUS_TABLES:
+        # A schema carrying the prefix is not proof somebody built it here, and
+        # a listing that raises on one hand-made schema hides every real one --
+        # the same reason _stamp tolerates a missing comment. Absent counts as
+        # zero rows, because that is what a reader can act on.
+        #
+        # This guard is also the only thing standing between an unvalidated
+        # schema name and the f-string below: to_regclass takes the name as a
+        # parameter and returns NULL rather than raising, so a name that could
+        # not be a relation never reaches the count. Anything that weakens it
+        # has to put the validation back.
+        present = db.execute(
+            text("SELECT to_regclass(:relation)"), {"relation": f"{schema}.{table}"}
+        ).scalar()
+        counts[table] = (
+            int(
+                db.execute(text(f"SELECT count(*) FROM {schema}.{table}")).scalar() or 0
+            )
+            if present is not None
+            else 0
+        )
+    return counts

--- a/scripts/memory_snapshot.py
+++ b/scripts/memory_snapshot.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Create, list and drop frozen copies of episodic memory (#736).
+
+An eval that reads live memory cannot tell you what it measured: the Distil
+polls, so the corpus grows between two runs of the same hunts and the score
+moves without the code changing. A snapshot is a schema holding a copy of the
+episodic tables; an eval process reads one by putting it on its search_path.
+
+Why a snapshot rather than an as-of filter, and why PGOPTIONS rather than the
+DSN, is written down once in core/memory/snapshot.py.
+
+Usage:
+    python scripts/memory_snapshot.py create              # named for today
+    python scripts/memory_snapshot.py create 2026_09_01
+    python scripts/memory_snapshot.py create control --empty
+    python scripts/memory_snapshot.py list
+    python scripts/memory_snapshot.py drop 2026_09_01
+
+Then point an eval process at one:
+
+    PGOPTIONS='-c search_path=episodic_snap_2026_09_01,public' <the eval>
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
+
+from core.memory.snapshot import (  # noqa: E402
+    SnapshotError,
+    create_snapshot,
+    drop_snapshot,
+    list_snapshots,
+)
+from core.storage.connection import get_db_manager  # noqa: E402
+
+
+def _create(args) -> int:
+    snapshot = create_snapshot(args.name, empty=args.empty)
+    total = sum(snapshot.rows.values())
+    print(f"{snapshot.name}  schema={snapshot.schema}  rows={total}")
+    for table, count in snapshot.rows.items():
+        print(f"  {table:<26} {count}")
+    print(f"\nRead it with:\n  PGOPTIONS='{snapshot.pgoptions}' <the eval process>")
+    return 0
+
+
+def _list(_args) -> int:
+    found = list_snapshots()
+    if not found:
+        print("no snapshots")
+        return 0
+    for snapshot in found:
+        stamp = snapshot.created_at.isoformat() if snapshot.created_at else "unknown"
+        total = sum(snapshot.rows.values())
+        label = "empty" if snapshot.is_empty else f"{total} rows"
+        print(f"{snapshot.name:<24} {stamp:<32} {label}")
+    return 0
+
+
+def _drop(args) -> int:
+    # Bounded because anything still reading the snapshot holds its locks and
+    # DROP waits rather than failing: a person at a terminal should be told
+    # something is reading it, not left watching a cursor.
+    drop_snapshot(args.name, lock_timeout="10s")
+    print(f"dropped {args.name}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    create_cmd = commands.add_parser(
+        "create", help="copy the live tier into a new schema"
+    )
+    create_cmd.add_argument("name", nargs="?", help="defaults to today's date")
+    create_cmd.add_argument(
+        "--empty",
+        action="store_true",
+        help="copy no rows: the control an A/B measures against",
+    )
+    create_cmd.set_defaults(run=_create)
+
+    commands.add_parser("list", help="every snapshot in the database").set_defaults(
+        run=_list
+    )
+
+    drop_cmd = commands.add_parser(
+        "drop", help="delete a snapshot and everything in it"
+    )
+    drop_cmd.add_argument("name")
+    drop_cmd.set_defaults(run=_drop)
+
+    args = parser.parse_args()
+    get_db_manager().initialize()
+    try:
+        return args.run(args)
+    except SnapshotError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/memory/test_snapshot.py
+++ b/tests/unit/memory/test_snapshot.py
@@ -1,0 +1,429 @@
+"""Freezing the tier for an eval run (#736), against a real Postgres.
+
+A snapshot is a schema copy selected by ``search_path``, so nothing here can be
+asserted against a fake: what is being tested is that Postgres resolves the
+tier's tables to the copy, that the copy stops moving when live moves, and that
+a read against it touches no live row. A double would agree with whatever this
+module happened to do.
+
+The eval process is simulated by putting ``PGOPTIONS`` in the environment and
+rebuilding the engine, which is what a separate process does at startup. It is
+rebuilt again on the way out, so a test that fails does not leave the manager
+pointing at a snapshot.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+
+from core.memory.recall import recall_entity
+from core.memory.snapshot import (
+    CORPUS_TABLES,
+    SNAPSHOT_PREFIX,
+    SnapshotError,
+    SnapshotExists,
+    create_snapshot,
+    drop_snapshot,
+    get_snapshot,
+    list_snapshots,
+    pgoptions_for,
+)
+from core.storage.connection import get_db_manager, get_db_session
+from core.storage.models import (
+    EpisodicGap,
+    EpisodicReadLog,
+    EpisodicSighting,
+    EpisodicVerdict,
+    EpisodicVerdictSource,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.database, pytest.mark.external_service]
+
+EPOCH = datetime(2026, 8, 1, tzinfo=timezone.utc)
+KEY = "ip:198.51.100.7"
+OTHER = "ip:198.51.100.8"
+
+
+@pytest.fixture
+def live():
+    """A session on the live tier, emptied first.
+
+    Every test here counts whole tables on both sides of a copy, so each starts
+    from nothing rather than filtering its own rows out.
+    """
+    db = get_db_session()
+    try:
+        for model in (
+            EpisodicVerdictSource,
+            EpisodicVerdict,
+            EpisodicSighting,
+            EpisodicGap,
+            EpisodicReadLog,
+        ):
+            db.query(model).delete()
+        db.commit()
+        yield db
+    finally:
+        db.rollback()
+        db.close()
+
+
+@pytest.fixture
+def snapshots():
+    """Names created by a test, dropped however it ends."""
+    made = []
+
+    def make(name, **kwargs):
+        made.append(name)
+        return create_snapshot(name, **kwargs)
+
+    try:
+        yield make
+    finally:
+        for name in made:
+            try:
+                drop_snapshot(name, lock_timeout="5s")
+            except SnapshotError:
+                pass
+
+
+@contextmanager
+def reading(snapshot: str):
+    """What an eval process does at startup, and undoes by exiting.
+
+    ``PGOPTIONS`` is read by libpq when a connection is opened, so the engine is
+    rebuilt to force new ones. Rebuilding again on the way out is not tidiness:
+    the manager is a singleton and every later test in the session would other-
+    wise read the snapshot.
+
+    The manager's own config is handed back rather than letting ``retarget()``
+    rebuild one, which would re-read ``DatabaseConfig()`` from the environment
+    and land on the origin database -- not the throwaway one ``conftest`` put
+    this process on. Only the engine is meant to change here.
+    """
+    manager = get_db_manager()
+    target = manager.config
+    before = os.environ.get("PGOPTIONS")
+    os.environ["PGOPTIONS"] = pgoptions_for(snapshot)
+    manager.retarget(target)
+    try:
+        yield
+    finally:
+        if before is None:
+            os.environ.pop("PGOPTIONS", None)
+        else:
+            os.environ["PGOPTIONS"] = before
+        manager.retarget(target)
+
+
+def sighting(db, key: str, *, investigation: str, concluded: datetime):
+    db.add(
+        EpisodicSighting(
+            entity_key=key,
+            investigation_kind="hunt",
+            investigation_id=investigation,
+            source_system="splunk",
+            hit_count=3,
+            attacker_influenceable=True,
+            first_seen=concluded - timedelta(hours=1),
+            last_seen=concluded,
+            concluded_at=concluded,
+        )
+    )
+
+
+def verdict(db, keys, *, investigation: str, concluded: datetime):
+    row = EpisodicVerdict(
+        investigation_kind="hunt",
+        investigation_id=investigation,
+        hypothesis_id=f"h-{investigation}",
+        statement="beaconing to a known-bad host",
+        outcome="proven",
+        rationale="regular interval, low jitter",
+        subject_entities=list(keys),
+        attacker_influenceable_only=False,
+        trust="agent",
+        first_seen=concluded - timedelta(hours=2),
+        last_seen=concluded,
+        window_source="observed",
+        concluded_at=concluded,
+    )
+    db.add(row)
+    db.flush()
+    db.add(
+        EpisodicVerdictSource(
+            verdict_id=row.id,
+            source_system="splunk",
+            stance="supports",
+            source_tier="telemetry",
+        )
+    )
+    return row
+
+
+def gap(db, keys, *, investigation: str, concluded: datetime):
+    db.add(
+        EpisodicGap(
+            investigation_kind="hunt",
+            investigation_id=investigation,
+            hypothesis_id=f"g-{investigation}",
+            statement="did anything else talk to it",
+            disposition="budget_exhausted",
+            reason="the hunt ran out of turns",
+            subject_entities=list(keys),
+            concluded_at=concluded,
+        )
+    )
+
+
+def seeded(db, *, investigation="hunt-1", key=KEY):
+    sighting(db, key, investigation=investigation, concluded=EPOCH)
+    verdict(db, [key], investigation=investigation, concluded=EPOCH)
+    gap(db, [key], investigation=investigation, concluded=EPOCH)
+    db.commit()
+
+
+def test_a_named_snapshot_holds_a_copy_of_the_live_tier(live, snapshots):
+    seeded(live)
+
+    held = snapshots("copy_of_live")
+
+    assert held.schema == SNAPSHOT_PREFIX + "copy_of_live"
+    assert held.rows == {
+        "episodic_sightings": 1,
+        "episodic_verdicts": 1,
+        "episodic_verdict_sources": 1,
+        "episodic_gaps": 1,
+    }
+    assert not held.is_empty
+
+
+def test_the_copy_matches_the_rows_it_was_taken_from(live, snapshots):
+    """The spec's own statement of what correctness is here.
+
+    Counting rows would pass a copy that garbled every column, and
+    ``INSERT ... SELECT`` matches by position -- so a column reordered between
+    the live table and the copy is exactly the failure this catches.
+    """
+    seeded(live)
+    held = snapshots("faithful")
+
+    try:
+        for table in CORPUS_TABLES:
+            original = live.execute(
+                text(f"SELECT * FROM public.{table} ORDER BY id")
+            ).fetchall()
+            copied = live.execute(
+                text(f"SELECT * FROM {held.schema}.{table} ORDER BY id")
+            ).fetchall()
+            assert copied == original, table
+            assert original, f"{table} seeded nothing, so this asserted nothing"
+    finally:
+        # Reading the snapshot through this session takes a lock on its tables
+        # and holds it until the transaction ends. The fixture drops the schema
+        # from a different session, and DROP ... CASCADE waits on that lock
+        # rather than failing -- so without this the suite hangs, it does not
+        # fail.
+        live.rollback()
+
+
+def test_a_listing_survives_a_schema_nobody_here_built(live, snapshots):
+    """A stray prefixed schema must not hide every real snapshot.
+
+    The same reason the creation stamp is optional: a listing is how an operator
+    finds what exists, and one that raises tells them nothing.
+    """
+    snapshots("real_one")
+    live.execute(text(f"CREATE SCHEMA {SNAPSHOT_PREFIX}handmade"))
+    live.commit()
+    try:
+        listed = {held.name: held for held in list_snapshots()}
+        assert "real_one" in listed
+        assert listed["handmade"].rows == {table: 0 for table in CORPUS_TABLES}
+    finally:
+        live.execute(text(f"DROP SCHEMA {SNAPSHOT_PREFIX}handmade CASCADE"))
+        live.commit()
+
+
+def test_an_eval_reads_a_named_snapshot_without_changing_a_query(live, snapshots):
+    """The point of the schema copy: recall's SQL is untouched."""
+    seeded(live)
+    snapshots("read_by_an_eval")
+
+    with reading("read_by_an_eval"):
+        result = recall_entity({"entity_key": KEY})
+
+    assert len(result["sightings"]) == 1
+    assert len(result["verdicts"]) == 1
+    assert len(result["gaps"]) == 1
+
+
+def test_an_empty_snapshot_recalls_nothing(live, snapshots):
+    """The control the whole measurement rests on."""
+    seeded(live)
+    held = snapshots("the_control", empty=True)
+    assert held.is_empty
+
+    with reading("the_control"):
+        result = recall_entity({"entity_key": KEY})
+
+    assert result["sightings"] == []
+    assert result["verdicts"] == []
+    assert result["gaps"] == []
+
+
+def test_two_reads_of_one_snapshot_return_the_same_rows(live, snapshots):
+    """``as_of`` is pinned because it defaults to now and would differ per call.
+
+    Two eval runs comparing scores hold it fixed for the same reason: the
+    freshness filter is part of what a run read, and letting it float would
+    make a rerun a different query rather than the same one.
+    """
+    seeded(live)
+    snapshots("read_twice")
+    asked = {"entity_key": KEY, "as_of": "2026-09-01T00:00:00Z"}
+
+    with reading("read_twice"):
+        first = recall_entity(dict(asked))
+        second = recall_entity(dict(asked))
+
+    assert first == second
+
+
+def test_a_write_to_the_live_tier_does_not_reach_a_snapshot(live, snapshots):
+    seeded(live)
+    snapshots("frozen")
+
+    sighting(live, KEY, investigation="hunt-2", concluded=EPOCH + timedelta(days=1))
+    verdict(live, [KEY], investigation="hunt-2", concluded=EPOCH + timedelta(days=1))
+    live.commit()
+
+    assert get_snapshot("frozen").rows["episodic_sightings"] == 1
+    with reading("frozen"):
+        result = recall_entity({"entity_key": KEY})
+    assert len(result["sightings"]) == 1
+
+    # The live tier did move; the snapshot is what did not.
+    assert len(recall_entity({"entity_key": KEY})["sightings"]) == 2
+
+
+def test_snapshots_coexist_and_are_selected_by_name(live, snapshots):
+    seeded(live)
+    snapshots("populated")
+    snapshots("empty_one", empty=True)
+
+    names = {held.name for held in list_snapshots()}
+    assert {"populated", "empty_one"} <= names
+
+    with reading("populated"):
+        assert len(recall_entity({"entity_key": KEY})["sightings"]) == 1
+    with reading("empty_one"):
+        assert recall_entity({"entity_key": KEY})["sightings"] == []
+
+
+def test_a_read_against_a_snapshot_leaves_the_live_journal_alone(live, snapshots):
+    """The failure with no error message.
+
+    ``search_path`` falls through, so a table missing from the copy resolves to
+    ``public`` -- and recall writes. If the journal were not copied, an eval's
+    reads would be logged against production and nothing would say so.
+    """
+    seeded(live)
+    snapshots("journal_stays_put")
+    before = live.query(EpisodicReadLog).count()
+
+    with reading("journal_stays_put"):
+        recall_entity({"entity_key": KEY})
+
+    live.rollback()  # a fresh read of what the other connection committed
+    assert live.query(EpisodicReadLog).count() == before
+
+
+def test_a_snapshot_owns_its_sequences(live, snapshots):
+    """A copy sharing the live sequence advances live state as the eval reads."""
+    seeded(live)
+    snapshots("own_sequences")
+    before = live.execute(
+        text("SELECT last_value FROM public.episodic_read_log_id_seq")
+    ).scalar()
+
+    with reading("own_sequences"):
+        recall_entity({"entity_key": KEY})
+
+    live.rollback()
+    after = live.execute(
+        text("SELECT last_value FROM public.episodic_read_log_id_seq")
+    ).scalar()
+    assert after == before
+
+
+def test_a_snapshot_taken_from_inside_a_snapshot_binds_its_own_keys(live, snapshots):
+    """The failure that is a valid constraint pointing at the wrong table.
+
+    pg_get_constraintdef renders against whatever search_path it finds, so with
+    a snapshot selected it qualifies the reference as public.episodic_verdicts
+    -- and replaying that text hands the new copy a foreign key into the live
+    tier. Nothing errors; the copy simply is not one.
+    """
+    seeded(live)
+    snapshots("taken_from")
+
+    with reading("taken_from"):
+        inner = snapshots("taken_inside")
+
+    referenced = live.execute(
+        text(
+            "SELECT confrelid::regclass::text FROM pg_constraint "
+            "WHERE contype = 'f' AND conrelid = CAST(:relation AS regclass)"
+        ),
+        {"relation": f"{inner.schema}.episodic_verdict_sources"},
+    ).scalar()
+    live.rollback()
+    assert referenced == f"{inner.schema}.episodic_verdicts"
+
+
+def test_the_copy_is_taken_at_one_instant(live, snapshots, monkeypatch):
+    """Four INSERT ... SELECT statements have to see the same tier.
+
+    Asserted on the isolation level rather than by interleaving a write, because
+    the copy loop offers nothing to interleave against -- which is the point,
+    but leaves this the honest way to pin the guarantee. Under the default READ
+    COMMITTED each statement takes its own snapshot and a Distil re-derive
+    landing mid-copy separates Verdicts from their sources.
+    """
+    import core.memory.snapshot as module
+
+    seen = {}
+    original = module._row_counts
+
+    def record(db, schema):
+        seen["isolation"] = db.execute(text("SHOW transaction_isolation")).scalar()
+        return original(db, schema)
+
+    monkeypatch.setattr(module, "_row_counts", record)
+    seeded(live)
+    snapshots("one_instant")
+
+    assert seen["isolation"] == "repeatable read"
+
+
+def test_a_snapshot_is_not_overwritten(live, snapshots):
+    snapshots("kept")
+    with pytest.raises(SnapshotExists):
+        create_snapshot("kept")
+
+
+def test_a_name_that_would_need_quoting_is_refused():
+    for name in ("2026-09-01", "Sept", "with space", "", "with;semicolon"):
+        with pytest.raises(SnapshotError):
+            pgoptions_for(name)
+
+
+def test_dropping_a_snapshot_that_is_not_there_says_so():
+    with pytest.raises(SnapshotError):
+        drop_snapshot("never_made")


### PR DESCRIPTION
Closes #736. Base is `episodic-memory`, one commit ahead of it.

## What this is

An eval that reads live memory cannot tell you what it measured. The Distil polls, so an investigation that ended Monday can be written Wednesday carrying Monday's `concluded_at` — re-run the same hunts a week apart and the corpus underneath them has grown, which moves the score without anyone touching the code.

A snapshot is a Postgres schema holding a copy of the episodic tables. Nothing is wired into recall: a process puts one on its `search_path` and every query in `core/memory/recall.py` reads the copy unchanged.

```
python scripts/memory_snapshot.py create              # named for today
python scripts/memory_snapshot.py create control --empty
PGOPTIONS='-c search_path=episodic_snap_2026_09_01,public' <the process that queries>
```

## Scope

**The issue carries `factory:needs-work` and three rejections.** Their mechanical objections were right and are designed around rather than argued with:

- *"a new catalog"* — there is none. `pg_namespace` already lists schemas and carries a comment per schema, so the creation stamp lives there and `list_snapshots` reads it back.
- *"`without code changes` is false"* — true of the DSN. `_ALLOWED_DSN_PARAMS` rejects `options`, so a snapshot named in the URL never reaches libpq. Selection is `PGOPTIONS`, which libpq reads for any parameter the connection string does not set. No change to `core/storage/connection.py`.
- *"`search_path` on a pooled connection is a footgun"* — it is, for `SET search_path`, which leaks to the next borrower. `PGOPTIONS` applies at connect time, so every connection in a pool comes up on the same schema and none can drift.

Their conclusion — that the freeze belongs to #732/#737 and this should not be built — is the part I disagree with. #732's journal and #737's fixture freeze *what a recorded run saw*. This freezes *what the next run will see*, which is the only thing that makes two runs comparable, and the epic asks for it in those terms.

## Design

**No catalog table**, as above. Row counts are computed on read rather than stored, because a stored count is a second copy of a fact that is wrong the moment anyone touches the schema.

**Names take no hyphens.** The schema has to survive a shell inside `PGOPTIONS`, where a quoted identifier would not. `episodic_snap_2026_09_01` is a bare identifier; `2026-09-01` is not.

**Kept, never overwritten.** `create` refuses an existing name — an old snapshot read by new code measures the code, a new one measures the system, and both are wanted.

## Four silent failures a naive copy has

Every one of these produces a wrong answer with no error. Each has a regression test, and each test was mutation-checked: reverting the fix fails exactly that test and nothing else.

1. **`search_path` falls through.** A table absent from the snapshot resolves against `public` — and recall *writes*. Without copying `episodic_read_log`, an eval's reads land in the production journal with nothing saying so. Tables are discovered by prefix rather than listed, so one added to the tier later is created empty here instead of becoming a hole pointing at live.

2. **`LIKE ... INCLUDING ALL` shares the live sequence.** The copied `bigserial` default still points at the original, so writing into a snapshot advances the live tier's counter — measured going from 1 to 2 on a single read. Defaults are repointed at sequences inside the schema.

3. **Foreign keys are not carried by `LIKE` at all**, and `pg_get_constraintdef` renders against whatever `search_path` it finds. Taking a snapshot from a process that already has one selected renders `REFERENCES public.episodic_verdicts`, and replaying that hands the new copy a foreign key into the live tier — a valid constraint on the wrong table. Both the render and the replay pin the path and restore what the caller had.

4. **The copy is four `INSERT ... SELECT` statements**, and under the default READ COMMITTED each takes its own snapshot. The Distil is a delete-then-insert that polls, so a re-derive landing between the Verdicts copy and the Verdict Sources copy yields Verdicts whose sources are missing. It runs at REPEATABLE READ — which is why `create_snapshot` owns its transaction and takes no caller session.

## What this does not do

**A hunt-driven eval is not frozen by this yet, and the module says so.** `PGOPTIONS` belongs on whichever process runs the query. For a Python caller of `recall_entity` that is the eval itself. A hunt reaches recall over `/internal/tools/invoke`, so the query runs in the long-lived backend and `PGOPTIONS` on the eval runner changes nothing — and setting it on that backend would point the Distil's writes at the snapshot too. What that case needs is a second backend that reads a snapshot and runs no Distil. Not built here.

**This freezes the exact-join tier only.** Narrative search's corpus lives outside Postgres, so "we froze memory" is true of half of what a run can recall. Stated in the module and in `CONTEXT.md` rather than left to be read as the whole of it.

**There is still no scorer.** The empty-vs-populated A/B has its mechanism and nothing to run through it; there is no eval-run kind and no decisions-to-conclusion metric. That gap is real and the factory named it.

## Vocabulary

`CONTEXT.md` gains a **Memory Snapshot** entry. The bare word `snapshot` sits on three existing `_Avoid_` lists (Recall Event, Projection, Golden), which is why the domain noun is qualified; `baseline` is left to **Golden**, so the empty snapshot is a **control**.

## Testing

15 unit tests in `tests/unit/memory/test_snapshot.py`, one per acceptance criterion plus the four failures above. Verified end-to-end across three real processes: live and a populated snapshot return the seeded rows, the empty control returns none, with no difference between them but the environment variable.

Full unit suite: 1892 passed, 19 failed — the same 19 as the untouched baseline, plus the same 3 pre-existing `mcp.server` collection errors. `flake8`, `black`, `isort` and `lint-imports` clean. **mypy unverified** — not installed in the venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
