### PR TITLE
Add operator-supplied CA trust for TLS-inspecting proxies

### DIFF
--- a/core/integrations/mcp/child_env.py
+++ b/core/integrations/mcp/child_env.py
@@ -5,7 +5,9 @@ and ignores ``REQUESTS_CA_BUNDLE`` / ``CURL_CA_BUNDLE`` — the names an operato
 would have used to trust an internal CA while the servers ran on requests. An
 on-prem MISP, PAN-OS or CAPE behind a private or inspecting CA would start
 failing verification on nothing but a library swap, so the legacy names are
-honored as aliases.
+honored as aliases. A resolved *file* path is also exported as
+``NODE_EXTRA_CA_CERTS`` so npx servers pick up the same bundle; Node has no
+directory equivalent, so a capath is left as ``SSL_CERT_DIR`` only.
 
 Forwarding also has to be explicit rather than inherited: ``stdio_client``
 narrows the child environment to ``HOME``, ``LOGNAME``, ``PATH``, ``SHELL``,
@@ -50,6 +52,7 @@ def ca_bundle_env() -> Dict[str, str]:
             return {}
         # httpx checks SSL_CERT_FILE before SSL_CERT_DIR, and cafile vs capath
         # are not interchangeable, so route by what the path actually is.
-        key = "SSL_CERT_DIR" if os.path.isdir(value) else "SSL_CERT_FILE"
-        return {key: value}
+        if os.path.isdir(value):
+            return {"SSL_CERT_DIR": value}
+        return {"SSL_CERT_FILE": value, "NODE_EXTRA_CA_CERTS": value}
     return {}

--- a/env.example
+++ b/env.example
@@ -287,6 +287,14 @@ VIGIL_CORS_ORIGINS=""
 # or a compose/Helm env entry. Setting it in this file has no effect.
 # VIGIL_DIR=""
 
+# Custom CA bundle for TLS-inspecting proxies. Point all three at a PEM on
+# disk so Python (httpx/requests) and Node (agent processes, npx MCP servers)
+# trust the inspecting CA with verification still enabled. Helm mounts the
+# file and sets these; Compose passes them through. Not Settings fields.
+# SSL_CERT_FILE=""
+# REQUESTS_CA_BUNDLE=""
+# NODE_EXTRA_CA_CERTS=""
+
 # Ceiling on uploaded evidence/ingest files, in megabytes.
 # MAX_UPLOAD_SIZE_MB=500
 

--- a/env.example
+++ b/env.example
@@ -291,6 +291,8 @@ VIGIL_CORS_ORIGINS=""
 # disk so Python (httpx/requests) and Node (agent processes, npx MCP servers)
 # trust the inspecting CA with verification still enabled. Helm mounts the
 # file and sets these; Compose passes them through. Not Settings fields.
+# SSL_CERT_FILE replaces the default store (include public CAs in the PEM too);
+# NODE_EXTRA_CA_CERTS appends.
 # SSL_CERT_FILE=""
 # REQUESTS_CA_BUNDLE=""
 # NODE_EXTRA_CA_CERTS=""

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -27,6 +27,15 @@ x-agent-env: &agent-env
   # placeholder only when the variable is absent, and the := form would set it
   # to an empty string the OpenAI client then sends as a real credential.
   - BIFROST_API_KEY
+  # Inspecting-proxy CA. Pass-through (no `:-` default): an empty SSL_CERT_FILE
+  # makes Python fail every HTTPS call. Bind-mount the operator PEM — Compose
+  # has no optional-volume syntax, so do not default the source to /dev/null.
+  #   volumes:
+  #     - ${VIGIL_CA_BUNDLE}:/etc/vigil/ca-bundle.pem:ro
+  # with SSL_CERT_FILE / REQUESTS_CA_BUNDLE / NODE_EXTRA_CA_CERTS=/etc/vigil/ca-bundle.pem
+  - SSL_CERT_FILE
+  - REQUESTS_CA_BUNDLE
+  - NODE_EXTRA_CA_CERTS
 
 services:
   postgres:
