### PR TITLE
env: give cloud agents agent-browser for live tests

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -62,6 +62,32 @@ RUN ARCH="$(dpkg --print-architecture)" \
     && helm version --short
 
 ########################################################
+# AGENT-BROWSER (live tests)
+########################################################
+
+# The factory asks every implementer to exercise its change live, with a
+# browser where there is a UI. agent-browser is a native binary; the release
+# asset is used rather than the npm package, whose wrapper wants Node 24 while
+# this repo's CI and frontend pin Node 18. Pinned like Helm above.
+# `install --with-deps` is run as root for Chrome's shared libraries; the
+# browser download itself lands per-user under ~/.agent-browser, so the ubuntu
+# user fetches its own copy below and root's is discarded.
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in amd64) AB_ARCH=x64 ;; arm64) AB_ARCH=arm64 ;; *) echo "unsupported arch $ARCH" && exit 1 ;; esac \
+    && AB_VERSION=v0.36.0 \
+    && curl --retry 3 --retry-delay 5 -fsSL -o /usr/local/bin/agent-browser \
+       "https://github.com/vercel-labs/agent-browser/releases/download/${AB_VERSION}/agent-browser-linux-${AB_ARCH}" \
+    && chmod +x /usr/local/bin/agent-browser \
+    && agent-browser --version \
+    && apt-get update \
+    && agent-browser install --with-deps \
+    && rm -rf /root/.agent-browser /var/lib/apt/lists/*
+
+# Chrome's user-namespace sandbox is unavailable under Ubuntu 24.04's AppArmor
+# defaults and inside VMs; without this every launch dies before DevTools starts.
+ENV AGENT_BROWSER_ARGS="--no-sandbox"
+
+########################################################
 # CONFIG UBUNTU USER
 ########################################################
 
@@ -80,3 +106,6 @@ RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
 RUN echo "ubuntu:ubuntu" | chpasswd
 
 USER ubuntu
+
+# Chrome for Testing, into /home/ubuntu/.agent-browser (system libraries are already in place).
+RUN agent-browser install


### PR DESCRIPTION
The factory now asks every implementer to exercise its change live — starting the app and driving it through its real entry point, with a browser where there is a UI — and to end each PR with a Verification section saying what was checked and what was not. The agents' machine had no browser, so that check was silently impossible; none of the last 15 factory PRs contains a screenshot or a blocked-check report.

## Changes

`.cursor/Dockerfile` only.

- Installs [agent-browser](https://github.com/vercel-labs/agent-browser) v0.36.0 from its GitHub release binary, pinned the same way Helm is. The npm package is not used: its wrapper requires Node 24 while CI and the frontend pin Node 18.
- Runs `agent-browser install --with-deps` as root for Chrome's shared libraries, then discards root's browser download.
- Sets `AGENT_BROWSER_ARGS="--no-sandbox"`. Ubuntu 24.04's AppArmor defaults block Chrome's user-namespace sandbox, and without this flag every launch dies before DevTools starts.
- Runs `agent-browser install` as the `ubuntu` user so Chrome for Testing lands in `/home/ubuntu/.agent-browser`, where the agent will look for it.

## Verification

- Built a trimmed copy of this Dockerfile (base packages, the new agent-browser section, the ubuntu user section; Docker and Helm sections dropped for time) on `linux/amd64`. The release binary downloads, `--with-deps` installs the shared libraries, Chrome 152 lands under both users, and as `ubuntu` the image runs `agent-browser open about:blank`, reads the title, and closes cleanly.
- Not run: the full Dockerfile with the Docker and Helm sections. Those are unchanged, and the new section does not depend on them.
- Not run: the image inside a Cursor cloud agent. The first agent to start on it is that test; if the build fails, Cursor falls back to its automatic setup and the agent's Verification section will say the browser was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
