### PR TITLE
feat(ledger): hash-chain agent_events on INSERT; ledger verify

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -428,6 +428,7 @@ jobs:
         run: |
           PGPASSWORD=test psql -h localhost -p 5432 -U test -d agent_test \
             -f infra/database/init/19_agent_ledger.sql \
+            -f infra/database/init/31_agent_ledger_hash_chain.sql \
             -f infra/database/init/20_agent_directives.sql \
             -f infra/database/init/21_agent_run_leases.sql
 
@@ -530,6 +531,7 @@ jobs:
         run: |
           PGPASSWORD=test psql -h localhost -p 5432 -U test -d deeptempo_test \
             -f infra/database/init/19_agent_ledger.sql \
+            -f infra/database/init/31_agent_ledger_hash_chain.sql \
             -f infra/database/init/20_agent_directives.sql \
             -f infra/database/init/21_agent_run_leases.sql
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,6 +107,7 @@ jobs:
         run: |
           PGPASSWORD=test psql -h localhost -p 5432 -U test -d deeptempo_test \
             -f infra/database/init/19_agent_ledger.sql \
+            -f infra/database/init/31_agent_ledger_hash_chain.sql \
             -f infra/database/init/20_agent_directives.sql \
             -f infra/database/init/21_agent_run_leases.sql
       

