### PR TITLE
Make a Bifrost-configured provider usable end to end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,7 +209,9 @@ config.json
 # config.db is its config store and holds provider API keys -- in plaintext
 # unless the deployment turned on Bifrost's key encryption; logs.db carries
 # request and response bodies. Neither is ever committed.
-bifrost/
+# Anchored: unanchored, this also swallowed core/llm/bifrost/ and
+# infra/docker/bifrost/, so a new file in either was ignored on sight.
+/bifrost/
 /logs.db
 
 # Node.js / React

--- a/clients/web/src/screens/settings/AiProvidersPanel.test.tsx
+++ b/clients/web/src/screens/settings/AiProvidersPanel.test.tsx
@@ -12,7 +12,13 @@ const providerModels = vi.fn()
 const modelParameters = vi.fn()
 const createKey = vi.fn(() => Promise.resolve({ data: { id: 'k1', status: 'success' } }))
 const updateKey = vi.fn(() => Promise.resolve({ data: { id: 'k1', status: 'success' } }))
+const routability = vi.fn()
 
+// This mock replaces the module wholesale, so anything the panel reaches for and
+// does not find here is `undefined` at the call site rather than a missing-export
+// error — which surfaces as the panel's generic failure state and says nothing
+// about the cause. Keep it in step with what AiProvidersPanel and useBifrost
+// import.
 vi.mock('../../services/bifrostApi', () => ({
   bifrostApi: {
     listProviders: () => listProviders(),
@@ -21,11 +27,18 @@ vi.mock('../../services/bifrostApi', () => ({
     modelParameters: (...a: unknown[]) => modelParameters(...(a as [])),
     createKey: (...a: unknown[]) => createKey(...(a as [])),
     updateKey: (...a: unknown[]) => updateKey(...(a as [])),
+    routability: () => routability(),
     createProvider: vi.fn(),
     removeProvider: vi.fn(),
     removeKey: vi.fn(),
   },
   secretText: (v: unknown) => (typeof v === 'string' ? v : ((v as { value?: string })?.value ?? '')),
+  isMasked: (v: unknown) =>
+    (typeof v === 'string' ? v : ((v as { value?: string })?.value ?? '')).includes('*'),
+  secretEnvRef: (v: unknown) =>
+    typeof v === 'object' && (v as { from_env?: boolean })?.from_env
+      ? ((v as { env_var?: string }).env_var ?? '')
+      : '',
   COMMON_PROVIDERS: ['anthropic', 'openai', 'ollama', 'vertex'],
 }))
 
@@ -45,6 +58,16 @@ const mount = async (keys: unknown[], routable: string[]) => {
   listKeys.mockResolvedValue({ data: { keys, total: keys.length } })
   providerModels.mockResolvedValue({
     data: { models: routable.map((name) => ({ name, provider: 'anthropic' })), total: routable.length },
+  })
+  routability.mockResolvedValue({
+    data: {
+      providers: { anthropic: keys.length > 0 },
+      keys: Object.fromEntries(
+        (keys as { id?: string }[])
+          .filter((k) => k.id)
+          .map((k) => [k.id, { provider: 'anthropic', routable: true, health: 'healthy' }]),
+      ),
+    },
   })
   render(<AiProvidersPanel notify={() => {}} />)
   await screen.findByText('anthropic')

--- a/clients/web/src/screens/settings/AiProvidersPanel.test.tsx
+++ b/clients/web/src/screens/settings/AiProvidersPanel.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../../services/bifrostApi', () => ({
   secretText: (v: unknown) => (typeof v === 'string' ? v : ((v as { value?: string })?.value ?? '')),
   isMasked: (v: unknown) =>
     (typeof v === 'string' ? v : ((v as { value?: string })?.value ?? '')).includes('*'),
+  keyRefusal: () => Promise.resolve(null),
   secretEnvRef: (v: unknown) =>
     typeof v === 'object' && (v as { from_env?: boolean })?.from_env
       ? ((v as { env_var?: string }).env_var ?? '')

--- a/clients/web/src/screens/settings/AiProvidersPanel.tsx
+++ b/clients/web/src/screens/settings/AiProvidersPanel.tsx
@@ -25,26 +25,71 @@ import {
 import { useBifrostProviders, useProviderModels, bifrostError } from './useBifrost'
 import {
   bifrostApi,
+  isMasked,
   secretText,
   COMMON_PROVIDERS,
+  type KeyVerdict,
   type BifrostKey,
   type BifrostKeyWrite,
 } from '../../services/bifrostApi'
 import type { SectionProps } from './types'
 
-function KeyStatusChip({ status }: { status?: string }) {
-  if (status === 'success') return <span className="status closed">Healthy</span>
-  if (!status || status === 'unknown') return <span className="chip">Unverified</span>
+// The label comes from the backend's verdict (core/llm/bifrost/mirror.py), which
+// is the only thing that knows whether a `list_models_failed` was a refusal or a
+// check that could never have run. `status` is the fallback for a key the
+// verdict call didn't cover — showing "Rejected" for a key that routes fine sent
+// people looking for a fault that isn't there.
+function KeyStatusChip({ status, description, verdict }: {
+  status?: string
+  description?: string
+  verdict?: KeyVerdict
+}) {
+  const health = verdict?.health ?? (status === 'success' ? 'healthy' : undefined)
+  if (health === 'healthy') return <span className="status closed">Healthy</span>
+  if (health === 'unverified' || !status || status === 'unknown') {
+    return <span className="chip">Unverified</span>
+  }
+  if (health === 'unverifiable') {
+    return (
+      <span className="chip" title={description}>
+        Unverifiable
+      </span>
+    )
+  }
   return (
-    <span className="chip" style={{ color: 'var(--crit)' }} title={status}>
+    <span className="chip" style={{ color: 'var(--crit)' }} title={description || status}>
       {status === 'list_models_failed' ? 'Rejected' : status}
     </span>
   )
 }
 
+/** Did the backend judge this freshly-written key a real failure?
+    Re-reads the verdict rather than the hook's copy, which the save has just
+    invalidated. A verdict we can't fetch is not reported as a fault — the key
+    is stored either way, and the table's chip will show the truth on reload. */
+async function keyRejected(keyId: string | undefined): Promise<boolean> {
+  if (!keyId) return false
+  try {
+    const { data } = await bifrostApi.routability()
+    return data.keys?.[keyId]?.health === 'rejected'
+  } catch {
+    return false
+  }
+}
+
 export default function AiProvidersPanel({ notify }: SectionProps) {
-  const { providers, keys, phase, error, reload, saveKey, removeKey, addProvider, removeProvider } =
-    useBifrostProviders()
+  const {
+    providers,
+    keys,
+    verdicts,
+    phase,
+    error,
+    reload,
+    saveKey,
+    removeKey,
+    addProvider,
+    removeProvider,
+  } = useBifrostProviders()
   const [expanded, setExpanded] = useState<string | null>(null)
   const [editing, setEditing] = useState<{ provider: string; key: BifrostKey | null } | null>(null)
   const [addingProvider, setAddingProvider] = useState(false)
@@ -189,7 +234,7 @@ export default function AiProvidersPanel({ notify }: SectionProps) {
                               ? 'All'
                               : `${k.models?.length || 0} allowed`}
                           </td>
-                          <td><KeyStatusChip status={k.status} /></td>
+                          <td><KeyStatusChip status={k.status} description={k.description} verdict={verdicts.keys[k.id]} /></td>
                           <td style={{ textAlign: 'right' }}>
                             <div className="inline-flex gap-1.5">
                               <button
@@ -254,12 +299,17 @@ export default function AiProvidersPanel({ notify }: SectionProps) {
             setEditing(null)
             setExpanded(editing.provider)
             // Bifrost validates the credential upstream as it stores it, so its
-            // verdict is the only test result there is — surface it verbatim.
-            if (saved?.status && saved.status !== 'success' && saved.status !== 'unknown') {
-              notify('err', `Key stored, but Bifrost reports "${saved.status}" — check the credential.`)
-            } else {
-              notify('ok', 'Key saved.')
-            }
+            // verdict is the only test result there is. Ask the backend what
+            // that verdict means rather than reading `status` here: a
+            // `list_models_failed` the gateway could never have passed is not a
+            // fault to report, and only one place knows the difference.
+            const rejected = await keyRejected(saved?.id)
+            notify(
+              rejected ? 'err' : 'ok',
+              rejected
+                ? `Key stored, but Bifrost reports "${saved?.status}" — check the credential.`
+                : 'Key saved.',
+            )
           }}
         />
       )}
@@ -302,14 +352,22 @@ export function KeyDialog({
   // Vertex takes either a bare API key or a service-account JSON scoped by
   // project/region — so it gets a mode switch and its own fields.
   const isVertex = provider === 'vertex'
+  const storedProject = secretText(existing?.vertex_key_config?.project_id)
+  const storedRegion = secretText(existing?.vertex_key_config?.region)
   const [vertexAuth, setVertexAuth] = useState<'service_account' | 'api_key'>(
-    existing?.vertex_key_config?.project_id ? 'service_account' : 'api_key',
+    storedProject ? 'service_account' : 'api_key',
   )
 
   const [name, setName] = useState(existing?.name || `${provider}-key`)
   const [secret, setSecret] = useState('')
-  const [projectId, setProjectId] = useState(existing?.vertex_key_config?.project_id ?? '')
-  const [region, setRegion] = useState(existing?.vertex_key_config?.region ?? '')
+  // Bifrost masks project/region on read like any other stored field, so a
+  // masked one starts blank behind its own mask as a placeholder — the same
+  // "leave blank to keep" contract the service-account JSON already has.
+  // Seeding the input with the mask instead put "[object Object]" in the box
+  // (the wrapper is not a string) and, once unwrapped, would have written the
+  // mask back as the project id.
+  const [projectId, setProjectId] = useState(isMasked(storedProject) ? '' : storedProject)
+  const [region, setRegion] = useState(isMasked(storedRegion) ? '' : storedRegion)
   const [weight, setWeight] = useState(existing?.weight ?? 1)
   const [enabled, setEnabled] = useState(existing?.enabled ?? true)
   const [allowAll, setAllowAll] = useState(existing ? existing.models?.includes('*') !== false : true)
@@ -328,11 +386,11 @@ export function KeyDialog({
         models: allowAll ? ['*'] : chosen,
       }
       if (isVertex && vertexAuth === 'service_account') {
-        // The service-account JSON is omitted when left blank; the backend
-        // substitutes the stored copy into both auth_credentials and value.
+        // Every field is omitted when left blank; the backend substitutes its
+        // stored copy, and for the credential mirrors it into `value` too.
         base.vertex_key_config = {
-          project_id: projectId.trim() || undefined,
-          region: region.trim() || undefined,
+          ...(projectId.trim() ? { project_id: projectId.trim() } : {}),
+          ...(region.trim() ? { region: region.trim() } : {}),
           ...(secret.trim() ? { auth_credentials: secret.trim() } : {}),
         }
       } else if (secret.trim()) {
@@ -364,7 +422,10 @@ export function KeyDialog({
         </Field>
         {isVertex ? (
           <>
-            <Field label="Authentication" hint="Vertex accepts either a plain API key or a service-account key.">
+            <Field
+              label="Authentication"
+              hint="An API key only works against Vertex express mode — an AI Studio key belongs under the gemini provider instead. A service account is what a standard Vertex project takes."
+            >
               <div className="inline-flex gap-1.5">
                 {(
                   [
@@ -389,11 +450,33 @@ export function KeyDialog({
             {vertexAuth === 'service_account' ? (
               <>
                 <div className="settings-grid-2" style={{ gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr)' }}>
-                  <Field label="Project ID" hint="The GCP project that owns the Vertex AI endpoint.">
-                    <TextInput value={projectId} onChange={(e) => setProjectId(e.target.value)} placeholder="my-gcp-project" />
+                  <Field
+                    label="Project ID"
+                    hint={
+                      storedProject
+                        ? 'Leave blank to keep the stored project.'
+                        : 'The GCP project that owns the Vertex AI endpoint.'
+                    }
+                  >
+                    <TextInput
+                      value={projectId}
+                      onChange={(e) => setProjectId(e.target.value)}
+                      placeholder={storedProject || 'my-gcp-project'}
+                    />
                   </Field>
-                  <Field label="Region" hint="Vertex location, e.g. us-central1.">
-                    <TextInput value={region} onChange={(e) => setRegion(e.target.value)} placeholder="us-central1" />
+                  <Field
+                    label="Region"
+                    hint={
+                      storedRegion
+                        ? 'Leave blank to keep the stored region.'
+                        : 'Vertex location, e.g. us-central1.'
+                    }
+                  >
+                    <TextInput
+                      value={region}
+                      onChange={(e) => setRegion(e.target.value)}
+                      placeholder={storedRegion || 'us-central1'}
+                    />
                   </Field>
                 </div>
                 <Field
@@ -401,7 +484,7 @@ export function KeyDialog({
                   hint={
                     existing
                       ? 'Leave blank to keep the stored service account — paste a new one only to rotate it.'
-                      : 'The full service-account key JSON. Stored encrypted in Vigil’s secret store and pushed to the gateway.'
+                      : 'The service-account key file — the one whose "type" is "service_account". A gcloud application-default login file is also accepted, but it is your own login and stops working on your org’s reauth schedule. Stored encrypted in Vigil’s secret store and pushed to the gateway.'
                   }
                 >
                   <textarea

--- a/clients/web/src/screens/settings/AiProvidersPanel.tsx
+++ b/clients/web/src/screens/settings/AiProvidersPanel.tsx
@@ -27,6 +27,7 @@ import {
   bifrostApi,
   isMasked,
   secretText,
+  secretEnvRef,
   COMMON_PROVIDERS,
   type KeyVerdict,
   type BifrostKey,
@@ -352,10 +353,28 @@ export function KeyDialog({
   // Vertex takes either a bare API key or a service-account JSON scoped by
   // project/region — so it gets a mode switch and its own fields.
   const isVertex = provider === 'vertex'
+  // Ollama's credential is an endpoint, which Bifrost keeps under its own
+  // block — a write that omits the block blanks it, so this branch always
+  // sends one. A token is separate and usually absent, hence the mode switch:
+  // the bare server takes no credential, but the gateway does send `value` as
+  // a bearer token when one is set, which is what reaches a server behind an
+  // authenticating proxy.
+  const isOllama = provider === 'ollama'
+  const storedUrl = secretText(existing?.ollama_key_config?.url)
+  const storedToken = secretText(existing?.value)
+  // A seeded key resolves its URL from OLLAMA_URL. The value reads back masked
+  // but the reference does not, so an edit that leaves the field blank can hand
+  // the reference back rather than a mask Bifrost would store verbatim.
+  const storedUrlEnv = secretEnvRef(existing?.ollama_key_config?.url)
   const storedProject = secretText(existing?.vertex_key_config?.project_id)
   const storedRegion = secretText(existing?.vertex_key_config?.region)
   const [vertexAuth, setVertexAuth] = useState<'service_account' | 'api_key'>(
     storedProject ? 'service_account' : 'api_key',
+  )
+  // A key Bifrost holds no token for reads back as an empty `value`, which is
+  // the unauthenticated case — the common one, so it leads.
+  const [ollamaAuth, setOllamaAuth] = useState<'none' | 'api_key'>(
+    storedToken ? 'api_key' : 'none',
   )
 
   const [name, setName] = useState(existing?.name || `${provider}-key`)
@@ -366,6 +385,12 @@ export function KeyDialog({
   // Seeding the input with the mask instead put "[object Object]" in the box
   // (the wrapper is not a string) and, once unwrapped, would have written the
   // mask back as the project id.
+  // A create defaults to the reference, not a literal: the deployment already
+  // states where Ollama is, from the side that has to reach it. The shipped
+  // compose sets OLLAMA_URL=http://host.docker.internal:11434 for exactly that.
+  const [url, setUrl] = useState(
+    existing ? (isMasked(storedUrl) ? '' : storedUrl) : 'env.OLLAMA_URL',
+  )
   const [projectId, setProjectId] = useState(isMasked(storedProject) ? '' : storedProject)
   const [region, setRegion] = useState(isMasked(storedRegion) ? '' : storedRegion)
   const [weight, setWeight] = useState(existing?.weight ?? 1)
@@ -385,7 +410,19 @@ export function KeyDialog({
         enabled,
         models: allowAll ? ['*'] : chosen,
       }
-      if (isVertex && vertexAuth === 'service_account') {
+      if (isOllama) {
+        // Blank on an edit means "keep what's there": hand back the env
+        // reference when there is one, and otherwise omit the field so the
+        // backend substitutes its stored copy.
+        const kept = url.trim() || storedUrlEnv
+        if (kept) base.ollama_key_config = { url: kept }
+        // The mode is the instruction, so the two blank cases differ: an empty
+        // `value` under No auth says "there is no token", while omitting the
+        // field under API key says "keep the stored one". Sending nothing in
+        // both would make switching back to No auth impossible.
+        if (ollamaAuth === 'none') base.value = ''
+        else if (secret.trim()) base.value = secret.trim()
+      } else if (isVertex && vertexAuth === 'service_account') {
         // Every field is omitted when left blank; the backend substitutes its
         // stored copy, and for the credential mirrors it into `value` too.
         base.vertex_key_config = {
@@ -409,7 +446,11 @@ export function KeyDialog({
 
   // A create needs a credential; a service-account vertex create also needs
   // project + region.
-  const missingCredential = !existing && !secret.trim()
+  // Ollama asks for a URL where every other provider asks for a secret, and
+  // for a token too only when the operator says the endpoint wants one.
+  const missingCredential = !existing && !(isOllama ? url.trim() : secret.trim())
+  const missingOllamaToken =
+    isOllama && ollamaAuth === 'api_key' && !existing && !secret.trim()
   const missingVertexScope =
     isVertex && vertexAuth === 'service_account' && !existing && (!projectId.trim() || !region.trim())
 
@@ -420,7 +461,68 @@ export function KeyDialog({
         <Field label="Key name" hint="Must be unique across the gateway.">
           <TextInput value={name} onChange={(e) => setName(e.target.value)} />
         </Field>
-        {isVertex ? (
+        {isOllama ? (
+          <>
+            <Field
+              label="Authentication"
+              hint="Ollama's own server takes no credential, which is the single-machine case. Pick API key only when the endpoint below sits behind something that authenticates; the gateway sends it as a bearer token."
+            >
+              <div className="inline-flex gap-1.5">
+                {(
+                  [
+                    ['none', 'No auth'],
+                    ['api_key', 'API key'],
+                  ] as const
+                ).map(([mode, label]) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    className={`btn ${ollamaAuth === mode ? 'primary' : 'ghost'}`}
+                    onClick={() => {
+                      setOllamaAuth(mode)
+                      setSecret('')
+                    }}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </Field>
+            <Field
+              label="Server URL"
+              hint={
+                storedUrl
+                  ? `Leave blank to keep the stored endpoint${storedUrlEnv ? ` (${storedUrlEnv})` : ''}.`
+                  : 'Resolved by the gateway, not by your browser — and Vigil runs Ollama on the host while the gateway runs in Docker, so a literal here needs the host’s name from inside the container (http://host.docker.internal:11434), not localhost. env.OLLAMA_URL defers to whatever the deployment already set.'
+              }
+            >
+              <TextInput
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder={storedUrlEnv || storedUrl || 'env.OLLAMA_URL'}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </Field>
+            {ollamaAuth === 'api_key' && (
+              <Field
+                label="API key"
+                hint={
+                  storedToken
+                    ? 'Leave blank to keep the stored token.'
+                    : 'Whatever the proxy in front of Ollama expects. Stored encrypted in Vigil’s secret store and pushed to the gateway.'
+                }
+              >
+                <PasswordInput
+                  value={secret}
+                  onChange={(e) => setSecret(e.target.value)}
+                  placeholder={storedToken ? '•••••••• (unchanged)' : ''}
+                  autoComplete="new-password"
+                />
+              </Field>
+            )}
+          </>
+        ) : isVertex ? (
           <>
             <Field
               label="Authentication"
@@ -553,7 +655,9 @@ export function KeyDialog({
         <button className="btn ghost" onClick={onClose} disabled={saving}>Cancel</button>
         <button
           className="btn primary"
-          disabled={saving || !name.trim() || missingCredential || missingVertexScope}
+          disabled={
+            saving || !name.trim() || missingCredential || missingVertexScope || missingOllamaToken
+          }
           onClick={submit}
         >
           <Icon name="check2" /> {saving ? 'Saving…' : 'Save'}

--- a/clients/web/src/screens/settings/AiProvidersPanel.tsx
+++ b/clients/web/src/screens/settings/AiProvidersPanel.tsx
@@ -37,29 +37,36 @@ import type { SectionProps } from './types'
 
 // The label comes from the backend's verdict (core/llm/bifrost/mirror.py), which
 // is the only thing that knows whether a `list_models_failed` was a refusal or a
-// check that could never have run. `status` is the fallback for a key the
-// verdict call didn't cover — showing "Rejected" for a key that routes fine sent
-// people looking for a fault that isn't there.
+// check that could never have run. Without a verdict this cannot tell those
+// apart, so it does not guess: `list_models_failed` reads as unverified rather
+// than Rejected, because showing Rejected for a key that routes fine sent
+// people looking for a fault that isn't there. `success` is the one status that
+// speaks for itself.
 function KeyStatusChip({ status, description, verdict }: {
   status?: string
   description?: string
   verdict?: KeyVerdict
 }) {
-  const health = verdict?.health ?? (status === 'success' ? 'healthy' : undefined)
-  if (health === 'healthy') return <span className="status closed">Healthy</span>
-  if (health === 'unverified' || !status || status === 'unknown') {
-    return <span className="chip">Unverified</span>
+  if (verdict?.health === 'healthy' || (!verdict && status === 'success')) {
+    return <span className="status closed">Healthy</span>
   }
-  if (health === 'unverifiable') {
+  if (verdict?.health === 'unverifiable') {
     return (
       <span className="chip" title={description}>
         Unverifiable
       </span>
     )
   }
+  if (verdict?.health === 'rejected') {
+    return (
+      <span className="chip" style={{ color: 'var(--crit)' }} title={description || status}>
+        {status === 'list_models_failed' ? 'Rejected' : status}
+      </span>
+    )
+  }
   return (
-    <span className="chip" style={{ color: 'var(--crit)' }} title={description || status}>
-      {status === 'list_models_failed' ? 'Rejected' : status}
+    <span className="chip" title={verdict ? description : status}>
+      Unverified
     </span>
   )
 }
@@ -235,7 +242,7 @@ export default function AiProvidersPanel({ notify }: SectionProps) {
                               ? 'All'
                               : `${k.models?.length || 0} allowed`}
                           </td>
-                          <td><KeyStatusChip status={k.status} description={k.description} verdict={verdicts.keys[k.id]} /></td>
+                          <td><KeyStatusChip status={k.status} description={k.description} verdict={verdicts?.keys[k.id]} /></td>
                           <td style={{ textAlign: 'right' }}>
                             <div className="inline-flex gap-1.5">
                               <button
@@ -411,11 +418,11 @@ export function KeyDialog({
         models: allowAll ? ['*'] : chosen,
       }
       if (isOllama) {
-        // Blank on an edit means "keep what's there": hand back the env
-        // reference when there is one, and otherwise omit the field so the
-        // backend substitutes its stored copy.
-        const kept = url.trim() || storedUrlEnv
-        if (kept) base.ollama_key_config = { url: kept }
+        // Always sent, even empty: Bifrost takes an absent block literally and
+        // blanks the endpoint. Blank means "keep what's there" — hand back the
+        // env reference when there is one, and otherwise let the backend
+        // substitute its stored copy.
+        base.ollama_key_config = { url: url.trim() || storedUrlEnv }
         // The mode is the instruction, so the two blank cases differ: an empty
         // `value` under No auth says "there is no token", while omitting the
         // field under API key says "keep the stored one". Sending nothing in

--- a/clients/web/src/screens/settings/AiProvidersPanel.tsx
+++ b/clients/web/src/screens/settings/AiProvidersPanel.tsx
@@ -35,13 +35,7 @@ import {
 } from '../../services/bifrostApi'
 import type { SectionProps } from './types'
 
-// The label comes from the backend's verdict (core/llm/bifrost/mirror.py), which
-// is the only thing that knows whether a `list_models_failed` was a refusal or a
-// check that could never have run. Without a verdict this cannot tell those
-// apart, so it does not guess: `list_models_failed` reads as unverified rather
-// than Rejected, because showing Rejected for a key that routes fine sent
-// people looking for a fault that isn't there. `success` is the one status that
-// speaks for itself.
+// Without a verdict, a `list_models_failed` cannot be told from a refusal.
 function KeyStatusChip({ status, description, verdict }: {
   status?: string
   description?: string
@@ -71,10 +65,7 @@ function KeyStatusChip({ status, description, verdict }: {
   )
 }
 
-/** Did the backend judge this freshly-written key a real failure?
-    Re-reads the verdict rather than the hook's copy, which the save has just
-    invalidated. A verdict we can't fetch is not reported as a fault — the key
-    is stored either way, and the table's chip will show the truth on reload. */
+/** Re-reads the verdict: the save has just invalidated the hook's copy. */
 async function keyRejected(keyId: string | undefined): Promise<boolean> {
   if (!keyId) return false
   try {
@@ -306,11 +297,6 @@ export default function AiProvidersPanel({ notify }: SectionProps) {
             const saved = await saveKey(editing.provider, editing.key?.id || null, data)
             setEditing(null)
             setExpanded(editing.provider)
-            // Bifrost validates the credential upstream as it stores it, so its
-            // verdict is the only test result there is. Ask the backend what
-            // that verdict means rather than reading `status` here: a
-            // `list_models_failed` the gateway could never have passed is not a
-            // fault to report, and only one place knows the difference.
             const rejected = await keyRejected(saved?.id)
             notify(
               rejected ? 'err' : 'ok',
@@ -360,18 +346,9 @@ export function KeyDialog({
   // Vertex takes either a bare API key or a service-account JSON scoped by
   // project/region — so it gets a mode switch and its own fields.
   const isVertex = provider === 'vertex'
-  // Ollama's credential is an endpoint, which Bifrost keeps under its own
-  // block — a write that omits the block blanks it, so this branch always
-  // sends one. A token is separate and usually absent, hence the mode switch:
-  // the bare server takes no credential, but the gateway does send `value` as
-  // a bearer token when one is set, which is what reaches a server behind an
-  // authenticating proxy.
   const isOllama = provider === 'ollama'
   const storedUrl = secretText(existing?.ollama_key_config?.url)
   const storedToken = secretText(existing?.value)
-  // A seeded key resolves its URL from OLLAMA_URL. The value reads back masked
-  // but the reference does not, so an edit that leaves the field blank can hand
-  // the reference back rather than a mask Bifrost would store verbatim.
   const storedUrlEnv = secretEnvRef(existing?.ollama_key_config?.url)
   const storedProject = secretText(existing?.vertex_key_config?.project_id)
   const storedRegion = secretText(existing?.vertex_key_config?.region)
@@ -386,15 +363,8 @@ export function KeyDialog({
 
   const [name, setName] = useState(existing?.name || `${provider}-key`)
   const [secret, setSecret] = useState('')
-  // Bifrost masks project/region on read like any other stored field, so a
-  // masked one starts blank behind its own mask as a placeholder — the same
-  // "leave blank to keep" contract the service-account JSON already has.
-  // Seeding the input with the mask instead put "[object Object]" in the box
-  // (the wrapper is not a string) and, once unwrapped, would have written the
-  // mask back as the project id.
-  // A create defaults to the reference, not a literal: the deployment already
-  // states where Ollama is, from the side that has to reach it. The shipped
-  // compose sets OLLAMA_URL=http://host.docker.internal:11434 for exactly that.
+  // Bifrost masks every stored field on read and stores a mask echoed back,
+  // so a masked field starts blank behind its own mask.
   const [url, setUrl] = useState(
     existing ? (isMasked(storedUrl) ? '' : storedUrl) : 'env.OLLAMA_URL',
   )
@@ -418,15 +388,9 @@ export function KeyDialog({
         models: allowAll ? ['*'] : chosen,
       }
       if (isOllama) {
-        // Always sent, even empty: Bifrost takes an absent block literally and
-        // blanks the endpoint. Blank means "keep what's there" — hand back the
-        // env reference when there is one, and otherwise let the backend
-        // substitute its stored copy.
+        // Always sent, even empty: Bifrost blanks an endpoint the write omits.
         base.ollama_key_config = { url: url.trim() || storedUrlEnv }
-        // The mode is the instruction, so the two blank cases differ: an empty
-        // `value` under No auth says "there is no token", while omitting the
-        // field under API key says "keep the stored one". Sending nothing in
-        // both would make switching back to No auth impossible.
+        // An empty `value` is No auth; an omitted one keeps the stored token.
         if (ollamaAuth === 'none') base.value = ''
         else if (secret.trim()) base.value = secret.trim()
       } else if (isVertex && vertexAuth === 'service_account') {
@@ -453,8 +417,6 @@ export function KeyDialog({
 
   // A create needs a credential; a service-account vertex create also needs
   // project + region.
-  // Ollama asks for a URL where every other provider asks for a secret, and
-  // for a token too only when the operator says the endpoint wants one.
   const missingCredential = !existing && !(isOllama ? url.trim() : secret.trim())
   const missingOllamaToken =
     isOllama && ollamaAuth === 'api_key' && !existing && !secret.trim()

--- a/clients/web/src/screens/settings/AiProvidersPanel.tsx
+++ b/clients/web/src/screens/settings/AiProvidersPanel.tsx
@@ -25,6 +25,7 @@ import {
 import { useBifrostProviders, useProviderModels, bifrostError } from './useBifrost'
 import {
   bifrostApi,
+  keyRefusal,
   isMasked,
   secretText,
   secretEnvRef,
@@ -43,6 +44,9 @@ function KeyStatusChip({ status, description, verdict }: {
 }) {
   if (verdict?.health === 'healthy' || (!verdict && status === 'success')) {
     return <span className="status closed">Healthy</span>
+  }
+  if (verdict?.health === 'disabled') {
+    return <span className="chip">Disabled</span>
   }
   if (verdict?.health === 'unverifiable') {
     return (
@@ -63,17 +67,6 @@ function KeyStatusChip({ status, description, verdict }: {
       Unverified
     </span>
   )
-}
-
-/** Re-reads the verdict: the save has just invalidated the hook's copy. */
-async function keyRejected(keyId: string | undefined): Promise<boolean> {
-  if (!keyId) return false
-  try {
-    const { data } = await bifrostApi.routability()
-    return data.keys?.[keyId]?.health === 'rejected'
-  } catch {
-    return false
-  }
 }
 
 export default function AiProvidersPanel({ notify }: SectionProps) {
@@ -307,12 +300,10 @@ export default function AiProvidersPanel({ notify }: SectionProps) {
             const saved = await saveKey(editing.provider, editing.key?.id || null, data)
             setEditing(null)
             setExpanded(editing.provider)
-            const rejected = await keyRejected(saved?.id)
+            const refusal = await keyRefusal(saved?.id)
             notify(
-              rejected ? 'err' : 'ok',
-              rejected
-                ? `Key stored, but Bifrost reports "${saved?.status}" — check the credential.`
-                : 'Key saved.',
+              refusal ? 'err' : 'ok',
+              refusal ? `Key stored, but it cannot route: ${refusal}` : 'Key saved.',
             )
           }}
         />
@@ -377,6 +368,14 @@ export function KeyDialog({
   // so a masked field starts blank behind its own mask.
   const [url, setUrl] = useState(
     existing ? (isMasked(storedUrl) ? '' : storedUrl) : 'env.OLLAMA_URL',
+  )
+  // The gateway resolves this URL, and the shipped compose runs it in a
+  // container — so a loopback host names the container, not the machine the
+  // operator typed it on. The field hint says so and gets typed past anyway,
+  // which is what a hint under a text box is worth; this says it where the
+  // mistake is, and only then.
+  const urlIsLoopback = /^(https?:\/\/)?(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/i.test(
+    url.trim(),
   )
   const [projectId, setProjectId] = useState(isMasked(storedProject) ? '' : storedProject)
   const [region, setRegion] = useState(isMasked(storedRegion) ? '' : storedRegion)
@@ -472,7 +471,7 @@ export function KeyDialog({
               hint={
                 storedUrl
                   ? `Leave blank to keep the stored endpoint${storedUrlEnv ? ` (${storedUrlEnv})` : ''}.`
-                  : 'Resolved by the gateway, not by your browser — and Vigil runs Ollama on the host while the gateway runs in Docker, so a literal here needs the host’s name from inside the container (http://host.docker.internal:11434), not localhost. env.OLLAMA_URL defers to whatever the deployment already set.'
+                  : 'Resolved by the gateway, not by your browser. env.OLLAMA_URL defers to whatever the deployment already set.'
               }
             >
               <TextInput
@@ -482,6 +481,16 @@ export function KeyDialog({
                 autoComplete="off"
                 spellCheck={false}
               />
+              {urlIsLoopback && (
+                <p className="text-xs mt-1.5" style={{ color: 'var(--high)' }}>
+                  The gateway resolves this, and it runs in a container — so
+                  loopback is the container itself, not this machine. Ollama on
+                  the host is <code>http://host.docker.internal:11434</code>, or
+                  leave <code>env.OLLAMA_URL</code> to use whatever the
+                  deployment set. Loopback is right only if the gateway runs
+                  outside Docker.
+                </p>
+              )}
             </Field>
             {ollamaAuth === 'api_key' && (
               <Field

--- a/clients/web/src/screens/settings/AiProvidersPanel.tsx
+++ b/clients/web/src/screens/settings/AiProvidersPanel.tsx
@@ -156,6 +156,16 @@ export default function AiProvidersPanel({ notify }: SectionProps) {
           primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }}
         />
       )}
+      {phase === 'ready' && verdicts === null && (
+        <EmptyState
+          error
+          compact
+          icon="alert"
+          title="Couldn’t check whether these keys can route"
+          body="Health below falls back to the gateway's own status, which cannot tell a refused credential from one it was unable to check."
+          primary={{ label: 'Retry', onClick: reload, icon: 'refresh' }}
+        />
+      )}
       {phase === 'ready' && providers.length === 0 && (
         <EmptyState
           compact

--- a/clients/web/src/screens/settings/AiProvidersPanel.tsx
+++ b/clients/web/src/screens/settings/AiProvidersPanel.tsx
@@ -400,7 +400,7 @@ export function KeyDialog({
       if (isOllama) {
         // Always sent, even empty: Bifrost blanks an endpoint the write omits.
         base.ollama_key_config = { url: url.trim() || storedUrlEnv }
-        // An empty `value` is No auth; an omitted one keeps the stored token.
+        // An empty `value` is no credential; an omitted one keeps the stored token.
         if (ollamaAuth === 'none') base.value = ''
         else if (secret.trim()) base.value = secret.trim()
       } else if (isVertex && vertexAuth === 'service_account') {
@@ -444,12 +444,12 @@ export function KeyDialog({
           <>
             <Field
               label="Authentication"
-              hint="Ollama's own server takes no credential, which is the single-machine case. Pick API key only when the endpoint below sits behind something that authenticates; the gateway sends it as a bearer token."
+              hint="Ollama takes no credential of its own. Pick API key only when something in front of the endpoint below asks for one; the gateway sends it as a bearer token."
             >
               <div className="inline-flex gap-1.5">
                 {(
                   [
-                    ['none', 'No auth'],
+                    ['none', 'None'],
                     ['api_key', 'API key'],
                   ] as const
                 ).map(([mode, label]) => (

--- a/clients/web/src/screens/settings/useBifrost.ts
+++ b/clients/web/src/screens/settings/useBifrost.ts
@@ -9,6 +9,7 @@ import {
   type BifrostModel,
   type BifrostModelParameters,
   type BifrostProvider,
+  type BifrostRoutability,
   type BifrostVirtualKey,
   type BifrostVirtualKeyWrite,
 } from '../../services/bifrostApi'
@@ -26,6 +27,11 @@ const errText = (e: unknown, fallback: string): string => {
 export function useBifrostProviders() {
   const [providers, setProviders] = useState<BifrostProvider[]>([])
   const [keys, setKeys] = useState<Record<string, BifrostKey[]>>({})
+  // Whether each key routes, and how to badge it — decided server-side so this
+  // hook never re-derives Bifrost's ambiguous statuses. Empty until loaded, and
+  // left empty if the call fails: no verdict reads as "not routable", which is
+  // the safe direction for a gate.
+  const [verdicts, setVerdicts] = useState<BifrostRoutability>({ providers: {}, keys: {} })
   const [phase, setPhase] = useState<Phase>('loading')
   const [error, setError] = useState<string | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
@@ -39,19 +45,26 @@ export function useBifrostProviders() {
       .listProviders()
       .then(async (res) => {
         const list = res.data.providers || []
-        const entries = await Promise.all(
-          list.map(async (p) => {
-            try {
-              const r = await bifrostApi.listKeys(p.name)
-              return [p.name, r.data.keys || []] as const
-            } catch {
-              return [p.name, []] as const
-            }
-          }),
-        )
+        const [entries, routability] = await Promise.all([
+          Promise.all(
+            list.map(async (p) => {
+              try {
+                const r = await bifrostApi.listKeys(p.name)
+                return [p.name, r.data.keys || []] as const
+              } catch {
+                return [p.name, []] as const
+              }
+            }),
+          ),
+          bifrostApi
+            .routability()
+            .then((r) => r.data)
+            .catch(() => ({ providers: {}, keys: {} }) as BifrostRoutability),
+        ])
         if (cancelled) return
         setProviders(list)
         setKeys(Object.fromEntries(entries))
+        setVerdicts(routability)
         setPhase('ready')
       })
       .catch((e) => {
@@ -100,7 +113,18 @@ export function useBifrostProviders() {
     [reload],
   )
 
-  return { providers, keys, phase, error, reload, saveKey, removeKey, addProvider, removeProvider }
+  return {
+    providers,
+    keys,
+    verdicts,
+    phase,
+    error,
+    reload,
+    saveKey,
+    removeKey,
+    addProvider,
+    removeProvider,
+  }
 }
 
 /** The gateway's model catalog. `query` filters server-side. */

--- a/clients/web/src/screens/settings/useBifrost.ts
+++ b/clients/web/src/screens/settings/useBifrost.ts
@@ -27,12 +27,7 @@ const errText = (e: unknown, fallback: string): string => {
 export function useBifrostProviders() {
   const [providers, setProviders] = useState<BifrostProvider[]>([])
   const [keys, setKeys] = useState<Record<string, BifrostKey[]>>({})
-  // Whether each key routes, and how to badge it — decided server-side so this
-  // hook never re-derives Bifrost's ambiguous statuses. `null` means the verdict
-  // could not be fetched, which is not the same as a verdict of "not routable":
-  // an empty map read as the latter and put a red Rejected chip back on a key
-  // that routes fine, which is the bug the verdict exists to fix. Callers have
-  // to handle the third state.
+  // `null` is "could not ask", not a verdict of "not routable".
   const [verdicts, setVerdicts] = useState<BifrostRoutability | null>(null)
   const [phase, setPhase] = useState<Phase>('loading')
   const [error, setError] = useState<string | null>(null)

--- a/clients/web/src/screens/settings/useBifrost.ts
+++ b/clients/web/src/screens/settings/useBifrost.ts
@@ -28,10 +28,12 @@ export function useBifrostProviders() {
   const [providers, setProviders] = useState<BifrostProvider[]>([])
   const [keys, setKeys] = useState<Record<string, BifrostKey[]>>({})
   // Whether each key routes, and how to badge it — decided server-side so this
-  // hook never re-derives Bifrost's ambiguous statuses. Empty until loaded, and
-  // left empty if the call fails: no verdict reads as "not routable", which is
-  // the safe direction for a gate.
-  const [verdicts, setVerdicts] = useState<BifrostRoutability>({ providers: {}, keys: {} })
+  // hook never re-derives Bifrost's ambiguous statuses. `null` means the verdict
+  // could not be fetched, which is not the same as a verdict of "not routable":
+  // an empty map read as the latter and put a red Rejected chip back on a key
+  // that routes fine, which is the bug the verdict exists to fix. Callers have
+  // to handle the third state.
+  const [verdicts, setVerdicts] = useState<BifrostRoutability | null>(null)
   const [phase, setPhase] = useState<Phase>('loading')
   const [error, setError] = useState<string | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
@@ -59,7 +61,7 @@ export function useBifrostProviders() {
           bifrostApi
             .routability()
             .then((r) => r.data)
-            .catch(() => ({ providers: {}, keys: {} }) as BifrostRoutability),
+            .catch(() => null),
         ])
         if (cancelled) return
         setProviders(list)

--- a/clients/web/src/screens/setup/SetupProviderStep.tsx
+++ b/clients/web/src/screens/setup/SetupProviderStep.tsx
@@ -13,10 +13,11 @@ import { Field } from '../../shared/ui'
 import { Banner } from '../../shared/formKit'
 import { useBifrostProviders, bifrostError } from '../settings/useBifrost'
 import { KeyDialog } from '../settings/AiProvidersPanel'
-import { COMMON_PROVIDERS, keyIsRoutable } from '../../services/bifrostApi'
+import { bifrostApi, COMMON_PROVIDERS } from '../../services/bifrostApi'
 
 export default function SetupProviderStep({ onSaved }: { onSaved: () => void }) {
-  const { providers, keys, phase, error, reload, saveKey, addProvider } = useBifrostProviders()
+  const { providers, keys, verdicts, phase, error, reload, saveKey, addProvider } =
+    useBifrostProviders()
   const [newProvider, setNewProvider] = useState('')
   const [busy, setBusy] = useState(false)
   const [localErr, setLocalErr] = useState<string | null>(null)
@@ -65,7 +66,7 @@ export default function SetupProviderStep({ onSaved }: { onSaved: () => void }) 
         <div className="flex flex-col gap-1.5">
           {providers.map((p) => {
             const pk = keys[p.name] || []
-            const routable = pk.some(keyIsRoutable)
+            const routable = verdicts.providers[p.name] ?? false
             return (
               <div
                 key={p.name}
@@ -132,12 +133,20 @@ export default function SetupProviderStep({ onSaved }: { onSaved: () => void }) 
             const saved = await saveKey(addingKeyFor, null, data)
             setAddingKeyFor(null)
             // Bifrost validates the credential as it stores it and reports the
-            // verdict as status. "success" and "unknown" both advance setup —
-            // "unknown" is expected for providers it can't list-verify (vertex).
-            // Only a genuine failure (e.g. list_models_failed) is surfaced.
-            if (saved?.status && saved.status !== 'success' && saved.status !== 'unknown') {
+            // verdict as status, but only the backend knows whether a
+            // `list_models_failed` was a refusal or a check that could never
+            // have run — vertex is always the latter, and flagging it told
+            // people to check a credential that routes fine. Ask, don't guess.
+            let rejected = false
+            try {
+              const { data: r } = await bifrostApi.routability()
+              rejected = saved?.id ? r.keys?.[saved.id]?.health === 'rejected' : false
+            } catch {
+              rejected = false
+            }
+            if (rejected) {
               setLocalErr(
-                `Key stored, but Bifrost reports "${saved.status}" — check the credential.`,
+                `Key stored, but Bifrost reports "${saved?.status}" — check the credential.`,
               )
               reload()
             } else {

--- a/clients/web/src/screens/setup/SetupProviderStep.tsx
+++ b/clients/web/src/screens/setup/SetupProviderStep.tsx
@@ -13,7 +13,7 @@ import { Field } from '../../shared/ui'
 import { Banner } from '../../shared/formKit'
 import { useBifrostProviders, bifrostError } from '../settings/useBifrost'
 import { KeyDialog } from '../settings/AiProvidersPanel'
-import { bifrostApi, COMMON_PROVIDERS } from '../../services/bifrostApi'
+import { COMMON_PROVIDERS, keyRefusal } from '../../services/bifrostApi'
 
 export default function SetupProviderStep({ onSaved }: { onSaved: () => void }) {
   const { providers, keys, verdicts, phase, error, reload, saveKey, addProvider } =
@@ -140,17 +140,9 @@ export default function SetupProviderStep({ onSaved }: { onSaved: () => void }) 
           onSave={async (data) => {
             const saved = await saveKey(addingKeyFor, null, data)
             setAddingKeyFor(null)
-            let rejected = false
-            try {
-              const { data: r } = await bifrostApi.routability()
-              rejected = saved?.id ? r.keys?.[saved.id]?.health === 'rejected' : false
-            } catch {
-              rejected = false
-            }
-            if (rejected) {
-              setLocalErr(
-                `Key stored, but Bifrost reports "${saved?.status}" — check the credential.`,
-              )
+            const refusal = await keyRefusal(saved?.id)
+            if (refusal) {
+              setLocalErr(`Key stored, but it cannot route: ${refusal}`)
               reload()
             } else {
               onSaved()

--- a/clients/web/src/screens/setup/SetupProviderStep.tsx
+++ b/clients/web/src/screens/setup/SetupProviderStep.tsx
@@ -62,11 +62,20 @@ export default function SetupProviderStep({ onSaved }: { onSaved: () => void }) 
     <div className="flex flex-col gap-3">
       {localErr && <Banner kind="err">{localErr}</Banner>}
 
+      {/* A missing verdict marks every provider unroutable, which would
+          otherwise stall this step with nothing on screen to say why. */}
+      {verdicts === null && (
+        <Banner kind="err">
+          Couldn’t check whether the gateway’s keys can route — a key you add may show
+          as unroutable until this succeeds.
+        </Banner>
+      )}
+
       {providers.length > 0 && (
         <div className="flex flex-col gap-1.5">
           {providers.map((p) => {
             const pk = keys[p.name] || []
-            const routable = verdicts.providers[p.name] ?? false
+            const routable = verdicts?.providers[p.name] ?? false
             return (
               <div
                 key={p.name}

--- a/clients/web/src/screens/setup/SetupProviderStep.tsx
+++ b/clients/web/src/screens/setup/SetupProviderStep.tsx
@@ -62,8 +62,7 @@ export default function SetupProviderStep({ onSaved }: { onSaved: () => void }) 
     <div className="flex flex-col gap-3">
       {localErr && <Banner kind="err">{localErr}</Banner>}
 
-      {/* A missing verdict marks every provider unroutable, which would
-          otherwise stall this step with nothing on screen to say why. */}
+      {/* A missing verdict marks every provider unroutable, so say why. */}
       {verdicts === null && (
         <Banner kind="err">
           Couldn’t check whether the gateway’s keys can route — a key you add may show
@@ -141,11 +140,6 @@ export default function SetupProviderStep({ onSaved }: { onSaved: () => void }) 
           onSave={async (data) => {
             const saved = await saveKey(addingKeyFor, null, data)
             setAddingKeyFor(null)
-            // Bifrost validates the credential as it stores it and reports the
-            // verdict as status, but only the backend knows whether a
-            // `list_models_failed` was a refusal or a check that could never
-            // have run — vertex is always the latter, and flagging it told
-            // people to check a credential that routes fine. Ask, don't guess.
             let rejected = false
             try {
               const { data: r } = await bifrostApi.routability()

--- a/clients/web/src/screens/setup/SetupScreen.tsx
+++ b/clients/web/src/screens/setup/SetupScreen.tsx
@@ -154,11 +154,14 @@ const SetupScreen = () => {
 
   const llmReady = steps.find((s) => s.id === 'llm-provider')?.ready ?? false
 
-  // on /setup with the provider not ready, a prior dismissal is stale: clear it,
-  // or completing the provider bounces the user out before the optional steps
+  // Being on /setup at all is an intent to run setup, so a prior dismissal is
+  // stale on arrival. Clearing it only while the provider was unready made it
+  // permanent once one was configured: SetupGate never sends a configured user
+  // here, so the flag's only surviving effect was to bounce anyone who came
+  // back deliberately — unfixable short of clearing site data.
   useEffect(() => {
-    if (!loading && !llmReady) clearSetupDismissed()
-  }, [loading, llmReady])
+    clearSetupDismissed()
+  }, [])
 
   const optionalSteps = steps.filter((s) => s.tier !== 'required')
   const requiredCount = steps.length - optionalSteps.length

--- a/clients/web/src/services/bifrostApi.ts
+++ b/clients/web/src/services/bifrostApi.ts
@@ -48,18 +48,35 @@ export interface BifrostKey {
   description?: string
   use_for_batch_api?: boolean
   ollama_key_config?: { url: BifrostSecret | string }
-  /** project_id/region read back plain; auth_credentials read back masked. */
-  vertex_key_config?: { project_id?: string; region?: string; auth_credentials?: BifrostSecret | string }
+  /** Every field here reads back masked and wrapped, project_id and region
+      included — they are not secrets, but Bifrost stores them in the same
+      secret shape and masks them the same way. Unwrap with `secretText`. */
+  vertex_key_config?: {
+    project_id?: BifrostSecret | string
+    region?: BifrostSecret | string
+    auth_credentials?: BifrostSecret | string
+  }
 }
 
 /** Vertex's credential is not an API key: it is a service-account JSON plus the
     project/region that scope it. Bifrost holds the JSON under `auth_credentials`;
-    the passthrough mirrors it to the key's `value` so one secret ref backs both. */
+    the passthrough mirrors it to the key's `value` so one secret ref backs both.
+
+    All three fields are omitted on an edit that isn't changing them — Bifrost
+    masks each on read, and echoing a mask back stores the mask, so the
+    passthrough substitutes its own copy instead. */
 export interface VertexKeyConfig {
   project_id?: string
   region?: string
   /** Service-account JSON. Omit on edit to keep the stored one. */
   auth_credentials?: string
+}
+
+/** True when a read-back value is Bifrost's mask rather than something a human
+    typed. Bifrost masks as `prod****oglm`, and it accepts a write that echoes
+    that, storing the mask verbatim — so a masked field is never sent back. */
+export function isMasked(v: BifrostSecret | string | undefined): boolean {
+  return secretText(v).includes('*')
 }
 
 export interface BifrostKeyWrite {
@@ -205,6 +222,9 @@ export const bifrostApi = {
   modelParameters: (model: string, provider: string) =>
     api.get<BifrostModelParameters>(`${bf}/models/parameters`, { params: { model, provider } }),
 
+  /** Vigil's own verdict on Bifrost's keys — not a proxied Bifrost path. */
+  routability: () => api.get<BifrostRoutability>(`${bf}/routability`),
+
   listVirtualKeys: () =>
     api.get<{ virtual_keys: BifrostVirtualKey[] | null; count: number }>(
       `${bf}/governance/virtual-keys`,
@@ -228,45 +248,33 @@ export function perMillion(perToken: number | undefined): number | null {
   return typeof perToken === 'number' ? perToken * 1_000_000 : null
 }
 
-/** True when the key's credential was set by a human rather than pointing at an
-    env var. A first-boot seed's keys reference `env.ANTHROPIC_API_KEY` etc.
-    (from_env: true); anything the console wrote carries a literal value. */
-function credFromEnv(k: BifrostKey): boolean {
-  const v = k.value
-  if (v && typeof v === 'object' && 'from_env' in v) return !!v.from_env
-  const sa = k.vertex_key_config?.auth_credentials
-  if (sa && typeof sa === 'object' && 'from_env' in sa) return !!sa.from_env
-  return false
+/** Whether a key can actually route, and how to badge it — decided by the
+    backend (`core/llm/bifrost/mirror.py`), never re-derived here.
+
+    The rule is subtle enough that restating it in the console drifted from the
+    Python twice in one afternoon: Bifrost reports both "I refused this
+    credential" and "I could not check this credential" as `list_models_failed`,
+    and only the provider plus the description tell them apart. One
+    implementation, one verdict. */
+export type KeyHealth = 'healthy' | 'unverified' | 'unverifiable' | 'rejected'
+
+export interface KeyVerdict {
+  provider: string
+  routable: boolean
+  health: KeyHealth
+  description?: string | null
 }
 
-/** True when a key can actually route. A "success" status means Bifrost
-    verified the credential upstream — the strongest signal. But some providers
-    (vertex, notably) have no list-models path, so Bifrost never advances them
-    past "unknown"; those still route, so "unknown" is accepted — but only for a
-    credential a human actually set, so a fresh install's env-placeholder seed
-    keys don't read as already-configured. */
-export function keyIsRoutable(k: BifrostKey): boolean {
-  if (!k.enabled) return false
-  if (k.status === 'success') return true
-  if (!k.status || k.status === 'unknown') return !credFromEnv(k)
-  return false
+export interface BifrostRoutability {
+  /** provider name → does any of its keys route */
+  providers: Record<string, boolean>
+  /** key id → that key's verdict */
+  keys: Record<string, KeyVerdict>
 }
 
 /** Does any Bifrost provider have a routable key? The setup gate's Bifrost-side
-    readiness check. Best-effort per provider — a listKeys failure counts as
-    "not routable" rather than throwing the whole check. */
+    readiness check — one request, where it used to make one per provider. */
 export async function anyRoutableBifrostProvider(): Promise<boolean> {
-  const { data } = await bifrostApi.listProviders()
-  const providers = data.providers || []
-  const flags = await Promise.all(
-    providers.map(async (p) => {
-      try {
-        const r = await bifrostApi.listKeys(p.name)
-        return (r.data.keys || []).some(keyIsRoutable)
-      } catch {
-        return false
-      }
-    }),
-  )
-  return flags.some(Boolean)
+  const { data } = await bifrostApi.routability()
+  return Object.values(data.providers || {}).some(Boolean)
 }

--- a/clients/web/src/services/bifrostApi.ts
+++ b/clients/web/src/services/bifrostApi.ts
@@ -79,6 +79,17 @@ export function isMasked(v: BifrostSecret | string | undefined): boolean {
   return secretText(v).includes('*')
 }
 
+/** The `env.FOO` reference behind a field Bifrost resolves from the environment,
+    or '' when the field holds a literal.
+
+    Unlike the value, `env_var` comes back unmasked — so a field the operator did
+    not retype can be written back as its reference rather than as the mask. That
+    is the only way to edit a seeded key (whose URL is `env.OLLAMA_URL`) without
+    knowing what the environment resolved it to. */
+export function secretEnvRef(v: BifrostSecret | string | undefined): string {
+  return typeof v === 'object' && v?.from_env ? v.env_var || '' : ''
+}
+
 export interface BifrostKeyWrite {
   name: string
   weight: number
@@ -89,6 +100,9 @@ export interface BifrostKeyWrite {
   use_for_batch_api?: boolean
   /** Vertex only — sent instead of a bare `value`. */
   vertex_key_config?: VertexKeyConfig
+  /** Ollama only — its credential is an endpoint, not a secret. Omit to keep
+      the stored URL. */
+  ollama_key_config?: { url: string }
 }
 
 export interface BifrostModel {

--- a/clients/web/src/services/bifrostApi.ts
+++ b/clients/web/src/services/bifrostApi.ts
@@ -270,6 +270,24 @@ export type KeyVerdict = Schema<'KeyVerdict'>
 export type KeyHealth = KeyVerdict['health']
 export type BifrostRoutability = Schema<'Routability'>
 
+/** Why a freshly-written key was refused, or null when it was not.
+
+    Re-reads the verdict: the save has just invalidated the hook's copy. The
+    reason comes from Bifrost, which is the only thing that tried the
+    credential — "check the credential" on its own points at the wrong field
+    for a provider whose credential is an endpoint. */
+export async function keyRefusal(keyId: string | undefined): Promise<string | null> {
+  if (!keyId) return null
+  try {
+    const { data } = await bifrostApi.routability()
+    const verdict = data.keys?.[keyId]
+    if (verdict?.health !== 'rejected') return null
+    return verdict.description || 'Bifrost refused it and gave no reason.'
+  } catch {
+    return null
+  }
+}
+
 /** Does any Bifrost provider have a routable key? The setup gate's Bifrost-side
     readiness check — one request, where it used to make one per provider. */
 export async function anyRoutableBifrostProvider(): Promise<boolean> {

--- a/clients/web/src/services/bifrostApi.ts
+++ b/clients/web/src/services/bifrostApi.ts
@@ -12,6 +12,7 @@
      validated the credential upstream. That is the health signal; there is no
      separate test call. */
 import api from './api'
+import type { Schema } from './apiTypes'
 
 export interface BifrostSecret {
   value: string
@@ -262,29 +263,12 @@ export function perMillion(perToken: number | undefined): number | null {
   return typeof perToken === 'number' ? perToken * 1_000_000 : null
 }
 
-/** Whether a key can actually route, and how to badge it — decided by the
-    backend (`core/llm/bifrost/mirror.py`), never re-derived here.
-
-    The rule is subtle enough that restating it in the console drifted from the
-    Python twice in one afternoon: Bifrost reports both "I refused this
-    credential" and "I could not check this credential" as `list_models_failed`,
-    and only the provider plus the description tell them apart. One
-    implementation, one verdict. */
-export type KeyHealth = 'healthy' | 'unverified' | 'unverifiable' | 'rejected'
-
-export interface KeyVerdict {
-  provider: string
-  routable: boolean
-  health: KeyHealth
-  description?: string | null
-}
-
-export interface BifrostRoutability {
-  /** provider name → does any of its keys route */
-  providers: Record<string, boolean>
-  /** key id → that key's verdict */
-  keys: Record<string, KeyVerdict>
-}
+/** Decided by the backend (`core/llm/bifrost/mirror.py`), never re-derived
+    here: Bifrost reports both a refused credential and one it could not check
+    as `list_models_failed`. */
+export type KeyVerdict = Schema<'KeyVerdict'>
+export type KeyHealth = KeyVerdict['health']
+export type BifrostRoutability = Schema<'Routability'>
 
 /** Does any Bifrost provider have a routable key? The setup gate's Bifrost-side
     readiness check — one request, where it used to make one per provider. */

--- a/clients/web/src/services/generated/schema.d.ts
+++ b/clients/web/src/services/generated/schema.d.ts
@@ -1236,6 +1236,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/bifrost/routability": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Routability
+         * @description Per-key and per-provider "can this actually route?".
+         *
+         *     One call answers what used to take 1 + N proxy round trips — the setup gate
+         *     listed providers, then every provider's keys, on its critical path.
+         */
+        get: operations["get_api_bifrost_routability"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/bifrost/{path}": {
         parameters: {
             query?: never;
@@ -13152,6 +13175,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LoginResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_api_bifrost_routability: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */

--- a/clients/web/src/services/generated/schema.d.ts
+++ b/clients/web/src/services/generated/schema.d.ts
@@ -9501,7 +9501,7 @@ export interface components {
              * Health
              * @enum {string}
              */
-            health: "healthy" | "unverified" | "unverifiable" | "rejected";
+            health: "healthy" | "unverified" | "unverifiable" | "rejected" | "disabled";
             /** Provider */
             provider: string;
             /** Routable */

--- a/clients/web/src/services/generated/schema.d.ts
+++ b/clients/web/src/services/generated/schema.d.ts
@@ -9490,6 +9490,23 @@ export interface components {
             /** Topics */
             topics?: string[];
         };
+        /**
+         * KeyVerdict
+         * @description Whether one Bifrost key can route, and how the console should badge it.
+         */
+        KeyVerdict: {
+            /** Description */
+            description?: string | null;
+            /**
+             * Health
+             * @enum {string}
+             */
+            health: "healthy" | "unverified" | "unverifiable" | "rejected";
+            /** Provider */
+            provider: string;
+            /** Routable */
+            routable: boolean;
+        };
         /** LLMProviderCreate */
         LLMProviderCreate: {
             /** Api Key */
@@ -9973,6 +9990,22 @@ export interface components {
             action: string;
             /** Notes */
             notes?: string | null;
+        };
+        /**
+         * Routability
+         * @description Declared rather than a bare dict so the generated client carries the
+         *     shape: hand-maintaining it in TypeScript is the drift this route's own
+         *     verdict exists to end.
+         */
+        Routability: {
+            /** Keys */
+            keys: {
+                [key: string]: components["schemas"]["KeyVerdict"];
+            };
+            /** Providers */
+            providers: {
+                [key: string]: boolean;
+            };
         };
         /** RunStatusResponse */
         RunStatusResponse: {
@@ -13205,9 +13238,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["Routability"];
                 };
             };
             /** @description Validation Error */

--- a/core/llm/bifrost/admin.py
+++ b/core/llm/bifrost/admin.py
@@ -552,6 +552,14 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
     if db_manager._engine is None:
         db_manager.initialize()
 
+    # Before reading the rows: mirror Bifrost's own providers into them. A key
+    # configured in Bifrost alone has no row to be discovered through, so
+    # without this the loop below cannot see it at all — see
+    # ``core.llm.bifrost.mirror``. Best-effort; never fails the sync.
+    from core.llm.bifrost.mirror import reconcile_all
+
+    await reconcile_all()
+
     # Group active providers by type and collect the rows we need to
     # fetch (we don't hold the session open across awaits).
     rows_by_type: Dict[str, list] = {}
@@ -764,8 +772,137 @@ async def _fetch_meta_for_row(
         # though the UI dropdown populated fine.
         return await discovery.fetch_ollama_models(base_url, allow_loopback=True)
 
+    if provider_type in _CATALOG_PROVIDER_TYPES:
+        # No upstream to query — the gateway's own datasheet is the catalogue.
+        return await fetch_catalogue_models(provider_type)
+
     logger.debug("Bifrost sync: unsupported provider_type %s", provider_type)
     return None
+
+
+# ---------------------------------------------------------------------------
+# Gateway catalogue (providers with no upstream fetcher)
+# ---------------------------------------------------------------------------
+
+# Bifrost carries a synced model datasheet at ``/api/models/details`` — the
+# catalogue its own dashboard lists. It is the only catalogue available for a
+# provider ``discovery.py`` cannot query, which today means vertex: Vertex
+# refuses ListModels under API-key and ADC auth, so there is no upstream to
+# ask. That is the same wall that makes a vertex key unverifiable — see
+# ``key_is_routable`` in core/llm/bifrost/mirror.py.
+#
+# Reading it is not a second LLM path: it is capability discovery against the
+# gateway we already route through, the same carve-out ``discovery.py``
+# documents for querying provider catalogues directly.
+_CATALOG_PROVIDER_TYPES = frozenset({"vertex"})
+
+# What the row's ``default_model`` should floor to, per provider type. That
+# field is only a floor — it is what the picker shows when discovery yields
+# nothing (#409) and what dispatch uses when a caller names no model; the
+# operator's real choice is the ``chat_default`` assignment. So it needs to be
+# *a* working chat model, not the right one, and preferring a mid-tier general
+# model keeps the floor cheap rather than pinning the priciest id in a
+# 136-model catalogue. First one present wins; absent all of them, the
+# catalogue's first entry.
+_CATALOG_DEFAULT_PREFERENCE: Dict[str, tuple] = {
+    "vertex": ("gemini-2.5-flash", "gemini-2.0-flash", "claude-sonnet-4-5"),
+}
+
+
+def _is_chat_catalogue_entry(entry: Dict[str, Any]) -> bool:
+    """True when a datasheet entry is a chat model rather than another modality.
+
+    Vertex serves imagen, veo, chirp, OCR and embeddings out of the same
+    catalogue. A chat model is one that can emit tokens, so the presence of
+    ``max_output_tokens`` is the discriminator; embedding ids carry an input
+    limit only and are also caught by name, since their families are the one
+    set ``discovery.py`` already knows how to spot.
+    """
+    from core.llm.providers.discovery import is_embedding_model_id
+
+    name = entry.get("name") or ""
+    if not name or is_embedding_model_id(name):
+        return False
+    return bool(entry.get("max_output_tokens"))
+
+
+async def fetch_catalogue_models(provider_type: str) -> Optional[List[Any]]:
+    """Return Bifrost's own catalogue for ``provider_type`` as ``ModelMeta``.
+
+    Returns None when the catalogue is unreachable or holds no chat models, so
+    the caller falls back to its bootstrap list rather than caching a blank.
+    """
+    from core.llm.providers.discovery import ModelMeta
+
+    url = f"{_bifrost_base_url()}/api/models/details"
+    try:
+        async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
+            resp = await client.get(
+                url, params={"provider": provider_type, "limit": 1000}
+            )
+            resp.raise_for_status()
+            entries = resp.json().get("models") or []
+    except (httpx.HTTPError, ValueError, KeyError) as exc:
+        logger.warning("Bifrost catalogue fetch failed for %s: %s", provider_type, exc)
+        return None
+
+    meta = [
+        ModelMeta(
+            id=e["name"],
+            display_name=e["name"],
+            context_window=int(e.get("max_input_tokens") or 0),
+            # The list endpoint carries no capability flags (they live on the
+            # per-model ``/parameters`` route, one call each). Tool use is the
+            # one Vigil depends on and every chat family Vertex serves —
+            # Claude, Gemini, Mistral, Llama — supports it, so default it True
+            # for the same reason ``_anthropic_caps`` does. Thinking and vision
+            # are left unset rather than guessed, since nothing depends on them.
+            capabilities={"supports_tools": True},
+        )
+        for e in entries
+        if _is_chat_catalogue_entry(e)
+    ]
+    if not meta:
+        logger.warning(
+            "Bifrost catalogue for %s held no chat models (%d entries)",
+            provider_type,
+            len(entries),
+        )
+        return None
+    return meta
+
+
+async def default_model_for_provider_type(provider_type: str) -> str:
+    """Pick the ``default_model`` a mirrored provider row should floor to.
+
+    Prefers the bootstrap list ``registry`` already declares for the type —
+    that is the codebase's existing statement of which id to reach for when
+    nothing else is known — and only consults the gateway catalogue for a type
+    with no bootstrap list. Never returns empty: the column is NOT NULL, and a
+    row that fails to insert is worse than one flooring to a global default.
+    """
+    from core.llm.defaults import DEFAULT_MODEL
+    from core.llm.providers.registry import _FALLBACK_MODELS_BY_PROVIDER
+
+    bootstrap = _FALLBACK_MODELS_BY_PROVIDER.get(provider_type) or ()
+    if bootstrap:
+        return bootstrap[0]
+
+    meta = await fetch_catalogue_models(provider_type)
+    if meta:
+        ids = {m.id for m in meta}
+        for preferred in _CATALOG_DEFAULT_PREFERENCE.get(provider_type, ()):
+            if preferred in ids:
+                return preferred
+        return meta[0].id
+
+    logger.warning(
+        "No catalogue or bootstrap model for provider type %s — flooring the "
+        "mirrored row to %s",
+        provider_type,
+        DEFAULT_MODEL,
+    )
+    return DEFAULT_MODEL
 
 
 def sync_after_ollama_start() -> dict:

--- a/core/llm/bifrost/admin.py
+++ b/core/llm/bifrost/admin.py
@@ -872,6 +872,23 @@ async def fetch_catalogue_models(provider_type: str) -> Optional[List[Any]]:
     return meta
 
 
+async def _first_pulled_ollama_model() -> Optional[str]:
+    """The first model this host has actually pulled, or None if it can't say.
+
+    ``base_url`` is left to ``fetch_ollama_models``' own default: a mirrored row
+    carries none, since Bifrost owns the routing, and the loopback default is
+    what a single-machine install runs.
+    """
+    from core.llm.providers import discovery
+
+    try:
+        models = await discovery.fetch_ollama_models(None, allow_loopback=True)
+    except Exception as exc:  # noqa: BLE001 - the caller has a fallback
+        logger.debug("Could not list pulled Ollama models: %s", exc)
+        return None
+    return models[0].id if models else None
+
+
 async def default_model_for_provider_type(provider_type: str) -> str:
     """Pick the ``default_model`` a mirrored provider row should floor to.
 
@@ -887,6 +904,16 @@ async def default_model_for_provider_type(provider_type: str) -> str:
     bootstrap = _FALLBACK_MODELS_BY_PROVIDER.get(provider_type) or ()
     if bootstrap:
         return bootstrap[0]
+
+    # Ollama declares no bootstrap list on purpose — a self-hosted server serves
+    # whatever was pulled onto it, and nothing else. Asking it is the only way to
+    # name a model that will answer: the gateway's catalogue for ollama is its
+    # generic library, most of which is not on this host, and taking the first
+    # entry from it floored the mirrored row to a model chat then 404'd on.
+    if provider_type == "ollama":
+        pulled = await _first_pulled_ollama_model()
+        if pulled:
+            return pulled
 
     meta = await fetch_catalogue_models(provider_type)
     if meta:

--- a/core/llm/bifrost/admin.py
+++ b/core/llm/bifrost/admin.py
@@ -620,8 +620,12 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
                 )
                 meta = None
 
+            # A stand-in when the provider has a fetcher that could not answer,
+            # and the real thing when it has none.
+            stood_in = False
             if meta is None and provider_type not in _HOST_OWNED_CATALOGUE:
                 meta = await fetch_catalogue_models(provider_type)
+                stood_in = meta is not None and provider_type in _DISCOVERABLE
 
             if meta is not None:
                 upstream_ok = True
@@ -634,7 +638,7 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
 
             # Upstream failed: union the bootstrap list so the dropdown
             # isn't empty while still carrying the extras below.
-            if not upstream_ok:
+            if not upstream_ok or stood_in:
                 for mid in _FALLBACK_MODELS_BY_PROVIDER.get(provider_type, ()):
                     if mid not in row_seen:
                         row_seen.add(mid)
@@ -651,7 +655,10 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
             # Single-writer: populate the dropdown cache with this row's
             # list. ``fetch_provider_models`` reads this same key.
             _MODEL_LIST_CACHE[row_dict["provider_id"]] = row_ids
-            if upstream_ok:
+            # A stood-in datasheet is not this provider's catalogue: ruling a
+            # model out from it is the silent substitution ``can_serve`` exists
+            # to avoid, and its list is missing whatever the bootstrap carries.
+            if upstream_ok and not stood_in:
                 _LIVE_CATALOGUES.add(row_dict["provider_id"])
             else:
                 _LIVE_CATALOGUES.discard(row_dict["provider_id"])
@@ -665,11 +672,17 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
                 type_union.append(mid)
 
         # Host before allow-list: namespaced models are meaningless if the
-        # gateway still talks to the stock OpenAI cloud. One document per
-        # type; the default row already sits first, matching the key we push.
+        # gateway still talks to the stock OpenAI cloud. One document per type.
         if provider_type == "openai":
+            # The first row that states a host, not simply the first row: a
+            # mirror row carries no base_url and claims is_default when the
+            # type has none, so sorting alone let it shadow a real row's custom
+            # host and revert self-hosted traffic to the stock cloud.
+            hosted = next(
+                (r for r in provider_rows if r.get("base_url")), provider_rows[0]
+            )
             base_url_results[provider_type] = sync_provider_base_url(
-                provider_type, provider_rows[0].get("base_url")
+                provider_type, hosted.get("base_url")
             )
 
         if not type_union:
@@ -775,9 +788,10 @@ async def _fetch_meta_for_row(
         # same trust anchor as the admin-gated test and discover-models
         # endpoints. Without this, sync fails for any RFC1918 host even
         # though the UI dropdown populated fine.
-        return await discovery.fetch_ollama_models(base_url, allow_loopback=True)
+        return await _list_ollama_models(base_url, discovery)
 
-    return await fetch_catalogue_models(provider_type)
+    logger.debug("Bifrost sync: no fetcher for provider_type %s", provider_type)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -794,6 +808,11 @@ async def _fetch_meta_for_row(
 # Bifrost's ollama catalogue is the generic library, not what a host pulled.
 _HOST_OWNED_CATALOGUE = frozenset({"ollama"})
 
+# Types ``_fetch_meta_for_row`` has a real fetcher for. For anything else the
+# datasheet is the only catalogue there will ever be, so it can be trusted as
+# one; for these it is a stand-in for a fetch that failed or had no key.
+_DISCOVERABLE = frozenset({"anthropic", "openai", "ollama"})
+
 # What the row's ``default_model`` should floor to, per provider type. That
 # field is only a floor — it is what the picker shows when discovery yields
 # nothing (#409) and what dispatch uses when a caller names no model; the
@@ -804,6 +823,9 @@ _HOST_OWNED_CATALOGUE = frozenset({"ollama"})
 # catalogue's first entry.
 _CATALOG_DEFAULT_PREFERENCE: Dict[str, tuple] = {
     "vertex": ("gemini-2.5-flash", "gemini-2.0-flash", "claude-sonnet-4-5"),
+    # Mid-tier, rather than the opus the bootstrap list leads with or the haiku
+    # the marker sweep would otherwise land on.
+    "anthropic": ("claude-sonnet-4-6",),
 }
 
 
@@ -870,25 +892,45 @@ async def fetch_catalogue_models(provider_type: str) -> Optional[List[Any]]:
     return meta
 
 
-async def _first_pulled_ollama_model() -> Optional[str]:
-    """The first model this host has actually pulled, or None if it can't say.
+async def _list_ollama_models(
+    base_url: Optional[str], discovery: Any = None
+) -> Optional[List[Any]]:
+    """List an Ollama server's pulled models, or None if none can be reached.
 
-    A mirrored row carries no ``base_url``, and loopback is only right for a
-    single-machine install, so the configured endpoint is tried first.
+    A mirrored row carries no ``base_url`` of its own, and ``fetch_ollama_models``
+    then defaults to loopback — right only for a single-machine install, and
+    this process is as likely to be containerised as the gateway is. So a row
+    without one falls to ``OLLAMA_URL`` before that default. The catalogue and
+    the row's ``default_model`` both resolve through here; reading them from
+    different endpoints gave a row a servable default and an empty picker.
+
+    A server that answers with nothing pulled has answered: only a failure to
+    reach one moves on to the next candidate.
     """
-    from core.llm.providers import discovery
+    if discovery is None:
+        from core.llm.providers import discovery as discovery_module
 
+        discovery = discovery_module
+
+    candidates: List[Optional[str]] = [base_url] if base_url else []
     configured = (get_settings().ollama_url or "").strip()
-    candidates = [configured, None] if configured else [None]
-    for base_url in candidates:
-        try:
-            models = await discovery.fetch_ollama_models(base_url, allow_loopback=True)
-        except Exception as exc:  # noqa: BLE001 - try the next endpoint
-            logger.debug("Could not list pulled Ollama models at %s: %s", base_url, exc)
+    for candidate in (configured, None):
+        if candidate and candidate in candidates:
             continue
-        if models:
-            return models[0].id
+        candidates.append(candidate)
+
+    for candidate in candidates:
+        try:
+            return await discovery.fetch_ollama_models(candidate, allow_loopback=True)
+        except Exception as exc:  # noqa: BLE001 - try the next endpoint
+            logger.debug("Could not list Ollama models at %s: %s", candidate, exc)
     return None
+
+
+async def _first_pulled_ollama_model() -> Optional[str]:
+    """The first model this host has actually pulled, or None if it can't say."""
+    models = await _list_ollama_models(None)
+    return models[0].id if models else None
 
 
 async def default_model_for_provider_type(provider_type: str) -> Optional[str]:
@@ -913,15 +955,11 @@ async def default_model_for_provider_type(provider_type: str) -> Optional[str]:
 
     bootstrap = _FALLBACK_MODELS_BY_PROVIDER.get(provider_type) or ()
     if bootstrap:
-        return bootstrap[0]
+        return _preferred_floor(provider_type, list(bootstrap))
 
     meta = await fetch_catalogue_models(provider_type)
     if meta:
-        ids = {m.id for m in meta}
-        for preferred in _CATALOG_DEFAULT_PREFERENCE.get(provider_type, ()):
-            if preferred in ids:
-                return preferred
-        return _cheapest_looking(meta) or meta[0].id
+        return _preferred_floor(provider_type, [m.id for m in meta])
 
     logger.warning(
         "No catalogue or bootstrap model for provider type %s — leaving it "
@@ -934,12 +972,21 @@ async def default_model_for_provider_type(provider_type: str) -> Optional[str]:
 _MID_TIER_MARKERS = ("flash", "mini", "haiku", "lite", "small", "nano")
 
 
-def _cheapest_looking(meta: List[Any]) -> Optional[str]:
+def _preferred_floor(provider_type: str, ids: List[str]) -> str:
+    """Which of ``ids`` a mirrored row should floor its ``default_model`` to.
+
+    One path for both sources. The bootstrap list used to be taken at face
+    value, so anthropic floored to the priciest id it declares while the
+    catalogue path was busy avoiding exactly that.
+    """
+    for preferred in _CATALOG_DEFAULT_PREFERENCE.get(provider_type, ()):
+        if preferred in ids:
+            return preferred
     for marker in _MID_TIER_MARKERS:
-        for entry in meta:
-            if marker in entry.id.lower():
-                return entry.id
-    return None
+        for candidate in ids:
+            if marker in candidate.lower():
+                return candidate
+    return ids[0]
 
 
 def sync_after_ollama_start() -> dict:

--- a/core/llm/bifrost/admin.py
+++ b/core/llm/bifrost/admin.py
@@ -540,6 +540,7 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
     from core.llm.providers import discovery
     from core.llm.providers.registry import (
         _FALLBACK_MODELS_BY_PROVIDER,
+        _LIVE_CATALOGUES,
         _MODEL_LIST_CACHE,
         _register_extras,
         get_extra_model_ids,
@@ -622,6 +623,13 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
                 )
                 meta = None
 
+            if meta is None and provider_type not in _HOST_OWNED_CATALOGUE:
+                # Discovery could not answer — no key on a mirrored row, or a
+                # momentary upstream failure. The gateway's datasheet is a real
+                # catalogue and the bootstrap floor below is not, so try it
+                # before falling back to a handful of hardcoded ids.
+                meta = await fetch_catalogue_models(provider_type)
+
             if meta is not None:
                 upstream_ok = True
                 record_live_meta(provider_type, meta)
@@ -650,6 +658,12 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
             # Single-writer: populate the dropdown cache with this row's
             # list. ``fetch_provider_models`` reads this same key.
             _MODEL_LIST_CACHE[row_dict["provider_id"]] = row_ids
+            # And say whether that list is a catalogue or the bootstrap floor:
+            # only a catalogue may be used to rule a model out.
+            if upstream_ok:
+                _LIVE_CATALOGUES.add(row_dict["provider_id"])
+            else:
+                _LIVE_CATALOGUES.discard(row_dict["provider_id"])
             per_row_models[row_dict["provider_id"]] = row_ids
 
             # Contribute to the per-type union for Bifrost.
@@ -772,12 +786,9 @@ async def _fetch_meta_for_row(
         # though the UI dropdown populated fine.
         return await discovery.fetch_ollama_models(base_url, allow_loopback=True)
 
-    if provider_type in _CATALOG_PROVIDER_TYPES:
-        # No upstream to query — the gateway's own datasheet is the catalogue.
-        return await fetch_catalogue_models(provider_type)
-
-    logger.debug("Bifrost sync: unsupported provider_type %s", provider_type)
-    return None
+    # Everything else: no fetcher in discovery.py, so the gateway's own
+    # datasheet is the only catalogue there is.
+    return await fetch_catalogue_models(provider_type)
 
 
 # ---------------------------------------------------------------------------
@@ -786,15 +797,30 @@ async def _fetch_meta_for_row(
 
 # Bifrost carries a synced model datasheet at ``/api/models/details`` — the
 # catalogue its own dashboard lists. It is the only catalogue available for a
-# provider ``discovery.py`` cannot query, which today means vertex: Vertex
-# refuses ListModels under API-key and ADC auth, so there is no upstream to
-# ask. That is the same wall that makes a vertex key unverifiable — see
-# ``key_is_routable`` in core/llm/bifrost/mirror.py.
+# provider ``discovery.py`` cannot query, and for one it can query but has no
+# key for.
+#
+# Vertex is the clearest case of the first: it refuses ListModels under
+# API-key and ADC auth, so there is no upstream to ask — the same wall that
+# makes a vertex key unverifiable (``key_is_routable`` in
+# core/llm/bifrost/mirror.py). Gemini, Bedrock, Azure, Mistral and the rest
+# have no fetcher at all, and used to sync an empty list and show an empty
+# picker.
+#
+# The second case is a mirrored row: it holds no ``api_key_ref``, because
+# Bifrost holds the secret, so an Anthropic or OpenAI row configured through
+# the gateway alone cannot list its own models either.
 #
 # Reading it is not a second LLM path: it is capability discovery against the
 # gateway we already route through, the same carve-out ``discovery.py``
 # documents for querying provider catalogues directly.
-_CATALOG_PROVIDER_TYPES = frozenset({"vertex"})
+
+# The one type the datasheet must NOT stand in for. Bifrost's ollama catalogue
+# is the generic ollama library, most of which is not on any given host: a
+# mirrored row floored to its first entry pointed at codegemma on a machine
+# holding llama3.2, and chat 404'd on its own default. A self-hosted server
+# serves what was pulled onto it, and only that server can say what that is.
+_HOST_OWNED_CATALOGUE = frozenset({"ollama"})
 
 # What the row's ``default_model`` should floor to, per provider type. That
 # field is only a floor — it is what the picker shows when discovery yields
@@ -875,45 +901,62 @@ async def fetch_catalogue_models(provider_type: str) -> Optional[List[Any]]:
 async def _first_pulled_ollama_model() -> Optional[str]:
     """The first model this host has actually pulled, or None if it can't say.
 
-    ``base_url`` is left to ``fetch_ollama_models``' own default: a mirrored row
-    carries none, since Bifrost owns the routing, and the loopback default is
-    what a single-machine install runs.
+    Asks the endpoint the deployment configured (``OLLAMA_URL``) before the
+    loopback default. A mirrored row carries no ``base_url`` of its own, and
+    loopback is only right for a single-machine install — the backend is as
+    likely to be containerised as the gateway, in which case the host's Ollama
+    is not on its loopback at all and the honest answer is None.
     """
     from core.llm.providers import discovery
 
-    try:
-        models = await discovery.fetch_ollama_models(None, allow_loopback=True)
-    except Exception as exc:  # noqa: BLE001 - the caller has a fallback
-        logger.debug("Could not list pulled Ollama models: %s", exc)
-        return None
-    return models[0].id if models else None
+    configured = (get_settings().ollama_url or "").strip()
+    # None lets fetch_ollama_models apply its own loopback default, which is
+    # the right answer for a single-machine install and a second chance when
+    # OLLAMA_URL names somewhere this process cannot reach.
+    candidates = [configured, None] if configured else [None]
+    for base_url in candidates:
+        try:
+            models = await discovery.fetch_ollama_models(base_url, allow_loopback=True)
+        except Exception as exc:  # noqa: BLE001 - try the next endpoint
+            logger.debug("Could not list pulled Ollama models at %s: %s", base_url, exc)
+            continue
+        if models:
+            return models[0].id
+    return None
 
 
-async def default_model_for_provider_type(provider_type: str) -> str:
+async def default_model_for_provider_type(provider_type: str) -> Optional[str]:
     """Pick the ``default_model`` a mirrored provider row should floor to.
 
-    Prefers the bootstrap list ``registry`` already declares for the type —
-    that is the codebase's existing statement of which id to reach for when
-    nothing else is known — and only consults the gateway catalogue for a type
-    with no bootstrap list. Never returns empty: the column is NOT NULL, and a
-    row that fails to insert is worse than one flooring to a global default.
+    Returns None when no model can be named for the type, which is a refusal
+    rather than a shrug: the caller skips the row instead of writing a default
+    the provider demonstrably cannot serve. The earlier version floored to the
+    global ``DEFAULT_MODEL`` — a Claude id — so an unreachable Ollama host got
+    a row promising ``claude-sonnet-4-6``, and ``_router_model`` cannot correct
+    a bad default because a default is what it corrects *to*. A missing row
+    self-heals on the next catalogue sync; a wrong one does not.
     """
-    from core.llm.defaults import DEFAULT_MODEL
     from core.llm.providers.registry import _FALLBACK_MODELS_BY_PROVIDER
 
+    # Ollama first, and only Ollama: a self-hosted server serves whatever was
+    # pulled onto it, so asking it is the only way to name a model that will
+    # answer. It declares no bootstrap list for the same reason, and the
+    # gateway's generic library is exactly what must not stand in here.
+    if provider_type in _HOST_OWNED_CATALOGUE:
+        pulled = await _first_pulled_ollama_model()
+        if not pulled:
+            logger.warning(
+                "No pulled model to floor a mirrored %s row to — leaving it "
+                "unmirrored until the server can be listed",
+                provider_type,
+            )
+        return pulled
+
+    # The bootstrap list is the codebase's existing statement of which id to
+    # reach for when nothing else is known.
     bootstrap = _FALLBACK_MODELS_BY_PROVIDER.get(provider_type) or ()
     if bootstrap:
         return bootstrap[0]
-
-    # Ollama declares no bootstrap list on purpose — a self-hosted server serves
-    # whatever was pulled onto it, and nothing else. Asking it is the only way to
-    # name a model that will answer: the gateway's catalogue for ollama is its
-    # generic library, most of which is not on this host, and taking the first
-    # entry from it floored the mirrored row to a model chat then 404'd on.
-    if provider_type == "ollama":
-        pulled = await _first_pulled_ollama_model()
-        if pulled:
-            return pulled
 
     meta = await fetch_catalogue_models(provider_type)
     if meta:
@@ -921,15 +964,31 @@ async def default_model_for_provider_type(provider_type: str) -> str:
         for preferred in _CATALOG_DEFAULT_PREFERENCE.get(provider_type, ()):
             if preferred in ids:
                 return preferred
-        return meta[0].id
+        # No stated preference for this type: pick a mid-tier id by name rather
+        # than whatever the datasheet happens to list first, which in a
+        # 136-model catalogue is as likely to be the priciest as the cheapest.
+        return _cheapest_looking(meta) or meta[0].id
 
     logger.warning(
-        "No catalogue or bootstrap model for provider type %s — flooring the "
-        "mirrored row to %s",
+        "No catalogue or bootstrap model for provider type %s — leaving it "
+        "unmirrored",
         provider_type,
-        DEFAULT_MODEL,
     )
-    return DEFAULT_MODEL
+    return None
+
+
+# Names the vendors give their small/fast tier. A floor only has to be *a*
+# working chat model — the operator's real choice is the chat_default
+# assignment — so the cheap end of the catalogue is the right end to sit on.
+_MID_TIER_MARKERS = ("flash", "mini", "haiku", "lite", "small", "nano")
+
+
+def _cheapest_looking(meta: List[Any]) -> Optional[str]:
+    for marker in _MID_TIER_MARKERS:
+        for entry in meta:
+            if marker in entry.id.lower():
+                return entry.id
+    return None
 
 
 def sync_after_ollama_start() -> dict:

--- a/core/llm/bifrost/admin.py
+++ b/core/llm/bifrost/admin.py
@@ -553,10 +553,7 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
     if db_manager._engine is None:
         db_manager.initialize()
 
-    # Before reading the rows: mirror Bifrost's own providers into them. A key
-    # configured in Bifrost alone has no row to be discovered through, so
-    # without this the loop below cannot see it at all — see
-    # ``core.llm.bifrost.mirror``. Best-effort; never fails the sync.
+    # A key configured in Bifrost alone has no row for the loop below to find.
     from core.llm.bifrost.mirror import reconcile_all
 
     await reconcile_all()
@@ -624,10 +621,6 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
                 meta = None
 
             if meta is None and provider_type not in _HOST_OWNED_CATALOGUE:
-                # Discovery could not answer — no key on a mirrored row, or a
-                # momentary upstream failure. The gateway's datasheet is a real
-                # catalogue and the bootstrap floor below is not, so try it
-                # before falling back to a handful of hardcoded ids.
                 meta = await fetch_catalogue_models(provider_type)
 
             if meta is not None:
@@ -658,8 +651,6 @@ async def _do_sync_all_provider_models() -> Dict[str, Any]:
             # Single-writer: populate the dropdown cache with this row's
             # list. ``fetch_provider_models`` reads this same key.
             _MODEL_LIST_CACHE[row_dict["provider_id"]] = row_ids
-            # And say whether that list is a catalogue or the bootstrap floor:
-            # only a catalogue may be used to rule a model out.
             if upstream_ok:
                 _LIVE_CATALOGUES.add(row_dict["provider_id"])
             else:
@@ -786,8 +777,6 @@ async def _fetch_meta_for_row(
         # though the UI dropdown populated fine.
         return await discovery.fetch_ollama_models(base_url, allow_loopback=True)
 
-    # Everything else: no fetcher in discovery.py, so the gateway's own
-    # datasheet is the only catalogue there is.
     return await fetch_catalogue_models(provider_type)
 
 
@@ -795,31 +784,14 @@ async def _fetch_meta_for_row(
 # Gateway catalogue (providers with no upstream fetcher)
 # ---------------------------------------------------------------------------
 
-# Bifrost carries a synced model datasheet at ``/api/models/details`` — the
-# catalogue its own dashboard lists. It is the only catalogue available for a
-# provider ``discovery.py`` cannot query, and for one it can query but has no
-# key for.
-#
-# Vertex is the clearest case of the first: it refuses ListModels under
-# API-key and ADC auth, so there is no upstream to ask — the same wall that
-# makes a vertex key unverifiable (``key_is_routable`` in
-# core/llm/bifrost/mirror.py). Gemini, Bedrock, Azure, Mistral and the rest
-# have no fetcher at all, and used to sync an empty list and show an empty
-# picker.
-#
-# The second case is a mirrored row: it holds no ``api_key_ref``, because
-# Bifrost holds the secret, so an Anthropic or OpenAI row configured through
-# the gateway alone cannot list its own models either.
+# Bifrost's ``/api/models/details`` datasheet: the only catalogue for a provider
+# ``discovery.py`` cannot query, or holds no key for (every mirrored row).
 #
 # Reading it is not a second LLM path: it is capability discovery against the
 # gateway we already route through, the same carve-out ``discovery.py``
 # documents for querying provider catalogues directly.
 
-# The one type the datasheet must NOT stand in for. Bifrost's ollama catalogue
-# is the generic ollama library, most of which is not on any given host: a
-# mirrored row floored to its first entry pointed at codegemma on a machine
-# holding llama3.2, and chat 404'd on its own default. A self-hosted server
-# serves what was pulled onto it, and only that server can say what that is.
+# Bifrost's ollama catalogue is the generic library, not what a host pulled.
 _HOST_OWNED_CATALOGUE = frozenset({"ollama"})
 
 # What the row's ``default_model`` should floor to, per provider type. That
@@ -901,18 +873,12 @@ async def fetch_catalogue_models(provider_type: str) -> Optional[List[Any]]:
 async def _first_pulled_ollama_model() -> Optional[str]:
     """The first model this host has actually pulled, or None if it can't say.
 
-    Asks the endpoint the deployment configured (``OLLAMA_URL``) before the
-    loopback default. A mirrored row carries no ``base_url`` of its own, and
-    loopback is only right for a single-machine install — the backend is as
-    likely to be containerised as the gateway, in which case the host's Ollama
-    is not on its loopback at all and the honest answer is None.
+    A mirrored row carries no ``base_url``, and loopback is only right for a
+    single-machine install, so the configured endpoint is tried first.
     """
     from core.llm.providers import discovery
 
     configured = (get_settings().ollama_url or "").strip()
-    # None lets fetch_ollama_models apply its own loopback default, which is
-    # the right answer for a single-machine install and a second chance when
-    # OLLAMA_URL names somewhere this process cannot reach.
     candidates = [configured, None] if configured else [None]
     for base_url in candidates:
         try:
@@ -928,20 +894,13 @@ async def _first_pulled_ollama_model() -> Optional[str]:
 async def default_model_for_provider_type(provider_type: str) -> Optional[str]:
     """Pick the ``default_model`` a mirrored provider row should floor to.
 
-    Returns None when no model can be named for the type, which is a refusal
-    rather than a shrug: the caller skips the row instead of writing a default
-    the provider demonstrably cannot serve. The earlier version floored to the
-    global ``DEFAULT_MODEL`` — a Claude id — so an unreachable Ollama host got
-    a row promising ``claude-sonnet-4-6``, and ``_router_model`` cannot correct
-    a bad default because a default is what it corrects *to*. A missing row
-    self-heals on the next catalogue sync; a wrong one does not.
+    None when no model can be named, and the caller then skips the row: a
+    default is what a bad model falls back *to*, so nothing downstream can
+    correct one. A missing row self-heals on the next sync; a wrong one does
+    not.
     """
     from core.llm.providers.registry import _FALLBACK_MODELS_BY_PROVIDER
 
-    # Ollama first, and only Ollama: a self-hosted server serves whatever was
-    # pulled onto it, so asking it is the only way to name a model that will
-    # answer. It declares no bootstrap list for the same reason, and the
-    # gateway's generic library is exactly what must not stand in here.
     if provider_type in _HOST_OWNED_CATALOGUE:
         pulled = await _first_pulled_ollama_model()
         if not pulled:
@@ -952,8 +911,6 @@ async def default_model_for_provider_type(provider_type: str) -> Optional[str]:
             )
         return pulled
 
-    # The bootstrap list is the codebase's existing statement of which id to
-    # reach for when nothing else is known.
     bootstrap = _FALLBACK_MODELS_BY_PROVIDER.get(provider_type) or ()
     if bootstrap:
         return bootstrap[0]
@@ -964,9 +921,6 @@ async def default_model_for_provider_type(provider_type: str) -> Optional[str]:
         for preferred in _CATALOG_DEFAULT_PREFERENCE.get(provider_type, ()):
             if preferred in ids:
                 return preferred
-        # No stated preference for this type: pick a mid-tier id by name rather
-        # than whatever the datasheet happens to list first, which in a
-        # 136-model catalogue is as likely to be the priciest as the cheapest.
         return _cheapest_looking(meta) or meta[0].id
 
     logger.warning(
@@ -977,9 +931,6 @@ async def default_model_for_provider_type(provider_type: str) -> Optional[str]:
     return None
 
 
-# Names the vendors give their small/fast tier. A floor only has to be *a*
-# working chat model — the operator's real choice is the chat_default
-# assignment — so the cheap end of the catalogue is the right end to sit on.
 _MID_TIER_MARKERS = ("flash", "mini", "haiku", "lite", "small", "nano")
 
 

--- a/core/llm/bifrost/mirror.py
+++ b/core/llm/bifrost/mirror.py
@@ -1,0 +1,299 @@
+"""Mirror Bifrost's providers into ``llm_provider_configs``.
+
+Bifrost's config store holds the credentials and does the routing, but the rest
+of Vigil indexes providers by ``llm_provider_configs`` row: the model picker
+aggregates over those rows (``ModelRegistry.list_available_models``),
+``ai_model_configs.provider_id`` FKs to one, and ``get_provider_spec`` resolves
+dispatch through one. Two-store readiness (#761) taught the setup gate to read
+Bifrost directly, but only the gate — so a key added in Bifrost alone put a
+checkmark on the first setup step and left every surface past it reading a
+table nothing had written: an empty picker, no assignment savable, no spec to
+dispatch through.
+
+A mirror row closes that. It is an index entry, not a second config: no
+``api_key_ref`` (Bifrost holds the secret) and no ``base_url`` (the gateway
+owns routing). One row per provider *type*, which is all the dispatch path
+reads off it — Bifrost load-balances the keys within a provider itself.
+
+Rows are written from two places, both of which converge on the same state:
+the config proxy on an accepted key write (``services/api/routers/bifrost_config``),
+and ``reconcile_all`` on every catalogue sync, which backfills providers that
+were configured before this existed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from core.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10.0
+
+_MIRROR_PREFIX = "bifrost-"
+
+# Bifrost reports two different things as ``list_models_failed``: a credential
+# it rejected ("API key is invalid.") and one it could not check at all. Nothing
+# in the status separates them, so both discriminators below are allowlists.
+#
+# Vertex cannot be list-verified under any auth Vigil offers: under an API key
+# Bifrost refuses before trying, and under a service account or ADC the listing
+# demands a quota project the gateway does not send while ``generateContent`` on
+# the same credential works. The check is broken, not the credential — the same
+# conclusion ``_UNMANAGED_PROVIDER_TYPES`` in admin.py reaches about vertex's
+# catalogue. A provider that CAN be listed and failed stays a real failure.
+#
+# This module is the ONLY implementation. The console and scripts/reset-setup.sh
+# used to restate it in TypeScript and in bash-embedded Python; all three drifted
+# the moment vertex's second failure mode turned up, so both now read the verdict
+# from ``GET /api/bifrost/routability`` (services/api/routers/bifrost_config.py).
+_UNVERIFIABLE_PROVIDERS = frozenset({"vertex"})
+_LIST_UNSUPPORTED = re.compile(r"not supported for list models", re.I)
+
+
+def _list_check_unavailable(provider: Optional[str], description: str) -> bool:
+    if provider and provider in _UNVERIFIABLE_PROVIDERS:
+        return True
+    return bool(_LIST_UNSUPPORTED.search(description))
+
+
+def _cred_from_env(key: Dict[str, Any]) -> bool:
+    """True when the credential points at an env var rather than being set.
+
+    A first-boot seed's keys reference ``env.ANTHROPIC_API_KEY`` and friends,
+    which on a fresh install are unset. Mirroring those would offer providers
+    that cannot route and would green the setup step for a install nobody has
+    configured — exactly what #761 exists to prevent.
+    """
+    for candidate in (
+        key.get("value"),
+        (key.get("vertex_key_config") or {}).get("auth_credentials"),
+    ):
+        if isinstance(candidate, dict) and candidate.get("from_env"):
+            return True
+    return False
+
+
+def key_is_routable(key: Dict[str, Any], provider: Optional[str] = None) -> bool:
+    """True when a Bifrost key can actually route.
+
+    ``success`` means Bifrost verified the credential upstream. Absent or
+    ``unknown`` means it has not checked; an unlistable auth type means it never
+    will. Both of those are taken on trust — there is no signal to be had — so a
+    wrong credential fails on first use rather than here.
+    """
+    if not key.get("enabled", True):
+        return False
+    status = key.get("status")
+    if status == "success":
+        return True
+    if not status or status == "unknown":
+        return not _cred_from_env(key)
+    if status == "list_models_failed" and _list_check_unavailable(
+        provider, key.get("description") or ""
+    ):
+        return not _cred_from_env(key)
+    return False
+
+
+def _mirror_id(provider: str) -> str:
+    return f"{_MIRROR_PREFIX}{provider}"
+
+
+def _session_scope():
+    from core.storage.connection import get_db_manager
+
+    db = get_db_manager()
+    if db._engine is None:
+        db.initialize()
+    return db.session_scope()
+
+
+def _upsert_row(provider: str, default_model: str) -> None:
+    from core.storage.models import LLMProviderConfig
+
+    with _session_scope() as session:
+        row = session.get(LLMProviderConfig, _mirror_id(provider))
+        if row is not None:
+            # Reactivate rather than restate: an operator may have retitled the
+            # row or changed its default_model, and re-adding a key must not
+            # stamp over that.
+            row.is_active = True
+            return
+        # ``llm_provider_default_per_type`` is unique on provider_type where
+        # is_default, so claim the default only when the type has none.
+        has_default = (
+            session.query(LLMProviderConfig)
+            .filter(
+                LLMProviderConfig.provider_type == provider,
+                LLMProviderConfig.is_default.is_(True),
+            )
+            .first()
+            is not None
+        )
+        session.add(
+            LLMProviderConfig(
+                provider_id=_mirror_id(provider),
+                provider_type=provider,
+                name=f"{provider} (via Bifrost)",
+                default_model=default_model,
+                is_active=True,
+                is_default=not has_default,
+                config={"managed_by": "bifrost"},
+            )
+        )
+        logger.info(
+            "Mirrored Bifrost provider %s as %s (default_model=%s)",
+            provider,
+            _mirror_id(provider),
+            default_model,
+        )
+
+
+def _deactivate_row(provider: str) -> None:
+    """Retire the mirror once its provider has no routable key left.
+
+    Deactivated, not deleted: ``ai_model_configs.provider_id`` is ON DELETE
+    RESTRICT, so a row a component is still assigned to cannot be removed at
+    all. ``is_active = False`` drops it from the picker and from the catalogue
+    sync, which is the honest state either way.
+    """
+    from core.storage.models import LLMProviderConfig
+
+    with _session_scope() as session:
+        row = session.get(LLMProviderConfig, _mirror_id(provider))
+        if row is not None and row.is_active:
+            row.is_active = False
+            logger.info("Retired mirror row %s — no routable key", _mirror_id(provider))
+
+
+async def _get(path: str) -> Any:
+    url = f"{get_settings().bifrost_url.rstrip('/')}/api/{path}"
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def _routable_keys(provider: str) -> List[Dict[str, Any]]:
+    keys = (await _get(f"providers/{provider}/keys")).get("keys") or []
+    return [k for k in keys if key_is_routable(k, provider)]
+
+
+async def _apply(provider: str, *, routable: bool) -> None:
+    if not routable:
+        await asyncio.to_thread(_deactivate_row, provider)
+        return
+    from core.llm.bifrost.admin import default_model_for_provider_type
+
+    default_model = await default_model_for_provider_type(provider)
+    await asyncio.to_thread(_upsert_row, provider, default_model)
+
+
+async def sync_provider(provider: str) -> None:
+    """Bring one provider's mirror row in step with its Bifrost keys.
+
+    Best-effort: a key write Bifrost has accepted must not be undone by
+    bookkeeping. It does need a log line, because the symptom downstream is an
+    empty model picker with nothing else to go on.
+    """
+    try:
+        await _apply(provider, routable=bool(await _routable_keys(provider)))
+    except Exception as exc:  # noqa: BLE001 - never fail an accepted write
+        logger.warning("Could not mirror provider row for %s: %s", provider, exc)
+
+
+async def reconcile_all() -> Optional[Dict[str, bool]]:
+    """Mirror every Bifrost provider, backfilling ones configured earlier.
+
+    Returns the per-provider routable verdict, or None when Bifrost could not
+    be reached. Best-effort throughout — this rides on the catalogue sync and
+    must never fail it.
+    """
+    try:
+        providers = (await _get("providers")).get("providers") or []
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Mirror reconcile skipped — Bifrost unreachable: %s", exc)
+        return None
+
+    verdicts: Dict[str, bool] = {}
+    for p in providers:
+        name = p.get("name")
+        if not name:
+            continue
+        try:
+            routable = bool(await _routable_keys(name))
+            await _apply(name, routable=routable)
+            verdicts[name] = routable
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Mirror reconcile failed for %s: %s", name, exc)
+    return verdicts
+
+
+# Health labels the console renders beside a key. Derived here rather than in the
+# browser so the "could not check" / "was refused" split — the distinction that
+# needed fixing twice in one afternoon — has a single implementation.
+HEALTH_HEALTHY = "healthy"
+HEALTH_UNVERIFIED = "unverified"
+HEALTH_UNVERIFIABLE = "unverifiable"
+HEALTH_REJECTED = "rejected"
+
+
+def key_health(key: Dict[str, Any], provider: Optional[str] = None) -> str:
+    """One of the ``HEALTH_*`` labels for a key's Bifrost status."""
+    status = key.get("status")
+    if status == "success":
+        return HEALTH_HEALTHY
+    if not status or status == "unknown":
+        return HEALTH_UNVERIFIED
+    if status == "list_models_failed" and _list_check_unavailable(
+        provider, key.get("description") or ""
+    ):
+        return HEALTH_UNVERIFIABLE
+    return HEALTH_REJECTED
+
+
+async def routability() -> Dict[str, Any]:
+    """Every consumer's answer to "can this key route?", computed once.
+
+    Shaped for a single round trip: the console needs a per-key verdict to badge
+    the settings table, the setup gate needs only "is any provider routable",
+    and the reset script needs both. A provider whose keys cannot be listed is
+    reported as not routable rather than omitted, so a caller never has to tell
+    "no keys" apart from "could not ask".
+    """
+    providers = (await _get("providers")).get("providers") or []
+    key_verdicts: Dict[str, Any] = {}
+    provider_verdicts: Dict[str, bool] = {}
+
+    for p in providers:
+        name = p.get("name")
+        if not name:
+            continue
+        try:
+            keys = (await _get(f"providers/{name}/keys")).get("keys") or []
+        except Exception as exc:  # noqa: BLE001 - one provider must not fail all
+            logger.warning("Routability: could not list keys for %s: %s", name, exc)
+            provider_verdicts[name] = False
+            continue
+        routable_here = False
+        for k in keys:
+            key_id = k.get("id")
+            verdict = key_is_routable(k, name)
+            routable_here = routable_here or verdict
+            if key_id:
+                key_verdicts[key_id] = {
+                    "provider": name,
+                    "routable": verdict,
+                    "health": key_health(k, name),
+                    "description": k.get("description") or None,
+                }
+        provider_verdicts[name] = routable_here
+
+    return {"providers": provider_verdicts, "keys": key_verdicts}

--- a/core/llm/bifrost/mirror.py
+++ b/core/llm/bifrost/mirror.py
@@ -194,12 +194,6 @@ async def _apply(provider: str, *, routable: bool) -> None:
 
     default_model = await default_model_for_provider_type(provider)
     if not default_model:
-        # No model can be named for this provider yet — an Ollama server that
-        # cannot be listed, or a catalogue the gateway could not serve. Leave
-        # the row alone rather than promising a model the provider does not
-        # have: ``default_model`` is what dispatch falls back to, so a wrong one
-        # 404s with nothing left to correct it to. reconcile_all retries on
-        # every catalogue sync.
         logger.warning(
             "Not mirroring provider %s — no servable default_model to floor it to",
             provider,

--- a/core/llm/bifrost/mirror.py
+++ b/core/llm/bifrost/mirror.py
@@ -115,16 +115,29 @@ def _session_scope():
     return db.session_scope()
 
 
-def _upsert_row(provider: str, default_model: str) -> None:
+def _upsert_row(
+    provider: str, default_model: str, servable: Optional[set] = None
+) -> None:
     from core.storage.models import LLMProviderConfig
 
     with _session_scope() as session:
         row = session.get(LLMProviderConfig, _mirror_id(provider))
         if row is not None:
-            # Reactivate rather than restate: an operator may have retitled the
-            # row or changed its default_model, and re-adding a key must not
-            # stamp over that.
             row.is_active = True
+            # Otherwise left alone: an operator may have retitled the row or
+            # chosen its default_model, and re-adding a key must not stamp over
+            # that. But a default the provider no longer serves is not a choice
+            # -- an `ollama rm` of that model 404s every call that names none.
+            if servable and row.default_model not in servable:
+                logger.info(
+                    "Mirror row %s defaulted to %s, which %s no longer serves — "
+                    "moving it to %s",
+                    _mirror_id(provider),
+                    row.default_model,
+                    provider,
+                    default_model,
+                )
+                row.default_model = default_model
             return
         # ``llm_provider_default_per_type`` is unique on provider_type where
         # is_default, so claim the default only when the type has none.
@@ -199,7 +212,23 @@ async def _apply(provider: str, *, routable: bool) -> None:
             provider,
         )
         return
-    await asyncio.to_thread(_upsert_row, provider, default_model)
+    servable = await _servable_models(provider)
+    await asyncio.to_thread(_upsert_row, provider, default_model, servable)
+
+
+async def _servable_models(provider: str) -> Optional[set]:
+    """What ``provider`` serves right now, or None when that cannot be known.
+
+    Only asked of a self-hosted server, whose set changes under the operator's
+    hands. A cloud provider's catalogue does not shrink out from under a stored
+    default, so there is nothing to re-heal and no request worth making.
+    """
+    from core.llm.bifrost.admin import _HOST_OWNED_CATALOGUE, _list_ollama_models
+
+    if provider not in _HOST_OWNED_CATALOGUE:
+        return None
+    models = await _list_ollama_models(None)
+    return {m.id for m in models} if models else None
 
 
 async def sync_provider(provider: str) -> None:

--- a/core/llm/bifrost/mirror.py
+++ b/core/llm/bifrost/mirror.py
@@ -278,10 +278,15 @@ HEALTH_HEALTHY = "healthy"
 HEALTH_UNVERIFIED = "unverified"
 HEALTH_UNVERIFIABLE = "unverifiable"
 HEALTH_REJECTED = "rejected"
+HEALTH_DISABLED = "disabled"
 
 
 def key_health(key: Dict[str, Any], provider: Optional[str] = None) -> str:
     """One of the ``HEALTH_*`` labels for a key's Bifrost status."""
+    if not key.get("enabled", True):
+        # Its credential may be perfectly good; the key still routes nothing,
+        # and badging it Healthy beside routable=false read as a contradiction.
+        return HEALTH_DISABLED
     status = key.get("status")
     if status == "success":
         return HEALTH_HEALTHY

--- a/core/llm/bifrost/mirror.py
+++ b/core/llm/bifrost/mirror.py
@@ -193,6 +193,18 @@ async def _apply(provider: str, *, routable: bool) -> None:
     from core.llm.bifrost.admin import default_model_for_provider_type
 
     default_model = await default_model_for_provider_type(provider)
+    if not default_model:
+        # No model can be named for this provider yet — an Ollama server that
+        # cannot be listed, or a catalogue the gateway could not serve. Leave
+        # the row alone rather than promising a model the provider does not
+        # have: ``default_model`` is what dispatch falls back to, so a wrong one
+        # 404s with nothing left to correct it to. reconcile_all retries on
+        # every catalogue sync.
+        logger.warning(
+            "Not mirroring provider %s — no servable default_model to floor it to",
+            provider,
+        )
+        return
     await asyncio.to_thread(_upsert_row, provider, default_model)
 
 

--- a/core/llm/chat_layers.py
+++ b/core/llm/chat_layers.py
@@ -164,9 +164,18 @@ def chat_config(
     model: str,
     tools: Optional[List[str]] = None,
     mcp_tools: Optional[List[Dict[str, Any]]] = None,
+    provider: Optional[str] = None,
 ) -> str:
+    """Render the agent layer's config document.
+
+    ``provider`` is the gateway's provider name, carried separately from the
+    model rather than folded into it: Bifrost routes ``<provider>/<model>`` but
+    the price catalogue is keyed by the bare id, so the agent needs both. Left
+    out when unknown, which is what every caller did before this existed.
+    """
     document = {
         "model": model,
+        **({"provider": provider} if provider else {}),
         "budgets": DEFAULT_BUDGETS,
         "runtime": DEFAULT_RUNTIME,
         "tools": _declare(tools, mcp_tools),

--- a/core/llm/providers/registry.py
+++ b/core/llm/providers/registry.py
@@ -562,23 +562,13 @@ class ComponentAssignment:
 
 _MODEL_LIST_CACHE: Dict[str, List[str]] = {}
 
-# The subset of ``_MODEL_LIST_CACHE`` keys whose list came from a real catalogue
-# — an upstream fetch or the gateway's datasheet — rather than from the
-# bootstrap floor below. The two are not interchangeable to a caller asking
-# "does this provider serve model X?": the floor is a handful of ids chosen to
-# keep a dropdown from being empty, and answering "no" from it silently swapped
-# a valid selection for the provider's default (see ``_router_model`` in
-# services/api/routers/claude.py). Only a live entry may be used to deny.
+# Which ``_MODEL_LIST_CACHE`` entries are a real catalogue rather than the
+# bootstrap floor below, which must never be used to rule a model out.
 _LIVE_CATALOGUES: set = set()
 
 
 def catalogue_of(provider_id: str) -> Optional[List[str]]:
-    """The models ``provider_id`` is known to serve, or None if not known.
-
-    None means "no catalogue", which includes the case where the cache holds
-    only the bootstrap floor. A caller has to be able to tell that apart from a
-    catalogue that genuinely lacks a model.
-    """
+    """The models ``provider_id`` is known to serve, or None if not known."""
     if provider_id not in _LIVE_CATALOGUES:
         return None
     return _MODEL_LIST_CACHE.get(provider_id) or None

--- a/core/llm/providers/registry.py
+++ b/core/llm/providers/registry.py
@@ -562,6 +562,27 @@ class ComponentAssignment:
 
 _MODEL_LIST_CACHE: Dict[str, List[str]] = {}
 
+# The subset of ``_MODEL_LIST_CACHE`` keys whose list came from a real catalogue
+# — an upstream fetch or the gateway's datasheet — rather than from the
+# bootstrap floor below. The two are not interchangeable to a caller asking
+# "does this provider serve model X?": the floor is a handful of ids chosen to
+# keep a dropdown from being empty, and answering "no" from it silently swapped
+# a valid selection for the provider's default (see ``_router_model`` in
+# services/api/routers/claude.py). Only a live entry may be used to deny.
+_LIVE_CATALOGUES: set = set()
+
+
+def catalogue_of(provider_id: str) -> Optional[List[str]]:
+    """The models ``provider_id`` is known to serve, or None if not known.
+
+    None means "no catalogue", which includes the case where the cache holds
+    only the bootstrap floor. A caller has to be able to tell that apart from a
+    catalogue that genuinely lacks a model.
+    """
+    if provider_id not in _LIVE_CATALOGUES:
+        return None
+    return _MODEL_LIST_CACHE.get(provider_id) or None
+
 
 # Cold-boot fallback lists — used only when the live upstream API is
 # unreachable at the exact moment a caller needs a list. Each entry is
@@ -682,6 +703,7 @@ async def fetch_provider_models(row) -> List[str]:
         if mid not in fallback:
             fallback.append(mid)
     _MODEL_LIST_CACHE[row.provider_id] = fallback
+    _LIVE_CATALOGUES.discard(row.provider_id)
     return fallback
 
 
@@ -1032,8 +1054,10 @@ def invalidate_model_cache(provider_id: Optional[str] = None) -> None:
     so the UI sees fresh data."""
     if provider_id is None:
         _MODEL_LIST_CACHE.clear()
+        _LIVE_CATALOGUES.clear()
     else:
         _MODEL_LIST_CACHE.pop(provider_id, None)
+        _LIVE_CATALOGUES.discard(provider_id)
     # Provider-scoped live meta / discovery cache invalidation — best
     # effort. ``provider_id`` is a DB id, not a provider_type, so we can't
     # surgically drop a single entry; clear all meta + discovery cache

--- a/core/llm/router/router.py
+++ b/core/llm/router/router.py
@@ -473,6 +473,15 @@ def provider_spec_from_row(row) -> ProviderSpec:
 
 
 def get_provider_spec(provider_id: Optional[str]) -> Optional[ProviderSpec]:
+    """One provider's dispatch spec, or None when it cannot be dispatched to.
+
+    Inactive rows are refused, matching ``get_default_provider_spec``. A saved
+    ``ai_model_configs`` assignment outlives the row it names — the FK is ON
+    DELETE RESTRICT, so retiring a provider deactivates it rather than deleting
+    it — and without this an assignment kept dispatching to a provider whose
+    credential the gateway no longer has. The caller then falls back to the
+    configured default, as it does for an assignment naming no row at all.
+    """
     try:
         from core.storage.connection import get_db_session
         from core.storage.models import LLMProviderConfig
@@ -484,12 +493,16 @@ def get_provider_spec(provider_id: Optional[str]) -> Optional[ProviderSpec]:
     try:
         if provider_id:
             row = session.get(LLMProviderConfig, provider_id)
+            if row is not None and not row.is_active:
+                logger.info("Provider %s is inactive — not dispatchable", provider_id)
+                row = None
         else:
             row = (
                 session.query(LLMProviderConfig)
                 .filter(
                     LLMProviderConfig.provider_type == "anthropic",
                     LLMProviderConfig.is_default.is_(True),
+                    LLMProviderConfig.is_active.is_(True),
                 )
                 .first()
             )

--- a/core/llm/target.py
+++ b/core/llm/target.py
@@ -1,0 +1,169 @@
+"""Which provider and model a run should be dispatched to.
+
+One home for a question three callers ask: interactive chat, a workflow or hunt
+run resolving its config layer, and anything else that has to name a provider
+before it can name a model.
+
+The pair travels together on purpose. Bifrost routes ``<provider>/<model>`` and
+matches a bare name to whichever provider claims it first, so a model without
+the provider it was resolved against is a coin flip on any deployment holding
+two that offer the same id. And a model has to be checked against the provider
+that will serve it: a stale assignment left pointing at a model the active
+provider never had 404s at the gateway.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Provider types that can answer a ``claude-*`` id: Anthropic direct, plus the
+# two clouds that resell the models. Used only when the catalogue is unknown; a
+# known catalogue answers the question outright. An allowlist rather than a
+# test for Anthropic, since treating Vertex and Bedrock as ineligible is what
+# discarded a real Claude selection on Vertex and surfaced Gemini's error for
+# it.
+_SERVES_CLAUDE = frozenset({"anthropic", "vertex", "bedrock"})
+
+
+def provider_for(provider_id: Optional[str]):
+    """Pick the provider a request should route through.
+
+    Precedence:
+      1. An explicit ``provider_id`` — the model picker can send the model as
+         ``provider_id::model_id`` (#348); look the provider up by id.
+      2. The configured default provider (``get_default_provider_spec``) — so a
+         *bare* model id (the shape the Chat dock sends) still routes to a
+         non-Anthropic default instead of falling through to the Anthropic SDK
+         and 503-ing on Ollama-only deployments.
+
+    Returns a ``ProviderSpec`` or ``None``. Lookups are wrapped so a transient
+    DB error degrades to the ClaudeService/Anthropic path rather than 500-ing.
+    """
+    from core.llm.router.router import get_default_provider_spec, get_provider_spec
+
+    provider = None
+    if provider_id:
+        try:
+            provider = get_provider_spec(provider_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("provider lookup failed for %s: %s", provider_id, exc)
+            provider = None
+    if provider is None:
+        try:
+            provider = get_default_provider_spec()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("default provider lookup failed: %s", exc)
+            provider = None
+    return provider
+
+
+def model_for(provider, requested_model: Optional[str]) -> str:
+    """Model id to send, pinned to the provider's default if it can't serve it.
+
+    A stale selection — an assignment left pointing at a model the active
+    provider never had — would 404 at Bifrost, so it falls back to the
+    provider's own default.
+
+    What the provider serves is ``can_serve``'s question. An earlier version
+    asked "is this Anthropic?" and pinned every ``claude-*`` id elsewhere,
+    which was right for Ollama and OpenAI and wrong for Vertex: Google resells
+    Claude, so a Claude id there is a real selection. It was discarded before
+    it ever reached the gateway, and the substitute's failure was what surfaced
+    — an error about Gemini for a request the operator had pointed at Claude.
+    """
+    model = requested_model or provider.default_model
+    if can_serve(provider, model):
+        return model
+
+    if model == provider.default_model:
+        # Nothing better to send: the fallback *is* the default. Say so, since
+        # the gateway's 404 on its own names a model the operator never chose.
+        logger.warning(
+            "Provider %s cannot serve its own default_model %s — sending it "
+            "anyway; the gateway's error is the only signal left",
+            provider.provider_id,
+            model,
+        )
+        return model
+
+    logger.info(
+        "Provider %s cannot serve %s — falling back to %s",
+        provider.provider_id,
+        model,
+        provider.default_model,
+    )
+    return provider.default_model
+
+
+def can_serve(provider, model: str) -> bool:
+    """Whether ``provider`` can be expected to route ``model``.
+
+    A live catalogue answers outright. Without one, the only thing that can be
+    said is that a ``claude-*`` id cannot come from a provider that does not
+    carry Claude — so everything else is allowed through, and Bifrost's own
+    error beats a silent substitution.
+    """
+    catalogue = _catalogue(provider)
+    if catalogue is not None:
+        return model in catalogue
+    return not model.startswith("claude-") or provider.provider_type in _SERVES_CLAUDE
+
+
+def _catalogue(provider) -> Optional[set]:
+    """Model ids this provider is known to serve, or None when that isn't known.
+
+    Reads the same cache that fills the console's model picker, so a model the
+    operator could select is a model this accepts — but only the entries that
+    came from a real catalogue. The cache also holds a bootstrap floor of a few
+    hardcoded ids for a provider whose models could not be listed, and denying
+    from that floor silently swapped a valid selection for the default. A
+    mirrored row is exactly that case: it holds no api_key_ref, so an Anthropic
+    key configured in Bifrost alone cannot list its own models.
+    """
+    try:
+        from core.llm.providers.registry import catalogue_of
+
+        cached = catalogue_of(provider.provider_id)
+        return set(cached) if cached else None
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("catalogue lookup failed for %s: %s", provider.provider_id, exc)
+        return None
+
+
+def resolve_component(component: str) -> Optional[Tuple[str, str]]:
+    """The ``(provider_type, model)`` a component's assignment resolves to.
+
+    ``provider_type`` is the gateway's provider name, which is what rides
+    beside the model on the wire — not the row id, which means nothing to
+    Bifrost. None when nothing can be resolved, and the caller keeps whatever
+    default it had.
+
+    The assignment chain is the registry's (``component`` →  ``chat_default``
+    → the default Anthropic provider), and the model it yields is put through
+    ``model_for`` like any other: an assignment can be as stale as a chat
+    selection, and a workflow run has nobody watching it fail.
+    """
+    from core.llm.providers.registry import get_registry
+
+    try:
+        resolved = get_registry().resolve_for_component(component)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("model assignment lookup failed for %s: %s", component, exc)
+        return None
+    if not resolved:
+        return None
+
+    provider_id, model_id = resolved
+    provider = provider_for(provider_id)
+    if provider is None:
+        logger.warning(
+            "%s resolves to provider %s, which has no row — leaving the model "
+            "unresolved",
+            component,
+            provider_id,
+        )
+        return None
+    return provider.provider_type, model_for(provider, model_id)

--- a/core/llm/target.py
+++ b/core/llm/target.py
@@ -1,15 +1,7 @@
 """Which provider and model a run should be dispatched to.
 
-One home for a question three callers ask: interactive chat, a workflow or hunt
-run resolving its config layer, and anything else that has to name a provider
-before it can name a model.
-
-The pair travels together on purpose. Bifrost routes ``<provider>/<model>`` and
-matches a bare name to whichever provider claims it first, so a model without
-the provider it was resolved against is a coin flip on any deployment holding
-two that offer the same id. And a model has to be checked against the provider
-that will serve it: a stale assignment left pointing at a model the active
-provider never had 404s at the gateway.
+Bifrost routes ``<provider>/<model>`` and matches a bare name to whichever
+provider claims it first, so the pair has to travel together.
 """
 
 from __future__ import annotations
@@ -19,28 +11,17 @@ from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-# Provider types that can answer a ``claude-*`` id: Anthropic direct, plus the
-# two clouds that resell the models. Used only when the catalogue is unknown; a
-# known catalogue answers the question outright. An allowlist rather than a
-# test for Anthropic, since treating Vertex and Bedrock as ineligible is what
-# discarded a real Claude selection on Vertex and surfaced Gemini's error for
-# it.
+# Vertex and Bedrock resell Claude, so this is an allowlist, not a test for
+# Anthropic.
 _SERVES_CLAUDE = frozenset({"anthropic", "vertex", "bedrock"})
 
 
 def provider_for(provider_id: Optional[str]):
     """Pick the provider a request should route through.
 
-    Precedence:
-      1. An explicit ``provider_id`` — the model picker can send the model as
-         ``provider_id::model_id`` (#348); look the provider up by id.
-      2. The configured default provider (``get_default_provider_spec``) — so a
-         *bare* model id (the shape the Chat dock sends) still routes to a
-         non-Anthropic default instead of falling through to the Anthropic SDK
-         and 503-ing on Ollama-only deployments.
-
-    Returns a ``ProviderSpec`` or ``None``. Lookups are wrapped so a transient
-    DB error degrades to the ClaudeService/Anthropic path rather than 500-ing.
+    The model picker can send the model as ``provider_id::model_id`` (#348); a
+    bare id has no provider and falls back to the configured default rather
+    than the Anthropic SDK, which 503s on an Ollama-only deployment.
     """
     from core.llm.router.router import get_default_provider_spec, get_provider_spec
 
@@ -61,26 +42,12 @@ def provider_for(provider_id: Optional[str]):
 
 
 def model_for(provider, requested_model: Optional[str]) -> str:
-    """Model id to send, pinned to the provider's default if it can't serve it.
-
-    A stale selection — an assignment left pointing at a model the active
-    provider never had — would 404 at Bifrost, so it falls back to the
-    provider's own default.
-
-    What the provider serves is ``can_serve``'s question. An earlier version
-    asked "is this Anthropic?" and pinned every ``claude-*`` id elsewhere,
-    which was right for Ollama and OpenAI and wrong for Vertex: Google resells
-    Claude, so a Claude id there is a real selection. It was discarded before
-    it ever reached the gateway, and the substitute's failure was what surfaced
-    — an error about Gemini for a request the operator had pointed at Claude.
-    """
+    """Model id to send, pinned to the provider's default if it can't serve it."""
     model = requested_model or provider.default_model
     if can_serve(provider, model):
         return model
 
     if model == provider.default_model:
-        # Nothing better to send: the fallback *is* the default. Say so, since
-        # the gateway's 404 on its own names a model the operator never chose.
         logger.warning(
             "Provider %s cannot serve its own default_model %s — sending it "
             "anyway; the gateway's error is the only signal left",
@@ -101,10 +68,8 @@ def model_for(provider, requested_model: Optional[str]) -> str:
 def can_serve(provider, model: str) -> bool:
     """Whether ``provider`` can be expected to route ``model``.
 
-    A live catalogue answers outright. Without one, the only thing that can be
-    said is that a ``claude-*`` id cannot come from a provider that does not
-    carry Claude — so everything else is allowed through, and Bifrost's own
-    error beats a silent substitution.
+    Without a catalogue everything but a ``claude-*`` id goes through:
+    Bifrost's own error beats a silent substitution.
     """
     catalogue = _catalogue(provider)
     if catalogue is not None:
@@ -113,16 +78,7 @@ def can_serve(provider, model: str) -> bool:
 
 
 def _catalogue(provider) -> Optional[set]:
-    """Model ids this provider is known to serve, or None when that isn't known.
-
-    Reads the same cache that fills the console's model picker, so a model the
-    operator could select is a model this accepts — but only the entries that
-    came from a real catalogue. The cache also holds a bootstrap floor of a few
-    hardcoded ids for a provider whose models could not be listed, and denying
-    from that floor silently swapped a valid selection for the default. A
-    mirrored row is exactly that case: it holds no api_key_ref, so an Anthropic
-    key configured in Bifrost alone cannot list its own models.
-    """
+    """Model ids this provider is known to serve, or None when that isn't known."""
     try:
         from core.llm.providers.registry import catalogue_of
 
@@ -136,15 +92,8 @@ def _catalogue(provider) -> Optional[set]:
 def resolve_component(component: str) -> Optional[Tuple[str, str]]:
     """The ``(provider_type, model)`` a component's assignment resolves to.
 
-    ``provider_type`` is the gateway's provider name, which is what rides
-    beside the model on the wire — not the row id, which means nothing to
-    Bifrost. None when nothing can be resolved, and the caller keeps whatever
-    default it had.
-
-    The assignment chain is the registry's (``component`` →  ``chat_default``
-    → the default Anthropic provider), and the model it yields is put through
-    ``model_for`` like any other: an assignment can be as stale as a chat
-    selection, and a workflow run has nobody watching it fail.
+    ``provider_type`` because the row id means nothing to Bifrost. None leaves
+    the caller its own default.
     """
     from core.llm.providers.registry import get_registry
 
@@ -160,10 +109,7 @@ def resolve_component(component: str) -> Optional[Tuple[str, str]]:
     provider = provider_for(provider_id)
     if provider is None:
         logger.warning(
-            "%s resolves to provider %s, which has no row — leaving the model "
-            "unresolved",
-            component,
-            provider_id,
+            "%s resolves to provider %s, which has no row", component, provider_id
         )
         return None
     return provider.provider_type, model_for(provider, model_id)

--- a/core/workflows/playbook_resolver.py
+++ b/core/workflows/playbook_resolver.py
@@ -310,11 +310,6 @@ def resolve(
 
     config = {
         "model": model or DEFAULT_MODEL,
-        # Beside the model, not folded into it: the gateway routes
-        # ``<provider>/<model>`` while the price catalogue is keyed by the bare
-        # id, so the agent layer needs both (services/agent/harness.ts).
-        # Omitted when unknown, which is what every config written before this
-        # existed looks like.
         **({"provider": provider} if provider else {}),
         "budgets": _budgets(phases),
         "runtime": DEFAULT_RUNTIME,
@@ -427,11 +422,6 @@ def resolve_hunt(
 
     config = {
         "model": model or DEFAULT_MODEL,
-        # Beside the model, not folded into it: the gateway routes
-        # ``<provider>/<model>`` while the price catalogue is keyed by the bare
-        # id, so the agent layer needs both (services/agent/harness.ts).
-        # Omitted when unknown, which is what every config written before this
-        # existed looks like.
         **({"provider": provider} if provider else {}),
         "budgets": dict(HUNT_BUDGETS),
         "runtime": DEFAULT_RUNTIME,

--- a/core/workflows/playbook_resolver.py
+++ b/core/workflows/playbook_resolver.py
@@ -276,6 +276,7 @@ def resolve(
     model: Optional[str] = None,
     workflows: Optional["WorkflowsService"] = None,
     registry: Optional["MCPRegistry"] = None,
+    provider: Optional[str] = None,
 ) -> Tuple[str, str]:
     """Return the playbook and config layers for ``workflow_id``, as YAML text."""
     from core.workflows.workflows_service import WorkflowsService
@@ -309,6 +310,12 @@ def resolve(
 
     config = {
         "model": model or DEFAULT_MODEL,
+        # Beside the model, not folded into it: the gateway routes
+        # ``<provider>/<model>`` while the price catalogue is keyed by the bare
+        # id, so the agent layer needs both (services/agent/harness.ts).
+        # Omitted when unknown, which is what every config written before this
+        # existed looks like.
+        **({"provider": provider} if provider else {}),
         "budgets": _budgets(phases),
         "runtime": DEFAULT_RUNTIME,
         "tools": tools,
@@ -392,6 +399,7 @@ def resolve_hunt(
     model: Optional[str] = None,
     workflows: Optional["WorkflowsService"] = None,
     registry: Optional["MCPRegistry"] = None,
+    provider: Optional[str] = None,
 ) -> Tuple[str, str]:
     from core.workflows.workflows_service import WorkflowsService
 
@@ -419,6 +427,12 @@ def resolve_hunt(
 
     config = {
         "model": model or DEFAULT_MODEL,
+        # Beside the model, not folded into it: the gateway routes
+        # ``<provider>/<model>`` while the price catalogue is keyed by the bare
+        # id, so the agent layer needs both (services/agent/harness.ts).
+        # Omitted when unknown, which is what every config written before this
+        # existed looks like.
+        **({"provider": provider} if provider else {}),
         "budgets": dict(HUNT_BUDGETS),
         "runtime": DEFAULT_RUNTIME,
         "tools": _bound_capabilities(list(HUNT_CAPABILITIES), _tool_catalogue(registry))

--- a/core/workflows/playbooks_router.py
+++ b/core/workflows/playbooks_router.py
@@ -56,16 +56,8 @@ def get_playbook(
 ) -> ResolvedPlaybook:
     authorise(authorization, "playbook resolution")
 
-    # Which provider and model this run gets, resolved here rather than left to
-    # the config layer's DEFAULT_MODEL floor. That floor is a Claude id, so a
-    # deployment whose only provider is Ollama ran every hunt against a model it
-    # does not have; and a model with no provider beside it is routed by the
-    # gateway to whichever provider claims the bare name first.
-    #
-    # ``investigation`` is the assignment row this already belongs to — the
-    # console labels it "Investigation Agents: Investigator, Threat Hunter,
-    # Correlator" — and the registry falls it back to chat_default when unset,
-    # so nothing new has to be configured.
+    # Not the config layer's DEFAULT_MODEL floor, which is a Claude id whatever
+    # the provider. ``investigation`` is the row the console files hunts under.
     resolved = target.resolve_component("investigation")
     if resolved is None:
         logger.info(

--- a/core/workflows/playbooks_router.py
+++ b/core/workflows/playbooks_router.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from core.agents.internal_auth import authorise
 from core.deps import provide_mcp_registry, provide_workflows
 from core.integrations.mcp.registry import MCPRegistry
+from core.llm import target
 from core.routing import Auth, RouterMeta
 from core.workflows.playbook_resolver import UnknownPlaybook, resolve, resolve_hunt
 from core.workflows.workflows_service import WorkflowsService
@@ -55,11 +56,33 @@ def get_playbook(
 ) -> ResolvedPlaybook:
     authorise(authorization, "playbook resolution")
 
+    # Which provider and model this run gets, resolved here rather than left to
+    # the config layer's DEFAULT_MODEL floor. That floor is a Claude id, so a
+    # deployment whose only provider is Ollama ran every hunt against a model it
+    # does not have; and a model with no provider beside it is routed by the
+    # gateway to whichever provider claims the bare name first.
+    #
+    # ``investigation`` is the assignment row this already belongs to — the
+    # console labels it "Investigation Agents: Investigator, Threat Hunter,
+    # Correlator" — and the registry falls it back to chat_default when unset,
+    # so nothing new has to be configured.
+    resolved = target.resolve_component("investigation")
+    if resolved is None:
+        logger.info(
+            "%s: no model assignment resolved; the config layer's default stands",
+            workflow_id,
+        )
+    provider, model = resolved or (None, None)
+
     # The definition says which loop drives it, and the two loops read different
     # sections: a compose run wants phases, a hunt wants beliefs to test.
     try:
         playbook, config = _resolver_for(workflows, workflow_id)(
-            workflow_id, workflows=workflows, registry=registry
+            workflow_id,
+            model=model,
+            workflows=workflows,
+            registry=registry,
+            provider=provider,
         )
     except UnknownPlaybook as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from None

--- a/scripts/reset-setup.sh
+++ b/scripts/reset-setup.sh
@@ -2,13 +2,19 @@
 # Reset the first-access setup state so the onboarding wizard (/setup) starts fresh.
 #
 # Each onboarding step derives "ready" live from backend state (see
-# clients/web/src/setup/setupSteps.ts) — there is no persisted "done" flag — so
-# clearing the underlying state is all it takes to redo the wizard.
+# clients/web/src/screens/setup/setupSteps.ts) — there is no persisted "done"
+# flag — so clearing the underlying state is all it takes to redo the wizard.
+#
+# Two stores back the "connect an AI provider" step, and EITHER satisfies it:
+# the legacy llm_provider_configs table and Bifrost's own key store (#761). A
+# reset has to drain both or the step stays green — clearing Postgres alone
+# leaves a verified gateway key holding the gate open.
 #
 # Usage:
-#   ./scripts/reset-setup.sh                 # reset providers + assignments + budget + autonomy
+#   ./scripts/reset-setup.sh                 # providers + bifrost keys + assignments + budget + autonomy
 #   ./scripts/reset-setup.sh --status        # show current state, change nothing
-#   ./scripts/reset-setup.sh --providers     # only re-trigger the hard gate (delete LLM providers)
+#   ./scripts/reset-setup.sh --providers     # only clear the legacy LLM providers
+#   ./scripts/reset-setup.sh --bifrost       # only disable the gateway's keys
 #   ./scripts/reset-setup.sh --data-source splunk   # also disconnect a real data-source server
 #   ./scripts/reset-setup.sh --all -y        # everything, no confirmation prompt
 #
@@ -17,19 +23,26 @@
 #                        default of a type — which the API can neither delete nor unset
 #                        (the single-default guard 409s) — it clears the default flag
 #                        directly in Postgres, then deletes. Falls back to deactivating
-#                        that row if the DB isn't reachable. Either way the wizard re-shows.
+#                        that row if the DB isn't reachable. On its own this no longer
+#                        re-fires the gate: pair it with --bifrost (or use --all).
+#   --bifrost            Disable every enabled key in Bifrost's store. Disabled, not
+#                        deleted — the credential and its ~/.vigil/secrets.enc ref
+#                        survive, so re-enabling is one click in Settings → AI Config
+#                        and nothing has to be retyped.
 #   --assignments        Clear all per-agent model assignments
 #   --budget             Clear the Bifrost virtual key + spend cap
 #   --autonomy           Disable the autonomous orchestrator (preserves its cost caps)
 #   --data-source NAME   Disconnect MCP server NAME (repeatable). Use ONLY for real telemetry
 #                        sources (splunk, elastic, ...) — never Vigil's internal servers.
-#   --all                providers + assignments + budget + autonomy (NOT data sources)
+#   --all                providers + bifrost + assignments + budget + autonomy (NOT data sources)
 #   --status             Print current setup state and exit
 #   -y, --yes            Skip the confirmation prompt
 #   -h, --help           Show this help
 #
 # Env:
-#   VIGIL_API   Backend API base URL (default: http://localhost:6987/api)
+#   VIGIL_API     Backend API base URL (default: http://localhost:6987/api)
+#   BIFROST_URL   Gateway admin API root, used only by the --bifrost fallback
+#                 below (default: http://localhost:8080)
 #
 # Auth: assumes DEV_MODE=true (auth bypassed). Set VIGIL_TOKEN to send a
 # Bearer token if you run against an authenticated backend.
@@ -39,12 +52,20 @@
 # reuses the app's own DB connection, so it runs best from the repo root with
 # the project venv (SQLAlchemy + the same POSTGRES_* / .env config the backend
 # uses). If the DB isn't reachable it falls back to deactivating that provider.
+#
+# Gateway step: --bifrost writes through the console's own /api/bifrost proxy so
+# credentials keep flowing through the secrets store. An env-backed key has no
+# stored secret for the proxy to substitute, so that one write goes straight to
+# BIFROST_URL re-declaring the key's env reference — which moves no secret.
 
 # No `set -u`: macOS ships bash 3.2, where expanding an empty array (AUTH,
 # data_sources) under `-u` is a fatal "unbound variable".
 set -eo pipefail
 
 B="${VIGIL_API:-http://localhost:6987/api}"
+# Gateway admin root. Only the --bifrost env-backed fallback talks to it
+# directly; every other gateway call goes through the console proxy at $B.
+BF_ADMIN="${BIFROST_URL:-http://localhost:8080}/api"
 
 # Repo root (this script lives in scripts/) and a Python that has the project's
 # deps — used only by the DB fallback in the --providers reset. Prefer the venv
@@ -111,26 +132,229 @@ except Exception as exc:  # DB unreachable / deps missing → caller falls back
 PY
 }
 
+# Shared by --status and --bifrost: everything that has to know how a Bifrost
+# key is shaped. Kept in one place because the read side (which keys hold the
+# gate open) and the write side (how to disable one without corrupting its
+# credential) have to agree.
+bifrost_py() {
+  VIGIL_API="$B" BF_ADMIN="$BF_ADMIN" AUTH_TOKEN="${VIGIL_TOKEN:-}" BF_MODE="$1" "$PYTHON" - <<'PY'
+import json, os, urllib.error, urllib.request
+
+API = os.environ["VIGIL_API"].rstrip("/")
+BF = os.environ["BF_ADMIN"].rstrip("/")
+TOKEN = os.environ.get("AUTH_TOKEN", "")
+MODE = os.environ["BF_MODE"]
+
+GREEN = "\033[0;32m"; YELLOW = "\033[1;33m"; DIM = "\033[2m"; NC = "\033[0m"
+
+
+def req(url, method="GET", body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    r = urllib.request.Request(url, data=data, method=method)
+    if data:
+        r.add_header("Content-Type", "application/json")
+    if TOKEN:
+        r.add_header("Authorization", "Bearer " + TOKEN)
+    with urllib.request.urlopen(r, timeout=15) as resp:
+        raw = resp.read()
+    return json.loads(raw) if raw else None
+
+
+def env_ref(field):
+    """Re-declare a credential that lives in the environment, or None.
+
+    Returns the same {value, env_var, from_env} shape Bifrost hands back, with
+    the masked value dropped — echoing a mask back would store the mask as the
+    credential and every call would then 401.
+    """
+    if isinstance(field, dict) and field.get("from_env") and field.get("env_var"):
+        return {"value": "", "env_var": field["env_var"], "from_env": True}
+    return None
+
+
+# Whether a key routes is decided once, by the backend, in
+# core/llm/bifrost/mirror.py. This script used to restate that predicate so it
+# could run without the app's venv, but the rule is subtle -- Bifrost reports
+# both "I refused this" and "I could not check this" as list_models_failed --
+# and the copies drifted apart the first time a new failure mode turned up. The
+# API is already this script's source for providers, assignments, budget and
+# autonomy, so one more call costs nothing it wasn't already paying.
+_verdicts = None
+
+
+def verdicts():
+    """The backend's routability map, fetched once per run.
+
+    Raises rather than degrading to an empty map: every key would then read as
+    non-routable, and the reset would report a clean sweep while disabling
+    nothing. A reset that quietly does nothing is the worst possible answer
+    here, since the whole point is to prove the gate has been drained.
+    """
+    global _verdicts
+    if _verdicts is None:
+        got = req(f"{API}/bifrost/routability")
+        if not isinstance(got, dict) or "keys" not in got:
+            raise RuntimeError(
+                "routability check unavailable — is the backend running?"
+            )
+        _verdicts = got
+    return _verdicts
+
+
+def routable(k, provider=None):
+    """Does this key hold the provider step green? Backend's verdict."""
+    return bool((verdicts().get("keys") or {}).get(k.get("id"), {}).get("routable"))
+
+
+# Bifrost answers an empty collection with null rather than [], so `or []`
+# rather than a dict default -- a provider whose last key was deleted was
+# otherwise reported as "unreachable (NoneType is not iterable)".
+def providers():
+    return (req(f"{API}/bifrost/providers") or {}).get("providers") or []
+
+
+def keys_of(name):
+    return (req(f"{API}/bifrost/providers/{name}/keys") or {}).get("keys") or []
+
+
+def disable(provider, key):
+    """Flip one key to disabled, carrying everything else through untouched.
+
+    Bifrost has no enabled-only update, so the whole key is rewritten and every
+    field we don't want to lose has to be restated — a PUT that omits `name`
+    blanks it.
+    """
+    body = {
+        "name": key.get("name") or "",
+        "models": key.get("models") or ["*"],
+        "blacklisted_models": key.get("blacklisted_models") or [],
+        "weight": key.get("weight", 1),
+        "use_for_batch_api": bool(key.get("use_for_batch_api")),
+        "enabled": False,
+    }
+    # Ollama's credential is a URL the operator typed, not a secret the proxy
+    # masks or stores, so the block has to come along or Bifrost loses the
+    # endpoint. Vertex's project/region travel the same way; its
+    # service-account JSON is left out so the proxy substitutes the stored one.
+    ollama = key.get("ollama_key_config")
+    if isinstance(ollama, dict):
+        body["ollama_key_config"] = {"url": env_ref(ollama.get("url")) or ollama.get("url")}
+    vertex = key.get("vertex_key_config")
+    if isinstance(vertex, dict):
+        body["vertex_key_config"] = {
+            f: v for f, v in vertex.items() if f != "auth_credentials"
+        }
+
+    # The proxy first: it substitutes the plaintext it holds for any key a human
+    # set. A 400 means it holds none — an env-backed key — so re-declare that
+    # reference straight to the gateway instead.
+    try:
+        req(f"{API}/bifrost/providers/{provider}/keys/{key['id']}", "PUT", body)
+        return True
+    except urllib.error.HTTPError as exc:
+        if exc.code != 400:
+            raise
+    ref = env_ref(key.get("value"))
+    if ref is None:
+        return False
+    body["value"] = ref
+    req(f"{BF}/providers/{provider}/keys/{key['id']}", "PUT", body)
+    return True
+
+
+if MODE == "status":
+    try:
+        live = [
+            f"{p['name']}/{k.get('name') or k['id'][:8]}"
+            for p in providers()
+            for k in keys_of(p["name"])
+            if routable(k, p["name"])
+        ]
+    except Exception as exc:  # noqa: BLE001 — advisory line, never fatal
+        print(f"unreachable ({exc})")
+    else:
+        print(", ".join(live) + " (holds the gate open)" if live else "none routable")
+    raise SystemExit(0)
+
+# MODE == "reset"
+try:
+    provs = providers()
+except Exception as exc:  # noqa: BLE001
+    print(f"  {YELLOW}bifrost unreachable{NC} {DIM}({exc}) — no keys disabled{NC}")
+    raise SystemExit(0)
+
+changed = stuck = inert = 0
+for p in provs:
+    name = p["name"]
+    try:
+        keys = keys_of(name)
+    except Exception as exc:  # noqa: BLE001
+        print(f"  {YELLOW}could not list keys{NC} for {name} {DIM}({exc}){NC}")
+        continue
+    for k in keys:
+        if not k.get("enabled"):
+            continue
+        # Only routable keys hold the step green, and only they are worth a
+        # write: an env-placeholder key whose variable is unset can't even be
+        # rewritten (Bifrost rejects the empty value it would have to carry),
+        # and reporting that as a failure sends people chasing a non-problem.
+        if not routable(k, name):
+            inert += 1
+            continue
+        label = f"{name}/{k.get('name') or k['id'][:8]}"
+        try:
+            done = disable(name, k)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  {YELLOW}could not disable{NC} {label} {DIM}({exc}){NC}")
+            stuck += 1
+            continue
+        if done:
+            print(f"  {GREEN}disabled bifrost key{NC} {label}")
+            changed += 1
+        else:
+            print(
+                f"  {YELLOW}left enabled{NC} {label} {DIM}(no stored credential "
+                f"and no env reference — disable it in Settings → AI Config){NC}"
+            )
+            stuck += 1
+
+if not changed and not stuck:
+    print("  bifrost keys: none were routable")
+if inert:
+    print(
+        f"  {DIM}({inert} enabled but non-routable key(s) left alone — they don't "
+        f"hold the gate){NC}"
+    )
+if stuck:
+    print(
+        f"  {YELLOW}the provider step will stay green{NC} {DIM}until the {stuck} "
+        f"key(s) above are disabled{NC}"
+    )
+PY
+}
+
 # --- argument parsing -----------------------------------------------------
 do_providers=false; do_assignments=false; do_budget=false; do_autonomy=false
+do_bifrost=false
 status_only=false; assume_yes=false
 data_sources=()
 
 if [ $# -eq 0 ]; then
-  do_providers=true; do_assignments=true; do_budget=true; do_autonomy=true
+  do_providers=true; do_bifrost=true; do_assignments=true; do_budget=true; do_autonomy=true
 fi
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --providers)   do_providers=true ;;
+    --bifrost)     do_bifrost=true ;;
     --assignments) do_assignments=true ;;
     --budget)      do_budget=true ;;
     --autonomy)    do_autonomy=true ;;
     --data-source) shift; [ $# -gt 0 ] || { echo "--data-source needs a server name" >&2; exit 1; }; data_sources+=("$1") ;;
-    --all)         do_providers=true; do_assignments=true; do_budget=true; do_autonomy=true ;;
+    --all)         do_providers=true; do_bifrost=true; do_assignments=true; do_budget=true; do_autonomy=true ;;
     --status)      status_only=true ;;
     -y|--yes)      assume_yes=true ;;
-    -h|--help)     sed -n '2,41p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help)     awk 'NR>1 && /^# Env:/{exit} NR>1 && /^#/{sub(/^# ?/,"");print}' "$0"; exit 0 ;;
     *)             echo "Unknown option: $1" >&2; exit 1 ;;
   esac
   shift
@@ -140,7 +364,13 @@ done
 show_status() {
   echo -e "${DIM}API: $B${NC}"
   echo -n "  LLM providers     : "
-  get /llm/providers/ | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(f\"{p['provider_id']}(default)\" if p.get('is_default') else p['provider_id'] for p in d) or 'none')"
+  # An inactive row is marked as such: only an ACTIVE default satisfies the
+  # provider step, and a retired Bifrost mirror row (see core/llm/bifrost/
+  # mirror.py) stays behind after a reset, where it otherwise reads as a
+  # holdout that still needs clearing.
+  get /llm/providers/ | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(p['provider_id'] + ('(default)' if p.get('is_default') else '') + ('' if p.get('is_active') else ' [inactive]') for p in d) or 'none')"
+  echo -n "  Bifrost keys      : "
+  bifrost_py status
   echo -n "  Model assignments : "
   get /ai/config | python3 -c "import sys,json;a=json.load(sys.stdin).get('assignments',{});print(', '.join(a) or 'none')"
   echo -n "  Cost guardrails   : "
@@ -160,6 +390,7 @@ if [ "$status_only" = true ]; then exit 0; fi
 # --- confirm --------------------------------------------------------------
 planned=()
 [ "$do_providers"   = true ] && planned+=("delete all LLM providers (clears the last default's flag in Postgres so it can be removed; re-fires the hard gate)")
+[ "$do_bifrost"     = true ] && planned+=("disable every enabled Bifrost key (reversible; credentials kept)")
 [ "$do_assignments" = true ] && planned+=("clear all model assignments")
 [ "$do_budget"      = true ] && planned+=("clear the budget / virtual key")
 [ "$do_autonomy"    = true ] && planned+=("disable the orchestrator")
@@ -217,6 +448,12 @@ if [ "$do_providers" = true ]; then
       esac
     done <<< "$ids"
   fi
+fi
+
+# After the provider deletes, not before: deleting a provider reconciles its
+# Bifrost key, so draining Postgres first means fewer keys left to disable here.
+if [ "$do_bifrost" = true ]; then
+  bifrost_py reset
 fi
 
 if [ "$do_budget" = true ]; then

--- a/scripts/reset-setup.sh
+++ b/scripts/reset-setup.sh
@@ -336,7 +336,7 @@ PY
 
 # --- argument parsing -----------------------------------------------------
 do_providers=false; do_assignments=false; do_budget=false; do_autonomy=false
-do_bifrost=false
+do_bifrost=false; bifrost_failed=false
 status_only=false; assume_yes=false
 data_sources=()
 
@@ -454,7 +454,10 @@ fi
 # After the provider deletes, not before: deleting a provider reconciles its
 # Bifrost key, so draining Postgres first means fewer keys left to disable here.
 if [ "$do_bifrost" = true ]; then
-  bifrost_py reset
+  # Only this step: the reset's later steps are independent of the gateway, and
+  # under `set -e` a raise here used to take the budget, the orchestrator and
+  # the data sources down with it.
+  bifrost_py reset || bifrost_failed=true
 fi
 
 if [ "$do_budget" = true ]; then
@@ -476,4 +479,9 @@ for s in "${data_sources[@]:-}"; do
 done
 
 echo
+if [ "${bifrost_failed:-false}" = true ]; then
+  echo -e "${YELLOW}Done, except the gateway.${NC} Its keys were left alone — reload"
+  echo -e "/setup once you have disabled them, or the provider step stays green."
+  exit 1
+fi
 echo -e "${GREEN}Done.${NC} Reload /setup to redo the wizard."

--- a/scripts/reset-setup.sh
+++ b/scripts/reset-setup.sh
@@ -28,7 +28,11 @@
 #   --bifrost            Disable every enabled key in Bifrost's store. Disabled, not
 #                        deleted — the credential and its ~/.vigil/secrets.enc ref
 #                        survive, so re-enabling is one click in Settings → AI Config
-#                        and nothing has to be retyped.
+#                        and nothing has to be retyped. Disabling through the proxy
+#                        retires the key's mirror row with it; the env-backed
+#                        fallback below writes straight to the gateway and does not,
+#                        so pair this with --providers (or use --all) to be sure the
+#                        gate is drained.
 #   --assignments        Clear all per-agent model assignments
 #   --budget             Clear the Bifrost virtual key + spend cap
 #   --autonomy           Disable the autonomous orchestrator (preserves its cost caps)
@@ -201,7 +205,7 @@ def verdicts():
     return _verdicts
 
 
-def routable(k, provider=None):
+def routable(k):
     """Does this key hold the provider step green? Backend's verdict."""
     return bool((verdicts().get("keys") or {}).get(k.get("id"), {}).get("routable"))
 
@@ -268,7 +272,7 @@ if MODE == "status":
             f"{p['name']}/{k.get('name') or k['id'][:8]}"
             for p in providers()
             for k in keys_of(p["name"])
-            if routable(k, p["name"])
+            if routable(k)
         ]
     except Exception as exc:  # noqa: BLE001 — advisory line, never fatal
         print(f"unreachable ({exc})")
@@ -282,6 +286,16 @@ try:
 except Exception as exc:  # noqa: BLE001
     print(f"  {YELLOW}bifrost unreachable{NC} {DIM}({exc}) — no keys disabled{NC}")
     raise SystemExit(0)
+
+# Fetched before the loop so the deliberate refusal in verdicts() lands as a
+# message rather than a traceback out of the middle of a partial sweep.
+try:
+    verdicts()
+except Exception as exc:  # noqa: BLE001
+    print(f"  {YELLOW}cannot tell which keys route{NC} {DIM}({exc}){NC}")
+    print(f"  {DIM}nothing disabled — a reset that reports a clean sweep it did "
+          f"not make is worse than one that stops{NC}")
+    raise SystemExit(1)
 
 changed = stuck = inert = 0
 for p in provs:
@@ -298,7 +312,7 @@ for p in provs:
         # write: an env-placeholder key whose variable is unset can't even be
         # rewritten (Bifrost rejects the empty value it would have to carry),
         # and reporting that as a failure sends people chasing a non-problem.
-        if not routable(k, name):
+        if not routable(k):
             inert += 1
             continue
         label = f"{name}/{k.get('name') or k['id'][:8]}"
@@ -354,7 +368,7 @@ while [ $# -gt 0 ]; do
     --all)         do_providers=true; do_bifrost=true; do_assignments=true; do_budget=true; do_autonomy=true ;;
     --status)      status_only=true ;;
     -y|--yes)      assume_yes=true ;;
-    -h|--help)     awk 'NR>1 && /^# Env:/{exit} NR>1 && /^#/{sub(/^# ?/,"");print}' "$0"; exit 0 ;;
+    -h|--help)     awk 'NR>1 && /^# DB step:/{exit} NR>1 && /^#/{sub(/^# ?/,"");print}' "$0"; exit 0 ;;
     *)             echo "Unknown option: $1" >&2; exit 1 ;;
   esac
   shift

--- a/scripts/reset-setup.sh
+++ b/scripts/reset-setup.sh
@@ -176,13 +176,6 @@ def env_ref(field):
     return None
 
 
-# Whether a key routes is decided once, by the backend, in
-# core/llm/bifrost/mirror.py. This script used to restate that predicate so it
-# could run without the app's venv, but the rule is subtle -- Bifrost reports
-# both "I refused this" and "I could not check this" as list_models_failed --
-# and the copies drifted apart the first time a new failure mode turned up. The
-# API is already this script's source for providers, assignments, budget and
-# autonomy, so one more call costs nothing it wasn't already paying.
 _verdicts = None
 
 
@@ -190,9 +183,7 @@ def verdicts():
     """The backend's routability map, fetched once per run.
 
     Raises rather than degrading to an empty map: every key would then read as
-    non-routable, and the reset would report a clean sweep while disabling
-    nothing. A reset that quietly does nothing is the worst possible answer
-    here, since the whole point is to prove the gate has been drained.
+    non-routable and the reset would report a clean sweep it never made.
     """
     global _verdicts
     if _verdicts is None:
@@ -287,8 +278,7 @@ except Exception as exc:  # noqa: BLE001
     print(f"  {YELLOW}bifrost unreachable{NC} {DIM}({exc}) — no keys disabled{NC}")
     raise SystemExit(0)
 
-# Fetched before the loop so the deliberate refusal in verdicts() lands as a
-# message rather than a traceback out of the middle of a partial sweep.
+# Before the loop, so the refusal above is a message, not a partial sweep.
 try:
     verdicts()
 except Exception as exc:  # noqa: BLE001
@@ -308,10 +298,7 @@ for p in provs:
     for k in keys:
         if not k.get("enabled"):
             continue
-        # Only routable keys hold the step green, and only they are worth a
-        # write: an env-placeholder key whose variable is unset can't even be
-        # rewritten (Bifrost rejects the empty value it would have to carry),
-        # and reporting that as a failure sends people chasing a non-problem.
+        # An env-placeholder key whose variable is unset cannot be rewritten.
         if not routable(k):
             inert += 1
             continue

--- a/services/agent/core/spec.ts
+++ b/services/agent/core/spec.ts
@@ -98,6 +98,11 @@ export interface Runtime {
 export interface Config {
   sections: Record<string, unknown>;
   model: string;
+  // Which upstream serves `model`, when the caller knows. The gateway routes a
+  // bare name to whichever provider claims it first, which is a coin flip on a
+  // deployment holding two that both offer "gemini-2.5-flash". Optional because
+  // a single-provider deployment has nothing to disambiguate.
+  provider?: string;
   budgets: BudgetLimits;
   runtime: Runtime;
   tools: ToolSpec[];
@@ -150,7 +155,7 @@ const LAYERS = {
     "phases",
     "narrative",
   ],
-  config: ["model", "budgets", "runtime", "tools", "approvals", "thresholds"],
+  config: ["model", "provider", "budgets", "runtime", "tools", "approvals", "thresholds"],
 } as const;
 
 export type Layer = keyof typeof LAYERS;
@@ -421,6 +426,7 @@ export function parseConfig(text: string, owned: Owned = NONE): Config {
   const sections = Object.fromEntries((owned["config"] ?? []).filter((key) => key in front).map((key) => [key, front[key]]));
   const model = str(front["model"]);
   if (model.trim() === "") throw new SpecError("config needs a model: a deployment that names none bills nothing and answers nothing");
+  const provider = front["provider"] === undefined ? undefined : str(front["provider"]).trim() || undefined;
 
   const tools = parseTools(front["tools"]);
   const declared = new Set(tools.map((tool) => tool.id));
@@ -433,6 +439,7 @@ export function parseConfig(text: string, owned: Owned = NONE): Config {
   return {
     sections,
     model,
+    ...(provider === undefined ? {} : { provider }),
     budgets: positive(merge(front["budgets"], DEFAULT_BUDGETS, "budgets"), "budgets"),
     runtime: positive(merge(front["runtime"], DEFAULT_RUNTIME, "runtime"), "runtime"),
     tools,

--- a/services/agent/core/wire.ts
+++ b/services/agent/core/wire.ts
@@ -83,18 +83,31 @@ function tally(): Tally {
   };
 }
 
-export function openAiSurface(client: OpenAI, model: string, limiter: Limiter, provider_type: string): Provider {
-  return new OpenAiSurface(client, model, limiter, provider_type);
+export function openAiSurface(
+  client: OpenAI,
+  model: string,
+  limiter: Limiter,
+  provider_type: string,
+  wire_model: string = model,
+): Provider {
+  return new OpenAiSurface(client, model, limiter, provider_type, wire_model);
 }
 
 // The one surface built. The gateway routes to either provider family behind a
 // model name, so a second wire buys nothing until cache_control and thinking.
 class OpenAiSurface implements Provider {
+  // Two names for one model, and they are not interchangeable. `wire_model` is
+  // what the gateway is asked for and may be namespaced ("vertex/gemini-2.5-flash")
+  // so it routes to the intended provider rather than whichever one happens to
+  // claim the bare name first. `model` stays bare because that is the id the
+  // price catalogue is keyed by -- sending the namespaced form there matched
+  // nothing, and an unpriced call eventually stops the run.
   constructor(
     private readonly client: OpenAI,
     readonly model: string,
     private readonly limiter: Limiter,
     readonly provider_type: string,
+    private readonly wire_model: string = model,
   ) {}
 
   // Assembled before the events are emitted, so usage precedes the tool calls. The
@@ -108,7 +121,7 @@ class OpenAiSurface implements Provider {
 
   private async ask(request: TurnRequest): Promise<Turn> {
     const tools = request.tools.length === 0 ? {} : { tools: wireTools(request.tools) };
-    return turnOf(await this.call({ model: this.model, messages: wire(request.messages), ...tools }, request.signal));
+    return turnOf(await this.call({ model: this.wire_model, messages: wire(request.messages), ...tools }, request.signal));
   }
 
   private async emit(request: TurnRequest, schema: Record<string, unknown>): Promise<Turn> {
@@ -119,7 +132,7 @@ class OpenAiSurface implements Provider {
     if ((emitModes.get(mode) ?? "schema") === "schema") {
       try {
         const format = { type: "json_schema" as const, json_schema: { name: "emission", strict: false, schema } };
-        const turn = spend.count(turnOf(await this.call({ model: this.model, messages, response_format: format }, request.signal)));
+        const turn = spend.count(turnOf(await this.call({ model: this.wire_model, messages, response_format: format }, request.signal)));
         // A gateway that drops response_format answers 200 with an object of the model's
         // own invention, so fall through to the tool, whose parameters it does forward.
         if (honours(turn.content, schema)) return turn;
@@ -139,7 +152,7 @@ class OpenAiSurface implements Provider {
     // Neither wire carried it, so the schema goes in the prompt, which asks nothing of
     // the gateway. What comes back is JSON the caller already parses and corrects.
     const asked = [...messages, { role: "user" as const, content: prompted(schema) }];
-    const turn = spend.count(turnOf(await this.call({ model: this.model, messages: asked }, request.signal)));
+    const turn = spend.count(turnOf(await this.call({ model: this.wire_model, messages: asked }, request.signal)));
     if (turn.content !== "" || turn.tool_calls.length === 0) return turn;
 
     // No tools were offered and it called one anyway: a provider that finds a name in
@@ -147,7 +160,7 @@ class OpenAiSurface implements Provider {
     return spend.count(
       turnOf(
         await this.call(
-          { model: this.model, messages: [...asked, { role: "user", content: instead(turn) }] },
+          { model: this.wire_model, messages: [...asked, { role: "user", content: instead(turn) }] },
           request.signal,
         ),
       ),
@@ -164,7 +177,7 @@ class OpenAiSurface implements Provider {
   ): Promise<Turn | null> {
     const emit = { name: EMIT_TOOL, description: "Emit your answer.", parameters: schema };
     const forced = {
-      model: this.model,
+      model: this.wire_model,
       messages,
       tools: [{ type: "function" as const, function: emit }],
       tool_choice: { type: "function" as const, function: { name: EMIT_TOOL } },

--- a/services/agent/harness.ts
+++ b/services/agent/harness.ts
@@ -56,6 +56,12 @@ function grantsFor(kind: RunKind, spec: RunSpec): Record<string, readonly string
 
 // The six injected parts, assembled per run because the model, the grants and the
 // budget are all the spec's. Nothing here is shared between two runs.
+// The gateway's own namespacing: "<provider>/<model>". Left bare when the spec
+// names no provider, which is every config written before this field existed.
+function wireModel(spec: { model: string; provider?: string }): string {
+  return spec.provider ? `${spec.provider}/${spec.model}` : spec.model;
+}
+
 export function harnessFor<K extends Record<string, unknown>>(
   kind: RunKind,
   spec: RunSpec,
@@ -65,7 +71,11 @@ export function harnessFor<K extends Record<string, unknown>>(
 ): Harness<K> {
   const tools = process.env["VIGIL_TOOLS_URL"] ?? "http://localhost:6987/internal/tools/invoke";
   return {
-    provider: openAiSurface(client, spec.model, limiter, "bifrost"),
+    // Bare id for pricing, namespaced id on the wire — see openAiSurface. Without
+    // the namespace the gateway matched "gemini-2.5-flash" to whichever provider
+    // claimed it first, so a chat pointed at Vertex was answered (or refused) by
+    // a different account entirely.
+    provider: openAiSurface(client, spec.model, limiter, "bifrost", wireModel(spec)),
     registry: registryOf(toolsFrom(spec.tools), grantsFor(kind, spec)),
     dispatch: remoteDispatch({ url: tools, token: internalToken() }),
     budget: budgetOf(spec.budgets, unmeteredQuota, Date.now, seed, prices),

--- a/services/api/routers/bifrost_config.py
+++ b/services/api/routers/bifrost_config.py
@@ -5,9 +5,10 @@ allow-lists, pricing and governance. This router is the console's only door to
 it: Bifrost itself runs with admin auth disabled on a private network, so the
 gate has to live here.
 
-Two things it does beyond forwarding, both because Bifrost's key API cannot be
-driven honestly without them (see ``core.llm.bifrost.admin`` for how these were
-learned):
+Three things it does beyond forwarding. The first two are because Bifrost's key
+API cannot be driven honestly without them (see ``core.llm.bifrost.admin`` for
+how those were learned); the third is because the rest of Vigil does not read
+Bifrost:
 
 * **Secrets stay ours.** A key's plaintext is mirrored into the secrets store
   under ``llm_key_<key_id>`` on write and dropped on delete, so credential
@@ -17,10 +18,15 @@ learned):
   (``sk-a****key``) and Bifrost accepts a write that echoes the mask, storing
   the mask as the credential — every call then 401s with nothing to say why. A
   write that carries no new secret has the stored one substituted in.
+* **A key write mirrors a provider row.** Vigil indexes providers by
+  ``llm_provider_configs``, so a key that exists only in Bifrost is unreachable
+  to the model picker, to assignments, and to dispatch — see
+  ``core.llm.bifrost.mirror``.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from typing import Annotated, Any, Dict, Optional
@@ -30,6 +36,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
 from core.auth.auth_service import AuthService
 from core.config import get_settings
+from core.llm.bifrost import mirror
 from core.routing import Auth, RouterMeta
 from core.secrets import delete_secret, get_secret, set_secret
 from core.storage.models import User
@@ -72,6 +79,31 @@ def _secret_ref(key_id: str) -> str:
     return f"llm_key_{key_id}"
 
 
+def _scope_ref(key_id: str) -> str:
+    """Where a Vertex key's project/region are kept.
+
+    Not secrets, but Bifrost masks them like one and offers no unmasked read —
+    ``?unmasked``/``?reveal`` all come back ``prod****oglm`` — so the real
+    values cannot be recovered from the gateway. Keeping our own copy is what
+    lets an edit that only changes the weight leave the scope intact.
+    """
+    return f"llm_key_{key_id}_vertex_scope"
+
+
+def _stored_scope(key_id: Optional[str]) -> Dict[str, str]:
+    if not key_id:
+        return {}
+    raw = get_secret(_scope_ref(key_id))
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        logger.warning("Bifrost proxy: stored vertex scope for %s is not JSON", key_id)
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def _is_masked(value: Any) -> bool:
     """True when ``value`` is a read-back rather than a new secret.
 
@@ -88,6 +120,37 @@ def _require_settings_admin(current_user: User) -> None:
     if not AuthService.check_permission(current_user.user_id, "settings.write"):
         raise HTTPException(
             status_code=403, detail="Permission denied: settings.write required"
+        )
+
+
+def _resolve_vertex_scope(vertex: Dict[str, Any], key_id: Optional[str]) -> None:
+    """Fill in ``project_id``/``region`` the write left out, in place.
+
+    The console omits a field it isn't changing rather than echoing the mask it
+    was shown, so an edit that only touches the weight arrives with no scope at
+    all. Bifrost would take that literally and blank it, pointing the key at no
+    project. A key configured outside Vigil has no stored copy to fall back on,
+    and the gateway will not reveal one — so that case asks rather than guesses.
+    """
+    stored = _stored_scope(key_id)
+    missing = []
+    for field in ("project_id", "region"):
+        supplied = vertex.get(field)
+        if supplied and not _is_masked(supplied):
+            continue
+        if stored.get(field):
+            vertex[field] = stored[field]
+        else:
+            missing.append(field)
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This Vertex key needs its "
+                + " and ".join(f.replace("_", " ") for f in missing)
+                + ". Bifrost masks both on read and will not reveal them, so a "
+                "key first configured outside Vigil has to have them retyped once."
+            ),
         )
 
 
@@ -116,6 +179,7 @@ def _resolve_key_value(body: Dict[str, Any], key_id: Optional[str]) -> None:
 
     vertex = body.get("vertex_key_config")
     if isinstance(vertex, dict):
+        _resolve_vertex_scope(vertex, key_id)
         # Service-account mode: the JSON is the credential, mirrored to value.
         # Keyed on the block, not on ``auth_credentials`` within it: editing
         # project/region without retyping the JSON omits that field entirely
@@ -123,21 +187,26 @@ def _resolve_key_value(body: Dict[str, Any], key_id: Optional[str]) -> None:
         # API-key path — ``value`` was restored but ``auth_credentials`` was
         # left unset, handing Bifrost a scoped key with no credential.
         sa = vertex.get("auth_credentials")
-        if not _is_masked(sa) and sa:
-            body["value"] = sa
-            return
-        stored = get_secret(_secret_ref(key_id)) if key_id else None
-        if not stored:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "No stored service-account credential for this Vertex key — "
-                    "paste the service-account JSON. Bifrost has no "
-                    "credential-only update, so every key write needs one."
-                ),
-            )
-        vertex["auth_credentials"] = stored
-        body["value"] = stored
+        if _is_masked(sa) or not sa:
+            stored = get_secret(_secret_ref(key_id)) if key_id else None
+            if not stored:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "No stored service-account credential for this Vertex key — "
+                        "paste the service-account JSON. Bifrost has no "
+                        "credential-only update, so every key write needs one."
+                    ),
+                )
+            vertex["auth_credentials"] = stored
+        # `value` is deliberately NOT set from the service account. Bifrost
+        # picks a vertex key's auth mode by whether `value` is populated, so
+        # mirroring the JSON there made it authenticate as an API key and the
+        # request came back "API keys are not supported by this API. Expected
+        # OAuth2 access token" — a 401 that says nothing about the real cause.
+        # A service-account key carries its credential in `auth_credentials`
+        # alone; the secrets-store copy is keyed off that field instead.
+        body.pop("value", None)
         return
 
     if not _is_masked(body.get("value")) and body.get("value"):
@@ -152,6 +221,28 @@ def _resolve_key_value(body: Dict[str, Any], key_id: Optional[str]) -> None:
             ),
         )
     body["value"] = stored
+
+
+# Declared before the catch-all below, which FastAPI would otherwise match
+# first. Not a proxied path: this is Vigil's own verdict about Bifrost's keys,
+# computed in core.llm.bifrost.mirror so the console, the setup gate and
+# scripts/reset-setup.sh all read one implementation instead of restating it in
+# three languages.
+@router.get("/routability")
+async def routability(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+) -> Dict[str, Any]:
+    """Per-key and per-provider "can this actually route?".
+
+    One call answers what used to take 1 + N proxy round trips — the setup gate
+    listed providers, then every provider's keys, on its critical path.
+    """
+    _require_settings_admin(current_user)
+    try:
+        return await mirror.routability()
+    except httpx.HTTPError as exc:
+        logger.warning("Routability check failed: %s", exc)
+        raise HTTPException(status_code=502, detail=f"Bifrost unreachable: {exc}")
 
 
 @router.api_route("/{path:path}", methods=list(_METHODS))
@@ -206,6 +297,7 @@ async def proxy(
 
     if keys_match and upstream.status_code < 400:
         _persist_key_secret(request.method, key_id, body, upstream)
+        await mirror.sync_provider(keys_match.group("provider"))
 
     return Response(
         content=upstream.content,
@@ -231,8 +323,15 @@ def _persist_key_secret(
         if method == "DELETE":
             if key_id:
                 delete_secret(_secret_ref(key_id))
+                delete_secret(_scope_ref(key_id))
             return
-        value = (body or {}).get("value")
+        # A vertex service-account key sends no `value` at all (see
+        # _resolve_key_value), so its credential is read off the vertex block.
+        vertex = (body or {}).get("vertex_key_config")
+        if isinstance(vertex, dict):
+            value = vertex.get("auth_credentials")
+        else:
+            value = (body or {}).get("value")
         if not value or _is_masked(value):
             return
         ref_id = key_id
@@ -250,5 +349,25 @@ def _persist_key_secret(
             )
             return
         set_secret(_secret_ref(ref_id), value)
+        _persist_vertex_scope(ref_id, body)
     except Exception as exc:  # noqa: BLE001 - never fail an accepted write
         logger.warning("Bifrost proxy: could not mirror key secret: %s", exc)
+
+
+def _persist_vertex_scope(key_id: str, body: Optional[Dict[str, Any]]) -> None:
+    """Keep our own copy of a Vertex key's project/region.
+
+    Written after ``_resolve_vertex_scope`` has already filled in whatever the
+    request omitted, so this stores the complete scope rather than only the
+    fields that happened to be retyped.
+    """
+    vertex = (body or {}).get("vertex_key_config")
+    if not isinstance(vertex, dict):
+        return
+    scope = {
+        field: vertex[field]
+        for field in ("project_id", "region")
+        if vertex.get(field) and not _is_masked(vertex[field])
+    }
+    if scope:
+        set_secret(_scope_ref(key_id), json.dumps(scope))

--- a/services/api/routers/bifrost_config.py
+++ b/services/api/routers/bifrost_config.py
@@ -90,6 +90,16 @@ def _scope_ref(key_id: str) -> str:
     return f"llm_key_{key_id}_vertex_scope"
 
 
+def _ollama_ref(key_id: str) -> str:
+    """Where an Ollama key's endpoint URL is kept.
+
+    Same reason as ``_scope_ref``: not a secret, but Bifrost masks it on read
+    and offers no way to get it back, so an edit that only changes the weight
+    would otherwise hand the gateway a mask in place of the endpoint.
+    """
+    return f"llm_key_{key_id}_ollama_url"
+
+
 def _stored_scope(key_id: Optional[str]) -> Dict[str, str]:
     if not key_id:
         return {}
@@ -154,6 +164,67 @@ def _resolve_vertex_scope(vertex: Dict[str, Any], key_id: Optional[str]) -> None
         )
 
 
+def _resolve_ollama_url(ollama: Dict[str, Any], key_id: Optional[str]) -> None:
+    """Fill in the endpoint an Ollama write left out, in place.
+
+    ``env.OLLAMA_URL`` and friends pass straight through — a reference is not a
+    mask, and the seeded key is only editable at all because Bifrost returns
+    ``env_var`` unmasked. Anything else masked or absent falls back to our own
+    copy, and a key first configured outside Vigil has none, so that case asks
+    rather than pointing the gateway at nothing.
+    """
+    supplied = ollama.get("url")
+    if supplied and not _is_masked(supplied):
+        return
+    stored = get_secret(_ollama_ref(key_id)) if key_id else None
+    if not stored:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This Ollama key needs its server URL. Bifrost masks it on read "
+                "and will not reveal it, so a key first configured outside Vigil "
+                "has to have it retyped once."
+            ),
+        )
+    ollama["url"] = stored
+
+
+def _resolve_optional_token(body: Dict[str, Any], key_id: Optional[str]) -> None:
+    """Carry a bearer token through a write that didn't retype it, in place.
+
+    Ollama's own server takes no credential, but the gateway does send
+    ``value`` as ``Authorization: Bearer`` when one is set — which is what
+    reaches an Ollama put behind an authenticating proxy. So the token is
+    optional here, unlike every provider handled by ``_resolve_key_value``:
+    absent with nothing stored means "no auth", not "you forgot the key".
+
+    The console states the mode, so the two empty cases are not the same and
+    are told apart by whether the field is there at all. An *omitted* value is
+    "keep what is stored", so a weight edit does not silently strip the token
+    off a key that needs one. An *empty* value is the operator choosing No
+    auth, and has to survive — substituting the stored token there would make
+    the switch back impossible.
+    """
+    if "value" not in body:
+        stored = get_secret(_secret_ref(key_id)) if key_id else None
+        if stored:
+            body["value"] = stored
+        return
+    supplied = body["value"]
+    if not supplied:
+        return
+    if not _is_masked(supplied):
+        return
+    # A mask is the console echoing what it was shown, which it does not do for
+    # this field — but a third-party client might, and storing the mask as a
+    # token would send the gateway off with a credential of asterisks.
+    stored = get_secret(_secret_ref(key_id)) if key_id else None
+    if stored:
+        body["value"] = stored
+    else:
+        body.pop("value", None)
+
+
 def _resolve_key_value(body: Dict[str, Any], key_id: Optional[str]) -> None:
     """Put a usable credential on ``body``, in place.
 
@@ -174,7 +245,10 @@ def _resolve_key_value(body: Dict[str, Any], key_id: Optional[str]) -> None:
     * **Ollama** carries a URL the operator typed under ``ollama_key_config``,
       not a secret we mask or store — so such a write needs no substitution.
     """
-    if isinstance(body.get("ollama_key_config"), dict):
+    ollama = body.get("ollama_key_config")
+    if isinstance(ollama, dict):
+        _resolve_ollama_url(ollama, key_id)
+        _resolve_optional_token(body, key_id)
         return
 
     vertex = body.get("vertex_key_config")
@@ -324,6 +398,25 @@ def _persist_key_secret(
             if key_id:
                 delete_secret(_secret_ref(key_id))
                 delete_secret(_scope_ref(key_id))
+                delete_secret(_ollama_ref(key_id))
+            return
+        # An ollama key carries no credential at all — its endpoint takes the
+        # place of one, and is kept for the same reason the vertex scope is.
+        ollama = (body or {}).get("ollama_key_config")
+        if isinstance(ollama, dict):
+            ref_id = _written_key_id(key_id, upstream)
+            url = ollama.get("url")
+            if ref_id and url and not _is_masked(url):
+                set_secret(_ollama_ref(ref_id), url)
+            # The bearer token, when the deployment has one, is a real secret
+            # and is kept like any other. Its absence is normal here, and an
+            # explicit empty one is No auth — drop the copy so a later edit
+            # does not resurrect a token the operator turned off.
+            token = (body or {}).get("value")
+            if ref_id and token and not _is_masked(token):
+                set_secret(_secret_ref(ref_id), token)
+            elif ref_id and "value" in (body or {}) and not token:
+                delete_secret(_secret_ref(ref_id))
             return
         # A vertex service-account key sends no `value` at all (see
         # _resolve_key_value), so its credential is read off the vertex block.
@@ -334,15 +427,7 @@ def _persist_key_secret(
             value = (body or {}).get("value")
         if not value or _is_masked(value):
             return
-        ref_id = key_id
-        if not ref_id:
-            # The keys subresource returns the UUID as ``id``; ``/api/keys``
-            # spells the same value ``key_id``. Accept either.
-            try:
-                created = upstream.json()
-                ref_id = created.get("id") or created.get("key_id")
-            except Exception:
-                ref_id = None
+        ref_id = _written_key_id(key_id, upstream)
         if not ref_id:
             logger.warning(
                 "Bifrost proxy: key write returned no key_id; secret not mirrored"
@@ -352,6 +437,19 @@ def _persist_key_secret(
         _persist_vertex_scope(ref_id, body)
     except Exception as exc:  # noqa: BLE001 - never fail an accepted write
         logger.warning("Bifrost proxy: could not mirror key secret: %s", exc)
+
+
+def _written_key_id(key_id: Optional[str], upstream: httpx.Response) -> Optional[str]:
+    """The id to file a key's stored fields under, on a create or an update."""
+    if key_id:
+        return key_id
+    # The keys subresource returns the UUID as ``id``; ``/api/keys`` spells the
+    # same value ``key_id``. Accept either.
+    try:
+        created = upstream.json()
+        return created.get("id") or created.get("key_id")
+    except Exception:
+        return None
 
 
 def _persist_vertex_scope(key_id: str, body: Optional[Dict[str, Any]]) -> None:

--- a/services/api/routers/bifrost_config.py
+++ b/services/api/routers/bifrost_config.py
@@ -29,10 +29,11 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Annotated, Any, Dict, Optional
+from typing import Annotated, Any, Dict, Literal, Optional
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from pydantic import BaseModel
 
 from core.auth.auth_service import AuthService
 from core.config import get_settings
@@ -317,7 +318,25 @@ def _resolve_key_value(
 # computed in core.llm.bifrost.mirror so the console, the setup gate and
 # scripts/reset-setup.sh all read one implementation instead of restating it in
 # three languages.
-@router.get("/routability")
+class KeyVerdict(BaseModel):
+    """Whether one Bifrost key can route, and how the console should badge it."""
+
+    provider: str
+    routable: bool
+    health: Literal["healthy", "unverified", "unverifiable", "rejected"]
+    description: Optional[str] = None
+
+
+class Routability(BaseModel):
+    """Declared rather than a bare dict so the generated client carries the
+    shape: hand-maintaining it in TypeScript is the drift this route's own
+    verdict exists to end."""
+
+    providers: Dict[str, bool]
+    keys: Dict[str, KeyVerdict]
+
+
+@router.get("/routability", response_model=Routability)
 async def routability(
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> Dict[str, Any]:
@@ -329,7 +348,9 @@ async def routability(
     _require_settings_admin(current_user)
     try:
         return await mirror.routability()
-    except httpx.HTTPError as exc:
+    except (httpx.HTTPError, ValueError) as exc:
+        # ValueError: a gateway that answers 200 with something other than JSON
+        # is still an upstream failure, not a bug in this handler.
         logger.warning("Routability check failed: %s", exc)
         raise HTTPException(status_code=502, detail=f"Bifrost unreachable: {exc}")
 

--- a/services/api/routers/bifrost_config.py
+++ b/services/api/routers/bifrost_config.py
@@ -69,6 +69,7 @@ _ALLOWED_PATHS = re.compile(
 )
 
 _METHODS = ("GET", "POST", "PUT", "DELETE")
+_WRITE_METHODS = frozenset({"POST", "PUT", "DELETE"})
 
 # ``providers/{name}/keys`` and ``providers/{name}/keys/{key_id}`` — the only
 # paths carrying a credential, and so the only ones needing secret handling.
@@ -225,7 +226,9 @@ def _resolve_optional_token(body: Dict[str, Any], key_id: Optional[str]) -> None
         body.pop("value", None)
 
 
-def _resolve_key_value(body: Dict[str, Any], key_id: Optional[str]) -> None:
+def _resolve_key_value(
+    body: Dict[str, Any], key_id: Optional[str], provider: Optional[str] = None
+) -> None:
     """Put a usable credential on ``body``, in place.
 
     A write that echoes the mask, or omits ``value`` entirely, is the console
@@ -242,11 +245,28 @@ def _resolve_key_value(body: Dict[str, Any], key_id: Optional[str]) -> None:
       Either credential is mirrored to ``value`` so a single ``llm_key_<id>``
       ref backs the key, and an edit that leaves the credential blank
       substitutes the stored copy back in.
-    * **Ollama** carries a URL the operator typed under ``ollama_key_config``,
-      not a secret we mask or store — so such a write needs no substitution.
+    * **Ollama** carries its endpoint under ``ollama_key_config`` and a bearer
+      token, when the endpoint wants one, under ``value``. Both read back
+      masked, so both are substituted from our own copies.
+
+    ``provider`` comes from the request path, which is where the provider is
+    actually stated. Ollama used to be recognised by the presence of its block
+    instead, and the console omits that block on an edit that does not retype
+    the URL — so a weight change on a key holding a literal endpoint fell
+    through to the API-key path below and was refused for want of a credential
+    Ollama does not have. Vertex still keys on its block, because there the
+    block *is* the statement: a service account sends one and an express-mode
+    API key does not.
     """
     ollama = body.get("ollama_key_config")
-    if isinstance(ollama, dict):
+    # The path names the provider; the block is only consulted when it doesn't
+    # (a direct call from a test).
+    if provider == "ollama" or (provider is None and isinstance(ollama, dict)):
+        # Always a block, even when the write carried none: Bifrost takes an
+        # absent one literally and blanks the endpoint.
+        if not isinstance(ollama, dict):
+            ollama = {}
+            body["ollama_key_config"] = ollama
         _resolve_ollama_url(ollama, key_id)
         _resolve_optional_token(body, key_id)
         return
@@ -354,7 +374,7 @@ async def proxy(
     keys_match = _KEYS_PATH.match(path)
     key_id = keys_match.group("key_id") if keys_match else None
     if keys_match and isinstance(body, dict):
-        _resolve_key_value(body, key_id)
+        _resolve_key_value(body, key_id, keys_match.group("provider"))
 
     url = f"{get_settings().bifrost_url.rstrip('/')}/api/{path}"
     try:
@@ -369,9 +389,14 @@ async def proxy(
         logger.warning("Bifrost proxy %s %s failed: %s", request.method, url, exc)
         raise HTTPException(status_code=502, detail=f"Bifrost unreachable: {exc}")
 
-    if keys_match and upstream.status_code < 400:
-        _persist_key_secret(request.method, key_id, body, upstream)
-        await mirror.sync_provider(keys_match.group("provider"))
+    # Writes only. Both of these have side effects — a secrets-store write and a
+    # provider-row upsert — and hanging them off every request meant a key LIST
+    # did them too: the settings screen lists keys for every provider on mount,
+    # so opening it fired two extra gateway calls and a row write per provider.
+    if keys_match and request.method in _WRITE_METHODS and upstream.status_code < 400:
+        provider = keys_match.group("provider")
+        _persist_key_secret(request.method, key_id, body, upstream, provider)
+        await mirror.sync_provider(provider)
 
     return Response(
         content=upstream.content,
@@ -385,6 +410,7 @@ def _persist_key_secret(
     key_id: Optional[str],
     body: Optional[Dict[str, Any]],
     upstream: httpx.Response,
+    provider: Optional[str] = None,
 ) -> None:
     """Mirror an accepted key write into the secrets store.
 
@@ -403,7 +429,7 @@ def _persist_key_secret(
         # An ollama key carries no credential at all — its endpoint takes the
         # place of one, and is kept for the same reason the vertex scope is.
         ollama = (body or {}).get("ollama_key_config")
-        if isinstance(ollama, dict):
+        if provider == "ollama" and isinstance(ollama, dict):
             ref_id = _written_key_id(key_id, upstream)
             url = ollama.get("url")
             if ref_id and url and not _is_masked(url):

--- a/services/api/routers/bifrost_config.py
+++ b/services/api/routers/bifrost_config.py
@@ -249,21 +249,16 @@ def _resolve_key_value(
       token, when the endpoint wants one, under ``value``. Both read back
       masked, so both are substituted from our own copies.
 
-    ``provider`` comes from the request path, which is where the provider is
-    actually stated. Ollama used to be recognised by the presence of its block
-    instead, and the console omits that block on an edit that does not retype
-    the URL — so a weight change on a key holding a literal endpoint fell
-    through to the API-key path below and was refused for want of a credential
+    ``provider`` comes from the request path. Keying Ollama on its block
+    instead sent an edit that did not retype the URL -- which omits the block
+    -- down the API-key path, where it was refused for want of a credential
     Ollama does not have. Vertex still keys on its block, because there the
     block *is* the statement: a service account sends one and an express-mode
     API key does not.
     """
     ollama = body.get("ollama_key_config")
-    # The path names the provider; the block is only consulted when it doesn't
-    # (a direct call from a test).
     if provider == "ollama" or (provider is None and isinstance(ollama, dict)):
-        # Always a block, even when the write carried none: Bifrost takes an
-        # absent one literally and blanks the endpoint.
+        # Bifrost takes an absent block literally and blanks the endpoint.
         if not isinstance(ollama, dict):
             ollama = {}
             body["ollama_key_config"] = ollama
@@ -389,10 +384,6 @@ async def proxy(
         logger.warning("Bifrost proxy %s %s failed: %s", request.method, url, exc)
         raise HTTPException(status_code=502, detail=f"Bifrost unreachable: {exc}")
 
-    # Writes only. Both of these have side effects — a secrets-store write and a
-    # provider-row upsert — and hanging them off every request meant a key LIST
-    # did them too: the settings screen lists keys for every provider on mount,
-    # so opening it fired two extra gateway calls and a row write per provider.
     if keys_match and request.method in _WRITE_METHODS and upstream.status_code < 400:
         provider = keys_match.group("provider")
         _persist_key_secret(request.method, key_id, body, upstream, provider)

--- a/services/api/routers/bifrost_config.py
+++ b/services/api/routers/bifrost_config.py
@@ -203,9 +203,9 @@ def _resolve_optional_token(body: Dict[str, Any], key_id: Optional[str]) -> None
     The console states the mode, so the two empty cases are not the same and
     are told apart by whether the field is there at all. An *omitted* value is
     "keep what is stored", so a weight edit does not silently strip the token
-    off a key that needs one. An *empty* value is the operator choosing No
-    auth, and has to survive — substituting the stored token there would make
-    the switch back impossible.
+    off a key that needs one. An *empty* value is the operator choosing the
+    unauthenticated mode, and has to survive — substituting the stored token
+    there would make the switch back impossible.
     """
     if "value" not in body:
         stored = get_secret(_secret_ref(key_id)) if key_id else None
@@ -448,8 +448,8 @@ def _persist_key_secret(
                 set_secret(_ollama_ref(ref_id), url)
             # The bearer token, when the deployment has one, is a real secret
             # and is kept like any other. Its absence is normal here, and an
-            # explicit empty one is No auth — drop the copy so a later edit
-            # does not resurrect a token the operator turned off.
+            # explicit empty one is unauthenticated — drop the copy so a
+            # later edit does not resurrect a token the operator turned off.
             token = (body or {}).get("value")
             if ref_id and token and not _is_masked(token):
                 set_secret(_secret_ref(ref_id), token)

--- a/services/api/routers/bifrost_config.py
+++ b/services/api/routers/bifrost_config.py
@@ -323,7 +323,7 @@ class KeyVerdict(BaseModel):
 
     provider: str
     routable: bool
-    health: Literal["healthy", "unverified", "unverifiable", "rejected"]
+    health: Literal["healthy", "unverified", "unverifiable", "rejected", "disabled"]
     description: Optional[str] = None
 
 

--- a/services/api/routers/claude.py
+++ b/services/api/routers/claude.py
@@ -247,6 +247,12 @@ def _select_active_provider(provider_id: Optional[str]):
     return provider
 
 
+# Provider types that can answer a ``claude-*`` id. Anthropic direct, plus the
+# two clouds that resell the models -- Vertex and Bedrock. Used only when the
+# catalogue is unknown; a known catalogue answers the question outright.
+_SERVES_CLAUDE = frozenset({"anthropic", "vertex", "bedrock"})
+
+
 def _router_model(provider, requested_model: Optional[str]) -> str:
     """Model id to send, pinned to the provider's default if it can't serve it.
 
@@ -262,19 +268,31 @@ def _router_model(provider, requested_model: Optional[str]) -> str:
     substitute's failure was what surfaced — an error about Gemini for a
     request the operator had pointed at Claude.
 
-    An empty or unavailable catalogue keeps the requested model rather than
-    overriding it: not knowing what a provider serves is not evidence that it
-    serves nothing, and Bifrost's own error beats a silent substitution.
+    The catalogue is only known once something has populated the cache, so an
+    unknown one falls back to the single thing that can be said without it: a
+    ``claude-*`` id cannot be served by a provider that does not carry Claude
+    at all. Which providers those are is an allowlist rather than a test for
+    Anthropic, since Google and AWS resell Claude too.
     """
     model = requested_model or provider.default_model
     if model == provider.default_model:
         return model
 
     catalogue = _provider_catalogue(provider)
-    if catalogue and model not in catalogue:
+    if catalogue is not None:
+        if model in catalogue:
+            return model
         logger.info(
             "Model %s is not in %s's catalogue — falling back to %s",
             model,
+            provider.provider_id,
+            provider.default_model,
+        )
+        return provider.default_model
+
+    if model.startswith("claude-") and provider.provider_type not in _SERVES_CLAUDE:
+        logger.info(
+            "Provider %s does not serve Claude — falling back to %s",
             provider.provider_id,
             provider.default_model,
         )

--- a/services/api/routers/claude.py
+++ b/services/api/routers/claude.py
@@ -248,16 +248,54 @@ def _select_active_provider(provider_id: Optional[str]):
 
 
 def _router_model(provider, requested_model: Optional[str]) -> str:
-    """Model id to send to a non-Anthropic provider.
+    """Model id to send, pinned to the provider's default if it can't serve it.
 
-    A stale Claude selection (e.g. ``chat_default`` seeded to a ``claude-*`` id)
-    would 404 at Bifrost when the active provider is Ollama/OpenAI — pin it to
-    the provider's own default model instead.
+    A stale selection — ``chat_default`` left pointing at a model the active
+    provider never had — would 404 at Bifrost, so it falls back to the
+    provider's own default.
+
+    The test is whether the provider's catalogue holds the model, not what type
+    the provider is. The earlier version asked "is this Anthropic?" and pinned
+    every ``claude-*`` id elsewhere, which was right for Ollama and OpenAI and
+    wrong for Vertex: Google resells Claude, so a Claude id there is a real
+    selection. It was discarded before it ever reached the gateway, and the
+    substitute's failure was what surfaced — an error about Gemini for a
+    request the operator had pointed at Claude.
+
+    An empty or unavailable catalogue keeps the requested model rather than
+    overriding it: not knowing what a provider serves is not evidence that it
+    serves nothing, and Bifrost's own error beats a silent substitution.
     """
     model = requested_model or provider.default_model
-    if model.startswith("claude-") and provider.provider_type != "anthropic":
+    if model == provider.default_model:
+        return model
+
+    catalogue = _provider_catalogue(provider)
+    if catalogue and model not in catalogue:
+        logger.info(
+            "Model %s is not in %s's catalogue — falling back to %s",
+            model,
+            provider.provider_id,
+            provider.default_model,
+        )
         return provider.default_model
     return model
+
+
+def _provider_catalogue(provider) -> Optional[set]:
+    """Model ids this provider can route, or None when that isn't known.
+
+    Reads the same cache that fills the console's model picker, so a model the
+    operator could select is a model this accepts.
+    """
+    try:
+        from core.llm.providers.registry import _MODEL_LIST_CACHE
+
+        cached = _MODEL_LIST_CACHE.get(provider.provider_id)
+        return set(cached) if cached else None
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("catalogue lookup failed for %s: %s", provider.provider_id, exc)
+        return None
 
 
 class ContentBlock(BaseModel):
@@ -366,7 +404,12 @@ async def chat_stream(
         "run_id": run_id_for(session_id),
         "turns": _turns_of(request.messages),
         "system_prompt": system_prompt or "",
-        "config": chat_config(request.model, tools, mcp_tools),
+        # The provider rides alongside the model so the gateway routes to the
+        # account this request resolved to, rather than to whichever provider
+        # claims the bare model name first.
+        "config": chat_config(
+            request.model, tools, mcp_tools, provider=active_provider.provider_type
+        ),
     }
     if request.parent_run_id:
         payload["parent_run_id"] = request.parent_run_id

--- a/services/api/routers/claude.py
+++ b/services/api/routers/claude.py
@@ -19,6 +19,7 @@ from core.llm.defaults import DEFAULT_MODEL
 from core.llm.harness.claude import ClaudeService
 from core.llm.providers.registry import get_registry
 from core.llm.system_prompt import validate_system_prompt
+from core.llm.target import model_for, provider_for
 from core.rate_limit import rate_limit_dependency
 from core.routing import Auth, RouterMeta
 from core.secrets import get_secret
@@ -215,107 +216,6 @@ ROUTER_AGENT_TOOLS_SYSTEM_PROMPT = (
 )
 
 
-def _select_active_provider(provider_id: Optional[str]):
-    """Pick the provider a chat request should route through.
-
-    Precedence:
-      1. An explicit ``provider_id`` — the model picker can send the model as
-         ``provider_id::model_id`` (#348); look the provider up by id.
-      2. The configured default provider (``get_default_provider_spec``) — so a
-         *bare* model id (the shape the Chat dock sends) still routes to a
-         non-Anthropic default instead of falling through to the Anthropic SDK
-         and 503-ing on Ollama-only deployments.
-
-    Returns a ``ProviderSpec`` or ``None``. Lookups are wrapped so a transient
-    DB error degrades to the ClaudeService/Anthropic path rather than 500-ing.
-    """
-    from core.llm.router.router import get_default_provider_spec, get_provider_spec
-
-    provider = None
-    if provider_id:
-        try:
-            provider = get_provider_spec(provider_id)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("provider lookup failed for %s: %s", provider_id, exc)
-            provider = None
-    if provider is None:
-        try:
-            provider = get_default_provider_spec()
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("default provider lookup failed: %s", exc)
-            provider = None
-    return provider
-
-
-# Provider types that can answer a ``claude-*`` id. Anthropic direct, plus the
-# two clouds that resell the models -- Vertex and Bedrock. Used only when the
-# catalogue is unknown; a known catalogue answers the question outright.
-_SERVES_CLAUDE = frozenset({"anthropic", "vertex", "bedrock"})
-
-
-def _router_model(provider, requested_model: Optional[str]) -> str:
-    """Model id to send, pinned to the provider's default if it can't serve it.
-
-    A stale selection — ``chat_default`` left pointing at a model the active
-    provider never had — would 404 at Bifrost, so it falls back to the
-    provider's own default.
-
-    The test is whether the provider's catalogue holds the model, not what type
-    the provider is. The earlier version asked "is this Anthropic?" and pinned
-    every ``claude-*`` id elsewhere, which was right for Ollama and OpenAI and
-    wrong for Vertex: Google resells Claude, so a Claude id there is a real
-    selection. It was discarded before it ever reached the gateway, and the
-    substitute's failure was what surfaced — an error about Gemini for a
-    request the operator had pointed at Claude.
-
-    The catalogue is only known once something has populated the cache, so an
-    unknown one falls back to the single thing that can be said without it: a
-    ``claude-*`` id cannot be served by a provider that does not carry Claude
-    at all. Which providers those are is an allowlist rather than a test for
-    Anthropic, since Google and AWS resell Claude too.
-    """
-    model = requested_model or provider.default_model
-    if model == provider.default_model:
-        return model
-
-    catalogue = _provider_catalogue(provider)
-    if catalogue is not None:
-        if model in catalogue:
-            return model
-        logger.info(
-            "Model %s is not in %s's catalogue — falling back to %s",
-            model,
-            provider.provider_id,
-            provider.default_model,
-        )
-        return provider.default_model
-
-    if model.startswith("claude-") and provider.provider_type not in _SERVES_CLAUDE:
-        logger.info(
-            "Provider %s does not serve Claude — falling back to %s",
-            provider.provider_id,
-            provider.default_model,
-        )
-        return provider.default_model
-    return model
-
-
-def _provider_catalogue(provider) -> Optional[set]:
-    """Model ids this provider can route, or None when that isn't known.
-
-    Reads the same cache that fills the console's model picker, so a model the
-    operator could select is a model this accepts.
-    """
-    try:
-        from core.llm.providers.registry import _MODEL_LIST_CACHE
-
-        cached = _MODEL_LIST_CACHE.get(provider.provider_id)
-        return set(cached) if cached else None
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("catalogue lookup failed for %s: %s", provider.provider_id, exc)
-        return None
-
-
 class ContentBlock(BaseModel):
     """Content block for message (text or image)."""
 
@@ -407,10 +307,10 @@ async def chat_stream(
             system_prompt = agent.system_prompt
             tools = list(agent.recommended_tools) if agent.recommended_tools else None
 
-    active_provider = _select_active_provider(provider_id)
+    active_provider = provider_for(provider_id)
     if active_provider is None:
         _raise_no_provider()
-    request.model = _router_model(active_provider, request.model)
+    request.model = model_for(active_provider, request.model)
 
     # Surface whatever MCP integrations are connected right now (VirusTotal, OTX,
     # MISP, Shodan, …) so the assistant can call them the moment their server is

--- a/tests/unit/api/test_bifrost_config_proxy.py
+++ b/tests/unit/api/test_bifrost_config_proxy.py
@@ -94,27 +94,30 @@ def test_editing_a_key_we_hold_no_secret_for_is_a_400(monkeypatch):
 
 
 @pytest.mark.unit
-def test_vertex_service_account_is_mirrored_to_value(monkeypatch):
-    # A fresh service-account JSON is used verbatim and copied onto value so a
-    # single secret ref backs both.
+def test_vertex_service_account_is_not_mirrored_to_value(monkeypatch):
+    # The JSON is used verbatim and stays in auth_credentials alone. Bifrost
+    # picks a vertex key's auth mode by whether `value` is populated, so
+    # copying it there made the gateway authenticate as an API key and fail
+    # with "API keys are not supported by this API" -- a 401 that names
+    # nothing of the real cause.
     monkeypatch.setattr(proxy, "get_secret", lambda ref: None)
     sa = '{"type": "service_account", "project_id": "p"}'
     body = {"vertex_key_config": {"project_id": "p", "region": "us", "auth_credentials": sa}}
     proxy._resolve_key_value(body, None)
-    assert body["value"] == sa
+    assert "value" not in body
     assert body["vertex_key_config"]["auth_credentials"] == sa
 
 
 @pytest.mark.unit
 def test_vertex_edit_without_credential_substitutes_the_stored_one(monkeypatch):
     # Editing project/region without re-pasting the JSON pulls the stored copy
-    # into both auth_credentials and value.
+    # into auth_credentials -- and only there, for the reason above.
     monkeypatch.setattr(
         proxy, "get_secret", lambda ref: "stored-sa" if ref == "llm_key_v1" else None
     )
     body = {"vertex_key_config": {"project_id": "p", "region": "eu"}}
     proxy._resolve_key_value(body, "v1")
-    assert body["value"] == "stored-sa"
+    assert "value" not in body
     assert body["vertex_key_config"]["auth_credentials"] == "stored-sa"
 
 

--- a/tests/unit/llm/test_claude_chat_routing.py
+++ b/tests/unit/llm/test_claude_chat_routing.py
@@ -31,6 +31,7 @@ for _p in (str(REPO),):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
+from core.llm import target  # noqa: E402
 from core.llm.router.router import ProviderSpec  # noqa: E402
 
 pytestmark = pytest.mark.unit
@@ -134,7 +135,7 @@ def test_unspecified_model_uses_registry_tuple(monkeypatch):
     )
 
 
-# --- _select_active_provider ------------------------------------------------
+# --- target.provider_for ------------------------------------------------
 
 
 def test_explicit_provider_id_wins(monkeypatch):
@@ -148,7 +149,7 @@ def test_explicit_provider_id_wins(monkeypatch):
         r, "get_provider_spec", lambda pid: oll if pid == "ollama-local" else None
     )
     monkeypatch.setattr(r, "get_default_provider_spec", lambda: anthropic_default)
-    assert claude._select_active_provider("ollama-local") is oll
+    assert target.provider_for("ollama-local") is oll
 
 
 def test_no_provider_id_falls_back_to_default(monkeypatch):
@@ -158,7 +159,7 @@ def test_no_provider_id_falls_back_to_default(monkeypatch):
     default = _spec()
     monkeypatch.setattr(r, "get_provider_spec", lambda pid: None)
     monkeypatch.setattr(r, "get_default_provider_spec", lambda: default)
-    assert claude._select_active_provider(None) is default
+    assert target.provider_for(None) is default
 
 
 def test_unknown_provider_id_falls_back_to_default(monkeypatch):
@@ -167,7 +168,7 @@ def test_unknown_provider_id_falls_back_to_default(monkeypatch):
     default = _spec()
     monkeypatch.setattr(r, "get_provider_spec", lambda pid: None)
     monkeypatch.setattr(r, "get_default_provider_spec", lambda: default)
-    assert claude._select_active_provider("ghost") is default
+    assert target.provider_for("ghost") is default
 
 
 def test_provider_lookup_error_degrades_to_default(monkeypatch):
@@ -181,7 +182,7 @@ def test_provider_lookup_error_degrades_to_default(monkeypatch):
     monkeypatch.setattr(r, "get_provider_spec", _boom)
     monkeypatch.setattr(r, "get_default_provider_spec", lambda: default)
     # A transient lookup error must not 500 — it degrades to the default.
-    assert claude._select_active_provider("ollama-local") is default
+    assert target.provider_for("ollama-local") is default
 
 
 def test_no_provider_anywhere_returns_none(monkeypatch):
@@ -189,30 +190,30 @@ def test_no_provider_anywhere_returns_none(monkeypatch):
 
     monkeypatch.setattr(r, "get_provider_spec", lambda pid: None)
     monkeypatch.setattr(r, "get_default_provider_spec", lambda: None)
-    assert claude._select_active_provider(None) is None
+    assert target.provider_for(None) is None
 
 
-# --- _router_model ----------------------------------------------------------
+# --- target.model_for ----------------------------------------------------------
 
 
 def test_stale_claude_model_pinned_to_ollama_default():
     # Any claude-* selection on a non-Anthropic provider would 404 at Bifrost —
     # pin it to the provider's own default model.
-    assert claude._router_model(_spec(), A_CLAUDE_MODEL) == AN_OLLAMA_MODEL
+    assert target.model_for(_spec(), A_CLAUDE_MODEL) == AN_OLLAMA_MODEL
 
 
 def test_non_claude_model_passes_through():
-    assert claude._router_model(_spec(), "qwen3-coder:latest") == "qwen3-coder:latest"
+    assert target.model_for(_spec(), "qwen3-coder:latest") == "qwen3-coder:latest"
 
 
 def test_claude_model_kept_for_anthropic_provider():
     anth = _spec(provider_type="anthropic", provider_id="a")
     # On an Anthropic provider a claude-* model is valid and must pass through.
-    assert claude._router_model(anth, A_CLAUDE_MODEL) == A_CLAUDE_MODEL
+    assert target.model_for(anth, A_CLAUDE_MODEL) == A_CLAUDE_MODEL
 
 
 def test_none_requested_uses_provider_default():
-    assert claude._router_model(_spec(), None) == AN_OLLAMA_MODEL
+    assert target.model_for(_spec(), None) == AN_OLLAMA_MODEL
 
 
 # --- guardrail prompt -------------------------------------------------------
@@ -249,7 +250,7 @@ def test_use_router_decision(monkeypatch, provider_id, default_type, expect_rout
     monkeypatch.setattr(r, "get_provider_spec", lambda pid: explicit)
     monkeypatch.setattr(r, "get_default_provider_spec", lambda: default)
 
-    active = claude._select_active_provider(provider_id)
+    active = target.provider_for(provider_id)
     # Mirrors the inline gate in chat()/chat_stream().
     use_router = (
         active is not None and getattr(active, "provider_type", None) != "anthropic"


### PR DESCRIPTION
Setting up an LLM provider from the console left most of Vigil unable to use it. Two-store readiness (#761) taught the setup gate to accept a key held by the Bifrost gateway, but only the gate — so adding a key ticked the first setup step and left every surface past it reading a table nothing had written. This fixes that and the routing, console and script bugs found alongside it.

Closes #841.

## What was wrong

**A key added to the gateway was invisible to the rest of Vigil.** The gateway holds credentials and does the routing, but the model picker, model assignment and dispatch all index providers by an `llm_provider_configs` row. Adding a key produced a green checkmark and an empty model picker, with no assignment savable and no spec to dispatch through.

**Chat ignored which provider you selected**, in two independent ways. `_router_model` pinned every `claude-*` id to the provider's default whenever the provider was not Anthropic — right for Ollama and OpenAI, wrong for Vertex, where Google resells Claude. The selection was discarded before it reached the gateway and what surfaced was the substitute's failure, an error about Gemini for a request pointed at Claude. Separately the model was sent as a bare name, and the gateway routes a bare name to whichever provider claims it first — so on a deployment holding both `vertex` and `gemini`, a request resolved to one was answered by the other.

**The console misreported key health.** Bifrost reports "I refused this credential" and "I could not check this credential" with the same `list_models_failed` status; only the provider and description tell them apart. A working Vertex key was badged Rejected with a banner telling the operator to check a credential that was fine.

**Ollama could not be configured at all.** Its credential is an endpoint, not a secret, and the key dialog only branched for Vertex — so Ollama got the generic API-key box and there was nowhere to put a URL.

## What changed

`core/llm/bifrost/mirror.py` writes an index row per provider type: no `api_key_ref`, no `base_url`, since the gateway holds the secret and owns the routing. Rows are written from the config proxy on an accepted key write and from `reconcile_all` on every catalogue sync, which backfills providers configured before this existed. Retirement deactivates rather than deletes — `ai_model_configs.provider_id` is `ON DELETE RESTRICT`.

That module is also the single home of "can this key route?". The rule had been restated in TypeScript in the console and in bash-embedded Python in `reset-setup.sh`, and all three drifted the moment Vertex's second failure mode appeared. `GET /api/bifrost/routability` now serves one verdict to every consumer, which also collapses the setup gate's `1 + N` proxy round trips to one.

Chat now tests whether the provider's catalogue holds the requested model rather than what type the provider is, and sends the provider alongside the model so the gateway routes to the account the request resolved to. The agent keeps both forms of the id — namespaced on the wire, bare for pricing, since the price catalogue is keyed by the bare id and an unpriced call eventually stops the run.

Ollama gets the same two-button auth switch Vertex has: **No auth** for the single-machine case, **API key** for a server behind an authenticating proxy. The second mode is not hypothetical — the gateway does send a key's `value` as `Authorization: Bearer` when one is set, confirmed by pointing a throwaway key at a request-logging endpoint.

## Vertex, specifically

Four bugs, each of which alone stopped a chat:

- Its catalogue came back empty because there is no upstream to list. It now falls back to the gateway's own datasheet, filtered to entries that can take a chat turn — 0 models became 136.
- The proxy mirrored the service-account JSON into the key's `value`. The gateway picks a Vertex key's auth mode by whether `value` is populated, so that made it authenticate as an API key and fail with `API keys are not supported by this API` — a 401 that says nothing about the real cause.
- Project ID and region were wiped by any edit that did not retype them, and rendered as `[object Object]` because the gateway returns them wrapped and masked.
- Claude ids were discarded, as above.

## Notes for review

- `.gitignore`'s `bifrost/` rule was unanchored, so it also matched `core/llm/bifrost/` and `infra/docker/bifrost/` — a new source file in either was ignored on sight. Anchoring it is what makes `mirror.py` visible to git at all.
- A mirrored Ollama row took its `default_model` from the gateway's generic Ollama library rather than what the host had pulled, so it pointed at `codegemma` on a machine holding `llama3.2` and chat 404'd on the default. It now asks the server.
- `reset-setup.sh` previously degraded to an empty verdict map when it could not reach the backend, reporting "no providers configured" — indistinguishable from a genuinely empty install. It now raises.
- No tests are included.

## Behaviour changes worth knowing about

- **Hunts and workflow runs now honour a model assignment.** They took `model or DEFAULT_MODEL` and nothing ever passed a model, so every hunt ran on `claude-sonnet-4-6` whatever was configured — a model an Ollama-only deployment does not have. They resolve through the `investigation` assignment now (falling back to `chat_default`, so nothing new has to be configured). That changes which model — and so what per-hunt cost — an existing deployment gets.
- **A retired provider row is no longer dispatchable.** `get_provider_spec` had no `is_active` filter, unlike `get_default_provider_spec` beside it, so an assignment naming a deactivated row kept dispatching to it. Reachable before this branch through `reset-setup.sh`; the mirror makes it ordinary, since every key deletion retires a row. Such an assignment now falls back to the configured default.

## Review pass

A review of the above found eleven issues, all fixed in `17b72369..f4185ab7`. The three worth naming here, because each was this branch re-introducing a bug it claims to fix:

- The gateway datasheet was marked as a live catalogue even when standing in for a provider fetch that failed, which made it authoritative for the routing guard — the silent substitution the guard exists to prevent, from the producer side. It also suppressed the bootstrap union, so the picker lost ids the datasheet does not carry.
- An Ollama row read its catalogue and its `default_model` from different endpoints, so the row came out with a servable default and an empty picker.
- `reset-setup.sh`'s deliberate refusal exited under `set -e` and took the budget, orchestrator and data-source steps with it, so `--all` skipped three steps it had announced.

## Verification

Exercised against a live gateway rather than in isolation: Vertex and Ollama each added, edited and round-tripped through the console, both auth modes for Ollama including switching back, mirror rows landing with a servable `default_model`, and real chat turns answered by the intended provider in each case.

