### PR TITLE
feat(integrations): Atomic Red Team vendor slice (Closes #833)

### DIFF
--- a/clients/web/src/config/integrations.ts
+++ b/clients/web/src/config/integrations.ts
@@ -2792,6 +2792,32 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     ],
     docs_url: 'https://capev2.readthedocs.io/en/latest/usage/api.html',
   },
+  {
+    id: 'atomic-red-team',
+    name: 'Atomic Red Team',
+    category: 'Forensics & Analysis',
+    description: 'Invoke one Atomic Red Team technique against a named range or staging replica. Operator installs the runner; Vigil does not vendor the atomics repo.',
+    functionality_type: 'Adversary Emulation',
+    fields: [
+      {
+        name: 'runner_path',
+        label: 'Runner path',
+        type: 'text',
+        required: true,
+        placeholder: '/usr/local/bin/art-runner',
+        helpText: 'Operator-installed executable. Invoked as `<runner> --technique <id>` with optional `--atomics-path`.',
+      },
+      {
+        name: 'atomics_path',
+        label: 'Atomics path',
+        type: 'text',
+        required: false,
+        placeholder: '/opt/atomic-red-team/atomics',
+        helpText: 'Directory of Atomic YAML tests. Leave empty if the runner has its own default.',
+      },
+    ],
+    docs_url: 'https://github.com/redcanaryco/atomic-red-team',
+  },
 
   {
     id: 'timesketch',

--- a/clients/web/src/screens/settings/integrationsData.ts
+++ b/clients/web/src/screens/settings/integrationsData.ts
@@ -49,6 +49,7 @@ export const MCP_CATEGORIES: McpCategory[] = [
   { label: 'Network Security', servers: ['vstrike'] },
   { label: 'Incident Management', servers: ['jira', 'pagerduty', 'slack', 'microsoft-teams'] },
   { label: 'Sandbox / Analysis', servers: ['joe-sandbox', 'hybrid-analysis', 'anyrun', 'url-analysis', 'ip-geolocation'] },
+  { label: 'Adversary Emulation', servers: ['atomic-red-team'] },
 ]
 
 export const SERVER_DESCRIPTIONS = new Map(Object.entries({
@@ -87,6 +88,7 @@ export const SERVER_DESCRIPTIONS = new Map(Object.entries({
   anyrun: 'Interactive malware sandbox for real-time analysis with process monitoring and network capture.',
   'url-analysis': 'Analyze suspicious URLs for phishing indicators, redirects, and malicious content.',
   'ip-geolocation': 'Look up geographic location, ISP, and organization info for IP addresses during investigations.',
+  'atomic-red-team': 'Invoke one Atomic Red Team technique against a named range. Disabled until toggled; saving config does not run the runner.',
 }))
 
 export function prettyServerName(name: string): string {

--- a/core/integrations/atomic_red_team/__init__.py
+++ b/core/integrations/atomic_red_team/__init__.py
@@ -1,0 +1,1 @@
+"""atomic-red-team integration slice."""

--- a/core/integrations/atomic_red_team/descriptor.py
+++ b/core/integrations/atomic_red_team/descriptor.py
@@ -1,0 +1,19 @@
+"""Atomic Red Team integration descriptor — source of truth for its registry entries."""
+
+from core.integrations._base.descriptor import (
+    IntegrationDescriptor,
+    IntegrationField,
+    register_descriptor,
+)
+
+ATOMIC_RED_TEAM = register_descriptor(
+    IntegrationDescriptor(
+        id="atomic-red-team",
+        category="Forensics & Analysis",
+        mcp_server_names=("atomic-red-team",),
+        fields=(
+            IntegrationField("runner_path"),
+            IntegrationField("atomics_path"),
+        ),
+    )
+)

--- a/core/integrations/atomic_red_team/tool.py
+++ b/core/integrations/atomic_red_team/tool.py
@@ -1,0 +1,206 @@
+"""Atomic Red Team MCP server (stdio).
+
+Thin invoke of one Atomic technique against a named ``environment_id``.
+The operator installs the runner; this slice does not vendor the atomics
+repo. The execute tool's JSON is the interface — an action trace, not
+fabricated sensor events and not a ledger write.
+
+Config comes from the descriptor: ``runner_path`` and ``atomics_path``
+from the stored integration config under the ``atomic-red-team`` id.
+"""
+
+import sys
+from pathlib import Path
+
+# Spawned as ``python3 core/integrations/<vendor>/tool.py`` with a narrowed env,
+# so the repo root is not on sys.path and PYTHONPATH is not forwarded. Add it
+# here so the ``core.*`` imports below resolve; otherwise they fail at spawn.
+_REPO_ROOT = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import asyncio
+import json
+import logging
+import subprocess
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Mapping, Optional
+
+import mcp.server.stdio
+import mcp.types as types
+from mcp.server import NotificationOptions, Server
+from mcp.server.models import InitializationOptions
+
+from core.integrations._base.config import resolve
+from core.integrations.atomic_red_team.descriptor import ATOMIC_RED_TEAM
+
+logger = logging.getLogger(__name__)
+
+RUNNER_TIMEOUT = 180
+
+# argv the operator-installed runner must accept. Technique is required;
+# ``--atomics-path`` is omitted when the field is empty (runner default).
+_TECHNIQUE_FLAG = "--technique"
+_ATOMICS_FLAG = "--atomics-path"
+
+
+def result(data: Any) -> List[types.TextContent]:
+    return [
+        types.TextContent(type="text", text=json.dumps(data, indent=2, default=str))
+    ]
+
+
+def _load_config() -> Dict[str, str]:
+    config = resolve(ATOMIC_RED_TEAM)
+    return {
+        "runner_path": (config.get("runner_path") or "").strip(),
+        "atomics_path": (config.get("atomics_path") or "").strip(),
+    }
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _runner_argv(runner_path: str, technique: str, atomics_path: str) -> List[str]:
+    argv = [runner_path, _TECHNIQUE_FLAG, technique]
+    if atomics_path:
+        argv.extend([_ATOMICS_FLAG, atomics_path])
+    return argv
+
+
+def execute_atomic(
+    arguments: Optional[dict],
+    config: Mapping[str, str],
+    *,
+    run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> Dict[str, Any]:
+    """Invoke one Atomic technique. Missing ``environment_id`` refuses first."""
+    args = arguments or {}
+    environment_id = str(args.get("environment_id") or "").strip()
+    if not environment_id:
+        return {"error": "environment_id required"}
+
+    technique = str(args.get("technique") or "").strip()
+    if not technique:
+        return {"error": "technique required"}
+
+    runner_path = (config.get("runner_path") or "").strip()
+    if not runner_path:
+        return {"error": "Atomic Red Team not configured (missing runner_path)"}
+
+    argv = _runner_argv(runner_path, technique, config.get("atomics_path") or "")
+    started_at = _now()
+    try:
+        completed = run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=RUNNER_TIMEOUT,
+            check=False,
+        )
+    except FileNotFoundError:
+        return {"error": f"runner not found: {runner_path}"}
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "technique": technique,
+            "environment_id": environment_id,
+            "command": argv,
+            "exit": None,
+            "stdout": exc.stdout or "",
+            "stderr": exc.stderr or "",
+            "started_at": started_at,
+            "finished_at": _now(),
+            "error": "runner timed out",
+        }
+
+    return {
+        "technique": technique,
+        "environment_id": environment_id,
+        "command": argv,
+        "exit": completed.returncode,
+        "stdout": completed.stdout or "",
+        "stderr": completed.stderr or "",
+        "started_at": started_at,
+        "finished_at": _now(),
+    }
+
+
+async def handle_list_tools() -> List[types.Tool]:
+    return [
+        types.Tool(
+            name="atomic_red_team_execute",
+            description=(
+                "Execute one Atomic Red Team technique against a named "
+                "environment_id (customer-provided range or staging replica). "
+                "Returns an action trace (technique, command, exit, stdout/"
+                "stderr, timestamps). Refuses if environment_id is missing. "
+                "Does not capture or invent sensor telemetry."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "technique": {
+                        "type": "string",
+                        "description": "ATT&CK technique id, e.g. T1003.001",
+                    },
+                    "environment_id": {
+                        "type": "string",
+                        "description": (
+                            "Id of the sanctioned range or staging replica. "
+                            "Required; the runner is not called without it."
+                        ),
+                    },
+                },
+                "required": ["technique", "environment_id"],
+            },
+        ),
+    ]
+
+
+async def handle_call_tool(name: str, arguments: Optional[dict]):
+    if name != "atomic_red_team_execute":
+        return result({"error": f"Unknown tool: {name}"})
+    return result(execute_atomic(arguments, _load_config()))
+
+
+async def _on_list_tools(_ctx, _params):
+    return types.ListToolsResult(tools=await handle_list_tools())
+
+
+async def _on_call_tool(_ctx, params):
+    try:
+        content = await handle_call_tool(params.name, params.arguments)
+    except Exception as exc:
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(exc))],
+            is_error=True,
+        )
+    return types.CallToolResult(content=content)
+
+
+server = Server(
+    "atomic-red-team",
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
+
+
+async def main() -> None:
+    async with mcp.server.stdio.stdio_server() as (read, write):
+        await server.run(
+            read,
+            write,
+            InitializationOptions(
+                server_name="atomic-red-team",
+                server_version="0.1.0",
+                capabilities=server.get_capabilities(
+                    notification_options=NotificationOptions(),
+                    experimental_capabilities={},
+                ),
+            ),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/env.example
+++ b/env.example
@@ -489,6 +489,12 @@ CAPE_SANDBOX_ENABLED="false"
 CAPE_SANDBOX_URL="http://localhost:8000"
 CAPE_SANDBOX_API_KEY=""
 
+# Atomic Red Team (MCP child — core/integrations/atomic_red_team/tool.py)
+# Operator installs the runner; we do not vendor the atomics repo. Empty
+# placeholders leave the MCP server dormant on boot. Not a Settings field.
+ATOMIC_RED_TEAM_RUNNER_PATH=""
+ATOMIC_RED_TEAM_ATOMICS_PATH=""
+
 # Hybrid Analysis / Any.Run already use get_integration_config(); these flags
 # just toggle whether the daemon auto-submission pipeline consults them.
 HYBRID_ANALYSIS_ENABLED="false"

--- a/env.example
+++ b/env.example
@@ -490,8 +490,10 @@ CAPE_SANDBOX_URL="http://localhost:8000"
 CAPE_SANDBOX_API_KEY=""
 
 # Atomic Red Team (MCP child — core/integrations/atomic_red_team/tool.py)
-# Operator installs the runner; we do not vendor the atomics repo. Empty
-# placeholders leave the MCP server dormant on boot. Not a Settings field.
+# Operator installs the runner; we do not vendor the atomics repo. Optional
+# env fallback for resolve(); Settings stores runner_path as non-secret JSON.
+# Do not put these in mcp-config.json ${…} placeholders — that would keep
+# the server dormant after a UI save (see the Elastic ratchet).
 ATOMIC_RED_TEAM_RUNNER_PATH=""
 ATOMIC_RED_TEAM_ATOMICS_PATH=""
 

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -346,7 +346,7 @@
       "args": ["core/integrations/atomic_red_team/tool.py"],
       "cwd": "${workspaceFolder}",
       "env": {
-        "ATOMIC_RED_TEAM_RUNNER_PATH": "${ATOMIC_RED_TEAM_RUNNER_PATH}"
+        "_setup_note": "Operator-installed Atomic Red Team runner. Configure runner_path (and optional atomics_path) in Settings → Integrations. The execute tool refuses without environment_id. Disabled by default; saving config does not invoke the runner."
       }
     },
 

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -341,6 +341,15 @@
       }
     },
 
