### PR TITLE
feat(ledger): application role may only INSERT and SELECT on agent_events

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -301,7 +301,9 @@ collide with the capability domains above often enough to belong beside them.
 
 **Ledger**:
 The append-only event log of one run, and its only durable record. Every other
-view of a run is derived from it rather than stored beside it.
+view of a run is derived from it rather than stored beside it. The application
+role `vigil_app` may `SELECT` and `INSERT`; `UPDATE`, `DELETE` and `TRUNCATE`
+are revoked at the database.
 _Avoid_: journal, audit log, history
 
 **Fold**:

--- a/clients/desktop/src/main.ts
+++ b/clients/desktop/src/main.ts
@@ -543,6 +543,22 @@ async function bringUpStandalone(): Promise<boolean> {
   }
 
   phase("services", "start");
+  // Existing volumes skip initdb. Apply SQL (including vigil_app) before the
+  // backend logs in as that role, or `up --wait` deadlocks on /api/health.
+  if ((await runCompose(composeArgs("up", "-d", "--wait", "postgres"))) !== 0) {
+    phase("services", "fail");
+    sendSplash("error", "The Vigil containers did not start. See the log above.");
+    return false;
+  }
+  if (
+    (await runCompose(
+      composeArgs("run", "--rm", "--no-deps", "--entrypoint", "sh", "db-seed", "/apply.sh"),
+    )) !== 0
+  ) {
+    phase("services", "fail");
+    sendSplash("error", "Could not prepare the database. See the log above.");
+    return false;
+  }
   if ((await runCompose(composeArgs("up", "-d", "--wait"))) !== 0) {
     phase("services", "fail");
     sendSplash("error", "The Vigil containers did not start. See the log above.");

--- a/clients/desktop/standalone/docker-compose.yml
+++ b/clients/desktop/standalone/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
       - POSTGRES_DB=deeptempo_soc
-      - POSTGRES_USER=deeptempo
+      - POSTGRES_USER=vigil_app
       - POSTGRES_PASSWORD=deeptempo_secure_password_change_me
       - OLLAMA_URL=${OLLAMA_URL:-http://host.docker.internal:11434}
       - BIFROST_URL=http://bifrost:8080

--- a/clients/desktop/standalone/initdb/00_apply.sh
+++ b/clients/desktop/standalone/initdb/00_apply.sh
@@ -26,10 +26,11 @@ for f in /db-init/*.sql; do
 done
 
 # vigil_app logs in with the password the apps already hold; the SQL file
-# cannot contain a literal.
+# cannot contain a literal. :'pw' is interpolated from --set, not -c.
 pw="${POSTGRES_PASSWORD:-${PGPASSWORD:-}}"
 if [ -n "$pw" ]; then
     echo "setting vigil_app password"
-    psql -v ON_ERROR_STOP=0 --set=pw="$pw" -c "ALTER ROLE vigil_app PASSWORD :'pw'" || true
+    printf '%s\n' "ALTER ROLE vigil_app PASSWORD :'pw';" \
+        | psql -v ON_ERROR_STOP=0 --set=pw="$pw" || true
 fi
 echo "apply complete"

--- a/clients/desktop/standalone/initdb/00_apply.sh
+++ b/clients/desktop/standalone/initdb/00_apply.sh
@@ -24,4 +24,12 @@ for f in /db-init/*.sql; do
     echo "applying $(basename "$f")"
     psql -v ON_ERROR_STOP=0 -q -f "$f" || true
 done
+
+# vigil_app logs in with the password the apps already hold; the SQL file
+# cannot contain a literal.
+pw="${POSTGRES_PASSWORD:-${PGPASSWORD:-}}"
+if [ -n "$pw" ]; then
+    echo "setting vigil_app password"
+    psql -v ON_ERROR_STOP=0 --set=pw="$pw" -c "ALTER ROLE vigil_app PASSWORD :'pw'" || true
+fi
 echo "apply complete"

--- a/infra/database/init/19_agent_ledger.sql
+++ b/infra/database/init/19_agent_ledger.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS agent_events (
 );
 
 COMMENT ON TABLE agent_events IS
-    'Append-only ledger owned solely by the agent layer; the projection is folded from these rows and never stored.';
+    'Append-only ledger owned solely by the agent layer; vigil_app may SELECT and INSERT only. The projection is folded from these rows and never stored.';
 
 COMMENT ON COLUMN agent_events.snapshot IS
     'The digest presented to the lead, selected only by replay and never by the fold.';

--- a/infra/database/init/30_vigil_app_role.sql
+++ b/infra/database/init/30_vigil_app_role.sql
@@ -1,0 +1,25 @@
+-- Runtime login for app processes. Schema owner stays the cluster POSTGRES_USER.
+-- Password is set by the apply wrapper from POSTGRES_PASSWORD; none here.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'vigil_app') THEN
+    CREATE ROLE vigil_app NOSUPERUSER LOGIN;
+  END IF;
+END
+$$;
+
+ALTER ROLE vigil_app NOSUPERUSER LOGIN;
+
+GRANT USAGE, CREATE ON SCHEMA public TO vigil_app;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO vigil_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO vigil_app;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO vigil_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO vigil_app;
+
+GRANT SELECT, INSERT ON TABLE agent_events TO vigil_app;
+REVOKE UPDATE, DELETE, TRUNCATE ON TABLE agent_events FROM vigil_app;

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -8,7 +8,7 @@ x-agent-env: &agent-env
   - POSTGRES_HOST=postgres
   - POSTGRES_PORT=5432
   - POSTGRES_DB=deeptempo_soc
-  - POSTGRES_USER=deeptempo
+  - POSTGRES_USER=vigil_app
   - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-deeptempo_secure_password_change_me}
   - REDIS_URL=redis://redis:6379/0
   # The four /internal endpoints. Each defaults to localhost:6987 in-process,
@@ -153,7 +153,7 @@ services:
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
       - POSTGRES_DB=deeptempo_soc
-      - POSTGRES_USER=deeptempo
+      - POSTGRES_USER=vigil_app
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-deeptempo_secure_password_change_me}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
@@ -197,7 +197,7 @@ services:
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
       - POSTGRES_DB=deeptempo_soc
-      - POSTGRES_USER=deeptempo
+      - POSTGRES_USER=vigil_app
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-deeptempo_secure_password_change_me}
       # AI
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
@@ -296,7 +296,7 @@ services:
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
       - POSTGRES_DB=deeptempo_soc
-      - POSTGRES_USER=deeptempo
+      - POSTGRES_USER=vigil_app
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-deeptempo_secure_password_change_me}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}

--- a/infra/docker/initdb/00_apply.sh
+++ b/infra/docker/initdb/00_apply.sh
@@ -26,10 +26,11 @@ for f in /db-init/*.sql; do
 done
 
 # vigil_app logs in with the password the apps already hold; the SQL file
-# cannot contain a literal.
+# cannot contain a literal. :'pw' is interpolated from --set, not -c.
 pw="${POSTGRES_PASSWORD:-${PGPASSWORD:-}}"
 if [ -n "$pw" ]; then
     echo "setting vigil_app password"
-    psql -v ON_ERROR_STOP=0 --set=pw="$pw" -c "ALTER ROLE vigil_app PASSWORD :'pw'" || true
+    printf '%s\n' "ALTER ROLE vigil_app PASSWORD :'pw';" \
+        | psql -v ON_ERROR_STOP=0 --set=pw="$pw" || true
 fi
 echo "apply complete"

--- a/infra/docker/initdb/00_apply.sh
+++ b/infra/docker/initdb/00_apply.sh
@@ -24,4 +24,12 @@ for f in /db-init/*.sql; do
     echo "applying $(basename "$f")"
     psql -v ON_ERROR_STOP=0 -q -f "$f" || true
 done
+
+# vigil_app logs in with the password the apps already hold; the SQL file
+# cannot contain a literal.
+pw="${POSTGRES_PASSWORD:-${PGPASSWORD:-}}"
+if [ -n "$pw" ]; then
+    echo "setting vigil_app password"
+    psql -v ON_ERROR_STOP=0 --set=pw="$pw" -c "ALTER ROLE vigil_app PASSWORD :'pw'" || true
+fi
 echo "apply complete"

--- a/infra/helm/vigil/files/database-init/19_agent_ledger.sql
+++ b/infra/helm/vigil/files/database-init/19_agent_ledger.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS agent_events (
 );
 
 COMMENT ON TABLE agent_events IS
-    'Append-only ledger owned solely by the agent layer; the projection is folded from these rows and never stored.';
+    'Append-only ledger owned solely by the agent layer; vigil_app may SELECT and INSERT only. The projection is folded from these rows and never stored.';
 
 COMMENT ON COLUMN agent_events.snapshot IS
     'The digest presented to the lead, selected only by replay and never by the fold.';

--- a/infra/helm/vigil/files/database-init/30_vigil_app_role.sql
+++ b/infra/helm/vigil/files/database-init/30_vigil_app_role.sql
@@ -1,0 +1,25 @@
+-- Runtime login for app processes. Schema owner stays the cluster POSTGRES_USER.
+-- Password is set by the apply wrapper from POSTGRES_PASSWORD; none here.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'vigil_app') THEN
+    CREATE ROLE vigil_app NOSUPERUSER LOGIN;
+  END IF;
+END
+$$;
+
+ALTER ROLE vigil_app NOSUPERUSER LOGIN;
+
+GRANT USAGE, CREATE ON SCHEMA public TO vigil_app;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO vigil_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO vigil_app;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO vigil_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO vigil_app;
+
+GRANT SELECT, INSERT ON TABLE agent_events TO vigil_app;
+REVOKE UPDATE, DELETE, TRUNCATE ON TABLE agent_events FROM vigil_app;

--- a/infra/helm/vigil/templates/_env.tpl
+++ b/infra/helm/vigil/templates/_env.tpl
@@ -99,8 +99,9 @@ helper. Prefer the Secret when both are set.
   value: {{ include "vigil.postgres.port" . | toString | quote }}
 - name: POSTGRES_DB
   value: {{ include "vigil.postgres.database" . | quote }}
+{{/* Runtime login; schema owner stays vigil.postgres.username (StatefulSet, db-init). */}}
 - name: POSTGRES_USER
