### PR TITLE
Drop the dead numeric fallbacks left by #520

### DIFF
--- a/core/auth/password_reset.py
+++ b/core/auth/password_reset.py
@@ -33,16 +33,12 @@ logger = logging.getLogger(__name__)
 
 
 RESET_TOKEN_PURPOSE = "vigil-password-reset"
-DEFAULT_TTL_SECONDS = 3600  # 1 hour
 
 _USED_TOKEN_PREFIX = "password_reset_used:"
 
 
 def _ttl_seconds() -> int:
-    try:
-        return get_settings().password_reset_ttl_seconds
-    except ValueError:
-        return DEFAULT_TTL_SECONDS
+    return get_settings().password_reset_ttl_seconds
 
 
 def _get_serializer() -> URLSafeTimedSerializer:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #642

## What

`get_settings()` builds a pydantic `Settings` object. `pydantic.ValidationError` subclasses `ValueError`, so `_ttl_seconds` in `core/auth/password_reset.py` swallowed a construction error for **any** field on a cache miss and returned `3600`. That is the fail-soft path #576 declined.

This PR strips that `try/except` and deletes `DEFAULT_TTL_SECONDS` (only used by the except branch). `Settings.password_reset_ttl_seconds` already defaults to 3600. `_ttl_seconds` stays so `tests/unit/auth/test_password_reset.py` can still monkeypatch TTL.

Startup already labels construction errors via `validate_settings_or_exit()` (#643). This does not retarget the catch at `ValidationError`.

## Left alone (still live guards)

- `darktrace_webhook_router._get_max_body_bytes` — `int()`s `system_config` `max_body_kb` first; Settings is only the fallback.
- `threat_feed_poller.poll_interval_seconds` — reads `get_integration_config("cloudforce_one")` first.
- Other `except ValueError` / `(TypeError, ValueError)` sites that wrap request bodies, STIX, Redis, JSON, UUIDs, integration rows, or `system_config`.

The Cloudy receiver already reads `cloudy_webhook_max_body_kb` as an `int` with no catch.

Out of scope: per-field coerce-or-default validators.

## Verification

- `pytest tests/unit/auth/test_password_reset.py tests/unit/integrations/test_darktrace_webhook.py` — 24 passed
- flake8 / black / isort clean on `core/auth/password_reset.py`
- Direct check: `_ttl_seconds()` still returns `3600` on valid Settings; a malformed `POSTGRES_PORT` now raises `ValidationError` instead of returning `3600`
- Wider grep of `core/` and `services/` for Settings-only numeric try/excepts; only `_ttl_seconds` was Settings-only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd0b860b-15b0-40fc-b619-e615c2aaba69?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd0b860b-15b0-40fc-b619-e615c2aaba69&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

