### PR TITLE
feat(detections): reconstruct a red run into per-step detection verdicts

### DIFF
--- a/core/agents/tool_registry.py
+++ b/core/agents/tool_registry.py
@@ -195,6 +195,7 @@ _SECURITY_TOOLS = frozenset(
         "get_coverage_stats",
         "get_detection_count",
         "lint_detections",
+        "reconstruct_run",
     }
 )
 

--- a/core/detections/reconstruction.py
+++ b/core/detections/reconstruction.py
@@ -1,0 +1,248 @@
+"""Correlate a red-run action trace to ingested Findings.
+
+Each step is joined on host / entity / time fields that are actually present
+on the Finding. Technique ids and other unknown keys on a step are ignored.
+Verdicts: rule | loglm | both | missed. LogLM-origin is ``data_source ==
+"loglm"``; any other correlated Finding is rule-origin.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
+
+Verdict = Literal["rule", "loglm", "both", "missed"]
+
+_LOG_LM = "loglm"
+
+_START_KEYS = ("started_at", "start", "start_time", "timestamp")
+_END_KEYS = ("ended_at", "end", "end_time")
+
+
+def reconstruct(steps: Any, findings: Any) -> Dict[str, Any]:
+    """Return one reconstruction record: a verdict per step, with citations."""
+    if not isinstance(steps, list):
+        return {"error": "steps must be a list of action-trace objects"}
+
+    rows = findings if isinstance(findings, list) else []
+    parsed: List[Dict[str, Any]] = []
+    for finding in rows:
+        if isinstance(finding, dict):
+            parsed.append(finding)
+
+    results: List[Dict[str, Any]] = []
+    for index, raw in enumerate(steps):
+        results.append(_reconstruct_step(index, raw, parsed))
+    return {"steps": results}
+
+
+def _reconstruct_step(
+    index: int, raw: Any, findings: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    record: Dict[str, Any] = {"index": index, "verdict": "missed", "citations": []}
+    if not isinstance(raw, dict):
+        return record
+
+    step_id = raw.get("id") or raw.get("step_id")
+    if step_id is not None and step_id != "":
+        record["id"] = step_id
+
+    window = _window(raw)
+    step_entities = _entities_from_step(raw)
+    if window is None or not _has_entity(step_entities):
+        return record
+
+    start, end = window
+    hits: List[Dict[str, Any]] = []
+    for finding in findings:
+        if _correlates(finding, start, end, step_entities):
+            hits.append(finding)
+
+    hits.sort(key=lambda item: str(item.get("finding_id") or ""))
+    record["verdict"] = _verdict(hits)
+    record["citations"] = [_cite(finding) for finding in hits]
+    return record
+
+
+def _correlates(
+    finding: Dict[str, Any],
+    start: datetime,
+    end: datetime,
+    step_entities: Dict[str, List[str]],
+) -> bool:
+    finding_ts = _parse_time(finding.get("timestamp"))
+    if finding_ts is None or finding_ts < start or finding_ts > end:
+        return False
+    context = finding.get("entity_context")
+    finding_entities = _entities_from_context(
+        context if isinstance(context, dict) else None
+    )
+    return _overlaps(step_entities, finding_entities)
+
+
+def _verdict(hits: List[Dict[str, Any]]) -> Verdict:
+    has_loglm = False
+    has_rule = False
+    for finding in hits:
+        if finding.get("data_source") == _LOG_LM:
+            has_loglm = True
+        else:
+            has_rule = True
+    if has_loglm and has_rule:
+        return "both"
+    if has_loglm:
+        return "loglm"
+    if has_rule:
+        return "rule"
+    return "missed"
+
+
+def _cite(finding: Dict[str, Any]) -> Dict[str, Any]:
+    citation: Dict[str, Any] = {"finding_id": finding.get("finding_id") or ""}
+    description = finding.get("description")
+    if isinstance(description, str) and description:
+        citation["description"] = description
+    context = finding.get("entity_context")
+    if isinstance(context, dict):
+        rule_name = context.get("rule_name")
+        if isinstance(rule_name, str) and rule_name.strip():
+            citation["rule_name"] = rule_name
+    return citation
+
+
+def _window(step: Dict[str, Any]) -> Optional[Tuple[datetime, datetime]]:
+    start = _first_time(step, _START_KEYS)
+    end = _first_time(step, _END_KEYS)
+    if start is None and end is None:
+        return None
+    if start is None:
+        start = end
+    if end is None:
+        end = start
+    if start is None or end is None:
+        return None
+    if end < start:
+        start, end = end, start
+    return start, end
+
+
+def _first_time(step: Dict[str, Any], keys: Iterable[str]) -> Optional[datetime]:
+    for key in keys:
+        parsed = _parse_time(step.get(key))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _entities_from_context(
+    entity_context: Optional[Dict[str, Any]],
+) -> Dict[str, List[str]]:
+    """Host / IP / user values, using ``build_entity_string`` spellings."""
+    if not entity_context:
+        return {"hostnames": [], "src_ips": [], "users": []}
+
+    src_ips = entity_context.get("src_ips") or []
+    if not src_ips and entity_context.get("src_ip"):
+        src_ips = [entity_context["src_ip"]]
+    hostnames = entity_context.get("hostnames") or []
+    if not hostnames and entity_context.get("hostname"):
+        hostnames = [entity_context["hostname"]]
+    users = entity_context.get("users") or entity_context.get("usernames") or []
+    if not users and entity_context.get("user"):
+        users = [entity_context["user"]]
+
+    return {
+        "hostnames": _as_values(hostnames),
+        "src_ips": _as_values(src_ips),
+        "users": _as_values(users),
+    }
+
+
+def _entities_from_step(step: Dict[str, Any]) -> Dict[str, List[str]]:
+    hostnames = (
+        step.get("hostnames")
+        or step.get("hostname")
+        or step.get("host")
+        or step.get("computer_name")
+        or []
+    )
+    src_ips = step.get("src_ips") or []
+    if not src_ips and step.get("src_ip"):
+        src_ips = [step["src_ip"]]
+    users = step.get("users") or step.get("usernames") or []
+    if not users:
+        user = step.get("user") or step.get("username")
+        users = [user] if user else []
+    return {
+        "hostnames": _as_values(hostnames),
+        "src_ips": _as_values(src_ips),
+        "users": _as_values(users),
+    }
+
+
+def _has_entity(entities: Dict[str, List[str]]) -> bool:
+    return any(entities[key] for key in ("hostnames", "src_ips", "users"))
+
+
+def _overlaps(
+    step_entities: Dict[str, List[str]], finding_entities: Dict[str, List[str]]
+) -> bool:
+    for key in ("hostnames", "src_ips", "users"):
+        if _folded(step_entities[key]) & _folded(finding_entities[key]):
+            return True
+    return False
+
+
+def _folded(values: List[str]) -> set[str]:
+    return {value.casefold() for value in values if value}
+
+
+def _as_values(value: Any) -> List[str]:
+    if value is None or isinstance(value, (dict, bool)):
+        return []
+    if isinstance(value, (list, tuple, set)):
+        out: List[str] = []
+        for item in value:
+            if item is None or isinstance(item, (dict, bool)) or item == "":
+                continue
+            text = str(item).strip()
+            if text:
+                out.append(text)
+        return out
+    text = str(value).strip()
+    return [text] if text else []
+
+
+def _parse_time(value: Any) -> Optional[datetime]:
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    if isinstance(value, datetime):
+        return _naive_utc(value)
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and value != value:
+            return None
+        number = float(value)
+        if abs(number) > 1e12:
+            number /= 1000.0
+        try:
+            return datetime.fromtimestamp(number, tz=timezone.utc).replace(tzinfo=None)
+        except (OverflowError, OSError, ValueError):
+            return None
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return _naive_utc(parsed)
+
+
+def _naive_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)

--- a/core/detections/reconstruction.py
+++ b/core/detections/reconstruction.py
@@ -36,6 +36,25 @@ def reconstruct(steps: Any, findings: Any) -> Dict[str, Any]:
     return {"steps": results}
 
 
+def span_for_steps(steps: Any) -> Optional[Tuple[datetime, datetime]]:
+    """Smallest window covering every step that has a parseable time range."""
+    if not isinstance(steps, list):
+        return None
+    starts: List[datetime] = []
+    ends: List[datetime] = []
+    for raw in steps:
+        if not isinstance(raw, dict):
+            continue
+        window = _window(raw)
+        if window is None:
+            continue
+        starts.append(window[0])
+        ends.append(window[1])
+    if not starts:
+        return None
+    return min(starts), max(ends)
+
+
 def _reconstruct_step(
     index: int, raw: Any, findings: List[Dict[str, Any]]
 ) -> Dict[str, Any]:

--- a/core/detections/tools.py
+++ b/core/detections/tools.py
@@ -13,7 +13,7 @@ import yaml
 
 from core.config import _safe_home
 from core.detections.lint import lint_sigma
-from core.detections.reconstruction import reconstruct
+from core.detections.reconstruction import reconstruct, span_for_steps
 from core.storage.database_data_service import DatabaseDataService
 
 
@@ -540,7 +540,12 @@ class SecurityDetectionsTools:
         Extra kwargs (including ``limit`` injected by ``/internal/tools/invoke``)
         are ignored so this does not freeze a later execute-tool JSON shape.
         """
