### PR TITLE
fix(web): don't label every Bifrost key "Disabled"

### DIFF
--- a/clients/web/src/screens/settings/AiProvidersPanel.test.tsx
+++ b/clients/web/src/screens/settings/AiProvidersPanel.test.tsx
@@ -147,3 +147,31 @@ describe('the models a key is fenced to', () => {
     expect(payload.value).toBeUndefined()
   })
 })
+
+/* Bifrost omits `enabled` from its read shape entirely. That is not an
+   omitempty elision -- the same payload serialises `use_for_batch_api: false`
+   and `use_anthropic_endpoints: false` -- so `!k.enabled` was true for every
+   key the gateway returned, and every key rendered as "Disabled". */
+describe('the “Disabled” badge', () => {
+  const expand = async () => {
+    fireEvent.click(screen.getByTitle('Expand'))
+    await screen.findByText('anthropic-key')
+  }
+
+  it('stays hidden for a key Bifrost returns without an `enabled` field', async () => {
+    const withoutEnabled: Record<string, unknown> = { ...FENCED }
+    delete withoutEnabled.enabled
+
+    await mount([withoutEnabled], ['claude-sonnet-5'])
+    await expand()
+
+    expect(screen.queryByText('Disabled')).not.toBeInTheDocument()
+  })
+
+  it('still shows for a key that was explicitly disabled', async () => {
+    await mount([{ ...FENCED, enabled: false }], ['claude-sonnet-5'])
+    await expand()
+
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
+  })
+})

--- a/clients/web/src/screens/settings/AiProvidersPanel.tsx
+++ b/clients/web/src/screens/settings/AiProvidersPanel.tsx
@@ -224,7 +224,7 @@ export default function AiProvidersPanel({ notify }: SectionProps) {
                           <td>
                             <div className="flex flex-col">
                               <span>{k.name}</span>
-                              {!k.enabled && <span className="text-xs text-tx-3">Disabled</span>}
+                              {k.enabled === false && <span className="text-xs text-tx-3">Disabled</span>}
                             </div>
                           </td>
                           <td className="font-mono text-xs">

--- a/clients/web/src/services/bifrostApi.ts
+++ b/clients/web/src/services/bifrostApi.ts
@@ -43,7 +43,10 @@ export interface BifrostKey {
   models: string[]
   blacklisted_models?: string[]
   weight: number
-  enabled: boolean
+  /** Absent from Bifrost's read shape — only a write carries it. Test
+      `enabled === false`, never `!enabled`: the latter reads every key the
+      gateway returns as disabled. */
+  enabled?: boolean
   /** Bifrost's own verdict: "success", "unknown", "list_models_failed", ... */
   status?: string
   description?: string


### PR DESCRIPTION
Every key in the AI Providers panel renders with a **"Disabled"** badge, regardless of its actual state.

## Cause

`AiProvidersPanel.tsx` shows the badge when `!k.enabled`, but Bifrost omits `enabled` from its key **read** shape entirely, so the expression is true for every key the gateway returns.

This is not an `omitempty` elision. The same response serialises `use_for_batch_api: false` and `use_anthropic_endpoints: false`, so `false` values *are* emitted — the field simply is not in that response struct. `BifrostKey.enabled` being typed as a required `boolean` on read is what hid it.

The editor already half-knew this: `KeyDialog` defaults with `existing?.enabled ?? true`, which is only meaningful if the field can be absent.

## Fix

- Test `k.enabled === false`, so only an explicit disable shows the badge.
- Mark `BifrostKey.enabled` optional, so the type says what the gateway actually sends. (The write shape keeps it required — a write does carry it.)

Three lines of production change.

## Relationship to #831

#831 fixed the *routing* half of this same misreading, moving the verdict server-side behind `GET /api/bifrost/routability`. The badge reads the absent field directly and was left behind.

## Tests

Two cases added to `AiProvidersPanel.test.tsx`: the badge stays hidden for a key returned without `enabled`, and still shows for one explicitly disabled.

Verified the first genuinely catches the bug — reverting the one-line change makes it fail and leaves the rest of the suite green. Full file: 7/7 passing, `tsc --noEmit` clean.

---

Found while running Vigil against an Azure AI Foundry-backed Bifrost, where the only provider is seeded from `config.json`. Happy to adjust naming or split the type change out if you would rather keep the two separate.