### PR TITLE
Add completed-hunt evidence pack for the Compliance agent

### DIFF
--- a/core/agents/builtins.py
+++ b/core/agents/builtins.py
@@ -374,12 +374,17 @@ Confidence scoring:
         "color": "#C7CEEA",
         "description": "Compliance monitoring and policy validation",
         "specialization": "Compliance & Policy",
-        "recommended_tools": ["list_findings", "get_finding", "list_cases"],
+        "recommended_tools": [
+            "list_findings",
+            "get_finding",
+            "list_cases",
+            "list_completed_hunts",
+        ],
         "max_tokens": 4096,
         "enable_thinking": False,
         "extra_principles": "- Document for compliance audits\n- Map findings to framework controls\n- Prioritize high-risk violations\n- Memory: mempalace_add_drawer all framework mappings to wing=compliance/control-mapping; mempalace_diary_write compliance decisions for audit trail",
         "methodology": """<methodology>
-1. Gather evidence via MCP tools
+1. Gather evidence via MCP tools; for an assessment window call list_completed_hunts
 2. Identify policy violations and assess severity
 3. Map to frameworks: NIST CSF, ISO 27001, CIS Controls, PCI-DSS, HIPAA, GDPR, SOC 2
 4. Evaluate control effectiveness

--- a/core/agents/projections.py
+++ b/core/agents/projections.py
@@ -4,12 +4,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from core.config import get_settings
 from core.secrets import get_secret
+from core.workflows.workflow_run_service import LIST_RUNS_MAX, WorkflowRunService
 
 logger = logging.getLogger(__name__)
 
@@ -86,3 +89,40 @@ async def write_narrative(run_id: str) -> Dict[str, Any]:
         detail = response.text[:400]
         raise RuntimeError(f"the agent layer answered {response.status_code}: {detail}")
     return response.json()
+
+
+THREAT_HUNT_WORKFLOW_ID = "threat-hunt"
+
+
+def parse_window_instant(value: str) -> datetime:
+    """ISO-8601 to naive UTC, matching workflow_runs columns."""
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is not None:
+        return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+# Completed threat-hunt projections for an assessment window. The projection is
+# the pack: hypotheses (with provenance), evidence provenance, verdict, checkpoint
+# resolutions, timestamps. A missing projection is skipped, not folded from
+# agent_events.
+async def pack_completed_hunts(
+    *, start: str, end: str, limit: int = LIST_RUNS_MAX
+) -> Dict[str, Any]:
+    started_at = parse_window_instant(start)
+    finished_at = parse_window_instant(end)
+    if started_at > finished_at:
+        raise ValueError("start must be at or before end")
+    cap = max(1, min(int(limit), LIST_RUNS_MAX))
+    runs = WorkflowRunService().list_runs(
+        workflow_id=THREAT_HUNT_WORKFLOW_ID,
+        status="completed",
+        started_at=started_at,
+        finished_at=finished_at,
+        limit=cap,
+    )
+    projections = await asyncio.gather(
+        *(read_projection(run["run_id"]) for run in runs)
+    )
+    hunts = [projection for projection in projections if projection is not None]
+    return {"start": start, "end": end, "hunts": hunts}

--- a/core/agents/projections.py
+++ b/core/agents/projections.py
@@ -92,37 +92,60 @@ async def write_narrative(run_id: str) -> Dict[str, Any]:
 
 
 THREAT_HUNT_WORKFLOW_ID = "threat-hunt"
+PROJECTION_READ_CONCURRENCY = 8
 
 
-def parse_window_instant(value: str) -> datetime:
-    """ISO-8601 to naive UTC, matching workflow_runs columns."""
+def _is_date_only(value: str) -> bool:
+    trimmed = value.rstrip("Zz")
+    return "T" not in trimmed and " " not in trimmed
+
+
+def parse_window_instant(value: str, *, end: bool = False) -> datetime:
+    """ISO-8601 to naive UTC, matching workflow_runs columns.
+
+    A date-only ``end`` is the last microsecond of that UTC day so an
+    assessment window named by dates includes the end date.
+    """
     parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     if parsed.tzinfo is not None:
-        return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    if end and _is_date_only(value):
+        return parsed.replace(hour=23, minute=59, second=59, microsecond=999999)
     return parsed
+
+
+async def _read_gated(run_id: str, gate: asyncio.Semaphore) -> Optional[Dict[str, Any]]:
+    async with gate:
+        return await read_projection(run_id)
 
 
 # Completed threat-hunt projections for an assessment window. The projection is
 # the pack: hypotheses (with provenance), evidence provenance, verdict, checkpoint
 # resolutions, timestamps. A missing projection is skipped, not folded from
-# agent_events.
+# agent_events. If every listed run fails to read, that is an error, not an
+# empty pack.
 async def pack_completed_hunts(
     *, start: str, end: str, limit: int = LIST_RUNS_MAX
 ) -> Dict[str, Any]:
     started_at = parse_window_instant(start)
-    finished_at = parse_window_instant(end)
+    finished_at = parse_window_instant(end, end=True)
     if started_at > finished_at:
         raise ValueError("start must be at or before end")
     cap = max(1, min(int(limit), LIST_RUNS_MAX))
     runs = WorkflowRunService().list_runs(
         workflow_id=THREAT_HUNT_WORKFLOW_ID,
         status="completed",
-        started_at=started_at,
+        finished_after=started_at,
         finished_at=finished_at,
         limit=cap,
     )
+    gate = asyncio.Semaphore(PROJECTION_READ_CONCURRENCY)
     projections = await asyncio.gather(
-        *(read_projection(run["run_id"]) for run in runs)
+        *(_read_gated(run["run_id"], gate) for run in runs)
     )
     hunts = [projection for projection in projections if projection is not None]
+    if runs and not hunts:
+        raise RuntimeError(
+            "could not read hunt projections for completed runs in the window"
+        )
     return {"start": start, "end": end, "hunts": hunts}

--- a/core/agents/tool_registry.py
+++ b/core/agents/tool_registry.py
@@ -8,6 +8,7 @@ from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional, Tuple
 
+from core.agents.projections import pack_completed_hunts
 from core.findings.similarity import similar_findings
 
 logger = logging.getLogger(__name__)
@@ -179,6 +180,11 @@ _DATA_TOOLS: Dict[str, Callable[[Any, Args], Any]] = {
     "get_technique_rollup": _technique_rollup,
 }
 
+
+async def _list_completed_hunts(args: Args) -> Any:
+    allowed = {key: args[key] for key in ("start", "end", "limit") if key in args}
+    return await pack_completed_hunts(**allowed)
+
 _SECURITY_TOOLS = frozenset(
     {
         "analyze_coverage",
@@ -276,6 +282,9 @@ async def execute_backend_tool(
         from core.storage.database_data_service import DatabaseDataService
 
         return _DATA_TOOLS[tool_name](DatabaseDataService(), args), True
+
+    if tool_name == "list_completed_hunts":
+        return await _list_completed_hunts(args), True
 
     if tool_name in _SECURITY_TOOLS:
         from core.detections.tools import get_security_detection_tools

--- a/core/agents/tool_registry.py
+++ b/core/agents/tool_registry.py
@@ -185,6 +185,7 @@ async def _list_completed_hunts(args: Args) -> Any:
     allowed = {key: args[key] for key in ("start", "end", "limit") if key in args}
     return await pack_completed_hunts(**allowed)
 
+
 _SECURITY_TOOLS = frozenset(
     {
         "analyze_coverage",

--- a/core/chat/context_manager.py
+++ b/core/chat/context_manager.py
@@ -86,7 +86,7 @@ class ContextManager:
         "list_findings": 12000,
         "search_findings": 12000,
         "list_cases": 12000,
-        "list_completed_hunts": 12000,
+        "list_completed_hunts": 30000,
         "semantic_search_findings": 12000,
         "nearest_neighbors": 12000,
     }

--- a/core/chat/context_manager.py
+++ b/core/chat/context_manager.py
@@ -86,6 +86,7 @@ class ContextManager:
         "list_findings": 12000,
         "search_findings": 12000,
         "list_cases": 12000,
+        "list_completed_hunts": 12000,
         "semantic_search_findings": 12000,
         "nearest_neighbors": 12000,
     }

--- a/core/llm/harness/claude.py
+++ b/core/llm/harness/claude.py
@@ -145,7 +145,7 @@ You have access to MCP (Model Context Protocol) tools that connect to various se
 1. **Findings & Cases**: Retrieve and analyze security findings and cases from DeepTempo
    - Finding IDs start with "f-" (e.g., "f-20260109-40d9379b")
    - Case IDs start with "case-" (e.g., "case-20260114-a1b2c3d4")
-   - Use deeptempo-findings server tools: list_findings, get_finding, list_cases, get_case, create_case, update_case
+   - Use deeptempo-findings server tools: list_findings, get_finding, list_cases, get_case, create_case, update_case, list_completed_hunts
 
 2. **Security Integrations**: Query data from various security platforms
    - The available integrations are dynamically loaded based on what's configured

--- a/core/llm/tool_schemas.py
+++ b/core/llm/tool_schemas.py
@@ -321,6 +321,35 @@ DEEPTEMPO_FINDING_TOOLS = [
             "required": ["case_id", "description", "action_taken"],
         },
     },
+    {
+        "name": "list_completed_hunts",
+        "description": (
+            "Return completed threat-hunt runs whose start and finish fall in "
+            "an assessment window. Each hunt is the existing hunt projection: "
+            "hypotheses (with provenance), evidence provenance, verdict, "
+            "checkpoint resolutions (approver identity), and timestamps. "
+            "Hunts whose projection is not yet available are omitted."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "start": {
+                    "type": "string",
+                    "description": "Window start (ISO-8601 timestamp)",
+                },
+                "end": {
+                    "type": "string",
+                    "description": "Window end (ISO-8601 timestamp)",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of completed hunts to return",
+                    "default": 200,
+                },
+            },
+            "required": ["start", "end"],
+        },
+    },
 ]
 
 # Attack Layer Tools

--- a/core/llm/tool_schemas.py
+++ b/core/llm/tool_schemas.py
@@ -324,8 +324,8 @@ DEEPTEMPO_FINDING_TOOLS = [
     {
         "name": "list_completed_hunts",
         "description": (
-            "Return completed threat-hunt runs whose start and finish fall in "
-            "an assessment window. Each hunt is the existing hunt projection: "
+            "Return completed threat-hunt runs that finished in an "
+            "assessment window. Each hunt is the existing hunt projection: "
             "hypotheses (with provenance), evidence provenance, verdict, "
             "checkpoint resolutions (approver identity), and timestamps. "
             "Hunts whose projection is not yet available are omitted."

--- a/core/workflows/workflow_run_service.py
+++ b/core/workflows/workflow_run_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select
@@ -15,10 +15,20 @@ from core.time import utcnow
 
 logger = logging.getLogger(__name__)
 
+# Same ceiling as GET /workflows/{workflow_id}/runs.
+LIST_RUNS_MAX = 200
+
 
 def generate_run_id() -> str:
     """Return a new run_id shaped ``wfr-YYYYMMDD-<uuid8>``."""
     return f"wfr-{utcnow().strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
+
+
+def _as_naive_utc(value: datetime) -> datetime:
+    """Match workflow_runs columns, which store naive UTC."""
+    if value.tzinfo is not None:
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value
 
 
 class WorkflowRunService:
@@ -135,11 +145,17 @@ class WorkflowRunService:
         *,
         workflow_id: Optional[str] = None,
         status: Optional[str] = None,
+        started_at: Optional[datetime] = None,
+        finished_at: Optional[datetime] = None,
         limit: int = 50,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
         """List runs, newest first. Does not include the (potentially
-        large) ``result_summary`` field — use ``get_run`` for detail."""
+        large) ``result_summary`` field — use ``get_run`` for detail.
+
+        ``started_at`` / ``finished_at`` are inclusive column bounds
+        (started no earlier than, finished no later than).
+        """
         try:
             db = get_db_manager()
             with db.session_scope() as session:
