### PR TITLE
feat(mcp): default-enable splunk-selfhosted

### DIFF
--- a/core/integrations/mcp/service.py
+++ b/core/integrations/mcp/service.py
@@ -292,6 +292,11 @@ class MCPService:
         "approval",
         "attack-layer",
         "mempalace",
+        # The self-hosted SIEM a hunt reads through telemetry_search -- the
+        # customer's own Splunk, the expected telemetry path, not an optional
+        # add-on. Safe to default-on: unset ${SPLUNK_*} placeholders leave it
+        # dormant (never connects, no error), not failing a boot.
+        "splunk-selfhosted",
     }
 
     def is_server_enabled(self, server_name: str) -> bool:


### PR DESCRIPTION
splunk-selfhosted is expected to be running locally in a self-hosted deployment, not a commercial add-on, so it belongs in the default-enabled set. The credential gate keeps it dormant (no error) when unconfigured, so this is safe where Splunk isn't present.

Adds `splunk-selfhosted` to `_DEFAULT_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)