-  value: {{ include "vigil.postgres.username" . | quote }}
+  value: "vigil_app"
 {{- if .Values.redis.bitnami.enabled }}
 {{- if .Values.redis.bitnami.auth.enabled }}
 - name: REDIS_PASSWORD

--- a/infra/helm/vigil/templates/db-init-job.yaml
+++ b/infra/helm/vigil/templates/db-init-job.yaml
@@ -131,6 +131,16 @@ spec:
               apply {{ . | quote }}
               {{- end }}
 
+              # vigil_app logs in with the password the apps already hold; the
+              # SQL file cannot contain a literal.
+              pw="${PGPASSWORD:-}"
+              if [ -z "$pw" ]; then
+                echo "ERROR: PGPASSWORD is empty; cannot set vigil_app password." >&2
+                exit 1
+              fi
+              echo "setting vigil_app password"
+              psql -v ON_ERROR_STOP=1 --set=pw="$pw" -c "ALTER ROLE vigil_app PASSWORD :'pw'"
+
               echo "Database initialization complete."
           volumeMounts:
             - name: sql

--- a/infra/helm/vigil/templates/db-init-job.yaml
+++ b/infra/helm/vigil/templates/db-init-job.yaml
@@ -139,7 +139,7 @@ spec:
                 exit 1
               fi
               echo "setting vigil_app password"