@@ -158,6 +167,10 @@ services:
       # which was the agent layer's address while it shared the backend process.
       - AGENT_URL=http://agent-serve:6989
       - PYTHONUNBUFFERED=1
+      # Inspecting-proxy CA. Pass-through; bind-mount the PEM (see x-agent-env).
+      - SSL_CERT_FILE
+      - REQUESTS_CA_BUNDLE
+      - NODE_EXTRA_CA_CERTS
     ports:
       - "6987:6987"
     depends_on:
@@ -224,6 +237,10 @@ services:
       # Logging
       - DAEMON_LOG_LEVEL=${DAEMON_LOG_LEVEL:-INFO}
       - PYTHONUNBUFFERED=1
+      # Inspecting-proxy CA. Pass-through; bind-mount the PEM (see x-agent-env).
+      - SSL_CERT_FILE
+      - REQUESTS_CA_BUNDLE
+      - NODE_EXTRA_CA_CERTS
       # Integrations (loaded from core/config)
       - SPLUNK_URL=${SPLUNK_URL}
       - SPLUNK_USERNAME=${SPLUNK_USERNAME}
@@ -287,6 +304,10 @@ services:
       - BIFROST_URL=${BIFROST_URL:-http://bifrost:8080}
       - REDIS_URL=redis://redis:6379/0
       - PYTHONUNBUFFERED=1
+      # Inspecting-proxy CA. Pass-through; bind-mount the PEM (see x-agent-env).
+      - SSL_CERT_FILE
+      - REQUESTS_CA_BUNDLE
+      - NODE_EXTRA_CA_CERTS
     depends_on:
       postgres:
         condition: service_healthy

--- a/infra/helm/vigil/templates/_env.tpl
+++ b/infra/helm/vigil/templates/_env.tpl
@@ -45,6 +45,51 @@ write. Include all three together, or none.
   {{- toYaml .Values.stateDirectory.volume | nindent 2 }}
 {{- end -}}
 
+{{/*
+Operator-supplied CA PEM for TLS-inspecting proxies. Include all three together
+(or none) on backend, daemon, llm-worker, agent-worker, and agent-serve only —
+the same rule as vigil.state*: env without the mount advertises a path the
+container cannot read. Empty existingSecret and existingConfigMap skip every
+helper. Prefer the Secret when both are set.
+*/}}
+{{- define "vigil.caBundleEnv" -}}
+{{- if or .Values.caBundle.existingSecret .Values.caBundle.existingConfigMap }}
+- name: SSL_CERT_FILE
+  value: {{ .Values.caBundle.mountPath | quote }}
+- name: REQUESTS_CA_BUNDLE
+  value: {{ .Values.caBundle.mountPath | quote }}
+- name: NODE_EXTRA_CA_CERTS
+  value: {{ .Values.caBundle.mountPath | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "vigil.caBundleVolumeMount" -}}
+{{- if or .Values.caBundle.existingSecret .Values.caBundle.existingConfigMap }}
+- name: vigil-ca-bundle
+  mountPath: {{ .Values.caBundle.mountPath }}
+  subPath: ca-bundle.pem
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+{{- define "vigil.caBundleVolume" -}}
+{{- if .Values.caBundle.existingSecret }}
+- name: vigil-ca-bundle
+  secret:
+    secretName: {{ .Values.caBundle.existingSecret | quote }}
+    items:
+      - key: {{ .Values.caBundle.key | default "ca.crt" | quote }}
+        path: ca-bundle.pem
+{{- else if .Values.caBundle.existingConfigMap }}
+- name: vigil-ca-bundle
+  configMap:
+    name: {{ .Values.caBundle.existingConfigMap | quote }}
+    items:
+      - key: {{ .Values.caBundle.key | default "ca.crt" | quote }}
+        path: ca-bundle.pem
+{{- end }}
+{{- end -}}
+
 {{- define "vigil.env" -}}
 - name: HOME
   value: "/home/vigil"

--- a/infra/helm/vigil/templates/agent-serve-deployment.yaml
+++ b/infra/helm/vigil/templates/agent-serve-deployment.yaml
@@ -65,6 +65,7 @@ spec:
                    every Redis variable -- it never touches the queue -- but the
                    block is shared, and one it does not read costs nothing. */}}
             {{- include "vigil.env" . | nindent 12 }}
