### PR TITLE
ci(release): sign published images with cosign (keyless)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     permissions:
       contents: read
       packages: write          # push to ghcr.io
-      id-token: write          # keyless cosign signing (future)
+      id-token: write          # keyless cosign signing
 
     steps:
       - name: Checkout (with submodules)
@@ -105,6 +105,7 @@ jobs:
         run: echo "version=$(tr -d '[:space:]' < .python-version)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push backend
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -121,6 +122,17 @@ jobs:
             PYTHON_VERSION=${{ steps.pin.outputs.version }}
           platforms: linux/amd64,linux/arm64
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      # Sign the multi-arch index digest, not the tags: tags are mutable and
+      # this job pushes linux/amd64,linux/arm64 as one manifest list.
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+          IMAGE: ghcr.io/vigil-soc/vigil-backend
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
   # ---------------------------------------------------------------------------
   # Build + push: daemon
   # ---------------------------------------------------------------------------
@@ -131,7 +143,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
+      id-token: write          # keyless cosign signing
 
     steps:
       - name: Checkout (with submodules)
@@ -172,6 +184,7 @@ jobs:
         run: echo "version=$(tr -d '[:space:]' < .python-version)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push daemon
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -186,6 +199,15 @@ jobs:
             PYTHON_VERSION=${{ steps.pin.outputs.version }}
           platforms: linux/amd64,linux/arm64
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+          IMAGE: ghcr.io/vigil-soc/vigil-daemon
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
   # ---------------------------------------------------------------------------
   # Build + push: agent (worker and serve run the same image)
   # ---------------------------------------------------------------------------
@@ -196,7 +218,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
+      id-token: write          # keyless cosign signing
 
     steps:
       # No submodules: the agent layer is TypeScript under services/agent and
