### PR TITLE
Pin runtime-fetched MCP servers to exact versions

### DIFF
--- a/mcp-config.json
+++ b/mcp-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://github.com/anthropics/anthropic-quickstarts/blob/main/mcp/config-schema.json",
 
-  "_comment_overview": "MCP Server Modernization: Official/community servers replace legacy tools/* where available. Tier 4 tools (no replacement) remain as custom implementations. Set env vars in .env or shell before starting.",
+  "_comment_overview": "MCP Server Modernization: Official/community servers replace legacy tools/* where available. Tier 4 tools (no replacement) remain as custom implementations. Set env vars in .env or shell before starting. Runtime-fetched servers (npx/uvx/docker) pin an exact version or digest so launch does not resolve registry HEAD.",
 
   "mcpServers": {
 
@@ -9,7 +9,7 @@
 
     "github": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "args": ["-y", "@modelcontextprotocol/server-github@2025.4.8"],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       }
@@ -53,7 +53,7 @@
 
     "security-detections": {
       "command": "npx",
-      "args": ["-y", "security-detections-mcp"],
+      "args": ["-y", "security-detections-mcp@3.3.0"],
       "env": {
         "SIGMA_PATHS": "${HOME}/security-detections/sigma/rules",
         "SPLUNK_PATHS": "${HOME}/security-detections/security_content/detections",
@@ -65,8 +65,9 @@
 
     "loglm": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "${LOGLM_MCP_URL}", "--header", "Authorization: Bearer ${LOGLM_MCP_TOKEN}"],
+      "args": ["-y", "mcp-remote@0.1.49", "${LOGLM_MCP_URL}", "--header", "Authorization: Bearer ${LOGLM_MCP_TOKEN}"],
       "env": {
+        "_security_note": "mcp-remote pinned to 0.1.49 (CVE-2025-6514 is fixed in 0.1.16+). Stay on 0.1.x; do not jump to 0.8.x.",
         "LOGLM_MCP_URL": "${LOGLM_MCP_URL}"
       }
     },