-        findings = DatabaseDataService().get_findings(limit=10000)
+        span = span_for_steps(steps)
+        findings = DatabaseDataService().get_findings(
+            limit=10000,
+            timestamp_start=span[0] if span else None,
+            timestamp_end=span[1] if span else None,
+        )
         return reconstruct(steps, findings)
 
 

--- a/core/detections/tools.py
+++ b/core/detections/tools.py
@@ -13,6 +13,8 @@ import yaml
 
 from core.config import _safe_home
 from core.detections.lint import lint_sigma
+from core.detections.reconstruction import reconstruct
+from core.storage.database_data_service import DatabaseDataService
 
 
 class SecurityDetectionsTools:
@@ -531,6 +533,15 @@ class SecurityDetectionsTools:
         run on ``add_source`` / clone; community corpora stay importable.
         """
         return lint_sigma(rule_yaml=rule_yaml, source_path=source_path)
+
+    async def reconstruct_run(self, steps: List[Dict], **_kwargs: object) -> Dict:
+        """Correlate an action trace to ingested Findings; return per-step verdicts.
+
+        Extra kwargs (including ``limit`` injected by ``/internal/tools/invoke``)
+        are ignored so this does not freeze a later execute-tool JSON shape.
+        """
+        findings = DatabaseDataService().get_findings(limit=10000)
+        return reconstruct(steps, findings)
 
 
 # Global instance for reuse

--- a/core/llm/tool_schemas.py
+++ b/core/llm/tool_schemas.py
@@ -108,6 +108,21 @@ SECURITY_DETECTION_TOOLS = [
             },
         },
     },
+    {
+        "name": "reconstruct_run",
+        "description": "Reconstruct a red-run action trace into per-step detection verdicts. Correlates each step to ingested Findings by host, entity, and time. Verdict is rule, loglm, both, or missed. Cite matching Finding ids. Unknown keys on a step are ignored.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "steps": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": "Action-trace steps. Join keys are host/entity/time (hostname, src_ip, user, started_at/ended_at or timestamp). Unknown keys are ignored.",
+                }
+            },
+            "required": ["steps"],
+        },
+    },
 ]
 
 # DeepTempo Findings Tools (Already implemented in backend)

--- a/core/storage/database_data_service.py
+++ b/core/storage/database_data_service.py
@@ -117,6 +117,8 @@ class DatabaseDataService:
         search_query: Optional[str] = None,
         sort_by: str = "timestamp",
         sort_order: str = "desc",
+        timestamp_start: Optional[datetime] = None,
+        timestamp_end: Optional[datetime] = None,
     ) -> List[Dict]:
         if self._demo_mode and self._demo_service:
             return self._demo_service.get_findings(limit)
@@ -133,6 +135,8 @@ class DatabaseDataService:
                     offset=offset,
                     sort_by=sort_by,
                     sort_order=sort_order,
+                    timestamp_start=timestamp_start,
+                    timestamp_end=timestamp_end,
                 )
                 return FindingSchema.dump_many(findings)
             except Exception as e:

--- a/core/storage/service.py
+++ b/core/storage/service.py
@@ -200,6 +200,8 @@ class DatabaseService:
         offset: int = 0,
         sort_by: str = "timestamp",
         sort_order: str = "desc",
+        timestamp_start: Optional[datetime] = None,
+        timestamp_end: Optional[datetime] = None,
     ) -> List[Finding]:
         """
         Get findings with optional filters, search, and pagination.