@@ -150,6 +166,14 @@ class WorkflowRunService:
                     stmt = stmt.where(WorkflowRun.workflow_id == workflow_id)
                 if status:
                     stmt = stmt.where(WorkflowRun.status == status)
+                if started_at is not None:
+                    stmt = stmt.where(
+                        WorkflowRun.started_at >= _as_naive_utc(started_at)
+                    )
+                if finished_at is not None:
+                    stmt = stmt.where(
+                        WorkflowRun.finished_at <= _as_naive_utc(finished_at)
+                    )
                 stmt = (
                     stmt.order_by(WorkflowRun.started_at.desc())
                     .limit(limit)

--- a/core/workflows/workflow_run_service.py
+++ b/core/workflows/workflow_run_service.py
@@ -147,14 +147,16 @@ class WorkflowRunService:
         status: Optional[str] = None,
         started_at: Optional[datetime] = None,
         finished_at: Optional[datetime] = None,
+        finished_after: Optional[datetime] = None,
         limit: int = 50,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
         """List runs, newest first. Does not include the (potentially
         large) ``result_summary`` field — use ``get_run`` for detail.
 
-        ``started_at`` / ``finished_at`` are inclusive column bounds
-        (started no earlier than, finished no later than).
+        ``started_at`` is an inclusive lower bound on when the run
+        started. ``finished_after`` / ``finished_at`` bound when it
+        finished (inclusive).
         """
         try:
             db = get_db_manager()
@@ -169,6 +171,10 @@ class WorkflowRunService:
                 if started_at is not None:
                     stmt = stmt.where(
                         WorkflowRun.started_at >= _as_naive_utc(started_at)
+                    )
+                if finished_after is not None:
+                    stmt = stmt.where(
+                        WorkflowRun.finished_at >= _as_naive_utc(finished_after)
                     )
                 if finished_at is not None:
                     stmt = stmt.where(

--- a/tests/unit/agents/test_completed_hunts.py
+++ b/tests/unit/agents/test_completed_hunts.py
@@ -1,0 +1,124 @@
+# Completed-hunt pack: list_runs composed with read_projection, no agent_events fold.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from core.agents.builtins import BUILTIN_AGENTS
+from core.agents.projections import pack_completed_hunts
+from core.agents.tool_registry import execute_backend_tool
+from core.llm.tool_schemas import ALL_TOOLS
+from core.workflows.workflow_run_service import LIST_RUNS_MAX
+
+pytestmark = pytest.mark.unit
+
+START = "2026-01-01T00:00:00Z"
+END = "2026-03-01T00:00:00Z"
+
+PROJECTION = {
+    "run_id": "wfr-kept",
+    "status": "terminal",
+    "hypotheses": [
+        {
+            "statement": "lateral SMB",
+            "provenance": "caller",
+            "status": "confirmed",
+        }
+    ],
+    "evidence": [{"provenance": "splunk", "summary": "auth storm"}],
+    "report": {
+        "created_at": "2026-02-01T00:00:00Z",
+        "terminated_at": "2026-02-01T01:00:00Z",
+        "hypotheses": [{"statement": "lateral SMB", "status": "confirmed"}],
+        "checkpoints": [
+            {"resolution": {"actor": "analyst@soc", "decision": "approve"}}
+        ],
+    },
+}
+
+
+class _Runs:
+    def __init__(self, runs, captured):
+        self._runs = runs
+        self._captured = captured
+
+    def list_runs(self, **kwargs):
+        self._captured.update(kwargs)
+        return list(self._runs)
+
+
+def _install(monkeypatch, runs, projections):
+    captured = {}
+    monkeypatch.setattr(
+        "core.agents.projections.WorkflowRunService",
+        lambda: _Runs(runs, captured),
+    )
+
+    async def _read(run_id):
+        return projections.get(run_id)
+
+    monkeypatch.setattr("core.agents.projections.read_projection", _read)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_pack_returns_the_projection_unchanged(monkeypatch):
+    _install(monkeypatch, [{"run_id": "wfr-kept"}], {"wfr-kept": PROJECTION})
+
+    result = await pack_completed_hunts(start=START, end=END)
+
+    assert result["hunts"] == [PROJECTION]
+    assert result["start"] == START
+    assert result["end"] == END
+
+
+@pytest.mark.asyncio
+async def test_pack_skips_a_run_whose_projection_is_missing(monkeypatch):
+    _install(
+        monkeypatch,
+        [{"run_id": "wfr-gone"}, {"run_id": "wfr-kept"}],
+        {"wfr-kept": PROJECTION},
+    )
+
+    result = await pack_completed_hunts(start=START, end=END)
+
+    assert [hunt["run_id"] for hunt in result["hunts"]] == ["wfr-kept"]
+
+
+@pytest.mark.asyncio
+async def test_pack_asks_list_runs_for_completed_threat_hunts_in_the_window(
+    monkeypatch,
+):
+    captured = _install(monkeypatch, [], {})
+
+    await pack_completed_hunts(start=START, end=END, limit=500)
+
+    assert captured["workflow_id"] == "threat-hunt"
+    assert captured["status"] == "completed"
+    assert captured["started_at"] == datetime(2026, 1, 1, 0, 0, 0)
+    assert captured["finished_at"] == datetime(2026, 3, 1, 0, 0, 0)
+    assert captured["limit"] == LIST_RUNS_MAX
+
+
+@pytest.mark.asyncio
+async def test_backend_tool_dispatches_the_pack(monkeypatch):
+    async def _pack(**kwargs):
+        return {"start": kwargs["start"], "end": kwargs["end"], "hunts": [PROJECTION]}
+
+    monkeypatch.setattr("core.agents.tool_registry.pack_completed_hunts", _pack)
+
+    result, handled = await execute_backend_tool(
+        "list_completed_hunts", {"start": START, "end": END}
+    )
+
+    assert handled is True
+    assert result["hunts"] == [PROJECTION]
+
+
+def test_schema_and_compliance_agent_name_the_tool():
+    names = {tool["name"] for tool in ALL_TOOLS}
+    assert "list_completed_hunts" in names
+    compliance = next(row for row in BUILTIN_AGENTS if row["id"] == "compliance")
+    assert "list_completed_hunts" in compliance["recommended_tools"]

--- a/tests/unit/agents/test_completed_hunts.py
+++ b/tests/unit/agents/test_completed_hunts.py
@@ -97,9 +97,33 @@ async def test_pack_asks_list_runs_for_completed_threat_hunts_in_the_window(
 
     assert captured["workflow_id"] == "threat-hunt"
     assert captured["status"] == "completed"
-    assert captured["started_at"] == datetime(2026, 1, 1, 0, 0, 0)
+    assert captured["finished_after"] == datetime(2026, 1, 1, 0, 0, 0)
     assert captured["finished_at"] == datetime(2026, 3, 1, 0, 0, 0)
     assert captured["limit"] == LIST_RUNS_MAX
+
+
+@pytest.mark.asyncio
+async def test_pack_date_only_end_includes_that_utc_day(monkeypatch):
+    captured = _install(monkeypatch, [], {})
+
+    await pack_completed_hunts(start="2026-01-01", end="2026-03-31")
+
+    assert captured["finished_after"] == datetime(2026, 1, 1, 0, 0, 0)
+    assert captured["finished_at"] == datetime(2026, 3, 31, 23, 59, 59, 999999)
+
+
+@pytest.mark.asyncio
+async def test_pack_errors_when_every_projection_is_missing(monkeypatch):
+    _install(monkeypatch, [{"run_id": "wfr-gone"}], {})
+
+    with pytest.raises(RuntimeError, match="could not read hunt projections"):
+        await pack_completed_hunts(start=START, end=END)
+
+
+@pytest.mark.asyncio
+async def test_pack_rejects_an_inverted_window():
+    with pytest.raises(ValueError, match="start must be at or before end"):
+        await pack_completed_hunts(start=END, end=START)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/test_workflow_run_service.py
+++ b/tests/unit/workflows/test_workflow_run_service.py
@@ -201,3 +201,34 @@ class TestListRuns:
         )
         ids = {row["run_id"] for row in in_window}
         assert ids == {mid}
+
+    def test_list_finished_after_includes_runs_that_started_earlier(
+        self, service, clean_runs
+    ):
+        overlap = service.begin_run(workflow_id="test-wf-finish", workflow_name="W")
+        mid = service.begin_run(workflow_id="test-wf-finish", workflow_name="W")
+        late = service.begin_run(workflow_id="test-wf-finish", workflow_name="W")
+        for run_id in (overlap, mid, late):
+            service.finalize_run(run_id, status="completed")
+
+        t_start = datetime(2026, 1, 1, 12, 0, 0)
+        t_mid = datetime(2026, 2, 1, 12, 0, 0)
+        t_late = datetime(2026, 3, 1, 12, 0, 0)
+        with get_db_manager().session_scope() as session:
+            for run_id, started, finished in (
+                (overlap, t_start, t_mid),
+                (mid, t_mid, t_mid + timedelta(hours=1)),
+                (late, t_late, t_late + timedelta(hours=1)),
+            ):
+                row = session.get(WorkflowRun, run_id)
+                row.started_at = started
+                row.finished_at = finished
+
+        in_window = service.list_runs(
+            workflow_id="test-wf-finish",
+            status="completed",
+            finished_after=datetime(2026, 1, 15),
+            finished_at=datetime(2026, 2, 15),
+        )
+        ids = {row["run_id"] for row in in_window}
+        assert ids == {overlap, mid}

--- a/tests/unit/workflows/test_workflow_run_service.py
+++ b/tests/unit/workflows/test_workflow_run_service.py
@@ -9,8 +9,12 @@ cleanly if not.
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
+
 import pytest
 
+from core.storage.connection import get_db_manager
+from core.storage.models import WorkflowRun
 from core.workflows.workflow_run_service import WorkflowRunService, generate_run_id
 
 
@@ -171,3 +175,29 @@ class TestListRuns:
         # ``list_runs`` calls to_dict(include_result=False) — result_summary
         # should not be in the envelope so list responses stay small.
         assert "result_summary" not in runs[0]
+
+    def test_list_respects_started_at_and_finished_at_bounds(self, service, clean_runs):
+        early = service.begin_run(workflow_id="test-wf-window", workflow_name="W")
+        mid = service.begin_run(workflow_id="test-wf-window", workflow_name="W")
+        late = service.begin_run(workflow_id="test-wf-window", workflow_name="W")
+        for run_id in (early, mid, late):
+            service.finalize_run(run_id, status="completed")
+
+        t0 = datetime(2026, 1, 1, 12, 0, 0)
+        t1 = datetime(2026, 2, 1, 12, 0, 0)
+        t2 = datetime(2026, 3, 1, 12, 0, 0)
+        stamps = {early: t0, mid: t1, late: t2}
+        with get_db_manager().session_scope() as session:
+            for run_id, started in stamps.items():
+                row = session.get(WorkflowRun, run_id)
+                row.started_at = started
+                row.finished_at = started + timedelta(hours=1)
+
+        in_window = service.list_runs(
+            workflow_id="test-wf-window",
+            status="completed",
+            started_at=datetime(2026, 1, 15),
+            finished_at=datetime(2026, 2, 15),
+        )
+        ids = {row["run_id"] for row in in_window}
+        assert ids == {mid}

--- a/tools/mcp/deeptempo_findings.py
+++ b/tools/mcp/deeptempo_findings.py
@@ -9,6 +9,7 @@ from typing import Optional
 import numpy as np
 from mcp.server.mcpserver import MCPServer
 
+from core.agents.projections import pack_completed_hunts
 from core.time import utcnow
 
 logger = logging.getLogger(__name__)
@@ -152,6 +153,20 @@ def get_finding(finding_id: str, **kwargs) -> str:
         return jdump({"error": f"Finding {finding_id} not found"})
     except Exception as e:
         logger.error(f"Error getting finding {finding_id}: {e}")
+        return jdump({"error": str(e)})
+
+
+@mcp.tool()
+async def list_completed_hunts(
+    start: str,
+    end: str,
+    limit: int = 200,
+    **kwargs,
+) -> str:
+    """Return completed threat-hunt projections for an assessment window."""
+    try:
+        return jdump(await pack_completed_hunts(start=start, end=end, limit=limit))
+    except Exception as e:
         return jdump({"error": str(e)})
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #429.

The Compliance agent could map findings and cases to frameworks, but it had no tool that could see a completed hunt. This adds `list_completed_hunts`: for an assessment window it lists completed `threat-hunt` runs and returns each existing `HuntProjection` (hypotheses with provenance, evidence provenance, verdict, checkpoint resolutions, timestamps).

## What landed

- **MCP + schema:** `list_completed_hunts` on the deeptempo-findings server and in `DEEPTEMPO_FINDING_TOOLS`, dispatched as a backend tool so chat does not depend on the MCP child.
- **Compliance agent:** the tool is on `recommended_tools` and named in its methodology.
- **Window:** `WorkflowRunService.list_runs` gained `started_at` / `finished_after` / `finished_at` bounds. The pack filters on completion time (a hunt that started before the window still appears). Date-only `end` is end-of-day UTC. Cap is 200, same as the run-list endpoint.
- **Reads:** `read_projection` only — missing projections are skipped; if every listed run fails to read, the tool errors instead of returning an empty pack. Concurrent reads are gated (8).

## Out of scope (per factory groom)

No new schema under `data/schemas/`, no DORA/NIS2/FFIEC catalog, no new MCP server, no `docs/` mapping, no hunt-ledger / `HuntProjection` / `DispatchRecord` changes, no invented check hashes.

## Verification

- 8 unit tests in `tests/unit/agents/test_completed_hunts.py` (pack pass-through, skip missing projection, all-missing error, inverted window, date-only end, 200 cap, backend dispatch, schema + recommended_tools)
- `test_tool_availability` and built-in agent registry tests still pass
- DB-backed `list_runs` window tests are in `tests/unit/workflows/test_workflow_run_service.py` (`external_service`; skipped here — no Postgres)
- flake8 / black / isort on the `core/` changes

Independent review of the full diff: no criticals. Addressed window-as-completion, date-only end, bulk-read failure, and read fan-out. Left `HuntProjection` intact (including `report_markdown`) rather than inventing a slimmer pack schema.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f2a46c0-3bda-4ce4-9081-1171848533e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f2a46c0-3bda-4ce4-9081-1171848533e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