-              psql -v ON_ERROR_STOP=1 --set=pw="$pw" -c "ALTER ROLE vigil_app PASSWORD :'pw'"
+              printf '%s\n' "ALTER ROLE vigil_app PASSWORD :'pw';" | psql -v ON_ERROR_STOP=1 --set=pw="$pw"
 
               echo "Database initialization complete."
           volumeMounts:

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -417,6 +417,7 @@ dbInit:
     - 27_episodic_read_log.sql
     - 28_case_closure_actor.sql
     - 29_episodic_distil_failures.sql
+    - 30_vigil_app_role.sql
   resources:
     requests:
       cpu: 50m

--- a/scripts/agent_up.sh
+++ b/scripts/agent_up.sh
@@ -31,7 +31,7 @@ export VIGIL_TOOLS_TOKEN="$AGENT_INTERNAL_TOKEN"
 export POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
 export POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 export POSTGRES_DB="${POSTGRES_DB:-deeptempo_soc}"
-export POSTGRES_USER="${POSTGRES_USER:-deeptempo}"
+export POSTGRES_USER="${POSTGRES_USER:-vigil_app}"
 export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-deeptempo_secure_password_change_me}"
 export REDIS_URL="${REDIS_URL:-redis://localhost:6379/0}"
 

--- a/tests/integration/test_ledger_app_role.py
+++ b/tests/integration/test_ledger_app_role.py
@@ -146,7 +146,14 @@ def test_force_terminal_appends_as_vigil_app(app_engine, monkeypatch):
         _insert_run(conn, run_id)
         conn.commit()
 
