### PR TITLE
Remove unused MCP Popen spawn; one child env path remains

### DIFF
--- a/core/integrations/mcp/service.py
+++ b/core/integrations/mcp/service.py
@@ -83,39 +83,6 @@ class MCPServer:
         # server. Read by mcp_client.connect_to_server at connect time.
         self.required_env_vars: List[str] = list(required_env_vars or [])
 
-    def start(self) -> bool:
-        """Start the MCP server."""
-        if self.process is not None:
-            logger.warning(f"Server {self.name} is already running")
-            return False
-
-        try:
-            # Prepare environment
-            env = os.environ.copy()  # noqa: ENV001 - MCP child process env
-            # httpx ignores REQUESTS_CA_BUNDLE, so inheriting it is not enough.
-            env.update(ca_bundle_env())
-            env.update(self.env)
-
-            # Start process
-            self.process = subprocess.Popen(
-                [self.command] + self.args,
-                cwd=self.cwd,
-                env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
-
-            self.status = "running"
-            self.start_time = datetime.now()
-            logger.info(f"Started MCP server: {self.name}")
-            return True
-
-        except Exception as e:
-            logger.error(f"Failed to start MCP server {self.name}: {e}")
-            self.status = "error"
-            return False
-
     def stop(self) -> bool:
         """Stop the MCP server."""
         if self.process is None:

--- a/tests/unit/integrations/test_mcp_child_ca_bundle.py
+++ b/tests/unit/integrations/test_mcp_child_ca_bundle.py
@@ -8,22 +8,27 @@ child environment to a six-name allowlist.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from mcp.client.stdio import get_default_environment
 
 from core.integrations.mcp.child_env import ca_bundle_env
+from core.integrations.mcp.client import MCPClient
+from core.integrations.mcp.service import MCPServer, MCPService
 
 pytestmark = pytest.mark.unit
 
 ROOT = Path(__file__).resolve().parents[3]
 
-# Where a tool server gets spawned. A new one that forgets the bundle is the
-# failure mode this guards: it works everywhere except behind a private CA.
-SPAWN_MODULES = (
-    "core/integrations/mcp/service.py",
-    "core/integrations/mcp/client.py",
+# Child env is assembled in _initialize_servers (parent snapshot) and spawned
+# once via StdioServerParameters. os.environ.copy() there is the snapshot, not
+# a second spawn — the deleted Popen path used to make that ambiguous.
+CHILD_ENV_SITES = (
+    ("core/integrations/mcp/service.py", "os.environ.copy()"),
+    ("core/integrations/mcp/client.py", "StdioServerParameters("),
 )
 
 _ALL_VARS = ("SSL_CERT_FILE", "SSL_CERT_DIR", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE")
@@ -88,14 +93,85 @@ def test_the_sdk_would_otherwise_strip_it(monkeypatch, tmp_path):
     assert "SSL_CERT_FILE" not in get_default_environment()
 
 
-@pytest.mark.parametrize("rel", SPAWN_MODULES)
-def test_every_spawn_site_forwards_the_bundle(rel):
+@pytest.mark.parametrize("rel, env_built", CHILD_ENV_SITES)
+def test_every_child_env_site_forwards_the_bundle(rel, env_built):
     """One ca_bundle_env() per place a child environment is built."""
     src = (ROOT / rel).read_text()
-    spawns = src.count("os.environ.copy()") + src.count("StdioServerParameters(")
+    built = src.count(env_built)
     forwards = src.count("ca_bundle_env()")
-    assert forwards >= spawns, (
-        f"{rel} builds {spawns} child environment(s) but forwards the CA "
+    assert built >= 1
+    assert forwards >= built, (
+        f"{rel} builds {built} child environment(s) but forwards the CA "
         f"bundle {forwards} time(s) — a server spawned without it fails TLS "
         "behind a private CA"
     )
+
+
+def test_mcp_server_does_not_popen_its_own_child():
+    """Runtime spawn is StdioServerParameters only; the Popen start is gone."""
+    assert not hasattr(MCPServer, "start")
+    service = (ROOT / "core/integrations/mcp/service.py").read_text()
+    assert "subprocess.Popen(" not in service
+
+
+def test_initialize_servers_snapshots_parent_env_into_server_env(tmp_path, monkeypatch):
+    """The live child env is the parent snapshot plus declared config entries."""
+    monkeypatch.setenv("VIGIL_PARENT_MARKER", "inherited")
+    (tmp_path / "mcp-config.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "demo": {
+                        "command": "python",
+                        "args": ["-m", "tools.demo"],
+                        "env": {"CUSTOM_FROM_CONFIG": "yes"},
+                    }
+                }
+            }
+        )
+    )
+    service = MCPService(project_root=tmp_path)
+    env = service.servers["demo"].env
+    assert env["VIGIL_PARENT_MARKER"] == "inherited"
+    assert env["CUSTOM_FROM_CONFIG"] == "yes"
+    assert env["PYTHONPATH"] == str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_stdio_params_receive_the_parent_snapshot_from_server_env():
+    """connect_to_server forwards server.env into the one spawn site as-is."""
+    snapshot = {"PARENT_MARKER": "from-parent", "PATH": "/bin"}
+    server = MCPServer(
+        name="demo",
+        command="python",
+        args=["-m", "tools.demo"],
+        cwd=".",
+        env=snapshot,
+    )
+
+    class _StubService:
+        servers = {"demo": server}
+
+        def is_server_enabled(self, name: str) -> bool:
+            return True
+
+    client = MCPClient(_StubService())
+    captured: dict = {}
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with patch(
+        "core.integrations.mcp.client.StdioServerParameters",
+        side_effect=lambda **kw: _capture(**kw),
+    ), patch(
+        "core.integrations.mcp.client.PersistentServerSession.connect",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        await client.connect_to_server("demo", persistent=True)
+
+    assert captured["env"]["PARENT_MARKER"] == "from-parent"
+    assert captured["command"] == "python"
+    assert captured["args"] == ["-m", "tools.demo"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #515.

`MCPServer.start` in `core/integrations/mcp/service.py` still spawned via `subprocess.Popen` with its own `os.environ.copy()`. Nothing called it: service-level `start_server` / `start_all` and `POST /servers/{name}/start` were already removed in #125. Runtime spawn is only `MCPClient.connect_to_server` → `StdioServerParameters`.

The live child already inherits the parent environment. `_initialize_servers` snapshots `os.environ` (plus `ca_bundle_env()`) into `server.env`, and the client forwards that dict. This is not a second #511 — proxy/CA contents stay there.

## Change

- Delete `MCPServer.start`. Confirmed no callers, including getattr/dynamic.
- Leave `get_status` / `is_running` (pgrep) / `test_server` / `stop_server` in place. They still back `services/api/routers/mcp.py` and detection-rules. `self.process` was only set by `start`; `stop()` is already a no-op.
- Do not change `connect_to_server` / `stdio_client` or env policy.

## Tests

- Source guard now treats `_initialize_servers`'s `os.environ.copy()` as the parent snapshot, not a spawn, and keeps `ca_bundle_env()` on that site plus `StdioServerParameters`.
- Asserts the Popen spawn stays gone.
- Asserts the surviving path: parent snapshot in `server.env` is passed into `StdioServerParameters`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30534329-747f-4070-bc64-318344d4b2cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30534329-747f-4070-bc64-318344d4b2cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

