### PR TITLE
Preserve nullable score, severity, and event time in finding ingest

### DIFF
--- a/clients/web/src/data/data.ts
+++ b/clients/web/src/data/data.ts
@@ -32,7 +32,7 @@ export const NAV: [IconName, string, ConsoleScreenKey | null, NavGate?][] = [
 
 export interface Finding {
   id: string
-  sev: 'Critical' | 'High' | 'Medium' | 'Low'
+  sev: 'Critical' | 'High' | 'Medium' | 'Low' | 'Unrated'
   tech: string
   conf: number
   tactic: string
@@ -42,13 +42,17 @@ export interface Finding {
   time: string
   /** `time` above is display-only and not safely comparable */
   ts?: number
-  score: number
+  score: number | null
   status: 'open' | 'investigating' | 'closed'
   /** entity_context keys the fixed fields don't cover. Sources disagree about
    *  these (CrowdStrike sends device_id and no dest_ips, Splunk the reverse), so
    *  they are carried through and rendered as columns derived from the rows. */
   extra?: Record<string, string>
 }
+
+export const MISSING_FINDING_SCORE = 'Not provided' as const
+export const MISSING_FINDING_SEVERITY = 'Unrated' as const
+export const MISSING_FINDING_TIME = 'Source time unavailable' as const
 
 export interface CaseRow {
   id: string

--- a/clients/web/src/data/mappers.test.ts
+++ b/clients/web/src/data/mappers.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MISSING_FINDING_SCORE,
+  MISSING_FINDING_SEVERITY,
+  MISSING_FINDING_TIME,
+} from './data'
+import { formatFindingScore, mapApiFinding } from './mappers'
+
+describe('mapApiFinding missing source fields', () => {
+  it('round-trips null score, severity, and timestamp to the console labels', () => {
+    const finding = mapApiFinding({
+      finding_id: 'f-null',
+      severity: null,
+      timestamp: null,
+      anomaly_score: null,
+      mitre_predictions: { 'Command and Control': 0.9 },
+    })
+
+    expect(finding.sev).toBe(MISSING_FINDING_SEVERITY)
+    expect(finding.score).toBeNull()
+    expect(formatFindingScore(finding.score)).toBe(MISSING_FINDING_SCORE)
+    expect(finding.time).toBe(MISSING_FINDING_TIME)
+    expect(finding.ts).toBeUndefined()
+  })
+
+  it('does not coerce an omitted score to zero or a missing severity to Medium', () => {
+    const finding = mapApiFinding({ finding_id: 'f-omitted' })
+
+    expect(finding.sev).toBe('Unrated')
+    expect(finding.score).toBeNull()
+    expect(finding.time).toBe('Source time unavailable')
+  })
+
+  it('still maps explicit medium / zero / a real timestamp', () => {
+    const finding = mapApiFinding({
+      finding_id: 'f-present',
+      severity: 'medium',
+      timestamp: '2026-07-21T12:00:00Z',
+      anomaly_score: 0,
+    })
+
+    expect(finding.sev).toBe('Medium')
+    expect(finding.score).toBe(0)
+    expect(formatFindingScore(finding.score)).toBe('0.00')
+    expect(finding.time).not.toBe(MISSING_FINDING_TIME)
+    expect(finding.ts).toBe(Date.parse('2026-07-21T12:00:00Z'))
+  })
+})

--- a/clients/web/src/data/mappers.ts
+++ b/clients/web/src/data/mappers.ts
@@ -1,5 +1,11 @@
 import { format } from 'date-fns'
-import type { CaseRow, Finding } from './data'
+import {
+  MISSING_FINDING_SCORE,
+  MISSING_FINDING_SEVERITY,
+  MISSING_FINDING_TIME,
+  type CaseRow,
+  type Finding,
+} from './data'
 import type { Schema } from '../services/apiTypes'
 import {
   prettyHandle,
@@ -18,10 +24,10 @@ export type ApiCase = Schema<'CaseSchema'>
 
 export interface ApiFinding {
   finding_id: string
-  severity?: string
+  severity?: string | null
   data_source?: string
-  timestamp?: string
-  anomaly_score?: number
+  timestamp?: string | null
+  anomaly_score?: number | null
   title?: string
   description?: string
   mitre_predictions?: Record<string, number>
@@ -99,12 +105,17 @@ function epochMs(s?: string): number | undefined {
   return Number.isNaN(d.getTime()) ? undefined : d.getTime()
 }
 
-function findingSev(s?: string): Finding['sev'] {
+function findingSev(s?: string | null): Finding['sev'] {
   const v = (s || '').toLowerCase()
   if (v === 'critical') return 'Critical'
   if (v === 'high') return 'High'
+  if (v === 'medium') return 'Medium'
   if (v === 'low') return 'Low'
-  return 'Medium'
+  return MISSING_FINDING_SEVERITY
+}
+
+export function formatFindingScore(score: number | null | undefined): string {
+  return typeof score === 'number' ? score.toFixed(2) : MISSING_FINDING_SCORE
 }
 
 /** mitre_predictions is keyed by *technique* id (e.g. "T1567.002") */
@@ -147,9 +158,9 @@ export function mapApiFinding(f: ApiFinding): Finding {
     src: f.data_source || DASH,
     host: ec?.hostnames?.[0] || DASH,
     user: ec?.usernames?.[0] || DASH,
-    time: fmt(f.timestamp, 'MMM d, HH:mm'),
-    ts: epochMs(f.timestamp),
-    score: typeof f.anomaly_score === 'number' ? f.anomaly_score : 0,
+    time: f.timestamp ? fmt(f.timestamp, 'MMM d, HH:mm') : MISSING_FINDING_TIME,
+    ts: epochMs(f.timestamp ?? undefined),
+    score: typeof f.anomaly_score === 'number' ? f.anomaly_score : null,
     status: findingStatus(f.status),
     extra: extraEntities(ec),
   }

--- a/clients/web/src/screens/dashboard/AttackTechniqueFindings.tsx
+++ b/clients/web/src/screens/dashboard/AttackTechniqueFindings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { attackApi } from '../../services/api'
-import { mapApiFinding, type ApiFinding } from '../../data/mappers'
+import { mapApiFinding, formatFindingScore, type ApiFinding } from '../../data/mappers'
 import type { Finding } from '../../data/data'
 import type { Phase } from '../cases/useCases'
 import SourceChip from '../../shared/SourceChip'
@@ -48,7 +48,7 @@ export default function AttackTechniqueFindings({ techniqueId }: { techniqueId: 
               <td><SourceChip source={f.src} /></td>
               <td><span className="mono">{f.host}</span></td>
               <td className="muted">{f.time}</td>
-              <td className="mono">{f.score.toFixed(2)}</td>
+              <td className="mono">{formatFindingScore(f.score)}</td>
             </tr>
           ))}
         </tbody>

--- a/clients/web/src/screens/dashboard/DashboardScreen.tsx
+++ b/clients/web/src/screens/dashboard/DashboardScreen.tsx
@@ -3,6 +3,7 @@ import { Icon } from '../../shared/icons'
 import { Pie, Hbars } from '../../shared/charts'
 import { useFindings, useDashboardKpis } from './useFindings'
 import type { Finding } from '../../data/data'
+import { formatFindingScore } from '../../data/mappers'
 import { useAttack } from './useAttack'
 import { useTimeline } from './useTimeline'
 import { EmptyState, FilterButton, FilterGroup } from '../../shared/ui'
@@ -61,7 +62,7 @@ function findingPrompt(f: Finding): string {
   const parts = [`${f.sev} severity`, `MITRE ${f.tech}${f.tactic !== NDASH ? ` (${f.tactic})` : ''}`, `source ${f.src}`]
   if (f.host !== NDASH) parts.push(`host ${f.host}`)
   if (f.user !== NDASH) parts.push(`user ${f.user}`)
-  parts.push(`anomaly score ${f.score.toFixed(2)}`)
+  parts.push(`anomaly score ${formatFindingScore(f.score)}`)
   return `Investigate finding ${f.id} — ${parts.join(', ')}. What happened and what should I do next?`
 }
 

--- a/clients/web/src/screens/dashboard/FindingPopup.test.tsx
+++ b/clients/web/src/screens/dashboard/FindingPopup.test.tsx
@@ -30,6 +30,30 @@ function openFinding(entityContext: Record<string, unknown>) {
   return render(<FindingPopup id="f-source-1" onClose={vi.fn()} />)
 }
 
+describe('FindingPopup missing source fields', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders Unrated, Not provided, and Source time unavailable when those fields are missing', async () => {
+    vi.mocked(findingsApi.getById).mockResolvedValueOnce({
+      data: {
+        finding_id: 'f-null',
+        severity: null,
+        timestamp: null,
+        anomaly_score: null,
+        status: 'new',
+        mitre_predictions: {},
+        entity_context: {},
+      },
+    } as never)
+
+    render(<FindingPopup id="f-null" onClose={vi.fn()} />)
+
+    expect(await screen.findByText('Unrated')).toBeInTheDocument()
+    expect(screen.getByText('Not provided')).toBeInTheDocument()
+    expect(screen.getByText('Source time unavailable')).toBeInTheDocument()
+  })
+})
+
 describe('FindingPopup source evidence', () => {
   beforeEach(() => vi.clearAllMocks())
 

--- a/clients/web/src/screens/dashboard/FindingPopup.tsx
+++ b/clients/web/src/screens/dashboard/FindingPopup.tsx
@@ -2,7 +2,7 @@
    the VStrike provider, which isn't mounted under the console shell. */
 import { useEffect, useState } from 'react'
 import { findingsApi } from '../../services/api'
-import { mapApiFinding, type ApiFinding } from '../../data/mappers'
+import { mapApiFinding, formatFindingScore, type ApiFinding } from '../../data/mappers'
 import { techniqueName } from '../../data/mitre'
 import { ConfirmDialog, EmptyState, Popup, Select } from '../../shared/ui'
 import { Icon } from '../../shared/icons'
@@ -314,7 +314,7 @@ export default function FindingPopup({
             </div>
             <div className="fp-metrics">
               <div className="fp-metric"><span className="fp-m-val">{f.conf}%</span><span className="fp-m-lab">confidence</span></div>
-              <div className="fp-metric"><span className="fp-m-val">{f.score.toFixed(2)}</span><span className="fp-m-lab">anomaly</span></div>
+              <div className="fp-metric"><span className="fp-m-val">{formatFindingScore(f.score)}</span><span className="fp-m-lab">anomaly</span></div>
             </div>
           </div>
 

--- a/clients/web/src/screens/dashboard/findingsColumns.tsx
+++ b/clients/web/src/screens/dashboard/findingsColumns.tsx
@@ -1,21 +1,19 @@
 import { Icon } from '../../shared/icons'
 import SourceChip from '../../shared/SourceChip'
 import type { ColumnDef } from '../../shared/DataTable'
-import type { Finding } from '../../data/data'
+import { MISSING_FINDING_SCORE, type Finding } from '../../data/data'
+import { formatFindingScore } from '../../data/mappers'
 
 const NDASH = '—'
 
-const SEV_RANK: Record<Finding['sev'], number> = { Critical: 4, High: 3, Medium: 2, Low: 1 }
+const SEV_RANK: Record<Finding['sev'], number> = {
+  Critical: 4, High: 3, Medium: 2, Low: 1, Unrated: 0,
+}
 const STATUS_RANK: Record<Finding['status'], number> = { open: 0, investigating: 1, closed: 2 }
 
-/** comparable time key: findings normally carry epoch-ms `ts`; when it's
- *  missing, fall back to the YYYYMMDD in the id plus HH:MM from the display string */
+/** comparable time key: epoch-ms `ts` when the source supplied a time */
 function timeKey(f: Finding): number {
-  if (typeof f.ts === 'number') return f.ts
-  const d = /(\d{8})/.exec(f.id)?.[1]
-  if (!d) return 0
-  const t = /(\d{1,2}):(\d{2})/.exec(f.time)
-  return Number(d) * 10000 + (t ? Number(t[1]) * 100 + Number(t[2]) : 0)
+  return typeof f.ts === 'number' ? f.ts : 0
 }
 
 function labelFor(key: string): string {
@@ -66,12 +64,16 @@ export function baseFindingColumns(
     {
       key: 'score', label: 'Score',
       render: (f) => (
-        <span className="scorebar">
-          <span className="track"><i className={f.score >= 0.8 ? 'hot' : ''} style={{ width: `${f.score * 100}%` }} /></span>
-          <span className="num">{f.score.toFixed(2)}</span>
-        </span>
+        typeof f.score === 'number' ? (
+          <span className="scorebar">
+            <span className="track"><i className={f.score >= 0.8 ? 'hot' : ''} style={{ width: `${f.score * 100}%` }} /></span>
+            <span className="num">{formatFindingScore(f.score)}</span>
+          </span>
+        ) : (
+          <span className="muted">{MISSING_FINDING_SCORE}</span>
+        )
       ),
-      sortVal: (f) => f.score, defaultDir: 'desc',
+      sortVal: (f) => f.score ?? Number.NEGATIVE_INFINITY, defaultDir: 'desc',
     },
     {
       key: 'status', label: 'Status',

--- a/clients/web/src/screens/dashboard/findingsExport.ts
+++ b/clients/web/src/screens/dashboard/findingsExport.ts
@@ -14,10 +14,11 @@ const FIXED_HEADERS = [
   'status',
 ]
 
-function csvCell(value: string | number): string {
+function csvCell(value: string | number | null): string {
   // CSV escaping does not stop spreadsheet formula execution. Finding fields
   // can originate in attacker-controlled telemetry, so make formula-looking
   // strings literal before they reach Excel or similar tools.
+  if (value == null) return ''
   const text = typeof value === 'string' && /^\s*[=+\-@]/.test(value)
     ? `'${value}`
     : String(value)
@@ -29,12 +30,12 @@ function timestamp(finding: Finding): string {
     const date = new Date(finding.ts)
     if (!Number.isNaN(date.getTime())) return date.toISOString()
   }
-  return finding.time
+  return ''
 }
 
 export function buildFindingsCsv(findings: Finding[]): string {
   const extraKeys = [...new Set(findings.flatMap((finding) => Object.keys(finding.extra ?? {})))].sort()
-  const rows: (string | number)[][] = [
+  const rows: (string | number | null)[][] = [
     [...FIXED_HEADERS, ...extraKeys],
     ...findings.map((finding) => [
       finding.id,

--- a/clients/web/src/styles.css
+++ b/clients/web/src/styles.css
@@ -789,6 +789,14 @@
       background: var(--ok);
    }
 
+   .sev.unrated {
+      color: var(--tx-2);
+   }
+
+   .sev.unrated .dot {
+      background: var(--tx-3);
+   }
+
    .tag {
       font-size: 11.5px;
       font-weight: 500;

--- a/core/ingestion/ingestion_service.py
+++ b/core/ingestion/ingestion_service.py
@@ -15,11 +15,12 @@ import csv
 import hashlib
 import json
 import logging
+import math
 import tempfile
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 from core.findings.source_evidence import (
     normalize_finding_source_evidence,
@@ -85,6 +86,25 @@ def _first_present(row: Dict[str, Any], aliases: tuple) -> Any:
         if row.get(alias) is not None:
             return row[alias]
     return None
+
+
+def _optional_float(value: Any) -> Optional[float]:
+    """Parse a numeric field; missing, empty, and NaN stay None."""
+    if value is None or value == "":
+        return None
+    parsed = float(value)
+    if math.isnan(parsed):
+        return None
+    return parsed
+
+
+def _content_finding_id(unique_key: str, event_ts: Optional[datetime] = None) -> str:
+    """Stable f-prefixed id. Omit the date segment when source time is absent
+    so a later reimport does not mint a new id from the ingest clock."""
+    id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:ID_HASH_WIDTH]
+    if event_ts is None:
+        return f"f-{id_hash}"
+    return f"f-{event_ts.strftime('%Y%m%d')}-{id_hash}"
 
 
 def row_identity_key(row: Dict[str, Any], columns: tuple) -> str:
@@ -156,31 +176,32 @@ class IngestionService:
         for key in self.stats:
             self.stats[key] = 0
 
-    def parse_timestamp(self, timestamp_value: Any) -> datetime:
+    def parse_timestamp(self, timestamp_value: Any) -> Optional[datetime]:
         """
         Parse various timestamp formats to datetime.
 
-        Args:
-            timestamp_value: Timestamp as string, int, or datetime
-
-        Returns:
-            datetime object
+        Missing or unparseable values stay None — a synthesized ingest-time
+        clock is not source time and would break reimport identity.
         """
         if isinstance(timestamp_value, datetime):
             return timestamp_value
 
-        if not timestamp_value:
-            return utcnow()
+        if timestamp_value is None or timestamp_value == "":
+            return None
 
         # If it's a Unix timestamp (int or float)
         if isinstance(timestamp_value, (int, float)):
+            if isinstance(timestamp_value, float) and math.isnan(timestamp_value):
+                return None
             try:
                 return datetime.fromtimestamp(timestamp_value)
             except (ValueError, OSError):
                 pass
 
         # Try various string formats
-        timestamp_str = str(timestamp_value)
+        timestamp_str = str(timestamp_value).strip()
+        if not timestamp_str:
+            return None
         formats = [
             "%Y-%m-%dT%H:%M:%S.%fZ",
             "%Y-%m-%dT%H:%M:%S.%f%z",
@@ -198,10 +219,8 @@ class IngestionService:
             except ValueError:
                 continue
 
-        logger.warning(
-            f"Could not parse timestamp: {timestamp_value}, using current time"
-        )
-        return utcnow()
+        logger.warning(f"Could not parse timestamp: {timestamp_value}, leaving unset")
+        return None
 
     def ingest_finding(self, finding_data: Dict[str, Any]) -> bool:
         """
@@ -230,14 +249,13 @@ class IngestionService:
                     self.stats["findings_skipped"] += 1
                     return True
 
-                # Parse timestamp
                 timestamp = self.parse_timestamp(finding_data.get("timestamp"))
 
                 # Create finding in database
                 finding = self.db_service.create_finding(
                     finding_id=finding_id,
                     mitre_predictions=finding_data.get("mitre_predictions", {}),
-                    anomaly_score=float(finding_data.get("anomaly_score", 0.0)),
+                    anomaly_score=_optional_float(finding_data.get("anomaly_score")),
                     timestamp=timestamp,
                     data_source=finding_data.get("data_source", "imported"),
                     external_id=finding_data.get("external_id"),
@@ -303,8 +321,8 @@ class IngestionService:
                 finding_data["timestamp"] = self.parse_timestamp(
                     finding_data.get("timestamp")
                 )
-                finding_data["anomaly_score"] = float(
-                    finding_data.get("anomaly_score", 0.0)
+                finding_data["anomaly_score"] = _optional_float(
+                    finding_data.get("anomaly_score")
                 )
             except Exception as e:
                 logger.error(
@@ -662,13 +680,13 @@ class IngestionService:
         return {
             "finding_id": finding_id,
             "mitre_predictions": mitre_predictions,
-            "anomaly_score": float(row.get("anomaly_score", 0.0)),
-            "timestamp": row.get("timestamp", utcnow().isoformat()),
+            "anomaly_score": _optional_float(row.get("anomaly_score")),
+            "timestamp": row.get("timestamp") or None,
             "data_source": row.get("data_source", "csv_import"),
             "entity_context": entity_context,
             "evidence_links": None,
             "cluster_id": row.get("cluster_id"),
-            "severity": row.get("severity"),
+            "severity": row.get("severity") or None,
             "status": row.get("status", "new"),
         }
 
@@ -682,11 +700,7 @@ class IngestionService:
         """
         sequence_id = str(row.get("sequence_id") or "").strip()
 
-        # Parse event_start as timestamp
-        event_start_str = row.get("event_start", "")
-        event_ts = (
-            self.parse_timestamp(event_start_str) if event_start_str else utcnow()
-        )
+        event_ts = self.parse_timestamp(row.get("event_start"))
 
         # sequence_id + attack_id keeps the same sequence distinct across
         # attack clusters; content identity covers rows carrying neither.
@@ -697,8 +711,7 @@ class IngestionService:
             unique_key = self._identity_fallback(
                 row, TEMPO_CSV_IDENTITY_COLUMNS, "sequence_id"
             )
-        id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:ID_HASH_WIDTH]
-        finding_id = f"f-{event_ts.strftime('%Y%m%d')}-{id_hash}"
+        finding_id = _content_finding_id(unique_key, event_ts)
 
         # MITRE tactic comes as a name (e.g. "Command and Control")
         mitre_predictions = {}
@@ -706,28 +719,22 @@ class IngestionService:
         if mitre_tactic:
             mitre_predictions[mitre_tactic] = 1.0
 
-        # incident_confidence is 0-100 scale; normalise to 0-1
-        raw_confidence = float(row.get("incident_confidence", 0))
-        anomaly_score = (
-            raw_confidence / 100.0 if raw_confidence > 1.0 else raw_confidence
-        )
-
-        # Derive severity from anomaly score
-        if anomaly_score >= 0.9:
-            severity = "critical"
-        elif anomaly_score >= 0.7:
-            severity = "high"
-        elif anomaly_score >= 0.4:
-            severity = "medium"
+        # incident_confidence is 0-100 scale; normalise to 0-1 when present
+        raw_confidence = _optional_float(row.get("incident_confidence"))
+        if raw_confidence is None:
+            anomaly_score = None
         else:
-            severity = "low"
+            anomaly_score = (
+                raw_confidence / 100.0 if raw_confidence > 1.0 else raw_confidence
+            )
 
         entity_context = {
             "src_ip": row.get("IP1", "").strip() or None,
             "dst_ip": row.get("IP2", "").strip() or None,
             "sequence_id": sequence_id,
-            "confidence_score": anomaly_score,
         }
+        if anomaly_score is not None:
+            entity_context["confidence_score"] = anomaly_score
         event_end_str = row.get("event_end", "")
         if event_end_str:
             entity_context["event_end"] = event_end_str
@@ -746,12 +753,12 @@ class IngestionService:
             "finding_id": finding_id,
             "mitre_predictions": mitre_predictions,
             "anomaly_score": anomaly_score,
-            "timestamp": event_ts.isoformat(),
+            "timestamp": event_ts.isoformat() if event_ts is not None else None,
             "data_source": row.get("data_source", "csv_import"),
             "entity_context": entity_context,
             "evidence_links": None,
             "cluster_id": cluster_id,
-            "severity": severity,
+            "severity": row.get("severity") or None,
             "status": "new",
         }
 
@@ -886,25 +893,22 @@ class IngestionService:
         """
         sequence_id = str(row.get("sequence_id") or "")
 
-        # Derive event timestamp from event_start_time (epoch milliseconds)
+        # event_start_time is epoch milliseconds when the source supplies it
         event_start_ms = row.get("event_start_time")
         if event_start_ms is not None:
             event_ts = datetime.utcfromtimestamp(int(event_start_ms) / 1000.0)
         else:
-            event_ts = utcnow()
+            event_ts = None
 
         unique_key = sequence_id or self._identity_fallback(
             row, PARQUET_IDENTITY_COLUMNS, "sequence_id"
         )
-        id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:ID_HASH_WIDTH]
-        finding_id = f"f-{event_ts.strftime('%Y%m%d')}-{id_hash}"
+        finding_id = _content_finding_id(unique_key, event_ts)
 
         # MITRE predictions from logits (softmax) when available, else from argmax label
         mitre_predictions = {}
         mitre_logits = row.get("mitre_logits")
         if mitre_logits is not None and len(mitre_logits) > 0:
-            import math
-
             max_l = max(mitre_logits)
             exps = [math.exp(logit - max_l) for logit in mitre_logits]
             total = sum(exps)
@@ -920,30 +924,16 @@ class IngestionService:
             else:
                 mitre_predictions[f"mitre_class_{int(mitre_pred)}"] = 1.0
 
-        # Severity from incident_pred (1=attack, 0=benign)
-        incident_pred = int(row.get("incident_pred", 0))
-        is_attack = incident_pred == 1
-
-        # anomaly_score from confidence_score if available, else derive from incident_pred
-        confidence = row.get("confidence_score")
-        if confidence is not None:
-            anomaly_score = float(confidence)
-        else:
-            anomaly_score = 0.85 if is_attack else 0.15
-
-        if is_attack:
-            severity = "critical" if anomaly_score >= 0.9 else "high"
-        else:
-            severity = "medium" if anomaly_score >= 0.5 else "low"
+        anomaly_score = _optional_float(row.get("confidence_score"))
 
         # Build entity_context with all available metadata
         entity_context = {
             "src_ip": row.get("focal_ip"),
             "dst_ip": row.get("engaged_ip"),
-            "incident_pred": incident_pred,
-            "confidence_score": anomaly_score,
             "sequence_id": sequence_id,
         }
+        if anomaly_score is not None:
+            entity_context["confidence_score"] = anomaly_score
 
         if row.get("event_start_time") is not None:
             entity_context["event_start_time"] = int(row["event_start_time"])
@@ -966,12 +956,12 @@ class IngestionService:
             "finding_id": finding_id,
             "mitre_predictions": mitre_predictions,
             "anomaly_score": anomaly_score,
-            "timestamp": event_ts.isoformat(),
+            "timestamp": event_ts.isoformat() if event_ts is not None else None,
             "data_source": data_source,
             "entity_context": entity_context,
             "evidence_links": None,
             "cluster_id": cluster_id,
-            "severity": severity,
+            "severity": row.get("severity") or None,
             "status": "new",
         }
 
@@ -986,13 +976,10 @@ class IngestionService:
     ) -> Dict[str, Any]:
         """Unscored finding shell for a schema with no known column layout."""
         timestamp = _first_present(row, ENTITY_FIELD_ALIASES["timestamp"])
-        event_ts = (
-            self.parse_timestamp(timestamp) if timestamp is not None else utcnow()
-        )
+        event_ts = self.parse_timestamp(timestamp) if timestamp is not None else None
 
         unique_key = row_identity_key(row, tuple(sorted(row.keys())))
-        id_hash = hashlib.sha256(unique_key.encode()).hexdigest()[:ID_HASH_WIDTH]
-        finding_id = f"f-{event_ts.strftime('%Y%m%d')}-{id_hash}"
+        finding_id = _content_finding_id(unique_key, event_ts)
 
         entity_context = {
             "src_ip": _first_present(row, ENTITY_FIELD_ALIASES["src_ip"]),
@@ -1006,13 +993,13 @@ class IngestionService:
         return {
             "finding_id": finding_id,
             "mitre_predictions": {},
-            "anomaly_score": 0.0,
-            "timestamp": event_ts.isoformat(),
+            "anomaly_score": _optional_float(row.get("anomaly_score")),
+            "timestamp": event_ts.isoformat() if event_ts is not None else None,
             "data_source": data_source,
             "entity_context": entity_context,
             "evidence_links": None,
             "cluster_id": None,
-            "severity": None,
+            "severity": row.get("severity") or None,
             "status": "unscored",
         }
 

--- a/core/storage/database_data_service.py
+++ b/core/storage/database_data_service.py
@@ -4,7 +4,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from core.config import is_demo_mode, vigil_path
 from core.exceptions import DatabaseError
@@ -22,6 +22,23 @@ logger = logging.getLogger(__name__)
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 FINDINGS_FILE = DATA_DIR / "findings.json"
 CASES_FILE = DATA_DIR / "cases.json"
+
+
+def _optional_score(value: Any) -> Optional[float]:
+    """Parse a score; missing, empty, and NaN stay None (do not coerce to 0.0)."""
+    if value is None or value == "":
+        return None
+    parsed = float(value)
+    if parsed != parsed:
+        return None
+    return parsed
+
+
+def _score_at_least(finding: Dict, minimum: float) -> bool:
+    """True when a finding's score is present and meets the floor. Null scores
+    are excluded, matching SQL `anomaly_score >= minimum` (NULL is not true)."""
+    score = finding.get("anomaly_score")
+    return score is not None and score >= minimum
 
 
 class DatabaseDataService:
@@ -198,9 +215,7 @@ class DatabaseDataService:
                 findings = [f for f in findings if f.get("cluster_id") == cluster_id]
             if min_anomaly_score is not None:
                 findings = [
-                    f
-                    for f in findings
-                    if f.get("anomaly_score", 0) >= min_anomaly_score
+                    f for f in findings if _score_at_least(f, min_anomaly_score)
                 ]
             if status:
                 findings = [f for f in findings if f.get("status") == status]
@@ -269,9 +284,7 @@ class DatabaseDataService:
                 findings = [f for f in findings if f.get("cluster_id") == cluster_id]
             if min_anomaly_score is not None:
                 findings = [
-                    f
-                    for f in findings
-                    if f.get("anomaly_score", 0) >= min_anomaly_score
+                    f for f in findings if _score_at_least(f, min_anomaly_score)
                 ]
             if status:
                 findings = [f for f in findings if f.get("status") == status]
@@ -365,8 +378,8 @@ class DatabaseDataService:
                 finding = self._db_service.create_finding(
                     finding_id=finding_data.get("finding_id"),
                     mitre_predictions=finding_data.get("mitre_predictions", {}),
-                    anomaly_score=float(finding_data.get("anomaly_score", 0.0)),
-                    timestamp=finding_data.get("timestamp", utcnow()),
+                    anomaly_score=_optional_score(finding_data.get("anomaly_score")),
+                    timestamp=finding_data.get("timestamp") or None,
                     data_source=finding_data.get("data_source", "imported"),
                     description=finding_data.get("description"),
                     entity_context=finding_data.get("entity_context"),
@@ -764,10 +777,10 @@ class DatabaseDataService:
                                     mitre_predictions=finding.get(
                                         "mitre_predictions", {}
                                     ),
-                                    anomaly_score=float(
-                                        finding.get("anomaly_score", 0.0)
+                                    anomaly_score=_optional_score(
+                                        finding.get("anomaly_score")
                                     ),
-                                    timestamp=finding.get("timestamp", utcnow()),
+                                    timestamp=finding.get("timestamp") or None,
                                     data_source=finding.get("data_source", "s3_import"),
                                     entity_context=finding.get("entity_context"),
                                     evidence_links=finding.get("evidence_links"),

--- a/core/storage/models.py
+++ b/core/storage/models.py
@@ -90,7 +90,7 @@ class Finding(Base):
     # Primary key
     finding_id: Mapped[str] = mapped_column(String(50), primary_key=True)
 
-    anomaly_score: Mapped[float] = mapped_column(Float, nullable=False)
+    anomaly_score: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
     # Human-readable description (populated from ingestion or synthesized from entity_context)
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -102,7 +102,7 @@ class Finding(Base):
     evidence_links: Mapped[Optional[List[dict]]] = mapped_column(JSONB, nullable=True)
 
     # Metadata
-    timestamp: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    timestamp: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     data_source: Mapped[str] = mapped_column(String(50), nullable=False)
     # Source-native ID. Combined with data_source it forms the dedup key
     # for federated ingest (see uniq_findings_source_extid).

--- a/core/storage/service.py
+++ b/core/storage/service.py
@@ -82,8 +82,8 @@ class DatabaseService:
         self,
         finding_id: str,
         mitre_predictions: dict,
-        anomaly_score: float,
-        timestamp: datetime,
+        anomaly_score: Optional[float],
+        timestamp: Optional[datetime],
         data_source: str,
         **kwargs,
     ) -> Optional[Finding]:
@@ -93,8 +93,8 @@ class DatabaseService:
         Args:
             finding_id: Unique finding ID
             mitre_predictions: MITRE ATT&CK predictions
-            anomaly_score: Anomaly score (0-1)
-            timestamp: Finding timestamp
+            anomaly_score: Anomaly score (0-1), or None when the source omitted it
+            timestamp: Finding timestamp, or None when the source omitted it
             data_source: Data source type
             **kwargs: Additional fields (entity_context, evidence_links, cluster_id, severity, status)
 
@@ -144,8 +144,8 @@ class DatabaseService:
                     r = by_id[finding_id]
                     finding = Finding(
                         finding_id=finding_id,
-                        anomaly_score=r.get("anomaly_score", 0.0),
-                        timestamp=r["timestamp"],
+                        anomaly_score=r.get("anomaly_score"),
+                        timestamp=r.get("timestamp"),
                         data_source=r.get("data_source", "imported"),
                         external_id=r.get("external_id"),
                         description=r.get("description"),

--- a/infra/database/init/25_nullable_finding_score_timestamp.sql
+++ b/infra/database/init/25_nullable_finding_score_timestamp.sql
@@ -1,0 +1,35 @@
+-- Allow findings.anomaly_score and findings.timestamp to be NULL.
+--
+-- LogLM rows can carry a classification and embedding without a sequence-level
+-- score or event time. Ingest used to invent 0.0 / utcnow() because these
+-- columns were NOT NULL. Severity is already nullable.
+--
+-- A NEW migration file (not edits to 01_init_schema.sql) is what reaches
+-- existing deployments: dbInit only runs a filename it hasn't applied before.
+-- Idempotent and self-guarding: safe to re-run, safe when the findings table
+-- is absent (fresh install).
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables WHERE table_name = 'findings'
+    ) THEN
+        RAISE NOTICE '25_nullable_finding_score_timestamp: findings table absent (fresh DB), nothing to alter';
+        RETURN;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'findings' AND column_name = 'anomaly_score'
+    ) THEN
+        ALTER TABLE findings ALTER COLUMN anomaly_score DROP NOT NULL;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'findings' AND column_name = 'timestamp'
+    ) THEN
+        ALTER TABLE findings ALTER COLUMN timestamp DROP NOT NULL;
+    END IF;
+    RAISE NOTICE '25_nullable_finding_score_timestamp: anomaly_score and timestamp are nullable';
+END $$;

--- a/infra/helm/vigil/files/database-init/25_nullable_finding_score_timestamp.sql
+++ b/infra/helm/vigil/files/database-init/25_nullable_finding_score_timestamp.sql
@@ -1,0 +1,35 @@
+-- Allow findings.anomaly_score and findings.timestamp to be NULL.
+--
+-- LogLM rows can carry a classification and embedding without a sequence-level
+-- score or event time. Ingest used to invent 0.0 / utcnow() because these
+-- columns were NOT NULL. Severity is already nullable.
+--
+-- A NEW migration file (not edits to 01_init_schema.sql) is what reaches
+-- existing deployments: dbInit only runs a filename it hasn't applied before.
+-- Idempotent and self-guarding: safe to re-run, safe when the findings table
+-- is absent (fresh install).
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables WHERE table_name = 'findings'
+    ) THEN
+        RAISE NOTICE '25_nullable_finding_score_timestamp: findings table absent (fresh DB), nothing to alter';
+        RETURN;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'findings' AND column_name = 'anomaly_score'
+    ) THEN
+        ALTER TABLE findings ALTER COLUMN anomaly_score DROP NOT NULL;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'findings' AND column_name = 'timestamp'
+    ) THEN
+        ALTER TABLE findings ALTER COLUMN timestamp DROP NOT NULL;
+    END IF;
+    RAISE NOTICE '25_nullable_finding_score_timestamp: anomaly_score and timestamp are nullable';
+END $$;

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -412,6 +412,7 @@ dbInit:
     - 22_workflow_run_deleted.sql
     - 23_drop_finding_embedding.sql
     - 24_finding_mitre_predictions.sql
+    - 25_nullable_finding_score_timestamp.sql
   resources:
     requests:
       cpu: 50m

--- a/tests/unit/ingestion/test_ingestion_nullable_fields.py
+++ b/tests/unit/ingestion/test_ingestion_nullable_fields.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from core.ingestion.ingestion_service import (  # noqa: E402
+    ID_HASH_WIDTH,
+    IngestionService,
+)
+from core.storage.database_data_service import _score_at_least  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def service():
+    return IngestionService()
+
+
+def _parquet_classified(**overrides):
+    """LogLM row with a classification and embedding but no score/time/severity."""
+    row = {
+        "sequence_id": "seq-null-fields",
+        "mitre_pred": 7,
+        "embedding": [0.1, 0.2, 0.3],
+        "focal_ip": "10.0.0.1",
+        "engaged_ip": "10.0.0.2",
+    }
+    row.update(overrides)
+    return row
+
+
+class _CaptureDb:
+    def __init__(self):
+        self.created: Dict[str, Any] = {}
+        self.batch: List[Dict[str, Any]] = []
+
+    def get_finding(self, finding_id):
+        return None
+
+    def create_finding(self, **kwargs):
+        self.created.update(kwargs)
+        return object()
+
+    def bulk_create_findings(self, rows):
+        self.batch.extend(rows)
+        return {"imported": len(rows), "skipped": 0}
+
+
+def test_parquet_null_score_severity_and_time_stay_null(service):
+    finding = service._parquet_row_to_finding(_parquet_classified())
+
+    assert finding["anomaly_score"] is None
+    assert finding["severity"] is None
+    assert finding["timestamp"] is None
+    assert finding["mitre_predictions"]["Command and Control"] == 1.0
+
+
+def test_parquet_does_not_derive_score_or_severity_from_incident_pred(service):
+    finding = service._parquet_row_to_finding(
+        _parquet_classified(incident_pred=1, confidence_score=None)
+    )
+
+    assert finding["anomaly_score"] is None
+    assert finding["severity"] is None
+    assert finding["entity_context"]["incident_pred"] == 1
+    assert "confidence_score" not in finding["entity_context"]
+
+
+def test_tempo_csv_null_confidence_and_time_stay_null(service):
+    finding = service._tempo_csv_row_to_finding(
+        {
+            "sequence_id": "s-1",
+            "mitre_tactic": "Command and Control",
+            "IP1": "10.0.0.1",
+            "IP2": "10.0.0.2",
+        }
+    )
+
+    assert finding["anomaly_score"] is None
+    assert finding["severity"] is None
+    assert finding["timestamp"] is None
+    assert finding["mitre_predictions"] == {"Command and Control": 1.0}
+
+
+def test_generic_row_does_not_invent_score_or_time(service):
+    finding = service._generic_row_to_finding({"src_ip": "10.0.0.1"})
+
+    assert finding["anomaly_score"] is None
+    assert finding["timestamp"] is None
+    assert finding["severity"] is None
+
+
+def test_parse_timestamp_leaves_missing_and_unparseable_as_none(service):
+    assert service.parse_timestamp(None) is None
+    assert service.parse_timestamp("") is None
+    assert service.parse_timestamp("not-a-time") is None
+
+
+def test_missing_event_time_id_is_stable_across_days(service, monkeypatch):
+    row = _parquet_classified()
+
+    monkeypatch.setattr(
+        "core.ingestion.ingestion_service.utcnow",
+        lambda: datetime(2026, 1, 1),
+    )
+    first = service._parquet_row_to_finding(row)["finding_id"]
+
+    monkeypatch.setattr(
+        "core.ingestion.ingestion_service.utcnow",
+        lambda: datetime(2026, 9, 3),
+    )
+    second = service._parquet_row_to_finding(row)["finding_id"]
+
+    assert first == second
+    assert first.startswith("f-")
+    assert "20260101" not in first
+    assert "20260903" not in first
+    assert len(first.rsplit("-", 1)[1]) == ID_HASH_WIDTH
+
+
+def test_distinct_null_time_rows_do_not_collapse(service):
+    a = service._parquet_row_to_finding(_parquet_classified(sequence_id="seq-a"))
+    b = service._parquet_row_to_finding(_parquet_classified(sequence_id="seq-b"))
+
+    assert a["finding_id"] != b["finding_id"]
+
+
+def test_ingest_finding_persists_null_score_severity_and_time(service):
+    db = _CaptureDb()
+    service.use_database = True
+    service.db_service = db
+
+    ok = service.ingest_finding(
+        {
+            "finding_id": "f-null-roundtrip",
+            "mitre_predictions": {"Command and Control": 0.9},
+            "anomaly_score": None,
+            "timestamp": None,
+            "severity": None,
+            "data_source": "flow",
+        }
+    )
+
+    assert ok is True
+    assert db.created["anomaly_score"] is None
+    assert db.created["timestamp"] is None
+    assert db.created["severity"] is None
+
+
+def test_batch_ingest_does_not_fill_null_score_or_time(service):
+    db = _CaptureDb()
+    service.use_database = True
+    service.db_service = db
+
+    service._ingest_finding_batch(
+        [
+            {
+                "finding_id": "f-null-batch",
+                "anomaly_score": None,
+                "timestamp": None,
+                "severity": None,
+            }
+        ]
+    )
+
+    assert db.batch[0]["anomaly_score"] is None
+    assert db.batch[0]["timestamp"] is None
+    assert db.batch[0]["severity"] is None
+
+
+def test_json_min_anomaly_score_excludes_null_scores():
+    rows = [
+        {"finding_id": "scored", "anomaly_score": 0.9},
+        {"finding_id": "missing-key"},
+        {"finding_id": "explicit-null", "anomaly_score": None},
+        {"finding_id": "zero", "anomaly_score": 0.0},
+    ]
+
+    kept = [f["finding_id"] for f in rows if _score_at_least(f, 0.0)]
+
+    assert kept == ["scored", "zero"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #503

## What

A LogLM row with a classification and embedding but no sequence-level score, severity, or event time now round-trips those fields as null instead of inventing `utcnow()`, `0.85`/`0.15`, or a score-derived severity.

- **Ingest:** `_parquet_row_to_finding`, `_tempo_csv_row_to_finding`, `_generic_row_to_finding`, `parse_timestamp`, `ingest_finding`, and `_ingest_finding_batch` leave missing score/time/severity as `None`.
- **Persist:** `Finding.anomaly_score` and `Finding.timestamp` are nullable. `create_finding` / `bulk_create_findings` / `DatabaseDataService.create_finding` no longer coerce `0.0` or now.
- **Identity:** when source time is absent, content ids stay `f-{16 hex}` with no ingest-date segment, so reimport still dedupes. `ID_HASH_WIDTH` is unchanged.
- **Filters:** JSON `min_anomaly_score` excludes null scores the same way SQL `>=` already does.
- **Console:** missing score → "Not provided", missing severity → "Unrated", missing timestamp → "Source time unavailable".

New dbInit `25_nullable_finding_score_timestamp.sql` (Helm `sqlFiles` included) DROPs NOT NULL on those two columns. Severity was already nullable.

## Out of scope (per factory groom)

- No embedding / ANN column, no 128-bit ids, no private-workspace config, no second MITRE tactics model.
- `source_evidence.py`, `similarity.py`, and `FindingMitrePrediction` left alone.
- VStrike's "timestamp + anomaly_score required on create" contract in `vstrike.py` left alone.

## Note on existing untimed rows

Rows ingested before this change with a synthesized `f-YYYYMMDD-{hash}` will not collide with the new `f-{hash}` form. Reimport of the same untimed file after deploy creates a new finding until the old row is removed.

## Test plan

- [x] `pytest tests/unit/ingestion/test_ingestion_nullable_fields.py tests/unit/ingestion/test_ingestion_finding_ids.py` — null round-trip, stable untimed ids, distinct rows, persist does not fill nulls
- [x] Frontend: mapper labels, FindingPopup renders Unrated / Not provided / Source time unavailable, findings columns/export
- [x] `tsc --noEmit`, eslint on touched files, black/isort/flake8 on touched Python
- [x] Helm init tree matches `infra/database/init/`; `25_…sql` listed in `dbInit.sqlFiles`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b8a0cca-97a6-41af-857a-fb3105edd114?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b8a0cca-97a6-41af-857a-fb3105edd114&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

