### PR TITLE
env: install Python/npm deps and start Postgres/Redis

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -4,5 +4,6 @@
     "dockerfile": "Dockerfile"
   },
   "user": "ubuntu",
-  "start": "sudo service docker start"
+  "install": "sudo python3 -m pip install --break-system-packages --upgrade pip && sudo python3 -m pip install --break-system-packages -r requirements.lock -r requirements-dev.txt && npm ci --prefix clients/web && npm ci --prefix services/agent",
+  "start": "bash -lc 'set -euo pipefail; sudo service docker start; docker compose -f infra/docker/docker-compose.yml up -d postgres redis; for i in $(seq 1 60); do if docker exec deeptempo-postgres pg_isready -U deeptempo -d deeptempo_soc >/dev/null 2>&1 && docker exec deeptempo-redis redis-cli ping 2>/dev/null | grep -q PONG; then exit 0; fi; sleep 1; done; echo \"postgres/redis did not become ready\" >&2; exit 1'"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -5,5 +5,5 @@
   },
   "user": "ubuntu",
   "install": "sudo python3 -m pip install --break-system-packages --ignore-installed -r requirements.lock -r requirements-dev.txt && npm ci --prefix clients/web && npm ci --prefix services/agent",
-  "start": "bash -lc 'set -euo pipefail; sudo service docker start; docker compose -f infra/docker/docker-compose.yml up -d postgres redis; for i in $(seq 1 60); do if docker exec deeptempo-postgres pg_isready -U deeptempo -d deeptempo_soc >/dev/null 2>&1 && docker exec deeptempo-redis redis-cli ping 2>/dev/null | grep -q PONG; then exit 0; fi; sleep 1; done; echo \"postgres/redis did not become ready\" >&2; exit 1'"
+  "start": "bash -lc 'sudo service docker start || true; set -euo pipefail; docker compose -f infra/docker/docker-compose.yml up -d postgres redis; for i in $(seq 1 60); do if docker exec deeptempo-postgres pg_isready -U deeptempo -d deeptempo_soc >/dev/null 2>&1 && docker exec deeptempo-redis redis-cli ping 2>/dev/null | grep -q PONG; then exit 0; fi; sleep 1; done; echo \"postgres/redis did not become ready\" >&2; exit 1'"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -4,6 +4,6 @@
     "dockerfile": "Dockerfile"
   },
   "user": "ubuntu",
-  "install": "sudo python3 -m pip install --break-system-packages -r requirements.lock -r requirements-dev.txt && npm ci --prefix clients/web && npm ci --prefix services/agent",
+  "install": "sudo python3 -m pip install --break-system-packages --ignore-installed -r requirements.lock -r requirements-dev.txt && npm ci --prefix clients/web && npm ci --prefix services/agent",
   "start": "bash -lc 'set -euo pipefail; sudo service docker start; docker compose -f infra/docker/docker-compose.yml up -d postgres redis; for i in $(seq 1 60); do if docker exec deeptempo-postgres pg_isready -U deeptempo -d deeptempo_soc >/dev/null 2>&1 && docker exec deeptempo-redis redis-cli ping 2>/dev/null | grep -q PONG; then exit 0; fi; sleep 1; done; echo \"postgres/redis did not become ready\" >&2; exit 1'"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -4,6 +4,6 @@
     "dockerfile": "Dockerfile"
   },
   "user": "ubuntu",
-  "install": "sudo python3 -m pip install --break-system-packages --upgrade pip && sudo python3 -m pip install --break-system-packages -r requirements.lock -r requirements-dev.txt && npm ci --prefix clients/web && npm ci --prefix services/agent",
+  "install": "sudo python3 -m pip install --break-system-packages -r requirements.lock -r requirements-dev.txt && npm ci --prefix clients/web && npm ci --prefix services/agent",
   "start": "bash -lc 'set -euo pipefail; sudo service docker start; docker compose -f infra/docker/docker-compose.yml up -d postgres redis; for i in $(seq 1 60); do if docker exec deeptempo-postgres pg_isready -U deeptempo -d deeptempo_soc >/dev/null 2>&1 && docker exec deeptempo-redis redis-cli ping 2>/dev/null | grep -q PONG; then exit 0; fi; sleep 1; done; echo \"postgres/redis did not become ready\" >&2; exit 1'"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes the environment gap that showed up across recent factory PRs: implementers could not run the same checks CI runs, or only after setting the machine up themselves.

**What was blocked**
- [#850](https://github.com/Vigil-SOC/vigil/pull/850) skipped Python pytest (`test_ledger_app_role.py` and the other ledger-wired integration files) because **pytest was not installed** and **compose Postgres on :5432 was not up**.
- [#851](https://github.com/Vigil-SOC/vigil/pull/851) had to start `deeptempo-postgres` by hand before the live `reconstruct_run` invoke; the DB-backed `external_service` job did not run.
- [#848](https://github.com/Vigil-SOC/vigil/pull/848) got through live approval checks against an app DB the author already had running. The same Postgres/Redis start is what CI’s `services:` block provides on every job.

Earlier factory PRs paid the same tax in pieces: pip/venv before pytest (#808, #810, #840), and skipped DB-backed unit tests because Postgres was not started (#804).

**What this changes**
`.cursor/environment.json` only:
- `install` does what CI does before tests: `pip install -r requirements.lock -r requirements-dev.txt` (with `--ignore-installed` so Debian’s urllib3 does not abort the install), plus `npm ci` in `clients/web` and `services/agent`.
- `start` brings up the compose Postgres and Redis CI declares (`pgvector/pgvector:pg16`, `redis:7-alpine` via `infra/docker/docker-compose.yml`) and waits until they accept connections. `service docker start` is allowed to no-op when the daemon is already up.

Docker, Helm, and `agent-browser` were already in the image. This does not add tools CI does not install.

**Verified**
- Local: pytest 9.1.1 on PATH; compose Postgres/Redis healthy; `test_ledger_app_role.py` 2 passed; `pytest tests/unit/ -m external_service` 147 passed / 3 skipped / 2 xfailed; agent `typecheck` passed. GitHub CI on this PR is green.
- Draft build [bld-20260910-18258917-36e7-4d24-a320-5e48bf214b2a](https://cursor.com/dashboard/cloud-agents/builds/bld-20260910-18258917-36e7-4d24-a320-5e48bf214b2a) succeeded. A fresh cloud agent booted from that build had pytest on PATH, healthy `deeptempo-postgres` / `deeptempo-redis` from `start`, and the same two pytest files plus agent typecheck passed with no extra setup.

A new cloud agent after merge should be able to run those commands without a prior pip/npm install or a hand-started database.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1121180-8ffc-4518-81ad-91076ca4ad17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1121180-8ffc-4518-81ad-91076ca4ad17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

