### PR TITLE
feat(detections): lint that rejects detections keyed to a specific IP, host, user or subnet

### DIFF
--- a/core/agents/tool_registry.py
+++ b/core/agents/tool_registry.py
@@ -194,6 +194,7 @@ _SECURITY_TOOLS = frozenset(
         "identify_gaps",
         "get_coverage_stats",
         "get_detection_count",
+        "lint_detections",
     }
 )
 

--- a/core/detections/lint.py
+++ b/core/detections/lint.py
@@ -74,6 +74,7 @@ _USER_FIELDS = frozenset(
         "logonuser",
     }
 )
+_ENV_TLDS = frozenset({"corp", "local", "internal", "lan"})
 _TOKEN = re.compile(r"[^\s,;'\"=]+")
 
 _SID = re.compile(r"^S-\d+(-\d+)+$", re.IGNORECASE)
@@ -195,15 +196,19 @@ def _findings_for(field: Optional[str], value: str) -> list[dict[str, str]]:
         findings.append(_finding(kind, literal, field_name))
 
     for token in _TOKEN.findall(value):
-        if ":" not in token:
+        ip_token = _unbracket_ip(token)
+        if ":" not in ip_token:
             continue
-        kind, literal = _classify_ip_token(token)
+        kind, literal = _classify_ip_token(ip_token)
         if kind is None or literal is None:
             continue
         findings.append(_finding(kind, literal, field_name))
 
-    for host in _ENV_HOST.findall(value):
+    hosts = _ENV_HOST.findall(value)
+    for host in hosts:
         findings.append(_finding("hostname", host, field_name))
+    if not hosts and _is_env_host_suffix(value):
+        findings.append(_finding("hostname", value.strip(), field_name))
 
     if _is_user_field(field_name):
         person = _specific_person(value)
@@ -211,6 +216,23 @@ def _findings_for(field: Optional[str], value: str) -> list[dict[str, str]]:
             findings.append(_finding("user", person, field_name))
 
     return findings
+
+
+def _unbracket_ip(token: str) -> str:
+    if token.startswith("[") and token.endswith("]") and token.count("]") == 1:
+        return token[1:-1]
+    return token
+
+
+def _is_env_host_suffix(value: str) -> bool:
+    """``*.local`` / ``.corp.local`` — environment TLD without a host label."""
+    token = value.strip().strip("'\"")
+    if token.startswith("*"):
+        token = token[1:]
+    if not token.startswith("."):
+        return False
+    labels = [part for part in token.lower().split(".") if part]
+    return bool(labels) and labels[-1] in _ENV_TLDS
 
 
 def _classify_ip_token(token: str) -> tuple[Optional[str], Optional[str]]:

