### PR TITLE
fix(mcp): keep a dropped session in the chat tool list

### DIFF
--- a/core/integrations/mcp/registry.py
+++ b/core/integrations/mcp/registry.py
@@ -53,13 +53,15 @@ class MCPRegistry:
             name for name, info in self._servers.items() if info.get("active", False)
         ]
 
-    def retain_only(self, active_names: List[str]) -> None:
-        """Mark exactly ``active_names`` active; deactivate every other server.
+    def set_active(self, server_name: str, active: bool) -> None:
+        """Mark one server active or inactive. No-op when it is not registered."""
+        info = self._servers.get(server_name)
+        if info is None:
+            return
+        info["active"] = active
 
-        Lets a live refresh make the registry reflect current connection state:
-        a server that has since disconnected stops offering its tools, without
-        needing a restart.
-        """
+    def retain_only(self, active_names: List[str]) -> None:
+        """Mark exactly ``active_names`` active; deactivate every other server."""
         wanted = set(active_names)
         for name, info in self._servers.items():
             info["active"] = name in wanted
@@ -177,9 +179,9 @@ def _normalised(tool: Dict[str, Any]) -> Dict[str, Any]:
 
 # Whether this deployment dials every configured MCP server at startup. Off by
 # default under DEV_MODE; an explicit ``mcp_auto_connect_on_startup`` wins either
-# way. ``refresh_from_client`` uses it to decide whether live connection state is
-# authoritative enough to prune servers. services/api/main.py makes the same call
-# for its own startup path; core/ cannot import services/, so the rule lives here.
+# way. ``populate_from_cache`` uses it to decide whether live connection state
+# gates the warm-start cache. services/api/main.py makes the same call for its
+# own startup path; core/ cannot import services/, so the rule lives here.
 def eager_connect_enabled() -> bool:
     from core.config import get_settings
 
@@ -242,18 +244,49 @@ def safe_tool_names(registry: Optional[MCPRegistry]) -> List[str]:
         return []
 
 
-def refresh_from_client(registry: MCPRegistry, prune: bool = True) -> int:
-    """Sync the registry to the client's LIVE connection state.
+def register_connected(registry: MCPRegistry, mcp_client, server_name: str) -> bool:
+    """Register one server from the client's ``tools_cache``.
+
+    Called where a connect succeeds so the registry tracks enable intent, not
+    the next reader's liveness check. Best effort: a failure logs at debug and
+    returns False, so an enable endpoint can keep its own result.
+    """
+    try:
+        tools = (getattr(mcp_client, "tools_cache", None) or {}).get(server_name)
+        if not isinstance(tools, list) or not tools:
+            return False
+        registry.register_server(
+            server_name,
+            _server_config(mcp_client, server_name),
+            [_normalised(t) for t in tools],
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — callers must not 500 on a registry write
+        logger.debug("Could not register MCP server %s: %s", server_name, exc)
+        return False
+
+
+def deactivate(registry: MCPRegistry, server_name: str) -> None:
+    """Stop offering a server's tools. Best effort; unknown names are a no-op."""
+    try:
+        registry.set_active(server_name, False)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not deactivate MCP server %s: %s", server_name, exc)
+
+
+def refresh_from_client(registry: MCPRegistry) -> int:
+    """Add servers that connected after startup from the client's ``tools_cache``.
 
     Unlike ``populate_from_cache`` (a boot warm-start that prefers the on-disk
     tool cache), this reads the running client's ``tools_cache`` and current
-    connection status, so a server connected *after* startup — e.g. a user just
-    saved its credential and enabled it — becomes usable on the next turn
-    without a restart, and one that has disconnected drops out. Cheap and
-    idempotent; call it wherever a turn assembles its tool list.
+    connection status so a server connected *after* startup — e.g. a dormant
+    retry came online, or ``call_tool`` created a session — becomes usable on
+    the next turn without a restart. Cheap and idempotent; call it wherever a
+    turn assembles its tool list.
 
-    ``prune=False`` adds without dropping, for a caller whose binding outlives
-    the moment it reads.
+    Does not deactivate. Removal follows disable via ``deactivate``, not
+    liveness: ``is_connected`` goes False on any failed call and stays there
+    until the next one reconnects, so it is not "unreachable".
     """
     from core.integrations.mcp.client import process_mcp_client
 