+    "atomic-red-team": {
+      "command": "python3",
+      "args": ["core/integrations/atomic_red_team/tool.py"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "ATOMIC_RED_TEAM_RUNNER_PATH": "${ATOMIC_RED_TEAM_RUNNER_PATH}"
+      }
+    },
+
     "ip-geolocation": {
       "command": "python3",
       "args": ["core/integrations/ip_geolocation/tool.py"],

--- a/tests/unit/_ratchets/test_integration_registries.py
+++ b/tests/unit/_ratchets/test_integration_registries.py
@@ -236,3 +236,18 @@ def test_elastic_mcp_config_declares_no_required_env_placeholders():
         if not k.startswith("_")
     }
     assert extract_required_env_vars(env, list(elastic.get("args") or [])) == []
+
+
+@pytest.mark.unit
+def test_atomic_red_team_mcp_config_declares_no_required_env_placeholders():
+    """runner_path is a non-secret Settings field. A ${ATOMIC_RED_TEAM_RUNNER_PATH}
+    placeholder would keep the server dormant after a UI save, because
+    split_secrets never writes that name."""
+    servers = json.loads(_MCP_CONFIG.read_text())["mcpServers"]
+    art = servers["atomic-red-team"]
+    env = {
+        k: str(v)
+        for k, v in (art.get("env") or {}).items()
+        if not k.startswith("_")
+    }
+    assert extract_required_env_vars(env, list(art.get("args") or [])) == []