@@ -233,6 +235,10 @@ class DatabaseService:
                 filters.append(Finding.anomaly_score >= min_anomaly_score)
             if status:
                 filters.append(Finding.status == status)
+            if timestamp_start is not None:
+                filters.append(Finding.timestamp >= timestamp_start)
+            if timestamp_end is not None:
+                filters.append(Finding.timestamp <= timestamp_end)
             if search_query:
                 from sqlalchemy import String, cast
 

--- a/tests/unit/detections/fixtures/recorded_red_run.json
+++ b/tests/unit/detections/fixtures/recorded_red_run.json
@@ -27,6 +27,13 @@
       "hostname": "ws01.corp.local",
       "src_ip": "10.0.1.50",
       "technique_id": "T1021.002"
+    },
+    {
+      "id": "step-4",
+      "started_at": "2026-09-10T12:20:00Z",
+      "ended_at": "2026-09-10T12:22:00Z",
+      "src_ip": "10.0.2.80",
+      "technique_id": "T1047"
     }
   ],
   "findings": [
@@ -69,6 +76,13 @@
       "description": "Credential dump with no hostname",
       "entity_context": { "usernames": ["administrator"] },
       "mitre_predictions": { "T1003.001": 0.9 }
+    },
+    {
+      "finding_id": "loglm-wmi-seq",
+      "data_source": "loglm",
+      "timestamp": "2026-09-10T12:21:00Z",
+      "description": "Anomalous WMI sequence",
+      "entity_context": { "src_ip": "10.0.2.80" }
     }
   ]
 }