@@ -267,33 +300,22 @@ def refresh_from_client(registry: MCPRegistry, prune: bool = True) -> int:
         logger.debug("Could not read MCP connection status: %s", exc)
         connected = {}
 
-    active: List[str] = []
+    added = 0
     for name, tools in tools_dict.items():
         if connected and not connected.get(name, False):
             continue
         registry.register_server(
             name, _server_config(mcp_client, name), [_normalised(t) for t in tools]
         )
-        active.append(name)
-    # Only prune when this boot dials eagerly and we actually have live status:
-    # then tools_cache/connected is the source of truth, so a disconnected
-    # server should drop out. In lazy mode the boot-populated set is intended
-    # availability (servers reconnect on first call), so we add without pruning
-    # to avoid wiping tools that are still reachable.
-    #
-    # A caller passes prune=False when it binds once and is read for a long time
-    # afterwards: is_connected goes False on any failed call and stays there
-    # until the next one reconnects, so it says "the last call failed", not
-    # "unreachable", and dropping the server costs more than keeping it.
-    if prune and eager_connect_enabled() and connected:
-        registry.retain_only(active)
-    return len(active)
+        added += 1
+    return added
 
 
 def live_mcp_tools(registry: MCPRegistry) -> List[Dict]:
-    """The connected MCP integrations' tools, Claude-API-shaped, for one turn.
+    """The MCP integrations currently offered, Claude-API-shaped, for one turn.
 
-    Refreshes the registry from the running client, then returns its tools
+    Refreshes the registry from the running client (add-path for servers
+    connected outside the enable endpoint), then returns its tools
     (server-prefixed names). Returns ``[]`` — never raises — when the client or
     registry is unavailable, so a caller can fall back to built-in tools. This
     is the one call a request path needs to surface live integrations.

--- a/core/workflows/playbook_resolver.py
+++ b/core/workflows/playbook_resolver.py
@@ -52,14 +52,10 @@ def _mcp_catalogue(registry: Optional["MCPRegistry"]) -> List[Dict[str, Any]]:
     # enabled+connected after boot binds here without a reload. No-op when there
     # is no process client. Best effort in its own right: a refresh that fails
     # must not cost us the registry we already hold, nor the cache fallback below.
-    #
-    # Without pruning: a run binds its capabilities once and then reads them for
-    # as long as it lasts, so a server dropped here for a stale is_connected is
-    # gone for the whole run even though the next call would reconnect it.
     try:
         from core.integrations.mcp.registry import refresh_from_client
 
-        refresh_from_client(registry, prune=False)
+        refresh_from_client(registry)
     except Exception as exc:  # noqa: BLE001
         logger.debug("MCP refresh failed while resolving tools: %s", exc)
 

--- a/services/api/routers/detection_rules.py
+++ b/services/api/routers/detection_rules.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from core.deps import provide_detection_rules, provide_mcp_client, provide_mcp_registry
 from core.detections.detection_rules_service import DetectionRulesService
-from core.integrations.mcp.registry import MCPRegistry, deactivate, register_connected
+from core.integrations.mcp.registry import MCPRegistry, register_connected
 from core.routing import Auth, RouterMeta
 
 logger = logging.getLogger(__name__)