--- a/infra/database/init/31_agent_ledger_hash_chain.sql
+++ b/infra/database/init/31_agent_ledger_hash_chain.sql
@@ -1,0 +1,73 @@
+-- Hash chain on agent_events: filled on INSERT so every writer shares one formula.
+-- prev_hash is empty at the first seq; event_hash is sha256(prev_hash || payload text).
+
+ALTER TABLE agent_events ADD COLUMN IF NOT EXISTS prev_hash text;
+ALTER TABLE agent_events ADD COLUMN IF NOT EXISTS event_hash text;
+
+COMMENT ON COLUMN agent_events.prev_hash IS
+    'event_hash of the previous seq in this run, or empty at the first row.';
+COMMENT ON COLUMN agent_events.event_hash IS
+    'sha256(prev_hash || CAST(payload AS text)), assigned on INSERT and never by the caller.';
+
+CREATE OR REPLACE FUNCTION agent_event_hash(prev_hash text, payload jsonb)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public
+AS $$
+  SELECT encode(
+    sha256(convert_to(coalesce(prev_hash, '') || CAST(payload AS text), 'UTF8')),
+    'hex'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION agent_events_assign_hashes()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  SELECT event_hash INTO NEW.prev_hash
+    FROM agent_events
+    WHERE run_id = NEW.run_id AND seq < NEW.seq
+    ORDER BY seq DESC
+    LIMIT 1;
+  NEW.prev_hash := coalesce(NEW.prev_hash, '');
+  NEW.event_hash := agent_event_hash(NEW.prev_hash, NEW.payload);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS agent_events_assign_hashes ON agent_events;
+CREATE TRIGGER agent_events_assign_hashes
+  BEFORE INSERT ON agent_events
+  FOR EACH ROW
+  EXECUTE FUNCTION agent_events_assign_hashes();
+
+DO $$
+DECLARE
+  rec record;
+  prev text;
+BEGIN
+  FOR rec IN
+    SELECT run_id, seq, payload
+      FROM agent_events
+     WHERE event_hash IS NULL
+     ORDER BY run_id, seq
+  LOOP
+    SELECT event_hash INTO prev
+      FROM agent_events
+     WHERE run_id = rec.run_id AND seq < rec.seq
+     ORDER BY seq DESC
+     LIMIT 1;
+    prev := coalesce(prev, '');
+    UPDATE agent_events
+       SET prev_hash = prev,
+           event_hash = agent_event_hash(prev, rec.payload)
+     WHERE run_id = rec.run_id AND seq = rec.seq;
+  END LOOP;
+END;
+$$;
+
+ALTER TABLE agent_events ALTER COLUMN prev_hash SET NOT NULL;
+ALTER TABLE agent_events ALTER COLUMN event_hash SET NOT NULL;

--- a/infra/helm/vigil/files/database-init/31_agent_ledger_hash_chain.sql
+++ b/infra/helm/vigil/files/database-init/31_agent_ledger_hash_chain.sql
@@ -1,0 +1,73 @@
+-- Hash chain on agent_events: filled on INSERT so every writer shares one formula.
+-- prev_hash is empty at the first seq; event_hash is sha256(prev_hash || payload text).
+
+ALTER TABLE agent_events ADD COLUMN IF NOT EXISTS prev_hash text;
+ALTER TABLE agent_events ADD COLUMN IF NOT EXISTS event_hash text;
+
+COMMENT ON COLUMN agent_events.prev_hash IS
+    'event_hash of the previous seq in this run, or empty at the first row.';
+COMMENT ON COLUMN agent_events.event_hash IS
+    'sha256(prev_hash || CAST(payload AS text)), assigned on INSERT and never by the caller.';
+
+CREATE OR REPLACE FUNCTION agent_event_hash(prev_hash text, payload jsonb)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public
+AS $$
+  SELECT encode(
+    sha256(convert_to(coalesce(prev_hash, '') || CAST(payload AS text), 'UTF8')),
+    'hex'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION agent_events_assign_hashes()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  SELECT event_hash INTO NEW.prev_hash
+    FROM agent_events
+    WHERE run_id = NEW.run_id AND seq < NEW.seq
+    ORDER BY seq DESC
+    LIMIT 1;
+  NEW.prev_hash := coalesce(NEW.prev_hash, '');
+  NEW.event_hash := agent_event_hash(NEW.prev_hash, NEW.payload);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS agent_events_assign_hashes ON agent_events;
+CREATE TRIGGER agent_events_assign_hashes
+  BEFORE INSERT ON agent_events
+  FOR EACH ROW
+  EXECUTE FUNCTION agent_events_assign_hashes();
+
+DO $$
+DECLARE
+  rec record;
+  prev text;
+BEGIN
+  FOR rec IN
+    SELECT run_id, seq, payload
+      FROM agent_events
+     WHERE event_hash IS NULL
+     ORDER BY run_id, seq
+  LOOP
+    SELECT event_hash INTO prev
+      FROM agent_events
+     WHERE run_id = rec.run_id AND seq < rec.seq
+     ORDER BY seq DESC
+     LIMIT 1;
+    prev := coalesce(prev, '');
+    UPDATE agent_events
+       SET prev_hash = prev,
+           event_hash = agent_event_hash(prev, rec.payload)
+     WHERE run_id = rec.run_id AND seq = rec.seq;
+  END LOOP;
+END;
+$$;
+
+ALTER TABLE agent_events ALTER COLUMN prev_hash SET NOT NULL;
+ALTER TABLE agent_events ALTER COLUMN event_hash SET NOT NULL;

--- a/infra/helm/vigil/values.yaml
+++ b/infra/helm/vigil/values.yaml
@@ -419,6 +419,7 @@ dbInit:
     - 29_episodic_distil_failures.sql
     - 30_approval_action_reversibility.sql
     - 30_vigil_app_role.sql
+    - 31_agent_ledger_hash_chain.sql
   resources:
     requests:
       cpu: 50m

--- a/scripts/agent_testdb.sh
+++ b/scripts/agent_testdb.sh
@@ -25,7 +25,7 @@ until docker exec "$NAME" pg_isready -U vigil -d vigil_test >/dev/null 2>&1; do 
 
 # Only the agent layer's own tables: these tests touch no other schema, and the
 # rest of infra/database/init assumes an ordering this does not need.
-for sql in 19_agent_ledger 20_agent_directives 21_agent_run_leases; do
+for sql in 19_agent_ledger 31_agent_ledger_hash_chain 20_agent_directives 21_agent_run_leases; do
   docker exec -i "$NAME" psql -q -U vigil -d vigil_test \
     -c "SET client_min_messages = warning" -f - < "infra/database/init/$sql.sql" >/dev/null
 done

--- a/scripts/check_comment_style.py
+++ b/scripts/check_comment_style.py
@@ -29,6 +29,7 @@ SCOPED = (
     "infra/database/init/19_agent_ledger.sql",
     "infra/database/init/20_agent_directives.sql",
     "infra/database/init/21_agent_run_leases.sql",
+    "infra/database/init/31_agent_ledger_hash_chain.sql",
 )
 SKIP = ("node_modules", "package-lock.json", "dist", "__pycache__")
 

--- a/services/agent/ledger/verify.ts
+++ b/services/agent/ledger/verify.ts
@@ -81,7 +81,7 @@ export function parseRunId(argv: readonly string[]): string | undefined {
     if (arg === undefined) throw new Error(USAGE);
     if (arg === "--run-id") {
       const value = argv[i + 1];
-      if (value === undefined || value.startsWith("-")) throw new Error(USAGE);
+      if (value === undefined || value === "" || value.startsWith("-")) throw new Error(USAGE);
       runId = value;
       i += 1;
       continue;

--- a/services/agent/ledger/verify.ts
+++ b/services/agent/ledger/verify.ts
@@ -1,0 +1,124 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import pg, { type Pool } from "pg";
+import { poolConfig } from "../core/db.js";
+
+export type ChainOk = { ok: true; events: number; runs: number };
+export type ChainBreak = {
+  ok: false;
+  runId: string;
+  seq: number;
+  reason: "prev_hash" | "payload";
+};
+export type VerifyResult = ChainOk | ChainBreak;
+
+const USAGE = "usage: ledger verify [--run-id <uuid>]";
+
+const FIRST_BREAK = `
+SELECT run_id, seq,
+       CASE
+         WHEN prev_hash IS DISTINCT FROM expected_prev THEN 'prev_hash'
+         ELSE 'payload'
+       END AS reason
+  FROM (
+    SELECT run_id, seq, prev_hash, event_hash,
+           coalesce(lag(event_hash) OVER (PARTITION BY run_id ORDER BY seq), '') AS expected_prev,
+           agent_event_hash(prev_hash, payload) AS expected_hash
+      FROM agent_events
+     WHERE ($1::uuid IS NULL OR run_id = $1)
+  ) c
+ WHERE prev_hash IS DISTINCT FROM expected_prev
+    OR event_hash IS DISTINCT FROM expected_hash
+ ORDER BY run_id, seq
+ LIMIT 1`;
+
+const COUNTS = `
+SELECT count(*)::int AS events, count(DISTINCT run_id)::int AS runs
+  FROM agent_events
+ WHERE ($1::uuid IS NULL OR run_id = $1)`;
+
+// Walks stored hashes against the SQL formula the INSERT trigger assigned.
+export async function verifyLedger(pool: Pool, runId?: string): Promise<VerifyResult> {
+  const key = runId ?? null;
+  const broken = await pool.query<{ run_id: string; seq: number; reason: string }>(FIRST_BREAK, [key]);
+  const row = broken.rows[0];
+  if (row !== undefined) {
+    return { ok: false, runId: String(row.run_id), seq: Number(row.seq), reason: asReason(row.reason) };
+  }
+  const counts = await pool.query<{ events: number; runs: number }>(COUNTS, [key]);
+  const totals = counts.rows[0];
+  return { ok: true, events: Number(totals?.events ?? 0), runs: Number(totals?.runs ?? 0) };
+}
+
+function asReason(value: string): ChainBreak["reason"] {
+  switch (value) {
+    case "prev_hash":
+    case "payload":
+      return value;
+    default:
+      throw new Error(`unexpected break reason: ${value}`);
+  }
+}
+
+export function formatVerify(result: VerifyResult): string {
+  if (result.ok) return `ok  ${result.events} events  ${result.runs} run(s)`;
+  switch (result.reason) {
+    case "prev_hash":
+      return `break  run=${result.runId}  seq=${result.seq}  prev_hash does not follow the previous event`;
+    case "payload":
+      return `break  run=${result.runId}  seq=${result.seq}  payload does not match event_hash`;
+    default: {
+      const _exhaustive: never = result.reason;
+      return _exhaustive;
+    }
+  }
+}
+
+export function parseRunId(argv: readonly string[]): string | undefined {
+  let runId: string | undefined;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === undefined) throw new Error(USAGE);
+    if (arg === "--run-id") {
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith("-")) throw new Error(USAGE);
+      runId = value;
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--run-id=")) {
+      const value = arg.slice("--run-id=".length);
+      if (value === "") throw new Error(USAGE);
+      runId = value;
+      continue;
+    }
+    throw new Error(USAGE);
+  }
+  return runId;
+}
+
+export async function main(argv: readonly string[] = process.argv.slice(2)): Promise<number> {
+  let runId: string | undefined;
+  try {
+    runId = parseRunId(argv);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : USAGE}\n`);
+    return 2;
+  }
+  const pool = new pg.Pool(poolConfig());
+  try {
+    const result = await verifyLedger(pool, runId);
+    process.stdout.write(`${formatVerify(result)}\n`);
+    return result.ok ? 0 : 1;
+  } finally {
+    await pool.end();
+  }
+}
+
+const invoked = process.argv[1];
+if (invoked !== undefined && import.meta.url === pathToFileURL(resolve(invoked)).href) {
+  main().then((code) => process.exit(code), (error: unknown) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(2);
+  });
+}

--- a/services/agent/package.json
+++ b/services/agent/package.json
@@ -14,7 +14,8 @@
     "test:integration": "vitest run tests/integration",
     "build": "tsc -p tsconfig.build.json",
     "worker": "tsx worker.ts",
-    "serve": "tsx serve.ts"
+    "serve": "tsx serve.ts",
+    "ledger:verify": "tsx ledger/verify.ts"
   },
   "dependencies": {
     "ajv": "^8.20.0",

--- a/services/agent/tests/integration/ledger.test.ts
+++ b/services/agent/tests/integration/ledger.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import pg from "pg";
 import { randomUUID } from "node:crypto";
 import { LedgerRepository } from "../../ledger/repository.js";
+import { verifyLedger } from "../../ledger/verify.js";
 import type { NewEvent, RunKind } from "../../contracts/events.js";
 import { TEST_DSN } from "../support/testdb.js";
 
@@ -95,4 +96,61 @@ describe("concurrent writers each take their own position", () => {
     );
     expect(rows[0]).toEqual({ seqs: "9", rows: "9" });
   });
+});
+
+// The INSERT trigger assigns the chain. verify recomputes that same SQL formula,
+// so a payload UPDATE the table owner can still issue is what it is for.
+describe("the ledger hash chain is assigned on insert and checked by verify", () => {
+  it("hashes a repository append and a raw INSERT with one SQL formula", async () => {
+    await ledger.append(runId, [runEvent(runId), terminalEvent(runId)]);
+    const other = randomUUID();
+    await pool.query(
+      "INSERT INTO agent_events (run_id, run_kind, seq, kind, payload, schema_version) VALUES ($1, 'hunt', 0, 'run', $2::jsonb, 1)",
+      [other, JSON.stringify({ seed: other })],
+    );
+
+    const { rows } = await pool.query<{ prev_hash: string; event_hash: string }>(
+      "SELECT prev_hash, event_hash FROM agent_events WHERE run_id = $1 ORDER BY seq",
+      [runId],
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.prev_hash).toBe("");
+    expect(rows[0]?.event_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(rows[1]?.prev_hash).toBe(rows[0]?.event_hash);
+    expect(await verifyLedger(pool, runId)).toEqual({ ok: true, events: 2, runs: 1 });
+    expect(await verifyLedger(pool, other)).toMatchObject({ ok: true, events: 1, runs: 1 });
+  });
+
+  it("names the first seq whose payload no longer matches its stored hash", async () => {
+    await ledger.append(runId, [runEvent(runId), terminalEvent(runId)]);
+    await pool.query("UPDATE agent_events SET payload = $2::jsonb WHERE run_id = $1 AND seq = 1", [
+      runId,
+      JSON.stringify({ outcome: "tampered", reason: "rewritten" }),
+    ]);
+
+    expect(await verifyLedger(pool, runId)).toEqual({
+      ok: false,
+      runId,
+      seq: 1,
+      reason: "payload",
+    });
+  });
+
+  it("verifies 100k events in under a minute", async () => {
+    await pool.query(
+      `INSERT INTO agent_events (run_id, run_kind, seq, kind, payload, schema_version)
+       SELECT $1, 'hunt', g, 'run', jsonb_build_object('n', g), 1
+         FROM generate_series(0, 99999) AS g
+        ORDER BY g`,
+      [runId],
+    );
+    try {
+      const started = Date.now();
+      const result = await verifyLedger(pool, runId);
+      expect(result).toEqual({ ok: true, events: 100_000, runs: 1 });
+      expect(Date.now() - started).toBeLessThan(60_000);
+    } finally {
+      await pool.query("DELETE FROM agent_events WHERE run_id = $1", [runId]);
+    }
+  }, 180_000);
 });

--- a/tests/integration/test_agent_run_walking_skeleton.py
+++ b/tests/integration/test_agent_run_walking_skeleton.py
@@ -37,6 +37,7 @@ def _redis_url() -> str:
 # 0001), so nothing else creates them for a test.
 AGENT_DDL = (
     "19_agent_ledger.sql",
+    "31_agent_ledger_hash_chain.sql",
     "20_agent_directives.sql",
     "21_agent_run_leases.sql",
 )

--- a/tests/integration/test_distil_poll_failures.py
+++ b/tests/integration/test_distil_poll_failures.py
@@ -38,6 +38,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # episodic half and not the ledger, so both are applied rather than assumed.
 DDL = (
     "19_agent_ledger.sql",
+    "31_agent_ledger_hash_chain.sql",
     "26_episodic_memory.sql",
     "29_episodic_distil_failures.sql",
 )

--- a/tests/integration/test_ledger_app_role.py
+++ b/tests/integration/test_ledger_app_role.py
@@ -84,6 +84,7 @@ def app_engine():
     password = _parts()["password"]
     with owner.connect() as conn:
         _apply_sql(conn, "19_agent_ledger.sql")
+        _apply_sql(conn, "31_agent_ledger_hash_chain.sql")
         _apply_sql(conn, "30_vigil_app_role.sql")
         escaped = password.replace("'", "''")
         conn.exec_driver_sql(f"ALTER ROLE vigil_app PASSWORD '{escaped}'")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #825

`agent_events` now carries a hash chain computed inside the locked append, not by the caller. One SQL formula on INSERT covers `LedgerRepository`, `force_terminal`, and the test inserts. `npm run ledger:verify -- [--run-id <uuid>]` walks that chain and names the first break.

## What changed
- New `31_agent_ledger_hash_chain.sql`: `prev_hash` / `event_hash` columns, `agent_event_hash()` (`sha256(prev_hash || CAST(payload AS text))`), BEFORE INSERT trigger, backfill, then NOT NULL. Helm copy + `dbInit.sqlFiles`. Wired into the agent-only apply lists (and `test_ledger_app_role.py`, so `vigil_app` INSERT still hits the trigger).
- `services/agent/ledger/verify.ts` — SQL recompute of the same formula; `--run-id` or all runs. No Python ledger layer and no `vigil` CLI package.
- Integration tests: append hashes, raw INSERT hashes, payload UPDATE detected at that seq, 100k verify under a minute.

## Review findings
- Independent review (fresh-eyes subagent on the full diff): no defects.
- No style or out-of-scope nits were raised that needed a disposition.

## Verification

Ran:
- `npm run typecheck` in `services/agent` — passed.
- `npm run build` (`tsc -p tsconfig.build.json`) — passed; emits `dist/ledger/verify.js`.
- `npx vitest run tests/integration/ledger.test.ts` — 8 passed, including tamper-at-seq-1 and 100k verify (suite ~1.8s).
- `npx vitest run tests/integration` — 40 passed (all agent integration files).
- `npx vitest run tests/core tests/hunt tests/chat` — 911 passed.
- `diff -r infra/database/init infra/helm/vigil/files/database-init` — in sync.
- `python3 scripts/check_comment_style.py` filtered to this change — no hits in `31_*.sql`, `ledger/verify.ts`, or `ledger.test.ts`.
- Live, against `scripts/agent_testdb.sh` (`postgres://vigil:vigil@localhost:55432/vigil_test`):
  - Appended two events through `LedgerRepository` (run `72a15dbb-315b-4523-8abe-228faa29221a`); seq 0 `prev_hash` empty, seq 1 chained.
  - `npm run ledger:verify -- --run-id <uuid>` → `ok  2 events  1 run(s)` exit 0.
  - `UPDATE agent_events SET payload = ... WHERE seq = 1`.
  - Same command → `break  run=72a15dbb-…  seq=1  payload does not match event_hash` exit 1.
  - `npm run ledger:verify` (all runs) named that same break.
  - `npm run ledger:verify -- --nope` → usage, exit 2.
- Backfill path: applied `19` only, inserted two rows, applied `31`; both rows hashed, `event_hash = agent_event_hash(prev_hash, payload)` and prev links held.

Did not run:
- Full `python3 scripts/check_comment_style.py` as a pass/fail gate — it reports 335 pre-existing violations under `services/agent/` and scoped Python files; none are in this diff. Not a regression from this change.
- Python `pytest` (`tests/integration/test_agent_run_walking_skeleton.py`, `test_distil_poll_failures.py`, `test_ledger_app_role.py`) — `pytest` is not installed here, and those tests want the compose Postgres on `:5432`, which was not up. Edits there are DDL filename wiring only. The `force_terminal`-shaped INSERT (omit hash columns) was exercised on the agent testdb instead.
- Agent ESLint — the agent package has no lint script.
- Browser / `agent-browser` — not applicable; this is a SQL + CLI change, no UI.
- GitHub Actions on this PR — not observed from this environment; local checks above are the evidence.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31e38518-09a8-44a0-9e4e-c1f7637d830e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31e38518-09a8-44a0-9e4e-c1f7637d830e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