+            {{- include "vigil.caBundleEnv" . | nindent 12 }}
             {{- with .Values.agentServe.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -98,6 +99,14 @@ spec:
             {{- toYaml .Values.agentServe.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- with include "vigil.caBundleVolumeMount" . }}
+          volumeMounts:
+            {{- . | nindent 12 }}
+          {{- end }}
+      {{- with include "vigil.caBundleVolume" . }}
+      volumes:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with .Values.agentServe.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/infra/helm/vigil/templates/agent-worker-deployment.yaml
+++ b/infra/helm/vigil/templates/agent-worker-deployment.yaml
@@ -59,6 +59,7 @@ spec:
                    $(VAR) substituted into either is not URL-encoded. */}}
             {{- include "vigil.env" . | nindent 12 }}
             {{- include "vigil.agentRedisEnv" . | nindent 12 }}
+            {{- include "vigil.caBundleEnv" . | nindent 12 }}
             {{- with .Values.agentWorker.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -96,6 +97,14 @@ spec:
             {{- toYaml .Values.agentWorker.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- with include "vigil.caBundleVolumeMount" . }}
+          volumeMounts:
+            {{- . | nindent 12 }}
+          {{- end }}
+      {{- with include "vigil.caBundleVolume" . }}
+      volumes:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with .Values.agentWorker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/infra/helm/vigil/templates/backend-deployment.yaml
+++ b/infra/helm/vigil/templates/backend-deployment.yaml
@@ -48,6 +48,7 @@ spec:
                   key: {{ include "vigil.postgres.passwordSecretKey" . }}
             {{- include "vigil.env" . | nindent 12 }}
             {{- include "vigil.stateEnv" . | nindent 12 }}
+            {{- include "vigil.caBundleEnv" . | nindent 12 }}
             {{- range $k, $v := .Values.backend.env }}
             - name: {{ $k }}
               value: {{ $v | quote }}
@@ -91,8 +92,10 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           volumeMounts:
             {{- include "vigil.stateVolumeMount" . | nindent 12 }}
+            {{- include "vigil.caBundleVolumeMount" . | nindent 12 }}
       volumes:
         {{- include "vigil.stateVolume" . | nindent 8 }}
+        {{- include "vigil.caBundleVolume" . | nindent 8 }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/infra/helm/vigil/templates/daemon-statefulset.yaml
+++ b/infra/helm/vigil/templates/daemon-statefulset.yaml
@@ -66,6 +66,7 @@ spec:
                   key: {{ include "vigil.postgres.passwordSecretKey" . }}
             {{- include "vigil.env" . | nindent 12 }}
             {{- include "vigil.stateEnv" . | nindent 12 }}
+            {{- include "vigil.caBundleEnv" . | nindent 12 }}
             {{- with .Values.daemon.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -105,12 +106,14 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           volumeMounts:
             {{- include "vigil.stateVolumeMount" . | nindent 12 }}
+            {{- include "vigil.caBundleVolumeMount" . | nindent 12 }}
             {{- if .Values.daemon.persistence.enabled }}
             - name: investigations
               mountPath: {{ .Values.daemon.persistence.mountPath }}
             {{- end }}
       volumes:
         {{- include "vigil.stateVolume" . | nindent 8 }}
+        {{- include "vigil.caBundleVolume" . | nindent 8 }}
       {{- with .Values.daemon.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/infra/helm/vigil/templates/llm-worker-deployment.yaml
+++ b/infra/helm/vigil/templates/llm-worker-deployment.yaml
@@ -46,6 +46,7 @@ spec:
                   key: {{ include "vigil.postgres.passwordSecretKey" . }}
             {{- include "vigil.env" . | nindent 12 }}
             {{- include "vigil.stateEnv" . | nindent 12 }}
+            {{- include "vigil.caBundleEnv" . | nindent 12 }}
             {{- with .Values.llmWorker.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -55,8 +56,10 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           volumeMounts:
             {{- include "vigil.stateVolumeMount" . | nindent 12 }}
+            {{- include "vigil.caBundleVolumeMount" . | nindent 12 }}
       volumes:
         {{- include "vigil.stateVolume" . | nindent 8 }}
+        {{- include "vigil.caBundleVolume" . | nindent 8 }}
       {{- with .Values.llmWorker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -470,6 +470,30 @@ stateDirectory:
     emptyDir: {}
 
 # -----------------------------------------------------------------------------
+# Custom CA bundle (TLS-inspecting proxies)
+# -----------------------------------------------------------------------------
+# Mount an operator-supplied PEM into backend, daemon, llm-worker, agent-worker,
+# and agent-serve, and set SSL_CERT_FILE, REQUESTS_CA_BUNDLE, and
+# NODE_EXTRA_CA_CERTS to that path. Python and Node then trust the inspecting
+# CA with verification still enabled. MCP children inherit the same vars.
+#
+# Point at an existing Secret or ConfigMap — this chart does not create one.
+# Leave both names empty (the default) to skip the mount. Prefer the Secret
+# when both are set.
+#
+#   kubectl create secret generic vigil-proxy-ca \
+#     --from-file=ca.crt=/path/to/corporate-ca.pem
+#
+#   caBundle:
+#     existingSecret: vigil-proxy-ca
+#     key: ca.crt
+caBundle:
+  existingSecret: ""
+  existingConfigMap: ""
+  key: ca.crt
+  mountPath: /etc/vigil/ca-bundle.pem
+
+# -----------------------------------------------------------------------------
 # Pod security
 # -----------------------------------------------------------------------------
 podSecurityContext:

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -476,6 +476,8 @@ stateDirectory:
 # and agent-serve, and set SSL_CERT_FILE, REQUESTS_CA_BUNDLE, and
 # NODE_EXTRA_CA_CERTS to that path. Python and Node then trust the inspecting
 # CA with verification still enabled. MCP children inherit the same vars.
+# SSL_CERT_FILE replaces the default store — the PEM should include public CAs
+# as well as the inspecting one. NODE_EXTRA_CA_CERTS appends.
 #
 # Point at an existing Secret or ConfigMap — this chart does not create one.
 # Leave both names empty (the default) to skip the mount. Prefer the Secret

--- a/tests/unit/_ratchets/test_settings_env_example.py
+++ b/tests/unit/_ratchets/test_settings_env_example.py
@@ -87,6 +87,11 @@ NOT_SETTINGS = {
     "AWS_REGION",
     "OTEL_TRACES_SAMPLER",
     "OTEL_TRACES_SAMPLER_ARG",
+    # TLS trust for inspecting proxies. Python and Node read these directly;
+    # ca_bundle_env() forwards them to MCP children. Not Settings fields.
+    "NODE_EXTRA_CA_CERTS",
+    "REQUESTS_CA_BUNDLE",
+    "SSL_CERT_FILE",
     # Consumed outside the Python backend (shell scripts, compose, Vite).
     "BIND_HOST",
     "GRAFANA_PASSWORD",

--- a/tests/unit/integrations/test_mcp_child_ca_bundle.py
+++ b/tests/unit/integrations/test_mcp_child_ca_bundle.py
@@ -46,12 +46,15 @@ def test_no_bundle_configured_leaves_httpx_on_certifi():
 
 @pytest.mark.parametrize("var", _ALL_VARS[:1] + _ALL_VARS[2:])
 def test_a_file_bundle_arrives_as_ssl_cert_file(monkeypatch, tmp_path, var):
-    """Whatever the operator called it, httpx only reads SSL_CERT_FILE."""
+    """httpx reads SSL_CERT_FILE; npx/Node reads NODE_EXTRA_CA_CERTS."""
     bundle = tmp_path / "corporate-ca.pem"
     bundle.write_text("-----BEGIN CERTIFICATE-----\n")
     monkeypatch.setenv(var, str(bundle))
 
-    assert ca_bundle_env() == {"SSL_CERT_FILE": str(bundle)}
+    assert ca_bundle_env() == {
+        "SSL_CERT_FILE": str(bundle),
+        "NODE_EXTRA_CA_CERTS": str(bundle),
+    }
 
 
 def test_a_directory_bundle_arrives_as_ssl_cert_dir(monkeypatch, tmp_path):
@@ -70,7 +73,10 @@ def test_the_httpx_native_name_wins(monkeypatch, tmp_path):
     monkeypatch.setenv("SSL_CERT_FILE", str(current))
     monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(legacy))
 
-    assert ca_bundle_env() == {"SSL_CERT_FILE": str(current)}
+    assert ca_bundle_env() == {
+        "SSL_CERT_FILE": str(current),
+        "NODE_EXTRA_CA_CERTS": str(current),
+    }
 
 
 def test_a_missing_path_falls_back_rather_than_breaking_tls(monkeypatch, tmp_path):
@@ -91,6 +97,7 @@ def test_the_sdk_would_otherwise_strip_it(monkeypatch, tmp_path):
     monkeypatch.setenv("SSL_CERT_FILE", str(bundle))
 
     assert "SSL_CERT_FILE" not in get_default_environment()
+    assert "NODE_EXTRA_CA_CERTS" not in get_default_environment()
 
 
 @pytest.mark.parametrize("rel, env_built", CHILD_ENV_SITES)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #512.

Vigil had no way to put an operator CA on disk in the app containers and point Python/Node at it, so TLS-inspecting proxies forced a disable-verify workaround. This adds the missing deploy-time path only: honor the existing env vars, mount a PEM, keep verification on.

## What landed

- **Helm:** `caBundle` values block (existing Secret or ConfigMap + key). Helpers next to `vigil.stateVolume` mount the PEM and set `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, and `NODE_EXTRA_CA_CERTS` on backend, daemon, llm-worker, agent-worker, and agent-serve. Agent-worker and agent-serve now have a volume stanza when a bundle is configured.
- **Compose:** the same three vars as pass-through on those five services, plus documented optional bind-mount of the operator file (no `/dev/null` dummy).
- **MCP children:** `ca_bundle_env()` also sets `NODE_EXTRA_CA_CERTS` when the resolved path is a file. Missing-path fallback is unchanged.
- **Docs:** `values.yaml` comments, `env.example`, compose. The new env.example keys are in `NOT_SETTINGS` — they are not Settings fields. `SSL_CERT_FILE` replaces the default store (include public CAs in the PEM); `NODE_EXTRA_CA_CERTS` appends.

## Out of scope (per factory groom)

No Settings / SystemConfig CA, no new disable-verify path, no Bifrost changes, no proxy env (#511), no `verify_proxy_tls` / per-integration `verify_ssl` changes, no extraVolumes-as-the-product, postgres/redis untouched.

## Verification

- `helm lint` (default + values-dev)
- `helm template` default: no CA env/volumes on any workload
- `helm template` with `caBundle.existingSecret`: all five app workloads get the three env vars + file mount; postgres/redis do not. ConfigMap path works; Secret wins if both are set
- `docker compose config`: the three vars pass through on backend, soc-daemon, llm-worker, agent-worker, agent-serve
- 16 unit tests: `tests/unit/integrations/test_mcp_child_ca_bundle.py` and `tests/unit/_ratchets/test_settings_env_example.py`
- black / isort / flake8 on the Python changes

No TLS-inspecting proxy was stood up. Independent review of the full diff approved.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a1d9dc0-517a-40d3-8762-9b08a3fea615?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a1d9dc0-517a-40d3-8762-9b08a3fea615&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