@@ -257,16 +257,8 @@ async def _restart_security_detections_mcp(
                 # Stop and restart
                 mcp_service.stop_server(server_name)
 
-                # Disconnect and reconnect MCP client
+                # Restart, not disable: a failed reconnect must not hide tools.
                 await mcp_client.disconnect_from_server(server_name)
-                try:
-                    deactivate(registry, server_name)
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug(
-                        "MCP registry deactivate during restart failed for %s: %s",
-                        server_name,
-                        exc,
-                    )
                 reconnected = await mcp_client.connect_to_server(
                     server_name, persistent=True
                 )

--- a/services/api/routers/detection_rules.py
+++ b/services/api/routers/detection_rules.py
@@ -6,8 +6,9 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from core.deps import provide_detection_rules, provide_mcp_client
+from core.deps import provide_detection_rules, provide_mcp_client, provide_mcp_registry
 from core.detections.detection_rules_service import DetectionRulesService
+from core.integrations.mcp.registry import MCPRegistry, deactivate, register_connected
 from core.routing import Auth, RouterMeta
 
 logger = logging.getLogger(__name__)
@@ -126,6 +127,7 @@ async def update_source(
     source_id: str,
     service: DetectionRulesService = Depends(provide_detection_rules),
     mcp_client=Depends(provide_mcp_client),
+    registry: MCPRegistry = Depends(provide_mcp_registry),
 ):
     """
     Update a single detection rule source (git pull or rescan).
@@ -140,7 +142,7 @@ async def update_source(
         source = service.update_source(source_id)
 
         # After updating, restart the security-detections MCP server to rebuild index
-        await _restart_security_detections_mcp(mcp_client, service)
+        await _restart_security_detections_mcp(mcp_client, service, registry)
 
         return {"success": True, "source": source}
     except ValueError as e:
@@ -154,6 +156,7 @@ async def update_source(
 async def update_all_sources(
     service: DetectionRulesService = Depends(provide_detection_rules),
     mcp_client=Depends(provide_mcp_client),
+    registry: MCPRegistry = Depends(provide_mcp_registry),
 ):
     """
     Update all detection rule sources (git pull all repos).
@@ -164,7 +167,7 @@ async def update_all_sources(
     results = service.update_all()
 
     # After updating all, restart the security-detections MCP server
-    await _restart_security_detections_mcp(mcp_client, service)
+    await _restart_security_detections_mcp(mcp_client, service, registry)
 
     return {"success": True, "results": results}
 
@@ -201,6 +204,7 @@ async def get_mcp_env(
 async def reload_service(
     service: DetectionRulesService = Depends(provide_detection_rules),
     mcp_client=Depends(provide_mcp_client),
+    registry: MCPRegistry = Depends(provide_mcp_registry),
 ):
     """
     Reload the detection rules service (re-reads config and rescans all sources).
@@ -225,13 +229,15 @@ async def reload_service(
     service._save_config()
 
     # Restart the MCP server
-    await _restart_security_detections_mcp(mcp_client, service)
+    await _restart_security_detections_mcp(mcp_client, service, registry)
 
     stats = service.get_stats()
     return {"success": True, "stats": stats}
 
 
-async def _restart_security_detections_mcp(mcp_client, service: DetectionRulesService):
+async def _restart_security_detections_mcp(
+    mcp_client, service: DetectionRulesService, registry: MCPRegistry
+):
     """
     Restart the security-detections MCP server to pick up new/updated rule sources.
     This triggers a re-index of all detection rules in the MCP server.
@@ -253,7 +259,26 @@ async def _restart_security_detections_mcp(mcp_client, service: DetectionRulesSe
 
                 # Disconnect and reconnect MCP client
                 await mcp_client.disconnect_from_server(server_name)
-                await mcp_client.connect_to_server(server_name, persistent=True)
+                try:
+                    deactivate(registry, server_name)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "MCP registry deactivate during restart failed for %s: %s",
+                        server_name,
+                        exc,
+                    )
+                reconnected = await mcp_client.connect_to_server(
+                    server_name, persistent=True
+                )
+                if reconnected:
+                    try:
+                        register_connected(registry, mcp_client, server_name)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug(
+                            "MCP registry register during restart failed for %s: %s",
+                            server_name,
+                            exc,
+                        )
 
                 logger.info(f"Restarted {server_name} MCP server with updated env vars")
             else:

--- a/services/api/routers/mcp.py
+++ b/services/api/routers/mcp.py
@@ -12,7 +12,8 @@ from typing import Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from core.deps import provide_mcp_client
+from core.deps import provide_mcp_client, provide_mcp_registry
+from core.integrations.mcp.registry import MCPRegistry, deactivate, register_connected
 from core.integrations.mcp.service import MCPService
 from core.routing import Auth, RouterMeta
 from core.storage.models import User
@@ -129,6 +130,7 @@ async def set_server_enabled(
     request: ServerEnabledRequest,
     current_user: User = Depends(get_current_active_user),
     mcp_client=Depends(provide_mcp_client),
+    registry: MCPRegistry = Depends(provide_mcp_registry),
 ):
     """Enable or disable an MCP server and apply the change at runtime.
 
@@ -184,6 +186,15 @@ async def set_server_enabled(
             except Exception as exc:  # noqa: BLE001
                 connected = False
                 error = f"{type(exc).__name__}: {exc}"
+            if connected:
+                try:
+                    register_connected(registry, mcp_client, server_name)
+                except Exception as exc:  # noqa: BLE001 — do not change this response
+                    logger.debug(
+                        "MCP registry register after enable failed for %s: %s",
+                        server_name,
+                        exc,
+                    )
     else:
         # Disable → stop any running monitor process + tear down the
         # persistent MCP session so tools disappear from the pool.
@@ -197,6 +208,14 @@ async def set_server_enabled(
                 logger.debug(
                     "Disconnect for %s failed (non-fatal): %s", server_name, exc
                 )
+        try:
+            deactivate(registry, server_name)
+        except Exception as exc:  # noqa: BLE001 — do not change this response
+            logger.debug(
+                "MCP registry deactivate after disable failed for %s: %s",
+                server_name,
+                exc,
+            )
 
     return {
         "success": True,

--- a/tests/integration/test_mcp_enable_transactional.py
+++ b/tests/integration/test_mcp_enable_transactional.py
@@ -26,6 +26,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
+from core.deps import provide_mcp_client, provide_mcp_registry
+from core.integrations.mcp.registry import MCPRegistry
+
 
 @pytest.fixture(scope="module")
 def client():
@@ -36,15 +39,16 @@ def client():
 
 
 @contextmanager
-def _override_mcp_client(client, fake_client):
-    """Swap the MCP client the handler receives (#459) for the duration."""
-    from core.deps import provide_mcp_client
-
+def _override_mcp(client, fake_client, registry=None):
+    """Swap the MCP client (and optionally registry) the handler receives."""
     client.app.dependency_overrides[provide_mcp_client] = lambda: fake_client
+    if registry is not None:
+        client.app.dependency_overrides[provide_mcp_registry] = lambda: registry
     try:
         yield
     finally:
         client.app.dependency_overrides.pop(provide_mcp_client, None)
+        client.app.dependency_overrides.pop(provide_mcp_registry, None)
 
 
 @pytest.fixture
@@ -79,7 +83,7 @@ class TestEnableTransactional:
         fake_client.get_last_error = MagicMock(return_value=None)
         fake_client.disconnect_from_server = AsyncMock(return_value=True)
 
-        with _override_mcp_client(client, fake_client):
+        with _override_mcp(client, fake_client):
             r = client.put(
                 "/api/mcp/servers/deeptempo-findings/enabled",
                 json={"enabled": True},
@@ -106,7 +110,7 @@ class TestEnableTransactional:
         )
         fake_client.disconnect_from_server = AsyncMock(return_value=True)
 
-        with _override_mcp_client(client, fake_client):
+        with _override_mcp(client, fake_client):
             r = client.put(
                 "/api/mcp/servers/virustotal/enabled",
                 json={"enabled": True},
@@ -125,7 +129,7 @@ class TestEnableTransactional:
         fake_client.connect_to_server = AsyncMock(return_value=True)
         fake_client.disconnect_from_server = AsyncMock(return_value=True)
 
-        with _override_mcp_client(client, fake_client):
+        with _override_mcp(client, fake_client):
             r = client.put(
                 "/api/mcp/servers/deeptempo-findings/enabled",
                 json={"enabled": False},
@@ -140,6 +144,87 @@ class TestEnableTransactional:
             "deeptempo-findings"
         )
         fake_client.connect_to_server.assert_not_called()
+
+
+@pytest.mark.integration
+class TestEnableUpdatesRegistry:
+    """Enable/disable must write the registry so chat sees the change with no refresh."""
+
+    def test_enable_makes_tools_visible_without_refresh(
+        self, client, fake_server_known
+    ):
+        registry = MCPRegistry()
+        fake_client = MagicMock()
+        fake_client.tools_cache = {
+            "deeptempo-findings": [
+                {
+                    "name": "list_findings",
+                    "description": "list them",
+                    "inputSchema": {},
+                }
+            ]
+        }
+        fake_client.connect_to_server = AsyncMock(return_value=True)
+        fake_client.get_last_error = MagicMock(return_value=None)
+
+        with _override_mcp(client, fake_client, registry):
+            r = client.put(
+                "/api/mcp/servers/deeptempo-findings/enabled",
+                json={"enabled": True},
+            )
+
+        assert r.status_code == 200, r.text
+        assert [t["name"] for t in registry.get_all_tools()] == [
+            "deeptempo-findings_list_findings"
+        ]
+
+    def test_disable_removes_tools_without_refresh(self, client, fake_server_known):
+        registry = MCPRegistry()
+        registry.register_server(
+            "deeptempo-findings",
+            {},
+            [{"name": "list_findings", "description": "list them", "inputSchema": {}}],
+        )
+        fake_client = MagicMock()
+        fake_client.disconnect_from_server = AsyncMock(return_value=True)
+
+        with _override_mcp(client, fake_client, registry):
+            r = client.put(
+                "/api/mcp/servers/deeptempo-findings/enabled",
+                json={"enabled": False},
+            )
+
+        assert r.status_code == 200, r.text
+        assert registry.get_all_tools() == []
+
+    def test_registry_write_failure_does_not_change_the_response(
+        self, client, fake_server_known
+    ):
+        registry = MCPRegistry()
+        fake_client = MagicMock()
+        fake_client.tools_cache = {
+            "deeptempo-findings": [
+                {"name": "list_findings", "description": "x", "inputSchema": {}}
+            ]
+        }
+        fake_client.connect_to_server = AsyncMock(return_value=True)
+        fake_client.get_last_error = MagicMock(return_value=None)
+
+        with patch(
+            "services.api.routers.mcp.register_connected",
+            side_effect=RuntimeError("registry down"),
+        ), _override_mcp(client, fake_client, registry):
+            r = client.put(
+                "/api/mcp/servers/deeptempo-findings/enabled",
+                json={"enabled": True},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["success"] is True
+        assert body["enabled"] is True
+        assert body["connected"] is True
+        assert body["error"] is None
 
 
 @pytest.mark.integration

--- a/tests/unit/integrations/test_mcp_registry_refresh.py
+++ b/tests/unit/integrations/test_mcp_registry_refresh.py
@@ -1,0 +1,103 @@
+"""Registry tracks enable intent, not the last call_tool's is_connected bit (#809)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.integrations.mcp.registry import (
+    MCPRegistry,
+    deactivate,
+    live_mcp_tools,
+    register_connected,
+)
+
+pytestmark = pytest.mark.unit
+
+TOOL = {
+    "name": "splunk_execute",
+    "description": "x",
+    "inputSchema": {},
+}
+FLAT = "splunk-selfhosted_splunk_execute"
+
+
+class _Client:
+    mcp_service = None
+    tools_cache = {"splunk-selfhosted": [TOOL]}
+
+    def __init__(self, connected: bool):
+        self._connected = connected
+
+    def get_connection_status(self):
+        return {"splunk-selfhosted": self._connected}
+
+
+def test_dropped_session_still_appears_in_live_mcp_tools(monkeypatch):
+    # is_connected is False after any failed call_tool until the next call
+    # reconnects. Pruning on that bit emptied the chat tool list for the
+    # rest of the process (#809).
+    monkeypatch.setattr(
+        "core.integrations.mcp.client.process_mcp_client",
+        lambda: _Client(connected=False),
+    )
+    monkeypatch.setattr(
+        "core.integrations.mcp.registry.eager_connect_enabled", lambda: True
+    )
+
+    registry = MCPRegistry()
+    registry.register_server("splunk-selfhosted", {}, [TOOL])
+    assert registry.get_tool_names() == [FLAT]
+
+    names = [t["name"] for t in live_mcp_tools(registry)]
+    assert names == [FLAT]
+
+
+def test_enable_then_disable_changes_tools_without_a_refresh():
+    registry = MCPRegistry()
+    client = _Client(connected=True)
+
+    assert register_connected(registry, client, "splunk-selfhosted") is True
+    assert registry.get_all_tools()[0]["name"] == FLAT
+
+    deactivate(registry, "splunk-selfhosted")
+    assert registry.get_all_tools() == []
+
+
+def test_live_mcp_tools_does_not_revive_a_disabled_server(monkeypatch):
+    # disconnect_from_server leaves tools_cache in place. A refresh that
+    # still registered from the cache would undo disable.
+    monkeypatch.setattr(
+        "core.integrations.mcp.client.process_mcp_client",
+        lambda: _Client(connected=False),
+    )
+    monkeypatch.setattr(
+        "core.integrations.mcp.registry.eager_connect_enabled", lambda: True
+    )
+
+    registry = MCPRegistry()
+    register_connected(registry, _Client(connected=True), "splunk-selfhosted")
+    deactivate(registry, "splunk-selfhosted")
+
+    assert [t["name"] for t in live_mcp_tools(registry)] == []
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_tool_reaches_a_runtime_enabled_server(monkeypatch):
+    from core.agents.mcp_tools import execute_mcp_tool
+
+    class _Callable(_Client):
+        async def call_tool(self, server, tool, args, timeout=30.0):
+            assert (server, tool) == ("splunk-selfhosted", "splunk_execute")
+            return {"content": [{"type": "text", "text": '{"ok": true}'}]}
+
+    client = _Callable(connected=True)
+    monkeypatch.setattr(
+        "core.integrations.mcp.client.process_mcp_client", lambda: client
+    )
+
+    registry = MCPRegistry()
+    assert register_connected(registry, client, "splunk-selfhosted") is True
+
+    rows, handled = await execute_mcp_tool(FLAT, {}, 5.0, registry)
+    assert handled is True
+    assert rows == [{"ok": True}]

--- a/tests/unit/integrations/test_mcp_registry_refresh.py
+++ b/tests/unit/integrations/test_mcp_registry_refresh.py
@@ -101,3 +101,40 @@ async def test_execute_mcp_tool_reaches_a_runtime_enabled_server(monkeypatch):
     rows, handled = await execute_mcp_tool(FLAT, {}, 5.0, registry)
     assert handled is True
     assert rows == [{"ok": True}]
+
+
+@pytest.mark.asyncio
+async def test_failed_detections_restart_keeps_registered_tools():
+    from services.api.routers.detection_rules import _restart_security_detections_mcp
+
+    registry = MCPRegistry()
+    registry.register_server(
+        "security-detections",
+        {},
+        [{"name": "search", "description": "x", "inputSchema": {}}],
+    )
+
+    class _Server:
+        env: dict = {}
+
+    class _Service:
+        servers = {"security-detections": _Server()}
+
+        def stop_server(self, name):
+            return None
+
+    class _Client:
+        mcp_service = _Service()
+
+        async def disconnect_from_server(self, name):
+            return True
+
+        async def connect_to_server(self, name, persistent=True):
+            return False
+
+    class _Rules:
+        def get_mcp_env_vars(self):
+            return {"SIGMA_PATHS": "/tmp"}
+
+    await _restart_security_detections_mcp(_Client(), _Rules(), registry)
+    assert registry.get_tool_names() == ["security-detections_search"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #809

## Summary

A failed MCP `call_tool` flipped `is_connected` and `refresh_from_client` treated that as “unreachable”, pruning the server from the chat tool list for the rest of the process. The registry now tracks enable/disable intent instead of liveness.

- Dropped the `prune` / `retain_only` path from `refresh_from_client` (and the `prune=False` flag #805 added for hunt resolve).
- Added `register_connected` and `deactivate`, written from `PUT /mcp/servers/{name}/enabled`. Detection-rules reconnect re-registers after a successful connect; it does not deactivate on disconnect (a restart is not a disable).
- `live_mcp_tools` still refreshes as an add-path for connects that happen outside those sites (`retry_dormant_if_ready`, `call_tool` with no session).
- `populate_from_cache` and `tests/unit/integrations/test_mcp_registry_population.py` are unchanged (#129).

## Independent review

- Detection-rules `deactivate` before reconnect would hide tools if reconnect failed — **fixed**: restart no longer deactivates; a unit test keeps tools on a failed reconnect.
- Disable might be undone if `get_connection_status()` is empty or raises — **dismissed**: after a successful disconnect status is `{name: False}` and the add-loop skip holds; empty status is the add-path hole the factory left as backstop, not a new liveness model.
- `test_live_mcp_tools_does_not_revive_a_disabled_server` only covers `connected=False` — **dismissed**: that is the disable-after-disconnect case the product requires.
- Brief tool blackout during a successful detections restart — **fixed** by not deactivating on that path.
- Add-path still skips on `is_connected` at refresh time — **dismissed**: factory said leave the `refresh_from_client` readers as the add-path; do not invent a parallel liveness model.
- `retain_only` is now unused — **dismissed**: factory asked to delete the call with `prune`, not the method.
- Unit tests still monkeypatch `eager_connect_enabled` though refresh no longer reads it — **dismissed**: factory asked those tests to force eager on for the old prune scenario.
- Double try/except around registry writes — **dismissed**: the endpoint contract requires the outer wrap even if the helpers swallow.
- `test_execute_mcp_tool_reaches_a_runtime_enabled_server` does not go through PUT — **dismissed**: the criterion is execute without a playbook resolve; PUT→registry is covered by the integration tests.

## Verification

- `pytest tests/unit/integrations/test_mcp_registry_refresh.py tests/unit/integrations/test_mcp_registry_population.py tests/unit/workflows/test_hunt_resolver.py tests/integration/test_mcp_enable_transactional.py --no-cov` — **54 passed** (Postgres required for the integration file; started `deeptempo-postgres` and `init_database()`).
- `flake8` on changed `services/` and `core/` files — **clean**.
- `black --check` and `isort --check-only` on those files — **clean**.
- `mypy services/ core/ --ignore-missing-imports` — **not a useful local signal**: without `--explicit-package-bases` this environment reports a duplicate-module mapping error and stops; with it, 243 errors in 70 files, none introduced in this diff. CI runs mypy with `continue-on-error`.
- `lint-imports` — **not run** (no import-layer change; `core/` → `core/` and existing `services/api` → `core` edges only).
- Live: started the API (uvicorn on the same asyncio loop as a real `approval` MCP child). `GET /api/health` → 200. Off-request `connect_to_server("approval")` succeeded, then `PUT /api/mcp/servers/approval/enabled` `{enabled: true}` → 200 `connected: true` and `registry.get_all_tools()` listed the five `approval_*` tools with no extra `refresh_from_client`. Flipped `is_connected` to false; `live_mcp_tools()` (what `chat_stream` calls) still returned those five tools. Report: `/opt/cursor/artifacts/mcp809_live_probe.json`.
- Live `PUT` disable of a live stdio session — **could not complete over HTTP**: `disconnect_from_server` inside the request hits a pre-existing Starlette `BaseHTTPMiddleware` / MCP stdio cancel-scope `CancelledError`. `deactivate()` in-process then cleared the tools. HTTP disable with a stubbed client is covered by the integration tests.
- `POST /api/claude/chat/stream` — **not run** (no LLM provider configured; `live_mcp_tools` is the function that route uses for the chat tool list).
- `agent-browser` — **not applicable** (API/registry change, no UI).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8b4110c-3fbc-4d3d-981f-bbcc79f50101?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8b4110c-3fbc-4d3d-981f-bbcc79f50101&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