@@ -234,6 +256,7 @@ jobs:
             org.opencontainers.image.licenses=Apache-2.0
 
       - name: Build and push agent
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -246,6 +269,15 @@ jobs:
           build-args: |
             VIGIL_VERSION=${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+          IMAGE: ghcr.io/vigil-soc/vigil-agent
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
 
   # ---------------------------------------------------------------------------
   # Smoke-test: pull the images and verify they start

--- a/README.md
+++ b/README.md
@@ -153,6 +153,18 @@ Auth bypass is enabled by default (`DEV_MODE=true`) for quick development. Full 
 > (`docker pull ghcr.io/vigil-soc/vigil-backend:<version>`) or check out a
 > release tag before running (`git checkout v<version>`). Find the newest
 > version on the [releases page](https://github.com/Vigil-SOC/vigil/releases/latest).
+>
+> Released images are signed keyless by
+> [`.github/workflows/release.yml`](.github/workflows/release.yml). Confirm a
+> pull came from that workflow (image tag drops the leading `v`; the certificate
+> identity uses the git tag):
+>
+> ```bash
+> cosign verify \
+>   --certificate-identity https://github.com/Vigil-SOC/vigil/.github/workflows/release.yml@refs/tags/v<version> \
+>   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+>   ghcr.io/vigil-soc/vigil-backend:<version>
+> ```
 
 ### Prerequisites
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,10 +22,24 @@ we do not backport to earlier minors.
 | Older `0.x` minors | ❌ | No backports. While in `0.x`, minor bumps may break agent prompts, workflow schemas, and MCP interfaces — see [contributing](https://vigilsoc.org/docs/contributing/#versioning-and-releases). |
 | `main` (unreleased) | ✅ | Reports welcome; note the commit SHA. |
 
-Container images (`ghcr.io/vigil-soc/vigil-backend`, `vigil-daemon`) and the
-Helm chart at `infra/helm/vigil/` follow the same window. Chart `version` and
-`appVersion` move in lockstep, so the chart version identifies the app release
-it deploys.
+Container images (`ghcr.io/vigil-soc/vigil-backend`, `vigil-daemon`,
+`vigil-agent`) and the Helm chart at `infra/helm/vigil/` follow the same window.
+Chart `version` and `appVersion` move in lockstep, so the chart version
+identifies the app release it deploys.
+
+Release images are signed keyless by `.github/workflows/release.yml` (GitHub
+OIDC → Fulcio, Rekor). Confirm an image came from that workflow — the identity
+is pinned to this file and issuer, not any Actions run in the repo. Image tags
+drop the leading `v`; the certificate identity uses the git tag:
+
+```bash
+cosign verify \
+  --certificate-identity https://github.com/Vigil-SOC/vigil/.github/workflows/release.yml@refs/tags/v<version> \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/vigil-soc/vigil-backend:<version>
+```
+
+The same invocation works for `vigil-daemon` and `vigil-agent`.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #829.

Sign the three images `release.yml` already publishes (`vigil-backend`, `vigil-daemon`, `vigil-agent`) with keyless `cosign sign` after push, and document `cosign verify` next to the in-repo install notes.

There is no frontend image — the SPA is bundled in `vigil-backend`. Signing is by the `docker/build-push-action` digest (the multi-arch index), not a tag loop. Identity on verify is pinned to this release workflow and `https://token.actions.githubusercontent.com`.

## Changes

- After each of the three existing build-push steps, install Cosign (`sigstore/cosign-installer@v4.1.2`) and `cosign sign --yes $IMAGE@$DIGEST`.
- `id-token: write` was already granted; the “(future)” comment is gone.
- `cosign verify` snippet in `README.md` (docker pull note) and `SECURITY.md` (container-images paragraph).

Out of scope, per the factory groom: no frontend image, no SBOM/provenance/attestations, no Helm admission policy, no signing on the disabled `build-images` job in `ci-cd.yml`, no `docs/` tree, no website-repo edits.

## Review findings

Independent review of the full diff (`e22e18b...HEAD`):

- No defects. Digest is the multi-arch index from `steps.push.outputs.digest`; keyless `cosign sign --yes IMAGE@DIGEST` matches existing GHCR login + `id-token: write`; documented `--certificate-identity` is the Fulcio SAN for this tag-triggered workflow file (not a repo-wide regexp); empty digest fails the job; out-of-scope items were not added.

## Verification

- **actionlint 1.7.12** (the project gate in `.github/workflows/ci-cd.yml`): `docker run --rm -v /workspace:/repo --workdir /repo rhysd/actionlint:1.7.12` — exit 0, no findings.
- **Live sign-by-digest + verify** (cosign v2.6.1, local registry): built `localhost:5000/vigil-backend:0.0.0-test`, signed `IMAGE@sha256:bdfb955cc0ee1eeb0509ffc21a29f6a02867191225296b167c5b409c9b116911` with a local key (workflow shape: digest, not a tag loop), then `cosign verify --key` succeeded — claims validated, `docker-manifest-digest` matched.
- **Documented `cosign verify` against that same signed image**: `--certificate-identity` + `--certificate-oidc-issuer` as in README/SECURITY — exit 12, `no certificate found on signature`. Expected: the local roundtrip is key-based; keyless OIDC only exists inside this workflow. Flags are accepted; identity check fails closed.
- **Documented `cosign verify` against `ghcr.io/vigil-soc/vigil-backend:0.5.0`**: command reached GHCR and resolved the image — exit 10, `no signatures found`. Expected until this workflow ships on a release tag.
- **GitHub Actions keyless OIDC sign**: not run — only exists inside `release.yml` on a `vX.Y.Z` tag in `Vigil-SOC/vigil`.
- **Typecheck / flake8 / frontend lint / unit tests**: not run — no application code changed.
- **Browser / UI**: not applicable — CI workflow and markdown only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc4d7982-963e-49c7-8109-5901d47a5f79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc4d7982-963e-49c7-8109-5901d47a5f79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