--- a/tests/unit/_ratchets/test_settings_env_example.py
+++ b/tests/unit/_ratchets/test_settings_env_example.py
@@ -51,6 +51,8 @@ NOT_SETTINGS = {
     "VSTRIKE_USERNAME",
     # Integration endpoints and options consumed inside MCP server child
     # processes, whose config protocol is the environment they are spawned with.
+    "ATOMIC_RED_TEAM_ATOMICS_PATH",
+    "ATOMIC_RED_TEAM_RUNNER_PATH",
     "CLOUDFORCE_ONE_COLLECTION_IDS",
     "CLOUDFORCE_ONE_TAXII_SERVER_URL",
     "CRIBL_URL",

--- a/tests/unit/integrations/test_atomic_red_team_tool.py
+++ b/tests/unit/integrations/test_atomic_red_team_tool.py
@@ -1,0 +1,74 @@
+"""Stubbed Atomic Red Team execute: trace shape and missing environment_id."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import core.integrations.atomic_red_team.tool as art
+
+
+@pytest.mark.unit
+class TestExecuteAtomic:
+    def test_missing_environment_id_refuses_before_the_runner(self):
+        calls: list = []
+
+        def boom(*_a, **_kw):
+            calls.append(True)
+            raise AssertionError("runner must not be invoked")
+
+        out = art.execute_atomic(
+            {"technique": "T1003.001"},
+            {"runner_path": "/opt/art", "atomics_path": "/opt/atomics"},
+            run=boom,
+        )
+        assert out == {"error": "environment_id required"}
+        assert calls == []
+
+        out = art.execute_atomic(
+            {"technique": "T1003.001", "environment_id": "   "},
+            {"runner_path": "/opt/art", "atomics_path": "/opt/atomics"},
+            run=boom,
+        )
+        assert out == {"error": "environment_id required"}
+        assert calls == []
+
+    def test_stubbed_run_returns_the_action_trace(self):
+        recorded = []
+
+        def fake_run(argv, **kwargs):
+            recorded.append((list(argv), kwargs))
+            return SimpleNamespace(
+                returncode=0,
+                stdout="[+] T1059.001 executed\n",
+                stderr="",
+            )
+
+        # A prod-looking id must still run — we do not substring-match "prod".
+        out = art.execute_atomic(
+            {"technique": "T1059.001", "environment_id": "prod-range"},
+            {"runner_path": "/opt/art-runner", "atomics_path": "/opt/atomics"},
+            run=fake_run,
+        )
+        assert recorded, "stub runner was not invoked"
+        argv, kwargs = recorded[0]
+        assert argv == [
+            "/opt/art-runner",
+            "--technique",
+            "T1059.001",
+            "--atomics-path",
+            "/opt/atomics",
+        ]
+        assert kwargs.get("capture_output") is True
+        assert out["technique"] == "T1059.001"
+        assert out["environment_id"] == "prod-range"
+        assert out["command"] == argv
+        assert out["exit"] == 0
+        assert out["stdout"] == "[+] T1059.001 executed\n"
+        assert out["stderr"] == ""
+        assert out["started_at"]
+        assert out["finished_at"]
+        assert "error" not in out
+        assert "events" not in out
+        assert "telemetry" not in out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #833

Cape-sized Atomic Red Team Vendor Slice. The execute tool JSON is the interface: one technique against a named `environment_id`, returning an action trace. Unconfigured stays absent (MCP default-off). Saving Settings config does not invoke the runner.

## What this PR does

- Adds `core/integrations/atomic_red_team/` (`descriptor.py` + `tool.py`, no `adapter.py`) with descriptor id / MCP key `atomic-red-team`.
- Registers the stdio server in `mcp-config.json` and a Settings catalog row under Adversary Emulation. Not added to `_DEFAULT_ENABLED`.
- `atomic_red_team_execute` requires `environment_id` (non-empty string) before the runner is invoked. No `"prod"` substring filter, no Environment entity.
- Trace shape: technique, environment_id, command, exit, stdout/stderr, timestamps. No fabricated sensor events, no Python `agent_events` writes, no `ActionType.EXECUTE_ATTACK`, no playbook/`mitre_analyst` grant (that is #837).
- Operator installs the runner; this PR does not vendor the atomics repo. ART has no LLM, so no Bifrost / one-egress change.
- `mcp-config.json` does **not** declare `${ATOMIC_RED_TEAM_RUNNER_PATH}`: `runner_path` is a non-secret Settings field, and that placeholder would keep the server dormant after a UI save (same class of bug as Elastic).

## Out of scope (per factory groom)

- `core/integrations/offensive/`, `OffensiveEngine`, a second stub
- Ledger writes from Python
- Approval domain changes
- Compose `approvals` / `mitre_analyst` builtins (#837)

## Independent review

- **Dormancy gate on `${ATOMIC_RED_TEAM_RUNNER_PATH}`** — real defect. Settings stores `runner_path` as non-secret JSON; `get_secret` never sees it, so the MCP child would stay dormant after a UI save. **Fixed** in `5ba166a` by dropping the placeholder and ratcheting it like Elastic.
- **`environment_id` is echoed in the trace, not passed on the runner argv** — not a defect. The groom requires a plain string on the execute call and a refuse-before-runner; it forbids modelling an Environment entity. Reconstruction reads the returned JSON.

## Verification

### Ran

- `pytest tests/unit/integrations/test_atomic_red_team_tool.py tests/unit/_ratchets/test_integration_registries.py tests/unit/_ratchets/test_settings_env_example.py tests/unit/integrations/test_config_resolver.py --no-cov` — 92 passed (14 after the dormancy follow-up on the subset that changed).
- `flake8` / `black --check` / `isort --check-only` on `core/integrations/atomic_red_team/` and the ART unit test — clean.
- `lint-imports` — 3 contracts kept.
- `mypy core/integrations/atomic_red_team/ --ignore-missing-imports` — one `inputSchema` vs `input_schema` on MCP `Tool`, same as Cape; CI mypy is continue-on-error.
- `npx tsc --noEmit` in `clients/web` — clean.
- `npm run lint` in `clients/web` — 0 errors (18 pre-existing warnings elsewhere).
- Live API: `GET /api/mcp/servers` includes `atomic-red-team` (41 servers); status `stopped` / `enabled: false`. `POST /api/config/integrations` persisted `runner_path`/`atomics_path`; MCP stayed disabled; no `atomic_red_team` / art-runner process.
- Live tool entry point against that stored config: missing `environment_id` → `{"error": "environment_id required"}`; stubbed run returned the action trace using `/tmp/art-runner-from-ui`.
- Live UI (`agent-browser` + desktop): Settings → Integrations search “Atomic Red Team” shows the card under Adversary Emulation, toggle off, status Off. Wizard has Runner path and Atomics path. Saving from the wizard toasts “configured. Enable it with the toggle if it isn’t already.” Toggle remained off; MCP still `stopped`/`enabled: false`; no runner process.

[Atomic Red Team card disabled](https://cursor.com/agents/bc-99b9ca77-fc19-4b27-8875-b4d7d6e59223/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fart-settings-card-disabled.png)
[Configure Atomic Red Team wizard](https://cursor.com/agents/bc-99b9ca77-fc19-4b27-8875-b4d7d6e59223/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fart-settings-wizard.png)
[art-settings-card-live.mp4](https://cursor.com/agents/bc-99b9ca77-fc19-4b27-8875-b4d7d6e59223/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fart-settings-card-live.mp4)

### Did not run

- Full `tests/run-tests.sh` / entire pytest tree — not needed; no shared runtime besides the registries ratchet, which was run.
- `services/agent` `npm run typecheck` / vitest — no agent-layer changes.
- Frontend `vitest` — catalog/data-only TS change, covered by `tsc`.
- `scripts/check_one_loop.py`, `scripts/check_comment_style.py` — no agent-loop or scoped comment-style files.
- Generated OpenAPI types regen — no API schema change.
- hadolint / actionlint — no Docker/workflow changes.
- Real Atomic Red Team binary invoke — operator installs the runner; this environment has none. Stubbed/recorded run is the acceptance.

### Blocked by the machine

- `agent-browser skills get core` failed (`Skills directory not found`). The CLI itself worked from `--help`; screenshots were taken with it.
- SetupGate requires an LLM provider before Settings. No model was configured on this VM; a dummy keyless Ollama provider row was inserted so the real Settings route could be opened. Not an ART defect.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99b9ca77-fc19-4b27-8875-b4d7d6e59223?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99b9ca77-fc19-4b27-8875-b4d7d6e59223&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