--- a/tests/unit/detections/fixtures/recorded_red_run.json
+++ b/tests/unit/detections/fixtures/recorded_red_run.json
@@ -1,0 +1,74 @@
+{
+  "steps": [
+    {
+      "id": "step-1",
+      "started_at": "2026-09-10T12:00:00Z",
+      "ended_at": "2026-09-10T12:05:00Z",
+      "hostname": "ws01.corp.local",
+      "src_ip": "10.0.1.50",
+      "user": "jsmith",
+      "technique_id": "T1059.001",
+      "atomic_guid": "f7c1e3d2-aaaa-4bbb-8ccc-0123456789ab",
+      "command": "powershell -EncodedCommand ..."
+    },
+    {
+      "id": "step-2",
+      "started_at": "2026-09-10T12:06:00Z",
+      "ended_at": "2026-09-10T12:08:00Z",
+      "hostname": "dc01.corp.local",
+      "src_ip": "10.0.1.10",
+      "technique_id": "T1003.001",
+      "atomic_guid": "0a3b4c5d-eeee-4fff-aaaa-abcdef012345"
+    },
+    {
+      "id": "step-3",
+      "started_at": "2026-09-10T12:10:00Z",
+      "ended_at": "2026-09-10T12:12:00Z",
+      "hostname": "ws01.corp.local",
+      "src_ip": "10.0.1.50",
+      "technique_id": "T1021.002"
+    }
+  ],
+  "findings": [
+    {
+      "finding_id": "elastic-enc-ps",
+      "data_source": "elastic",
+      "timestamp": "2026-09-10T12:01:30Z",
+      "description": "Encoded PowerShell command line",
+      "entity_context": {
+        "hostnames": ["WS01.CORP.LOCAL"],
+        "src_ips": ["10.0.1.50"],
+        "usernames": ["jsmith"],
+        "rule_name": "Encoded PowerShell"
+      },
+      "mitre_predictions": { "T1059.001": 0.95 }
+    },
+    {
+      "finding_id": "loglm-seq-1",
+      "data_source": "loglm",
+      "timestamp": "2026-09-10T12:02:00Z",
+      "description": "Anomalous process sequence",
+      "entity_context": { "src_ip": "10.0.1.50" }
+    },
+    {
+      "finding_id": "elastic-lsass-other-host",
+      "data_source": "elastic",
+      "timestamp": "2026-09-10T12:07:00Z",
+      "description": "LSASS memory access",
+      "entity_context": {
+        "hostnames": ["other-host"],
+        "src_ips": ["10.9.9.9"],
+        "rule_name": "LSASS Access"
+      },
+      "mitre_predictions": { "T1003.001": 0.99 }
+    },
+    {
+      "finding_id": "elastic-no-host",
+      "data_source": "elastic",
+      "timestamp": "2026-09-10T12:07:15Z",
+      "description": "Credential dump with no hostname",
+      "entity_context": { "usernames": ["administrator"] },
+      "mitre_predictions": { "T1003.001": 0.9 }
+    }
+  ]
+}

