### PR TITLE
feat(web): integrate VStrike and improve findings triage

### DIFF
--- a/clients/web/src/data/data.ts
+++ b/clients/web/src/data/data.ts
@@ -32,6 +32,9 @@ export const NAV: [IconName, string, ConsoleScreenKey | null, NavGate?][] = [
 
 export interface Finding {
   id: string
+  title?: string
+  sourceIp?: string
+  destinationIp?: string
   sev: 'Critical' | 'High' | 'Medium' | 'Low' | 'Unrated'
   tech: string
   conf: number

--- a/clients/web/src/data/findingPresentation.test.ts
+++ b/clients/web/src/data/findingPresentation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { findingEndpoints, findingTitle, sourceTime, sourceTimestamp } from './findingPresentation'
+import { mapApiFinding } from './mappers'
+
+describe('finding presentation', () => {
+  it('maps explicit endpoints before flattening metadata and rejects ambiguous or invalid roles', () => {
+    expect(findingEndpoints({ source_ip: '192.0.2.2', src_ips: ['192.0.2.2'], dest_ips: ['198.51.100.10'] }))
+      .toEqual({ sourceIp: '192.0.2.2', destinationIp: '198.51.100.10' })
+    for (const source of [['192.0.2.2', '192.0.2.20'], ['192.0.2.2', 'invalid'], '192.0.2.2/32', '2001:db8::1', '192.000.2.2']) {
+      expect(findingEndpoints({ source_ips: source }).sourceIp).toBeUndefined()
+    }
+    expect(findingEndpoints({ ips: ['192.0.2.2'], nodes: [{ source_ip: '192.0.2.2' }] })).toEqual({ sourceIp: undefined, destinationIp: undefined })
+  })
+  it('keeps source titles and missing scores instead of inventing detection claims', () => {
+    const finding = mapApiFinding({ finding_id: 'synthetic-1', title: 'Unusual transfer', entity_context: { source_ip: '192.0.2.2', destination_ip: '198.51.100.10' } })
+    expect(findingTitle(finding)).toBe('Unusual transfer')
+    expect(finding.score).toBeNull()
+    expect(finding.sev).toBe('Unrated')
+    expect(finding.sourceIp).toBe('192.0.2.2')
+    expect(findingTitle({ src: 'flow', tech: '—' })).toBe('Network flow finding')
+  })
+  it('interprets naive timestamps as UTC and retains explicit offsets', () => {
+    expect(sourceTimestamp('2026-01-02T12:00:00')).toBe(sourceTimestamp('2026-01-02T12:00:00Z'))
+    expect(sourceTimestamp('2026-01-02T07:00:00-05:00')).toBe(sourceTimestamp('2026-01-02T12:00:00Z'))
+    expect(sourceTime('2026-01-02T12:00:00')).toContain('12:00:00 UTC')
+    expect(sourceTime(null)).toBe('Source time unavailable')
+    expect(sourceTimestamp('invalid')).toBeUndefined()
+  })
+})

--- a/clients/web/src/data/findingPresentation.ts
+++ b/clients/web/src/data/findingPresentation.ts
@@ -1,0 +1,52 @@
+import type { Finding } from './data'
+import { MISSING_FINDING_TIME } from './data'
+import { techniqueName } from './mitre'
+
+export function findingTitle(finding: Pick<Finding, 'title' | 'tech' | 'src'>): string {
+  if (finding.title?.trim()) return finding.title
+  if (finding.tech !== '—') return techniqueName(finding.tech) || finding.tech
+  return /flow|netflow/i.test(finding.src) ? 'Network flow finding' : 'Security finding'
+}
+
+export function sourceTimestamp(value?: string | null): number | undefined {
+  if (!value) return undefined
+  // The API also returns naive UTC datetimes; never interpret these as local time.
+  const iso = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(value) ? value : `${value}Z`
+  const timestamp = Date.parse(iso)
+  return Number.isFinite(timestamp) ? timestamp : undefined
+}
+
+export function sourceTime(value?: string | null): string {
+  const timestamp = sourceTimestamp(value)
+  return timestamp === undefined ? MISSING_FINDING_TIME : new Intl.DateTimeFormat('en-US', {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit',
+    hour12: false, timeZone: 'UTC',
+  }).format(timestamp) + ' UTC'
+}
+
+export function ipv4(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const parts = value.trim().split('.')
+  return parts.length === 4 && parts.every((part) => /^(0|[1-9]\d{0,2})$/.test(part) && Number(part) <= 255)
+    ? parts.join('.') : undefined
+}
+
+const SOURCE_KEYS = ['source_ip', 'source_ips', 'src_ip', 'src_ips', 'srcip', 'sourceIp']
+const DESTINATION_KEYS = ['destination_ip', 'destination_ips', 'dest_ip', 'dest_ips', 'dst_ip', 'dst_ips', 'dstip', 'destinationIp']
+
+/** Read only explicit role-bearing fields, before entity metadata is flattened.
+ * Multiple distinct addresses or malformed aliases do not define a single flow.
+ */
+export function findingEndpoints(context: Record<string, unknown> | undefined): { sourceIp?: string; destinationIp?: string } {
+  const one = (keys: string[]): string | undefined => {
+    const values = keys.flatMap((key) => {
+      const value = context?.[key]
+      return value == null ? [] : Array.isArray(value) ? value : [value]
+    })
+    const normalized = values.map(ipv4)
+    if (!normalized.length || normalized.some((value) => !value)) return undefined
+    const unique = new Set(normalized)
+    return unique.size === 1 ? normalized[0] : undefined
+  }
+  return { sourceIp: one(SOURCE_KEYS), destinationIp: one(DESTINATION_KEYS) }
+}

--- a/clients/web/src/data/mappers.ts
+++ b/clients/web/src/data/mappers.ts
@@ -1,8 +1,8 @@
 import { format } from 'date-fns'
+import { findingEndpoints, sourceTime, sourceTimestamp } from './findingPresentation'
 import {
   MISSING_FINDING_SCORE,
   MISSING_FINDING_SEVERITY,
-  MISSING_FINDING_TIME,
   type CaseRow,
   type Finding,
 } from './data'
@@ -133,7 +133,7 @@ function topTechnique(preds?: Record<string, number>): { tech: string; conf: num
 }
 
 /** already surfaced as fixed columns; the rest become `extra` */
-const MAPPED_ENTITY_KEYS = new Set(['hostnames', 'usernames'])
+const MAPPED_ENTITY_KEYS = new Set(['hostnames', 'usernames', 'source_evidence'])
 
 function extraEntities(ec: ApiFinding['entity_context']): Record<string, string> | undefined {
   if (!ec) return undefined
@@ -151,6 +151,8 @@ export function mapApiFinding(f: ApiFinding): Finding {
   const ec = f.entity_context
   return {
     id: f.finding_id,
+    title: f.title,
+    ...findingEndpoints(ec),
     sev: findingSev(f.severity),
     tech,
     conf,
@@ -158,8 +160,8 @@ export function mapApiFinding(f: ApiFinding): Finding {
     src: f.data_source || DASH,
     host: ec?.hostnames?.[0] || DASH,
     user: ec?.usernames?.[0] || DASH,
-    time: f.timestamp ? fmt(f.timestamp, 'MMM d, HH:mm') : MISSING_FINDING_TIME,
-    ts: epochMs(f.timestamp ?? undefined),
+    time: sourceTime(f.timestamp),
+    ts: sourceTimestamp(f.timestamp),
     score: typeof f.anomaly_score === 'number' ? f.anomaly_score : null,
     status: findingStatus(f.status),
     extra: extraEntities(ec),

--- a/clients/web/src/integrations/vstrike/README.md
+++ b/clients/web/src/integrations/vstrike/README.md
@@ -1,0 +1,55 @@
+# VStrike network context
+
+Enable **CloudCurrent VStrike** in **Settings → Integrations** and configure its URL,
+username, and password. The Dashboard's **VStrike** tab opens the external graph.
+When several networks are available, choose one explicitly. Network and storyline
+choices come from the configured account; no deployment or scenario is hard-coded.
+
+A finding's inline **VStrike** action carries its source and destination IPv4
+addresses into that view. The same action is available in finding details.
+Missing, ambiguous, non-IPv4, or invalid endpoint pairs disable the action.
+The view retains the requested addresses and offers **Retry selection**,
+**Back to finding**, and **Back to results**. Search, filters, sorting, pagination,
+column preferences, and table scroll survive this round trip. Existing CSV export
+still exports the filtered and sorted queue.
+
+**VStrike events** opens an on-demand drawer of external danger events for the
+selected storyline. It reads at most 100 source events per page (API maximum 250)
+and refreshes five seconds after each completed read, only while the drawer is
+open. A full page is labeled as potentially truncated. Failed refreshes preserve
+the last successful page with a stale-data message. These events are never stored
+as Vigil findings and are never assigned model scores or Vigil severity.
+Source times display in UTC; absent timestamps remain unavailable.
+
+## Embedding and configuration
+
+The graph is initialized lazily and its iframe survives Dashboard tab changes.
+It is disposed when the Dashboard unmounts. A minimum 1280 × 720 internal viewport
+avoids provider initialization failures in narrow containers; the view scales
+within the available space. **Expand graph** provides more room.
+
+The default Vigil Content Security Policy admits the configured VStrike origin
+only in `frame-src`, on HTML responses. It does not grant that origin script or
+API access to Vigil. A custom `VIGIL_CSP_POLICY` remains authoritative and must
+explicitly allow the provider origin in `frame-src`. Credentials and transient
+iframe tokens stay out of findings, URL navigation state, and browser storage.
+
+## Provider contract and limits
+
+The workflow uses `network-list`, `ui-login-token`, `ui-network-load`,
+`storyline-list`, `ui-storyline-apply`, `ui-storyline-forward`,
+`ui-storyline-backward`, `storyline-events-get`, and `ui-find-by-ip-then-zoom`.
+The event/apply calls identify collections as `storylineSetId`. VCR steps have no
+arguments. Unsupported selection tools return HTTP 501; other provider failures
+return an error without exposing raw authenticated URLs.
+
+An accepted MCP command is **not proof of rendered highlighting or zoom**. The UI
+explicitly says selection was requested and remains unconfirmed. Exact matching,
+camera framing, and path highlighting remain provider responsibilities. This
+change does not fix provider prefix matching or promise an exact path highlight.
+Use **Reconnect** if the embedded provider shows a login screen.
+
+The iframe load event can precede the provider's WebSocket registration. Network
+loading has one delayed attempt and one bounded retry; a matching state message
+from the exact iframe origin and window cancels the retry. Selection is reapplied
+after a retry, while outdated responses cannot override newer UI context.

--- a/clients/web/src/integrations/vstrike/README.md
+++ b/clients/web/src/integrations/vstrike/README.md
@@ -2,6 +2,10 @@
 
 Enable **CloudCurrent VStrike** in **Settings → Integrations** and configure its URL,
 username, and password. The Dashboard's **VStrike** tab opens the external graph.
+The tab, inline finding/detail actions, and events button are shown only after
+integration settings have loaded and VStrike is enabled. Disabling it closes the
+graph and events drawer, cancels provider retries/polling, and returns an active
+VStrike view to the preserved findings queue.
 When several networks are available, choose one explicitly. Network and storyline
 choices come from the configured account; no deployment or scenario is hard-coded.
 

--- a/clients/web/src/integrations/vstrike/VStrikeEvents.tsx
+++ b/clients/web/src/integrations/vstrike/VStrikeEvents.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import { vstrikeApi, type VStrikeFault } from './api'
+import { sourceTime } from '../../data/findingPresentation'
+import { Icon } from '../../shared/icons'
+
+export default function VStrikeEvents({ storylineId, onFocus }: { storylineId: string; onFocus: (ips: string[]) => void }) {
+  const [faults, setFaults] = useState<VStrikeFault[]>([])
+  const [checked, setChecked] = useState<string>()
+  const [error, setError] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [truncated, setTruncated] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout>
+    setFaults([]); setChecked(undefined); setError(false); setLoading(true); setTruncated(false)
+    const poll = async () => {
+      try {
+        const { data } = await vstrikeApi.faults(storylineId)
+        if (cancelled) return
+        setFaults(data.faults); setChecked(data.fetched_at); setTruncated(data.truncated); setError(false)
+      } catch {
+        if (!cancelled) setError(true)
+      } finally {
+        if (!cancelled) { setLoading(false); timer = setTimeout(() => { void poll() }, 5_000) }
+      }
+    }
+    if (storylineId) void poll()
+    else setLoading(false)
+    return () => { cancelled = true; clearTimeout(timer) }
+  }, [storylineId])
+  return <section aria-label="VStrike scenario events">
+    <p className="muted">External simulation events. These are separate from Vigil findings and model scores.</p>
+    {!storylineId ? <p>Choose a network and storyline above to read events.</p> : <>
+      <p role="status">{loading ? 'Reading VStrike events…' : `${faults.length} scenario event${faults.length === 1 ? '' : 's'}`}{truncated && ' · latest page only'}</p>
+      {checked && <p className="muted">Last checked {sourceTime(checked)}</p>}
+      {error && <p role="alert">Refresh failed.{checked ? ' Showing the last successful read.' : ' Try reconnecting to VStrike.'}</p>}
+      {!loading && !error && !faults.length && <p>No danger events were returned for this storyline.</p>}
+      <div className="vstrike-event-list">{faults.map((fault) => <article key={fault.event_id}>
+        <h3>{fault.label || 'VStrike event'}</h3>
+        <time>{sourceTime(fault.occurred_at)}</time>
+        <p>{fault.description}</p>
+        {fault.source_level && <p className="muted">VStrike level: {fault.source_level}</p>}
+        <div className="vstrike-event-action"><span className="mono">{fault.ip4s.join(', ') || 'No IPv4 address'}</span>
+          <button className="btn ghost" disabled={!fault.ip4s.length} onClick={() => onFocus(fault.ip4s)}><Icon name="graph" size={14} />Open in graph</button></div>
+        <details><summary>Measurement details</summary><dl>{Object.entries(fault.measurement).map(([key, value]) => <div key={key}><dt>{key}</dt><dd>{value}</dd></div>)}</dl></details>
+      </article>)}</div>
+    </>}
+  </section>
+}

--- a/clients/web/src/integrations/vstrike/VStrikePanel.test.tsx
+++ b/clients/web/src/integrations/vstrike/VStrikePanel.test.tsx
@@ -1,0 +1,153 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import VStrikePanel, { type GraphRequest } from './VStrikePanel'
+import VStrikeEvents from './VStrikeEvents'
+import { options } from './api'
+
+const mocks = vi.hoisted(() => ({ enabled: true, connect: vi.fn(), networks: vi.fn(), storylines: vi.fn(), loadNetwork: vi.fn(), focus: vi.fn(), faults: vi.fn(), applyStoryline: vi.fn(), step: vi.fn() }))
+vi.mock('../../extensions/ExtensionProvider', () => ({ useExtensions: () => ({ enabledIntegrations: mocks.enabled ? ['vstrike'] : [], loading: false }) }))
+vi.mock('./api', async (original) => ({ ...await original<typeof import('./api')>(), vstrikeApi: mocks }))
+
+const request: GraphRequest = { id: 1, ips: ['192.0.2.2', '198.51.100.10'], findingId: 'synthetic-1' }
+const baseProps = { active: true, request, eventsOpen: false, onCloseEvents: vi.fn(), onOpenEvents: vi.fn(), onFocus: vi.fn(), onBack: vi.fn(), onBackToFinding: vi.fn(), onConfigure: vi.fn() }
+
+beforeEach(() => {
+  vi.clearAllMocks(); mocks.enabled = true
+  mocks.connect.mockResolvedValue({ data: { iframe_url: 'https://vstrike.example.test/login?token=synthetic' } })
+  mocks.networks.mockResolvedValue({ data: { networks: [{ networkId: 'network-1', name: 'Example network' }] } })
+  mocks.storylines.mockResolvedValue({ data: { storylines: [{ storylineSetId: 'storyline-1', name: 'Example scenario' }] } })
+  mocks.loadNetwork.mockResolvedValue({}); mocks.focus.mockResolvedValue({}); mocks.applyStoryline.mockResolvedValue({})
+  mocks.faults.mockResolvedValue({ data: { faults: [], fetched_at: '2026-01-02T12:00:00Z', truncated: false, limit: 100 } })
+  vi.stubGlobal('ResizeObserver', class { observe() {} disconnect() {} })
+  Object.defineProperty(HTMLDialogElement.prototype, 'showModal', { configurable: true, value() { this.setAttribute('open', '') } })
+  Object.defineProperty(HTMLDialogElement.prototype, 'close', { configurable: true, value() { this.removeAttribute('open') } })
+})
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals() })
+
+async function ready() {
+  const frame = await screen.findByTitle('CloudCurrent VStrike network visualization')
+  fireEvent.load(frame)
+  // Network acknowledgement must come from this exact iframe, not another tab.
+  fireEvent(window, new MessageEvent('message', { origin: 'https://vstrike.example.test', source: (frame as HTMLIFrameElement).contentWindow, data: { type: 'vstrike:state', networkId: 'network-1' } }))
+  return frame
+}
+
+describe('VStrike network workflow', () => {
+  it('keeps disabled integrations idle and directs configuration', () => {
+    mocks.enabled = false
+    render(<VStrikePanel {...baseProps} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure VStrike' }))
+    expect(baseProps.onConfigure).toHaveBeenCalled()
+    expect(mocks.connect).not.toHaveBeenCalled()
+  })
+  it('uses the configured network and exposes selection as unconfirmed', async () => {
+    render(<VStrikePanel {...baseProps} />)
+    await ready()
+    await waitFor(() => expect(mocks.focus).toHaveBeenCalledWith('network-1', request.ips))
+    expect(await screen.findByText(/has not confirmed highlighting or zoom/)).toBeVisible()
+    expect(screen.getByLabelText('VStrike storyline')).toHaveValue('storyline-1')
+    fireEvent.click(screen.getByRole('button', { name: 'Back to finding' }))
+    expect(baseProps.onBackToFinding).toHaveBeenCalledWith('synthetic-1')
+  })
+  it('requires a choice when more than one network is available', async () => {
+    mocks.networks.mockResolvedValue({ data: { networks: [{ id: 'network-1', name: 'One' }, { id: 'network-2', name: 'Two' }] } })
+    render(<VStrikePanel {...baseProps} />)
+    await screen.findByTitle('CloudCurrent VStrike network visualization')
+    expect(screen.getByLabelText('VStrike network')).toHaveValue('')
+    expect(mocks.focus).not.toHaveBeenCalled()
+  })
+  it('preserves the iframe across tab changes and does not apply a late selection result', async () => {
+    let resolve: (value: unknown) => void = () => {}
+    mocks.focus.mockImplementationOnce(() => new Promise((done) => { resolve = done }))
+    const view = render(<VStrikePanel {...baseProps} />)
+    const frame = await ready()
+    await waitFor(() => expect(mocks.focus).toHaveBeenCalled())
+    view.rerender(<VStrikePanel {...baseProps} active={false} />)
+    await act(async () => resolve({}))
+    view.rerender(<VStrikePanel {...baseProps} />)
+    expect(screen.getByTitle('CloudCurrent VStrike network visualization')).toBe(frame)
+    expect(screen.queryByText(/has not confirmed highlighting or zoom/)).not.toBeInTheDocument()
+    expect(mocks.connect).toHaveBeenCalledTimes(1)
+  })
+  it('bounds network retries and reapplies the current selection after a retry', async () => {
+    vi.useFakeTimers()
+    render(<VStrikePanel {...baseProps} />)
+    await act(async () => {})
+    fireEvent.load(screen.getByTitle('CloudCurrent VStrike network visualization'))
+    await act(async () => { vi.advanceTimersByTime(1_000) })
+    expect(mocks.loadNetwork).toHaveBeenCalledTimes(1)
+    expect(mocks.focus).toHaveBeenCalledTimes(1)
+    await act(async () => { vi.advanceTimersByTime(11_000) })
+    expect(mocks.loadNetwork).toHaveBeenCalledTimes(2)
+    expect(mocks.focus).toHaveBeenCalledTimes(2)
+    await act(async () => { vi.advanceTimersByTime(60_000) })
+    expect(mocks.loadNetwork).toHaveBeenCalledTimes(2)
+    expect(mocks.focus).toHaveBeenLastCalledWith('network-1', request.ips)
+  })
+  it('waits for the replacement iframe before selecting after reconnect', async () => {
+    render(<VStrikePanel {...baseProps} />)
+    await ready()
+    await waitFor(() => expect(mocks.focus).toHaveBeenCalledTimes(1))
+    fireEvent.click(screen.getByRole('button', { name: 'Reconnect' }))
+    await screen.findByTitle('CloudCurrent VStrike network visualization')
+    expect(mocks.focus).toHaveBeenCalledTimes(1)
+    await ready()
+    await waitFor(() => expect(mocks.focus).toHaveBeenCalledTimes(2))
+  })
+  it('ignores messages with the wrong origin or window and cancels retries only for the matching iframe', async () => {
+    vi.useFakeTimers()
+    render(<VStrikePanel {...baseProps} />)
+    await act(async () => {})
+    const frame = screen.getByTitle('CloudCurrent VStrike network visualization') as HTMLIFrameElement
+    fireEvent.load(frame)
+    const data = { type: 'vstrike:state', networkId: 'network-1' }
+    fireEvent(window, new MessageEvent('message', { origin: 'https://vstrike.example.test', source: window, data }))
+    fireEvent(window, new MessageEvent('message', { origin: 'https://untrusted.example.test', source: frame.contentWindow, data }))
+    await act(async () => {})
+    expect(mocks.focus).not.toHaveBeenCalled()
+    fireEvent(window, new MessageEvent('message', { origin: 'https://vstrike.example.test', source: frame.contentWindow, data }))
+    await act(async () => { vi.advanceTimersByTime(60_000) })
+    expect(mocks.focus).toHaveBeenCalledTimes(1)
+    expect(mocks.loadNetwork).not.toHaveBeenCalled()
+  })
+  it('does not expose authenticated URLs in provider errors', async () => {
+    mocks.connect.mockRejectedValue(new Error('https://vstrike.example.test?token=do-not-display'))
+    render(<VStrikePanel {...baseProps} />)
+    expect(await screen.findByText('VStrike is unavailable')).toBeVisible()
+    expect(screen.queryByText(/do-not-display/)).not.toBeInTheDocument()
+  })
+  it('normalizes options without choosing a named deployment', () => {
+    expect(options([{ networkId: 'one', name: 'Any network' }, { networkId: 'one' }, null], ['networkId'])).toEqual([{ id: 'one', label: 'Any network' }])
+  })
+})
+
+describe('external scenario drawer', () => {
+  it('reads only while open, reports truncation and keeps measurement zero', async () => {
+    mocks.faults.mockResolvedValue({ data: { faults: [{ event_id: 'event-1', label: 'Synthetic event', description: 'Example only', occurred_at: '2026-01-02T12:00:00Z', source_level: 'danger', ip4s: ['192.0.2.2'], measurement: { value: '0' } }], fetched_at: '2026-01-02T12:00:01Z', truncated: true, limit: 100 } })
+    const view = render(<VStrikePanel {...baseProps} />)
+    await ready()
+    expect(mocks.faults).not.toHaveBeenCalled()
+    view.rerender(<VStrikePanel {...baseProps} eventsOpen />)
+    const drawer = await screen.findByRole('dialog', { name: 'VStrike events' })
+    expect(await within(drawer).findByText('Synthetic event')).toBeVisible()
+    expect(within(drawer).getByText(/latest page only/)).toBeVisible()
+    fireEvent.click(within(drawer).getByText('Measurement details'))
+    expect(within(drawer).getByText('0')).toBeInTheDocument()
+    fireEvent.click(within(drawer).getByRole('button', { name: 'Open in graph' }))
+    expect(baseProps.onFocus).toHaveBeenCalledWith(['192.0.2.2'])
+    view.unmount()
+    vi.useFakeTimers(); await act(async () => { vi.advanceTimersByTime(10_000) })
+    expect(mocks.faults).toHaveBeenCalledTimes(1)
+  })
+  it('retains the last page on a failed refresh without inventing an empty success', async () => {
+    vi.useFakeTimers()
+    const view = render(<VStrikeEvents storylineId="storyline-1" onFocus={vi.fn()} />)
+    await act(async () => {})
+    mocks.faults.mockRejectedValueOnce(new Error('offline'))
+    await act(async () => { vi.advanceTimersByTime(5_000) })
+    expect(screen.getByRole('alert')).toHaveTextContent('Showing the last successful read')
+    view.unmount()
+    await act(async () => { vi.advanceTimersByTime(10_000) })
+    expect(mocks.faults).toHaveBeenCalledTimes(2)
+  })
+})

--- a/clients/web/src/integrations/vstrike/VStrikePanel.tsx
+++ b/clients/web/src/integrations/vstrike/VStrikePanel.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useExtensions } from '../../extensions/ExtensionProvider'
+import { EmptyState } from '../../shared/ui'
+import { Icon } from '../../shared/icons'
+import FindingsDrawer from '../../screens/dashboard/FindingsDrawer'
+import VStrikeEvents from './VStrikeEvents'
+import { actionError, options, vstrikeApi, type VStrikeOption } from './api'
+
+export interface GraphRequest { id: number; ips: string[]; findingId?: string }
+interface Props {
+  active: boolean
+  request: GraphRequest | null
+  eventsOpen: boolean
+  onCloseEvents: () => void
+  onOpenEvents: () => void
+  onFocus: (ips: string[]) => void
+  onBack: () => void
+  onBackToFinding: (id: string) => void
+  onConfigure: () => void
+}
+
+export default function VStrikePanel(props: Props) {
+  const { active, request, eventsOpen, onCloseEvents, onConfigure } = props
+  const { enabledIntegrations, loading: integrationsLoading } = useExtensions()
+  const enabled = enabledIntegrations.includes('vstrike')
+  const [connection, setConnection] = useState(0)
+  const [phase, setPhase] = useState<'loading' | 'ready' | 'error'>('loading')
+  const [url, setUrl] = useState<string>()
+  const [loaded, setLoaded] = useState(false)
+  const [networks, setNetworks] = useState<VStrikeOption[]>([])
+  const [network, setNetwork] = useState('')
+  const [networkLoaded, setNetworkLoaded] = useState('')
+  const [networkAttempt, setNetworkAttempt] = useState(0)
+  const [storylines, setStorylines] = useState<VStrikeOption[]>([])
+  const [storyline, setStoryline] = useState('')
+  const [storylinesLoading, setStorylinesLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [selection, setSelection] = useState<'idle' | 'pending' | 'requested' | 'error'>('idle')
+  const [fullscreen, setFullscreen] = useState(false)
+  const iframe = useRef<HTMLIFrameElement>(null)
+  const surface = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(1280)
+  const guard = `${connection}:${network}:${request?.id}:${active}:${enabled}`
+  const currentGuard = useRef(guard)
+  currentGuard.current = guard
+  const autoFocus = useRef('')
+
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+    setPhase('loading'); setUrl(undefined); setLoaded(false); setNetworkLoaded(''); setError(''); setSelection('idle'); setBusy(false)
+    Promise.all([vstrikeApi.connect(), vstrikeApi.networks()]).then(([token, list]) => {
+      if (cancelled) return
+      const candidate = new URL(token.data.iframe_url)
+      if (!['http:', 'https:'].includes(candidate.protocol) || candidate.username || candidate.password) throw new Error('Invalid iframe URL')
+      const next = options(list.data.networks, ['networkId', 'id', 'network_id'])
+      setUrl(candidate.href); setNetworks(next)
+      setNetwork((previous) => next.some((item) => item.id === previous) ? previous : next.length === 1 ? next[0].id : '')
+      setPhase('ready')
+    }).catch(() => { if (!cancelled) { setPhase('error'); setError(actionError('connect to VStrike')) } })
+    return () => { cancelled = true }
+  }, [connection, enabled])
+
+  useEffect(() => {
+    setStorylines([]); setStoryline(''); setNetworkLoaded(''); setSelection('idle'); setBusy(false)
+    if (!enabled || !network) { setStorylinesLoading(false); return }
+    let cancelled = false
+    setStorylinesLoading(true)
+    vstrikeApi.storylines(network).then(({ data }) => {
+      if (cancelled) return
+      const list = options(data.storylines, ['storylineSetId', 'id', 'storylineId', 'storyline_id'])
+      setStorylines(list); setStoryline(list.length === 1 ? list[0].id : '')
+    }).catch(() => { if (!cancelled) setError(actionError('list storylines')) })
+      .finally(() => { if (!cancelled) setStorylinesLoading(false) })
+    return () => { cancelled = true }
+  }, [network, enabled, connection])
+
+  useEffect(() => {
+    if (!url || !loaded || !network || !enabled) return
+    let cancelled = false
+    let confirmed = false
+    const load = async () => {
+      try {
+        await vstrikeApi.loadNetwork(network)
+        if (!cancelled) { setNetworkLoaded(network); setNetworkAttempt((value) => value + 1) }
+      } catch { if (!cancelled) setError(actionError('load the network')) }
+    }
+    // iframe load can precede the provider's WebSocket registration. Retry once.
+    const timers = [1_000, 12_000].map((delay) => setTimeout(() => { if (!confirmed) void load() }, delay))
+    const onMessage = (event: MessageEvent) => {
+      if (event.source !== iframe.current?.contentWindow || event.origin !== new URL(url).origin) return
+      if (event.data?.type === 'vstrike:state' && event.data.networkId === network) {
+        confirmed = true; timers.forEach(clearTimeout); setNetworkLoaded(network)
+      }
+    }
+    window.addEventListener('message', onMessage)
+    return () => { cancelled = true; timers.forEach(clearTimeout); window.removeEventListener('message', onMessage) }
+  }, [url, loaded, network, enabled])
+
+  useEffect(() => {
+    if (!active) setFullscreen(false)
+    const target = surface.current
+    if (!active || !target) return
+    const observer = new ResizeObserver(([entry]) => { if (entry.contentRect.width > 0) setWidth(entry.contentRect.width) })
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [active, phase, fullscreen])
+
+  const select = useCallback(async () => {
+    if (!request || !network || !loaded || !enabled) return
+    const started = currentGuard.current
+    setSelection('pending'); setError('')
+    try {
+      await vstrikeApi.focus(network, request.ips)
+      if (started === currentGuard.current) setSelection('requested')
+    } catch {
+      if (started === currentGuard.current) { setSelection('error'); setError(actionError('request the selection')) }
+    }
+  }, [request, network, loaded, enabled])
+
+  useEffect(() => {
+    if (!active || !request || !network || networkLoaded !== network || !loaded) return
+    const key = `${connection}:${network}:${networkAttempt}:${request.id}`
+    if (autoFocus.current === key) return
+    autoFocus.current = key
+    void select()
+  }, [active, request, networkLoaded, network, loaded, connection, networkAttempt, select])
+
+  useEffect(() => {
+    if (!active) { setSelection((value) => value === 'pending' ? 'idle' : value); setBusy(false) }
+  }, [active])
+
+  const action = async (call: () => Promise<unknown>, label: string) => {
+    const started = currentGuard.current
+    setBusy(true); setError('')
+    try { await call() } catch { if (started === currentGuard.current) setError(actionError(label)) }
+    finally { if (started === currentGuard.current) setBusy(false) }
+  }
+  const reconnect = () => {
+    setLoaded(false); setNetworkLoaded(''); setSelection('idle'); setBusy(false)
+    setConnection((value) => value + 1)
+  }
+  const controls = <div className="vstrike-controls">
+    <label>Network<select aria-label="VStrike network" value={network} disabled={busy || selection === 'pending'} onChange={(event) => setNetwork(event.target.value)}>
+      <option value="">{networks.length ? 'Choose network' : 'No networks available'}</option>{networks.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}
+    </select></label>
+    <label>Storyline<select aria-label="VStrike storyline" value={storyline} disabled={!network || storylinesLoading || busy} onChange={(event) => setStoryline(event.target.value)}>
+      <option value="">{storylinesLoading ? 'Loading storylines…' : 'Choose storyline'}</option>{storylines.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}
+    </select></label>
+  </div>
+  const settings = <EmptyState icon="graph" title={integrationsLoading ? 'Checking VStrike configuration…' : 'Connect VStrike'}
+    body="Enable CloudCurrent VStrike and configure its URL and credentials in Integrations to view network context."
+    primary={{ label: 'Configure VStrike', onClick: onConfigure, icon: 'gear' }} />
+  const frameWidth = Math.max(1280, width)
+  const scale = Math.min(1, width / frameWidth)
+  const frameHeight = Math.max(720, 540 / scale)
+
+  return <>
+    <section className={`vstrike-panel${active ? '' : ' vstrike-parked'}${fullscreen ? ' vstrike-fullscreen' : ''}`} aria-hidden={!active}>
+      {!enabled ? settings : phase === 'loading' ? <EmptyState loading icon="graph" title="Opening VStrike…" /> : phase === 'error' ? <EmptyState error icon="alert" title="VStrike is unavailable" body={error}
+        primary={{ label: 'Reconnect', onClick: reconnect, icon: 'refresh' }} secondary={{ label: 'Configure VStrike', onClick: onConfigure, icon: 'gear' }} /> : <>
+        <div className="vstrike-toolbar">{controls}
+          <button className="btn ghost" disabled={!storyline || !networkLoaded || busy} onClick={() => void action(() => vstrikeApi.applyStoryline(network, storyline), 'apply the storyline')}>Apply</button>
+          <button className="btn ghost icon" title="Previous storyline frame" disabled={!storyline || !networkLoaded || busy} onClick={() => void action(() => vstrikeApi.step('backward'), 'step backward')}><Icon name="chevL" /></button>
+          <button className="btn ghost icon" title="Next storyline frame" disabled={!storyline || !networkLoaded || busy} onClick={() => void action(() => vstrikeApi.step('forward'), 'step forward')}><Icon name="chevR" /></button>
+          <button className="btn ghost" onClick={props.onOpenEvents}>VStrike events</button>
+          <button className="btn ghost" onClick={reconnect}><Icon name="refresh" size={14} />Reconnect</button>
+          <button className="btn ghost" onClick={() => setFullscreen((value) => !value)}>{fullscreen ? 'Exit expanded view' : 'Expand graph'}</button>
+        </div>
+        {request && <div className="vstrike-selection" aria-label="Requested graph selection" role="region">
+          <strong className="mono">{request.ips.join(' → ')}</strong>
+          <p role="status">{selection === 'pending' ? 'Requesting selection…' : selection === 'requested' ? 'Selection requested · VStrike has not confirmed highlighting or zoom.' : selection === 'error' ? 'Selection could not be requested.' : !network ? 'Choose the network containing these endpoints.' : networkLoaded ? 'Use Retry selection to request focus.' : 'Waiting for the VStrike view.'}</p>
+          <button className="btn ghost" disabled={!networkLoaded || !loaded || selection === 'pending' || busy} onClick={() => void select()}>Retry selection</button>
+          {request.findingId && <button className="btn ghost" onClick={() => props.onBackToFinding(request.findingId!)}>Back to finding</button>}
+          <button className="btn ghost" onClick={props.onBack}>Back to results</button>
+        </div>}
+        {error && <p role="alert" className="vstrike-error">{error}</p>}
+        <p className="vstrike-note">External VStrike network context. If the graph shows a login screen, use Reconnect.</p>
+        <div ref={surface} className="vstrike-frame" style={{ height: Math.max(540, frameHeight * scale) }}>
+          {url && <iframe ref={iframe} title="CloudCurrent VStrike network visualization" src={url} referrerPolicy="no-referrer"
+            onLoad={() => setLoaded(true)} style={{ width: frameWidth, height: frameHeight, transform: `scale(${scale})` }} />}
+        </div>
+      </>}
+    </section>
+    {eventsOpen && <FindingsDrawer title="VStrike events" onClose={onCloseEvents}>
+      {!enabled ? settings : phase === 'loading' ? <p>Opening VStrike…</p> : phase === 'error' ? <p role="alert">{error}</p> : <>{controls}<VStrikeEvents storylineId={storyline} onFocus={props.onFocus} /></>}
+    </FindingsDrawer>}
+  </>
+}

--- a/clients/web/src/integrations/vstrike/VStrikePanel.tsx
+++ b/clients/web/src/integrations/vstrike/VStrikePanel.tsx
@@ -22,7 +22,7 @@ interface Props {
 export default function VStrikePanel(props: Props) {
   const { active, request, eventsOpen, onCloseEvents, onConfigure } = props
   const { enabledIntegrations, loading: integrationsLoading } = useExtensions()
-  const enabled = enabledIntegrations.includes('vstrike')
+  const enabled = !integrationsLoading && enabledIntegrations.includes('vstrike')
   const [connection, setConnection] = useState(0)
   const [phase, setPhase] = useState<'loading' | 'ready' | 'error'>('loading')
   const [url, setUrl] = useState<string>()

--- a/clients/web/src/integrations/vstrike/api.ts
+++ b/clients/web/src/integrations/vstrike/api.ts
@@ -1,0 +1,43 @@
+import api from '../../services/api'
+
+export interface VStrikeFault {
+  event_id: string
+  occurred_at: string | null
+  label: string
+  description: string
+  source_level: string
+  ip4s: string[]
+  measurement: Record<string, string>
+}
+
+const root = '/integrations/vstrike'
+export const vstrikeApi = {
+  connect: () => api.post<{ iframe_url: string }>(`${root}/ui/iframe-token`),
+  networks: () => api.get<{ networks: unknown[] }>(`${root}/ui/networks`),
+  loadNetwork: (networkId: string) => api.post(`${root}/ui/load-network`, { network_id: networkId }),
+  storylines: (networkId: string) => api.get<{ storylines: unknown[] }>(`${root}/storylines`, { params: { network_id: networkId } }),
+  applyStoryline: (networkId: string, storylineId: string) => api.post(`${root}/ui/storyline-apply`, { network_id: networkId, storyline_id: storylineId }),
+  step: (direction: 'forward' | 'backward') => api.post(`${root}/ui/storyline-${direction}`),
+  focus: (networkId: string, ip4s: string[]) => api.post(`${root}/ui/find-by-ip-then-zoom`, { network_id: networkId, ip4s }),
+  faults: (storylineId: string) => api.post<{ faults: VStrikeFault[]; fetched_at: string; truncated: boolean; limit: number }>(`${root}/faults/query`, { storyline_id: storylineId, limit: 100 }),
+}
+
+export interface VStrikeOption { id: string; label: string }
+export function options(values: unknown, idKeys: string[]): VStrikeOption[] {
+  if (!Array.isArray(values)) return []
+  const unique = new Map<string, VStrikeOption>()
+  for (const item of values) {
+    if (!item || typeof item !== 'object') continue
+    const raw = item as Record<string, unknown>
+    const id = idKeys.map((key) => raw[key]).find((value) => typeof value === 'string' && value.trim())
+    if (typeof id !== 'string' || unique.has(id)) continue
+    const label = [raw.name, raw.label, raw.title, raw.description].find((value) => typeof value === 'string' && value.trim())
+    unique.set(id, { id, label: typeof label === 'string' ? label : id })
+  }
+  return [...unique.values()]
+}
+
+/** Don't surface raw provider errors: they may carry token URLs. */
+export function actionError(action: string): string {
+  return `Could not ${action}. Check VStrike configuration or reconnect and try again.`
+}

--- a/clients/web/src/screens/dashboard/DashboardScreen.test.tsx
+++ b/clients/web/src/screens/dashboard/DashboardScreen.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import DashboardScreen from './DashboardScreen'
+import { ToastProvider } from '../../shell/toast'
+import type { Finding } from '../../data/data'
+
+const state = vi.hoisted(() => ({ rows: [] as Finding[] }))
+vi.mock('./useFindings', () => ({
+  useFindings: () => ({ rows: state.rows, phase: 'ready', reload: vi.fn() }),
+  useDashboardKpis: () => ({ kpis: { findingsTotal: 41, findingsCritical: 30, findingsHigh: 10, casesTotal: 9, casesOpen: 2, casesInvestigating: 1 }, reload: vi.fn() }),
+}))
+vi.mock('./FindingPopup', () => ({ default: ({ id, onClose }: { id: string | null; onClose: () => void }) => id ? <section role="dialog" aria-label="Finding detail">{id}<button onClick={onClose}>Close finding</button></section> : null }))
+vi.mock('../../integrations/vstrike/VStrikePanel', () => ({ default: ({ active, request, onBack, onBackToFinding }: { active: boolean; request: { findingId: string }; onBack: () => void; onBackToFinding: (id: string) => void }) => active ? <section>Requested graph<button onClick={onBack}>Back to results</button><button onClick={() => onBackToFinding(request.findingId)}>Back to finding</button></section> : null }))
+const go = vi.fn()
+function mount() { return render(<MemoryRouter><ToastProvider><DashboardScreen openChat={vi.fn()} go={go} goSettings={vi.fn()} setViewFull={vi.fn()} /></ToastProvider></MemoryRouter>) }
+
+beforeEach(() => {
+  localStorage.clear(); vi.clearAllMocks()
+  state.rows = Array.from({ length: 40 }, (_, index) => ({ id: `synthetic-${index}`, title: `Example finding ${index}`, sev: index < 30 ? 'Critical' : 'High', tech: '—', conf: 0, tactic: '—', src: 'flow', host: '—', user: '—', time: '', ts: index, score: index / 40, status: 'open', sourceIp: '192.0.2.2', destinationIp: '198.51.100.10' }))
+  Object.defineProperty(HTMLDialogElement.prototype, 'showModal', { configurable: true, value() { this.setAttribute('open', '') } })
+  Object.defineProperty(HTMLDialogElement.prototype, 'close', { configurable: true, value() { this.removeAttribute('open') } })
+})
+
+describe('findings queue navigation', () => {
+  it('keeps filters, sort, page, and scroll through detail and graph', () => {
+    mount()
+    fireEvent.click(screen.getByRole('button', { name: 'Filter critical findings' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search findings' }), { target: { value: '192.0.2.2' } })
+    fireEvent.click(screen.getByRole('columnheader', { name: 'Score' }))
+    fireEvent.click(screen.getByTitle('Next page'))
+    expect(screen.getByText('11–20 of 30')).toBeVisible()
+    const table = screen.getByRole('table').parentElement!
+    table.scrollTop = 100; table.scrollLeft = 90; fireEvent.scroll(table)
+    fireEvent.click(screen.getByRole('button', { name: 'Example finding 19' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Close finding' }))
+    fireEvent.click(screen.getByRole('button', { name: 'View synthetic-19 endpoints in VStrike' }))
+    expect(screen.getByText('Requested graph')).toBeVisible()
+    fireEvent.click(screen.getByRole('button', { name: 'Back to finding' }))
+    expect(screen.getByRole('dialog')).toHaveTextContent('synthetic-19')
+    fireEvent.click(screen.getByRole('button', { name: 'Close finding' }))
+    expect(screen.getByText('11–20 of 30')).toBeVisible()
+    expect(screen.getByRole('textbox', { name: 'Search findings' })).toHaveValue('192.0.2.2')
+    expect(screen.getByText('Severity: critical ×')).toBeVisible()
+    expect(table.scrollTop).toBe(100); expect(table.scrollLeft).toBe(90)
+  })
+  it('separates columns from filtering and retains display preferences when clearing filters', () => {
+    mount()
+    fireEvent.click(screen.getByRole('button', { name: 'Columns' }))
+    const drawer = screen.getByRole('dialog', { name: 'Columns' })
+    fireEvent.click(within(drawer).getByRole('checkbox', { name: 'Host' }))
+    fireEvent(drawer, new Event('cancel', { bubbles: true }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Filter critical findings' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all filters' }))
+    expect(screen.getByRole('columnheader', { name: 'Host' })).toBeVisible()
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }))
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+  })
+  it('counts active cases without closed cases and opens the cases screen', () => {
+    mount()
+    const button = screen.getByRole('button', { name: 'Open active cases' })
+    expect(within(button).getByText('3')).toBeVisible()
+    fireEvent.click(button)
+    expect(go).toHaveBeenCalledWith('cases')
+  })
+  it('disables the inline action when there is no complete endpoint pair', () => {
+    state.rows[39].destinationIp = undefined
+    mount()
+    expect(screen.getByRole('button', { name: 'View synthetic-39 endpoints in VStrike' })).toBeDisabled()
+  })
+})

--- a/clients/web/src/screens/dashboard/DashboardScreen.test.tsx
+++ b/clients/web/src/screens/dashboard/DashboardScreen.test.tsx
@@ -6,6 +6,7 @@ import { ToastProvider } from '../../shell/toast'
 import type { Finding } from '../../data/data'
 
 const state = vi.hoisted(() => ({ rows: [] as Finding[] }))
+vi.mock('../../extensions/ExtensionProvider', () => ({ useExtensions: () => ({ enabledIntegrations: ['vstrike'], loading: false, extensions: [], mountPoints: [], reload: vi.fn() }) }))
 vi.mock('./useFindings', () => ({
   useFindings: () => ({ rows: state.rows, phase: 'ready', reload: vi.fn() }),
   useDashboardKpis: () => ({ kpis: { findingsTotal: 41, findingsCritical: 30, findingsHigh: 10, casesTotal: 9, casesOpen: 2, casesInvestigating: 1 }, reload: vi.fn() }),

--- a/clients/web/src/screens/dashboard/DashboardScreen.tsx
+++ b/clients/web/src/screens/dashboard/DashboardScreen.tsx
@@ -1,3 +1,4 @@
+import { useExtensions } from '../../extensions/ExtensionProvider'
 import VStrikePanel, { type GraphRequest } from '../../integrations/vstrike/VStrikePanel'
 import FindingsDrawer from './FindingsDrawer'
 import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
@@ -26,12 +27,22 @@ import {
 type DashTab = 'findings' | 'attack' | 'timeline' | 'vstrike'
 
 export default function DashboardScreen({ openChat, goSettings, go }: ConsoleScreenProps) {
+  const { enabledIntegrations, loading: integrationsLoading } = useExtensions()
+  const vstrikeEnabled = !integrationsLoading && enabledIntegrations.includes('vstrike')
   const [tab, setTab] = useState<DashTab>('findings')
   const [visitedVStrike, setVisitedVStrike] = useState(false)
   const [eventsOpen, setEventsOpen] = useState(false)
   const [graphRequest, setGraphRequest] = useState<GraphRequest | null>(null)
   const [detailId, setDetailId] = useState<string | null>(null)
   const requestSequence = useRef(0)
+  const activeTab = tab === 'vstrike' && !vstrikeEnabled ? 'findings' : tab
+  useEffect(() => {
+    if (vstrikeEnabled) return
+    setTab((value) => value === 'vstrike' ? 'findings' : value)
+    setVisitedVStrike(false)
+    setEventsOpen(false)
+    setGraphRequest(null)
+  }, [vstrikeEnabled])
   const showVStrike = (ips?: string[], findingId?: string) => {
     if (ips?.length) setGraphRequest({ id: ++requestSequence.current, ips, findingId })
     setVisitedVStrike(true); setEventsOpen(false); setDetailId(null); setTab('vstrike')
@@ -44,8 +55,8 @@ export default function DashboardScreen({ openChat, goSettings, go }: ConsoleScr
     ['findings', 'Findings'],
     ['attack', 'ATT&CK'],
     ['timeline', 'Timeline'],
-    ['vstrike', 'VStrike'],
   ]
+  if (vstrikeEnabled) tabs.push(['vstrike', 'VStrike'])
   return (
     <>
       <div className="flex items-center gap-3 flex-wrap px-[22px] py-[13px] border-b border-line tabbar">
@@ -54,8 +65,8 @@ export default function DashboardScreen({ openChat, goSettings, go }: ConsoleScr
             <button
               key={k}
               role="tab"
-              aria-selected={tab === k}
-              className={`tab${tab === k ? ' active' : ''}`}
+              aria-selected={activeTab === k}
+              className={`tab${activeTab === k ? ' active' : ''}`}
               onClick={() => { setDetailId(null); if (k === 'vstrike') showVStrike(); else setTab(k) }}
             >
               {label}
@@ -63,13 +74,13 @@ export default function DashboardScreen({ openChat, goSettings, go }: ConsoleScr
           ))}
         </div>
       </div>
-      <div hidden={tab !== 'findings'}>
-        <FindingsTab active={tab === 'findings'} openChat={openChat} goSettings={goSettings} go={go}
-          detailId={detailId} onDetail={setDetailId} onVStrike={openFindingGraph} onEvents={openEvents} />
+      <div hidden={activeTab !== 'findings'}>
+        <FindingsTab active={activeTab === 'findings'} openChat={openChat} goSettings={goSettings} go={go}
+          detailId={detailId} onDetail={setDetailId} onVStrike={vstrikeEnabled ? openFindingGraph : undefined} onEvents={vstrikeEnabled ? openEvents : undefined} />
       </div>
-      {tab === 'attack' && <AttackTab />}
-      {tab === 'timeline' && <TimelineTab />}
-      {visitedVStrike && <VStrikePanel active={tab === 'vstrike'} request={graphRequest} eventsOpen={eventsOpen}
+      {activeTab === 'attack' && <AttackTab />}
+      {activeTab === 'timeline' && <TimelineTab />}
+      {vstrikeEnabled && visitedVStrike && <VStrikePanel active={activeTab === 'vstrike'} request={graphRequest} eventsOpen={eventsOpen}
         onCloseEvents={() => setEventsOpen(false)} onOpenEvents={openEvents} onFocus={(ips) => showVStrike(ips)}
         onBack={() => setTab('findings')} onBackToFinding={(id) => { setTab('findings'); setDetailId(id) }}
         onConfigure={() => goSettings('integrations')} />}
@@ -88,7 +99,7 @@ function findingPrompt(f: Finding): string {
 }
 
 function FindingsTab({ openChat, goSettings, go, active, detailId, onDetail, onVStrike, onEvents }: Pick<ConsoleScreenProps, 'openChat' | 'goSettings' | 'go'> & {
-  active: boolean; detailId: string | null; onDetail: (id: string | null) => void; onVStrike: (finding: Finding) => void; onEvents: () => void
+  active: boolean; detailId: string | null; onDetail: (id: string | null) => void; onVStrike?: (finding: Finding) => void; onEvents?: () => void
 }) {
   const { notify } = useToast()
   const { rows, phase, error, reload } = useFindings()
@@ -251,7 +262,7 @@ function FindingsTab({ openChat, goSettings, go, active, detailId, onDetail, onV
 
         </FilterButton>
         <button className="btn ghost" onClick={() => setColumnsOpen(true)}>Columns</button>
-        <button className="btn ghost" onClick={onEvents}>VStrike events</button>
+        {onEvents && <button className="btn ghost" onClick={onEvents}>VStrike events</button>}
         <button className="btn ghost" onClick={() => openChat()}><Icon name="brain" />Ask Vigil</button>
         {columnsOpen && <FindingsDrawer title="Columns" onClose={() => setColumnsOpen(false)}>
           <p className="muted">Choose which fields appear in the findings queue.</p>

--- a/clients/web/src/screens/dashboard/DashboardScreen.tsx
+++ b/clients/web/src/screens/dashboard/DashboardScreen.tsx
@@ -1,3 +1,5 @@
+import VStrikePanel, { type GraphRequest } from '../../integrations/vstrike/VStrikePanel'
+import FindingsDrawer from './FindingsDrawer'
 import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Icon } from '../../shared/icons'
 import { Pie, Hbars } from '../../shared/charts'
@@ -21,15 +23,28 @@ import {
   saveFindingsViewPreferences,
 } from './findingsPreferences'
 
-type DashTab = 'findings' | 'attack' | 'timeline' | 'entity'
+type DashTab = 'findings' | 'attack' | 'timeline' | 'vstrike'
 
-export default function DashboardScreen({ openChat, goSettings }: ConsoleScreenProps) {
+export default function DashboardScreen({ openChat, goSettings, go }: ConsoleScreenProps) {
   const [tab, setTab] = useState<DashTab>('findings')
+  const [visitedVStrike, setVisitedVStrike] = useState(false)
+  const [eventsOpen, setEventsOpen] = useState(false)
+  const [graphRequest, setGraphRequest] = useState<GraphRequest | null>(null)
+  const [detailId, setDetailId] = useState<string | null>(null)
+  const requestSequence = useRef(0)
+  const showVStrike = (ips?: string[], findingId?: string) => {
+    if (ips?.length) setGraphRequest({ id: ++requestSequence.current, ips, findingId })
+    setVisitedVStrike(true); setEventsOpen(false); setDetailId(null); setTab('vstrike')
+  }
+  const openEvents = () => { setVisitedVStrike(true); setEventsOpen(true) }
+  const openFindingGraph = (finding: Finding) => {
+    if (finding.sourceIp && finding.destinationIp) showVStrike([finding.sourceIp, finding.destinationIp], finding.id)
+  }
   const tabs: [DashTab, string][] = [
     ['findings', 'Findings'],
     ['attack', 'ATT&CK'],
     ['timeline', 'Timeline'],
-    ['entity', 'Entity Graph'],
+    ['vstrike', 'VStrike'],
   ]
   return (
     <>
@@ -41,17 +56,23 @@ export default function DashboardScreen({ openChat, goSettings }: ConsoleScreenP
               role="tab"
               aria-selected={tab === k}
               className={`tab${tab === k ? ' active' : ''}`}
-              onClick={() => setTab(k)}
+              onClick={() => { setDetailId(null); if (k === 'vstrike') showVStrike(); else setTab(k) }}
             >
               {label}
             </button>
           ))}
         </div>
       </div>
-      {tab === 'findings' && <FindingsTab openChat={openChat} goSettings={goSettings} />}
+      <div hidden={tab !== 'findings'}>
+        <FindingsTab active={tab === 'findings'} openChat={openChat} goSettings={goSettings} go={go}
+          detailId={detailId} onDetail={setDetailId} onVStrike={openFindingGraph} onEvents={openEvents} />
+      </div>
       {tab === 'attack' && <AttackTab />}
       {tab === 'timeline' && <TimelineTab />}
-      {tab === 'entity' && <EntityStub />}
+      {visitedVStrike && <VStrikePanel active={tab === 'vstrike'} request={graphRequest} eventsOpen={eventsOpen}
+        onCloseEvents={() => setEventsOpen(false)} onOpenEvents={openEvents} onFocus={(ips) => showVStrike(ips)}
+        onBack={() => setTab('findings')} onBackToFinding={(id) => { setTab('findings'); setDetailId(id) }}
+        onConfigure={() => goSettings('integrations')} />}
     </>
   )
 }
@@ -66,7 +87,9 @@ function findingPrompt(f: Finding): string {
   return `Investigate finding ${f.id} — ${parts.join(', ')}. What happened and what should I do next?`
 }
 
-function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openChat' | 'goSettings'>) {
+function FindingsTab({ openChat, goSettings, go, active, detailId, onDetail, onVStrike, onEvents }: Pick<ConsoleScreenProps, 'openChat' | 'goSettings' | 'go'> & {
+  active: boolean; detailId: string | null; onDetail: (id: string | null) => void; onVStrike: (finding: Finding) => void; onEvents: () => void
+}) {
   const { notify } = useToast()
   const { rows, phase, error, reload } = useFindings()
   const { kpis, reload: reloadKpis } = useDashboardKpis()
@@ -74,9 +97,18 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
   const [query, setQuery] = useState('')
   const [sev, setSev] = useState(initialPreferences.severity)
   const [src, setSrc] = useState(initialPreferences.source)
-  const [detailId, setDetailId] = useState<string | null>(null)
   const [pageSize, setPageSize] = useState(10)
   const [page, setPage] = useState(1)
+  const [columnsOpen, setColumnsOpen] = useState(false)
+  const [columnQuery, setColumnQuery] = useState('')
+  const tableRef = useRef<HTMLDivElement>(null)
+  const savedScroll = useRef({ top: 0, left: 0 })
+  useLayoutEffect(() => {
+    if (active && tableRef.current) {
+      tableRef.current.scrollTop = savedScroll.current.top
+      tableRef.current.scrollLeft = savedScroll.current.left
+    }
+  }, [active])
   // null = untouched, so use each column's default visibility. An empty Set is
   // meaningfully different: the user unhid everything.
   const [hiddenCols, setHiddenCols] = useState<Set<string> | null>(
@@ -87,12 +119,13 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
   // code change here
   const allColumns = useMemo(() => {
     const base = baseFindingColumns(
-      (f) => setDetailId(f.id),
+      (f) => onDetail(f.id),
       (f) => openChat(findingPrompt(f)),
+      onVStrike,
     )
     const extra = extraFindingColumns(rows)
     return [...base.slice(0, -1), ...extra, base[base.length - 1]]
-  }, [rows, openChat])
+  }, [rows, openChat, onVStrike, onDetail])
 
   const defaultHidden = useMemo(
     () => new Set(allColumns.filter((c) => c.visible === false).map((c) => c.key)),
@@ -168,27 +201,27 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
 
   return (
     <>
-      <div className="grid grid-cols-4 border-b border-line">
-        <div className="relative flex flex-col gap-[3px] px-[22px] py-4 border-r border-line-soft last:border-r-0">
+      <div className="findings-kpis grid grid-cols-2 md:grid-cols-4 border-b border-line">
+        <button aria-label="Clear findings filters" onClick={() => { setQuery(''); setSev('any'); setSrc('any') }} className="text-left relative flex flex-col gap-[3px] px-[22px] py-4 border-r border-line-soft last:border-r-0">
           <span className="text-[11px] font-semibold tracking-[0.07em] uppercase text-tx-3 truncate">Total Findings</span>
           <div className="flex items-baseline gap-2.5"><span className="text-[30px] font-semibold tracking-[-0.02em] leading-[1.1]">{kpi(kpis?.findingsTotal)}</span></div>
           <span className="text-xs text-tx-faint">{kpis ? `${kpis.findingsCritical} critical · ${kpis.findingsHigh} high` : ' '}</span>
-        </div>
-        <div className="relative flex flex-col gap-[3px] px-[22px] py-4 border-r border-line-soft last:border-r-0">
+        </button>
+        <button aria-label="Open active cases" onClick={() => { go('cases') }} className="text-left relative flex flex-col gap-[3px] px-[22px] py-4 border-r border-line-soft last:border-r-0">
           <span className="text-[11px] font-semibold tracking-[0.07em] uppercase text-tx-3 truncate">Active Cases</span>
-          <div className="flex items-baseline gap-2.5"><span className="text-[30px] font-semibold tracking-[-0.02em] leading-[1.1]">{kpi(kpis?.casesTotal)}</span></div>
+          <div className="flex items-baseline gap-2.5"><span className="text-[30px] font-semibold tracking-[-0.02em] leading-[1.1]">{kpi(kpis ? kpis.casesOpen + kpis.casesInvestigating : undefined)}</span></div>
           <span className="text-xs text-tx-faint">{kpis ? `${kpis.casesOpen} open · ${kpis.casesInvestigating} investigating` : ' '}</span>
-        </div>
-        <div className="relative flex flex-col gap-[3px] px-[22px] py-4 border-r border-line-soft last:border-r-0">
+        </button>
+        <button aria-label="Filter critical findings" onClick={() => { setSev((value) => value === 'critical' ? 'any' : 'critical') }} className="text-left relative flex flex-col gap-[3px] px-[22px] py-4 border-r border-line-soft last:border-r-0">
           <span className="text-[11px] font-semibold tracking-[0.07em] uppercase text-tx-3 truncate">Critical Alerts</span>
           <div className="flex items-baseline gap-2.5"><span className="text-[30px] font-semibold tracking-[-0.02em] leading-[1.1] text-crit">{kpi(kpis?.findingsCritical)}</span></div>
           <span className="text-xs text-tx-faint">requires immediate attention</span>
-        </div>
-        <div className="relative flex flex-col gap-[3px] px-[22px] py-4 border-r border-line-soft last:border-r-0">
+        </button>
+        <button aria-label="Filter high findings" onClick={() => { setSev((value) => value === 'high' ? 'any' : 'high') }} className="text-left relative flex flex-col gap-[3px] px-[22px] py-4 border-r border-line-soft last:border-r-0">
           <span className="text-[11px] font-semibold tracking-[0.07em] uppercase text-tx-3 truncate">High Priority</span>
           <div className="flex items-baseline gap-2.5"><span className="text-[30px] font-semibold tracking-[-0.02em] leading-[1.1] text-high">{kpi(kpis?.findingsHigh)}</span></div>
           <span className="text-xs text-tx-faint">review within 24h</span>
-        </div>
+        </button>
       </div>
 
       <div className="flex items-center gap-3 flex-wrap px-[22px] py-[13px] border-b border-line">
@@ -198,7 +231,7 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
         </div>
         <FilterButton
           activeCount={(sev !== 'any' ? 1 : 0) + (src !== 'any' ? 1 : 0)}
-          onClearAll={() => { setSev('any'); setSrc('any'); setHiddenCols(null) }}
+          onClearAll={() => { setSev('any'); setSrc('any') }}
         >
           <FilterGroup
             label="Severity"
@@ -215,8 +248,16 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
             ]}
           />
           <FilterGroup label="Source" value={src} onSelect={setSrc} options={srcOptions} />
+
+        </FilterButton>
+        <button className="btn ghost" onClick={() => setColumnsOpen(true)}>Columns</button>
+        <button className="btn ghost" onClick={onEvents}>VStrike events</button>
+        <button className="btn ghost" onClick={() => openChat()}><Icon name="brain" />Ask Vigil</button>
+        {columnsOpen && <FindingsDrawer title="Columns" onClose={() => setColumnsOpen(false)}>
+          <p className="muted">Choose which fields appear in the findings queue.</p>
+          <div className="search"><input aria-label="Search columns" placeholder="Search columns…" value={columnQuery} onChange={(event) => setColumnQuery(event.target.value)} /></div>
           <ColumnPicker
-            columns={allColumns}
+            columns={allColumns.filter((column) => column.label.toLowerCase().includes(columnQuery.toLowerCase()))}
             hidden={effectiveHidden}
             onToggle={(key) => setHiddenCols((h) => {
               const next = new Set(h ?? defaultHidden)
@@ -225,7 +266,8 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
               return next
             })}
           />
-        </FilterButton>
+          <button className="btn ghost" onClick={() => setHiddenCols(null)}>Restore default columns</button>
+        </FindingsDrawer>}
         <div className="flex-1" />
         <button className="btn ghost icon" title="Refresh" onClick={refresh}><Icon name="refresh" /></button>
         <button
@@ -236,7 +278,14 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
         ><Icon name="download" /> Export</button>
       </div>
 
-      <div className="table-wrap list-scroll list-scroll-kpi">
+      {(query || sev !== 'any' || src !== 'any') && <div className="findings-chips">
+        {query && <button className="chip" onClick={() => setQuery('')}>Search: {query} ×</button>}
+        {sev !== 'any' && <button className="chip" onClick={() => setSev('any')}>Severity: {sev} ×</button>}
+        {src !== 'any' && <button className="chip" onClick={() => setSrc('any')}>Source: {src} ×</button>}
+        <button className="btn ghost" onClick={() => { setQuery(''); setSev('any'); setSrc('any') }}>Clear all filters</button>
+      </div>}
+      <div className="table-wrap list-scroll list-scroll-kpi" ref={tableRef}
+        onScroll={(event) => { if (active) savedScroll.current = { top: event.currentTarget.scrollTop, left: event.currentTarget.scrollLeft } }}>
         <DataTable
           columns={columns}
           rows={paged}
@@ -245,7 +294,7 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
           error={error}
           sort={sort}
           onSort={toggleSort}
-          onRowClick={(f) => setDetailId(f.id)}
+          onRowClick={(f) => onDetail(f.id)}
           onRetry={refresh}
           className="tbl findings-tbl"
           loadingMessage={<EmptyState loading table compact icon="search" title="Loading findings…" />}
@@ -288,7 +337,7 @@ function FindingsTab({ openChat, goSettings }: Pick<ConsoleScreenProps, 'openCha
           ><Icon name="chevR" size={14} /></button>
         </span>
       </div>
-      <FindingPopup id={detailId} onClose={() => setDetailId(null)} onChanged={() => { reload(); reloadKpis() }} onConfigureAi={() => goSettings('ai-config')} />
+      <FindingPopup id={active ? detailId : null} onOpenInVStrike={onVStrike} onClose={() => onDetail(null)} onChanged={() => { reload(); reloadKpis() }} onConfigureAi={() => goSettings('ai-config')} />
     </>
   )
 }
@@ -414,17 +463,6 @@ function AttackTab() {
   )
 }
 
-function EntityStub() {
-  return (
-    <div className="entity-empty">
-      <EmptyState
-        icon="graph"
-        title="No entity graph yet"
-        body="Host, user, and source relationships appear here once findings include entity fields."
-      />
-    </div>
-  )
-}
 
 const DAY = 86400000
 

--- a/clients/web/src/screens/dashboard/FindingPopup.tsx
+++ b/clients/web/src/screens/dashboard/FindingPopup.tsx
@@ -1,5 +1,6 @@
-/* The embedded VStrike NetworkContextPanel is deliberately not ported: it needs
-   the VStrike provider, which isn't mounted under the console shell. */
+import FindingVStrikeAction from './FindingVStrikeAction'
+import { findingTitle } from '../../data/findingPresentation'
+import type { Finding } from '../../data/data'
 import { useEffect, useState } from 'react'
 import { findingsApi } from '../../services/api'
 import { mapApiFinding, formatFindingScore, type ApiFinding } from '../../data/mappers'
@@ -161,11 +162,13 @@ export default function FindingPopup({
   onClose,
   onChanged,
   onConfigureAi,
+  onOpenInVStrike,
 }: {
   id: string | null
   onClose: () => void
   onChanged?: () => void
   onConfigureAi?: () => void
+  onOpenInVStrike?: (finding: Finding) => void
 }) {
   const [raw, setRaw] = useState<RawFinding | null>(null)
   const [phase, setPhase] = useState<Phase>('loading')
@@ -318,11 +321,17 @@ export default function FindingPopup({
             </div>
           </div>
 
+          <div className="finding-context-summary">
+            <h3>{findingTitle(f)}</h3>
+            <p className="mono">{f.sourceIp || 'Source IPv4 unavailable'} → {f.destinationIp || 'Destination IPv4 unavailable'}</p>
+            {sourceEvidence?.status === 'available' && <p>{sourceEvidence.totalRecords} source records{sourceEvidence.truncated ? ' · preview truncated' : ''}</p>}
+            {onOpenInVStrike && <FindingVStrikeAction finding={f} onOpen={onOpenInVStrike} />}
+          </div>
           <div className="kv-grid fp-grid">
             <span className="k">Source</span><span className="v"><SourceChip source={f.src} /></span>
             <span className="k">Host</span><span className="v mono">{f.host}</span>
             <span className="k">User</span><span className="v mono">{f.user}</span>
-            <span className="k">Time</span><span className="v">{f.time}</span>
+            <span className="k">Time (UTC)</span><span className="v">{f.time}</span>
             <span className="k">Status</span>
             <span className="v" style={{ maxWidth: 220 }}>
               <Select value={status} options={STATUS_OPTIONS} onSelect={changeStatus} />

--- a/clients/web/src/screens/dashboard/FindingVStrikeAction.tsx
+++ b/clients/web/src/screens/dashboard/FindingVStrikeAction.tsx
@@ -1,0 +1,10 @@
+import type { Finding } from '../../data/data'
+import { Icon } from '../../shared/icons'
+
+export default function FindingVStrikeAction({ finding, onOpen }: { finding: Finding; onOpen: (finding: Finding) => void }) {
+  const valid = Boolean(finding.sourceIp && finding.destinationIp)
+  return <button className="btn ghost finding-vstrike" disabled={!valid}
+    aria-label={`View ${finding.id} endpoints in VStrike`}
+    title={valid ? 'Open source and destination in VStrike' : 'A single source and destination IPv4 address are required'}
+    onClick={(event) => { event.stopPropagation(); onOpen(finding) }}><Icon name="graph" size={14} />VStrike</button>
+}

--- a/clients/web/src/screens/dashboard/FindingsDrawer.tsx
+++ b/clients/web/src/screens/dashboard/FindingsDrawer.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useId, useRef, type ReactNode } from 'react'
+import { Icon } from '../../shared/icons'
+
+export default function FindingsDrawer({ title, onClose, children }: { title: string; onClose: () => void; children: ReactNode }) {
+  const ref = useRef<HTMLDialogElement>(null)
+  const id = useId()
+  useEffect(() => {
+    const dialog = ref.current
+    const opener = document.activeElement
+    dialog?.showModal()
+    return () => {
+      dialog?.close()
+      if (opener instanceof HTMLElement && opener.isConnected) opener.focus()
+    }
+  }, [])
+  return <dialog ref={ref} className="findings-drawer" aria-labelledby={id} onCancel={(event) => { event.preventDefault(); onClose() }}>
+    <header><h2 id={id}>{title}</h2><button className="btn ghost icon" aria-label={`Close ${title}`} onClick={onClose}><Icon name="close" /></button></header>
+    <div className="findings-drawer-body">{children}</div>
+  </dialog>
+}

--- a/clients/web/src/screens/dashboard/SourceEvidenceSection.tsx
+++ b/clients/web/src/screens/dashboard/SourceEvidenceSection.tsx
@@ -1,11 +1,11 @@
+import { sourceTime, sourceTimestamp } from '../../data/findingPresentation'
 import { SOURCE_TELEMETRY_LABELS, type SourceEvidence } from '../../data/sourceEvidence'
 import type { ReactNode } from 'react'
 
 const EMPTY = '—'
 
 function displayValue(value: unknown): string {
-  if (value === null) return 'null'
-  if (value === undefined || value === '') return EMPTY
+  if (value == null || value === '') return EMPTY
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return String(value)
   try {
     return JSON.stringify(value)
@@ -33,13 +33,13 @@ function NetFlowTable({ evidence }: { evidence: SourceEvidence }) {
       <table className="source-evidence-table">
         <caption className="sr-only">NetFlow records attached to this finding</caption>
         <thead><tr>
-          <th scope="col">Time</th><th scope="col">Source</th><th scope="col">Destination</th>
+          <th scope="col">Time (UTC)</th><th scope="col">Source</th><th scope="col">Destination</th>
           <th scope="col">Protocol</th><th scope="col">Packets F/B</th>
           <th scope="col">Bytes F/B</th><th scope="col">Duration</th>
         </tr></thead>
         <tbody>{evidence.records.map((record, index) => (
           <tr key={`${displayValue(record.timestamp)}-${index}`}>
-            <td className="mono">{displayValue(record.timestamp)}</td>
+            <td className="mono">{sourceTime(typeof record.timestamp === 'string' ? record.timestamp : undefined)}</td>
             <td className="mono">{endpoint(record.source_ip, record.source_port)}</td>
             <td className="mono">{endpoint(record.destination_ip, record.destination_port)}</td>
             <td className="mono">{displayValue(record.protocol)}</td>
@@ -59,13 +59,13 @@ function DnsTable({ evidence }: { evidence: SourceEvidence }) {
       <table className="source-evidence-table">
         <caption className="sr-only">DNS records attached to this finding</caption>
         <thead><tr>
-          <th scope="col">Time</th><th scope="col">Client</th><th scope="col">Server</th>
+          <th scope="col">Time (UTC)</th><th scope="col">Client</th><th scope="col">Server</th>
           <th scope="col">Query</th><th scope="col">Type</th><th scope="col">Answer</th>
           <th scope="col">Rcode</th><th scope="col">TTL</th>
         </tr></thead>
         <tbody>{evidence.records.map((record, index) => (
           <tr key={`${displayValue(record.timestamp)}-${displayValue(record.query)}-${index}`}>
-            <td className="mono">{displayValue(record.timestamp)}</td>
+            <td className="mono">{sourceTime(typeof record.timestamp === 'string' ? record.timestamp : undefined)}</td>
             <td className="mono">{displayValue(record.client_ip)}</td>
             <td className="mono">{displayValue(record.server_ip)}</td>
             <td className="mono">{displayValue(record.query)}</td>
@@ -123,6 +123,9 @@ export function SourceEvidenceSection({ evidence }: { evidence?: SourceEvidence 
     )
   }
 
+  evidence = { ...evidence, records: [...evidence.records].sort((left, right) =>
+    (sourceTimestamp(typeof left.timestamp === 'string' ? left.timestamp : undefined) ?? Number.POSITIVE_INFINITY)
+    - (sourceTimestamp(typeof right.timestamp === 'string' ? right.timestamp : undefined) ?? Number.POSITIVE_INFINITY)) }
   const recordCount = evidence.records.length
   const countLabel = evidence.totalRecords > 0
     ? `${recordCount} of ${evidence.totalRecords} records`

--- a/clients/web/src/screens/dashboard/VStrikeAvailability.test.tsx
+++ b/clients/web/src/screens/dashboard/VStrikeAvailability.test.tsx
@@ -1,0 +1,130 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { ExtensionProvider, useExtensions } from '../../extensions/ExtensionProvider'
+import { mapApiFinding } from '../../data/mappers'
+import { ToastProvider } from '../../shell/toast'
+import DashboardScreen from './DashboardScreen'
+
+const mocks = vi.hoisted(() => ({
+  config: vi.fn(), finding: vi.fn(), connect: vi.fn(), networks: vi.fn(),
+  storylines: vi.fn(), loadNetwork: vi.fn(), focus: vi.fn(), faults: vi.fn(),
+}))
+vi.mock('../../services/api', () => ({
+  default: {},
+  configApi: { getIntegrations: mocks.config },
+  findingsApi: { getById: mocks.finding },
+}))
+vi.mock('../../integrations/vstrike/api', async (original) => ({
+  ...await original<typeof import('../../integrations/vstrike/api')>(), vstrikeApi: mocks,
+}))
+const rawFinding = {
+  finding_id: 'synthetic-availability', title: 'Example flow', severity: 'high',
+  data_source: 'flow', timestamp: '2026-01-02T12:00:00Z', anomaly_score: 0.8,
+  status: 'open', entity_context: { source_ip: '192.0.2.2', destination_ip: '198.51.100.10' },
+}
+const rows = [mapApiFinding(rawFinding)]
+vi.mock('./useFindings', () => ({
+  useFindings: () => ({ rows, phase: 'ready', reload: vi.fn() }),
+  useDashboardKpis: () => ({ kpis: undefined, reload: vi.fn() }),
+}))
+
+function RefreshIntegrationSettings() {
+  const { reload } = useExtensions()
+  return <button onClick={reload}>Refresh integration settings</button>
+}
+function mount() {
+  return render(<ExtensionProvider><MemoryRouter><ToastProvider>
+    <RefreshIntegrationSettings />
+    <DashboardScreen openChat={vi.fn()} go={vi.fn()} goSettings={vi.fn()} setViewFull={vi.fn()} />
+  </ToastProvider></MemoryRouter></ExtensionProvider>)
+}
+function expectNoVStrike() {
+  expect(screen.queryByRole('tab', { name: 'VStrike' })).not.toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: /VStrike/ })).not.toBeInTheDocument()
+  expect(screen.queryByTitle('CloudCurrent VStrike network visualization')).not.toBeInTheDocument()
+}
+function settingsUnavailable(state: string) {
+  if (state === 'loading') mocks.config.mockImplementation(() => new Promise(() => {}))
+  else if (state === 'failed') mocks.config.mockRejectedValue(new Error('Configuration unavailable'))
+  else mocks.config.mockResolvedValue({ data: { enabled_integrations: ['unrelated-integration'] } })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks(); localStorage.clear()
+  mocks.config.mockResolvedValue({ data: { enabled_integrations: ['vstrike'] } })
+  mocks.finding.mockResolvedValue({ data: rawFinding })
+  mocks.connect.mockResolvedValue({ data: { iframe_url: 'https://vstrike.example.test/login?token=synthetic' } })
+  mocks.networks.mockResolvedValue({ data: { networks: [{ id: 'network-1', name: 'Example network' }] } })
+  mocks.storylines.mockResolvedValue({ data: { storylines: [{ id: 'storyline-1', name: 'Example scenario' }] } })
+  mocks.loadNetwork.mockResolvedValue({}); mocks.focus.mockResolvedValue({})
+  mocks.faults.mockResolvedValue({ data: { faults: [], fetched_at: '2026-01-02T12:00:00Z', truncated: false } })
+  vi.stubGlobal('ResizeObserver', class { observe() {} disconnect() {} })
+  Object.defineProperty(HTMLDialogElement.prototype, 'showModal', { configurable: true, value() { this.setAttribute('open', '') } })
+  Object.defineProperty(HTMLDialogElement.prototype, 'close', { configurable: true, value() { this.removeAttribute('open') } })
+})
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals() })
+
+describe('VStrike integration availability', () => {
+  it.each(['disabled', 'loading', 'failed'])('hides every entry point and sends no provider requests when settings are %s', async (state) => {
+    settingsUnavailable(state)
+    mount()
+    await act(async () => {})
+    expectNoVStrike()
+    fireEvent.click(screen.getByRole('button', { name: 'Example flow' }))
+    const detail = await screen.findByRole('dialog')
+    await within(detail).findByRole('heading', { name: 'Example flow' })
+    expectNoVStrike()
+    expect(mocks.connect).not.toHaveBeenCalled()
+    expect(mocks.networks).not.toHaveBeenCalled()
+    expect(mocks.faults).not.toHaveBeenCalled()
+  })
+
+  it('restores entry points when enabled and opens the graph from real finding details', async () => {
+    settingsUnavailable('disabled')
+    mount()
+    await act(async () => {})
+    expectNoVStrike()
+    mocks.config.mockResolvedValue({ data: { enabled_integrations: ['vstrike'] } })
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh integration settings' }))
+    expect(await screen.findByRole('tab', { name: 'VStrike' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'VStrike events' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'View synthetic-availability endpoints in VStrike' })).toBeEnabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Example flow' }))
+    const detail = await screen.findByRole('dialog')
+    fireEvent.click(await within(detail).findByRole('button', { name: /endpoints in VStrike/ }))
+    expect(await screen.findByTitle('CloudCurrent VStrike network visualization')).toBeVisible()
+    expect(screen.getByRole('tab', { name: 'VStrike' })).toHaveAttribute('aria-selected', 'true')
+    expect(mocks.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['disabled', 'loading', 'failed'])('closes active graph/events, ignores a late read, and preserves the queue when settings become %s', async (state) => {
+    mount()
+    await screen.findByRole('tab', { name: 'VStrike' })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search findings' }), { target: { value: '192.0.2.2' } })
+    fireEvent.click(screen.getByRole('button', { name: /endpoints in VStrike/ }))
+    const frame = await screen.findByTitle('CloudCurrent VStrike network visualization') as HTMLIFrameElement
+    fireEvent.load(frame)
+    fireEvent(window, new MessageEvent('message', { origin: 'https://vstrike.example.test', source: frame.contentWindow, data: { type: 'vstrike:state', networkId: 'network-1' } }))
+    await waitFor(() => expect(mocks.focus).toHaveBeenCalledTimes(1))
+    let finishRead: (value: unknown) => void = () => {}
+    mocks.faults.mockImplementationOnce(() => new Promise((resolve) => { finishRead = resolve }))
+    fireEvent.click(screen.getByRole('button', { name: 'VStrike events' }))
+    await screen.findByRole('dialog', { name: 'VStrike events' })
+    expect(mocks.faults).toHaveBeenCalledTimes(1)
+    settingsUnavailable(state)
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh integration settings' }))
+    await act(async () => {})
+    expectNoVStrike()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Findings' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('textbox', { name: 'Search findings' })).toHaveValue('192.0.2.2')
+    vi.useFakeTimers()
+    await act(async () => { finishRead({ data: { faults: [], fetched_at: '2026-01-02T12:00:00Z', truncated: false } }) })
+    await act(async () => { vi.advanceTimersByTime(20_000) })
+    expect(mocks.faults).toHaveBeenCalledTimes(1)
+    expect(mocks.connect).toHaveBeenCalledTimes(1)
+    expect(mocks.focus).toHaveBeenCalledTimes(1)
+    expect(mocks.loadNetwork).not.toHaveBeenCalled()
+  })
+})

--- a/clients/web/src/screens/dashboard/findingsColumns.test.ts
+++ b/clients/web/src/screens/dashboard/findingsColumns.test.ts
@@ -37,10 +37,10 @@ describe('adaptive findings columns', () => {
     expect(deviceCol.render(splunk)).toMatchObject({ props: { children: '—' } })
   })
 
-  it('preserves the default 11-column view', () => {
+  it('provides the endpoint column and keeps detailed fields optional', () => {
     const base = baseFindingColumns(() => {}, () => {})
-    expect(base).toHaveLength(11)
+    expect(base).toHaveLength(12)
     expect(base.filter((c) => c.sortVal).map((c) => c.key)).toEqual(['sev', 'time', 'score', 'status'])
-    expect(base.filter((c) => c.searchVal).map((c) => c.key)).toEqual(['id', 'tech', 'src', 'host', 'user'])
+    expect(base.filter((c) => c.searchVal).map((c) => c.key)).toEqual(['id', 'tech', 'endpoints', 'src', 'host', 'user'])
   })
 })

--- a/clients/web/src/screens/dashboard/findingsColumns.tsx
+++ b/clients/web/src/screens/dashboard/findingsColumns.tsx
@@ -1,3 +1,5 @@
+import FindingVStrikeAction from './FindingVStrikeAction'
+import { findingTitle } from '../../data/findingPresentation'
 import { Icon } from '../../shared/icons'
 import SourceChip from '../../shared/SourceChip'
 import type { ColumnDef } from '../../shared/DataTable'
@@ -23,12 +25,13 @@ function labelFor(key: string): string {
 export function baseFindingColumns(
   onView: (f: Finding) => void,
   onInvestigate: (f: Finding) => void,
+  onVStrike?: (f: Finding) => void,
 ): ColumnDef<Finding>[] {
   return [
     {
-      key: 'id', label: 'Finding ID',
-      render: (f) => <span className="id-cell">{f.id}</span>,
-      searchVal: (f) => f.id,
+      key: 'id', label: 'Finding',
+      render: (f) => <span className="finding-title-cell"><button onClick={(event) => { event.stopPropagation(); onView(f) }}>{findingTitle(f)}</button><small className="mono muted">{f.id}</small></span>,
+      searchVal: (f) => `${f.id} ${findingTitle(f)}`,
     },
     {
       key: 'sev', label: 'Severity',
@@ -36,28 +39,33 @@ export function baseFindingColumns(
       sortVal: (f) => SEV_RANK[f.sev], defaultDir: 'desc',
     },
     {
-      key: 'tech', label: 'MITRE Technique',
+      key: 'tech', label: 'MITRE Technique', visible: false,
       render: (f) => <><span className="tag">{f.tech}</span> <span className="muted">{f.conf}%</span></>,
       searchVal: (f) => f.tech,
     },
-    { key: 'tactic', label: 'Tactic', render: (f) => f.tactic },
+    { key: 'tactic', label: 'Tactic', visible: false, render: (f) => f.tactic },
+    {
+      key: 'endpoints', label: 'Endpoints',
+      render: (f) => <span className="mono">{f.sourceIp || NDASH} → {f.destinationIp || NDASH}</span>,
+      searchVal: (f) => `${f.sourceIp || ''} ${f.destinationIp || ''}`,
+    },
     {
       key: 'src', label: 'Source',
       render: (f) => <SourceChip source={f.src} />,
       searchVal: (f) => f.src,
     },
     {
-      key: 'host', label: 'Host',
+      key: 'host', label: 'Host', visible: false,
       render: (f) => <span className="mono">{f.host}</span>,
       searchVal: (f) => f.host,
     },
     {
-      key: 'user', label: 'User',
+      key: 'user', label: 'User', visible: false,
       render: (f) => <span className="mono muted">{f.user}</span>,
       searchVal: (f) => f.user,
     },
     {
-      key: 'time', label: 'Time',
+      key: 'time', label: 'Time (UTC)',
       render: (f) => <span className="muted">{f.time}</span>,
       sortVal: timeKey, defaultDir: 'desc',
     },
@@ -84,9 +92,11 @@ export function baseFindingColumns(
     {
       key: 'actions', label: 'Actions', headless: true,
       render: (f) => (
-        <span className="row-act">
+        <span className="finding-actions">
+          {onVStrike && <FindingVStrikeAction finding={f} onOpen={onVStrike} />}
+          <span className="row-act">
           <button title="View" onClick={(e) => { e.stopPropagation(); onView(f) }}><Icon name="eye" /></button>
-          <button title="Investigate with Vigil" onClick={(e) => { e.stopPropagation(); onInvestigate(f) }}><Icon name="brain" /></button>
+          <button title="Investigate with Vigil" onClick={(e) => { e.stopPropagation(); onInvestigate(f) }}><Icon name="brain" /></button></span>
         </span>
       ),
     },

--- a/clients/web/src/services/generated/schema.d.ts
+++ b/clients/web/src/services/generated/schema.d.ts
@@ -4584,6 +4584,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/integrations/vstrike/faults/query": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Query Faults
+         * @description Read a bounded external event page. This route never writes findings.
+         */
+        post: operations["post_api_integrations_vstrike_faults_query"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/integrations/vstrike/findings": {
         parameters: {
             query?: never;
@@ -4868,6 +4888,26 @@ export interface paths {
          * @description Set the camera position and rotation explicitly.
          */
         post: operations["post_api_integrations_vstrike_ui_camera-position"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/integrations/vstrike/ui/find-by-ip-then-zoom": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Ui Find By Ip Then Zoom
+         * @description Forward an explicit selection request without asserting visual success.
+         */
+        post: operations["post_api_integrations_vstrike_ui_find-by-ip-then-zoom"];
         delete?: never;
         options?: never;
         head?: never;
@@ -10796,6 +10836,16 @@ export interface components {
                 [key: string]: unknown;
             } | null;
         };
+        /** VStrikeFaultQueryRequest */
+        VStrikeFaultQueryRequest: {
+            /**
+             * Limit
+             * @default 100
+             */
+            limit: number;
+            /** Storyline Id */
+            storyline_id: string;
+        };
         /**
          * VStrikeFinding
          * @description A single finding pushed from VStrike.
@@ -10843,6 +10893,13 @@ export interface components {
              * @enum {string}
              */
             status: "updated" | "created" | "failed";
+        };
+        /** VStrikeFocusRequest */
+        VStrikeFocusRequest: {
+            /** Ip4S */
+            ip4s: string[];
+            /** Network Id */
+            network_id: string;
         };
         /**
          * VStrikeHealthResponse
@@ -18733,6 +18790,43 @@ export interface operations {
             };
         };
     };
+    post_api_integrations_vstrike_faults_query: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VStrikeFaultQueryRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     post_api_integrations_vstrike_findings: {
         parameters: {
             query?: never;
@@ -19208,6 +19302,43 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["VStrikeCameraPositionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    "post_api_integrations_vstrike_ui_find-by-ip-then-zoom": {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VStrikeFocusRequest"];
             };
         };
         responses: {

--- a/clients/web/src/shell/SocConsole.test.tsx
+++ b/clients/web/src/shell/SocConsole.test.tsx
@@ -225,14 +225,14 @@ describe('SocConsole', () => {
     }
   })
 
-  it('switches every Dashboard tab including the interactive Timeline', async () => {
+  it('switches the available Dashboard tabs and hides VStrike when disabled', async () => {
     renderConsole()
     fireEvent.click(screen.getByRole('tab', { name: 'ATT&CK' }))
     expect(screen.getByText(/Techniques by occurrence/)).toBeInTheDocument()
     fireEvent.click(screen.getByRole('tab', { name: 'Timeline' }))
     expect(await screen.findByText(/events$/)).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('tab', { name: 'VStrike' }))
-    expect(await screen.findByRole('button', { name: 'Configure VStrike' })).toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: 'VStrike' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /VStrike/ })).not.toBeInTheDocument()
   })
 
   it('restores and clears versioned findings preferences', async () => {

--- a/clients/web/src/shell/SocConsole.test.tsx
+++ b/clients/web/src/shell/SocConsole.test.tsx
@@ -231,8 +231,8 @@ describe('SocConsole', () => {
     expect(screen.getByText(/Techniques by occurrence/)).toBeInTheDocument()
     fireEvent.click(screen.getByRole('tab', { name: 'Timeline' }))
     expect(await screen.findByText(/events$/)).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('tab', { name: 'Entity Graph' }))
-    expect(screen.getByText('No entity graph yet')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('tab', { name: 'VStrike' }))
+    expect(await screen.findByRole('button', { name: 'Configure VStrike' })).toBeInTheDocument()
   })
 
   it('restores and clears versioned findings preferences', async () => {

--- a/clients/web/src/shell/SocConsole.tsx
+++ b/clients/web/src/shell/SocConsole.tsx
@@ -358,7 +358,7 @@ function SocConsoleInner() {
           (the dock has its own close control, so showing both is redundant) and
           while a full-bleed detail view is open (e.g. a case detail, which has
           its own "Open in Vigil" action — two Vigil buttons would be redundant) */}
-      {!chatOpen && !viewFull && (
+      {!chatOpen && !viewFull && current !== 'dashboard' && (
         <button
           className="chat-fab"
           title="Ask Vigil - AI assistant"

--- a/clients/web/src/styles.css
+++ b/clients/web/src/styles.css
@@ -6868,3 +6868,54 @@
 .hunt-hero-example:hover { border-color: var(--accent-line); color: var(--tx); background: var(--bg-2); }
 .hunt-hero-example svg { flex: 0 0 auto; color: var(--accent-2); }
 .hunt-hero-tip { margin-top: 16px; font-size: 12px; line-height: 1.5; max-width: 460px; }
+
+/* Findings queue and optional external network context. */
+.finding-title-cell { display: grid; gap: 4px; min-width: 190px; max-width: 340px; white-space: normal; }
+.finding-title-cell > button { text-align: left; font-weight: 600; color: var(--tx); }
+.finding-title-cell > small { font-size: 11px; overflow-wrap: anywhere; }
+.finding-actions { display: inline-flex; align-items: center; gap: 8px; }
+.finding-actions .row-act { display: inline-flex; }
+.finding-vstrike { white-space: nowrap; }
+.findings-tbl td:last-child, .findings-tbl th:last-child { position: sticky; right: 0; background: var(--panel); z-index: 1; }
+.findings-chips { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 8px 22px; border-bottom: 1px solid var(--line); }
+.finding-context-summary { margin: 12px 0 20px; padding: 16px; border: 1px solid var(--line); border-radius: 10px; overflow-wrap: anywhere; }
+.finding-context-summary h3 { margin: 0; font-size: 16px; }
+.findings-drawer { position: fixed; inset: 0 0 0 auto; margin: 0; height: 100dvh; max-height: 100dvh; width: min(540px, 100vw); max-width: 100vw; color: var(--tx, #20232a); background: var(--panel, #fff); border: 0; border-left: 1px solid var(--line, #ddd); padding: 0; box-shadow: -10px 0 50px #0002; }
+.findings-drawer::backdrop { background: #10152650; }
+.findings-drawer > header { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 18px 22px; border-bottom: 1px solid var(--line, #ddd); }
+.findings-drawer h2 { margin: 0; font-size: 18px; }
+.findings-drawer-body { padding: 20px 22px; overflow-y: auto; height: calc(100% - 76px); }
+.vstrike-panel { padding: 16px 22px 24px; }
+.vstrike-parked { position: fixed; left: -20000px; top: 0; width: 1280px; height: 720px; visibility: hidden; pointer-events: none; }
+.vstrike-fullscreen { position: fixed; inset: 0; z-index: 90; overflow: auto; background: var(--panel, #fff); }
+.vstrike-controls, .vstrike-toolbar { display: flex; gap: 10px; align-items: end; flex-wrap: wrap; }
+.vstrike-controls label { display: flex; flex-direction: column; gap: 5px; font-size: 11px; color: var(--tx-3); }
+.vstrike-controls select { width: 220px; max-width: 100%; border: 1px solid var(--line); border-radius: 7px; padding: 8px; background: var(--panel); color: var(--tx); font-size: 13px; }
+.vstrike-selection { margin-top: 14px; padding: 14px; border: 1px solid var(--line); border-radius: 9px; overflow-wrap: anywhere; }
+.vstrike-selection .btn { margin-right: 6px; margin-top: 6px; }
+.vstrike-note { color: var(--tx-3); font-size: 12px; }
+.vstrike-error { color: var(--crit); }
+.vstrike-frame { position: relative; overflow: hidden; width: 100%; border: 1px solid var(--line); border-radius: 10px; background: #f6f7f9; }
+.vstrike-frame iframe { display: block; border: 0; transform-origin: top left; max-width: none; }
+.vstrike-event-list { display: grid; gap: 12px; }
+.vstrike-event-list article { border: 1px solid var(--line); border-radius: 10px; padding: 14px; overflow-wrap: anywhere; }
+.vstrike-event-list h3 { margin: 0 0 6px; font-size: 14px; }
+.vstrike-event-list time { color: var(--tx-3); font-size: 11px; }
+.vstrike-event-list details { margin-top: 14px; color: var(--tx-2); font-size: 12px; }
+.vstrike-event-list summary { cursor: pointer; }
+.vstrike-event-list dl > div { display: grid; grid-template-columns: 80px 1fr; gap: 8px; }
+.vstrike-event-list dd { margin: 0; }
+.vstrike-event-action { display: flex; justify-content: space-between; align-items: center; gap: 10px; flex-wrap: wrap; }
+@media (max-width: 700px) {
+  .vstrike-panel { padding: 12px; }
+  .vstrike-controls, .vstrike-controls label { width: 100%; }
+  .vstrike-controls select { width: 100%; }
+  .finding-actions .row-act { display: none; }
+}
+
+.findings-kpis > button { background: transparent; color: var(--tx); border-top: 0; border-bottom: 0; border-left: 0; cursor: pointer; }
+.findings-kpis > button:hover { background: var(--panel); }
+.finding-title-cell > button { background: transparent; border: 0; padding: 0; font: inherit; font-weight: 600; cursor: pointer; }
+.finding-title-cell > button:hover { color: var(--accent); }
+.findings-drawer .filter-group-label { display: none; }
+.findings-drawer .search { margin-bottom: 12px; width: 100%; max-width: none; }

--- a/core/integrations/vstrike/client.py
+++ b/core/integrations/vstrike/client.py
@@ -751,6 +751,50 @@ class VStrikeService:
             args["networkId"] = network_id
         return self._call_mcp_tool("ui-camera-node", args)
 
+    def ui_find_by_ip_then_zoom(self, network_id: str, ip4s: List[str]) -> Any:
+        """Request a selection; tool acceptance does not confirm rendered focus."""
+        try:
+            return self._call_mcp_tool(
+                "ui-find-by-ip-then-zoom", {"networkId": network_id, "ip4s": ip4s}
+            )
+        except RuntimeError as exc:
+            message = str(exc).lower()
+            if any(
+                term in message
+                for term in (
+                    "-32601",
+                    "method not found",
+                    "tool not found",
+                    "unknown tool",
+                    "not implemented",
+                    "unsupported",
+                )
+            ):
+                raise VStrikeToolNotImplemented(
+                    "VStrike does not support selection by IPv4 address."
+                ) from exc
+            raise
+
+    def storyline_faults_page(
+        self, storyline_id: str, limit: int
+    ) -> List[Dict[str, Any]]:
+        """Read one bounded newest-first page using the storyline-set contract."""
+        result = self._call_mcp_tool(
+            "storyline-events-get",
+            {
+                "storylineSetId": storyline_id,
+                "level": "danger",
+                "first": 0,
+                "rows": limit,
+                "sortField": "date",
+                "sortOrder": "desc",
+            },
+        )
+        events = _extract_list(result, ("events", "results", "items", "data"))
+        if events is None:
+            raise RuntimeError("VStrike returned an invalid event page.")
+        return events[:limit]
+
     def ui_camera_position(
         self,
         position: Dict[str, float],
@@ -770,7 +814,7 @@ class VStrikeService:
         self, storyline_id: str, *, network_id: Optional[str] = None
     ) -> Any:
         """Apply the specified storyline to the active network view."""
-        args: Dict[str, Any] = {"storylineId": storyline_id}
+        args: Dict[str, Any] = {"storylineSetId": storyline_id}
         if network_id:
             args["networkId"] = network_id
         return self._call_mcp_tool("ui-storyline-apply", args)
@@ -784,17 +828,11 @@ class VStrikeService:
 
     def ui_storyline_forward(self, *, network_id: Optional[str] = None) -> Any:
         """Step forward in the storyline timeline."""
-        args: Dict[str, Any] = {}
-        if network_id:
-            args["networkId"] = network_id
-        return self._call_mcp_tool("ui-storyline-forward", args)
+        return self._call_mcp_tool("ui-storyline-forward", {})
 
     def ui_storyline_backward(self, *, network_id: Optional[str] = None) -> Any:
         """Step backward in the storyline timeline."""
-        args: Dict[str, Any] = {}
-        if network_id:
-            args["networkId"] = network_id
-        return self._call_mcp_tool("ui-storyline-backward", args)
+        return self._call_mcp_tool("ui-storyline-backward", {})
 
     # ------------------------------------------------------------------ #
     # Defensive wrappers for VStrike's net-new MCP tools.

--- a/core/integrations/vstrike/events.py
+++ b/core/integrations/vstrike/events.py
@@ -1,0 +1,73 @@
+"""Bounded projection of external scenario events, separate from Findings."""
+
+from datetime import datetime, timezone
+from ipaddress import IPv4Address
+from typing import Any
+
+
+def _text(value: Any) -> str:
+    if isinstance(value, (str, int, float, bool)):
+        return str(value)[:2000]
+    return ""
+
+
+def _time(value: Any) -> str | None:
+    try:
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            seconds = value / 1000 if abs(value) >= 100_000_000_000 else value
+            parsed = datetime.fromtimestamp(seconds, tz=timezone.utc)
+        elif isinstance(value, str):
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        else:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat()
+    except (ValueError, OverflowError, OSError):
+        return None
+
+
+def project_faults(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Allowlisted fields only; preserve zero values and unknown event times."""
+    unique: dict[str, dict[str, Any]] = {}
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        event_id = _text(event.get("eventId") or event.get("event_id"))
+        if not event_id:
+            continue
+        properties = event.get("properties")
+        properties = properties if isinstance(properties, dict) else {}
+        measurement = properties.get("rawMeasurement")
+        measurement = measurement if isinstance(measurement, dict) else {}
+        ips = event.get("ip4s")
+        addresses: list[str] = []
+        for value in ips[:50] if isinstance(ips, list) else []:
+            try:
+                if isinstance(value, str):
+                    addresses.append(str(IPv4Address(value)))
+            except ValueError:
+                pass
+        fault = {
+            "event_id": event_id,
+            "occurred_at": _time(event.get("date", event.get("timestamp"))),
+            "label": _text(event.get("label") or properties.get("label")),
+            "description": _text(
+                event.get("description") or properties.get("description")
+            ),
+            "source_level": _text(event.get("level")),
+            "ip4s": list(dict.fromkeys(addresses)),
+            "measurement": {
+                key: _text(measurement.get(key))
+                for key in ("type", "initiator", "target", "key", "value")
+                if measurement.get(key) is not None
+            },
+        }
+        previous = unique.get(event_id)
+        if previous is None or (fault["occurred_at"] or "") > (
+            previous["occurred_at"] or ""
+        ):
+            unique[event_id] = fault
+    return sorted(
+        unique.values(), key=lambda fault: fault["occurred_at"] or "", reverse=True
+    )

--- a/core/integrations/vstrike/frame_origin.py
+++ b/core/integrations/vstrike/frame_origin.py
@@ -1,0 +1,31 @@
+"""Resolve the configured embedding origin without returning credentials."""
+
+import ipaddress
+import re
+from urllib.parse import urlsplit
+
+from core.config import get_integration_config
+from core.secrets import get_secret
+
+
+def configured_frame_origin() -> str | None:
+    """Only a configured HTTP(S) origin may be added to the default frame policy."""
+    try:
+        config = get_integration_config("vstrike") or {}
+        value = get_secret("VSTRIKE_BASE_URL") or config.get("url")
+        if not isinstance(value, str):
+            return None
+        parsed = urlsplit(value)
+        host = parsed.hostname
+        if parsed.scheme not in {"http", "https"} or not host:
+            return None
+        if parsed.username or parsed.password:
+            return None
+        if ":" in host:
+            host = f"[{ipaddress.IPv6Address(host)}]"
+        elif not re.fullmatch(r"[a-zA-Z0-9.-]+", host):
+            return None
+        port = f":{parsed.port}" if parsed.port else ""
+        return f"{parsed.scheme}://{host}{port}"
+    except (ValueError, TypeError):
+        return None

--- a/env.example
+++ b/env.example
@@ -444,10 +444,10 @@ DARKTRACE_MAX_BODY_KB="1024"
 # as a Bearer token. DEV_MODE=true bypasses the inbound auth check.
 # UI control: VSTRIKE_USERNAME / VSTRIKE_PASSWORD enable Vigil to log into
 # VStrike's MCP server (POST /mcp-login → JWT) and embed VStrike's network
-# visualization as an iframe in place of the default entity graph. When
-# these are set, the frontend hard-replaces the EntityGraph with a
-# VStrike iframe in the Dashboard "Entity Graph" tab and the Investigation
-# workspace.
+# visualization in the Dashboard's VStrike tab. Enable the integration in
+# Settings to use it.
+# The default CSP admits only this configured origin for frames. A custom
+# VIGIL_CSP_POLICY must explicitly allow that origin in frame-src.
 VSTRIKE_BASE_URL="https://vstrike.net"
 VSTRIKE_API_KEY=""
 VSTRIKE_VERIFY_SSL="true"

--- a/services/api/middleware/security_headers.py
+++ b/services/api/middleware/security_headers.py
@@ -14,6 +14,7 @@ ignore HSTS on plain HTTP anyway and emitting it would be noise.
 import logging
 from typing import Callable, Optional
 
+from starlette.concurrency import run_in_threadpool
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -106,6 +107,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             get_settings().vigil_csp_enabled if csp_enabled is None else csp_enabled
         )
         self.csp_policy = csp_policy or get_settings().vigil_csp_policy or DEFAULT_CSP
+        self.default_frame_policy = not (csp_policy or get_settings().vigil_csp_policy)
         # Admit allowlisted connector origins so the browser may import their
         # bundle + call their BFF. Read once at startup (restart to change).
         try:
@@ -148,7 +150,23 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             )
 
         if self.csp_enabled:
-            response.headers.setdefault("Content-Security-Policy", self.csp_policy)
+            policy = self.csp_policy
+            if self.default_frame_policy and "text/html" in response.headers.get(
+                "content-type", ""
+            ):
+                from core.integrations.vstrike.frame_origin import (
+                    configured_frame_origin,
+                )
+
+                try:
+                    origin = await run_in_threadpool(configured_frame_origin)
+                except Exception:
+                    origin = None
+                if origin:
+                    # Only the iframe may contact this origin. Scripts and API
+                    # connections keep their existing policy. Custom CSP wins.
+                    policy += f"; frame-src 'self' {origin}"
+            response.headers.setdefault("Content-Security-Policy", policy)
 
         if self.hsts_enabled and self._is_https(request):
             response.headers.setdefault(

--- a/services/api/routers/vstrike.py
+++ b/services/api/routers/vstrike.py
@@ -17,13 +17,14 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, IPvAnyAddress, field_validator
 
 from core.config import get_settings
 from core.integrations.vstrike.client import (
     VStrikeToolNotImplemented,
     get_vstrike_service,
 )
+from core.integrations.vstrike.events import project_faults
 from core.integrations.vstrike.schemas import (
     VStrikeFindingResult,
     VStrikeHealthResponse,
@@ -569,6 +570,61 @@ def ui_camera_node(request: VStrikeCameraNodeRequest) -> dict:
         logger.error("VStrike ui-camera-node failed: %s", e)
         raise HTTPException(status_code=502, detail=str(e))
     return {"ok": True, "result": result}
+
+
+class VStrikeFocusRequest(BaseModel):
+    network_id: str = Field(min_length=1, max_length=256)
+    ip4s: list[IPvAnyAddress] = Field(min_length=1, max_length=50)
+
+    @field_validator("network_id")
+    @classmethod
+    def nonblank_network(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("network_id is required")
+        return value.strip()
+
+    @field_validator("ip4s")
+    @classmethod
+    def ipv4_only(cls, addresses: list[IPvAnyAddress]) -> list[IPvAnyAddress]:
+        if any(address.version != 4 for address in addresses):
+            raise ValueError("VStrike selection currently supports IPv4 only")
+        return addresses
+
+
+@authenticated_router.post("/ui/find-by-ip-then-zoom")
+def ui_find_by_ip_then_zoom(request: VStrikeFocusRequest) -> dict:
+    """Forward an explicit selection request without asserting visual success."""
+    service = _ui_service_or_503()
+    addresses = list(dict.fromkeys(str(address) for address in request.ip4s))
+    try:
+        service.ui_find_by_ip_then_zoom(request.network_id, addresses)
+    except VStrikeToolNotImplemented:
+        raise HTTPException(501, "VStrike does not support selection by IPv4 address.")
+    except Exception:
+        # Provider exceptions can contain authenticated URLs or response bodies.
+        raise HTTPException(502, "VStrike could not accept the selection request.")
+    return {"status": "requested", "network_id": request.network_id, "ip4s": addresses}
+
+
+class VStrikeFaultQueryRequest(BaseModel):
+    storyline_id: str = Field(min_length=1, max_length=256, pattern=r"\S")
+    limit: int = Field(default=100, ge=1, le=250)
+
+
+@authenticated_router.post("/faults/query")
+def query_faults(request: VStrikeFaultQueryRequest) -> dict:
+    """Read a bounded external event page. This route never writes findings."""
+    service = _ui_service_or_503()
+    try:
+        events = service.storyline_faults_page(request.storyline_id, request.limit)
+    except Exception:
+        raise HTTPException(502, "VStrike events could not be read. Try again.")
+    return {
+        "faults": project_faults(events),
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+        "limit": request.limit,
+        "truncated": len(events) >= request.limit,
+    }
 
 
 class VStrikeCameraPositionRequest(BaseModel):

--- a/tests/integration/test_vstrike_findings_ui.py
+++ b/tests/integration/test_vstrike_findings_ui.py
@@ -1,0 +1,129 @@
+"""Synthetic contract tests for the optional external visualization workflow."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from core.integrations.vstrike.client import VStrikeToolNotImplemented
+from core.integrations.vstrike.events import project_faults
+from services.api.routers import vstrike
+
+
+def test_focus_is_a_request_and_never_claims_visual_success():
+    service = MagicMock(has_ui_credentials=True)
+    with patch.object(vstrike, "get_vstrike_service", return_value=service):
+        response = vstrike.ui_find_by_ip_then_zoom(
+            vstrike.VStrikeFocusRequest(
+                network_id="example-network",
+                ip4s=["192.0.2.2", "192.0.2.2", "198.51.100.10"],
+            )
+        )
+    assert response == {
+        "status": "requested",
+        "network_id": "example-network",
+        "ip4s": ["192.0.2.2", "198.51.100.10"],
+    }
+    service.ui_find_by_ip_then_zoom.assert_called_once_with(
+        "example-network", response["ip4s"]
+    )
+
+
+@pytest.mark.parametrize(
+    "addresses",
+    [[], ["192.0.2.2/32"], ["192.0.2"], ["2001:db8::1"], ["192.0.2.2"] * 51],
+)
+def test_focus_rejects_invalid_and_unsupported_addresses(addresses):
+    with pytest.raises(ValidationError):
+        vstrike.VStrikeFocusRequest(network_id="example-network", ip4s=addresses)
+
+
+def test_blank_network_is_rejected():
+    with pytest.raises(ValidationError):
+        vstrike.VStrikeFocusRequest(network_id="  ", ip4s=["192.0.2.2"])
+
+
+@pytest.mark.parametrize(
+    "error, status",
+    [(RuntimeError("token=private"), 502), (VStrikeToolNotImplemented("private"), 501)],
+)
+def test_focus_errors_do_not_expose_provider_data(error, status):
+    service = MagicMock(has_ui_credentials=True)
+    service.ui_find_by_ip_then_zoom.side_effect = error
+    with patch.object(
+        vstrike, "get_vstrike_service", return_value=service
+    ), pytest.raises(HTTPException) as caught:
+        vstrike.ui_find_by_ip_then_zoom(
+            vstrike.VStrikeFocusRequest(
+                network_id="example-network", ip4s=["192.0.2.2"]
+            )
+        )
+    assert caught.value.status_code == status
+    assert "private" not in caught.value.detail
+
+
+def test_events_preserve_unknown_time_zero_and_explicit_source_level():
+    result = project_faults(
+        [
+            {
+                "eventId": "one",
+                "date": "2026-01-02T07:00:00-05:00",
+                "level": "danger",
+                "ip4s": ["192.0.2.2", "192.0.2.2", "not-an-ip"],
+                "properties": {"rawMeasurement": {"value": 0, "secret": "excluded"}},
+            },
+            {"eventId": "one", "date": "2026-01-01T12:00:00Z"},
+            {"eventId": "unknown", "date": "bad"},
+            {"missing": "id"},
+        ]
+    )
+    assert len(result) == 2
+    assert result[0]["occurred_at"] == "2026-01-02T12:00:00+00:00"
+    assert result[0]["ip4s"] == ["192.0.2.2"]
+    assert result[0]["measurement"] == {"value": "0"}
+    assert result[1]["occurred_at"] is None
+    assert result[1]["source_level"] == ""
+    assert all("severity" not in row and "score" not in row for row in result)
+
+
+def test_event_read_is_bounded_and_does_not_call_storage():
+    service = MagicMock(has_ui_credentials=True)
+    service.storyline_faults_page.return_value = [{"eventId": "one"}]
+    with patch.object(
+        vstrike, "get_vstrike_service", return_value=service
+    ), patch.object(vstrike, "data_service") as storage:
+        result = vstrike.query_faults(
+            vstrike.VStrikeFaultQueryRequest(storyline_id="example-scenario", limit=1)
+        )
+    assert result["truncated"] is True
+    assert result["limit"] == 1
+    assert storage.mock_calls == []
+    service.storyline_faults_page.assert_called_once_with("example-scenario", 1)
+    with pytest.raises(ValidationError):
+        vstrike.VStrikeFaultQueryRequest(storyline_id="example-scenario", limit=251)
+
+
+def test_new_routes_require_auth_before_contacting_vstrike(monkeypatch):
+    from services.api.middleware import auth
+
+    monkeypatch.setattr(auth, "DEV_MODE", False)
+    app = FastAPI()
+    app.include_router(vstrike.authenticated_router, prefix="/api/integrations/vstrike")
+    with patch.object(vstrike, "get_vstrike_service") as service:
+        client = TestClient(app)
+        for path, payload in [
+            (
+                "ui/find-by-ip-then-zoom",
+                {"network_id": "example-network", "ip4s": ["192.0.2.2"]},
+            ),
+            ("faults/query", {"storyline_id": "example-scenario"}),
+        ]:
+            assert (
+                client.post(
+                    f"/api/integrations/vstrike/{path}", json=payload
+                ).status_code
+                == 401
+            )
+    service.assert_not_called()

--- a/tests/integration/test_vstrike_frame_policy.py
+++ b/tests/integration/test_vstrike_frame_policy.py
@@ -1,0 +1,64 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from fastapi.testclient import TestClient
+
+from core.integrations.vstrike.frame_origin import configured_frame_origin
+from services.api.middleware.security_headers import SecurityHeadersMiddleware
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        (
+            "https://vstrike.example.test/path?ignored=true",
+            "https://vstrike.example.test",
+        ),
+        ("http://127.0.0.1:9000", "http://127.0.0.1:9000"),
+        ("https://[2001:db8::1]:443/path", "https://[2001:db8::1]:443"),
+        ("https://user:password@example.test", None),
+        ("javascript:alert(1)", None),
+        ("https://example.test;script-src%20*", None),
+        ("https://example.test:invalid", None),
+    ],
+)
+def test_frame_origin_is_a_validated_origin_only(url, expected):
+    with patch(
+        "core.integrations.vstrike.frame_origin.get_integration_config",
+        return_value={"url": url},
+    ), patch("core.integrations.vstrike.frame_origin.get_secret", return_value=None):
+        assert configured_frame_origin() == expected
+
+
+def test_default_document_policy_admits_only_configured_frame_origin():
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware)
+    app.get("/")(lambda: HTMLResponse("<p>Vigil</p>"))
+    app.get("/api/check")(lambda: {"ok": True})
+    with patch(
+        "core.integrations.vstrike.frame_origin.configured_frame_origin",
+        return_value="https://vstrike.example.test",
+    ):
+        client = TestClient(app)
+        policy = client.get("/").headers["content-security-policy"]
+        assert "frame-src 'self' https://vstrike.example.test" in policy
+        assert "script-src 'self';" in policy
+        assert "frame-ancestors 'none'" in policy
+        assert (
+            "vstrike.example.test"
+            not in client.get("/api/check").headers["content-security-policy"]
+        )
+
+
+def test_custom_policy_remains_authoritative():
+    app = FastAPI()
+    policy = "default-src 'self'; frame-src 'none'"
+    app.add_middleware(SecurityHeadersMiddleware, csp_policy=policy)
+    app.get("/")(lambda: HTMLResponse("<p>Vigil</p>"))
+    with patch(
+        "core.integrations.vstrike.frame_origin.configured_frame_origin"
+    ) as resolve:
+        assert TestClient(app).get("/").headers["content-security-policy"] == policy
+    resolve.assert_not_called()

--- a/tests/unit/integrations/test_vstrike_service.py
+++ b/tests/unit/integrations/test_vstrike_service.py
@@ -928,7 +928,7 @@ def test_ui_storyline_apply_passes_storyline_id():
 
     payload = mock_post.call_args.kwargs["json"]
     assert payload["params"]["name"] == "ui-storyline-apply"
-    assert payload["params"]["arguments"]["storylineId"] == "s1"
+    assert payload["params"]["arguments"]["storylineSetId"] == "s1"
 
 
 def test_ui_storyline_mode_passes_mode():
@@ -945,7 +945,7 @@ def test_ui_storyline_mode_passes_mode():
     assert payload["params"]["arguments"]["mode"] == "replay"
 
 
-def test_ui_storyline_forward_passes_network_id():
+def test_ui_storyline_forward_has_no_mcp_arguments():
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
@@ -956,10 +956,10 @@ def test_ui_storyline_forward_passes_network_id():
 
     payload = mock_post.call_args.kwargs["json"]
     assert payload["params"]["name"] == "ui-storyline-forward"
-    assert payload["params"]["arguments"]["networkId"] == "net-1"
+    assert payload["params"]["arguments"] == {}
 
 
-def test_ui_storyline_backward_passes_network_id():
+def test_ui_storyline_backward_has_no_mcp_arguments():
     svc = _ui_service()
     _jwt_cache[(svc.base_url, svc.username)] = ("jwt-A", 9_999_999_999.0)
     with patch(
@@ -970,7 +970,7 @@ def test_ui_storyline_backward_passes_network_id():
 
     payload = mock_post.call_args.kwargs["json"]
     assert payload["params"]["name"] == "ui-storyline-backward"
-    assert payload["params"]["arguments"]["networkId"] == "net-1"
+    assert payload["params"]["arguments"] == {}
 
 
 # ---------------------------------------------------------------------------
@@ -1227,3 +1227,43 @@ def test_ui_rightpanel_focus_forwards_extras_for_future_compat():
 
     args = mock_post.call_args.kwargs["json"]["params"]["arguments"]
     assert args == {"future_field": "x"}
+
+
+def test_fault_page_uses_bounded_storyline_set_contract():
+    svc = _ui_service()
+    with patch.object(svc, "_call_mcp_tool", return_value={"events": [{"eventId": "one"}]}) as call:
+        assert svc.storyline_faults_page("example-scenario", 100) == [{"eventId": "one"}]
+    call.assert_called_once_with("storyline-events-get", {
+        "storylineSetId": "example-scenario", "level": "danger", "first": 0,
+        "rows": 100, "sortField": "date", "sortOrder": "desc",
+    })
+
+
+def test_fault_page_rejects_malformed_results():
+    svc = _ui_service()
+    with patch.object(svc, "_call_mcp_tool", return_value={"invalid": "shape"}):
+        with pytest.raises(RuntimeError, match="invalid event page"):
+            svc.storyline_faults_page("example-scenario", 100)
+
+
+def test_ipv4_focus_preserves_full_addresses_in_mcp_request():
+    svc = _ui_service()
+    with patch.object(svc, "_call_mcp_tool", return_value={"ok": True}) as call:
+        svc.ui_find_by_ip_then_zoom("example-network", ["192.0.2.2", "192.0.2.20"])
+    call.assert_called_once_with("ui-find-by-ip-then-zoom", {"networkId": "example-network", "ip4s": ["192.0.2.2", "192.0.2.20"]})
+
+
+@pytest.mark.parametrize("message", ["unknown tool", "method not found (-32601)"])
+def test_ipv4_focus_reports_unsupported_tool(message):
+    svc = _ui_service()
+    from core.integrations.vstrike.client import VStrikeToolNotImplemented
+    with patch.object(svc, "_call_mcp_tool", side_effect=RuntimeError(message)):
+        with pytest.raises(VStrikeToolNotImplemented):
+            svc.ui_find_by_ip_then_zoom("example-network", ["192.0.2.2"])
+
+
+def test_ipv4_focus_retains_transport_failure_type():
+    svc = _ui_service()
+    with patch.object(svc, "_call_mcp_tool", side_effect=RuntimeError("unreachable")):
+        with pytest.raises(RuntimeError, match="unreachable"):
+            svc.ui_find_by_ip_then_zoom("example-network", ["192.0.2.2"])


### PR DESCRIPTION
A finding with a source and destination IPv4 pair now has an inline **VStrike** action that opens external network context and preserves the analyst's place in the findings queue. This replaces the Dashboard's unused Entity Graph placeholder with a configurable VStrike view and improves the surrounding triage workflow.

## Changes

- Show the VStrike tab, inline finding/detail actions, and events entry point only after integration settings have loaded with VStrike enabled. Disabling it closes active graph/events, stops retries/polling, ignores late responses, and restores the preserved findings queue.
- Add a lazy VStrike iframe with account-provided network/storyline choices, apply and step controls, reconnect, expanded view, bounded initialization retry, and guards against stale responses. The requested endpoints stay visible with retry and return actions.
- Put external scenario events in an on-demand drawer. Reads are bounded, refresh only while open, label incomplete pages, retain the last page on refresh failure, and keep source events separate from Vigil findings and model scores.
- Improve findings with readable titles, source/destination context, inline actions, separate searchable column controls, visible filter chips, working KPI shortcuts, the correct active-case count, and a toolbar Ask Vigil action. Search, filters, sort, pagination, column preferences, and scroll survive graph/detail navigation; CSV export is preserved.
- Display finding/evidence times consistently in UTC, retain missing scores/timestamps, and order evidence chronologically without mutating the source records.
- Add authenticated selection and bounded event-read endpoints, align storyline/VCR calls with the provider contract, regenerate API types, and allow only the configured provider origin in the default document `frame-src`. Custom CSP policies remain authoritative.

## Validation

- Web production build passes; **220 tests across 24 files** pass. ESLint has zero errors and 18 existing warnings.
- **149 focused backend tests** pass, covering VStrike service/UI contracts, new validation/auth behavior, CSP, and router discovery. Python formatting/lint and all three import-layer contracts pass.
- Seven additional integration-availability regressions cover disabled/loading/failed settings, enabling, and disabling during an active graph/event read.
- Browser walkthrough with an isolated synthetic provider verifies hidden dashboard/detail controls and zero provider requests while disabled, restored actions when enabled, desktop/640px layouts, modal dismissal and focus restoration, queue-state preservation, inline selection, reconnect, and the events drawer. No browser error/warning logs were observed.
- Secret/privacy and generated-artifact review completed. Only generic code and synthetic test fixtures are included.

## Provider limits and coordination

An accepted selection command does not establish that VStrike rendered the requested highlighting or zoom. The UI explicitly reports **selection requested, highlighting/zoom unconfirmed**. Live-provider camera framing, exact matching, and path highlighting still require provider-side validation; this PR does not claim to fix them. The inline finding action currently requires one unambiguous IPv4 address per endpoint.

There is overlap with #838, which removes the old Entity Graph stub. This PR introduces a named external VStrike view and does not depend on the legacy entity-graph API. Coordinate the Dashboard, environment comments, and generated schema changes when merging either PR.
