### PR TITLE
Prefix cookies and CSRF paths so subdirectory deploys authenticate

### DIFF
--- a/clients/web/src/services/skillsApi.ts
+++ b/clients/web/src/services/skillsApi.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { basePath } from '../config/basePath'
 
 /**
  * Client for the Skills API (GitHub issue #82).
@@ -61,7 +62,7 @@ export interface SkillImportResult {
 }
 
 const client = axios.create({
-  baseURL: '/api/skills',
+  baseURL: `${basePath}/api/skills`,
   headers: { 'Content-Type': 'application/json' },
 })
 

--- a/core/auth/auth_cookies.py
+++ b/core/auth/auth_cookies.py
@@ -21,10 +21,26 @@ logger = logging.getLogger(__name__)
 ACCESS_COOKIE_NAME = "access_token"
 REFRESH_COOKIE_NAME = "refresh_token"
 
-# Path scoping: refresh cookie is only sent to the refresh endpoint so it
-# isn't exposed to every API call the browser makes.
-ACCESS_COOKIE_PATH = "/"
-REFRESH_COOKIE_PATH = "/api/auth/refresh"
+# Unprefixed Path values. Prefixed at set/clear time from vigil_context_path
+# so a subdirectory deploy (example.com/vigil) still sends cookies.
+_ACCESS_COOKIE_PATH = "/"
+_REFRESH_COOKIE_PATH = "/api/auth/refresh"
+
+
+def context_path_prefix() -> str:
+    """Normalized VIGIL_CONTEXT_PATH (no trailing slash). Empty at root."""
+    return get_settings().vigil_context_path.rstrip("/")
+
+
+def cookie_root_path() -> str:
+    """Path for access + CSRF cookies: `{prefix}/` or `/`."""
+    prefix = context_path_prefix()
+    return f"{prefix}/" if prefix else _ACCESS_COOKIE_PATH
+
+
+def refresh_cookie_path() -> str:
+    """Path for the refresh cookie: `{prefix}/api/auth/refresh`."""
+    return f"{context_path_prefix()}{_REFRESH_COOKIE_PATH}"
 
 
 def _cookie_secure() -> bool:
@@ -69,7 +85,7 @@ def set_auth_cookies(
         httponly=True,
         secure=secure,
         samesite=samesite,
-        path=ACCESS_COOKIE_PATH,
+        path=cookie_root_path(),
     )
     response.set_cookie(
         REFRESH_COOKIE_NAME,
@@ -78,7 +94,7 @@ def set_auth_cookies(
         httponly=True,
         secure=secure,
         samesite=samesite,
-        path=REFRESH_COOKIE_PATH,
+        path=refresh_cookie_path(),
     )
 
 
@@ -89,13 +105,13 @@ def clear_auth_cookies(response: Response) -> None:
     samesite = _cookie_samesite()
     response.delete_cookie(
         ACCESS_COOKIE_NAME,
-        path=ACCESS_COOKIE_PATH,
+        path=cookie_root_path(),
         secure=secure,
         samesite=samesite,
     )
     response.delete_cookie(
         REFRESH_COOKIE_NAME,
-        path=REFRESH_COOKIE_PATH,
+        path=refresh_cookie_path(),
         secure=secure,
         samesite=samesite,
     )

--- a/env.example
+++ b/env.example
@@ -251,6 +251,8 @@ PASSWORD_RESET_TTL_SECONDS="3600"
 
 # Frontend URL used to build password-reset links sent via email. When
 # unset the reset email includes the raw token with a "(token)" prefix.
+# Under a subdirectory deploy this must include the same prefix as
+# VIGIL_CONTEXT_PATH, e.g. "https://example.com/vigil".
 VIGIL_FRONTEND_URL=""
 
 # -----------------------------------------------------------------------------
@@ -278,7 +280,9 @@ SMTP_FROM="noreply@vigil.local"
 VIGIL_CORS_ORIGINS=""
 
 # Sub-path the whole app is served under when behind a reverse proxy, e.g.
-# "/vigil". Empty serves at the root.
+# "/vigil". Empty serves at the root. The proxy must forward the prefix
+# unchanged (not strip it). Ingress path and VIGIL_CONTEXT_PATH must match;
+# VIGIL_FRONTEND_URL for password-reset links must include the same prefix.
 # VIGIL_CONTEXT_PATH=""
 
 # The State Directory: where Vigil keeps credentials, MCP enable flags, detection
@@ -355,6 +359,8 @@ VIGIL_CSRF_ENABLED="true"
 VIGIL_CSRF_REPORT_ONLY="false"
 # Comma-separated path prefixes exempt from CSRF checks (webhooks that
 # authenticate themselves with HMAC, server-to-server ingestion endpoints).
+# App-root relative; the API prefixes each entry with VIGIL_CONTEXT_PATH.
+# Fully-qualified paths that already include the prefix are left as-is.
 VIGIL_CSRF_EXEMPT_PATHS="/api/webhooks/,/api/ingest/"
 
 # -----------------------------------------------------------------------------

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -433,6 +433,8 @@ ingress:
   hosts:
     - host: vigil.local
       paths:
+        # Subdirectory deploys (e.g. /vigil) must set config.VIGIL_CONTEXT_PATH
+        # to the same string; the chart does not derive one from the other.
         - path: /
           pathType: Prefix
   tls: []
@@ -620,6 +622,7 @@ config:
   AUTH_MIN_PASSWORD_LENGTH: "12"
   AUTH_PASSWORD_HISTORY_LIMIT: "5"
   PASSWORD_RESET_TTL_SECONDS: "3600"
+  # Include the context path under a subdirectory (e.g. https://example.com/vigil).
   VIGIL_FRONTEND_URL: ""
 
   # Email backend
@@ -632,6 +635,10 @@ config:
 
   # HTTP security headers + CORS
   VIGIL_CORS_ORIGINS: ""
+  # Sub-directory the app is served under (e.g. "/vigil"). Empty = root.
+  # Must match ingress path; the chart does not derive one from the other.
+  # The reverse proxy must forward the prefix unchanged.
+  VIGIL_CONTEXT_PATH: ""
   VIGIL_HSTS_ENABLED: "true"
   VIGIL_HSTS_MAX_AGE: "31536000"
   VIGIL_FRAME_OPTIONS_ENABLED: "true"
@@ -643,6 +650,7 @@ config:
   # CSRF
   VIGIL_CSRF_ENABLED: "true"
   VIGIL_CSRF_REPORT_ONLY: "true"
+  # App-root relative; the API prefixes each entry with VIGIL_CONTEXT_PATH.
   VIGIL_CSRF_EXEMPT_PATHS: "/api/webhooks/,/api/ingest/"
 
   # Auth cookies

--- a/services/api/middleware/csrf.py
+++ b/services/api/middleware/csrf.py
@@ -36,6 +36,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
+from core.auth.auth_cookies import context_path_prefix, cookie_root_path
 from core.config import get_settings
 
 logger = logging.getLogger(__name__)
@@ -48,10 +49,29 @@ UNSAFE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 _DEFAULT_EXEMPT = ("/api/webhooks/", "/api/ingest/")
 
 
-def _parse_exempt_paths(raw: Optional[str]) -> tuple:
-    if not raw:
-        return _DEFAULT_EXEMPT
-    return tuple(p.strip() for p in raw.split(",") if p.strip())
+def _apply_context_path(path: str, prefix: str) -> str:
+    """Prefix an app-root path with VIGIL_CONTEXT_PATH.
+
+    Already-prefixed paths are left alone so an operator can set fully
+    qualified VIGIL_CSRF_EXEMPT_PATHS without doubling.
+    """
+    if not path.startswith("/"):
+        path = "/" + path
+    if not prefix or path == prefix or path.startswith(prefix + "/"):
+        return path
+    return f"{prefix}{path}"
+
+
+def _parse_exempt_paths(
+    raw: Optional[str], context_path: Optional[str] = None
+) -> tuple:
+    prefix = context_path_prefix() if context_path is None else context_path.rstrip("/")
+    bases = (
+        tuple(p.strip() for p in raw.split(",") if p.strip())
+        if raw
+        else _DEFAULT_EXEMPT
+    )
+    return tuple(_apply_context_path(p, prefix) for p in bases)
 
 
 class CSRFMiddleware(BaseHTTPMiddleware):
@@ -129,7 +149,7 @@ class CSRFMiddleware(BaseHTTPMiddleware):
                 httponly=False,  # JS must be able to read it
                 secure=self.cookie_secure,
                 samesite="strict",
-                path="/",
+                path=cookie_root_path(),
             )
 
         return response

--- a/services/api/middleware/csrf.py
+++ b/services/api/middleware/csrf.py
@@ -52,12 +52,17 @@ _DEFAULT_EXEMPT = ("/api/webhooks/", "/api/ingest/")
 def _apply_context_path(path: str, prefix: str) -> str:
     """Prefix an app-root path with VIGIL_CONTEXT_PATH.
 
-    Already-prefixed paths are left alone so an operator can set fully
-    qualified VIGIL_CSRF_EXEMPT_PATHS without doubling.
+    Already-prefixed paths (``{prefix}/api/...``) are left alone so an
+    operator can set fully qualified VIGIL_CSRF_EXEMPT_PATHS without
+    doubling. The skip is ``{prefix}/api``, not ``{prefix}/``, so a
+    context path of ``/api`` does not treat Helm's ``/api/webhooks/``
+    as already done.
     """
     if not path.startswith("/"):
         path = "/" + path
-    if not prefix or path == prefix or path.startswith(prefix + "/"):
+    if not prefix:
+        return path
+    if path == prefix or path == prefix + "/api" or path.startswith(prefix + "/api/"):
         return path
     return f"{prefix}{path}"
 

--- a/tests/unit/api/test_context_path.py
+++ b/tests/unit/api/test_context_path.py
@@ -1,0 +1,172 @@
+"""VIGIL_CONTEXT_PATH must prefix cookies, CSRF exemptions, and mounted routes.
+
+Importing ``services.api.main`` with a non-empty context path would bake
+``_CONTEXT_PATH`` into this process and hide every ``/api/`` route from
+``tests/security/test_route_auth_coverage.py``. These tests never set the
+env var for that module: cookies/CSRF read settings at call time, and
+router prefix is exercised through ``mount_routers``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+from fastapi import FastAPI, Response
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-only-secret-not-for-prod")
+
+pytestmark = pytest.mark.unit
+
+
+def _set_cookie_headers(headers) -> list[str]:
+    getter = getattr(headers, "get_list", None) or getattr(headers, "getlist")
+    return getter("set-cookie")
+
+
+def _cookie_paths(response: Response) -> dict[str, str]:
+    found: dict[str, str] = {}
+    for header in _set_cookie_headers(response.headers):
+        name = header.split("=", 1)[0]
+        match = re.search(r";\s*Path=([^;]*)", header, re.I)
+        if match:
+            found[name] = match.group(1)
+    return found
+
+
+def _mounted_paths(app: FastAPI) -> list[str]:
+    paths: list[str] = []
+
+    def visit(obj) -> None:
+        if type(obj).__name__ == "_IncludedRouter":
+            for candidate in obj.effective_candidates():
+                visit(candidate)
+            return
+        path = getattr(obj, "path", None)
+        if isinstance(path, str):
+            paths.append(getattr(obj, "path_format", None) or path)
+
+    for route in app.routes:
+        visit(route)
+    return paths
+
+
+@pytest.mark.parametrize(
+    "prefix, access, refresh",
+    [
+        ("", "/", "/api/auth/refresh"),
+        ("/", "/", "/api/auth/refresh"),
+        ("/vigil", "/vigil/", "/vigil/api/auth/refresh"),
+        ("/vigil/", "/vigil/", "/vigil/api/auth/refresh"),
+    ],
+)
+def test_auth_cookie_paths_follow_context_path(monkeypatch, prefix, access, refresh):
+    from core.auth.auth_cookies import (
+        ACCESS_COOKIE_NAME,
+        REFRESH_COOKIE_NAME,
+        clear_auth_cookies,
+        set_auth_cookies,
+    )
+    from core.config import get_settings
+
+    monkeypatch.setenv("VIGIL_CONTEXT_PATH", prefix)
+    get_settings.cache_clear()
+
+    set_response = Response()
+    set_auth_cookies(set_response, "access-token", "refresh-token")
+    assert _cookie_paths(set_response) == {
+        ACCESS_COOKIE_NAME: access,
+        REFRESH_COOKIE_NAME: refresh,
+    }
+
+    clear_response = Response()
+    clear_auth_cookies(clear_response)
+    assert _cookie_paths(clear_response) == {
+        ACCESS_COOKIE_NAME: access,
+        REFRESH_COOKIE_NAME: refresh,
+    }
+
+
+@pytest.mark.parametrize(
+    "raw, context_path, expected",
+    [
+        (None, "", ("/api/webhooks/", "/api/ingest/")),
+        (None, "/vigil", ("/vigil/api/webhooks/", "/vigil/api/ingest/")),
+        (
+            "/api/webhooks/,/api/ingest/",
+            "/vigil",
+            ("/vigil/api/webhooks/", "/vigil/api/ingest/"),
+        ),
+        ("/vigil/api/webhooks/", "/vigil", ("/vigil/api/webhooks/",)),
+    ],
+)
+def test_csrf_exempt_paths_follow_context_path(raw, context_path, expected):
+    from services.api.middleware.csrf import _parse_exempt_paths
+
+    assert _parse_exempt_paths(raw, context_path) == expected
+
+
+def test_csrf_exempt_matching_requires_the_prefix():
+    from services.api.middleware.csrf import CSRFMiddleware, _parse_exempt_paths
+
+    inner = FastAPI()
+    middleware = CSRFMiddleware(
+        inner,
+        enabled=True,
+        exempt_paths=_parse_exempt_paths(None, "/vigil"),
+    )
+    assert middleware._is_exempt("/vigil/api/webhooks/darktrace")
+    assert middleware._is_exempt("/vigil/api/ingest/upload")
+    assert not middleware._is_exempt("/api/webhooks/darktrace")
+    assert not middleware._is_exempt("/vigil/api/cases")
+
+
+def test_csrf_cookie_path_follows_context_path(monkeypatch):
+    from core.config import get_settings
+    from services.api.middleware.csrf import CSRF_COOKIE_NAME, CSRFMiddleware
+
+    monkeypatch.setenv("VIGIL_CONTEXT_PATH", "/vigil")
+    get_settings.cache_clear()
+
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware, enabled=True, report_only=False)
+
+    @app.get("/vigil/")
+    def root():
+        return {"ok": True}
+
+    response = TestClient(app).get("/vigil/")
+    cookie = next(
+        c
+        for c in _set_cookie_headers(response.headers)
+        if c.startswith(CSRF_COOKIE_NAME)
+    )
+    match = re.search(r";\s*Path=([^;]*)", cookie, re.I)
+    assert match is not None
+    assert match.group(1) == "/vigil/"
+
+
+def test_mount_routers_prefixes_api_routes():
+    from services.api.discovery import mount_routers
+
+    app = FastAPI()
+    mount_routers(app, context_path="/vigil")
+    paths = _mounted_paths(app)
+
+    assert any(p.startswith("/vigil/api/") for p in paths)
+    assert any(p.startswith("/vigil/api/auth") for p in paths)
+    assert not any(p.startswith("/api/") and not p.startswith("/vigil/") for p in paths)
+    assert not any(p == "/metrics" or p.startswith("/metrics") for p in paths)
+
+
+def test_mount_routers_empty_prefix_keeps_root_api_paths():
+    from services.api.discovery import mount_routers
+
+    app = FastAPI()
+    mount_routers(app, context_path="")
+    paths = _mounted_paths(app)
+
+    assert any(p.startswith("/api/") for p in paths)
+    assert not any(p.startswith("/vigil/") for p in paths)

--- a/tests/unit/api/test_context_path.py
+++ b/tests/unit/api/test_context_path.py
@@ -100,12 +100,30 @@ def test_auth_cookie_paths_follow_context_path(monkeypatch, prefix, access, refr
             ("/vigil/api/webhooks/", "/vigil/api/ingest/"),
         ),
         ("/vigil/api/webhooks/", "/vigil", ("/vigil/api/webhooks/",)),
+        ("/api/webhooks/", "/api", ("/api/api/webhooks/",)),
     ],
 )
 def test_csrf_exempt_paths_follow_context_path(raw, context_path, expected):
     from services.api.middleware.csrf import _parse_exempt_paths
 
     assert _parse_exempt_paths(raw, context_path) == expected
+
+
+def test_csrf_middleware_prefixes_helm_defaults_from_settings(monkeypatch):
+    """Helm leaves VIGIL_CSRF_EXEMPT_PATHS app-root relative; only the
+    context path is set. That is production ``add_middleware(CSRFMiddleware)``."""
+    from core.config import get_settings
+    from services.api.middleware.csrf import CSRFMiddleware
+
+    monkeypatch.setenv("VIGIL_CONTEXT_PATH", "/vigil")
+    monkeypatch.setenv("VIGIL_CSRF_EXEMPT_PATHS", "/api/webhooks/,/api/ingest/")
+    get_settings.cache_clear()
+
+    middleware = CSRFMiddleware(FastAPI(), enabled=True)
+    assert middleware._is_exempt("/vigil/api/webhooks/darktrace")
+    assert middleware._is_exempt("/vigil/api/ingest/upload")
+    assert not middleware._is_exempt("/api/webhooks/darktrace")
+    assert not middleware._is_exempt("/vigil/api/cases")
 
 
 def test_csrf_exempt_matching_requires_the_prefix():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #308

Subdirectory serving (`VIGIL_CONTEXT_PATH=/vigil`) already prefixed API routers and the SPA. Sessions still broke: the refresh cookie was hard-coded to `/api/auth/refresh`, CSRF exemptions stayed at `/api/webhooks/` and `/api/ingest/`, and `skillsApi.ts` called `/api/skills` without the SPA base path.

## Changes

- Compute access/CSRF cookie `Path` as `{prefix}/` and refresh as `{prefix}/api/auth/refresh` at set/clear time. Empty prefix keeps `/` and `/api/auth/refresh`.
- Prefix default and Helm CSRF exempt paths with the context path (already-qualified `{prefix}/api/...` values are left alone).
- Point `skillsApi.ts` at `basePath`. LocalStorage bearer auth is unchanged.
- Add `VIGIL_CONTEXT_PATH: ""` to Helm `values.config`. Operators set it to the same string as the ingress path; the chart does not derive one from the other.
- Expand `env.example`: proxy forwards the prefix, ingress path must match, `VIGIL_FRONTEND_URL` for reset links must include the prefix.

`/metrics` stays unprefixed. No FastAPI `root_path`, no second base-URL setting, no Ingress-to-env wiring, no nginx/compose harness.

## Tests

- `tests/unit/api/test_context_path.py` — cookie Path set/clear, CSRF exempt matching (including Helm defaults via settings), `mount_routers` prefix.
- Also ran `tests/security/test_route_auth_coverage.py` (must keep seeing `/api/` in this process) and `tests/unit/_ratchets/test_settings_env_example.py`.
- Frontend `tsc` and eslint on `skillsApi.ts`.
- `black` / `isort` / `flake8` on the Python edits.

Independent review of the full diff found no critical issues. Follow-up: test the Helm settings path for CSRF exemptions, and do not treat `/api/webhooks/` as already prefixed when the context path is `/api`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-099a606f-28ba-4305-abe3-e568e01d6bc5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-099a606f-28ba-4305-abe3-e568e01d6bc5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

