### PR TITLE
Keep a dropped MCP session in the chat tool list

### DIFF
--- a/core/integrations/mcp/registry.py
+++ b/core/integrations/mcp/registry.py
@@ -64,6 +64,12 @@ class MCPRegistry:
         for name, info in self._servers.items():
             info["active"] = name in wanted
 
+    def set_active(self, server_name: str, active: bool) -> None:
+        """Mark one server active or inactive. No-op if it is not registered."""
+        info = self._servers.get(server_name)
+        if info is not None:
+            info["active"] = active
+
     def get_all_tools(self) -> List[Dict]:
         """
         Get all tools from all active servers, formatted for Claude API.
@@ -177,9 +183,9 @@ def _normalised(tool: Dict[str, Any]) -> Dict[str, Any]:
 
 # Whether this deployment dials every configured MCP server at startup. Off by
 # default under DEV_MODE; an explicit ``mcp_auto_connect_on_startup`` wins either
-# way. ``refresh_from_client`` uses it to decide whether live connection state is
-# authoritative enough to prune servers. services/api/main.py makes the same call
-# for its own startup path; core/ cannot import services/, so the rule lives here.
+# way. ``populate_from_cache`` uses it to decide whether live connection state
+# gates the warm-start cache. services/api/main.py makes the same call for its
+# own startup path; core/ cannot import services/, so the rule lives here.
 def eager_connect_enabled() -> bool:
     from core.config import get_settings
 
@@ -242,18 +248,51 @@ def safe_tool_names(registry: Optional[MCPRegistry]) -> List[str]:
         return []
 
 
-def refresh_from_client(registry: MCPRegistry, prune: bool = True) -> int:
-    """Sync the registry to the client's LIVE connection state.
+def register_connected(registry: MCPRegistry, mcp_client, server_name: str) -> bool:
+    """Register one server from the client's ``tools_cache``.
+
+    Best effort: a failure logs at debug and returns False so a mutation site
+    (enable, reconnect) can keep its own result.
+    """
+    try:
+        tools = (getattr(mcp_client, "tools_cache", None) or {}).get(server_name)
+        if not isinstance(tools, list) or not tools:
+            return False
+        registry.register_server(
+            server_name,
+            _server_config(mcp_client, server_name),
+            [_normalised(t) for t in tools],
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "Could not register connected MCP server %s: %s", server_name, exc
+        )
+        return False
+
+
+def deactivate(registry: MCPRegistry, server_name: str) -> None:
+    """Stop offering this server's tools. Best effort; disable is the intent."""
+    try:
+        registry.set_active(server_name, False)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not deactivate MCP server %s: %s", server_name, exc)
+
+
+def refresh_from_client(registry: MCPRegistry) -> int:
+    """Add currently-connected servers from the client's ``tools_cache``.
 
     Unlike ``populate_from_cache`` (a boot warm-start that prefers the on-disk
     tool cache), this reads the running client's ``tools_cache`` and current
     connection status, so a server connected *after* startup — e.g. a user just
     saved its credential and enabled it — becomes usable on the next turn
-    without a restart, and one that has disconnected drops out. Cheap and
-    idempotent; call it wherever a turn assembles its tool list.
+    without a restart. Cheap and idempotent; call it wherever a turn assembles
+    its tool list.
 
-    ``prune=False`` adds without dropping, for a caller whose binding outlives
-    the moment it reads.
+    Does not remove servers. ``is_connected`` means "the last call failed", not
+    "unreachable", so a session that dropped after a successful connect stays
+    offered until someone disables it. Disable is the intent signal and goes
+    through ``deactivate``.
     """
     from core.integrations.mcp.client import process_mcp_client
 
@@ -267,27 +306,15 @@ def refresh_from_client(registry: MCPRegistry, prune: bool = True) -> int:
         logger.debug("Could not read MCP connection status: %s", exc)
         connected = {}
 
-    active: List[str] = []
+    added = 0
     for name, tools in tools_dict.items():
         if connected and not connected.get(name, False):
             continue
         registry.register_server(
             name, _server_config(mcp_client, name), [_normalised(t) for t in tools]
         )
-        active.append(name)
-    # Only prune when this boot dials eagerly and we actually have live status:
-    # then tools_cache/connected is the source of truth, so a disconnected
-    # server should drop out. In lazy mode the boot-populated set is intended
-    # availability (servers reconnect on first call), so we add without pruning
-    # to avoid wiping tools that are still reachable.
-    #
-    # A caller passes prune=False when it binds once and is read for a long time
-    # afterwards: is_connected goes False on any failed call and stays there
-    # until the next one reconnects, so it says "the last call failed", not
-    # "unreachable", and dropping the server costs more than keeping it.
-    if prune and eager_connect_enabled() and connected:
-        registry.retain_only(active)
-    return len(active)
+        added += 1
+    return added
 
 
 def live_mcp_tools(registry: MCPRegistry) -> List[Dict]:

--- a/core/workflows/playbook_resolver.py
+++ b/core/workflows/playbook_resolver.py
@@ -52,14 +52,10 @@ def _mcp_catalogue(registry: Optional["MCPRegistry"]) -> List[Dict[str, Any]]:
     # enabled+connected after boot binds here without a reload. No-op when there
     # is no process client. Best effort in its own right: a refresh that fails
     # must not cost us the registry we already hold, nor the cache fallback below.
-    #
-    # Without pruning: a run binds its capabilities once and then reads them for
-    # as long as it lasts, so a server dropped here for a stale is_connected is
-    # gone for the whole run even though the next call would reconnect it.
     try:
         from core.integrations.mcp.registry import refresh_from_client
 
-        refresh_from_client(registry, prune=False)
+        refresh_from_client(registry)
     except Exception as exc:  # noqa: BLE001
         logger.debug("MCP refresh failed while resolving tools: %s", exc)
 

--- a/services/api/routers/detection_rules.py
+++ b/services/api/routers/detection_rules.py
@@ -6,8 +6,9 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from core.deps import provide_detection_rules, provide_mcp_client
+from core.deps import provide_detection_rules, provide_mcp_client, provide_mcp_registry
 from core.detections.detection_rules_service import DetectionRulesService
+from core.integrations.mcp.registry import MCPRegistry, register_connected
 from core.routing import Auth, RouterMeta
 
 logger = logging.getLogger(__name__)
@@ -126,6 +127,7 @@ async def update_source(
     source_id: str,
     service: DetectionRulesService = Depends(provide_detection_rules),
     mcp_client=Depends(provide_mcp_client),
+    registry: MCPRegistry = Depends(provide_mcp_registry),
 ):
     """
     Update a single detection rule source (git pull or rescan).
@@ -140,7 +142,7 @@ async def update_source(
         source = service.update_source(source_id)
 
         # After updating, restart the security-detections MCP server to rebuild index
-        await _restart_security_detections_mcp(mcp_client, service)
+        await _restart_security_detections_mcp(mcp_client, service, registry)
 
         return {"success": True, "source": source}
     except ValueError as e:
@@ -154,6 +156,7 @@ async def update_source(
 async def update_all_sources(
     service: DetectionRulesService = Depends(provide_detection_rules),
     mcp_client=Depends(provide_mcp_client),
+    registry: MCPRegistry = Depends(provide_mcp_registry),
 ):
     """
     Update all detection rule sources (git pull all repos).
