### PR TITLE
chore(release): pin the next release to 0.6.0

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -24,6 +24,7 @@
   "packages": {
     ".": {
       "package-name": "vigil",
+      "release-as": "0.6.0",
       "include-component-in-tag": false,
       "version-file": "VERSION",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Pins the open release PR (#684) to **0.6.0**.

## Why

release-please currently proposes `0.5.1`, even though the range since `v0.5.0` carries six features (episodic memory, root-cause-analysis runs, concurrent MCP connect, the runnable hunt console, findings-view export, splunk-selfhosted by default). Adding `release-as` to the `.` package overrides the computed bump, so the next push to `main` retitles #684 to `chore(main): release 0.6.0` and the tag lands as `v0.6.0`.

## The pin is sticky

`release-as` is not consumed on use — every release PR stays `0.6.0` until the key is removed. **Follow-up required: drop it once `v0.6.0` is tagged.**

## Related, not fixed here

`bump-minor-pre-major` and `bump-patch-for-minor-pre-major` sit at the config root rather than inside the `.` package block, which is the likely reason features bumped a patch instead of a minor. Left alone so this PR is only the pin; worth a separate change before `v0.7.0` so the version resolves correctly on its own.