--- a/tests/unit/detections/test_reconstruct_run.py
+++ b/tests/unit/detections/test_reconstruct_run.py
@@ -1,0 +1,98 @@
+"""Per-step reconstruction of a red run (#835)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.detections.reconstruction import reconstruct
+from core.detections.tools import SecurityDetectionsTools
+
+pytestmark = pytest.mark.unit
+
+FIXTURE = Path(__file__).parent / "fixtures" / "recorded_red_run.json"
+
+
+def _recorded():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _verdicts(result: dict) -> list[str]:
+    return [step["verdict"] for step in result["steps"]]
+
+
+def test_recorded_run_missed_when_window_has_no_entity_time_overlap():
+    recorded = _recorded()
+    result = reconstruct(recorded["steps"], recorded["findings"])
+
+    by_id = {step["id"]: step for step in result["steps"]}
+    missed = by_id["step-2"]
+    assert missed["verdict"] == "missed"
+    assert missed["citations"] == []
+
+    empty_window = by_id["step-3"]
+    assert empty_window["verdict"] == "missed"
+    assert empty_window["citations"] == []
+
+
+def test_recorded_run_both_when_rule_and_loglm_hit_the_same_step():
+    recorded = _recorded()
+    result = reconstruct(recorded["steps"], recorded["findings"])
+
+    step = next(item for item in result["steps"] if item["id"] == "step-1")
+    assert step["verdict"] == "both"
+    cited = {item["finding_id"]: item for item in step["citations"]}
+    assert set(cited) == {"elastic-enc-ps", "loglm-seq-1"}
+    assert cited["elastic-enc-ps"]["description"] == "Encoded PowerShell command line"
+    assert cited["elastic-enc-ps"]["rule_name"] == "Encoded PowerShell"
+    assert cited["loglm-seq-1"]["description"] == "Anomalous process sequence"
+
+
+def test_no_loglm_findings_never_emits_loglm():
+    recorded = _recorded()
+    findings = [
+        finding for finding in recorded["findings"] if finding["data_source"] != "loglm"
+    ]
+    result = reconstruct(recorded["steps"], findings)
+
+    assert "loglm" not in _verdicts(result)
+    assert "both" not in _verdicts(result)
+    by_id = {step["id"]: step for step in result["steps"]}
+    assert by_id["step-1"]["verdict"] == "rule"
+    assert by_id["step-2"]["verdict"] == "missed"
+
+
+def test_unknown_step_keys_are_ignored_and_do_not_join_on_technique_id():
+    recorded = _recorded()
+    result = reconstruct(recorded["steps"], recorded["findings"])
+    step = next(item for item in result["steps"] if item["id"] == "step-2")
+    assert step["verdict"] == "missed"
+
+
+@pytest.mark.asyncio
+async def test_backend_tool_dispatches_reconstruct_run(monkeypatch):
+    from core.agents.tool_registry import execute_backend_tool
+    from core.llm.tool_schemas import ALL_TOOLS
+
+    recorded = _recorded()
+
+    class _Store:
+        def get_findings(self, **_kwargs):
+            return recorded["findings"]
+
+    monkeypatch.setattr("core.detections.tools.DatabaseDataService", lambda: _Store())
+
+    assert any(tool["name"] == "reconstruct_run" for tool in ALL_TOOLS)
+
+    result, handled = await execute_backend_tool(
+        "reconstruct_run",
+        {"steps": recorded["steps"], "limit": 2, "technique_id": "T1059.001"},
+    )
+    assert handled is True
+    assert _verdicts(result) == ["both", "missed", "missed"]
+
+    tools = SecurityDetectionsTools()
+    via_tools = await tools.reconstruct_run(steps=recorded["steps"])
+    assert via_tools["steps"][0]["verdict"] == "both"

--- a/tests/unit/detections/test_reconstruct_run.py
+++ b/tests/unit/detections/test_reconstruct_run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -37,6 +38,14 @@ def test_recorded_run_missed_when_window_has_no_entity_time_overlap():
     assert empty_window["citations"] == []
 
 
+def test_recorded_run_loglm_when_only_loglm_hits_the_step():
+    recorded = _recorded()
+    result = reconstruct(recorded["steps"], recorded["findings"])
+    step = next(item for item in result["steps"] if item["id"] == "step-4")
+    assert step["verdict"] == "loglm"
+    assert [item["finding_id"] for item in step["citations"]] == ["loglm-wmi-seq"]
+
+
 def test_recorded_run_both_when_rule_and_loglm_hit_the_same_step():
     recorded = _recorded()
     result = reconstruct(recorded["steps"], recorded["findings"])
@@ -62,6 +71,7 @@ def test_no_loglm_findings_never_emits_loglm():
     by_id = {step["id"]: step for step in result["steps"]}
     assert by_id["step-1"]["verdict"] == "rule"
     assert by_id["step-2"]["verdict"] == "missed"
+    assert by_id["step-4"]["verdict"] == "missed"
 
 
 def test_unknown_step_keys_are_ignored_and_do_not_join_on_technique_id():
@@ -91,8 +101,42 @@ async def test_backend_tool_dispatches_reconstruct_run(monkeypatch):
         {"steps": recorded["steps"], "limit": 2, "technique_id": "T1059.001"},
     )
     assert handled is True
-    assert _verdicts(result) == ["both", "missed", "missed"]
+    assert _verdicts(result) == ["both", "missed", "missed", "loglm"]
+
+    no_loglm = [
+        finding for finding in recorded["findings"] if finding["data_source"] != "loglm"
+    ]
+
+    class _RulesOnly:
+        def get_findings(self, **_kwargs):
+            return no_loglm
+
+    monkeypatch.setattr(
+        "core.detections.tools.DatabaseDataService", lambda: _RulesOnly()
+    )
+    result, handled = await execute_backend_tool(
+        "reconstruct_run", {"steps": recorded["steps"]}
+    )
+    assert handled is True
+    assert "loglm" not in _verdicts(result)
+    assert "both" not in _verdicts(result)
 
     tools = SecurityDetectionsTools()
     via_tools = await tools.reconstruct_run(steps=recorded["steps"])
-    assert via_tools["steps"][0]["verdict"] == "both"
+    assert _verdicts(via_tools) == ["rule", "missed", "missed", "missed"]
+
+
+@pytest.mark.asyncio
+async def test_tool_reads_findings_in_the_trace_window(monkeypatch):
+    recorded = _recorded()
+    seen: dict = {}
+
+    class _Store:
+        def get_findings(self, **kwargs):
+            seen.update(kwargs)
+            return recorded["findings"]
+
+    monkeypatch.setattr("core.detections.tools.DatabaseDataService", lambda: _Store())
+    await SecurityDetectionsTools().reconstruct_run(steps=recorded["steps"])
+    assert seen["timestamp_start"] == datetime(2026, 9, 10, 12, 0, 0)
+    assert seen["timestamp_end"] == datetime(2026, 9, 10, 12, 22, 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #835

Adds `reconstruct_run` in the detections domain. An agent passes an action-trace step list and gets one JSON record of per-step **rule / loglm / both / missed** verdicts with Finding citations. The harness journals that return as `dispatch`; this PR does not write `agent_events`.

Correlation is host / entity / time on ingested Findings (`entity_context` hostnames / `src_ip` / users and `Finding.timestamp`, same spellings as `build_entity_string`). Unknown keys on a step are ignored so this does not freeze #833's execute JSON. LogLM-origin is `data_source == "loglm"`; any other correlated Finding is rule-origin. No new flag, no skill zip, no Ledger writer, no ART slice, no `mitre_analyst` grant.

## Independent review

- Findings load was the newest 10k rows globally, not the step window — **fixed**: `get_findings` accepts `timestamp_start` / `timestamp_end`; `reconstruct_run` passes the trace span.
- `loglm` as a positive verdict was untested — **fixed**: recorded-run step-4 is LogLM-only; unit dispatch and live HTTP cover it.
- `rule_name` is read from `entity_context.rule_name`, not Elastic/Splunk `metadata` — **dismissed**: factory said cite rule name when present; those metadata keys are not Finding columns; `description` still cites.
- Timestamp-only steps are a zero-width window — **dismissed**: not specified slack; the fixture uses explicit `started_at` / `ended_at`.
- OR across host / IP / user — **dismissed**: the groom said match fields that exist, not AND every field.
- Destination IPs are ignored — **dismissed**: the groom named hostnames / `src_ip` / users.
- Duplicate technique-id non-join assertion — **dismissed**: still fails if we joined on `technique_id`; not a behavior bug.

## Verification

**Ran**
- `pytest tests/unit/detections/ tests/unit/storage/test_finding_mitre_predictions.py tests/unit/agents/test_tools_router.py --no-cov` — 62 passed.
- `flake8` on the changed Python files — clean.
- `isort --check-only` / `black --check` on the changed detections files — clean after format.
- `lint-imports` — 3 contracts kept.
- Live: started Postgres (`deeptempo-postgres`) and uvicorn on `:6987` (`/api/health` → postgresql, schema ok). Seeded the recorded-run Findings, then `POST /internal/tools/invoke` with `tool=reconstruct_run`:
  - full trace → `both`, `missed`, `missed`, `loglm` (citations on step-1: elastic + loglm)
  - empty future window → `missed`
  - after deleting LogLM rows → `rule`, `missed`, `missed`, `missed` (no `loglm` / `both`)
  - LogLM-only rows → `loglm`, `missed`, `missed`, `loglm`

**Did not run**
- `mypy services/ core/` — not applicable as a gate for this slice; a targeted `mypy` on the new module followed existing `core/storage` / `core/detections/tools.py` errors on main.
- Frontend / `agent-browser` — not applicable; no UI in this issue.
- DB-backed `external_service` pytest job — out of time relative to the live Postgres invoke, which already exercised the windowed `get_findings` path against a real database.
- Agent harness `journalExecuted` / Ledger append — not applicable; this PR returns JSON and does not add a writer. The invoke envelope is one row (`steps` is not an unwrap key).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85e25df8-3da4-41d7-a0a4-3d29a7077b32?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85e25df8-3da4-41d7-a0a4-3d29a7077b32&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