--- a/core/detections/lint.py
+++ b/core/detections/lint.py
@@ -1,0 +1,271 @@
+"""Lint Sigma rules for match keys tied to one environment.
+
+A detection keyed to a literal address, hostname, account, or CIDR matches
+one environment and generalises to nothing. Address/IOC matching belongs to
+threat intel; this check stays on the rule's ``detection`` and ``logsource``
+values so title/description/falsepositives cannot false-hit.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+import yaml
+
+_REWRITE = (
+    "Rewrite around behaviour: process lineage, command-line arguments, "
+    "parent-child relationships, or protocol/technique patterns — not a "
+    "specific host, address, account, or subnet."
+)
+
+# IPv4 (optional CIDR). Candidates are confirmed with ipaddress.
+_IPV4 = re.compile(r"(?<![\d.])(?:\d{1,3}\.){3}\d{1,3}(?:/\d{1,2})?(?![\d.])")
+
+# FQDNs whose last label is an environment TLD. Negative lookahead stops
+# ``foo.local.exe`` matching as a ``.local`` host.
+_ENV_HOST = re.compile(
+    r"(?i)(?<![A-Za-z0-9.-])(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+"
+    r"(?:corp|local|internal|lan)(?![A-Za-z0-9.-])"
+)
+
+_IPV4_BROADCAST = ipaddress.IPv4Address("255.255.255.255")
+
+# Built-in / role accounts — not a specific person. Spec names SYSTEM,
+# Administrator, root, krbtgt and wildcards; nearby role names are the same cut.
+_WELL_KNOWN_USERS = frozenset(
+    {
+        "system",
+        "administrator",
+        "administrators",
+        "admin",
+        "root",
+        "krbtgt",
+        "guest",
+        "defaultaccount",
+        "localservice",
+        "networkservice",
+        "anonymouslogon",
+        "anonymous",
+        "everyone",
+        "authenticatedusers",
+        "wdagutilityaccount",
+        "user",
+        "users",
+    }
+)
+
+_USER_FIELDS = frozenset(
+    {
+        "user",
+        "username",
+        "userid",
+        "account",
+        "accountname",
+        "targetuser",
+        "targetusername",
+        "subjectuser",
+        "subjectusername",
+        "srcuser",
+        "destuser",
+        "dstuser",
+        "logonuser",
+    }
+)
+_TOKEN = re.compile(r"[^\s,;'\"=]+")
+
+_SID = re.compile(r"^S-\d+(-\d+)+$", re.IGNORECASE)
+_PERSON_USER = re.compile(r"^[A-Za-z][A-Za-z0-9._-]{1,64}$")
+
+
+def lint_sigma(
+    *,
+    rule_yaml: Optional[str] = None,
+    source_path: Optional[str] = None,
+) -> dict[str, Any]:
+    """Lint a Sigma YAML string, or every ``.yml`` under a source path."""
+    if (rule_yaml is None) == (source_path is None):
+        return {
+            "error": "Pass exactly one of rule_yaml or source_path",
+            "passed": False,
+        }
+    if source_path is not None:
+        return _lint_source(Path(source_path))
+    return _lint_yaml(rule_yaml or "")
+
+
+def _lint_source(root: Path) -> dict[str, Any]:
+    if not root.exists():
+        return {"error": f"Source path does not exist: {root}", "passed": False}
+
+    files = [root] if root.is_file() else sorted(root.rglob("*.yml"))
+    if root.is_file() and root.suffix.lower() != ".yml":
+        return {"error": "Source file must be a .yml Sigma rule", "passed": False}
+
+    results: list[dict[str, Any]] = []
+    scanned = 0
+    for path in files:
+        if path.is_dir() or path.suffix.lower() != ".yml":
+            continue
+        scanned += 1
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            results.append(
+                {
+                    "file": str(path),
+                    "passed": False,
+                    "error": str(exc),
+                }
+            )
+            continue
+        report = _lint_yaml(text)
+        report["file"] = str(path)
+        if not report.get("passed"):
+            results.append(report)
+
+    rejected = len(results)
+    return {
+        "passed": rejected == 0,
+        "rules_scanned": scanned,
+        "rules_rejected": rejected,
+        "results": results,
+        "rewrite_guidance": _REWRITE if rejected else None,
+    }
+
+
+def _lint_yaml(text: str) -> dict[str, Any]:
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        return {"passed": False, "error": f"YAML parse error: {exc}"}
+
+    if parsed is None:
+        return {"passed": True, "findings": [], "rewrite_guidance": None}
+    if not isinstance(parsed, dict):
+        return {"passed": False, "error": "Sigma rule YAML must be a mapping"}
+
+    findings: list[dict[str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for section in ("detection", "logsource"):
+        if section not in parsed:
+            continue
+        for field, value in _iter_strings(parsed[section]):
+            for finding in _findings_for(field, value):
+                key = (finding["kind"], finding["value"], finding["field"])
+                if key in seen:
+                    continue
+                seen.add(key)
+                findings.append(finding)
+
+    passed = not findings
+    return {
+        "passed": passed,
+        "title": parsed.get("title") if isinstance(parsed.get("title"), str) else None,
+        "findings": findings,
+        "rewrite_guidance": _guidance(findings) if findings else None,
+    }
+
+
+def _iter_strings(
+    node: Any, field: Optional[str] = None
+) -> Iterable[tuple[Optional[str], str]]:
+    if isinstance(node, dict):
+        for key, child in node.items():
+            yield from _iter_strings(child, str(key) if key is not None else field)
+        return
+    if isinstance(node, list):
+        for child in node:
+            yield from _iter_strings(child, field)
+        return
+    if isinstance(node, str):
+        yield field, node
+
+
+def _findings_for(field: Optional[str], value: str) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    field_name = field or ""
+
+    for token in _IPV4.findall(value):
+        kind, literal = _classify_ip_token(token)
+        if kind is None or literal is None:
+            continue
+        findings.append(_finding(kind, literal, field_name))
+
+    for token in _TOKEN.findall(value):
+        if ":" not in token:
+            continue
+        kind, literal = _classify_ip_token(token)
+        if kind is None or literal is None:
+            continue
+        findings.append(_finding(kind, literal, field_name))
+
+    for host in _ENV_HOST.findall(value):
+        findings.append(_finding("hostname", host, field_name))
+
+    if _is_user_field(field_name):
+        person = _specific_person(value)
+        if person is not None:
+            findings.append(_finding("user", person, field_name))
+
+    return findings
+
+
+def _classify_ip_token(token: str) -> tuple[Optional[str], Optional[str]]:
+    if "/" in token:
+        try:
+            ipaddress.ip_network(token, strict=False)
+        except ValueError:
+            return None, None
+        return "cidr", token
+    try:
+        ip = ipaddress.ip_address(token)
+    except ValueError:
+        return None, None
+    if ip.is_loopback:
+        return None, None
+    if ip == _IPV4_BROADCAST:
+        return None, None
+    return "ip", token
+
+
+def _is_user_field(field: str) -> bool:
+    stem = _field_stem(field)
+    if stem in _USER_FIELDS:
+        return True
+    return stem.endswith("username") or stem.endswith("accountname")
+
+
+def _field_stem(field: str) -> str:
+    base = field.split("|", 1)[0]
+    last = base.split(".")[-1]
+    return last.lower().replace("-", "").replace("_", "")
+
+
+def _specific_person(value: str) -> Optional[str]:
+    raw = value.strip().strip("'\"")
+    if not raw or "*" in raw or "?" in raw:
+        return None
+    principal = raw.split("\\")[-1]
+    principal = principal.split("@")[0].strip()
+    if not principal or _SID.match(principal):
+        return None
+    if principal.endswith("$"):
+        return None
+    folded = principal.lower().replace(" ", "")
+    if folded in _WELL_KNOWN_USERS:
+        return None
+    if not _PERSON_USER.match(principal):
+        return None
+    return principal
+
+
+def _finding(kind: str, value: str, field: str) -> dict[str, str]:
+    return {"kind": kind, "value": value, "field": field}
+
+
+def _guidance(findings: list[dict[str, str]]) -> str:
+    literals = ", ".join(f"{item['kind']} {item['value']}" for item in findings)
+    return f"Rule is keyed to environment-specific literals ({literals}). {_REWRITE}"

--- a/core/detections/tools.py
+++ b/core/detections/tools.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional
 import yaml
 
 from core.config import _safe_home
+from core.detections.lint import lint_sigma
 
 
 class SecurityDetectionsTools:
@@ -518,6 +519,18 @@ class SecurityDetectionsTools:
                 techniques.extend([t.upper() for t in techs])
 
         return techniques
+
+    async def lint_detections(
+        self,
+        rule_yaml: Optional[str] = None,
+        source_path: Optional[str] = None,
+    ) -> Dict:
+        """Reject Sigma rules keyed to a specific IP, host, user, or subnet.
+
+        Pass a rule YAML string or a directory of ``.yml`` files. Does not
+        run on ``add_source`` / clone; community corpora stay importable.
+        """
+        return lint_sigma(rule_yaml=rule_yaml, source_path=source_path)
 
 
 # Global instance for reuse

--- a/core/llm/tool_schemas.py
+++ b/core/llm/tool_schemas.py
@@ -91,6 +91,23 @@ SECURITY_DETECTION_TOOLS = [
             },
         },
     },
+    {
+        "name": "lint_detections",
+        "description": "Lint Sigma detection rules for match keys tied to a specific IP, hostname, user, or subnet. Returns rewrite guidance to make the rule behavioural. Pass rule_yaml for one rule or source_path to walk .yml files under an existing source. Does not block importing community rule sources.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "rule_yaml": {
+                    "type": "string",
+                    "description": "Sigma rule YAML to lint. Pass this or source_path, not both.",
+                },
+                "source_path": {
+                    "type": "string",
+                    "description": "Directory of Sigma .yml files (or a single .yml file) to lint.",
+                },
+            },
+        },
+    },
 ]
 
 # DeepTempo Findings Tools (Already implemented in backend)

--- a/tests/unit/detections/test_lint.py
+++ b/tests/unit/detections/test_lint.py
@@ -1,0 +1,137 @@
+"""Sigma environment-literal lint (#826)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.detections.lint import lint_sigma
+from core.detections.tools import SecurityDetectionsTools
+
+pytestmark = pytest.mark.unit
+
+HOST_IP_USER_RULE = """
+title: Host-keyed successful logon
+description: >
+  Mentions 203.0.113.50 and helpdesk.internal and mjones only in prose.
+falsepositives:
+  - Traffic to 198.51.100.10 on ws01.lan
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    DestinationIp:
+      - 10.1.2.3
+      - 10.1.0.0/16
+    ComputerName: dc01.corp.local
+    TargetUserName: jsmith
+  condition: selection
+"""
+
+BEHAVIOURAL_RULE = """
+title: Encoded PowerShell command line
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection:
+    Image|endswith:
+      - '\\powershell.exe'
+      - '\\pwsh.exe'
+    CommandLine|contains:
+      - '-EncodedCommand'
+      - '-enc '
+    User: SYSTEM
+    DestinationIp: 127.0.0.1
+  filter:
+    TargetUserName:
+      - Administrator
+      - root
+      - krbtgt
+      - '*'
+    DestinationIp: 255.255.255.255
+  condition: selection and not filter
+"""
+
+
+def _values(result: dict) -> set[str]:
+    return {item["value"] for item in result.get("findings") or []}
+
+
+def test_host_ip_user_keyed_rule_is_rejected_with_guidance():
+    result = lint_sigma(rule_yaml=HOST_IP_USER_RULE)
+    assert result["passed"] is False
+    kinds = {item["kind"] for item in result["findings"]}
+    assert {"ip", "cidr", "hostname", "user"} <= kinds
+    assert "10.1.2.3" in _values(result)
+    assert "10.1.0.0/16" in _values(result)
+    assert "dc01.corp.local" in _values(result)
+    assert "jsmith" in _values(result)
+    guidance = result["rewrite_guidance"] or ""
+    assert "10.1.2.3" in guidance
+    assert "behaviour" in guidance.lower()
+
+
+def test_literals_in_title_description_and_falsepositives_are_ignored():
+    result = lint_sigma(rule_yaml=HOST_IP_USER_RULE)
+    values = _values(result)
+    assert "203.0.113.50" not in values
+    assert "helpdesk.internal" not in values
+    assert "mjones" not in values
+    assert "198.51.100.10" not in values
+    assert "ws01.lan" not in values
+
+
+def test_behavioural_process_cmdline_rule_passes():
+    result = lint_sigma(rule_yaml=BEHAVIOURAL_RULE)
+    assert result["passed"] is True
+    assert result["findings"] == []
+    assert result["rewrite_guidance"] is None
+
+
+@pytest.mark.asyncio
+async def test_tool_lints_yaml_string_and_source_path(tmp_path: Path):
+    tools = SecurityDetectionsTools()
+
+    rejected = await tools.lint_detections(rule_yaml=HOST_IP_USER_RULE)
+    assert rejected["passed"] is False
+    assert rejected["rewrite_guidance"]
+
+    passed = await tools.lint_detections(rule_yaml=BEHAVIOURAL_RULE)
+    assert passed["passed"] is True
+
+    source = tmp_path / "sigma-rules"
+    source.mkdir()
+    (source / "bad.yml").write_text(HOST_IP_USER_RULE)
+    (source / "good.yml").write_text(BEHAVIOURAL_RULE)
+    (source / "notes.yaml").write_text(HOST_IP_USER_RULE)
+    (source / "readme.txt").write_text("10.1.2.3 dc01.corp.local jsmith")
+
+    walked = await tools.lint_detections(source_path=str(source))
+    assert walked["rules_scanned"] == 2
+    assert walked["rules_rejected"] == 1
+    assert walked["passed"] is False
+    assert walked["results"][0]["file"].endswith("bad.yml")
+
+
+@pytest.mark.asyncio
+async def test_backend_tool_dispatches_lint_detections():
+    from core.agents.tool_registry import execute_backend_tool
+    from core.llm.tool_schemas import ALL_TOOLS
+
+    assert any(tool["name"] == "lint_detections" for tool in ALL_TOOLS)
+
+    result, handled = await execute_backend_tool(
+        "lint_detections", {"rule_yaml": HOST_IP_USER_RULE}
+    )
+    assert handled is True
+    assert result["passed"] is False
+    assert result["rewrite_guidance"]
+
+    result, handled = await execute_backend_tool(
+        "lint_detections", {"rule_yaml": BEHAVIOURAL_RULE}
+    )
+    assert handled is True
+    assert result["passed"] is True

--- a/tests/unit/detections/test_lint.py
+++ b/tests/unit/detections/test_lint.py
@@ -91,6 +91,23 @@ def test_behavioural_process_cmdline_rule_passes():
     assert result["rewrite_guidance"] is None
 
 
+def test_environment_tld_suffix_and_glob_are_rejected():
+    rule = """
+title: Domain-suffixed workstation
+logsource:
+  product: windows
+detection:
+  selection:
+    ComputerName|endswith: '.corp.local'
+    HostName: '*.local'
+  condition: selection
+"""
+    result = lint_sigma(rule_yaml=rule)
+    assert result["passed"] is False
+    assert {item["kind"] for item in result["findings"]} == {"hostname"}
+    assert result["rewrite_guidance"]
+
+
 @pytest.mark.asyncio
 async def test_tool_lints_yaml_string_and_source_path(tmp_path: Path):
     tools = SecurityDetectionsTools()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #826.

A caller can hand Vigil a Sigma rule (or a local `.yml` source) and get a deterministic reject-or-pass when the match is keyed to an environment literal, with rewrite guidance to make it behavioural.

## What landed

`lint_sigma` walks parsed YAML `detection` and `logsource` values only (title / description / falsepositives cannot false-hit):

- IPs except loopback and IPv4 broadcast (public C2 literals included; IOC matching is threat intel)
- CIDRs
- Hostnames under `.corp` / `.local` / `.internal` / `.lan`, including `*.local` / `|endswith: '.corp.local'` suffixes
- Account-field values that look like a specific person; not SYSTEM, Administrator, root, krbtgt, or `*`

One function, two call paths: a rule YAML string, or a walk of `.yml` under an existing source path. Exposed as `lint_detections` on `SecurityDetectionsTools`, registered in `_SECURITY_TOOLS` and `SECURITY_DETECTION_TOOLS`.

Out of scope, as groomed: no fork port, no `validation/` package, no replay / judge / repair, no pySigma, no HTTP surface, no Settings panel, and `add_source` / clone is unchanged.

## Independent review

- Hostname globs (`*.local`, `|endswith: '.corp.local'`) passed — **fixed**; suffix/glob forms now reject, with a unit test.
- Bracketed IPv6 (`[2001:db8::1]`) was not classified — **fixed**; brackets are stripped before `ipaddress`.
- Extra tests for `::1`, `DOMAIN\\jsmith`, SIDs, `MACHINE$`, `foo.local.exe` — **dismissed**: the issue asked for a host/IP/user reject and a behavioural pass; those shapes are handled by the heuristic and are low-value assertions.
- Case-sensitive `*.YML` on Linux directory walks — **dismissed**: Sigma sources use `.yml`.
- IPs inside non-IP fields (e.g. CommandLine) are flagged — **dismissed**: the groomed stance is any IP in detection values, including public C2.
- `host_01.corp` reported as `01.corp` — **dismissed**: still rejects; underscore is not a DNS label and is not worth a parser change.
- `_WELL_KNOWN_USERS` includes nearby role names (`admin`, `guest`) beyond the four named accounts — **dismissed**: those are roles, not a specific person; same cut as the spec.
- Schema does not `oneOf` `rule_yaml` / `source_path` — **dismissed**: runtime enforces exactly one; other detection tools use optional properties the same way.

## Verification

- `pytest tests/unit/detections/test_lint.py --no-cov` — 6 passed (host/IP/user reject with guidance, behavioural process/cmdline pass, title/description/falsepositives ignored, TLD suffix/glob reject, YAML-string + source-path tool, `execute_backend_tool` dispatch)
- `pytest tests/unit/detections/test_backend_tools.py -m "not external_service" --no-cov` — `test_tool_availability` passed (`lint_detections` is in `ALL_TOOLS`)
- `black --check` on the five changed files — pass
- `isort --check-only` on the five changed files — pass
- `flake8` on `core/detections/lint.py`, `core/detections/tools.py`, `core/agents/tool_registry.py`, `core/llm/tool_schemas.py` — pass
- `mypy core/detections/lint.py --ignore-missing-imports` — pass
- `mypy core/detections/tools.py --ignore-missing-imports` — 2 pre-existing errors (`by_source` untyped; `object` not indexable at the coverage-stats index). Not introduced here; CI mypy is `continue-on-error`
- `lint-imports` — 3 contracts kept
- Live entry point: `execute_backend_tool("lint_detections", ...)` on the reject YAML, the behavioural YAML, and a two-file temp source (`bad.yml` + `good.yml`) — reject with IP/host/user findings and rewrite guidance; behavioural pass; walk scanned 2 / rejected 1
- GitHub CI on `6583356` — 15 successful, 2 skipped (Docker image build/scan), 0 failed
- `flake8 services/ core/` (full local CI lint job) — not run locally (ran the changed files; CI Lint Backend passed)
- Full `tests/unit/` + `tests/security/` locally — not run (out of time; CI Unit Tests - Backend passed)
- UI / agent-browser — not applicable (no Settings panel, no HTTP surface)
- Full SigmaHQ clone as a live target — not applicable (groomed out; would fail wholesale on IOC-keyed community rules)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9f3954e-4ded-4b92-8312-1dc223df2f03?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9f3954e-4ded-4b92-8312-1dc223df2f03&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