@@ -75,7 +76,7 @@
 
     "crowdstrike": {
       "command": "uvx",
-      "args": ["falcon-mcp"],
+      "args": ["falcon-mcp==0.19.0"],
       "env": {
         "FALCON_CLIENT_ID": "${FALCON_CLIENT_ID}",
         "FALCON_CLIENT_SECRET": "${FALCON_CLIENT_SECRET}",
@@ -85,7 +86,7 @@
 
     "sentinelone": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/Sentinel-One/purple-mcp.git", "purple-mcp", "--mode", "stdio"],
+      "args": ["--from", "git+https://github.com/Sentinel-One/purple-mcp.git@v0.7.0", "purple-mcp", "--mode", "stdio"],
       "env": {
         "PURPLEMCP_CONSOLE_TOKEN": "${SENTINELONE_API_TOKEN}",
         "PURPLEMCP_CONSOLE_BASE_URL": "${SENTINELONE_CONSOLE_URL}"
@@ -94,19 +95,19 @@
 
     "azure-sentinel": {
       "command": "npx",
-      "args": ["-y", "mcp-remote@^0.1.16", "https://sentinelmcp.microsoft.com/v1/mcp"],
+      "args": ["-y", "mcp-remote@0.1.49", "https://sentinelmcp.microsoft.com/v1/mcp"],
       "env": {
         "_setup_note": "Microsoft Sentinel MCP (GA Nov 2025). Requires: (1) Onboarding to Microsoft Sentinel data lake, (2) Microsoft Entra OAuth. See: https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-get-started",
-        "_security_note": "mcp-remote pinned to >=0.1.16 to avoid CVE-2025-6514 (RCE via malicious authorization_endpoint in OAuth metadata). Do not remove the version pin."
+        "_security_note": "mcp-remote pinned to 0.1.49 (CVE-2025-6514 is fixed in 0.1.16+). Stay on 0.1.x; do not jump to 0.8.x."
       }
     },
 
     "splunk": {
       "command": "npx",
-      "args": ["-y", "mcp-remote@^0.1.16", "${SPLUNK_MCP_URL}"],
+      "args": ["-y", "mcp-remote@0.1.49", "${SPLUNK_MCP_URL}"],
       "env": {
         "_setup_note": "Splunk Official MCP Server. Deploy via Azure Marketplace (Splunk-hosted) or self-managed. See: https://www.splunk.com/en_us/blog/artificial-intelligence/unlocking-ai-driven-operations-with-splunk-mcp-server-on-azure-marketplace.html",
-        "_security_note": "mcp-remote pinned to >=0.1.16 to avoid CVE-2025-6514 (RCE via malicious authorization_endpoint in OAuth metadata). Do not remove the version pin.",
+        "_security_note": "mcp-remote pinned to 0.1.49 (CVE-2025-6514 is fixed in 0.1.16+). Stay on 0.1.x; do not jump to 0.8.x.",
         "SPLUNK_MCP_URL": "${SPLUNK_MCP_URL}"
       }
     },
@@ -134,7 +135,7 @@
 
     "pagerduty": {
       "command": "uvx",
-      "args": ["pagerduty-mcp", "--enable-write-tools"],
+      "args": ["pagerduty-mcp==1.1.0", "--enable-write-tools"],
       "env": {
         "PAGERDUTY_USER_API_KEY": "${PAGERDUTY_API_KEY}",
         "PAGERDUTY_API_HOST": "https://api.pagerduty.com"
@@ -146,17 +147,19 @@
       "args": ["run", "-i", "--rm",
         "-e", "OKTA_DOMAIN=${OKTA_DOMAIN}",
         "-e", "OKTA_API_TOKEN=${OKTA_API_TOKEN}",
-        "mcp/okta-mcp-fctr"
+        "mcp/okta-mcp-fctr@sha256:8d6cd51e1836802e18bfc12ae772962f4ce3fdec667f472eec66bba811e4a27c"
       ],
-      "env": {}
+      "env": {
+        "_setup_note": "Docker Hub only publishes latest for this image; the digest pins the multi-arch index so launch does not float."
+      }
     },
 
     "jira": {
       "command": "npx",
-      "args": ["-y", "mcp-remote@^0.1.16", "https://mcp.atlassian.com/v1/mcp"],
+      "args": ["-y", "mcp-remote@0.1.49", "https://mcp.atlassian.com/v1/mcp"],
       "env": {
         "_setup_note": "Atlassian Rovo MCP Server (official). Covers Jira + Confluence + Compass. Uses OAuth 2.1 via browser flow. See: https://github.com/atlassian/atlassian-mcp-server",
-        "_security_note": "mcp-remote pinned to >=0.1.16 to avoid CVE-2025-6514 (RCE via malicious authorization_endpoint in OAuth metadata). Do not remove the version pin."
+        "_security_note": "mcp-remote pinned to 0.1.49 (CVE-2025-6514 is fixed in 0.1.16+). Stay on 0.1.x; do not jump to 0.8.x."
       }
     },
 
@@ -174,7 +177,7 @@
 
     "virustotal": {
       "command": "npx",
-      "args": ["-y", "@burtthecoder/mcp-virustotal"],
+      "args": ["-y", "@burtthecoder/mcp-virustotal@1.0.25"],
       "env": {
         "VIRUSTOTAL_API_KEY": "${VIRUSTOTAL_API_KEY}"
       }
@@ -182,14 +185,14 @@
 
     "shodan": {
       "command": "npx",
-      "args": ["-y", "@burtthecoder/mcp-shodan"],
+      "args": ["-y", "@burtthecoder/mcp-shodan@1.0.22"],
       "env": {
         "SHODAN_API_KEY": "${SHODAN_API_KEY}"
       }
     },
     "firecrawl": {
       "command": "npx",
-      "args": ["-y", "firecrawl-mcp"],
+      "args": ["-y", "firecrawl-mcp@3.24.0"],
       "env": {
         "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"
       }
@@ -197,8 +200,8 @@
 
     "gcp-secops": {
       "command": "uvx",
-      "_comment": "Pin mcp<2: this server uses the v1 mcp.server.fastmcp API, which mcp 2.x removed.",
-      "args": ["--with", "mcp<2", "--from", "google-secops-mcp", "secops_mcp"],
+      "_comment": "Pin mcp 1.x: this server uses the v1 mcp.server.fastmcp API, which mcp 2.x removed.",
+      "args": ["--with", "mcp==1.29.1", "--from", "google-secops-mcp==0.7.1", "secops_mcp"],
       "env": {
         "CHRONICLE_PROJECT_ID": "${CHRONICLE_PROJECT_ID}",
         "CHRONICLE_CUSTOMER_ID": "${CHRONICLE_CUSTOMER_ID}",
@@ -208,8 +211,8 @@
 
     "gcp-threat-intel": {
       "command": "uvx",
-      "_comment": "Pin mcp<2: this server uses the v1 mcp.server.fastmcp API, which mcp 2.x removed.",
-      "args": ["--with", "mcp<2", "gti_mcp"],
+      "_comment": "Pin mcp 1.x: this server uses the v1 mcp.server.fastmcp API, which mcp 2.x removed.",
+      "args": ["--with", "mcp==1.29.1", "--from", "gti-mcp==0.1.3", "gti_mcp"],
       "env": {
         "VT_APIKEY": "${VIRUSTOTAL_API_KEY}"
       }
@@ -217,14 +220,14 @@
 
     "gcp-scc": {
       "command": "uvx",
-      "_comment": "Pin mcp<2: this server uses the v1 mcp.server.fastmcp API, which mcp 2.x removed.",
-      "args": ["--with", "mcp<2", "scc_mcp"],
+      "_comment": "Pin mcp 1.x: this server uses the v1 mcp.server.fastmcp API, which mcp 2.x removed.",
+      "args": ["--with", "mcp==1.29.1", "--from", "scc-mcp==0.1.1", "scc_mcp"],
       "env": {}
     },
 
     "aws-security": {
       "command": "uvx",
-      "args": ["awslabs.well-architected-security-mcp-server@latest"],
+      "args": ["awslabs.well-architected-security-mcp-server==0.2.0"],
       "env": {
         "_setup_note": "AWS Well-Architected Security Assessment MCP. Covers GuardDuty, Security Hub, Inspector, IAM Access Analyzer. Requires AWS credentials. See: https://awslabs.github.io/mcp/servers/well-architected-security-mcp-server",
         "AWS_REGION": "${AWS_REGION}",
@@ -234,7 +237,7 @@
 
     "cribl-stream": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/pebbletek/cribl-mcp.git", "cribl-mcp"],
+      "args": ["--from", "git+https://github.com/pebbletek/cribl-mcp.git@v0.1.12", "cribl-mcp"],
       "env": {
         "_setup_note": "Cribl Stream MCP (community, MIT). See: https://docs.cribl.io/copilot/cribl-mcp-server/",
         "CRIBL_BASE_URL": "${CRIBL_BASE_URL}",

--- a/tests/unit/_ratchets/test_mcp_runtime_pins.py
+++ b/tests/unit/_ratchets/test_mcp_runtime_pins.py
@@ -1,0 +1,166 @@
+"""Runtime-fetched MCP servers must pin an exact artifact, not registry HEAD.
+
+npx / uvx / docker entries in mcp-config.json download code at process start.
+An unpinned spec, a version range, @latest, or a git default branch makes two
+identical deploys diverge and is a supply-chain footgun. In-repo python3
+servers and joe-sandbox's local ``uv --directory`` clone are not registry
+resolves and are left alone.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MCP_CONFIG = _REPO_ROOT / "mcp-config.json"
+
+_FLOATING_GIT_REFS = {"HEAD", "head", "main", "master", "latest", "dev", "develop"}
+_RANGE_IN_VERSION = re.compile(r"[<>=^~*]")
+_EXACT_PYPI = re.compile(r"==[A-Za-z0-9][A-Za-z0-9._-]*$")
+_GIT_REF = re.compile(r"\.git@([^#]+)$")
+_SHA256 = re.compile(r"@sha256:[0-9a-f]{64}$")
+
+# uvx flags that consume the next argv token as a package spec.
+_UVX_SPEC_FLAGS = {
+    "--from",
+    "--with",
+    "--with-editable",
+    "--with-requirements",
+}
+
+
+def _servers() -> dict[str, dict]:
+    raw = json.loads(_MCP_CONFIG.read_text())["mcpServers"]
+    return {k: v for k, v in raw.items() if isinstance(v, dict)}
+
+
+def _npm_version(spec: str) -> str | None:
+    """Return the version suffix of an npm package spec, or None if missing."""
+    rest = spec[1:] if spec.startswith("@") else spec
+    if "@" not in rest:
+        return None
+    return rest.rsplit("@", 1)[1]
+
+
+def _npm_pinned(spec: str) -> bool:
+    version = _npm_version(spec)
+    return bool(version) and not _RANGE_IN_VERSION.search(version) and version != "latest"
+
+
+def _npx_package(args: list[str]) -> str | None:
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-p", "--package") and i + 1 < len(args):
+            return args[i + 1]
+        if arg.startswith("-"):
+            i += 1
+            continue
+        return arg
+    return None
+
+
+def _pypi_or_git_pinned(spec: str) -> bool:
+    if spec.startswith("git+") or "git+" in spec:
+        match = _GIT_REF.search(spec.split("#", 1)[0])
+        return bool(match) and match.group(1) not in _FLOATING_GIT_REFS
+    return bool(_EXACT_PYPI.search(spec))
+
+
+def _uvx_unpinned(args: list[str]) -> list[str]:
+    """Return package specs that are missing an exact pin."""
+    unpinned: list[str] = []
+    has_from = False
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in _UVX_SPEC_FLAGS and i + 1 < len(args):
+            spec = args[i + 1]
+            if arg == "--from":
+                has_from = True
+            if not _pypi_or_git_pinned(spec):
+                unpinned.append(spec)
+            i += 2
+            continue
+        if arg.startswith("-"):
+            i += 1
+            continue
+        # First positional is the package unless --from already named it.
+        if not has_from and not _pypi_or_git_pinned(arg):
+            unpinned.append(arg)
+        break
+    return unpinned
+
+
+def _docker_image(args: list[str]) -> str | None:
+    skip_next = False
+    images: list[str] = []
+    for arg in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in ("-e", "--env", "-v", "--volume", "-w", "--workdir", "--name", "-u"):
+            skip_next = True
+            continue
+        if arg.startswith("-") or arg == "run":
+            continue
+        images.append(arg)
+    return images[-1] if images else None
+
+
+@pytest.mark.unit
+def test_runtime_fetched_mcp_servers_are_pinned():
+    unpinned: dict[str, str] = {}
+    inspected = 0
+    for name, config in _servers().items():
+        command = config.get("command")
+        args = [a for a in config.get("args") or [] if isinstance(a, str)]
+        if command == "npx":
+            inspected += 1
+            package = _npx_package(args)
+            if not package or not _npm_pinned(package):
+                unpinned[name] = package or "(missing npx package)"
+        elif command == "uvx":
+            inspected += 1
+            leftover = _uvx_unpinned(args)
+            if leftover:
+                unpinned[name] = ", ".join(leftover)
+        elif command == "docker":
+            inspected += 1
+            image = _docker_image(args)
+            if not image or not _SHA256.search(image):
+                unpinned[name] = image or "(missing docker image)"
+
+    assert inspected >= 15, (
+        "expected to inspect npx/uvx/docker MCP servers; the ratchet is "
+        f"vacuous if launchers were renamed ({inspected} found)"
+    )
+    assert not unpinned, (
+        "runtime-fetched MCP servers must pin an exact version, git tag/SHA, "
+        "or image digest — not @latest, a range, or git HEAD:\n"
+        + "\n".join(f"  {name}: {detail}" for name, detail in sorted(unpinned.items()))
+    )
+
+
+@pytest.mark.unit
+def test_mcp_remote_stays_inside_the_0_1_cve_window():
+    """CVE-2025-6514 is fixed in 0.1.16; jumping to 0.8.x is a separate decision."""
+    offenders: dict[str, str] = {}
+    found = 0
+    for name, config in _servers().items():
+        for arg in config.get("args") or []:
+            if not isinstance(arg, str) or not arg.startswith("mcp-remote"):
+                continue
+            found += 1
+            version = _npm_version(arg) or ""
+            if not version.startswith("0.1.") or _RANGE_IN_VERSION.search(version):
+                offenders[name] = arg
+    assert found, "no mcp-remote specs found; the CVE pin ratchet is vacuous"
+    assert not offenders, (
+        "mcp-remote must stay on an exact 0.1.x pin (CVE-2025-6514 window), "
+        f"not a range or 0.8.x: {offenders}"
+    )

--- a/tests/unit/_ratchets/test_mcp_runtime_pins.py
+++ b/tests/unit/_ratchets/test_mcp_runtime_pins.py
@@ -18,18 +18,38 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _MCP_CONFIG = _REPO_ROOT / "mcp-config.json"
 
-_FLOATING_GIT_REFS = {"HEAD", "head", "main", "master", "latest", "dev", "develop"}
-_RANGE_IN_VERSION = re.compile(r"[<>=^~*]")
-_EXACT_PYPI = re.compile(r"==[A-Za-z0-9][A-Za-z0-9._-]*$")
+# Concrete versions only: 1.2.3, 2025.4.8. Dist-tags, x-ranges, and pre-releases
+# are not pins.
+_EXACT_VERSION = re.compile(r"^[0-9]+(\.[0-9]+)*$")
+_EXACT_PYPI = re.compile(r"==([0-9]+(?:\.[0-9]+)*)$")
 _GIT_REF = re.compile(r"\.git@([^#]+)$")
 _SHA256 = re.compile(r"@sha256:[0-9a-f]{64}$")
+_MCP_REMOTE_PATCH = re.compile(r"^0\.1\.(\d+)$")
+_FLOATING_GIT_REFS = {"HEAD", "head", "main", "master", "latest", "dev", "develop"}
 
-# uvx flags that consume the next argv token as a package spec.
-_UVX_SPEC_FLAGS = {
-    "--from",
-    "--with",
+# uvx flags whose next token is a package spec that must be pinned.
+_UVX_SPEC_FLAGS = {"--from", "--with"}
+# uvx flags whose next token is not a package (interpreter, path, index).
+_UVX_VALUE_FLAGS = {
+    "--python",
     "--with-editable",
     "--with-requirements",
+    "--index",
+    "--extra-index-url",
+}
+_DOCKER_VALUE_FLAGS = {
+    "-e",
+    "--env",
+    "-v",
+    "--volume",
+    "-w",
+    "--workdir",
+    "--name",
+    "-u",
+    "--user",
+    "--platform",
+    "-p",
+    "--publish",
 }
 
 
@@ -48,7 +68,7 @@ def _npm_version(spec: str) -> str | None:
 
 def _npm_pinned(spec: str) -> bool:
     version = _npm_version(spec)
-    return bool(version) and not _RANGE_IN_VERSION.search(version) and version != "latest"
+    return bool(version) and bool(_EXACT_VERSION.fullmatch(version))
 
 
 def _npx_package(args: list[str]) -> str | None:
@@ -64,10 +84,19 @@ def _npx_package(args: list[str]) -> str | None:
     return None
 
 
+def _git_pinned(spec: str) -> bool:
+    match = _GIT_REF.search(spec.split("#", 1)[0])
+    if not match:
+        return False
+    ref = match.group(1)
+    if ref in _FLOATING_GIT_REFS or ref.startswith(("refs/heads/", "refs/remotes/")):
+        return False
+    return True
+
+
 def _pypi_or_git_pinned(spec: str) -> bool:
     if spec.startswith("git+") or "git+" in spec:
-        match = _GIT_REF.search(spec.split("#", 1)[0])
-        return bool(match) and match.group(1) not in _FLOATING_GIT_REFS
+        return _git_pinned(spec)
     return bool(_EXACT_PYPI.search(spec))
 
 
@@ -84,6 +113,9 @@ def _uvx_unpinned(args: list[str]) -> list[str]:
                 has_from = True
             if not _pypi_or_git_pinned(spec):
                 unpinned.append(spec)
+            i += 2
+            continue
+        if arg in _UVX_VALUE_FLAGS:
             i += 2
             continue
         if arg.startswith("-"):
@@ -103,13 +135,56 @@ def _docker_image(args: list[str]) -> str | None:
         if skip_next:
             skip_next = False
             continue
-        if arg in ("-e", "--env", "-v", "--volume", "-w", "--workdir", "--name", "-u"):
+        if arg in _DOCKER_VALUE_FLAGS:
             skip_next = True
             continue
         if arg.startswith("-") or arg == "run":
             continue
         images.append(arg)
     return images[-1] if images else None
+
+
+def _mcp_remote_in_cve_window(version: str) -> bool:
+    """CVE-2025-6514 is fixed in 0.1.16; stay on exact 0.1.N with N >= 16."""
+    match = _MCP_REMOTE_PATCH.fullmatch(version)
+    return bool(match) and int(match.group(1)) >= 16
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "spec, ok",
+    [
+        ("pkg@1.2.3", True),
+        ("@scope/pkg@2025.4.8", True),
+        ("pkg", False),
+        ("pkg@latest", False),
+        ("pkg@Latest", False),
+        ("pkg@next", False),
+        ("pkg@^0.1.16", False),
+        ("pkg@0.1.x", False),
+    ],
+)
+def test_npm_pin_helper(spec: str, ok: bool):
+    assert _npm_pinned(spec) is ok
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "spec, ok",
+    [
+        ("falcon-mcp==0.19.0", True),
+        ("falcon-mcp==latest", False),
+        ("mcp<2", False),
+        ("mcp==1.29.1", True),
+        ("git+https://github.com/org/repo.git@v0.7.0", True),
+        ("git+https://github.com/org/repo.git", False),
+        ("git+https://github.com/org/repo.git@HEAD", False),
+        ("git+https://github.com/org/repo.git@main", False),
+        ("git+https://github.com/org/repo.git@refs/heads/main", False),
+    ],
+)
+def test_pypi_or_git_pin_helper(spec: str, ok: bool):
+    assert _pypi_or_git_pinned(spec) is ok
 
 
 @pytest.mark.unit
@@ -157,10 +232,30 @@ def test_mcp_remote_stays_inside_the_0_1_cve_window():
                 continue
             found += 1
             version = _npm_version(arg) or ""
-            if not version.startswith("0.1.") or _RANGE_IN_VERSION.search(version):
+            if not _mcp_remote_in_cve_window(version):
                 offenders[name] = arg
-    assert found, "no mcp-remote specs found; the CVE pin ratchet is vacuous"
-    assert not offenders, (
-        "mcp-remote must stay on an exact 0.1.x pin (CVE-2025-6514 window), "
-        f"not a range or 0.8.x: {offenders}"
+    assert found >= 3, (
+        "expected several mcp-remote specs; the CVE pin ratchet is vacuous "
+        f"if they were renamed ({found} found)"
     )
+    assert not offenders, (
+        "mcp-remote must stay on an exact 0.1.N pin with N>=16 "
+        f"(CVE-2025-6514 window), not a range or 0.8.x: {offenders}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "version, ok",
+    [
+        ("0.1.16", True),
+        ("0.1.49", True),
+        ("0.1.15", False),
+        ("0.1.0", False),
+        ("0.1.x", False),
+        ("0.8.3", False),
+        ("^0.1.16", False),
+    ],
+)
+def test_mcp_remote_cve_window_helper(version: str, ok: bool):
+    assert _mcp_remote_in_cve_window(version) is ok


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #516

## What

Pin every runtime-fetched MCP server in `mcp-config.json` so process start resolves a known artifact instead of registry HEAD.

- **npx / uvx:** exact versions (current registry latest), including `firecrawl` which the original list missed.
- **mcp-remote:** `0.1.49` — latest inside the existing `^0.1.16` CVE-2025-6514 window. Not jumped to 0.8.x.
- **sentinelone / cribl-stream:** git HEAD replaced with tagged refs (`purple-mcp@v0.7.0`, `cribl-mcp@v0.1.12`).
- **okta:** Docker image pinned to the multi-arch index digest (Hub only publishes `latest`).
- **aws-security:** `@latest` replaced with `==0.2.0`.
- **gcp-\*:** `mcp<2` and unpinned package names replaced with `mcp==1.29.1` plus exact `--from` specs.

A ratchet in `tests/unit/_ratchets/test_mcp_runtime_pins.py` fails if an npx/uvx/docker entry loses its pin, rejects dist-tags / `==latest` / `refs/heads/*`, and keeps `mcp-remote` on exact `0.1.N` with `N >= 16`.

## Out of scope (per factory groom)

- No second startup preflight — `_connect_enabled_mcp_servers` already probes enabled servers.
- No vendoring into backend/daemon images.
- `/api/health` is unchanged.
- `joe-sandbox` local `uv --directory` clone left alone.

## Test plan

- [x] Pin ratchet (26 tests: live config + negative helpers for dist-tags, git HEAD, CVE floor)
- [x] Live-config placeholder scan still finds Okta / LogLM credentials after the pin edits
- [x] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfab58ec-0fca-4929-aac7-c064d3271416?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfab58ec-0fca-4929-aac7-c064d3271416&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