-    monkeypatch.setattr(run_cancel, "get_db_session", sessionmaker(bind=app_engine))
+    Session = sessionmaker(bind=app_engine)
+
+    def _as_app():
+        session = Session()
+        assert session.execute(text("SELECT current_user")).scalar() == "vigil_app"
+        return session
+
+    monkeypatch.setattr(run_cancel, "get_db_session", _as_app)
 
     assert run_cancel.force_terminal(str(run_id), "stopped from the console") is True
 

--- a/tests/integration/test_ledger_app_role.py
+++ b/tests/integration/test_ledger_app_role.py
@@ -1,0 +1,162 @@
+"""vigil_app may INSERT and SELECT agent_events; UPDATE and DELETE fail at Postgres.
+
+Issue #824. Connects as the app role, not the owner, and does not consult
+has_table_privilege.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from urllib.parse import quote
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.orm import sessionmaker
+
+from core.workflows import run_cancel
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INIT = REPO_ROOT / "infra" / "database" / "init"
+SCRATCH_DB = "vigil_test_ledger_grants"
+INSUFFICIENT_PRIVILEGE = "42501"
+
+
+def _parts():
+    return {
+        "user": os.getenv("POSTGRES_USER", "deeptempo"),
+        "password": os.getenv("POSTGRES_PASSWORD", "deeptempo_secure_password_change_me"),
+        "host": os.getenv("POSTGRES_HOST", "localhost"),
+        "port": os.getenv("POSTGRES_PORT", "5432"),
+    }
+
+
+def _url(database: str, user: str | None = None, password: str | None = None) -> str:
+    parts = _parts()
+    who = user if user is not None else parts["user"]
+    pw = password if password is not None else parts["password"]
+    return (
+        f"postgresql://{quote(who, safe='')}:{quote(pw, safe='')}"
+        f"@{parts['host']}:{parts['port']}/{database}"
+    )
+
+
+def _postgres_available() -> bool:
+    try:
+        eng = create_engine(_url("postgres"), isolation_level="AUTOCOMMIT")
+        with eng.connect():
+            return True
+    except Exception:
+        return False
+
+
+pytestmark.append(
+    pytest.mark.skipif(
+        not _postgres_available(),
+        reason="requires a local PostgreSQL (docker compose up -d postgres)",
+    )
+)
+
+
+def _apply_sql(conn, name: str) -> None:
+    conn.exec_driver_sql((INIT / name).read_text())
+
+
+def _pgcode(exc: ProgrammingError) -> str | None:
+    orig = getattr(exc, "orig", None)
+    return getattr(orig, "pgcode", None)
+
+
+@pytest.fixture(scope="module")
+def app_engine():
+    """Owner provisions the role; tests connect as vigil_app."""
+    admin = create_engine(_url("postgres"), isolation_level="AUTOCOMMIT")
+    with admin.connect() as c:
+        c.execute(text(f"DROP DATABASE IF EXISTS {SCRATCH_DB} WITH (FORCE)"))
+        c.execute(text(f"CREATE DATABASE {SCRATCH_DB}"))
+
+    owner = create_engine(_url(SCRATCH_DB))
+    password = _parts()["password"]
+    with owner.connect() as conn:
+        _apply_sql(conn, "19_agent_ledger.sql")
+        _apply_sql(conn, "30_vigil_app_role.sql")
+        escaped = password.replace("'", "''")
+        conn.exec_driver_sql(f"ALTER ROLE vigil_app PASSWORD '{escaped}'")
+        conn.commit()
+
+    app = create_engine(_url(SCRATCH_DB, user="vigil_app", password=password))
+    yield app
+
+    app.dispose()
+    owner.dispose()
+    with admin.connect() as c:
+        c.execute(text(f"DROP DATABASE IF EXISTS {SCRATCH_DB} WITH (FORCE)"))
+    admin.dispose()
+
+
+def _insert_run(conn, run_id: uuid.UUID) -> None:
+    conn.execute(
+        text(
+            "INSERT INTO agent_events "
+            "(run_id, seq, run_kind, kind, payload, schema_version) "
+            "VALUES (:run_id, 0, 'hunt', 'run', CAST(:payload AS jsonb), 1)"
+        ),
+        {"run_id": str(run_id), "payload": json.dumps({"seed": str(run_id)})},
+    )
+
+
+def test_vigil_app_insert_succeeds_update_and_delete_fail(app_engine):
+    run_id = uuid.uuid4()
+    with app_engine.connect() as conn:
+        _insert_run(conn, run_id)
+        conn.commit()
+        kind = conn.execute(
+            text("SELECT kind FROM agent_events WHERE run_id = :r"),
+            {"r": str(run_id)},
+        ).scalar_one()
+    assert kind == "run"
+
+    with pytest.raises(ProgrammingError) as updated:
+        with app_engine.connect() as conn:
+            conn.execute(
+                text("UPDATE agent_events SET kind = 'tampered' WHERE run_id = :r"),
+                {"r": str(run_id)},
+            )
+            conn.commit()
+    assert _pgcode(updated.value) == INSUFFICIENT_PRIVILEGE
+
+    with pytest.raises(ProgrammingError) as deleted:
+        with app_engine.connect() as conn:
+            conn.execute(
+                text("DELETE FROM agent_events WHERE run_id = :r"),
+                {"r": str(run_id)},
+            )
+            conn.commit()
+    assert _pgcode(deleted.value) == INSUFFICIENT_PRIVILEGE
+
+
+def test_force_terminal_appends_as_vigil_app(app_engine, monkeypatch):
+    run_id = uuid.uuid4()
+    with app_engine.connect() as conn:
+        _insert_run(conn, run_id)
+        conn.commit()
+
+    monkeypatch.setattr(run_cancel, "get_db_session", sessionmaker(bind=app_engine))
+
+    assert run_cancel.force_terminal(str(run_id), "stopped from the console") is True
+
+    with app_engine.connect() as conn:
+        kinds = (
+            conn.execute(
+                text("SELECT kind FROM agent_events WHERE run_id = :r ORDER BY seq"),
+                {"r": str(run_id)},
+            )
+            .scalars()
+            .all()
+        )
+    assert kinds == ["run", "terminal"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #824

Append-only on `agent_events` is now a grant. Schema init still connects as the owner (`deeptempo` / `vigil.postgres.username`). Runtime processes connect as `vigil_app` through the existing `POSTGRES_USER` knob and hold `SELECT, INSERT` only on the ledger.

## What changed

- `infra/database/init/30_vigil_app_role.sql` (mirrored in Helm `database-init`, listed in `dbInit.sqlFiles`) creates `NOSUPERUSER LOGIN` role `vigil_app`, grants DML on current tables, `USAGE` on sequences, `CREATE` on `public`, and `ALTER DEFAULT PRIVILEGES` for owner-created objects. Then `GRANT SELECT, INSERT` and `REVOKE UPDATE, DELETE, TRUNCATE` on `agent_events` only.
- Apply wrappers (`infra/docker/initdb/00_apply.sh`, desktop copy, Helm db-init Job) set `vigil_app`'s password from `POSTGRES_PASSWORD` / `PGPASSWORD` via psql stdin (`:'pw'`). No password literal in the SQL file.
- Compose app services (including `x-agent-env`), desktop backend, Helm `vigil.env`, and `scripts/agent_up.sh` connect as `vigil_app`. Postgres container, db-seed, StatefulSet, and db-init Job stay on the owner.
- Desktop standalone starts postgres, applies SQL (so existing volumes get the role), then `up --wait` for the apps; the post-`create_all` seed is unchanged.
- Ledger definition in `CONTEXT.md` and the `agent_events` table comment state the grant.
- Integration test connects as `vigil_app` (not the owner, not `has_table_privilege`): `INSERT` succeeds, `UPDATE`/`DELETE` fail with `42501`, and `force_terminal` appends as `vigil_app`.

## Review findings

- Existing desktop volumes skip initdb, so `up --wait` on the backend before db-seed would deadlock waiting for `vigil_app` — **fixed** in `clients/desktop/src/main.ts` by applying SQL against healthy postgres first.
- Helm app pods may CrashLoop until the post-install db-init hook creates the role — **dismissed**: notes kept the Job on the owner and `vigil.env` on `vigil_app`; the backend `startupProbe` already allows 300s for that hook.
- Infra compose db-seed waits up to 60s then applies anyway — **dismissed**: not a deadlock; `restart: unless-stopped` picks up the role on the next backend start.
- Compose `00_apply.sh` still `|| true`s a failed password set — **dismissed**: same initdb contract as the rest of the script (a failing initdb.d script leaves a half-built data dir); Helm Job fails hard; live wrapper run printed `ALTER ROLE` and TCP login succeeded.
- `ALTER DEFAULT PRIVILEGES` has no `FOR ROLE <owner>` — **dismissed**: init always runs as the owner; hardcoding `deeptempo` would break Helm’s `vigil.postgres.username`.
- Sequence grant is `USAGE, SELECT` rather than `USAGE` only — **dismissed**: `SELECT` is the usual `currval` companion, not a restriction on other tables.
- `env.example` still comments `POSTGRES_USER=deeptempo` — **dismissed**: notes named compose, desktop compose, and Helm `vigil.env` only.
- `scripts/agent_up.sh` does not unset `DATABASE_URL` — **dismissed**: compose `x-agent-env` already has no DSN; a host `.env` `DATABASE_URL` is the pre-existing local-dev path and was not in scope.
- `force_terminal` test did not assert `current_user` — **fixed**: the session wrapper now asserts `vigil_app`.
- Tests do not issue `TRUNCATE`, cover other tables’ DML, or drive TypeScript `LedgerRepository` — **dismissed**: acceptance is UPDATE or DELETE at the database; notes allow `force_terminal`; other-table DML is granted in SQL and not in the required test.

## Verification

**Ran**

- `pytest tests/integration/test_ledger_app_role.py -v --no-cov` against live Postgres 16 (`pgvector/pgvector:pg16`, owner `deeptempo`) — 2 passed (`INSERT`/`SELECT` as `vigil_app`; `UPDATE`/`DELETE` raise `ProgrammingError` pgcode `42501`; `force_terminal` appends and `current_user` is `vigil_app`).
- Live entry point: ran `infra/docker/initdb/00_apply.sh` against that Postgres (applies `30_vigil_app_role.sql`, prints `setting vigil_app password` / `ALTER ROLE`). Then `psql` as `vigil_app` over the Docker network (password auth, not the local socket): `INSERT` succeeded; `UPDATE`, `DELETE`, and `TRUNCATE` returned `permission denied for table agent_events`; wrong password failed with `FATAL: password authentication failed`.
- Live Python entry point: `POSTGRES_USER=vigil_app python -c init_database(create_tables=True)` — `current_user=vigil_app`, `create_all` provisioned 56 public tables, subsequent `UPDATE agent_events` still `42501`.
- `diff -q infra/database/init infra/helm/vigil/files/database-init --exclude=README.md` — identical.
- `helm lint infra/helm/vigil` — 0 failed locally (warning: chart directory missing subchart tarballs). GitHub `Lint and Template` and `chart-testing` passed on this head.
- `scripts/check_comment_style.py` — no findings in `19_agent_ledger.sql` / `30_vigil_app_role.sql` (gate reports many pre-existing hits elsewhere; CI marks it continue-on-error).
- GitHub CI on `ee95c05` — 19 checks, none failed. Passed: Lint Backend, Lint Frontend, Lint Dockerfiles, Lint and Template, chart-testing, Unit Tests (Backend, Backend DB-backed, Frontend, Agent Layer), Integration Tests, Generated API Types, Agent Image, Build Frontend, Security Scan (Python, NPM), Setup Path (ubuntu, macos). Skipped (workflow `if:` on this event): Build Docker Images, Scan Docker Images.

**Did not run**

- `helm install` — machine could not: no Kubernetes cluster.
- Full `docker compose` backend image build and UI — not applicable as a UI change; the grant was exercised through psql and `init_database` as `vigil_app`.
- Desktop Electron launch — machine could not: no display / packaged app. Startup-order fix was reviewed in `main.ts` and matches `compose up --wait postgres` → `db-seed /apply.sh` → `up --wait`.
- TypeScript `LedgerRepository.append` as `vigil_app` — not applicable; notes allow `force_terminal`, which was run live in pytest.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df68c24d-8d31-416a-a257-541119070242?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df68c24d-8d31-416a-a257-541119070242&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