@@ -164,7 +167,7 @@ async def update_all_sources(
     results = service.update_all()
 
     # After updating all, restart the security-detections MCP server
-    await _restart_security_detections_mcp(mcp_client, service)
+    await _restart_security_detections_mcp(mcp_client, service, registry)
 
     return {"success": True, "results": results}
 
@@ -201,6 +204,7 @@ async def get_mcp_env(
 async def reload_service(
     service: DetectionRulesService = Depends(provide_detection_rules),
     mcp_client=Depends(provide_mcp_client),
+    registry: MCPRegistry = Depends(provide_mcp_registry),
 ):
     """
     Reload the detection rules service (re-reads config and rescans all sources).
@@ -225,13 +229,17 @@ async def reload_service(
     service._save_config()
 
     # Restart the MCP server
-    await _restart_security_detections_mcp(mcp_client, service)
+    await _restart_security_detections_mcp(mcp_client, service, registry)
 
     stats = service.get_stats()
     return {"success": True, "stats": stats}
 
 
-async def _restart_security_detections_mcp(mcp_client, service: DetectionRulesService):
+async def _restart_security_detections_mcp(
+    mcp_client,
+    service: DetectionRulesService,
+    registry: Optional[MCPRegistry] = None,
+):
     """
     Restart the security-detections MCP server to pick up new/updated rule sources.
     This triggers a re-index of all detection rules in the MCP server.
@@ -254,6 +262,13 @@ async def _restart_security_detections_mcp(mcp_client, service: DetectionRulesSe
                 # Disconnect and reconnect MCP client
                 await mcp_client.disconnect_from_server(server_name)
                 await mcp_client.connect_to_server(server_name, persistent=True)
+                if registry is not None:
+                    try:
+                        register_connected(registry, mcp_client, server_name)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug(
+                            "MCP registry write failed (non-fatal): %s", exc
+                        )
 
                 logger.info(f"Restarted {server_name} MCP server with updated env vars")
             else:

--- a/services/api/routers/mcp.py
+++ b/services/api/routers/mcp.py
@@ -12,7 +12,8 @@ from typing import Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from core.deps import provide_mcp_client
+from core.deps import provide_mcp_client, provide_mcp_registry
+from core.integrations.mcp.registry import MCPRegistry, deactivate, register_connected
 from core.integrations.mcp.service import MCPService
 from core.routing import Auth, RouterMeta
 from core.storage.models import User
@@ -76,6 +77,14 @@ class _ServiceProxy:
 mcp_service = _ServiceProxy()
 
 
+def _best_effort_registry(action, *args) -> None:
+    """A registry write must not change the enable endpoint's status or body."""
+    try:
+        action(*args)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("MCP registry write failed (non-fatal): %s", exc)
+
+
 class ServerEnabledRequest(BaseModel):
     """Request body for enabling/disabling a server."""
 
@@ -129,6 +138,7 @@ async def set_server_enabled(
     request: ServerEnabledRequest,
     current_user: User = Depends(get_current_active_user),
     mcp_client=Depends(provide_mcp_client),
+    registry: MCPRegistry = Depends(provide_mcp_registry),
 ):
     """Enable or disable an MCP server and apply the change at runtime.
 
@@ -176,7 +186,11 @@ async def set_server_enabled(
                 connected = await mcp_client.connect_to_server(
                     server_name, persistent=True
                 )
-                if not connected:
+                if connected:
+                    _best_effort_registry(
+                        register_connected, registry, mcp_client, server_name
+                    )
+                else:
                     error = mcp_client.get_last_error(server_name)
                     missing_credentials = mcp_client.get_missing_credentials(
                         server_name
@@ -197,6 +211,7 @@ async def set_server_enabled(
                 logger.debug(
                     "Disconnect for %s failed (non-fatal): %s", server_name, exc
                 )
+        _best_effort_registry(deactivate, registry, server_name)
 
     return {
         "success": True,

--- a/tests/integration/test_mcp_enable_transactional.py
+++ b/tests/integration/test_mcp_enable_transactional.py
@@ -47,6 +47,27 @@ def _override_mcp_client(client, fake_client):
         client.app.dependency_overrides.pop(provide_mcp_client, None)
 
 
+@contextmanager
+def _override_registry(client, registry):
+    from core.deps import provide_mcp_registry
+
+    client.app.dependency_overrides[provide_mcp_registry] = lambda: registry
+    try:
+        yield
+    finally:
+        client.app.dependency_overrides.pop(provide_mcp_registry, None)
+
+
+def _connected_client(server_name, tools):
+    fake_client = MagicMock()
+    fake_client.connect_to_server = AsyncMock(return_value=True)
+    fake_client.get_last_error = MagicMock(return_value=None)
+    fake_client.disconnect_from_server = AsyncMock(return_value=True)
+    fake_client.tools_cache = {server_name: tools}
+    fake_client.mcp_service.servers = {}
+    return fake_client
+
+
 @pytest.fixture
 def fake_server_known():
     """Patch mcp_service so ``deeptempo-findings`` is a known, settable server."""
@@ -74,12 +95,16 @@ class TestEnableTransactional:
     def test_enable_triggers_connect_and_reports_connected(
         self, client, fake_server_known
     ):
+        from core.integrations.mcp.registry import MCPRegistry
+
         fake_client = MagicMock()
         fake_client.connect_to_server = AsyncMock(return_value=True)
         fake_client.get_last_error = MagicMock(return_value=None)
         fake_client.disconnect_from_server = AsyncMock(return_value=True)
 
-        with _override_mcp_client(client, fake_client):
+        with _override_mcp_client(client, fake_client), _override_registry(
+            client, MCPRegistry()
+        ):
             r = client.put(
                 "/api/mcp/servers/deeptempo-findings/enabled",
                 json={"enabled": True},
@@ -98,6 +123,8 @@ class TestEnableTransactional:
     def test_enable_with_missing_creds_reports_error_not_raising(
         self, client, fake_server_known
     ):
+        from core.integrations.mcp.registry import MCPRegistry
+
         # Simulate the credential-missing / FileNotFoundError / etc. case.
         fake_client = MagicMock()
         fake_client.connect_to_server = AsyncMock(return_value=False)
@@ -106,7 +133,9 @@ class TestEnableTransactional:
         )
         fake_client.disconnect_from_server = AsyncMock(return_value=True)
 
-        with _override_mcp_client(client, fake_client):
+        with _override_mcp_client(client, fake_client), _override_registry(
+            client, MCPRegistry()
+        ):
             r = client.put(
                 "/api/mcp/servers/virustotal/enabled",
                 json={"enabled": True},
@@ -121,11 +150,15 @@ class TestEnableTransactional:
         assert "VIRUSTOTAL_API_KEY" in (body["error"] or "")
 
     def test_disable_triggers_disconnect(self, client, fake_server_known):
+        from core.integrations.mcp.registry import MCPRegistry
+
         fake_client = MagicMock()
         fake_client.connect_to_server = AsyncMock(return_value=True)
         fake_client.disconnect_from_server = AsyncMock(return_value=True)
 
-        with _override_mcp_client(client, fake_client):
+        with _override_mcp_client(client, fake_client), _override_registry(
+            client, MCPRegistry()
+        ):
             r = client.put(
                 "/api/mcp/servers/deeptempo-findings/enabled",
                 json={"enabled": False},
@@ -140,6 +173,85 @@ class TestEnableTransactional:
             "deeptempo-findings"
         )
         fake_client.connect_to_server.assert_not_called()
+
+    def test_enable_writes_tools_to_the_registry_without_a_refresh(
+        self, client, fake_server_known
+    ):
+        from core.integrations.mcp.registry import MCPRegistry
+
+        registry = MCPRegistry()
+        fake_client = _connected_client(
+            "deeptempo-findings",
+            [{"name": "search", "description": "x", "inputSchema": {}}],
+        )
+
+        with _override_mcp_client(client, fake_client), _override_registry(
+            client, registry
+        ):
+            r = client.put(
+                "/api/mcp/servers/deeptempo-findings/enabled",
+                json={"enabled": True},
+            )
+
+        assert r.status_code == 200, r.text
+        assert r.json()["connected"] is True
+        assert [t["name"] for t in registry.get_all_tools()] == [
+            "deeptempo-findings_search"
+        ]
+
+    def test_disable_removes_tools_from_the_registry_without_a_refresh(
+        self, client, fake_server_known
+    ):
+        from core.integrations.mcp.registry import MCPRegistry
+
+        registry = MCPRegistry()
+        registry.register_server(
+            "deeptempo-findings",
+            {},
+            [{"name": "search", "description": "x", "inputSchema": {}}],
+        )
+        fake_client = _connected_client("deeptempo-findings", [])
+
+        with _override_mcp_client(client, fake_client), _override_registry(
+            client, registry
+        ):
+            r = client.put(
+                "/api/mcp/servers/deeptempo-findings/enabled",
+                json={"enabled": False},
+            )
+
+        assert r.status_code == 200, r.text
+        assert r.json()["enabled"] is False
+        assert registry.get_all_tools() == []
+
+    def test_registry_write_failure_does_not_change_the_response(
+        self, client, fake_server_known
+    ):
+        from core.integrations.mcp.registry import MCPRegistry
+
+        registry = MCPRegistry()
+        fake_client = _connected_client(
+            "deeptempo-findings",
+            [{"name": "search", "description": "x", "inputSchema": {}}],
+        )
+
+        with _override_mcp_client(client, fake_client), _override_registry(
+            client, registry
+        ), patch(
+            "services.api.routers.mcp.register_connected",
+            side_effect=RuntimeError("registry down"),
+        ):
+            r = client.put(
+                "/api/mcp/servers/deeptempo-findings/enabled",
+                json={"enabled": True},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["success"] is True
+        assert body["enabled"] is True
+        assert body["connected"] is True
+        assert body["error"] is None
 
 
 @pytest.mark.integration

--- a/tests/unit/integrations/test_mcp_registry_intent.py
+++ b/tests/unit/integrations/test_mcp_registry_intent.py
@@ -1,0 +1,105 @@
+"""Registry tracks intent (enabled), not the last call_tool's is_connected bit (#809)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.agents.mcp_tools import execute_mcp_tool
+from core.integrations.mcp.registry import (
+    MCPRegistry,
+    deactivate,
+    live_mcp_tools,
+    register_connected,
+)
+
+pytestmark = pytest.mark.unit
+
+TOOL = {
+    "name": "splunk_execute",
+    "description": "x",
+    "inputSchema": {},
+}
+
+
+class _Client:
+    mcp_service = None
+    tools_cache = {"splunk-selfhosted": [TOOL]}
+
+    def __init__(self, connected=False):
+        self._connected = connected
+
+    def get_connection_status(self):
+        return {"splunk-selfhosted": self._connected}
+
+
+def _register(registry=None, client=None):
+    registry = registry or MCPRegistry()
+    client = client or _Client(connected=True)
+    assert register_connected(registry, client, "splunk-selfhosted")
+    return registry, client
+
+
+def test_dropped_session_still_appears_in_live_mcp_tools(monkeypatch):
+    # The bug: is_connected is False after any failed call_tool, refresh pruned
+    # the server, and chat never offered it again so nothing could reconnect.
+    monkeypatch.setattr(
+        "core.integrations.mcp.registry.eager_connect_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        "core.integrations.mcp.client.process_mcp_client", lambda: _Client(False)
+    )
+
+    registry = MCPRegistry()
+    registry.register_server("splunk-selfhosted", {}, [TOOL])
+    assert registry.get_tool_names() == ["splunk-selfhosted_splunk_execute"]
+
+    names = [t["name"] for t in live_mcp_tools(registry)]
+    assert names == ["splunk-selfhosted_splunk_execute"]
+
+
+def test_enable_makes_tools_visible_without_refresh():
+    registry, _ = _register()
+    assert [t["name"] for t in registry.get_all_tools()] == [
+        "splunk-selfhosted_splunk_execute"
+    ]
+
+
+def test_disable_hides_tools_without_refresh():
+    registry, _ = _register()
+    deactivate(registry, "splunk-selfhosted")
+    assert registry.get_all_tools() == []
+
+
+def test_disabled_server_is_not_resurrected_by_live_refresh(monkeypatch):
+    # disconnect_from_server leaves tools_cache; without deactivate the old
+    # prune-on-read hide would be gone and disable would leak tools into chat.
+    monkeypatch.setattr(
+        "core.integrations.mcp.registry.eager_connect_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        "core.integrations.mcp.client.process_mcp_client", lambda: _Client(False)
+    )
+
+    registry, _ = _register()
+    deactivate(registry, "splunk-selfhosted")
+    assert [t["name"] for t in live_mcp_tools(registry)] == []
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_tool_after_runtime_enable_without_a_resolve(monkeypatch):
+    registry, client = _register()
+
+    async def _call(server, tool, args, timeout=30.0):
+        assert (server, tool, args) == ("splunk-selfhosted", "splunk_execute", {})
+        return {"content": [{"type": "text", "text": '{"ok": true}'}]}
+
+    client.call_tool = _call
+    monkeypatch.setattr(
+        "core.integrations.mcp.client.process_mcp_client", lambda: client
+    )
+
+    rows, handled = await execute_mcp_tool(
+        "splunk-selfhosted_splunk_execute", {}, 5.0, registry
+    )
+    assert handled is True
+    assert rows == [{"ok": True}]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #809

One failed `call_tool` was permanently removing that MCP server from chat until the backend restarted. `is_connected` means "the last call failed", not "unreachable", but `refresh_from_client` treated it as unreachable and pruned the server. Chat (`live_mcp_tools`) is a prune-on-read caller, so the tools vanished and nothing could reconnect them.

## Changes

- Stop `refresh_from_client` from pruning. Drop the `prune` parameter (#805's opt-out) along with the `retain_only` call.
- Add `register_connected` / `deactivate` (and `MCPRegistry.set_active`) and call them where connection intent actually changes: `PUT /mcp/servers/{name}/enabled` and the detection-rules disconnect/reconnect pair.
- Registry writes are best-effort: a raise does not change that endpoint's status or body.
- Leave `populate_from_cache` and the four `refresh_from_client` readers as they are. A server that never came up this boot is still gated (#129).

## Tests

- `tests/unit/integrations/test_mcp_registry_intent.py` — dropped session stays in `live_mcp_tools`; enable/disable without a refresh; disable is not resurrected by a live refresh; `execute_mcp_tool` after a runtime enable without a playbook resolve.
- `tests/integration/test_mcp_enable_transactional.py` — PUT enable/disable updates `registry.get_all_tools()`; a registry write that raises still returns 200 with the same body.
- `tests/unit/integrations/test_mcp_registry_population.py` unmodified.

Independent review of the full diff: pending.

## Verification

In progress — checks and live exercise will be filled in after the test run.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cfddded-95ad-4753-b6e1-5d5d1c92afbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cfddded-95ad-4753-b6e1-5d5d1c92afbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

