### PR TITLE
fix(integrations): Azure Sentinel descriptor/config never matched what ingestion reads

### DIFF
--- a/clients/web/src/config/integrations.ts
+++ b/clients/web/src/config/integrations.ts
@@ -920,12 +920,6 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
     functionality_type: 'Log Analysis & SIEM',
     fields: [
       {
-        name: 'workspace_id',
-        label: 'Workspace ID',
-        type: 'text',
-        required: true,
-      },
-      {
         name: 'tenant_id',
         label: 'Tenant ID',
         type: 'text',
@@ -942,6 +936,27 @@ export const INTEGRATIONS: IntegrationMetadata[] = [
         label: 'Client Secret',
         type: 'password',
         required: true,
+      },
+      {
+        name: 'subscription_id',
+        label: 'Subscription ID',
+        type: 'text',
+        required: true,
+        placeholder: 'Azure subscription containing the Sentinel workspace',
+      },
+      {
+        name: 'resource_group',
+        label: 'Resource Group',
+        type: 'text',
+        required: true,
+        placeholder: 'Resource group of the Log Analytics workspace',
+      },
+      {
+        name: 'workspace_name',
+        label: 'Workspace Name',
+        type: 'text',
+        required: true,
+        placeholder: 'Log Analytics workspace name (not its GUID)',
       },
     ],
     docs_url: 'https://docs.microsoft.com/en-us/azure/sentinel/',

--- a/core/integrations/azure_sentinel/descriptor.py
+++ b/core/integrations/azure_sentinel/descriptor.py
@@ -1,4 +1,17 @@
-"""Azure Sentinel descriptor — source of truth for its registry entries."""
+"""Azure Sentinel descriptor — source of truth for its registry entries.
+
+The field set below must match what ``ingestion.py`` actually reads: it used
+to declare ``workspace_id, tenant_id, client_id, client_secret`` while
+``fetch_alerts`` read ``tenant_id, client_id, client_secret, subscription_id,
+resource_group, workspace_name`` and guarded on ``all([...])`` of those six.
+Three of the six had no way to be populated through the Settings UI, so the
+guard could never pass and ``fetch_alerts`` always returned ``[]`` — Azure
+Sentinel ingestion could not work at all. ``subscription_id``,
+``resource_group`` and ``workspace_name`` identify the Log Analytics workspace
+that ``SecurityInsights.incidents.list`` is scoped to; ``workspace_id`` (the
+workspace GUID) was never one of the values that call takes, so it is dropped
+rather than carried along unused.
+"""
 
 from core.integrations._base.descriptor import (
     IntegrationDescriptor,
@@ -12,10 +25,12 @@ AZURE_SENTINEL = register_descriptor(
         category="SIEM",
         mcp_server_names=("azure-sentinel",),
         fields=(
-            IntegrationField("workspace_id"),
             IntegrationField("tenant_id"),
             IntegrationField("client_id"),
             IntegrationField("client_secret", secret=True),
+            IntegrationField("subscription_id"),
+            IntegrationField("resource_group"),
+            IntegrationField("workspace_name"),
         ),
     )
 )

--- a/core/integrations/azure_sentinel/ingestion.py
+++ b/core/integrations/azure_sentinel/ingestion.py
@@ -42,10 +42,25 @@ class AzureSentinelIngestion(SIEMIngestionService):
         Returns:
             List of raw incident dictionaries
         """
+        # A missing Azure SDK used to be swallowed by the blanket
+        # `except ImportError: return []` below, which made "azure-identity was
+        # never installed" indistinguishable from "there were no incidents".
+        # Raise here instead, with an install hint, so the failure is visible.
+        # This import happens outside the try/except Exception block below so
+        # the RuntimeError is not itself swallowed back into an empty list;
+        # SIEMIngestionAdapter already isolates per-source exceptions, so one
+        # broken source still cannot take the poller down.
         try:
             from azure.identity import ClientSecretCredential
             from azure.mgmt.securityinsight import SecurityInsights
+        except ImportError as exc:
+            raise RuntimeError(
+                "Azure SDK not installed for the Azure Sentinel integration "
+                f"({exc}). Install: pip install azure-mgmt-securityinsight "
+                "azure-identity"
+            ) from exc
 
+        try:
             # Get config
             tenant_id = self.config.get("tenant_id")
             client_id = self.config.get("client_id")
@@ -139,11 +154,6 @@ class AzureSentinelIngestion(SIEMIngestionService):
             logger.info(f"Fetched {len(incidents)} incidents from Azure Sentinel")
             return incidents
 
-        except ImportError:
-            logger.error(
-                "Azure SDK not installed. Install: pip install azure-mgmt-securityinsight azure-identity"
-            )
-            return []
         except Exception as e:
             logger.error(f"Error fetching Azure Sentinel incidents: {e}")
             return []

--- a/tests/unit/integrations/test_azure_sentinel_ingestion.py
+++ b/tests/unit/integrations/test_azure_sentinel_ingestion.py
@@ -1,0 +1,101 @@
+"""Unit tests for core/integrations/azure_sentinel/ingestion.py.
+
+Covers the two bugs fixed here:
+
+1. The descriptor/ingestion field mismatch: ``descriptor.py`` used to declare
+   ``workspace_id, tenant_id, client_id, client_secret`` while ``fetch_alerts``
+   read six different fields (including three the descriptor never declared),
+   so the completeness guard could never pass. ``test_required_fields_are_all_
+   declared_on_the_descriptor`` pins the two lists together so they cannot
+   drift apart again.
+2. ``except ImportError: return []`` made a missing Azure SDK indistinguishable
+   from an empty result set. ``test_missing_sdk_raises_instead_of_returning_
+   empty`` pins the fix: a missing SDK now raises with an install hint.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.integrations.azure_sentinel.descriptor import AZURE_SENTINEL
+from core.integrations.azure_sentinel.ingestion import AzureSentinelIngestion
+
+REQUIRED_FIELDS = (
+    "tenant_id",
+    "client_id",
+    "client_secret",
+    "subscription_id",
+    "resource_group",
+    "workspace_name",
+)
+
+
+@pytest.fixture
+def ingestion():
+    with patch(
+        "core.integrations.azure_sentinel.ingestion.get_integration_config"
+    ) as mock_config:
+        mock_config.return_value = {}
+        svc = AzureSentinelIngestion()
+        yield svc
+
+
+@pytest.fixture
+def stub_azure_sdk():
+    """Stand in for the azure-identity / azure-mgmt-securityinsight packages,
+    which are not declared as a dependency upstream, so tests that need the
+    deferred import inside fetch_alerts() to succeed must fake it out."""
+    import sys
+    import types
+
+    identity_mod = types.ModuleType("azure.identity")
+    identity_mod.ClientSecretCredential = MagicMock()
+    securityinsight_mod = types.ModuleType("azure.mgmt.securityinsight")
+    securityinsight_mod.SecurityInsights = MagicMock()
+    azure_mod = types.ModuleType("azure")
+    mgmt_mod = types.ModuleType("azure.mgmt")
+
+    with patch.dict(
+        sys.modules,
+        {
+            "azure": azure_mod,
+            "azure.identity": identity_mod,
+            "azure.mgmt": mgmt_mod,
+            "azure.mgmt.securityinsight": securityinsight_mod,
+        },
+    ):
+        yield
+
+
+def test_required_fields_are_all_declared_on_the_descriptor():
+    """Every field fetch_alerts() reads must be one the descriptor declares.
+
+    This is the regression the upstream bug hinged on: three of the six
+    fields ingestion read had no way to be populated because the descriptor
+    (and, transitively, the Settings form) never offered them.
+    """
+    declared = set(AZURE_SENTINEL.field_names)
+    assert set(REQUIRED_FIELDS) <= declared, (
+        "AzureSentinelIngestion.fetch_alerts() reads a field the descriptor "
+        f"does not declare: missing {set(REQUIRED_FIELDS) - declared}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_incomplete_config_returns_empty_without_raising(
+    ingestion, stub_azure_sdk
+):
+    ingestion.config = {"tenant_id": "t", "client_id": "c"}
+    alerts = await ingestion.fetch_alerts()
+    assert alerts == []
+
+
+@pytest.mark.asyncio
+async def test_missing_sdk_raises_instead_of_returning_empty(ingestion):
+    """A missing azure-identity/azure-mgmt-securityinsight install must be
+    loud, not indistinguishable from "no incidents found"."""
+    ingestion.config = {field: "x" for field in REQUIRED_FIELDS}
+
+    with patch("builtins.__import__", side_effect=ImportError("no module")):
+        with pytest.raises(RuntimeError, match="Azure SDK not installed"):
+            await ingestion.fetch_alerts()


### PR DESCRIPTION
## The bug

Three registries have to agree for the Azure Sentinel integration to work at all:

1. `core/integrations/azure_sentinel/descriptor.py` — declares the config fields the Settings UI collects.
2. `clients/web/src/config/integrations.ts` — the Settings form itself.
3. `core/integrations/azure_sentinel/ingestion.py` — what `fetch_alerts` actually reads.

Before this PR, (1) and (2) agreed with each other (`workspace_id, tenant_id, client_id, client_secret`), but not with (3): `fetch_alerts` reads `tenant_id, client_id, client_secret, subscription_id, resource_group, workspace_name` and only proceeds if `all([...])` of those six is truthy.

Three of those six — `subscription_id`, `resource_group`, `workspace_name` — had no way to ever be populated, since neither the descriptor nor the Settings form offered them. The `all([...])` guard could therefore never pass, and `fetch_alerts` always logged "Azure Sentinel configuration incomplete" and returned `[]`, no matter how correctly an operator filled in the Settings UI. **Azure Sentinel ingestion has never worked upstream.**

`workspace_id` (the Log Analytics workspace GUID) isn't one of the values `fetch_alerts` reads at all — `SecurityInsights.incidents.list` is scoped by `subscription_id` + `resource_group` + `workspace_name`, not the GUID — so this PR drops it rather than adding a fourth field nobody reads.

### Fix
- `descriptor.py` now declares the six fields ingestion actually reads.
- `integrations.ts` now collects those same six fields, so the descriptor and the Settings form agree with ingestion for the first time.

### A related, smaller bug in the same file

`except ImportError: return []` in `fetch_alerts` made "azure-identity / azure-mgmt-securityinsight was never installed" indistinguishable from "there were no incidents this poll" — both silently produced `[]`. This PR raises a `RuntimeError` with an install hint instead. `SIEMIngestionAdapter` already isolates per-source exceptions, so a missing SDK on one source can't take the rest of the poller down; it just stops being silent about it.

Happy to split this into two PRs (the registry fix vs. the `ImportError` behavior change) if you'd prefer to review them separately — let me know.

## Testing

- `tests/unit/_ratchets/test_integration_registries.py` — 8 passed (this is the ratchet that enforces descriptor/catalog agreement; it now passes for `azure-sentinel` for the first time)
- Added `tests/unit/integrations/test_azure_sentinel_ingestion.py` — 3 passed. Covers (a) every field the completeness guard checks is declared on the descriptor, as a regression test for the drift described above, and (b) a missing SDK raises instead of returning `[]`.
- `tests/unit/integrations/test_integration_secrets.py`, `test_integration_id_hyphens.py` — 31 passed, unaffected by this change.
- `clients/web`: `npx tsc --noEmit` — clean.

Found while running Vigil against Azure and noticing Sentinel incidents never showed up regardless of configuration.

Related: #857 (independent, a Bifrost "Disabled" badge fix from us also open against this repo).
