### PR TITLE
fix(mcp): bind runtime-enabled MCP servers in hunt resolve

### DIFF
--- a/core/integrations/mcp/registry.py
+++ b/core/integrations/mcp/registry.py
@@ -242,7 +242,7 @@ def safe_tool_names(registry: Optional[MCPRegistry]) -> List[str]:
         return []
 
 
-def refresh_from_client(registry: MCPRegistry) -> int:
+def refresh_from_client(registry: MCPRegistry, prune: bool = True) -> int:
     """Sync the registry to the client's LIVE connection state.
 
     Unlike ``populate_from_cache`` (a boot warm-start that prefers the on-disk
@@ -251,6 +251,9 @@ def refresh_from_client(registry: MCPRegistry) -> int:
     saved its credential and enabled it — becomes usable on the next turn
     without a restart, and one that has disconnected drops out. Cheap and
     idempotent; call it wherever a turn assembles its tool list.
+
+    ``prune=False`` adds without dropping, for a caller whose binding outlives
+    the moment it reads.
     """
     from core.integrations.mcp.client import process_mcp_client
 
@@ -277,7 +280,12 @@ def refresh_from_client(registry: MCPRegistry) -> int:
     # server should drop out. In lazy mode the boot-populated set is intended
     # availability (servers reconnect on first call), so we add without pruning
     # to avoid wiping tools that are still reachable.
-    if eager_connect_enabled() and connected:
+    #
+    # A caller passes prune=False when it binds once and is read for a long time
+    # afterwards: is_connected goes False on any failed call and stays there
+    # until the next one reconnects, so it says "the last call failed", not
+    # "unreachable", and dropping the server costs more than keeping it.
+    if prune and eager_connect_enabled() and connected:
         registry.retain_only(active)
     return len(active)
 

--- a/core/workflows/playbook_resolver.py
+++ b/core/workflows/playbook_resolver.py
@@ -49,9 +49,16 @@ def _mcp_catalogue(registry: Optional["MCPRegistry"]) -> List[Dict[str, Any]]:
     if registry is None:
         return []
     try:
+        # Sync to the running client's live connection state first: a server
+        # enabled+connected after boot must bind here without a reload (and one
+        # since disconnected must drop). No-op when there is no process client.
+        from core.integrations.mcp.registry import refresh_from_client
+
+        refresh_from_client(registry)
         tools = registry.get_all_tools()
         # An empty registry and a deployment with no integrations resolve differently,
         # so fill from the cache before concluding a capability binds to nothing.
+        # Only reached with no live client (boot warm-start / subprocess / tests).
         if not tools:
             from core.integrations.mcp.registry import populate_from_cache
 

--- a/core/workflows/playbook_resolver.py
+++ b/core/workflows/playbook_resolver.py
@@ -48,17 +48,25 @@ def _tool_catalogue(registry: Optional["MCPRegistry"]) -> Dict[str, Dict[str, An
 def _mcp_catalogue(registry: Optional["MCPRegistry"]) -> List[Dict[str, Any]]:
     if registry is None:
         return []
+    # Sync to the running client's live connection state first, so a server
+    # enabled+connected after boot binds here without a reload. No-op when there
+    # is no process client. Best effort in its own right: a refresh that fails
+    # must not cost us the registry we already hold, nor the cache fallback below.
+    #
+    # Without pruning: a run binds its capabilities once and then reads them for
+    # as long as it lasts, so a server dropped here for a stale is_connected is
+    # gone for the whole run even though the next call would reconnect it.
     try:
-        # Sync to the running client's live connection state first: a server
-        # enabled+connected after boot must bind here without a reload (and one
-        # since disconnected must drop). No-op when there is no process client.
         from core.integrations.mcp.registry import refresh_from_client
 
-        refresh_from_client(registry)
+        refresh_from_client(registry, prune=False)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("MCP refresh failed while resolving tools: %s", exc)
+
+    try:
         tools = registry.get_all_tools()
         # An empty registry and a deployment with no integrations resolve differently,
         # so fill from the cache before concluding a capability binds to nothing.
-        # Only reached with no live client (boot warm-start / subprocess / tests).
         if not tools:
             from core.integrations.mcp.registry import populate_from_cache
 

--- a/tests/unit/workflows/test_hunt_resolver.py
+++ b/tests/unit/workflows/test_hunt_resolver.py
@@ -353,3 +353,35 @@ class TestTheCapabilityReport:
         report = capability_report(_Registry())
         assert "telemetry_search" in report["bound"]
         assert "telemetry_search" not in report["unbound"]
+
+    def test_binds_a_server_connected_after_boot_without_a_reload(self, monkeypatch):
+        # The bug: a server enabled+connected at runtime stayed invisible to the
+        # resolver until a reload rewrote the on-disk cache. The report must sync
+        # from the live client, so a just-connected server binds on the next turn.
+        from core.integrations.mcp.registry import MCPRegistry
+        from core.workflows.playbook_resolver import capability_report
+
+        class _LiveClient:
+            mcp_service = None
+            # Raw, unprefixed tool name as the live client caches it; the
+            # registry re-prefixes it with the server on get_all_tools().
+            tools_cache = {
+                "splunk-selfhosted": [
+                    {
+                        "name": "splunk_execute",
+                        "description": "Execute SPL",
+                        "inputSchema": {},
+                    }
+                ]
+            }
+
+            def get_connection_status(self):
+                return {"splunk-selfhosted": True}
+
+        monkeypatch.setattr(
+            "core.integrations.mcp.client.process_mcp_client", lambda: _LiveClient()
+        )
+
+        # A fresh registry knows nothing of the server; refresh_from_client fills it.
+        registry = MCPRegistry()
+        assert "telemetry_search" in capability_report(registry)["bound"]


### PR DESCRIPTION
resolve_hunt bound telemetry_search off a stale registry cache, so a server enabled at runtime (e.g. splunk-selfhosted) was invisible to a hunt until a full restart — the hunt reported the capability unbound and never reached Splunk.

`_mcp_catalogue` now calls `refresh_from_client(registry)` before enumerating tools, so resolve binds against the live MCP client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)